### PR TITLE
Add detailed panic message in relative_property_ty

### DIFF
--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -761,7 +761,10 @@ impl<'a, T> EvaluationContext<'a, T> {
                     // The `Path::elements` property is not in the NativeClass
                     return &Type::PathData;
                 }
-                sc.items[*item_index].ty.lookup_property(prop_name).unwrap()
+                let item = &sc.items[*item_index];
+                item.ty.lookup_property(prop_name).unwrap_or_else(|| {
+                    panic!("Failed to lookup property {prop_name} for {}", item.name)
+                })
             }
         }
     }


### PR DESCRIPTION
When I was implementing custom bitmap cursors, I hit this unwrap() which was a bit confusing (as unwraps tend to be.)

What this is seems to be saying is that the specific property can't be found for this component - and this displays the property name and the internal struct name. This should normally never be hit, only when you're messing around with the compiler like I was.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
