### PR TITLE
Fix crashes with 0-length diagnostics

### DIFF
--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -301,18 +301,7 @@ impl Diagnostic {
 
     /// Return the length of this diagnostic in UTF-8 encoded bytes.
     pub fn length(&self) -> usize {
-        let length = self.span.span.length;
-        // If the length is 0, try to return a length of at least one character.
-        // Make sure this does fall on a new character, as otherwise string indexing may break.
-        // See also: https://github.com/slint-ui/slint/issues/10273
-        if length == 0 {
-            if let Some(source) = self.span.source_file.as_ref().and_then(|file| file.source()) {
-                let offset = self.span.span.offset;
-                let next_char = source.ceil_char_boundary(offset + 1);
-                return next_char - offset;
-            }
-        }
-        length
+        self.span.span.length
     }
 
     // NOTE: The return-type differs from the Spanned trait.

--- a/internal/compiler/tests/syntax/fuzzing/6588.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6588.slint
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
-//^^^error{Expected comma or brace}
+//|^^error{Expected comma or brace}
 
 import { Bmp
 


### PR DESCRIPTION
Previously, if the inner length was 0, it would return one, which may fall
in the middle of a character boundary. This might be confusing to
downstream consumers (like the LSP).

Closes #10273

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
