### PR TITLE
[clippy] use .to_string instead of format! macro as we display exact text

### DIFF
--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -49,9 +49,9 @@ impl TryFrom<&str> for RenderingRotation {
             180 => Self::Rotate180,
             270 => Self::Rotate270,
             _ => {
-                return Err(format!(
-                    "Invalid value for rotation. Must be one of 0, 90, 180, or 270"
-                ));
+                return Err(
+                    "Invalid value for rotation. Must be one of 0, 90, 180, or 270".to_string()
+                );
             }
         })
     }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1826,7 +1826,7 @@ fn generate_item_tree(
                     .map(|l| format!("slint::private_api::string_to_slice({l:?})"))
                     .join(", ")
             ));
-            create_code.push(format!("slint::cbindgen_private::slint_translate_set_bundled_languages(slint::private_api::make_slice(std::span(languages)));"));
+            create_code.push("slint::cbindgen_private::slint_translate_set_bundled_languages(slint::private_api::make_slice(std::span(languages)));".to_string());
         }
 
         create_code.push("self->globals = &self->m_globals;".into());
@@ -3842,7 +3842,7 @@ fn compile_builtin_function_call(
             format!("{}.scale_factor()", access_window_field(ctx))
         }
         BuiltinFunction::GetWindowDefaultFontSize => {
-            format!("slint::private_api::get_resolved_default_font_size(*this)")
+            "slint::private_api::get_resolved_default_font_size(*this)".to_string()
         }
         BuiltinFunction::AnimationTick => "slint::cbindgen_private::slint_animation_tick()".into(),
         BuiltinFunction::Debug => {
@@ -4316,7 +4316,7 @@ fn compile_builtin_function_call(
             "self->update_timers()".into()
         }
         BuiltinFunction::DetectOperatingSystem => {
-            format!("slint::cbindgen_private::slint_detect_operating_system()")
+            "slint::cbindgen_private::slint_detect_operating_system()".to_string()
         }
         // start and stop are unreachable because they are lowered to simple assignment of running
         BuiltinFunction::StartTimer => unreachable!(),


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
