### PR TITLE
Make Window::hide as experimental

### DIFF
--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -597,6 +597,18 @@ impl TypeRegister {
         register.types.remove("DropEvent").unwrap(); // Also removed in xtask/src/slintdocs.rs
 
         register.elements.remove("StyledText").unwrap();
+        register.types.remove("styled-text").unwrap();
+
+        match register.elements.get_mut("Window").unwrap() {
+            ElementType::Builtin(b) => {
+                Rc::get_mut(b)
+                    .expect("Should not be shared at this point")
+                    .properties
+                    .remove("hide")
+                    .unwrap();
+            }
+            _ => unreachable!(),
+        }
 
         Rc::new(RefCell::new(register))
     }


### PR DESCRIPTION
We are not happy with the current behavior:
 - Closes the preview
 - works on sub windows, instead of being a compiler error

CC #10502 


Note: this also mark "styled-text" as experimental because it is useless without StyledText
