### PR TITLE
[clippy] use std::io::Error::other instead of "std::io::Error::new(std::io::ErrorKind::Other..)"

### DIFF
--- a/internal/core/graphics/image/svg.rs
+++ b/internal/core/graphics/image/svg.rs
@@ -84,7 +84,7 @@ pub fn load_from_path(
     let option = usvg::Options::default();
     usvg::Tree::from_data(&svg_data, &option)
         .map(|svg| ParsedSVG { svg_tree: svg, cache_key })
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        .map_err(std::io::Error::other)
 }
 
 pub fn load_from_data(slice: &[u8], cache_key: ImageCacheKey) -> Result<ParsedSVG, usvg::Error> {

--- a/tools/tr-extractor/main.rs
+++ b/tools/tr-extractor/main.rs
@@ -62,8 +62,7 @@ fn main() -> std::io::Result<()> {
         .unwrap_or_else(|| format!("{}.po", args.domain.as_deref().unwrap_or("messages")).into());
 
     let mut messages = if args.join_existing {
-        polib::po_file::parse(&output)
-            .map_err(|x| std::io::Error::new(std::io::ErrorKind::Other, x))?
+        polib::po_file::parse(&output).map_err(|x| std::io::Error::other(x))?
     } else {
         let package = args.package_name.as_ref().map(|x| x.as_ref()).unwrap_or("PACKAGE");
         let version = args.package_version.as_ref().map(|x| x.as_ref()).unwrap_or("VERSION");
@@ -98,9 +97,8 @@ fn process_file(
     args: &Cli,
 ) -> std::io::Result<()> {
     let mut diag = BuildDiagnostics::default();
-    let syntax_node = i_slint_compiler::parser::parse_file(path, &mut diag).ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::Other, diag.to_string_vec().join(", "))
-    })?;
+    let syntax_node = i_slint_compiler::parser::parse_file(path, &mut diag)
+        .ok_or_else(|| std::io::Error::other(diag.to_string_vec().join(", ")))?;
     visit_node(syntax_node, messages, None, args);
 
     Ok(())


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
