### PR TITLE
Remove StyledText from public API for now

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -423,7 +423,7 @@ fn gen_corelib(
         .with_src(crate_dir.join("string.rs"))
         .with_src(crate_dir.join("styled_text.rs"))
         .with_src(crate_dir.join("slice.rs"))
-        .with_after_include("namespace slint { struct SharedString; struct StyledText; }")
+        .with_after_include("namespace slint { struct SharedString; namespace private_api { struct StyledText; } namespace cbindgen_private { using private_api::StyledText; }}")
         .generate()
         .context("Unable to generate bindings for slint_string_internal.h")?
         .write_to_file(include_dir.join("slint_string_internal.h"));

--- a/api/cpp/include/slint_string.h
+++ b/api/cpp/include/slint_string.h
@@ -223,6 +223,8 @@ private:
     void *inner; // opaque
 };
 
+namespace private_api {
+
 /// Styled text that has been parsed and seperated into paragraphs
 struct StyledText
 {
@@ -259,7 +261,6 @@ public:
 private:
     void *inner;
 };
-namespace private_api {
 
 template<typename T>
 inline cbindgen_private::Slice<T> make_slice(const T *ptr, size_t len)
@@ -282,5 +283,4 @@ inline cbindgen_private::Slice<uint8_t> string_to_slice(std::string_view str)
     return make_slice(reinterpret_cast<const uint8_t *>(str.data()), str.size());
 }
 }
-
 }

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -11,8 +11,8 @@ extern crate std;
 use alloc::rc::Rc;
 use core::ffi::c_void;
 use i_slint_core::SharedString;
-use i_slint_core::api::StyledText;
 use i_slint_core::items::OperatingSystemType;
+use i_slint_core::styled_text::StyledText;
 use i_slint_core::window::{WindowAdapter, ffi::WindowAdapterRcOpaque};
 
 pub mod platform;
@@ -242,11 +242,11 @@ pub extern "C" fn slint_detect_operating_system() -> OperatingSystemType {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn slint_escape_markdown(text: &mut SharedString) -> &SharedString {
-    *text = i_slint_core::escape_markdown(text).into();
+    *text = i_slint_core::styled_text::escape_markdown(text).into();
     text
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn slint_parse_markdown(text: &SharedString, out: &mut StyledText) {
-    *out = i_slint_core::parse_markdown(text);
+    *out = i_slint_core::styled_text::parse_markdown(text);
 }

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -163,7 +163,7 @@ pub mod re_exports {
     pub use core::iter::FromIterator;
     pub use core::option::{Option, Option::*};
     pub use core::result::{Result, Result::*};
-    pub use i_slint_core::{escape_markdown, format, parse_markdown};
+    pub use i_slint_core::styled_text::{StyledText, escape_markdown, parse_markdown};
     // This one is empty when Qt is not available, which triggers a warning
     pub use euclid::approxeq::ApproxEq;
     #[allow(unused_imports)]
@@ -172,7 +172,7 @@ pub mod re_exports {
         AccessibilityAction, AccessibleStringProperty, SupportedAccessibilityAction,
     };
     pub use i_slint_core::animations::{EasingCurve, animation_tick, current_tick};
-    pub use i_slint_core::api::{LogicalPosition, StyledText};
+    pub use i_slint_core::api::LogicalPosition;
     pub use i_slint_core::callbacks::Callback;
     pub use i_slint_core::date_time::*;
     pub use i_slint_core::detect_operating_system;
@@ -210,7 +210,7 @@ pub mod re_exports {
     pub use i_slint_core::window::{
         InputMethodRequest, WindowAdapter, WindowAdapterRc, WindowInner,
     };
-    pub use i_slint_core::{Color, Coord, SharedString, SharedVector};
+    pub use i_slint_core::{Color, Coord, SharedString, SharedVector, format};
     pub use i_slint_core::{ItemTreeVTable_static, MenuVTable_static};
     pub use num_traits::float::Float;
     pub use num_traits::ops::euclid::Euclid;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -558,7 +558,7 @@ impl CppType for Type {
             Type::LayoutCache => Some("slint::SharedVector<float>".into()),
             Type::ArrayOfU16 => Some("slint::SharedVector<uint16_t>".into()),
             Type::Easing => Some("slint::cbindgen_private::EasingCurve".into()),
-            Type::StyledText => Some("slint::StyledText".into()),
+            Type::StyledText => Some("slint::private_api::StyledText".into()),
             _ => None,
         }
     }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -745,6 +745,9 @@ impl Expression {
     }
 
     fn from_at_markdown(node: syntax_nodes::AtMarkdown, ctx: &mut LookupCtx) -> Expression {
+        if !ctx.diag.enable_experimental {
+            ctx.diag.push_error("The @markdown() function is experimental".into(), &node);
+        }
         let Some(string) = node
             .child_text(SyntaxKind::StringLiteral)
             .and_then(|s| crate::literals::unescape_string(&s))

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -18,7 +18,6 @@ pub use crate::graphics::{
     Brush, Color, Image, LoadImageError, Rgb8Pixel, Rgba8Pixel, RgbaColor, SharedPixelBuffer,
 };
 pub use crate::sharedvector::SharedVector;
-pub use crate::styled_text::StyledText;
 pub use crate::{format, string::SharedString, string::ToSharedString};
 
 /// A position represented in the coordinate space of logical pixels. That is the space before applying

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -299,7 +299,7 @@ pub trait HasFont {
 #[allow(missing_docs)]
 pub enum PlainOrStyledText {
     Plain(SharedString),
-    Styled(crate::api::StyledText),
+    Styled(crate::styled_text::StyledText),
 }
 
 /// Trait for an item that represents an string towards the renderer

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -13,7 +13,6 @@ use super::{
     TextHorizontalAlignment, TextOverflow, TextStrokeStyle, TextVerticalAlignment, TextWrap,
     VoidArg, WindowItem,
 };
-use crate::api;
 use crate::graphics::{Brush, Color, FontRequest};
 use crate::input::{
     FocusEvent, FocusEventResult, FocusReason, InputEventFilterResult, InputEventResult, KeyEvent,
@@ -231,7 +230,7 @@ impl ComplexText {
 pub struct StyledTextItem {
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub text: Property<api::StyledText>,
+    pub text: Property<crate::styled_text::StyledText>,
     pub font_size: Property<LogicalLength>,
     pub font_weight: Property<i32>,
     pub color: Property<Brush>,

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -167,33 +167,3 @@ pub fn detect_operating_system() -> OperatingSystemType {
 pub fn is_apple_platform() -> bool {
     matches!(detect_operating_system(), OperatingSystemType::Macos | OperatingSystemType::Ios)
 }
-
-pub fn escape_markdown(text: &str) -> alloc::string::String {
-    let mut out = alloc::string::String::with_capacity(text.len());
-
-    for c in text.chars() {
-        match c {
-            '*' => out.push_str("\\*"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '_' => out.push_str("\\_"),
-            '#' => out.push_str("\\#"),
-            '-' => out.push_str("\\-"),
-            '`' => out.push_str("\\`"),
-            '&' => out.push_str("\\&"),
-            _ => out.push(c),
-        }
-    }
-
-    out
-}
-
-#[cfg_attr(not(feature = "std"), allow(unused))]
-pub fn parse_markdown(text: &str) -> crate::api::StyledText {
-    #[cfg(feature = "std")]
-    {
-        crate::api::StyledText::parse(text).unwrap()
-    }
-    #[cfg(not(feature = "std"))]
-    Default::default()
-}

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -54,7 +54,7 @@ macro_rules! declare_ValueType_2 {
             crate::items::MenuEntry,
             crate::items::DropEvent,
             crate::model::ModelRc<crate::items::MenuEntry>,
-            crate::api::StyledText,
+            crate::styled_text::StyledText,
             $(crate::items::$Name,)*
         ];
     };

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -588,3 +588,32 @@ pub mod ffi {
         unsafe { core::ptr::write(out, ss.clone()) }
     }
 }
+
+pub fn escape_markdown(text: &str) -> alloc::string::String {
+    let mut out = alloc::string::String::with_capacity(text.len());
+
+    for c in text.chars() {
+        match c {
+            '*' => out.push_str("\\*"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '_' => out.push_str("\\_"),
+            '#' => out.push_str("\\#"),
+            '-' => out.push_str("\\-"),
+            '`' => out.push_str("\\`"),
+            '&' => out.push_str("\\&"),
+            _ => out.push(c),
+        }
+    }
+
+    out
+}
+
+pub fn parse_markdown(_text: &str) -> StyledText {
+    #[cfg(feature = "std")]
+    {
+        StyledText::parse(_text).unwrap()
+    }
+    #[cfg(not(feature = "std"))]
+    Default::default()
+}

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -10,6 +10,7 @@ use i_slint_core::component_factory::FactoryContext;
 use i_slint_core::graphics::euclid::approxeq::ApproxEq as _;
 use i_slint_core::items::*;
 use i_slint_core::model::{Model, ModelExt, ModelRc};
+use i_slint_core::styled_text::StyledText;
 #[cfg(feature = "internal")]
 use i_slint_core::window::WindowInner;
 use smol_str::SmolStr;
@@ -51,6 +52,7 @@ pub enum ValueType {
     /// Correspond to `image` type in .slint.
     Image,
     /// Correspond to `styled-text` type in .slint.
+    #[doc(hidden)]
     StyledText,
     /// The type is not a public type but something internal.
     #[doc(hidden)]
@@ -130,8 +132,9 @@ pub enum Value {
     #[doc(hidden)]
     /// Correspond to the `component-factory` type in .slint
     ComponentFactory(ComponentFactory) = 12,
+    #[doc(hidden)] // make visible when we make StyledText public
     /// Correspond to the `styled-text` type in .slint
-    StyledText(i_slint_core::api::StyledText) = 13,
+    StyledText(StyledText) = 13,
     #[doc(hidden)]
     ArrayOfU16(SharedVector<u16>) = 14,
 }
@@ -253,7 +256,7 @@ declare_value_conversion!(PathData => [PathData]);
 declare_value_conversion!(EasingCurve => [i_slint_core::animations::EasingCurve]);
 declare_value_conversion!(LayoutCache => [SharedVector<f32>] );
 declare_value_conversion!(ComponentFactory => [ComponentFactory] );
-declare_value_conversion!(StyledText => [i_slint_core::api::StyledText] );
+declare_value_conversion!(StyledText => [StyledText] );
 declare_value_conversion!(ArrayOfU16 => [SharedVector<u16>] );
 
 /// Implement From / TryFrom for Value that convert a `struct` to/from `Value::Struct`

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -14,7 +14,7 @@ use i_slint_compiler::{diagnostics::BuildDiagnostics, object_tree::PropertyDecla
 use i_slint_core::accessibility::{
     AccessibilityAction, AccessibleStringProperty, SupportedAccessibilityAction,
 };
-use i_slint_core::api::{LogicalPosition, StyledText};
+use i_slint_core::api::LogicalPosition;
 use i_slint_core::component_factory::ComponentFactory;
 use i_slint_core::item_tree::{
     IndexRange, ItemRc, ItemTree, ItemTreeNode, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable,
@@ -32,6 +32,7 @@ use i_slint_core::platform::PlatformError;
 use i_slint_core::properties::{ChangeTracker, InterpolatedPropertyValue};
 use i_slint_core::rtti::{self, AnimatedBindingKind, FieldOffset, PropertyInfo};
 use i_slint_core::slice::Slice;
+use i_slint_core::styled_text::StyledText;
 use i_slint_core::timers::Timer;
 use i_slint_core::window::{WindowAdapterRc, WindowInner};
 use i_slint_core::{Brush, Color, Property, SharedString, SharedVector};

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1544,12 +1544,12 @@ fn call_builtin_function(
         BuiltinFunction::EscapeMarkdown => {
             let text: SharedString =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
-            Value::String(corelib::escape_markdown(&text).into())
+            Value::String(corelib::styled_text::escape_markdown(&text).into())
         }
         BuiltinFunction::ParseMarkdown => {
             let text: SharedString =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
-            Value::StyledText(corelib::parse_markdown(&text))
+            Value::StyledText(corelib::styled_text::parse_markdown(&text))
         }
     }
 }


### PR DESCRIPTION
The StyledText element is still experimental API, so keep all the StyledText apis as private.

Also make `@markdown` as experimental
