### PR TITLE
Add angle-aware interpolation modes for animations

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/animation.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/animation.mdx
@@ -70,3 +70,55 @@ Can be any of the following. See [`easings.net`](https://easings.net/) for a vis
 Use this to set or change the direction of the animation.
 </SlintProperty>
 
+### interpolation
+<SlintProperty propName="interpolation" typeName="enum" enumName="Interpolation">
+Specifies how values are interpolated during the animation.
+
+- `linear` (default): Standard linear interpolation between the start and end values. This is the default for all property types.
+
+The `angle-*` modes are specifically designed for angle properties where the interpolation path matters:
+- `angle-shorter`: Interpolates via the shorter arc
+- `angle-longer`: Interpolates via the longer arc
+- `angle-clockwise`: Always rotates clockwise
+- `angle-counterclockwise`: Always rotates counterclockwise
+
+For example, when animating an angle from 10° to 350°:
+- `linear`: Rotates 340° clockwise (numeric interpolation through 180°)
+- `angle-shorter`: Rotates 20° counterclockwise (the shorter path)
+- `angle-longer`: Rotates 340° clockwise (the longer path)
+- `angle-clockwise`: Rotates 340° clockwise
+- `angle-counterclockwise`: Rotates 20° counterclockwise
+</SlintProperty>
+
+**Example:**
+
+```slint
+export component Example inherits Window {
+    preferred-width: 200px;
+    preferred-height: 200px;
+
+    in-out property <angle> rotation: 10deg;
+
+    Rectangle {
+        width: 100px;
+        height: 20px;
+        x: 50px;
+        y: 90px;
+        background: blue;
+        transform-rotation: rotation;
+        transform-origin: { x: 0px, y: 10px };
+
+        animate transform-rotation {
+            duration: 1000ms;
+            interpolation: angle-shorter;
+        }
+    }
+
+    TouchArea {
+        clicked => {
+            rotation = rotation == 10deg ? 350deg : 10deg;
+        }
+    }
+}
+```
+

--- a/docs/astro/src/content/docs/guide/language/coding/animation.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/animation.mdx
@@ -70,24 +70,22 @@ Can be any of the following. See [`easings.net`](https://easings.net/) for a vis
 Use this to set or change the direction of the animation.
 </SlintProperty>
 
-### interpolation
-<SlintProperty propName="interpolation" typeName="enum" enumName="Interpolation">
-Specifies how values are interpolated during the animation.
+### angle-interpolation
+<SlintProperty propName="angle-interpolation" typeName="enum" enumName="AngleInterpolation">
+Specifies how angle values are interpolated during the animation. Only allowed on animations of `angle` properties.
 
-- `linear` (default): Standard linear interpolation between the start and end values. This is the default for all property types.
-
-The `angle-*` modes are specifically designed for angle properties where the interpolation path matters:
-- `angle-shorter`: Interpolates via the shorter arc
-- `angle-longer`: Interpolates via the longer arc
-- `angle-clockwise`: Always rotates clockwise
-- `angle-counterclockwise`: Always rotates counterclockwise
+- `linear` (default): Standard linear interpolation, treating the angle as a plain number.
+- `angle-shorter`: Interpolates via the shorter arc.
+- `angle-longer`: Interpolates via the longer arc.
+- `angle-clockwise`: Always rotates clockwise.
+- `angle-counterclockwise`: Always rotates counterclockwise.
 
 For example, when animating an angle from 10° to 350°:
-- `linear`: Rotates 340° clockwise (numeric interpolation through 180°)
-- `angle-shorter`: Rotates 20° counterclockwise (the shorter path)
-- `angle-longer`: Rotates 340° clockwise (the longer path)
-- `angle-clockwise`: Rotates 340° clockwise
-- `angle-counterclockwise`: Rotates 20° counterclockwise
+- `linear`: Rotates 340° clockwise (numeric interpolation through 180°).
+- `angle-shorter`: Rotates 20° counterclockwise (the shorter path).
+- `angle-longer`: Rotates 340° clockwise (the longer path).
+- `angle-clockwise`: Rotates 340° clockwise.
+- `angle-counterclockwise`: Rotates 20° counterclockwise.
 </SlintProperty>
 
 **Example:**
@@ -110,7 +108,7 @@ export component Example inherits Window {
 
         animate transform-rotation {
             duration: 1000ms;
-            interpolation: angle-shorter;
+            angle-interpolation: angle-shorter;
         }
     }
 

--- a/docs/astro/src/content/docs/guide/language/coding/animation.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/animation.mdx
@@ -75,17 +75,17 @@ Use this to set or change the direction of the animation.
 Specifies how angle values are interpolated during the animation. Only allowed on animations of `angle` properties.
 
 - `linear` (default): Standard linear interpolation, treating the angle as a plain number.
-- `angle-shorter`: Interpolates via the shorter arc.
-- `angle-longer`: Interpolates via the longer arc.
-- `angle-clockwise`: Always rotates clockwise.
-- `angle-counterclockwise`: Always rotates counterclockwise.
+- `shorter`: Interpolates along the shorter arc between the two angles.
+- `longer`: Interpolates along the longer arc between the two angles.
+- `increasing`: The angle value always increases during the animation, wrapping around if necessary.
+- `decreasing`: The angle value always decreases during the animation, wrapping around if necessary.
 
 For example, when animating an angle from 10° to 350°:
-- `linear`: Rotates 340° clockwise (numeric interpolation through 180°).
-- `angle-shorter`: Rotates 20° counterclockwise (the shorter path).
-- `angle-longer`: Rotates 340° clockwise (the longer path).
-- `angle-clockwise`: Rotates 340° clockwise.
-- `angle-counterclockwise`: Rotates 20° counterclockwise.
+- `linear`: Goes from 10° to 350° as a plain number (passes through 180°).
+- `shorter`: Goes via the shorter arc (the angle decreases by 20°, through 0°).
+- `longer`: Goes via the longer arc (the angle increases by 340°, through 180°).
+- `increasing`: The angle increases by 340° (10° → 180° → 350°).
+- `decreasing`: The angle decreases by 20° (10° → 0° → -10°).
 </SlintProperty>
 
 **Example:**
@@ -108,7 +108,7 @@ export component Example inherits Window {
 
         animate transform-rotation {
             duration: 1000ms;
-            angle-interpolation: angle-shorter;
+            angle-interpolation: shorter;
         }
     }
 

--- a/docs/astro/src/content/docs/reference/language/animations.mdx
+++ b/docs/astro/src/content/docs/reference/language/animations.mdx
@@ -38,8 +38,9 @@ animate <property> {
   A qualified name such as `other.property` is not allowed here; it is a compile error to refer to a property of another element.
 - The body may contain only bindings of the form `field: value;`.
   Any other statement is a compile error.
-- The only fields are `delay`, `duration`, `easing`, `iteration-count`, `direction`, and `enabled`.
+- The only fields are `delay`, `duration`, `easing`, `iteration-count`, `direction`, `enabled`, and `angle-interpolation`.
   Binding any other name is a compile error.
+  `angle-interpolation` is allowed only when every animated property has the type `angle`; using it elsewhere is a compile error.
   Every field is optional.
 
 Attaching two `animate` blocks to the same property is a compile error.
@@ -108,6 +109,59 @@ The direction in which each iteration plays.
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
 Whether the animation runs.
 When `false`, a change sets the property to its target value at once, with no delay, easing, or iteration.
+</SlintProperty>
+
+### angle-interpolation
+<SlintProperty propName="angle-interpolation" typeName="enum" enumName="AngleInterpolation" defaultValue="linear">
+How an `angle` property moves between its start and target values.
+This field is allowed only when animating properties of type `angle`.
+
+- `linear`: The angle is interpolated as a plain number.
+- `shorter`: The angle moves along the shorter arc between the two values.
+- `longer`: The angle moves along the longer arc between the two values.
+- `increasing`: The angle value always increases, wrapping around when the target is smaller.
+- `decreasing`: The angle value always decreases, wrapping around when the target is larger.
+
+With any mode other than `linear`, the animated value stays within 0° to 360° while the animation runs.
+Once it finishes, the property holds the target value exactly as written.
+
+For example, when animating from 10° to 350°:
+
+- `linear` passes through 180° and covers 340°.
+- `shorter` decreases through 0° and covers 20°.
+- `longer` increases through 180° and covers 340°.
+- `increasing` increases through 180° and covers 340°.
+- `decreasing` decreases through 0° and covers 20°.
+
+```slint
+export component Example inherits Window {
+    preferred-width: 200px;
+    preferred-height: 200px;
+
+    in-out property <angle> rotation: 10deg;
+
+    Rectangle {
+        width: 100px;
+        height: 20px;
+        x: 50px;
+        y: 90px;
+        background: blue;
+        transform-rotation: rotation;
+        transform-origin: { x: 0px, y: 10px };
+
+        animate transform-rotation {
+            duration: 1000ms;
+            angle-interpolation: shorter;
+        }
+    }
+
+    TouchArea {
+        clicked => {
+            rotation = rotation == 10deg ? 350deg : 10deg;
+        }
+    }
+}
+```
 </SlintProperty>
 
 ## Transitions

--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -612,7 +612,7 @@
         "interpolation-mode": {
             "patterns": [
                 {
-                    "match": "(?<!-)\\b(linear|angle-shorter|angle-longer|angle-clockwise|angle-counterclockwise)\\b(?!-)",
+                    "match": "(?<!-)\\b(linear|shorter|longer|increasing|decreasing)\\b(?!-)",
                     "name": "support.constant.interpolation-mode.slint"
                 }
             ]

--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -609,6 +609,14 @@
                 }
             ]
         },
+        "interpolation-mode": {
+            "patterns": [
+                {
+                    "match": "(?<!-)\\b(linear|angle-shorter|angle-longer|angle-clockwise|angle-counterclockwise)\\b(?!-)",
+                    "name": "support.constant.interpolation-mode.slint"
+                }
+            ]
+        },
         "number": {
             "patterns": [
                 {
@@ -630,6 +638,9 @@
                 },
                 {
                     "include": "#boolean"
+                },
+                {
+                    "include": "#interpolation-mode"
                 },
                 {
                     "begin": "(@(tr|linear-gradient|radial-gradient|conic-gradient|image-url))\\s*(\\()",
@@ -681,7 +692,7 @@
                     },
                     "patterns": [
                         {
-                            "match": "(?<!-)\\b(delay|duration|iteration-count|easing|direction)\\s*:",
+                            "match": "(?<!-)\\b(delay|duration|iteration-count|easing|direction|interpolation)\\s*:",
                             "captures": {
                                 "1": {
                                     "name": "keyword.other.animate.setting.slint"

--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -692,7 +692,7 @@
                     },
                     "patterns": [
                         {
-                            "match": "(?<!-)\\b(delay|duration|iteration-count|easing|direction|interpolation)\\s*:",
+                            "match": "(?<!-)\\b(delay|duration|iteration-count|easing|direction|angle-interpolation)\\s*:",
                             "captures": {
                                 "1": {
                                     "name": "keyword.other.animate.setting.slint"

--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -609,6 +609,14 @@
                 }
             ]
         },
+        "interpolation-mode": {
+            "patterns": [
+                {
+                    "match": "(?<!-)\\b(linear|shorter|longer|increasing|decreasing)\\b(?!-)",
+                    "name": "support.constant.interpolation-mode.slint"
+                }
+            ]
+        },
         "number": {
             "patterns": [
                 {
@@ -630,6 +638,9 @@
                 },
                 {
                     "include": "#boolean"
+                },
+                {
+                    "include": "#interpolation-mode"
                 },
                 {
                     "begin": "(@(tr|linear-gradient|radial-gradient|conic-gradient|image-url))\\s*(\\()",
@@ -681,7 +692,7 @@
                     },
                     "patterns": [
                         {
-                            "match": "(?<!-)\\b(delay|duration|iteration-count|easing|direction)\\s*:",
+                            "match": "(?<!-)\\b(delay|duration|iteration-count|easing|direction|angle-interpolation)\\s*:",
                             "captures": {
                                 "1": {
                                     "name": "keyword.other.animate.setting.slint"

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -7,7 +7,7 @@ module.exports = grammar({
   name: "slint",
 
   extras: ($) => [/[\s\r\n]+/, $.comment],
-  conflicts: ($) => [[$._assignment_value_block], [$.assignment_block]],
+  conflicts: ($) => [[$._assignment_value_block], [$.assignment_block], [$.easing_kind_identifier, $.interpolation_mode_identifier]],
 
   rules: {
     sourcefile: ($) => repeat($._definition),

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -7,7 +7,7 @@ module.exports = grammar({
   name: "slint",
 
   extras: ($) => [/[\s\r\n]+/, $.comment],
-  conflicts: ($) => [[$._assignment_value_block], [$.assignment_block], [$.easing_kind_identifier, $.interpolation_mode_identifier]],
+  conflicts: ($) => [[$._assignment_value_block], [$.assignment_block]],
 
   rules: {
     sourcefile: ($) => repeat($._definition),
@@ -728,15 +728,6 @@ module.exports = grammar({
         seq("cubic-bezier", $.arguments),
       ),
 
-    interpolation_mode_identifier: ($) =>
-      choice(
-        "linear",
-        "angle-shorter",
-        "angle-longer",
-        "angle-clockwise",
-        "angle-counterclockwise",
-      ),
-
     user_type_identifier: ($) => prec(1, $._identifier),
     _type_identifier: ($) =>
       choice($.builtin_type_identifier, $.user_type_identifier),
@@ -794,7 +785,6 @@ module.exports = grammar({
         $.percent_value,
         $.relative_font_size_value,
         $.easing_kind_identifier,
-        $.interpolation_mode_identifier,
       ),
 
     comment: (_) =>

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -273,7 +273,7 @@ module.exports = grammar({
     animate_statement: ($) => seq("animate", $.expression, $.animate_body),
 
     animate_option_identifier: (_) =>
-      choice("delay", "duration", "iteration-count", "direction", "easing"),
+      choice("delay", "duration", "iteration-count", "direction", "easing", "interpolation"),
 
     animate_option: ($) =>
       seq(
@@ -728,6 +728,15 @@ module.exports = grammar({
         seq("cubic-bezier", $.arguments),
       ),
 
+    interpolation_mode_identifier: ($) =>
+      choice(
+        "linear",
+        "angle-shorter",
+        "angle-longer",
+        "angle-clockwise",
+        "angle-counterclockwise",
+      ),
+
     user_type_identifier: ($) => prec(1, $._identifier),
     _type_identifier: ($) =>
       choice($.builtin_type_identifier, $.user_type_identifier),
@@ -785,6 +794,7 @@ module.exports = grammar({
         $.percent_value,
         $.relative_font_size_value,
         $.easing_kind_identifier,
+        $.interpolation_mode_identifier,
       ),
 
     comment: (_) =>

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -273,7 +273,7 @@ module.exports = grammar({
     animate_statement: ($) => seq("animate", $.expression, $.animate_body),
 
     animate_option_identifier: (_) =>
-      choice("delay", "duration", "iteration-count", "direction", "easing", "interpolation"),
+      choice("delay", "duration", "iteration-count", "direction", "easing", "angle-interpolation"),
 
     animate_option: ($) =>
       seq(

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -369,7 +369,15 @@ module.exports = grammar({
       seq("animate", choice("*", commaSep1($.expression)), $.animate_body),
 
     animate_option_identifier: (_) =>
-      choice("delay", "duration", "iteration-count", "direction", "easing", "enabled"),
+      choice(
+        "delay",
+        "duration",
+        "iteration-count",
+        "direction",
+        "easing",
+        "enabled",
+        "angle-interpolation",
+      ),
 
     animate_option: ($) =>
       seq(

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -569,20 +569,18 @@ macro_rules! for_each_enums {
             }
 
             /// This enum describes the interpolation method for angle values during animation.
-            /// Similar to [Qt's RotationAnimation.direction](https://doc.qt.io/qt-6/qml-qtquick-rotationanimation.html#direction-prop)
-            /// and [CSS hue-interpolation-method](https://developer.mozilla.org/en-US/docs/Web/CSS/hue-interpolation-method).
             #[non_exhaustive]
             enum AngleInterpolation {
                 /// Standard linear interpolation between start and end values, treating the angle as a plain number.
                 Linear,
-                /// Interpolate via the shorter arc. Rotating from 10° to 350° will traverse only 20 degrees counterclockwise.
-                AngleShorter,
-                /// Interpolate via the longer arc. Rotating from 10° to 350° will traverse 340 degrees clockwise.
-                AngleLonger,
-                /// Always rotate clockwise.
-                AngleClockwise,
-                /// Always rotate counterclockwise.
-                AngleCounterclockwise,
+                /// Interpolate along the shorter arc. Animating from 10° to 350° traverses 20° via the angle value decreasing.
+                Shorter,
+                /// Interpolate along the longer arc. Animating from 10° to 350° traverses 340° via the angle value increasing.
+                Longer,
+                /// The angle value always increases during the animation, wrapping around if necessary.
+                Increasing,
+                /// The angle value always decreases during the animation, wrapping around if necessary.
+                Decreasing,
             }
 
             /// This enum describes the scrollbar visibility

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -568,6 +568,24 @@ macro_rules! for_each_enums {
                 AlternateReverse,
             }
 
+            /// This enum describes the interpolation method for property values during animation.
+            /// The `angle-*` variants are particularly useful for angle values where the interpolation path matters.
+            /// Similar to [Qt's RotationAnimation.direction](https://doc.qt.io/qt-6/qml-qtquick-rotationanimation.html#direction-prop)
+            /// and [CSS hue-interpolation-method](https://developer.mozilla.org/en-US/docs/Web/CSS/hue-interpolation-method).
+            #[non_exhaustive]
+            enum Interpolation {
+                /// Standard linear interpolation between start and end values. This is the default for all property types.
+                Linear,
+                /// For angles: interpolate via the shorter arc. Rotating from 10° to 350° will traverse only 20 degrees counterclockwise.
+                AngleShorter,
+                /// For angles: interpolate via the longer arc. Rotating from 10° to 350° will traverse 340 degrees clockwise.
+                AngleLonger,
+                /// For angles: always rotate clockwise.
+                AngleClockwise,
+                /// For angles: always rotate counterclockwise.
+                AngleCounterclockwise,
+            }
+
             /// This enum describes the scrollbar visibility
             #[non_exhaustive]
             enum ScrollBarPolicy {

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -568,21 +568,20 @@ macro_rules! for_each_enums {
                 AlternateReverse,
             }
 
-            /// This enum describes the interpolation method for property values during animation.
-            /// The `angle-*` variants are particularly useful for angle values where the interpolation path matters.
+            /// This enum describes the interpolation method for angle values during animation.
             /// Similar to [Qt's RotationAnimation.direction](https://doc.qt.io/qt-6/qml-qtquick-rotationanimation.html#direction-prop)
             /// and [CSS hue-interpolation-method](https://developer.mozilla.org/en-US/docs/Web/CSS/hue-interpolation-method).
             #[non_exhaustive]
-            enum Interpolation {
-                /// Standard linear interpolation between start and end values. This is the default for all property types.
+            enum AngleInterpolation {
+                /// Standard linear interpolation between start and end values, treating the angle as a plain number.
                 Linear,
-                /// For angles: interpolate via the shorter arc. Rotating from 10° to 350° will traverse only 20 degrees counterclockwise.
+                /// Interpolate via the shorter arc. Rotating from 10° to 350° will traverse only 20 degrees counterclockwise.
                 AngleShorter,
-                /// For angles: interpolate via the longer arc. Rotating from 10° to 350° will traverse 340 degrees clockwise.
+                /// Interpolate via the longer arc. Rotating from 10° to 350° will traverse 340 degrees clockwise.
                 AngleLonger,
-                /// For angles: always rotate clockwise.
+                /// Always rotate clockwise.
                 AngleClockwise,
-                /// For angles: always rotate counterclockwise.
+                /// Always rotate counterclockwise.
                 AngleCounterclockwise,
             }
 

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -595,6 +595,24 @@ macro_rules! for_each_enums {
                 AlternateReverse,
             }
 
+            /// This enum describes the interpolation method for angle values during animation.
+            ///
+            /// With any mode other than `linear`, the animated value stays within 0° to 360°
+            /// while the animation runs. Once it finishes, the property holds the target value.
+            #[non_exhaustive]
+            enum AngleInterpolation {
+                /// Standard linear interpolation between start and end values, treating the angle as a plain number.
+                Linear,
+                /// Interpolate along the shorter arc. Animating from 10° to 350° traverses 20° via the angle value decreasing.
+                Shorter,
+                /// Interpolate along the longer arc. Animating from 10° to 350° traverses 340° via the angle value increasing.
+                Longer,
+                /// The angle value always increases during the animation, wrapping around if necessary.
+                Increasing,
+                /// The angle value always decreases during the animation, wrapping around if necessary.
+                Decreasing,
+            }
+
             /// This enum describes the scrollbar visibility
             #[non_exhaustive]
             enum ScrollBarPolicy {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2737,6 +2737,7 @@ component PropertyAnimation {
     in property <AnimationDirection> direction;
     in property <easing> easing;
     in property <float> iteration-count: 1.0;
+    in property <Interpolation> interpolation;
     //-is_non_item_type
 }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2737,7 +2737,7 @@ component PropertyAnimation {
     in property <AnimationDirection> direction;
     in property <easing> easing;
     in property <float> iteration-count: 1.0;
-    in property <Interpolation> interpolation;
+    in property <AngleInterpolation> angle-interpolation;
     //-is_non_item_type
 }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -3009,6 +3009,7 @@ component PropertyAnimation {
     in property <easing> easing;
     in property <float> iteration-count: 1.0;
     in property <bool> enabled: true;
+    in property <AngleInterpolation> angle-interpolation;
     //-is_non_item_type
 }
 

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -564,6 +564,10 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             ),
             (SmolStr::new_static("easing"), Type::Easing),
             (SmolStr::new_static("delay"), Type::Int32),
+            (
+                SmolStr::new_static("interpolation"),
+                Type::Enumeration(BUILTIN.with(|e| e.enums.Interpolation.clone())),
+            ),
         ])
     }
 

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -565,8 +565,8 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             (SmolStr::new_static("easing"), Type::Easing),
             (SmolStr::new_static("delay"), Type::Int32),
             (
-                SmolStr::new_static("interpolation"),
-                Type::Enumeration(BUILTIN.with(|e| e.enums.Interpolation.clone())),
+                SmolStr::new_static("angle-interpolation"),
+                Type::Enumeration(BUILTIN.with(|e| e.enums.AngleInterpolation.clone())),
             ),
         ])
     }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -769,6 +769,10 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             (SmolStr::new_static("easing"), Type::Easing),
             (SmolStr::new_static("delay"), Type::Int32),
             (SmolStr::new_static("enabled"), Type::Bool),
+            (
+                SmolStr::new_static("angle-interpolation"),
+                Type::Enumeration(BUILTIN.enums.AngleInterpolation.clone()),
+            ),
         ])
     }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2334,33 +2334,18 @@ fn animation_element_from_node(
         );
         None
     } else {
-        // Check if angle-* interpolation mode is used with a non-angle property
-        for binding in anim.Binding() {
-            let Some(ident) = binding.child_token(SyntaxKind::Identifier) else { continue };
-            if parser::normalize_identifier(ident.text()) != "interpolation" {
-                continue;
-            }
-            // Check if the binding value is a simple identifier (QualifiedName)
-            let binding_expr = binding.BindingExpression();
-            let Some(expr) = binding_expr.Expression() else { continue };
-            let Some(qn) = expr.QualifiedName() else { continue };
-            let mode = qn.text().to_string();
-            let normalized_mode = parser::normalize_identifier(&mode);
-            // Check for angle-* interpolation modes
-            if matches!(
-                normalized_mode.as_str(),
-                "angle-shorter" | "angle-longer" | "angle-clockwise" | "angle-counterclockwise"
-            ) && prop_type != Type::Angle
-            {
-                diag.push_error(
-                    format!(
-                        "The '{}' interpolation mode can only be used with angle properties, but '{}' has type {}",
-                        mode.trim(),
-                        prop_name.text().to_string().trim(),
-                        prop_type
-                    ),
-                    &qn,
-                );
+        // The `interpolation` property is only meaningful for angle properties
+        if prop_type != Type::Angle {
+            for binding in anim.Binding() {
+                let Some(ident) = binding.child_token(SyntaxKind::Identifier) else {
+                    continue;
+                };
+                if parser::normalize_identifier(ident.text()) == "interpolation" {
+                    diag.push_error(
+                        "The 'interpolation' property is only allowed when animating angle properties".into(),
+                        &ident,
+                    );
+                }
             }
         }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2334,15 +2334,15 @@ fn animation_element_from_node(
         );
         None
     } else {
-        // The `interpolation` property is only meaningful for angle properties
+        // The `angle-interpolation` property is only meaningful for angle properties
         if prop_type != Type::Angle {
             for binding in anim.Binding() {
                 let Some(ident) = binding.child_token(SyntaxKind::Identifier) else {
                     continue;
                 };
-                if parser::normalize_identifier(ident.text()) == "interpolation" {
+                if parser::normalize_identifier(ident.text()) == "angle-interpolation" {
                     diag.push_error(
-                        "The 'interpolation' property is only allowed when animating angle properties".into(),
+                        "The 'angle-interpolation' property is only allowed when animating angle properties".into(),
                         &ident,
                     );
                 }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2323,7 +2323,7 @@ fn animation_element_from_node(
     diag: &mut BuildDiagnostics,
     tr: &TypeRegister,
 ) -> Option<ElementRc> {
-    let anim_type = tr.property_animation_type_for_property(prop_type);
+    let anim_type = tr.property_animation_type_for_property(prop_type.clone());
     if !matches!(anim_type, ElementType::Builtin(..)) {
         diag.push_error(
             format!(
@@ -2334,6 +2334,36 @@ fn animation_element_from_node(
         );
         None
     } else {
+        // Check if angle-* interpolation mode is used with a non-angle property
+        for binding in anim.Binding() {
+            let Some(ident) = binding.child_token(SyntaxKind::Identifier) else { continue };
+            if parser::normalize_identifier(ident.text()) != "interpolation" {
+                continue;
+            }
+            // Check if the binding value is a simple identifier (QualifiedName)
+            let binding_expr = binding.BindingExpression();
+            let Some(expr) = binding_expr.Expression() else { continue };
+            let Some(qn) = expr.QualifiedName() else { continue };
+            let mode = qn.text().to_string();
+            let normalized_mode = parser::normalize_identifier(&mode);
+            // Check for angle-* interpolation modes
+            if matches!(
+                normalized_mode.as_str(),
+                "angle-shorter" | "angle-longer" | "angle-clockwise" | "angle-counterclockwise"
+            ) && prop_type != Type::Angle
+            {
+                diag.push_error(
+                    format!(
+                        "The '{}' interpolation mode can only be used with angle properties, but '{}' has type {}",
+                        mode.trim(),
+                        prop_name.text().to_string().trim(),
+                        prop_type
+                    ),
+                    &qn,
+                );
+            }
+        }
+
         let mut anim_element =
             Element { id: "".into(), base_type: anim_type, ..Default::default() };
         anim_element.parse_bindings(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3963,7 +3963,7 @@ fn animation_element_from_node(
     diag: &mut BuildDiagnostics,
     tr: &TypeRegister,
 ) -> Option<ElementRc> {
-    let anim_type = tr.property_animation_type_for_property(prop_type);
+    let anim_type = tr.property_animation_type_for_property(prop_type.clone());
     if !matches!(anim_type, ElementType::Builtin(..)) {
         diag.push_error(
             format!(
@@ -3974,6 +3974,21 @@ fn animation_element_from_node(
         );
         None
     } else {
+        // The `angle-interpolation` property is only meaningful for angle properties
+        if prop_type != Type::Angle {
+            for binding in anim.Binding() {
+                let Some(ident) = binding.child_token(SyntaxKind::Identifier) else {
+                    continue;
+                };
+                if parser::normalize_identifier(ident.text()) == "angle-interpolation" {
+                    diag.push_error(
+                        "The 'angle-interpolation' property is only allowed when animating angle properties".into(),
+                        &ident,
+                    );
+                }
+            }
+        }
+
         let mut anim_element =
             Element { id: "".into(), base_type: anim_type, ..Default::default() };
         anim_element.parse_bindings(

--- a/internal/compiler/tests/syntax/basic/property_animation.slint
+++ b/internal/compiler/tests/syntax/basic/property_animation.slint
@@ -10,4 +10,32 @@ export TestCase := Rectangle {
         x: 0phx;
 //      ^error{Unknown property x in PropertyAnimation}
     }
+
+    // Test: angle-* interpolation modes should only be used with angle properties
+    animate width {
+        interpolation: angle-shorter;
+//                     >           <error{The 'angle-shorter' interpolation mode can only be used with angle properties, but 'width' has type length}
+    }
+    animate height {
+        interpolation: angle-longer;
+//                     >          <error{The 'angle-longer' interpolation mode can only be used with angle properties, but 'height' has type length}
+    }
+    animate opacity {
+        interpolation: angle-clockwise;
+//                     >             <error{The 'angle-clockwise' interpolation mode can only be used with angle properties, but 'opacity' has type float}
+    }
+
+    // Valid: linear interpolation can be used with any property type
+    animate min-width {
+        interpolation: linear;
+    }
+
+    // Valid: angle-* interpolation with angle properties
+    property <angle> my-angle;
+    animate my-angle {
+        interpolation: angle-shorter;
+    }
+    animate transform-rotation {
+        interpolation: angle-counterclockwise;
+    }
 }

--- a/internal/compiler/tests/syntax/basic/property_animation.slint
+++ b/internal/compiler/tests/syntax/basic/property_animation.slint
@@ -11,26 +11,17 @@ export TestCase := Rectangle {
 //      ^error{Unknown property x in PropertyAnimation}
     }
 
-    // Test: angle-* interpolation modes should only be used with angle properties
+    // Test: interpolation property is rejected for non-angle properties
     animate width {
         interpolation: angle-shorter;
-//                     >           <error{The 'angle-shorter' interpolation mode can only be used with angle properties, but 'width' has type length}
+//      >           <error{The 'interpolation' property is only allowed when animating angle properties}
     }
     animate height {
-        interpolation: angle-longer;
-//                     >          <error{The 'angle-longer' interpolation mode can only be used with angle properties, but 'height' has type length}
-    }
-    animate opacity {
-        interpolation: angle-clockwise;
-//                     >             <error{The 'angle-clockwise' interpolation mode can only be used with angle properties, but 'opacity' has type float}
-    }
-
-    // Valid: linear interpolation can be used with any property type
-    animate min-width {
         interpolation: linear;
+//      >           <error{The 'interpolation' property is only allowed when animating angle properties}
     }
 
-    // Valid: angle-* interpolation with angle properties
+    // Valid: interpolation with angle properties
     property <angle> my-angle;
     animate my-angle {
         interpolation: angle-shorter;

--- a/internal/compiler/tests/syntax/basic/property_animation.slint
+++ b/internal/compiler/tests/syntax/basic/property_animation.slint
@@ -11,22 +11,22 @@ export TestCase := Rectangle {
 //      ^error{Unknown property x in PropertyAnimation}
     }
 
-    // Test: interpolation property is rejected for non-angle properties
+    // Test: angle-interpolation property is rejected for non-angle properties
     animate width {
-        interpolation: angle-shorter;
-//      >           <error{The 'interpolation' property is only allowed when animating angle properties}
+        angle-interpolation: angle-shorter;
+//      >                 <error{The 'angle-interpolation' property is only allowed when animating angle properties}
     }
     animate height {
-        interpolation: linear;
-//      >           <error{The 'interpolation' property is only allowed when animating angle properties}
+        angle-interpolation: linear;
+//      >                 <error{The 'angle-interpolation' property is only allowed when animating angle properties}
     }
 
-    // Valid: interpolation with angle properties
+    // Valid: angle-interpolation with angle properties
     property <angle> my-angle;
     animate my-angle {
-        interpolation: angle-shorter;
+        angle-interpolation: angle-shorter;
     }
     animate transform-rotation {
-        interpolation: angle-counterclockwise;
+        angle-interpolation: angle-counterclockwise;
     }
 }

--- a/internal/compiler/tests/syntax/basic/property_animation.slint
+++ b/internal/compiler/tests/syntax/basic/property_animation.slint
@@ -13,7 +13,7 @@ export TestCase := Rectangle {
 
     // Test: angle-interpolation property is rejected for non-angle properties
     animate width {
-        angle-interpolation: angle-shorter;
+        angle-interpolation: shorter;
 //      >                 <error{The 'angle-interpolation' property is only allowed when animating angle properties}
     }
     animate height {
@@ -24,9 +24,9 @@ export TestCase := Rectangle {
     // Valid: angle-interpolation with angle properties
     property <angle> my-angle;
     animate my-angle {
-        angle-interpolation: angle-shorter;
+        angle-interpolation: shorter;
     }
     animate transform-rotation {
-        angle-interpolation: angle-counterclockwise;
+        angle-interpolation: decreasing;
     }
 }

--- a/internal/compiler/tests/syntax/basic/property_animation.slint
+++ b/internal/compiler/tests/syntax/basic/property_animation.slint
@@ -10,4 +10,23 @@ export TestCase := Rectangle {
         x: 0phx;
 //      ^error{Unknown property x in PropertyAnimation}
     }
+
+    // Test: angle-interpolation property is rejected for non-angle properties
+    animate width {
+        angle-interpolation: shorter;
+//      >                 <error{The 'angle-interpolation' property is only allowed when animating angle properties}
+    }
+    animate height {
+        angle-interpolation: linear;
+//      >                 <error{The 'angle-interpolation' property is only allowed when animating angle properties}
+    }
+
+    // Valid: angle-interpolation with angle properties
+    property <angle> my-angle;
+    animate my-angle {
+        angle-interpolation: shorter;
+    }
+    animate transform-rotation {
+        angle-interpolation: decreasing;
+    }
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1228,9 +1228,8 @@ pub struct PropertyAnimation {
     pub direction: AnimationDirection,
     #[rtti_field]
     pub easing: crate::animations::EasingCurve,
-    /// Interpolation method (e.g., for angles where path direction matters)
     #[rtti_field]
-    pub interpolation: Interpolation,
+    pub angle_interpolation: AngleInterpolation,
 }
 
 impl Default for PropertyAnimation {
@@ -1243,7 +1242,7 @@ impl Default for PropertyAnimation {
             iteration_count: 1.,
             direction: Default::default(),
             easing: Default::default(),
-            interpolation: Default::default(),
+            angle_interpolation: Default::default(),
         }
     }
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1228,6 +1228,9 @@ pub struct PropertyAnimation {
     pub direction: AnimationDirection,
     #[rtti_field]
     pub easing: crate::animations::EasingCurve,
+    /// Interpolation method (e.g., for angles where path direction matters)
+    #[rtti_field]
+    pub interpolation: Interpolation,
 }
 
 impl Default for PropertyAnimation {
@@ -1240,6 +1243,7 @@ impl Default for PropertyAnimation {
             iteration_count: 1.,
             direction: Default::default(),
             easing: Default::default(),
+            interpolation: Default::default(),
         }
     }
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1236,6 +1236,9 @@ pub struct PropertyAnimation {
     pub easing: crate::animations::EasingCurve,
     #[rtti_field]
     pub enabled: bool,
+    /// Interpolation method for angle properties (which arc / direction to take)
+    #[rtti_field]
+    pub angle_interpolation: AngleInterpolation,
 }
 
 impl Default for PropertyAnimation {
@@ -1249,6 +1252,7 @@ impl Default for PropertyAnimation {
             direction: Default::default(),
             easing: Default::default(),
             enabled: true,
+            angle_interpolation: Default::default(),
         }
     }
 }

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::{
     animations::physics_simulation,
-    items::{AnimationDirection, PropertyAnimation},
+    items::{AnimationDirection, Interpolation, PropertyAnimation},
     lengths::LogicalLength,
 };
 use euclid::Length;
@@ -139,7 +139,11 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
                         if reversed(current_iteration) { 1. - progress } else { progress }
                     };
                     let t = crate::animations::easing_curve(&self.details.easing, progress);
-                    let val = self.from_value.interpolate(&self.to_value, t);
+                    let val = self.from_value.interpolate_with_mode(
+                        &self.to_value,
+                        t,
+                        self.details.interpolation,
+                    );
 
                     (val, false)
                 } else {
@@ -252,11 +256,92 @@ pub trait InterpolatedPropertyValue: PartialEq + Default + 'static {
     /// easing curves it may over- or undershoot though.
     #[must_use]
     fn interpolate(&self, target_value: &Self, t: f32) -> Self;
+
+    /// Returns the interpolated value with a specific interpolation mode.
+    /// This is particularly useful for angle values where the interpolation path matters.
+    /// The default implementation ignores the mode and uses linear interpolation.
+    #[must_use]
+    fn interpolate_with_mode(&self, target_value: &Self, t: f32, _mode: Interpolation) -> Self {
+        self.interpolate(target_value, t)
+    }
 }
 
 impl InterpolatedPropertyValue for f32 {
     fn interpolate(&self, target_value: &Self, t: f32) -> Self {
         self + t * (target_value - self)
+    }
+
+    fn interpolate_with_mode(&self, target_value: &Self, t: f32, mode: Interpolation) -> Self {
+        // Slint stores angles in DEGREES (not radians), so we use 180° and 360° as constants
+        const HALF_ROTATION: f32 = 180.0;
+        const FULL_ROTATION: f32 = 360.0;
+
+        match mode {
+            Interpolation::Linear => self.interpolate(target_value, t),
+            Interpolation::AngleShorter => {
+                // Normalize the difference to find the shorter arc
+                let mut diff = target_value - self;
+                // Normalize diff to be within [-180, 180]
+                while diff > HALF_ROTATION {
+                    diff -= FULL_ROTATION;
+                }
+                while diff < -HALF_ROTATION {
+                    diff += FULL_ROTATION;
+                }
+                self + t * diff
+            }
+            Interpolation::AngleLonger => {
+                // Normalize the difference to find the longer arc
+                let mut diff = target_value - self;
+                // Normalize diff to be within [-180, 180] first
+                while diff > HALF_ROTATION {
+                    diff -= FULL_ROTATION;
+                }
+                while diff < -HALF_ROTATION {
+                    diff += FULL_ROTATION;
+                }
+                // Then flip to the longer arc
+                if diff > 0.0 {
+                    diff -= FULL_ROTATION;
+                } else if diff < 0.0 {
+                    diff += FULL_ROTATION;
+                }
+                // If diff is exactly 0, no rotation needed
+                self + t * diff
+            }
+            Interpolation::AngleClockwise => {
+                // Always rotate clockwise (positive direction)
+                let mut diff = target_value - self;
+                // First normalize to [-180, 180]
+                while diff > HALF_ROTATION {
+                    diff -= FULL_ROTATION;
+                }
+                while diff < -HALF_ROTATION {
+                    diff += FULL_ROTATION;
+                }
+                // If diff is not positive, add 360 to make it clockwise
+                if diff <= 0.0 {
+                    diff += FULL_ROTATION;
+                }
+                self + t * diff
+            }
+            Interpolation::AngleCounterclockwise => {
+                // Always rotate counterclockwise (negative direction)
+                let mut diff = target_value - self;
+                // First normalize to [-180, 180]
+                while diff > HALF_ROTATION {
+                    diff -= FULL_ROTATION;
+                }
+                while diff < -HALF_ROTATION {
+                    diff += FULL_ROTATION;
+                }
+                // If diff is not negative, subtract 360 to make it counterclockwise
+                if diff >= 0.0 {
+                    diff -= FULL_ROTATION;
+                }
+                self + t * diff
+            }
+        }
     }
 }
 
@@ -1080,5 +1165,146 @@ mod animation_tests {
             .with(|driver| driver.update_animations(start_time + 2 * DURATION + DURATION / 2));
 
         assert_eq!(get_prop_value(&compo.width), 300);
+    }
+
+    // Tests for Interpolation modes (angle interpolation)
+    // Note: Slint stores angles in DEGREES (not radians)
+    mod interpolation_tests {
+        use super::*;
+
+        const EPSILON: f32 = 0.1; // 0.1 degree tolerance
+
+        fn approx_eq(a: f32, b: f32) -> bool {
+            (a - b).abs() < EPSILON
+        }
+
+        #[test]
+        fn test_linear_interpolation() {
+            // Linear interpolation: 10° to 350° should go through 180° (340° rotation)
+            let from = 10.0_f32;
+            let to = 350.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::Linear);
+            let expected = 180.0_f32;
+            assert!(approx_eq(mid, expected), "Linear: expected {}°, got {}°", expected, mid);
+        }
+
+        #[test]
+        fn test_angle_shorter_interpolation() {
+            // Shorter arc: 10° to 350° should go counterclockwise (20° rotation)
+            // At t=0.5, we should be at 0° (or 360°)
+            let from = 10.0_f32;
+            let to = 350.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleShorter);
+            let expected = 0.0_f32;
+            assert!(
+                approx_eq(mid, expected),
+                "AngleShorter mid: expected {}°, got {}°",
+                expected,
+                mid
+            );
+
+            // At t=1.0, we should be at -10° (equivalent to 350°)
+            let end = from.interpolate_with_mode(&to, 1.0, Interpolation::AngleShorter);
+            let expected_end = -10.0_f32;
+            assert!(
+                approx_eq(end, expected_end),
+                "AngleShorter end: expected {}°, got {}°",
+                expected_end,
+                end
+            );
+        }
+
+        #[test]
+        fn test_angle_longer_interpolation() {
+            // Longer arc: 10° to 100° normally takes 90° clockwise (shorter)
+            // Longer should take 270° counterclockwise
+            let from = 10.0_f32;
+            let to = 100.0_f32;
+
+            // At t=0.5, we should be at 10° - 135° = -125°
+            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleLonger);
+            let expected = -125.0_f32;
+            assert!(
+                approx_eq(mid, expected),
+                "AngleLonger mid: expected {}°, got {}°",
+                expected,
+                mid
+            );
+        }
+
+        #[test]
+        fn test_angle_clockwise_interpolation() {
+            // Clockwise: always go in positive direction
+            // From 350° to 10°, should go 350° -> 360° -> 10° (20° rotation)
+            let from = 350.0_f32;
+            let to = 10.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleClockwise);
+            // Mid should be at 360°
+            let expected = 360.0_f32;
+            assert!(
+                approx_eq(mid, expected),
+                "AngleClockwise mid: expected {}°, got {}°",
+                expected,
+                mid
+            );
+
+            // At t=1.0, we should be at 370° (which is 10° + 360°)
+            let end = from.interpolate_with_mode(&to, 1.0, Interpolation::AngleClockwise);
+            let expected_end = 370.0_f32;
+            assert!(
+                approx_eq(end, expected_end),
+                "AngleClockwise end: expected {}°, got {}°",
+                expected_end,
+                end
+            );
+        }
+
+        #[test]
+        fn test_angle_counterclockwise_interpolation() {
+            // Counterclockwise: always go in negative direction
+            // From 10° to 350°, should go 10° -> 0° -> -10° (20° counterclockwise)
+            let from = 10.0_f32;
+            let to = 350.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleCounterclockwise);
+            // Mid should be at 0°
+            let expected = 0.0_f32;
+            assert!(
+                approx_eq(mid, expected),
+                "AngleCounterclockwise mid: expected {}°, got {}°",
+                expected,
+                mid
+            );
+
+            // At t=1.0, we should be at -10° (which is 350° - 360°)
+            let end = from.interpolate_with_mode(&to, 1.0, Interpolation::AngleCounterclockwise);
+            let expected_end = -10.0_f32;
+            assert!(
+                approx_eq(end, expected_end),
+                "AngleCounterclockwise end: expected {}°, got {}°",
+                expected_end,
+                end
+            );
+        }
+
+        #[test]
+        fn test_angle_shorter_already_shortest() {
+            // When the linear path is already shortest, AngleShorter should behave like Linear
+            let from = 10.0_f32;
+            let to = 100.0_f32;
+
+            let mid_linear = from.interpolate_with_mode(&to, 0.5, Interpolation::Linear);
+            let mid_shorter = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleShorter);
+
+            assert!(
+                approx_eq(mid_linear, mid_shorter),
+                "AngleShorter should equal Linear when path is already shortest: {}° vs {}°",
+                mid_linear,
+                mid_shorter
+            );
+        }
     }
 }

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::{
     animations::physics_simulation,
-    items::{AnimationDirection, Interpolation, PropertyAnimation},
+    items::{AngleInterpolation, AnimationDirection, PropertyAnimation},
     lengths::LogicalLength,
 };
 use euclid::Length;
@@ -142,7 +142,7 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
                     let val = self.from_value.interpolate_with_mode(
                         &self.to_value,
                         t,
-                        self.details.interpolation,
+                        self.details.angle_interpolation,
                     );
 
                     (val, false)
@@ -261,7 +261,12 @@ pub trait InterpolatedPropertyValue: PartialEq + Default + 'static {
     /// This is particularly useful for angle values where the interpolation path matters.
     /// The default implementation ignores the mode and uses linear interpolation.
     #[must_use]
-    fn interpolate_with_mode(&self, target_value: &Self, t: f32, _mode: Interpolation) -> Self {
+    fn interpolate_with_mode(
+        &self,
+        target_value: &Self,
+        t: f32,
+        _mode: AngleInterpolation,
+    ) -> Self {
         self.interpolate(target_value, t)
     }
 }
@@ -271,14 +276,14 @@ impl InterpolatedPropertyValue for f32 {
         self + t * (target_value - self)
     }
 
-    fn interpolate_with_mode(&self, target_value: &Self, t: f32, mode: Interpolation) -> Self {
+    fn interpolate_with_mode(&self, target_value: &Self, t: f32, mode: AngleInterpolation) -> Self {
         // Slint stores angles in DEGREES (not radians), so we use 180° and 360° as constants
         const HALF_ROTATION: f32 = 180.0;
         const FULL_ROTATION: f32 = 360.0;
 
         match mode {
-            Interpolation::Linear => self.interpolate(target_value, t),
-            Interpolation::AngleShorter => {
+            AngleInterpolation::Linear => self.interpolate(target_value, t),
+            AngleInterpolation::AngleShorter => {
                 // Normalize the difference to find the shorter arc
                 let mut diff = target_value - self;
                 // Normalize diff to be within [-180, 180]
@@ -290,7 +295,7 @@ impl InterpolatedPropertyValue for f32 {
                 }
                 self + t * diff
             }
-            Interpolation::AngleLonger => {
+            AngleInterpolation::AngleLonger => {
                 // Normalize the difference to find the longer arc
                 let mut diff = target_value - self;
                 // Normalize diff to be within [-180, 180] first
@@ -309,7 +314,7 @@ impl InterpolatedPropertyValue for f32 {
                 // If diff is exactly 0, no rotation needed
                 self + t * diff
             }
-            Interpolation::AngleClockwise => {
+            AngleInterpolation::AngleClockwise => {
                 // Always rotate clockwise (positive direction)
                 let mut diff = target_value - self;
                 // First normalize to [-180, 180]
@@ -325,7 +330,7 @@ impl InterpolatedPropertyValue for f32 {
                 }
                 self + t * diff
             }
-            Interpolation::AngleCounterclockwise => {
+            AngleInterpolation::AngleCounterclockwise => {
                 // Always rotate counterclockwise (negative direction)
                 let mut diff = target_value - self;
                 // First normalize to [-180, 180]
@@ -1167,7 +1172,7 @@ mod animation_tests {
         assert_eq!(get_prop_value(&compo.width), 300);
     }
 
-    // Tests for Interpolation modes (angle interpolation)
+    // Tests for AngleInterpolation modes (angle interpolation)
     // Note: Slint stores angles in DEGREES (not radians)
     mod interpolation_tests {
         use super::*;
@@ -1184,7 +1189,7 @@ mod animation_tests {
             let from = 10.0_f32;
             let to = 350.0_f32;
 
-            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::Linear);
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Linear);
             let expected = 180.0_f32;
             assert!(approx_eq(mid, expected), "Linear: expected {}°, got {}°", expected, mid);
         }
@@ -1196,7 +1201,7 @@ mod animation_tests {
             let from = 10.0_f32;
             let to = 350.0_f32;
 
-            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleShorter);
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleShorter);
             let expected = 0.0_f32;
             assert!(
                 approx_eq(mid, expected),
@@ -1206,7 +1211,7 @@ mod animation_tests {
             );
 
             // At t=1.0, we should be at -10° (equivalent to 350°)
-            let end = from.interpolate_with_mode(&to, 1.0, Interpolation::AngleShorter);
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::AngleShorter);
             let expected_end = -10.0_f32;
             assert!(
                 approx_eq(end, expected_end),
@@ -1224,7 +1229,7 @@ mod animation_tests {
             let to = 100.0_f32;
 
             // At t=0.5, we should be at 10° - 135° = -125°
-            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleLonger);
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleLonger);
             let expected = -125.0_f32;
             assert!(
                 approx_eq(mid, expected),
@@ -1241,7 +1246,7 @@ mod animation_tests {
             let from = 350.0_f32;
             let to = 10.0_f32;
 
-            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleClockwise);
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleClockwise);
             // Mid should be at 360°
             let expected = 360.0_f32;
             assert!(
@@ -1252,7 +1257,7 @@ mod animation_tests {
             );
 
             // At t=1.0, we should be at 370° (which is 10° + 360°)
-            let end = from.interpolate_with_mode(&to, 1.0, Interpolation::AngleClockwise);
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::AngleClockwise);
             let expected_end = 370.0_f32;
             assert!(
                 approx_eq(end, expected_end),
@@ -1269,7 +1274,8 @@ mod animation_tests {
             let from = 10.0_f32;
             let to = 350.0_f32;
 
-            let mid = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleCounterclockwise);
+            let mid =
+                from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleCounterclockwise);
             // Mid should be at 0°
             let expected = 0.0_f32;
             assert!(
@@ -1280,7 +1286,8 @@ mod animation_tests {
             );
 
             // At t=1.0, we should be at -10° (which is 350° - 360°)
-            let end = from.interpolate_with_mode(&to, 1.0, Interpolation::AngleCounterclockwise);
+            let end =
+                from.interpolate_with_mode(&to, 1.0, AngleInterpolation::AngleCounterclockwise);
             let expected_end = -10.0_f32;
             assert!(
                 approx_eq(end, expected_end),
@@ -1296,8 +1303,9 @@ mod animation_tests {
             let from = 10.0_f32;
             let to = 100.0_f32;
 
-            let mid_linear = from.interpolate_with_mode(&to, 0.5, Interpolation::Linear);
-            let mid_shorter = from.interpolate_with_mode(&to, 0.5, Interpolation::AngleShorter);
+            let mid_linear = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Linear);
+            let mid_shorter =
+                from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleShorter);
 
             assert!(
                 approx_eq(mid_linear, mid_shorter),

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -277,76 +277,60 @@ impl InterpolatedPropertyValue for f32 {
     }
 
     fn interpolate_with_mode(&self, target_value: &Self, t: f32, mode: AngleInterpolation) -> Self {
-        // Slint stores angles in DEGREES (not radians), so we use 180° and 360° as constants
-        const HALF_ROTATION: f32 = 180.0;
         const FULL_ROTATION: f32 = 360.0;
+        const HALF_ROTATION: f32 = 180.0;
 
-        match mode {
-            AngleInterpolation::Linear => self.interpolate(target_value, t),
-            AngleInterpolation::AngleShorter => {
-                // Normalize the difference to find the shorter arc
-                let mut diff = target_value - self;
-                // Normalize diff to be within [-180, 180]
-                while diff > HALF_ROTATION {
-                    diff -= FULL_ROTATION;
-                }
-                while diff < -HALF_ROTATION {
-                    diff += FULL_ROTATION;
-                }
-                self + t * diff
+        // Difference normalized to (-180, 180]; for an exact 180° opposite, the sign of the
+        // original delta is preserved so the traversal direction follows the user's input.
+        let shorter = || {
+            let raw = target_value - self;
+            let d = raw.rem_euclid(FULL_ROTATION);
+            if d > HALF_ROTATION || (d == HALF_ROTATION && raw < 0.0) {
+                d - FULL_ROTATION
+            } else {
+                d
             }
-            AngleInterpolation::AngleLonger => {
-                // Normalize the difference to find the longer arc
-                let mut diff = target_value - self;
-                // Normalize diff to be within [-180, 180] first
-                while diff > HALF_ROTATION {
-                    diff -= FULL_ROTATION;
+        };
+
+        let diff = match mode {
+            AngleInterpolation::Linear => return self.interpolate(target_value, t),
+            AngleInterpolation::Shorter => shorter(),
+            AngleInterpolation::Longer => {
+                let s = shorter();
+                if s > 0.0 {
+                    s - FULL_ROTATION
+                } else if s < 0.0 {
+                    s + FULL_ROTATION
+                } else {
+                    // shorter() returned 0: either target == self (no motion) or
+                    // the endpoints are coterminal (raw is a non-zero multiple of 360°).
+                    // For the coterminal case, take a full rotation in the direction
+                    // of the user-supplied delta.
+                    let raw = target_value - self;
+                    if raw > 0.0 {
+                        FULL_ROTATION
+                    } else if raw < 0.0 {
+                        -FULL_ROTATION
+                    } else {
+                        0.0
+                    }
                 }
-                while diff < -HALF_ROTATION {
-                    diff += FULL_ROTATION;
-                }
-                // Then flip to the longer arc
-                if diff > 0.0 {
-                    diff -= FULL_ROTATION;
-                } else if diff < 0.0 {
-                    diff += FULL_ROTATION;
-                }
-                // If diff is exactly 0, no rotation needed
-                self + t * diff
             }
-            AngleInterpolation::AngleClockwise => {
-                // Always rotate clockwise (positive direction)
-                let mut diff = target_value - self;
-                // First normalize to [-180, 180]
-                while diff > HALF_ROTATION {
-                    diff -= FULL_ROTATION;
-                }
-                while diff < -HALF_ROTATION {
-                    diff += FULL_ROTATION;
-                }
-                // If diff is not positive, add 360 to make it clockwise
-                if diff <= 0.0 {
-                    diff += FULL_ROTATION;
-                }
-                self + t * diff
+            AngleInterpolation::Increasing => {
+                let d = (target_value - self).rem_euclid(FULL_ROTATION);
+                if d == 0.0 && target_value != self { FULL_ROTATION } else { d }
             }
-            AngleInterpolation::AngleCounterclockwise => {
-                // Always rotate counterclockwise (negative direction)
-                let mut diff = target_value - self;
-                // First normalize to [-180, 180]
-                while diff > HALF_ROTATION {
-                    diff -= FULL_ROTATION;
+            AngleInterpolation::Decreasing => {
+                let d = (target_value - self).rem_euclid(FULL_ROTATION);
+                if d == 0.0 {
+                    // target == self: no motion; otherwise a full negative rotation
+                    if target_value == self { 0.0 } else { -FULL_ROTATION }
+                } else {
+                    d - FULL_ROTATION
                 }
-                while diff < -HALF_ROTATION {
-                    diff += FULL_ROTATION;
-                }
-                // If diff is not negative, subtract 360 to make it counterclockwise
-                if diff >= 0.0 {
-                    diff -= FULL_ROTATION;
-                }
-                self + t * diff
             }
-        }
+        };
+        self + t * diff
     }
 }
 
@@ -1195,123 +1179,177 @@ mod animation_tests {
         }
 
         #[test]
-        fn test_angle_shorter_interpolation() {
-            // Shorter arc: 10° to 350° should go counterclockwise (20° rotation)
-            // At t=0.5, we should be at 0° (or 360°)
+        fn test_shorter_interpolation() {
+            // Shorter arc: 10° to 350° goes via the angle decreasing (20° total)
             let from = 10.0_f32;
             let to = 350.0_f32;
 
-            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleShorter);
-            let expected = 0.0_f32;
-            assert!(
-                approx_eq(mid, expected),
-                "AngleShorter mid: expected {}°, got {}°",
-                expected,
-                mid
-            );
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Shorter);
+            assert!(approx_eq(mid, 0.0), "Shorter mid: expected 0°, got {}°", mid);
 
-            // At t=1.0, we should be at -10° (equivalent to 350°)
-            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::AngleShorter);
-            let expected_end = -10.0_f32;
-            assert!(
-                approx_eq(end, expected_end),
-                "AngleShorter end: expected {}°, got {}°",
-                expected_end,
-                end
-            );
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(end, -10.0), "Shorter end: expected -10°, got {}°", end);
         }
 
         #[test]
-        fn test_angle_longer_interpolation() {
-            // Longer arc: 10° to 100° normally takes 90° clockwise (shorter)
-            // Longer should take 270° counterclockwise
+        fn test_longer_interpolation() {
+            // Longer arc: 10° to 100° normally takes 90° (shorter)
+            // Longer takes 270° in the decreasing direction
             let from = 10.0_f32;
             let to = 100.0_f32;
 
-            // At t=0.5, we should be at 10° - 135° = -125°
-            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleLonger);
-            let expected = -125.0_f32;
-            assert!(
-                approx_eq(mid, expected),
-                "AngleLonger mid: expected {}°, got {}°",
-                expected,
-                mid
-            );
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Longer);
+            assert!(approx_eq(mid, -125.0), "Longer mid: expected -125°, got {}°", mid);
         }
 
         #[test]
-        fn test_angle_clockwise_interpolation() {
-            // Clockwise: always go in positive direction
-            // From 350° to 10°, should go 350° -> 360° -> 10° (20° rotation)
+        fn test_increasing_interpolation() {
+            // Increasing: angle value always increases
+            // From 350° to 10°, goes 350° -> 360° -> 370° (20° total)
             let from = 350.0_f32;
             let to = 10.0_f32;
 
-            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleClockwise);
-            // Mid should be at 360°
-            let expected = 360.0_f32;
-            assert!(
-                approx_eq(mid, expected),
-                "AngleClockwise mid: expected {}°, got {}°",
-                expected,
-                mid
-            );
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Increasing);
+            assert!(approx_eq(mid, 360.0), "Increasing mid: expected 360°, got {}°", mid);
 
-            // At t=1.0, we should be at 370° (which is 10° + 360°)
-            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::AngleClockwise);
-            let expected_end = 370.0_f32;
-            assert!(
-                approx_eq(end, expected_end),
-                "AngleClockwise end: expected {}°, got {}°",
-                expected_end,
-                end
-            );
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::Increasing);
+            assert!(approx_eq(end, 370.0), "Increasing end: expected 370°, got {}°", end);
         }
 
         #[test]
-        fn test_angle_counterclockwise_interpolation() {
-            // Counterclockwise: always go in negative direction
-            // From 10° to 350°, should go 10° -> 0° -> -10° (20° counterclockwise)
+        fn test_decreasing_interpolation() {
+            // Decreasing: angle value always decreases
+            // From 10° to 350°, goes 10° -> 0° -> -10° (20° total)
             let from = 10.0_f32;
             let to = 350.0_f32;
 
-            let mid =
-                from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleCounterclockwise);
-            // Mid should be at 0°
-            let expected = 0.0_f32;
-            assert!(
-                approx_eq(mid, expected),
-                "AngleCounterclockwise mid: expected {}°, got {}°",
-                expected,
-                mid
-            );
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Decreasing);
+            assert!(approx_eq(mid, 0.0), "Decreasing mid: expected 0°, got {}°", mid);
 
-            // At t=1.0, we should be at -10° (which is 350° - 360°)
-            let end =
-                from.interpolate_with_mode(&to, 1.0, AngleInterpolation::AngleCounterclockwise);
-            let expected_end = -10.0_f32;
-            assert!(
-                approx_eq(end, expected_end),
-                "AngleCounterclockwise end: expected {}°, got {}°",
-                expected_end,
-                end
-            );
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::Decreasing);
+            assert!(approx_eq(end, -10.0), "Decreasing end: expected -10°, got {}°", end);
         }
 
         #[test]
-        fn test_angle_shorter_already_shortest() {
-            // When the linear path is already shortest, AngleShorter should behave like Linear
+        fn test_shorter_already_shortest() {
+            // When the linear path is already shortest, Shorter matches Linear
             let from = 10.0_f32;
             let to = 100.0_f32;
 
             let mid_linear = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Linear);
-            let mid_shorter =
-                from.interpolate_with_mode(&to, 0.5, AngleInterpolation::AngleShorter);
+            let mid_shorter = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Shorter);
 
             assert!(
                 approx_eq(mid_linear, mid_shorter),
-                "AngleShorter should equal Linear when path is already shortest: {}° vs {}°",
+                "Shorter should equal Linear when path is already shortest: {}° vs {}°",
                 mid_linear,
                 mid_shorter
+            );
+        }
+
+        #[test]
+        fn test_shorter_180_tie_preserves_sign() {
+            // For an exact 180° opposite, the traversal direction follows the sign of
+            // the user-supplied delta: positive raw delta increases, negative decreases.
+
+            // 90° -> 270° (raw +180): value increases through 180° to 270°.
+            let mid = 90.0_f32.interpolate_with_mode(&270.0, 0.5, AngleInterpolation::Shorter);
+            assert!(approx_eq(mid, 180.0), "Shorter +180 tie mid: expected 180°, got {}°", mid);
+            let end = 90.0_f32.interpolate_with_mode(&270.0, 1.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(end, 270.0), "Shorter +180 tie end: expected 270°, got {}°", end);
+
+            // 270° -> 90° (raw -180): value decreases through 180° to 90°.
+            // Mid lands on 180° but the underlying delta is -180, not +180.
+            let mid = 270.0_f32.interpolate_with_mode(&90.0, 0.5, AngleInterpolation::Shorter);
+            assert!(approx_eq(mid, 180.0), "Shorter -180 tie mid: expected 180°, got {}°", mid);
+            let end = 270.0_f32.interpolate_with_mode(&90.0, 1.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(end, 90.0), "Shorter -180 tie end: expected 90°, got {}°", end);
+
+            // Longer takes the opposite arc, so for raw +180 it goes negative
+            // (90 + 0.5 * -180 = 0).
+            let mid = 90.0_f32.interpolate_with_mode(&270.0, 0.5, AngleInterpolation::Longer);
+            assert!(approx_eq(mid, 0.0), "Longer +180 tie mid: expected 0°, got {}°", mid);
+
+            // For raw -180 Longer goes positive (270 + 0.5 * 180 = 360).
+            let mid = 270.0_f32.interpolate_with_mode(&90.0, 0.5, AngleInterpolation::Longer);
+            assert!(approx_eq(mid, 360.0), "Longer -180 tie mid: expected 360°, got {}°", mid);
+        }
+
+        #[test]
+        fn test_no_motion_when_target_equals_self() {
+            // When the target value equals the current value, every mode must stay put
+            // for the whole duration of the animation (no spurious full rotation).
+            for mode in [
+                AngleInterpolation::Linear,
+                AngleInterpolation::Shorter,
+                AngleInterpolation::Longer,
+                AngleInterpolation::Increasing,
+                AngleInterpolation::Decreasing,
+            ] {
+                for &v in &[0.0_f32, 100.0, -45.0] {
+                    let mid = v.interpolate_with_mode(&v, 0.5, mode);
+                    assert!(
+                        approx_eq(mid, v),
+                        "{:?} from {}° to {}° at t=0.5: expected {}°, got {}°",
+                        mode,
+                        v,
+                        v,
+                        v,
+                        mid
+                    );
+                    let end = v.interpolate_with_mode(&v, 1.0, mode);
+                    assert!(
+                        approx_eq(end, v),
+                        "{:?} from {}° to {}° at t=1.0: expected {}°, got {}°",
+                        mode,
+                        v,
+                        v,
+                        v,
+                        end
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn test_increasing_decreasing_full_rotation() {
+            // When `to - from` is a non-zero multiple of 360 (visually the same angle),
+            // Increasing/Decreasing should still rotate a full turn.
+            let mid_inc =
+                10.0_f32.interpolate_with_mode(&370.0, 0.5, AngleInterpolation::Increasing);
+            assert!(
+                approx_eq(mid_inc, 190.0),
+                "Increasing 10→370 mid: expected 190°, got {}°",
+                mid_inc
+            );
+
+            let mid_dec =
+                10.0_f32.interpolate_with_mode(&370.0, 0.5, AngleInterpolation::Decreasing);
+            assert!(
+                approx_eq(mid_dec, -170.0),
+                "Decreasing 10→370 mid: expected -170°, got {}°",
+                mid_dec
+            );
+        }
+
+        #[test]
+        fn test_longer_coterminal_full_rotation() {
+            // For coterminal endpoints (raw delta is a non-zero multiple of 360°), Longer
+            // takes a full rotation in the direction of the user-supplied delta. Shorter
+            // intentionally stays put because the endpoints are visually identical.
+            let mid_long = 10.0_f32.interpolate_with_mode(&370.0, 0.5, AngleInterpolation::Longer);
+            assert!(
+                approx_eq(mid_long, 190.0),
+                "Longer 10→370 mid: expected 190°, got {}°",
+                mid_long
+            );
+
+            let mid_long_neg =
+                10.0_f32.interpolate_with_mode(&-350.0, 0.5, AngleInterpolation::Longer);
+            assert!(
+                approx_eq(mid_long_neg, -170.0),
+                "Longer 10→-350 mid: expected -170°, got {}°",
+                mid_long_neg
             );
         }
     }

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -1,13 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore coterminal
 use super::*;
 use crate::{
     animations::simulations::{
         Parameter, Simulation,
         spring::{SpringDurationBounceParameters, SpringParameters, SpringRegime},
     },
-    items::{AnimationDirection, PropertyAnimation},
+    items::{AngleInterpolation, AnimationDirection, PropertyAnimation},
     lengths::LogicalLength,
 };
 use euclid::Length;
@@ -280,7 +281,11 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
                                 self.compute_interpolated_value()
                             } else {
                                 let progress = if reversed(current_iteration) { 1. - t } else { t };
-                                let val = self.from_value.interpolate(&to_value, progress);
+                                let val = self.from_value.interpolate_with_mode(
+                                    &to_value,
+                                    progress,
+                                    self.details.angle_interpolation,
+                                );
                                 (self.apply_map(val), false)
                             }
                         }
@@ -316,7 +321,11 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
                         if reversed(current_iteration) { 1. - progress } else { progress }
                     };
                     let t = crate::animations::easing_curve(&self.details.easing, progress);
-                    let val = self.from_value.interpolate(&to_value, t);
+                    let val = self.from_value.interpolate_with_mode(
+                        &to_value,
+                        t,
+                        self.details.angle_interpolation,
+                    );
 
                     (self.apply_map(val), false)
                 } else {
@@ -460,6 +469,19 @@ pub trait InterpolatedPropertyValue: PartialEq + Default + 'static {
     fn scalar_delta(&self, _target_value: &Self) -> f32 {
         0.0
     }
+
+    /// Returns the interpolated value with a specific interpolation mode.
+    /// This is particularly useful for angle values where the interpolation path matters.
+    /// The default implementation ignores the mode and uses linear interpolation.
+    #[must_use]
+    fn interpolate_with_mode(
+        &self,
+        target_value: &Self,
+        t: f32,
+        _mode: AngleInterpolation,
+    ) -> Self {
+        self.interpolate(target_value, t)
+    }
 }
 
 impl InterpolatedPropertyValue for f32 {
@@ -469,6 +491,67 @@ impl InterpolatedPropertyValue for f32 {
 
     fn scalar_delta(&self, target_value: &Self) -> f32 {
         target_value - self
+    }
+
+    fn interpolate_with_mode(&self, target_value: &Self, t: f32, mode: AngleInterpolation) -> Self {
+        // f32::rem_euclid is not always available in no_std builds, and when it is it has a
+        // different signature than num_traits::Euclid::rem_euclid (issue #11333).
+        const FULL_ROTATION: f32 = 360.0;
+        const HALF_ROTATION: f32 = 180.0;
+
+        // Difference normalized to (-180, 180]; for an exact 180° opposite, the sign of the
+        // original delta is preserved so the traversal direction follows the user's input.
+        let shorter = || {
+            let raw = target_value - self;
+            let d = num_traits::Euclid::rem_euclid(&raw, &FULL_ROTATION);
+            if d > HALF_ROTATION || (d == HALF_ROTATION && raw < 0.0) {
+                d - FULL_ROTATION
+            } else {
+                d
+            }
+        };
+
+        let diff = match mode {
+            AngleInterpolation::Linear => return self.interpolate(target_value, t),
+            AngleInterpolation::Shorter => shorter(),
+            AngleInterpolation::Longer => {
+                let s = shorter();
+                if s > 0.0 {
+                    s - FULL_ROTATION
+                } else if s < 0.0 {
+                    s + FULL_ROTATION
+                } else {
+                    // shorter() returned 0: either target == self (no motion) or
+                    // the endpoints are coterminal (raw is a non-zero multiple of 360°).
+                    // For the coterminal case, take a full rotation in the direction
+                    // of the user-supplied delta.
+                    let raw = target_value - self;
+                    if raw > 0.0 {
+                        FULL_ROTATION
+                    } else if raw < 0.0 {
+                        -FULL_ROTATION
+                    } else {
+                        0.0
+                    }
+                }
+            }
+            AngleInterpolation::Increasing => {
+                let d = num_traits::Euclid::rem_euclid(&(target_value - self), &FULL_ROTATION);
+                if d == 0.0 && target_value != self { FULL_ROTATION } else { d }
+            }
+            AngleInterpolation::Decreasing => {
+                let d = num_traits::Euclid::rem_euclid(&(target_value - self), &FULL_ROTATION);
+                if d == 0.0 {
+                    // target == self: no motion; otherwise a full negative rotation
+                    if target_value == self { 0.0 } else { -FULL_ROTATION }
+                } else {
+                    d - FULL_ROTATION
+                }
+            }
+        };
+        // Keep the value inside a single turn so that the animation ends on a normalized
+        // angle (e.g. 350° → 10° with `Increasing` ends at 10°, not 370°).
+        num_traits::Euclid::rem_euclid(&(self + t * diff), &FULL_ROTATION)
     }
 }
 
@@ -1735,5 +1818,246 @@ mod animation_tests {
             driver.update_animations(start_time + core::time::Duration::from_millis(3000))
         });
         compo.width.handle.access(|binding| assert!(binding.is_some()));
+    }
+
+    // Tests for AngleInterpolation modes (angle interpolation)
+    // Note: Slint stores angles in DEGREES (not radians)
+    mod interpolation_tests {
+        use super::*;
+
+        const EPSILON: f32 = 0.1; // 0.1 degree tolerance
+
+        fn approx_eq(a: f32, b: f32) -> bool {
+            (a - b).abs() < EPSILON
+        }
+
+        #[test]
+        fn test_linear_interpolation() {
+            // Linear interpolation: 10° to 350° should go through 180° (340° rotation)
+            let from = 10.0_f32;
+            let to = 350.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Linear);
+            let expected = 180.0_f32;
+            assert!(approx_eq(mid, expected), "Linear: expected {}°, got {}°", expected, mid);
+        }
+
+        #[test]
+        fn test_shorter_interpolation() {
+            // Shorter arc: 10° to 350° goes via the angle decreasing (20° total)
+            let from = 10.0_f32;
+            let to = 350.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Shorter);
+            assert!(approx_eq(mid, 0.0), "Shorter mid: expected 0°, got {}°", mid);
+
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(end, 350.0), "Shorter end: expected 350°, got {}°", end);
+        }
+
+        #[test]
+        fn test_longer_interpolation() {
+            // Longer arc: 10° to 100° normally takes 90° (shorter)
+            // Longer takes 270° in the decreasing direction
+            let from = 10.0_f32;
+            let to = 100.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Longer);
+            assert!(approx_eq(mid, 235.0), "Longer mid: expected 235°, got {}°", mid);
+        }
+
+        #[test]
+        fn test_increasing_interpolation() {
+            // Increasing: angle value always increases
+            // From 350° to 10°, goes 350° -> 0° -> 10° (20° total, wrapping at 360°)
+            let from = 350.0_f32;
+            let to = 10.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Increasing);
+            assert!(approx_eq(mid, 0.0), "Increasing mid: expected 0°, got {}°", mid);
+
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::Increasing);
+            assert!(approx_eq(end, 10.0), "Increasing end: expected 10°, got {}°", end);
+        }
+
+        #[test]
+        fn test_decreasing_interpolation() {
+            // Decreasing: angle value always decreases
+            // From 10° to 350°, goes 10° -> 0° -> 350° (20° total, wrapping at 0°)
+            let from = 10.0_f32;
+            let to = 350.0_f32;
+
+            let mid = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Decreasing);
+            assert!(approx_eq(mid, 0.0), "Decreasing mid: expected 0°, got {}°", mid);
+
+            let end = from.interpolate_with_mode(&to, 1.0, AngleInterpolation::Decreasing);
+            assert!(approx_eq(end, 350.0), "Decreasing end: expected 350°, got {}°", end);
+        }
+
+        #[test]
+        fn test_shorter_already_shortest() {
+            // When the linear path is already shortest, Shorter matches Linear
+            let from = 10.0_f32;
+            let to = 100.0_f32;
+
+            let mid_linear = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Linear);
+            let mid_shorter = from.interpolate_with_mode(&to, 0.5, AngleInterpolation::Shorter);
+
+            assert!(
+                approx_eq(mid_linear, mid_shorter),
+                "Shorter should equal Linear when path is already shortest: {}° vs {}°",
+                mid_linear,
+                mid_shorter
+            );
+        }
+
+        #[test]
+        fn test_shorter_180_tie_preserves_sign() {
+            // For an exact 180° opposite, the traversal direction follows the sign of
+            // the user-supplied delta: positive raw delta increases, negative decreases.
+
+            // 90° -> 270° (raw +180): value increases through 180° to 270°.
+            let mid = 90.0_f32.interpolate_with_mode(&270.0, 0.5, AngleInterpolation::Shorter);
+            assert!(approx_eq(mid, 180.0), "Shorter +180 tie mid: expected 180°, got {}°", mid);
+            let end = 90.0_f32.interpolate_with_mode(&270.0, 1.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(end, 270.0), "Shorter +180 tie end: expected 270°, got {}°", end);
+
+            // 270° -> 90° (raw -180): value decreases through 180° to 90°.
+            // Mid lands on 180° but the underlying delta is -180, not +180.
+            let mid = 270.0_f32.interpolate_with_mode(&90.0, 0.5, AngleInterpolation::Shorter);
+            assert!(approx_eq(mid, 180.0), "Shorter -180 tie mid: expected 180°, got {}°", mid);
+            let end = 270.0_f32.interpolate_with_mode(&90.0, 1.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(end, 90.0), "Shorter -180 tie end: expected 90°, got {}°", end);
+
+            // Longer takes the opposite arc, so for raw +180 it goes negative
+            // (90 + 0.5 * -180 = 0).
+            let mid = 90.0_f32.interpolate_with_mode(&270.0, 0.5, AngleInterpolation::Longer);
+            assert!(approx_eq(mid, 0.0), "Longer +180 tie mid: expected 0°, got {}°", mid);
+
+            // For raw -180 Longer goes positive (270 + 0.5 * 180 = 360, normalized to 0).
+            let mid = 270.0_f32.interpolate_with_mode(&90.0, 0.5, AngleInterpolation::Longer);
+            assert!(approx_eq(mid, 0.0), "Longer -180 tie mid: expected 0°, got {}°", mid);
+        }
+
+        #[test]
+        fn test_no_motion_when_target_equals_self() {
+            // When the target value equals the current value, every mode must stay put
+            // for the whole duration of the animation (no spurious full rotation).
+            // The angle-aware modes report the value normalized to a single turn.
+            for mode in [
+                AngleInterpolation::Linear,
+                AngleInterpolation::Shorter,
+                AngleInterpolation::Longer,
+                AngleInterpolation::Increasing,
+                AngleInterpolation::Decreasing,
+            ] {
+                for &v in &[0.0_f32, 100.0, -45.0] {
+                    let expected = if matches!(mode, AngleInterpolation::Linear) {
+                        v
+                    } else {
+                        num_traits::Euclid::rem_euclid(&v, &360.0)
+                    };
+                    let mid = v.interpolate_with_mode(&v, 0.5, mode);
+                    assert!(
+                        approx_eq(mid, expected),
+                        "{:?} from {}° to {}° at t=0.5: expected {}°, got {}°",
+                        mode,
+                        v,
+                        v,
+                        expected,
+                        mid
+                    );
+                    let end = v.interpolate_with_mode(&v, 1.0, mode);
+                    assert!(
+                        approx_eq(end, expected),
+                        "{:?} from {}° to {}° at t=1.0: expected {}°, got {}°",
+                        mode,
+                        v,
+                        v,
+                        expected,
+                        end
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn test_increasing_decreasing_full_rotation() {
+            // When `to - from` is a non-zero multiple of 360 (visually the same angle),
+            // Increasing/Decreasing should still rotate a full turn.
+            let mid_inc =
+                10.0_f32.interpolate_with_mode(&370.0, 0.5, AngleInterpolation::Increasing);
+            assert!(
+                approx_eq(mid_inc, 190.0),
+                "Increasing 10→370 mid: expected 190°, got {}°",
+                mid_inc
+            );
+
+            let mid_dec =
+                10.0_f32.interpolate_with_mode(&370.0, 0.5, AngleInterpolation::Decreasing);
+            assert!(
+                approx_eq(mid_dec, 190.0),
+                "Decreasing 10→370 mid: expected 190°, got {}°",
+                mid_dec
+            );
+        }
+
+        #[test]
+        fn test_longer_coterminal_full_rotation() {
+            // For coterminal endpoints (raw delta is a non-zero multiple of 360°), Longer
+            // takes a full rotation in the direction of the user-supplied delta. Shorter
+            // intentionally stays put because the endpoints are visually identical.
+            let mid_long = 10.0_f32.interpolate_with_mode(&370.0, 0.5, AngleInterpolation::Longer);
+            assert!(
+                approx_eq(mid_long, 190.0),
+                "Longer 10→370 mid: expected 190°, got {}°",
+                mid_long
+            );
+
+            let mid_long_neg =
+                10.0_f32.interpolate_with_mode(&-350.0, 0.5, AngleInterpolation::Longer);
+            assert!(
+                approx_eq(mid_long_neg, 190.0),
+                "Longer 10→-350 mid: expected 190°, got {}°",
+                mid_long_neg
+            );
+        }
+
+        #[test]
+        fn test_angle_modes_normalize_to_single_turn() {
+            // Every angle-aware mode keeps the interpolated value in [0°, 360°), so an
+            // animation never ends on a value like 370° or -10°. A negative start value
+            // is reported normalized from the first frame on (visually identical).
+            let start = (-45.0_f32).interpolate_with_mode(&45.0, 0.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(start, 315.0), "Shorter -45→45 start: expected 315°, got {}°", start);
+            let mid = (-45.0_f32).interpolate_with_mode(&45.0, 0.5, AngleInterpolation::Shorter);
+            assert!(approx_eq(mid, 0.0), "Shorter -45→45 mid: expected 0°, got {}°", mid);
+            let end = (-45.0_f32).interpolate_with_mode(&45.0, 1.0, AngleInterpolation::Shorter);
+            assert!(approx_eq(end, 45.0), "Shorter -45→45 end: expected 45°, got {}°", end);
+
+            for mode in [
+                AngleInterpolation::Shorter,
+                AngleInterpolation::Longer,
+                AngleInterpolation::Increasing,
+                AngleInterpolation::Decreasing,
+            ] {
+                for (from, to) in
+                    [(350.0_f32, 10.0_f32), (10.0, 350.0), (10.0, 370.0), (-90.0, 90.0)]
+                {
+                    for step in 0..=10 {
+                        let v = from.interpolate_with_mode(&to, step as f32 / 10.0, mode);
+                        assert!(
+                            (0.0..360.0).contains(&v),
+                            "{:?} {}→{} at step {}: {}° is outside [0°, 360°)",
+                            mode,
+                            from,
+                            to,
+                            step,
+                            v
+                        );
+                    }
+                }
+            }
+        }
     }
 }

--- a/internal/interpreter/bindings.rs
+++ b/internal/interpreter/bindings.rs
@@ -518,6 +518,11 @@ pub(crate) fn value_to_property_animation(v: Value) -> PropertyAnimation {
     if let Some(Value::Bool(b)) = s.get_field("enabled") {
         anim.enabled = *b;
     }
+    if let Some(angle_interpolation) = s.get_field("angle-interpolation")
+        && let Ok(parsed) = angle_interpolation.clone().try_into()
+    {
+        anim.angle_interpolation = parsed;
+    }
     anim
 }
 

--- a/internal/interpreter/erased.rs
+++ b/internal/interpreter/erased.rs
@@ -9,7 +9,7 @@
 use crate::Value;
 use core::pin::Pin;
 use i_slint_core::graphics::Brush;
-use i_slint_core::items::{ItemVTable, PropertyAnimation};
+use i_slint_core::items::{AngleInterpolation, ItemVTable, PropertyAnimation};
 use i_slint_core::properties::InterpolatedPropertyValue;
 use i_slint_core::rtti::{AnimatedBindingKind, TwoWayBindingMapping};
 use i_slint_core::{Callback, Property};
@@ -82,6 +82,15 @@ impl InterpolatedPropertyValue for Value {
             }
             (Value::Brush(a), Value::Brush(b)) => Value::Brush(Brush::interpolate(a, b, t)),
             _ => target.clone(),
+        }
+    }
+
+    fn interpolate_with_mode(&self, target: &Self, t: f32, mode: AngleInterpolation) -> Self {
+        match (self, target) {
+            (Value::Number(a), Value::Number(b)) => {
+                Value::Number((*a as f32).interpolate_with_mode(&(*b as f32), t, mode) as f64)
+            }
+            _ => self.interpolate(target, t),
         }
     }
 }

--- a/tests/cases/properties/property_animation.slint
+++ b/tests/cases/properties/property_animation.slint
@@ -28,6 +28,12 @@ TestCase := Rectangle {
         direction: alternate-reverse;
         iteration-count: 2;
     }
+
+    property<angle> rotation: 10deg;
+    animate rotation {
+        duration: 600ms;
+        interpolation: angle-shorter;
+    }
 }
 
 /*

--- a/tests/cases/properties/property_animation.slint
+++ b/tests/cases/properties/property_animation.slint
@@ -32,7 +32,7 @@ TestCase := Rectangle {
     property<angle> rotation: 10deg;
     animate rotation {
         duration: 600ms;
-        interpolation: angle-shorter;
+        angle-interpolation: angle-shorter;
     }
 }
 

--- a/tests/cases/properties/property_animation.slint
+++ b/tests/cases/properties/property_animation.slint
@@ -31,8 +31,8 @@ TestCase := Rectangle {
 
     property<angle> rotation: 10deg;
     animate rotation {
-        duration: 600ms;
-        angle-interpolation: angle-shorter;
+        duration: 1200ms;
+        angle-interpolation: shorter;
     }
 }
 
@@ -43,19 +43,24 @@ let instance = TestCase::new().unwrap();
 assert_eq!(instance.get_hello(), 40);
 assert_eq!(instance.get_binding_dep(), 100);
 assert_eq!(instance.get_direction(), 100);
+assert_eq!(instance.get_rotation(), 10.);
 instance.set_condition(false);
 instance.set_hello(60);
 instance.set_direction(200);
+instance.set_rotation(350.);
 // no time has elapsed yet
 assert_eq!(instance.get_hello(), 40);
 assert_eq!(instance.get_binding_dep(), 100);
 assert_eq!(instance.get_direction(), 200);
+assert_eq!(instance.get_rotation(), 10.);
 
 // Half the animation
 slint_testing::mock_elapsed_time(600);
 assert_eq!(instance.get_hello(), 50);
 assert_eq!(instance.get_binding_dep(), 125);
 assert_eq!(instance.get_direction(), 100);
+// shorter arc from 10° to 350° spans -20°; mid-point lands on 0°
+assert_eq!(instance.get_rotation(), 0.);
 
 
 // Remaining half
@@ -63,21 +68,26 @@ slint_testing::mock_elapsed_time(600);
 assert_eq!(instance.get_hello(), 60);
 assert_eq!(instance.get_binding_dep(), 150);
 assert_eq!(instance.get_direction(), 200);
+assert_eq!(instance.get_rotation(), 350.);
 
 slint_testing::mock_elapsed_time(100);
 assert_eq!(instance.get_hello(), 60);
 assert_eq!(instance.get_binding_dep(), 150);
 assert_eq!(instance.get_direction(), 200);
+assert_eq!(instance.get_rotation(), 350.);
 
 // Changing the value and waiting should have effect without
 // querying the value (because te dirty event should cause the animation to start)
 instance.set_condition(true);
 instance.set_hello(30);
 instance.set_direction(100);
+instance.set_rotation(10.);
 slint_testing::mock_elapsed_time(600);
 assert_eq!(instance.get_hello(), 45);
 assert_eq!(instance.get_binding_dep(), 125);
 assert_eq!(instance.get_direction(), 200);
+// shorter arc from 350° to 10° spans +20°; mid-point lands on 360°
+assert_eq!(instance.get_rotation(), 360.);
 
 ```
 
@@ -88,19 +98,23 @@ const TestCase &instance = *handle;
 assert_eq(instance.get_hello(), 40);
 assert_eq(instance.get_binding_dep(), 100);
 assert_eq(instance.get_direction(), 100);
+assert_eq(instance.get_rotation(), 10.f);
 instance.set_condition(false);
 instance.set_hello(60);
 instance.set_direction(200);
+instance.set_rotation(350.f);
 // no time has elapsed yet
 assert_eq(instance.get_hello(), 40);
 assert_eq(instance.get_binding_dep(), 100);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 10.f);
 
 // Half the animation
 slint_testing::mock_elapsed_time(600);
 assert_eq(instance.get_hello(), 50);
 assert_eq(instance.get_binding_dep(), 125);
 assert_eq(instance.get_direction(), 100);
+assert_eq(instance.get_rotation(), 0.f);
 
 
 // Remaining half
@@ -108,21 +122,25 @@ slint_testing::mock_elapsed_time(600);
 assert_eq(instance.get_hello(), 60);
 assert_eq(instance.get_binding_dep(), 150);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 350.f);
 
 slint_testing::mock_elapsed_time(100);
 assert_eq(instance.get_hello(), 60);
 assert_eq(instance.get_binding_dep(), 150);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 350.f);
 
 // Changing the value and waiting should have effect without
 // querying the value (because te dirty event should cause the animation to start)
 instance.set_condition(true);
 instance.set_hello(30);
 instance.set_direction(100);
+instance.set_rotation(10.f);
 slint_testing::mock_elapsed_time(600);
 assert_eq(instance.get_hello(), 45);
 assert_eq(instance.get_binding_dep(), 125);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 360.f);
 ```
 
 ```js
@@ -130,37 +148,45 @@ var instance = new slint.TestCase({});
 assert.equal(instance.hello, 40);
 assert.equal(instance.binding_dep, 100);
 assert.equal(instance.direction, 100);
+assert.equal(instance.rotation, 10);
 instance.condition = false;
 instance.hello = 60;
 instance.direction = 200;
+instance.rotation = 350;
 // no time has elapsed yet
 assert.equal(instance.hello, 40);
 assert.equal(instance.binding_dep, 100);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 10);
 
 // Half the animation
 slintlib.private_api.mock_elapsed_time(600);
 assert.equal(instance.hello, 50);
 assert.equal(instance.binding_dep, 125);
 assert.equal(instance.direction, 100);
+assert.equal(instance.rotation, 0);
 // Remaining half
 slintlib.private_api.mock_elapsed_time(600);
 assert.equal(instance.hello, 60);
 assert.equal(instance.binding_dep, 150);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 350);
 slintlib.private_api.mock_elapsed_time(100);
 assert.equal(instance.hello, 60);
 assert.equal(instance.binding_dep, 150);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 350);
 
 // Changing the value and waiting should have effect without
 // querying the value (because te dirty event should cause the animation to start)
 instance.condition = true;
 instance.hello = 30;
 instance.direction = 100;
+instance.rotation = 10;
 slintlib.private_api.mock_elapsed_time(600);
 assert.equal(instance.hello, 45);
 assert.equal(instance.binding_dep, 125);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 360);
 ```
 */

--- a/tests/cases/properties/property_animation.slint
+++ b/tests/cases/properties/property_animation.slint
@@ -28,6 +28,12 @@ export component TestCase inherits Rectangle {
         direction: alternate-reverse;
         iteration-count: 2;
     }
+
+    in-out property<angle> rotation: 10deg;
+    animate rotation {
+        duration: 1200ms;
+        angle-interpolation: shorter;
+    }
 }
 
 /*
@@ -37,19 +43,24 @@ let instance = TestCase::new().unwrap();
 assert_eq!(instance.get_hello(), 40);
 assert_eq!(instance.get_binding_dep(), 100);
 assert_eq!(instance.get_direction(), 100);
+assert_eq!(instance.get_rotation(), 10.);
 instance.set_condition(false);
 instance.set_hello(60);
 instance.set_direction(200);
+instance.set_rotation(350.);
 // no time has elapsed yet
 assert_eq!(instance.get_hello(), 40);
 assert_eq!(instance.get_binding_dep(), 100);
 assert_eq!(instance.get_direction(), 200);
+assert_eq!(instance.get_rotation(), 10.);
 
 // Half the animation
 slint_testing::mock_elapsed_time(600);
 assert_eq!(instance.get_hello(), 50);
 assert_eq!(instance.get_binding_dep(), 125);
 assert_eq!(instance.get_direction(), 100);
+// shorter arc from 10° to 350° spans -20°; mid-point lands on 0°
+assert_eq!(instance.get_rotation(), 0.);
 
 
 // Remaining half
@@ -57,21 +68,26 @@ slint_testing::mock_elapsed_time(600);
 assert_eq!(instance.get_hello(), 60);
 assert_eq!(instance.get_binding_dep(), 150);
 assert_eq!(instance.get_direction(), 200);
+assert_eq!(instance.get_rotation(), 350.);
 
 slint_testing::mock_elapsed_time(100);
 assert_eq!(instance.get_hello(), 60);
 assert_eq!(instance.get_binding_dep(), 150);
 assert_eq!(instance.get_direction(), 200);
+assert_eq!(instance.get_rotation(), 350.);
 
 // Changing the value and waiting should have effect without
 // querying the value (because te dirty event should cause the animation to start)
 instance.set_condition(true);
 instance.set_hello(30);
 instance.set_direction(100);
+instance.set_rotation(10.);
 slint_testing::mock_elapsed_time(600);
 assert_eq!(instance.get_hello(), 45);
 assert_eq!(instance.get_binding_dep(), 125);
 assert_eq!(instance.get_direction(), 200);
+// shorter arc from 350° to 10° spans +20°; mid-point wraps around to 0°
+assert_eq!(instance.get_rotation(), 0.);
 
 ```
 
@@ -82,19 +98,23 @@ const TestCase &instance = *handle;
 assert_eq(instance.get_hello(), 40);
 assert_eq(instance.get_binding_dep(), 100);
 assert_eq(instance.get_direction(), 100);
+assert_eq(instance.get_rotation(), 10.f);
 instance.set_condition(false);
 instance.set_hello(60);
 instance.set_direction(200);
+instance.set_rotation(350.f);
 // no time has elapsed yet
 assert_eq(instance.get_hello(), 40);
 assert_eq(instance.get_binding_dep(), 100);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 10.f);
 
 // Half the animation
 slint_testing::mock_elapsed_time(600);
 assert_eq(instance.get_hello(), 50);
 assert_eq(instance.get_binding_dep(), 125);
 assert_eq(instance.get_direction(), 100);
+assert_eq(instance.get_rotation(), 0.f);
 
 
 // Remaining half
@@ -102,21 +122,25 @@ slint_testing::mock_elapsed_time(600);
 assert_eq(instance.get_hello(), 60);
 assert_eq(instance.get_binding_dep(), 150);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 350.f);
 
 slint_testing::mock_elapsed_time(100);
 assert_eq(instance.get_hello(), 60);
 assert_eq(instance.get_binding_dep(), 150);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 350.f);
 
 // Changing the value and waiting should have effect without
 // querying the value (because te dirty event should cause the animation to start)
 instance.set_condition(true);
 instance.set_hello(30);
 instance.set_direction(100);
+instance.set_rotation(10.f);
 slint_testing::mock_elapsed_time(600);
 assert_eq(instance.get_hello(), 45);
 assert_eq(instance.get_binding_dep(), 125);
 assert_eq(instance.get_direction(), 200);
+assert_eq(instance.get_rotation(), 0.f);
 ```
 
 ```js
@@ -124,37 +148,45 @@ var instance = new slint.TestCase({});
 assert.equal(instance.hello, 40);
 assert.equal(instance.binding_dep, 100);
 assert.equal(instance.direction, 100);
+assert.equal(instance.rotation, 10);
 instance.condition = false;
 instance.hello = 60;
 instance.direction = 200;
+instance.rotation = 350;
 // no time has elapsed yet
 assert.equal(instance.hello, 40);
 assert.equal(instance.binding_dep, 100);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 10);
 
 // Half the animation
 slintlib.private_api.mock_elapsed_time(600);
 assert.equal(instance.hello, 50);
 assert.equal(instance.binding_dep, 125);
 assert.equal(instance.direction, 100);
+assert.equal(instance.rotation, 0);
 // Remaining half
 slintlib.private_api.mock_elapsed_time(600);
 assert.equal(instance.hello, 60);
 assert.equal(instance.binding_dep, 150);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 350);
 slintlib.private_api.mock_elapsed_time(100);
 assert.equal(instance.hello, 60);
 assert.equal(instance.binding_dep, 150);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 350);
 
 // Changing the value and waiting should have effect without
 // querying the value (because te dirty event should cause the animation to start)
 instance.condition = true;
 instance.hello = 30;
 instance.direction = 100;
+instance.rotation = 10;
 slintlib.private_api.mock_elapsed_time(600);
 assert.equal(instance.hello, 45);
 assert.equal(instance.binding_dep, 125);
 assert.equal(instance.direction, 200);
+assert.equal(instance.rotation, 0);
 ```
 */

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2390,7 +2390,7 @@ component ABC {
 export component MainWindow inherits Window {
     animate background { duration: 800ms;}
     animate x { duration: 100ms; easing: ease-out-bounce; }
-    animate rotation { duration: 600ms; angle-interpolation: angle-shorter; }
+    animate rotation { duration: 600ms; angle-interpolation: shorter; }
     Rectangle {}
 }
 "#,
@@ -2403,7 +2403,7 @@ export component MainWindow inherits Window {
     }
     animate rotation {
         duration: 600ms;
-        angle-interpolation: angle-shorter;
+        angle-interpolation: shorter;
     }
     Rectangle { }
 }

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2390,7 +2390,7 @@ component ABC {
 export component MainWindow inherits Window {
     animate background { duration: 800ms;}
     animate x { duration: 100ms; easing: ease-out-bounce; }
-    animate rotation { duration: 600ms; interpolation: angle-shorter; }
+    animate rotation { duration: 600ms; angle-interpolation: angle-shorter; }
     Rectangle {}
 }
 "#,
@@ -2403,7 +2403,7 @@ export component MainWindow inherits Window {
     }
     animate rotation {
         duration: 600ms;
-        interpolation: angle-shorter;
+        angle-interpolation: angle-shorter;
     }
     Rectangle { }
 }

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2390,6 +2390,7 @@ component ABC {
 export component MainWindow inherits Window {
     animate background { duration: 800ms;}
     animate x { duration: 100ms; easing: ease-out-bounce; }
+    animate rotation { duration: 600ms; interpolation: angle-shorter; }
     Rectangle {}
 }
 "#,
@@ -2399,6 +2400,10 @@ export component MainWindow inherits Window {
     animate x {
         duration: 100ms;
         easing: ease-out-bounce;
+    }
+    animate rotation {
+        duration: 600ms;
+        interpolation: angle-shorter;
     }
     Rectangle { }
 }

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2967,6 +2967,7 @@ component ABC {
 export component MainWindow inherits Window {
     animate background { duration: 800ms;}
     animate x { duration: 100ms; easing: ease-out-bounce; }
+    animate rotation { duration: 600ms; angle-interpolation: shorter; }
     Rectangle {}
 }
 "#,
@@ -2976,6 +2977,10 @@ export component MainWindow inherits Window {
     animate x {
         duration: 100ms;
         easing: ease-out-bounce;
+    }
+    animate rotation {
+        duration: 600ms;
+        angle-interpolation: shorter;
     }
     Rectangle { }
 }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -363,10 +363,36 @@ pub(crate) fn completion_at(
         return Some(r);
     } else if node.kind() == SyntaxKind::PropertyAnimation {
         let global_tr = document_cache.global_type_registry();
+        let doc = node.source_file().and_then(|sf| document_cache.get_document_for_source_file(sf));
+        let tr = doc.map(|d| &d.local_registry).unwrap_or(&global_tr);
+
+        // Hide `angle-interpolation` if we can prove every animated property is not an angle.
+        let exclude_angle_interpolation = lookup_current_element_type(node.clone(), tr)
+            .is_some_and(|element_type| {
+                let mut any_resolved = false;
+                let mut all_non_angle = true;
+                for qn in node.children().filter_map(syntax_nodes::QualifiedName::new) {
+                    let Some(prop_name) = i_slint_compiler::parser::identifier_text(&qn) else {
+                        continue;
+                    };
+                    let lookup = element_type.lookup_property(prop_name.as_str());
+                    if !lookup.property_type.is_property_type() {
+                        continue;
+                    }
+                    any_resolved = true;
+                    if matches!(lookup.property_type, Type::Angle) {
+                        all_non_angle = false;
+                        break;
+                    }
+                }
+                any_resolved && all_non_angle
+            });
+
         let r = global_tr
             .property_animation_type_for_property(Type::Float32)
             .property_list()
             .into_iter()
+            .filter(|(k, _)| !(exclude_angle_interpolation && k.as_str() == "angle-interpolation"))
             .map(|(k, t)| {
                 let mut c = CompletionItem::new_simple(k.to_string(), t.to_string());
                 c.kind = Some(CompletionItemKind::PROPERTY);
@@ -1889,6 +1915,23 @@ mod tests {
         res.iter().find(|ci| ci.label == "direction").unwrap();
         res.iter().find(|ci| ci.label == "iteration-count").unwrap();
         res.iter().find(|ci| ci.label == "easing").unwrap();
+        // angle-interpolation should not be suggested for a non-angle property
+        assert!(!res.iter().any(|ci| ci.label == "angle-interpolation"));
+    }
+
+    #[test]
+    fn animation_completion_angle() {
+        let source = r#"
+            component Foo {
+                Rectangle {
+                    animate transform-rotation {
+                        🔺
+                    }
+                }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "duration").unwrap();
         res.iter().find(|ci| ci.label == "angle-interpolation").unwrap();
     }
 
@@ -1961,10 +2004,10 @@ mod tests {
         "#;
         let res = get_completions(source).unwrap();
         res.iter().find(|ci| ci.label == "linear").unwrap();
-        res.iter().find(|ci| ci.label == "angle-shorter").unwrap();
-        res.iter().find(|ci| ci.label == "angle-longer").unwrap();
-        res.iter().find(|ci| ci.label == "angle-clockwise").unwrap();
-        res.iter().find(|ci| ci.label == "angle-counterclockwise").unwrap();
+        res.iter().find(|ci| ci.label == "shorter").unwrap();
+        res.iter().find(|ci| ci.label == "longer").unwrap();
+        res.iter().find(|ci| ci.label == "increasing").unwrap();
+        res.iter().find(|ci| ci.label == "decreasing").unwrap();
     }
 
     #[test]

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -1889,7 +1889,7 @@ mod tests {
         res.iter().find(|ci| ci.label == "direction").unwrap();
         res.iter().find(|ci| ci.label == "iteration-count").unwrap();
         res.iter().find(|ci| ci.label == "easing").unwrap();
-        res.iter().find(|ci| ci.label == "interpolation").unwrap();
+        res.iter().find(|ci| ci.label == "angle-interpolation").unwrap();
     }
 
     #[test]
@@ -1954,7 +1954,7 @@ mod tests {
                 Text {
                     width: 20px;
                     animate width {
-                        interpolation: 🔺;
+                        angle-interpolation: 🔺;
                     }
                 }
             }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -1889,6 +1889,7 @@ mod tests {
         res.iter().find(|ci| ci.label == "direction").unwrap();
         res.iter().find(|ci| ci.label == "iteration-count").unwrap();
         res.iter().find(|ci| ci.label == "easing").unwrap();
+        res.iter().find(|ci| ci.label == "interpolation").unwrap();
     }
 
     #[test]
@@ -1944,6 +1945,26 @@ mod tests {
             ..Default::default()
         }]);
         assert_completions_found(expected, &res);
+    }
+
+    #[test]
+    fn animation_interpolation_completion() {
+        let source = r#"
+            component Foo {
+                Text {
+                    width: 20px;
+                    animate width {
+                        interpolation: 🔺;
+                    }
+                }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "linear").unwrap();
+        res.iter().find(|ci| ci.label == "angle-shorter").unwrap();
+        res.iter().find(|ci| ci.label == "angle-longer").unwrap();
+        res.iter().find(|ci| ci.label == "angle-clockwise").unwrap();
+        res.iter().find(|ci| ci.label == "angle-counterclockwise").unwrap();
     }
 
     #[test]

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -477,10 +477,37 @@ pub(crate) fn completion_at(
         return Some(r);
     } else if node.kind() == SyntaxKind::PropertyAnimation {
         let global_tr = document_cache.global_type_registry();
+        let doc = node.source_file().and_then(|sf| document_cache.get_document_for_source_file(sf));
+        let tr = doc.map(|d| &d.local_registry).unwrap_or(&global_tr);
+
+        // Hide `angle-interpolation` if we can prove every animated property is not an angle.
+        let exclude_angle_interpolation = lookup_current_element_type(node.clone(), tr)
+            .is_some_and(|element_type| {
+                let mut any_resolved = false;
+                let mut all_non_angle = true;
+                for qn in node.children().filter_map(syntax_nodes::QualifiedName::new) {
+                    let Some(prop_name) = i_slint_compiler::parser::identifier_text(&qn) else {
+                        continue;
+                    };
+                    let lookup = element_type
+                        .lookup_property(prop_name.as_str(), PropertyLookupMode::ComponentLocal);
+                    if !lookup.property_type.is_property_type() {
+                        continue;
+                    }
+                    any_resolved = true;
+                    if matches!(lookup.property_type, Type::Angle) {
+                        all_non_angle = false;
+                        break;
+                    }
+                }
+                any_resolved && all_non_angle
+            });
+
         let r = global_tr
             .property_animation_type_for_property(Type::Float32)
             .property_list()
             .into_iter()
+            .filter(|(k, _)| !(exclude_angle_interpolation && k.as_str() == "angle-interpolation"))
             .map(|(k, t)| {
                 let mut c = CompletionItem::new_simple(k.to_string(), t.to_string());
                 c.kind = Some(CompletionItemKind::PROPERTY);
@@ -2227,6 +2254,24 @@ mod tests {
         res.iter().find(|ci| ci.label == "direction").unwrap();
         res.iter().find(|ci| ci.label == "iteration-count").unwrap();
         res.iter().find(|ci| ci.label == "easing").unwrap();
+        // angle-interpolation should not be suggested for a non-angle property
+        assert!(!res.iter().any(|ci| ci.label == "angle-interpolation"));
+    }
+
+    #[test]
+    fn animation_completion_angle() {
+        let source = r#"
+            component Foo {
+                Rectangle {
+                    animate transform-rotation {
+                        🔺
+                    }
+                }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "duration").unwrap();
+        res.iter().find(|ci| ci.label == "angle-interpolation").unwrap();
     }
 
     #[test]
@@ -2282,6 +2327,26 @@ mod tests {
             ..Default::default()
         }]);
         assert_completions_found(expected, &res);
+    }
+
+    #[test]
+    fn animation_interpolation_completion() {
+        let source = r#"
+            component Foo {
+                Text {
+                    width: 20px;
+                    animate width {
+                        angle-interpolation: 🔺;
+                    }
+                }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "linear").unwrap();
+        res.iter().find(|ci| ci.label == "shorter").unwrap();
+        res.iter().find(|ci| ci.label == "longer").unwrap();
+        res.iter().find(|ci| ci.label == "increasing").unwrap();
+        res.iter().find(|ci| ci.label == "decreasing").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Add `interpolation` property to animations with support for:
- `linear` (default): Standard numeric interpolation
- `angle-shorter`: Take the shorter arc for angle values
- `angle-longer`: Take the longer arc for angle values
- `angle-clockwise`: Always rotate clockwise
- `angle-counterclockwise`: Always rotate counterclockwise

This is useful for `transform-rotation` and other angle properties where the interpolation path matters. For example, animating from 10° to 350° with `angle-shorter` will rotate 20° counterclockwise instead of 340° clockwise.

Similar to Qt's RotationAnimation.direction and CSS hue-interpolation-method.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
