### PR TITLE
Add logging to LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5905,6 +5905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "material-gallery"
 version = "1.15.0"
 dependencies = [
@@ -6484,6 +6493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8925,6 +8943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9239,6 +9266,8 @@ dependencies = [
  "smol_str 0.3.2",
  "spin_on",
  "tikv-jemallocator",
+ "tracing",
+ "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -10410,6 +10439,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -10764,6 +10823,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,8 @@ glutin = { version = "0.32.0", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 itertools = { version = "0.14" }
 log = { version = "0.4.17" }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }
 resvg = { version = "0.46.0", default-features = false, features = ["text", "raster-images"] }
 rowan = { version = "0.16.1" }
 rustybuzz = { version = "0.20.0" }

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -93,6 +93,8 @@ by_address = { workspace = true }
 clru = { workspace = true }
 dissimilar = "1.0.7"
 itertools = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # Not updated because of https://github.com/gluon-lang/lsp-types/issues/284
 lsp-types = { version = "0.95.0" }
 serde = { workspace = true }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -213,6 +213,12 @@ impl RequestHandler {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     let args: Cli = Cli::parse();
     if !args.backend.is_empty() {
         // Safety: there are no other threads at this point
@@ -344,6 +350,7 @@ fn main_loop(connection: Connection, init_param: InitializeParams, cli_args: Cli
             let to_preview = to_preview_clone.clone();
             // let server_notifier = server_notifier_.clone();
             Box::pin(async move {
+                tracing::trace!("Importing file: {}", path);
                 let contents = std::fs::read_to_string(&path);
                 if let Ok(url) = Url::from_file_path(&path) {
                     if let Ok(contents) = &contents {
@@ -489,6 +496,11 @@ async fn handle_notification(req: lsp_server::Notification, ctx: &Rc<Context>) -
         }
         DidChangeTextDocument::METHOD => {
             let mut params: DidChangeTextDocumentParams = serde_json::from_value(req.params)?;
+            tracing::debug!(
+                "Document changed: {} (version: {})",
+                params.text_document.uri,
+                params.text_document.version
+            );
             load_document(
                 ctx,
                 params.content_changes.pop().unwrap().text,
@@ -502,6 +514,7 @@ async fn handle_notification(req: lsp_server::Notification, ctx: &Rc<Context>) -
         DidChangeWatchedFiles::METHOD => {
             let params: DidChangeWatchedFilesParams = serde_json::from_value(req.params)?;
             for fe in params.changes {
+                tracing::debug!("Watched file changed: {} (type: {:?})", fe.uri, fe.typ);
                 trigger_file_watcher(ctx, fe.uri, fe.typ).await?;
             }
             Ok(())
@@ -567,6 +580,12 @@ async fn handle_preview_to_lsp_message(
     use crate::common::PreviewToLspMessage as M;
     match message {
         M::Diagnostics { uri, version, diagnostics } => {
+            if diagnostics.is_empty() {
+                // This is very common, so we log it at trace level
+                tracing::trace!("Preview: Empty diagnostics {}", uri);
+            } else {
+                tracing::debug!("Preview: {} diagnostics for {}", diagnostics.len(), uri);
+            }
             crate::common::lsp_to_editor::notify_lsp_diagnostics(
                 &ctx.server_notifier,
                 uri,


### PR DESCRIPTION
Use RUST_LOG=slint_lsp=debug or another tracing level for the best
experience.

This has been quite useful for debugging the live-preview related
update issues.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
