### PR TITLE
Winit and software renderer: Fix window stops refreshing

### DIFF
--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -148,11 +148,10 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
             })
         };
 
-        winit_window.pre_present_notify();
-
         let size = region.bounding_box_size();
         if let Some((w, h)) = Option::zip(NonZeroU32::new(size.width), NonZeroU32::new(size.height))
         {
+            winit_window.pre_present_notify();
             let pos = region.bounding_box_origin();
             target_buffer
                 .present_with_damage(&[softbuffer::Rect {


### PR DESCRIPTION
Do not call pre_present_notify if we're not going to present any damage, otherwise we stop getting repaint event.

Fixes #7663
