### PR TITLE
interpreter: fix test_multi_components on macOS

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2135,6 +2135,7 @@ fn lang_type_to_value_type() {
 
 #[test]
 fn test_multi_components() {
+    i_slint_backend_testing::init_no_event_loop();
     let result = spin_on::spin_on(
         Compiler::default().build_from_source(
             r#"


### PR DESCRIPTION
The test was failing on macOS because it would create a window (and thus an EventLoop) on a non-main thread. Initializing the testing backend prevents this.
