### PR TITLE
Layer rendering: always cache the full layer regardless of the clip

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1482,7 +1482,6 @@ impl QtItemRenderer<'_> {
     }
 
     fn render_and_blend_layer(&mut self, alpha_tint: f32, self_rc: &ItemRc) -> RenderingResult {
-        let current_clip = self.get_current_clip();
         let mut layer_image = self.render_layer(self_rc, &|| {
             // We don't need to include the size of the opacity item itself, since it has no content.
             let children_rect = i_slint_core::properties::evaluate_no_tracking(|| {
@@ -1490,7 +1489,6 @@ impl QtItemRenderer<'_> {
                     &i_slint_core::item_rendering::item_children_bounding_rect(
                         &self_rc.item_tree(),
                         self_rc.index() as isize,
-                        &current_clip,
                     ),
                 )
             });

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -209,18 +209,13 @@ pub fn render_component_items(
 
 /// Compute the bounding rect of all children. This does /not/ include item's own bounding rect. Remember to run this
 /// via `evaluate_no_tracking`.
-pub fn item_children_bounding_rect(
-    component: &ItemTreeRc,
-    index: isize,
-    clip_rect: &LogicalRect,
-) -> LogicalRect {
-    item_children_bounding_rect_inner(component, index, clip_rect, Default::default())
+pub fn item_children_bounding_rect(component: &ItemTreeRc, index: isize) -> LogicalRect {
+    item_children_bounding_rect_inner(component, index, Default::default())
 }
 
 fn item_children_bounding_rect_inner(
     component: &ItemTreeRc,
     index: isize,
-    clip_rect: &LogicalRect,
     transform: crate::lengths::ItemTransform,
 ) -> LogicalRect {
     let mut bounding_rect = LogicalRect::zero();
@@ -235,18 +230,12 @@ fn item_children_bounding_rect_inner(
                 .unwrap_or_default()
                 .then_translate(item_geometry.origin.to_vector());
 
-            let offset: LogicalPoint = item_geometry.origin.cast();
-            let local_clip_rect = clip_rect.translate(-offset.to_vector());
-
-            if let Some(clipped_item_geometry) = item_geometry.intersection(&clip_rect.cast()) {
-                bounding_rect = bounding_rect.union(&clipped_item_geometry.cast());
-            }
+            bounding_rect = bounding_rect.union(&item_geometry.cast());
 
             if !item.as_ref().clips_children() {
                 bounding_rect = bounding_rect.union(&item_children_bounding_rect_inner(
                     component,
                     index as isize,
-                    &local_clip_rect,
                     transform.then(&children_transform),
                 ));
             }

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1135,14 +1135,12 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
     }
 
     fn render_and_blend_layer(&mut self, alpha_tint: f32, item_rc: &ItemRc) -> RenderingResult {
-        let current_clip = self.get_current_clip();
         if let Some((layer_origin, layer_image)) = self.render_layer(item_rc, &|| {
             // We don't need to include the size of the opacity item itself, since it has no content.
             i_slint_core::properties::evaluate_no_tracking(|| {
                 i_slint_core::item_rendering::item_children_bounding_rect(
                     item_rc.item_tree(),
                     item_rc.index() as isize,
-                    &current_clip,
                 )
             })
         }) && let Some(layer_size) = layer_image.size()

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -323,14 +323,12 @@ impl<'a> SkiaItemRenderer<'a> {
     }
 
     fn render_and_blend_layer(&mut self, item_rc: &ItemRc) -> RenderingResult {
-        let current_clip = self.get_current_clip();
         if let Some((layer_offset, layer_image)) = self.render_layer(item_rc, &|| {
             // We don't need to include the size of the "layer" item itself, since it has no content.
             i_slint_core::properties::evaluate_no_tracking(|| {
                 i_slint_core::item_rendering::item_children_bounding_rect(
                     item_rc.item_tree(),
                     item_rc.index() as isize,
-                    &current_clip,
                 )
             })
         }) {


### PR DESCRIPTION
Otherwise we cache too small layers.
(or worse, empty without any dependency tracking)

This causes https://github.com/slint-ui/slint/issues/10277 
Fixes #10277
