### PR TITLE
interpreter: store the window_adapter in the global storage

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -17,8 +17,9 @@ use i_slint_core::item_rendering::{
     CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage,
     RenderRectangle, RenderText,
 };
-use i_slint_core::item_tree::ParentItemTraversalMode;
-use i_slint_core::item_tree::{ItemTreeRc, ItemTreeRef, ItemTreeWeak};
+use i_slint_core::item_tree::{
+    ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeWeak, ParentItemTraversalMode,
+};
 use i_slint_core::items::{
     self, ColorScheme, FillRule, ImageRendering, ItemRc, ItemRef, Layer, LineCap, LineJoin,
     MouseCursor, Opacity, PointerEventButton, RenderingResult, TextWrap,
@@ -1952,7 +1953,7 @@ fn into_qsize(logical_size: i_slint_core::api::LogicalSize) -> qttypes::QSize {
 }
 
 impl WindowAdapterInternal for QtWindow {
-    fn register_item_tree(&self) {
+    fn register_item_tree(&self, _: ItemTreeRefPin) {
         self.tree_structure_changed.replace(true);
     }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -28,7 +28,7 @@ use crate::renderer::WinitCompatibleRenderer;
 
 use corelib::item_tree::ItemTreeRc;
 #[cfg(enable_accesskit)]
-use corelib::item_tree::ItemTreeRef;
+use corelib::item_tree::{ItemTreeRef, ItemTreeRefPin};
 use corelib::items::{ColorScheme, MouseCursor};
 #[cfg(enable_accesskit)]
 use corelib::items::{ItemRc, ItemRef};
@@ -1495,7 +1495,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
     }
 
     #[cfg(enable_accesskit)]
-    fn register_item_tree(&self) {
+    fn register_item_tree(&self, _: ItemTreeRefPin) {
         let Some(accesskit_adapter_cell) = self.accesskit_adapter() else { return };
         // If the accesskit_adapter is already borrowed, this means the new items were created when the tree was built and there is no need to re-visit them
         if let Ok(mut a) = accesskit_adapter_cell.try_borrow_mut() {

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -179,7 +179,7 @@ pub fn register_item_tree(item_tree_rc: &ItemTreeRc, window_adapter: Option<Wind
         }
     });
     if let Some(adapter) = window_adapter.as_ref().and_then(|a| a.internal(crate::InternalToken)) {
-        adapter.register_item_tree();
+        adapter.register_item_tree(ItemTreeRc::borrow_pin(item_tree_rc));
     }
 }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -15,7 +15,7 @@ use crate::input::{
     MouseEvent, MouseInputState, PointerEventButton, TextCursorBlinker, key_codes,
 };
 use crate::item_tree::{
-    ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeVTable, ItemTreeWeak, ItemWeak,
+    ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable, ItemTreeWeak, ItemWeak,
     ParentItemTraversalMode,
 };
 use crate::items::{ColorScheme, InputType, ItemRef, MouseCursor, PopupClosePolicy};
@@ -165,7 +165,7 @@ pub trait WindowAdapter {
 #[doc(hidden)]
 pub trait WindowAdapterInternal: core::any::Any {
     /// This function is called by the generated code when a component and therefore its tree of items are created.
-    fn register_item_tree(&self) {}
+    fn register_item_tree(&self, _: ItemTreeRefPin) {}
 
     /// This function is called by the generated code when a component and therefore its tree of items are destroyed. The
     /// implementation typically uses this to free the underlying graphics resources.

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -849,6 +849,10 @@ fn call_builtin_function(
 
             generativity::make_guard!(guard);
             let compiled = enclosing_component.description.popup_menu_description.unerase(guard);
+            let extra_data = enclosing_component
+                .description
+                .extra_data_offset
+                .apply(enclosing_component.as_ref());
             let inst = crate::dynamic_item_tree::instantiate(
                 compiled.clone(),
                 Some(enclosing_component.self_weak().get().unwrap().clone()),
@@ -856,7 +860,7 @@ fn call_builtin_function(
                 Some(&crate::dynamic_item_tree::WindowOptions::UseExistingWindow(
                     component.window_adapter(),
                 )),
-                Default::default(),
+                extra_data.globals.get().unwrap().clone(),
             );
 
             generativity::make_guard!(guard);
@@ -2039,11 +2043,11 @@ pub(crate) fn enclosing_component_instance_for_element<'a, 'new_id>(
     match component_instance {
         ComponentInstance::InstanceRef(component) => {
             if enclosing.is_global() && !Rc::ptr_eq(enclosing, &component.description.original) {
-                let root = component.toplevel_instance(guard);
                 ComponentInstance::GlobalComponent(
-                    root.description
+                    component
+                        .description
                         .extra_data_offset
-                        .apply(root.instance.get_ref())
+                        .apply(component.instance.get_ref())
                         .globals
                         .get()
                         .unwrap()

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -216,13 +216,14 @@ fn repeater_instances(
     generativity::make_guard!(guard);
     let rep =
         crate::dynamic_item_tree::get_repeater_by_name(component, elem.borrow().id.as_str(), guard);
+    let extra_data = component.description.extra_data_offset.apply(component.as_ref());
     rep.0.as_ref().ensure_updated(|| {
         crate::dynamic_item_tree::instantiate(
             rep.1.clone(),
             component.self_weak().get().cloned(),
             None,
             None,
-            Default::default(),
+            extra_data.globals.get().unwrap().clone(),
         )
     });
     rep.0.as_ref().instances_vec()


### PR DESCRIPTION
The motivation is to fix issue #8377: when reloading the live-preview, images are getting rendered wrong.
The actual problem is that the cache is poisoned with wrong pointer, that's because the unregister_item_tree function is not called for the item trees generated by the ComponentContainer when the ComponentContainer reloads itself.
The reason is that in the `impl Drop for ErasedItemTreeBox`, the root weak is already detached from the Rc (we are called from the Rc's drop). So we need to find a better way to access the window_adapter

The trick is to use the global storage to store the window adapter. This is also how we do it in C++/Rust.

Fixes #8377

