### PR TITLE
todo example: Re-add border for the quit dialog

### DIFF
--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -50,6 +50,7 @@ export component MainWindow inherits Window {
 
         confirm_popup_layout := Dialog {
             height:100%; width: 100%;
+            background: transparent;
 
             confirm_popup_text := Text {
                 text: "Some items are not done, are you sure you wish to quit?";


### PR DESCRIPTION
Commit b37c956911f62b36392d1992bd6baa9aa6a4831d made Dialog have a background (implicitly because it's lowered to a WindowItem). This means the border behind the Dialog element isn't visible.

Re-add it by making the background transparent.

Fixes #10298

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
