### PR TITLE
Remove SlintInternal.open-url for the 1.15 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4974,7 +4974,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "web-time",
- "webbrowser",
  "wgpu 26.0.1",
  "wgpu 27.0.1",
 ]
@@ -11218,22 +11217,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webbrowser"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f1243ef785213e3a32fa0396093424a3a6ea566f9948497e5a2309261a4c97"
-dependencies = [
- "core-foundation 0.10.1",
- "jni",
- "log",
- "ndk-context",
- "objc2 0.6.3",
- "objc2-foundation 0.3.2",
- "url",
- "web-sys",
 ]
 
 [[package]]

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -241,11 +241,6 @@ pub extern "C" fn slint_detect_operating_system() -> OperatingSystemType {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn slint_open_url(url: &SharedString) {
-    i_slint_core::open_url(url)
-}
-
-#[unsafe(no_mangle)]
 pub extern "C" fn slint_escape_markdown(text: &mut SharedString) -> &SharedString {
     *text = i_slint_core::escape_markdown(text).into();
     text

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -115,7 +115,6 @@ pub enum BuiltinFunction {
     StartTimer,
     StopTimer,
     RestartTimer,
-    OpenUrl,
     ParseMarkdown,
     EscapeMarkdown,
 }
@@ -289,7 +288,6 @@ declare_builtin_function_types!(
     StartTimer: (Type::ElementReference) -> Type::Void,
     StopTimer: (Type::ElementReference) -> Type::Void,
     RestartTimer: (Type::ElementReference) -> Type::Void,
-    OpenUrl: (Type::String) -> Type::Void,
     EscapeMarkdown: (Type::String) -> Type::String,
     ParseMarkdown: (Type::String) -> Type::StyledText
 );
@@ -389,7 +387,6 @@ impl BuiltinFunction {
             BuiltinFunction::StartTimer => false,
             BuiltinFunction::StopTimer => false,
             BuiltinFunction::RestartTimer => false,
-            BuiltinFunction::OpenUrl => false,
             BuiltinFunction::ParseMarkdown | BuiltinFunction::EscapeMarkdown => false,
         }
     }
@@ -470,7 +467,6 @@ impl BuiltinFunction {
             BuiltinFunction::StartTimer => false,
             BuiltinFunction::StopTimer => false,
             BuiltinFunction::RestartTimer => false,
-            BuiltinFunction::OpenUrl => false,
             BuiltinFunction::ParseMarkdown | BuiltinFunction::EscapeMarkdown => true,
         }
     }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4394,10 +4394,6 @@ fn compile_builtin_function_call(
                 panic!("internal error: invalid args to RetartTimer {arguments:?}")
             }
         }
-        BuiltinFunction::OpenUrl => {
-            let url = a.next().unwrap();
-            format!("slint::cbindgen_private::slint_open_url({})", url)
-        }
         BuiltinFunction::EscapeMarkdown => {
             let text = a.next().unwrap();
             format!("slint::private_api::escape_markdown({})", text)

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3532,10 +3532,6 @@ fn compile_builtin_function_call(
                 panic!("internal error: invalid args to RestartTimer {arguments:?}")
             }
         }
-        BuiltinFunction::OpenUrl => {
-            let url = a.next().unwrap();
-            quote!(sp::open_url(&#url))
-        }
         BuiltinFunction::EscapeMarkdown => {
             let text = a.next().unwrap();
             quote!(sp::escape_markdown(&#text))

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -158,7 +158,6 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::StartTimer => 10,
         BuiltinFunction::StopTimer => 10,
         BuiltinFunction::RestartTimer => 10,
-        BuiltinFunction::OpenUrl => isize::MAX,
         BuiltinFunction::ParseMarkdown | BuiltinFunction::EscapeMarkdown => isize::MAX,
     }
 }

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -804,7 +804,6 @@ impl LookupObject for SlintInternal {
         .or_else(|| f("date-now", b(BuiltinFunction::DateNow)))
         .or_else(|| f("valid-date", b(BuiltinFunction::ValidDate)))
         .or_else(|| f("parse-date", b(BuiltinFunction::ParseDate)))
-        .or_else(|| f("open-url", b(BuiltinFunction::OpenUrl)))
     }
 }
 

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -41,7 +41,6 @@ std = [
   "chrono/wasmbind",
   "chrono/clock",
   "dep:sys-locale",
-  "dep:webbrowser",
   "shared-fontique",
   "dep:pulldown-cmark",
   "dep:thiserror",
@@ -128,7 +127,6 @@ wgpu-27 = { workspace = true, optional = true }
 
 tr = { workspace = true, optional = true }
 
-webbrowser = { version = "1.0.6", optional = true }
 htmlparser = { version = "0.2.1", optional = true }
 thiserror = { version = "2.0.17", optional = true }
 

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -168,14 +168,6 @@ pub fn is_apple_platform() -> bool {
     matches!(detect_operating_system(), OperatingSystemType::Macos | OperatingSystemType::Ios)
 }
 
-#[cfg_attr(not(feature = "std"), allow(unused))]
-pub fn open_url(url: &str) {
-    #[cfg(feature = "std")]
-    if let Err(err) = webbrowser::open(url) {
-        debug_log!("Error opening url {}: {}", url, err);
-    }
-}
-
 pub fn escape_markdown(text: &str) -> alloc::string::String {
     let mut out = alloc::string::String::with_capacity(text.len());
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1541,12 +1541,6 @@ fn call_builtin_function(
                 panic!("internal error: argument to RestartTimer must be an element")
             }
         }
-        BuiltinFunction::OpenUrl => {
-            let url: SharedString =
-                eval_expression(&arguments[0], local_context).try_into().unwrap();
-            corelib::open_url(&url);
-            Value::Void
-        }
         BuiltinFunction::EscapeMarkdown => {
             let text: SharedString =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();


### PR DESCRIPTION
The plan is to re-add it as part of #10513

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
