### PR TITLE
use QPalette::AlternateBase for alternate-background in qt backend

### DIFF
--- a/internal/backends/qt/qt_widgets/palette.rs
+++ b/internal/backends/qt/qt_widgets/palette.rs
@@ -92,7 +92,7 @@ impl NativePalette {
         self.background.set(Brush::from(background));
 
         let alternate_background = cpp!(unsafe[] -> u32 as "QRgb" {
-            return qApp->palette().color(QPalette::Base).rgba();
+            return qApp->palette().color(QPalette::AlternateBase).rgba();
         });
         let alternate_background = Color::from_argb_encoded(alternate_background);
         self.alternate_background.set(Brush::from(alternate_background));


### PR DESCRIPTION
<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

A small issue i noticed while working on my app was that on the Qt backend, `alternate-background` wasn't actually doing anything, so I did a quick fix. I think it would be nice if in the future we could use an expanded color palette. I have noticed that `QPalette` doesn't seem to include colors like the window decoration, which apps like Dolphin seem to be able to use through `kcolorscheme`, perhaps something to consider for the future.

<img width="1273" height="84" alt="image" src="https://github.com/user-attachments/assets/ab5ceae2-61c9-4760-b22d-f6b97f135622" />
