### PR TITLE
widgets: make the cut/paste/cut function work even if the widget is disabled

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
@@ -105,15 +105,18 @@ Selects all text.
 
 ### clear-selection()
 Clears the selection.
+This function takes effect regardless of the `read-only` and `enabled` properties.
 
 ### copy()
 Copies the selected text to the clipboard.
 
 ### cut()
 Copies the selected text to the clipboard and removes it from the editable area.
+This function takes effect regardless of the `read-only` and `enabled` properties.
 
 ### paste()
 Pastes the text content of the clipboard at the cursor position.
+This function takes effect regardless of the `read-only` and `enabled` properties.
 
 ## Callbacks
 

--- a/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
@@ -87,10 +87,10 @@ The horizontal alignment of the text.
 -   **`clear-focus()`** Call this function to remove keyboard focus from this `TextEdit` if it currently has the focus. See also <Link type="FocusHandling" label="focus handling" />.
 -   **`set-selection-offsets(int, int)`** Selects the text between two UTF-8 offsets.
 -   **`select-all()`** Selects all text.
--   **`clear-selection()`** Clears the selection.
+-   **`clear-selection()`** Clears the selection. This function takes effect regardless of the `read-only` and `enabled` properties.
 -   **`copy()`** Copies the selected text to the clipboard.
--   **`cut()`** Copies the selected text to the clipboard and removes it from the editable area.
--   **`paste()`** Pastes the text content of the clipboard at the cursor position.
+-   **`cut()`** Copies the selected text to the clipboard and removes it from the editable area. This function takes effect regardless of the `read-only` and `enabled` properties.
+-   **`paste()`** Pastes the text content of the clipboard at the cursor position. This function takes effect regardless of the `read-only` and `enabled` properties.
 
 ## Callbacks
 

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -33,15 +33,11 @@ export component LineEditBase inherits Rectangle {
     }
 
     public function clear-selection() {
-        if (!root.read-only && root.enabled) {
-           text-input.clear-selection();
-        }
+        text-input.clear-selection();
     }
 
     public function cut() {
-        if (!root.read-only && root.enabled) {
-           text-input.cut();
-        }
+        text-input.cut();
     }
 
     public function copy() {
@@ -49,9 +45,7 @@ export component LineEditBase inherits Rectangle {
     }
 
     public function paste() {
-        if (!root.read-only && root.enabled) {
-            text-input.paste();
-        }
+        text-input.paste();
     }
 
     // on width < 1px or if the `TextInput` is clipped it cannot be focused therefore min-width 1px

--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -47,9 +47,7 @@ export component TextEditBase inherits Rectangle {
     }
 
     public function cut() {
-        if (!root.read_only && root.enabled) {
-           text-input.cut();
-        }
+        text-input.cut();
     }
 
     public function copy() {
@@ -57,9 +55,7 @@ export component TextEditBase inherits Rectangle {
     }
 
     public function paste() {
-        if (!root.read_only && root.enabled) {
-           text-input.paste();
-        }
+        text-input.paste();
     }
 
     forward-focus: text-input;

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -100,9 +100,7 @@ export component TextEdit {
     }
 
     public function cut() {
-        if (!root.read-only && root.enabled) {
-            text-input.cut();
-        }
+        text-input.cut();
     }
 
     public function copy() {
@@ -110,9 +108,7 @@ export component TextEdit {
     }
 
     public function paste() {
-        if (!root.read-only && root.enabled) {
-            text-input.paste();
-        }
+        text-input.paste();
     }
 
     forward-focus: text-input;

--- a/tests/cases/widgets/lineedit.slint
+++ b/tests/cases/widgets/lineedit.slint
@@ -6,6 +6,8 @@ export component TestCase inherits Window {
     width: 200px;
     height: 200px;
 
+    forward-focus: edit1;
+
     edit1 := LineEdit {
         y: 0px;
         width: 10 * self.height; // Test that there is no height for width dependency (loop)
@@ -28,6 +30,13 @@ export component TestCase inherits Window {
 /*
 
 ```rust
+
+fn ctrl_key(instance: &TestCase, key: &str) {
+    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+    slint_testing::send_keyboard_string_sequence(instance, key);
+    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
+}
+
 use slint::{SharedString};
 
 let instance = TestCase::new().unwrap();
@@ -41,26 +50,40 @@ instance.set_text("Hello👋".into());
 assert_eq!(instance.get_text(), "Hello👋");
 
 instance.invoke_select_all();
-
 instance.invoke_cut();
-assert_eq!(instance.get_text(), "");
+assert_eq!(instance.get_text(), "", "cut should remove the text");
+
+instance.set_text("Hello👋".into());
+instance.invoke_cut();
+assert_eq!(instance.get_text(), "Hello👋");
+ctrl_key(&instance, "a");
+ctrl_key(&instance, "x");
+assert_eq!(instance.get_text(), "", "shortcut should have worked");
+ctrl_key(&instance, "v");
+assert_eq!(instance.get_text(), "Hello👋");
+
 
 // Read Only
-instance.set_text("Hello👋".into());
-assert_eq!(instance.get_text(), "Hello👋");
+instance.set_text("👋Hello".into());
+assert_eq!(instance.get_text(), "👋Hello");
 instance.set_read_only(true);
-instance.invoke_select_all();
-
+ctrl_key(&instance, "a");
+ctrl_key(&instance, "x");
+assert_eq!(instance.get_text(), "👋Hello");
 instance.invoke_cut();
-assert_eq!(instance.get_text(), "Hello👋");
+assert_eq!(instance.get_text(), "", "programmatic should have worked even if read-only");
 
 instance.set_read_only(false);
 
 // Enabled
+ctrl_key(&instance, "v");
 instance.set_enabled(false);
 instance.invoke_select_all();
+ctrl_key(&instance, "x");
+assert_eq!(instance.get_text(), "👋Hello");
 instance.invoke_cut();
-assert_eq!(instance.get_text(), "Hello👋");
+assert_eq!(instance.get_text(), "", "programmatic should have worked even if disabled");
+instance.set_text("👋Hello".into());
 
 // Font Family
 instance.set_font_family("sans-sherif".into());

--- a/tests/cases/widgets/textedit.slint
+++ b/tests/cases/widgets/textedit.slint
@@ -31,6 +31,12 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use slint::SharedString;
 
+fn ctrl_key(instance: &TestCase, key: &str) {
+    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+    slint_testing::send_keyboard_string_sequence(instance, key);
+    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
+}
+
 let instance = TestCase::new().unwrap();
 
 let edits = Rc::new(RefCell::new(Vec::new()));
@@ -94,6 +100,11 @@ slint_testing::send_keyboard_string_sequence(&instance, "Xxx");
 assert_eq!(instance.get_text(), "Xxx");
 instance.invoke_paste();
 assert_eq!(instance.get_text(), "XxxHello👋");
+ctrl_key(&instance, "a");
+slint_testing::send_keyboard_string_sequence(&instance, "Xxx");
+assert_eq!(instance.get_text(), "Xxx");
+ctrl_key(&instance, "v");
+assert_eq!(instance.get_text(), "XxxHello👋");
 
 let mut edit_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::edit");
 let edit = edit_search.next().unwrap();
@@ -102,13 +113,17 @@ instance.set_read_only(true);
 assert_eq!(edit.accessible_read_only(), Some(true));
 
 instance.set_read_only(true);
-instance.invoke_paste();
+ctrl_key(&instance, "v");
 assert_eq!(instance.get_text(), "XxxHello👋");
+instance.invoke_paste();
+assert_eq!(instance.get_text(), "XxxHello👋Hello👋");
 instance.set_read_only(false);
 
 instance.set_enabled(false);
+ctrl_key(&instance, "v");
+assert_eq!(instance.get_text(), "XxxHello👋Hello👋");
 instance.invoke_paste();
-assert_eq!(instance.get_text(), "XxxHello👋");
+assert_eq!(instance.get_text(), "XxxHello👋Hello👋Hello👋");
 
 assert_eq!(instance.get_font_italic(), false);
 instance.set_font_italic(true);


### PR DESCRIPTION
Programmatic use of these function should work in any case. But of course, the keyboard shortcut don't

This basically reverts https://github.com/slint-ui/slint/pull/10189 and https://github.com/slint-ui/slint/pull/10175

CC: @Montel 
