### PR TITLE
GridLayout: change back the type of row/col/rowspan/colspan to int

### DIFF
--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -41,10 +41,10 @@ pub const RESERVED_LAYOUT_PROPERTIES: &[(&str, Type)] = &[
 ];
 
 pub const RESERVED_GRIDLAYOUT_PROPERTIES: &[(&str, Type)] = &[
-    ("col", Type::Float32),
-    ("row", Type::Float32),
-    ("colspan", Type::Float32),
-    ("rowspan", Type::Float32),
+    ("col", Type::Int32),
+    ("row", Type::Int32),
+    ("colspan", Type::Int32),
+    ("rowspan", Type::Int32),
 ];
 
 macro_rules! declare_enums {


### PR DESCRIPTION
They were changed to float as part of the gridlayout refactor, but i don't think this was necessary

cc @dfaure-kdab 