### PR TITLE
Fix menu item spacing in Fluent style

### DIFF
--- a/internal/compiler/widgets/fluent/menu.slint
+++ b/internal/compiler/widgets/fluent/menu.slint
@@ -41,7 +41,7 @@ export component MenuFrame inherits MenuFrameBase {
     drop-shadow-color: FluentPalette.shadow;
     drop-shadow-offset-y: 8px;
     drop-shadow-blur: 16px;
-    margin: 1px;
+    margin: 5px;
     layout-min-width: 280px;
 }
 
@@ -53,11 +53,13 @@ export component MenuItem {
     callback clear-current <=> base.clear-current;
     callback activate <=> base.activate;
 
-    min-height: entry.is-separator ? 1px : max(40px, base.min-height);
-    max-height: entry.is-separator ? 1px : base.max-height;
+    min-height: entry.is-separator ? 9px : max(32px, base.min-height);
+    max-height: entry.is-separator ? 9px : base.max-height;
 
     HorizontalLayout {
-        padding: 5px;
+        padding: entry.is-separator ? 4px : 1px;
+        padding-left: entry.is-separator ? 0px : 1px;
+        padding-right: entry.is-separator ? 0px : 1px;
 
         base := MenuItemBase {
             default-foreground: FluentPalette.foreground;


### PR DESCRIPTION
Due to the 5px padding on the MenuItem, there was an excessive 10px space between menu items. This padding has been reduced to 1px, since it seems Fluent UI does have a bit of space between menu items. The MenuItem minimum height was reduced from 40px to 32px accordingly.

The MenuFrame margin was increased from 1px to 4px, such that there is still enough space between the menu items and the menu border.

For separators, the padding was reduced to 3px such that the space between regular menu items and the separator matches the space between the menu items and the menu frame.

ChangeLog: Fix menu item spacing in Fluent style
