### PR TITLE
CI: Qt tests now run

### DIFF
--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -114,7 +114,7 @@ jobs:
                   SLINT_CREATE_SCREENSHOTS: 1
               shell: bash
             - name: Run tests (qt)
-              run: cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --bin test-driver-rust -- _qt --test-threads=1
+              run: cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python _qt -- --test-threads=1
               shell: bash
             - name: live-preview for rust test
               env:


### PR DESCRIPTION
The previous command did not actually run any tests:

```

    Finished `test` profile [unoptimized] target(s) in 1.99s
     Running `/home/runner/work/slint/slint/target/debug/deps/test_driver_rust-37da0e6c6e863e1f _qt --test-threads=1`

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
```

Remove the `--bin test-driver-rust` so that all tests are considered, and move the `_qt` to the correct side of `-- [ARGS]` so that only test names containing this string are run.

Now we get widgets tests with the Qt style for Rust and the interpreter:


```
     Running `/home/runner/work/slint/slint/target/debug/deps/test_driver_interpreter-60f38bf8f910f0ed _qt --test-threads=1`

running 19 tests
test test_interpreter_widgets_about_qt ... ok
test test_interpreter_widgets_button_qt ... ok
test test_interpreter_widgets_checkbox_qt ... ok
test test_interpreter_widgets_combobox_qt ... ok
test test_interpreter_widgets_contextmenu_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_datepicker_qt ... ok
test test_interpreter_widgets_groupbox_qt ... ok
test test_interpreter_widgets_lineedit_qt ... ok
test test_interpreter_widgets_listview_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_menubar_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_scrollview_qt ... ok
test test_interpreter_widgets_slider_basic_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_slider_default_value_qt ... ok
test test_interpreter_widgets_spinbox_default_value_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_switch_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_tableview_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_tabwidget_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_textedit_qt ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test test_interpreter_widgets_timepicker_qt ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 540 filtered out; finished in 3.19s

     Running `/home/runner/work/slint/slint/target/debug/deps/widgets_qt-07156366ce8d8cf4 _qt --test-threads=1`

running 18 tests
test widgets_about_qt::t_0 ... ok
test widgets_button_qt::t_0 ... ok
test widgets_checkbox_qt::t_0 ... ok
test widgets_combobox_qt::t_0 ... ok
test widgets_contextmenu_qt::t_0 ... ok
test widgets_groupbox_qt::t_0 ... ok
test widgets_lineedit_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_listview_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_menubar_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_scrollview_qt::t_0 ... ok
test widgets_slider_basic_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_slider_default_value_qt::t_0 ... ok
test widgets_spinbox_default_value_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_switch_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_tableview_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_tabwidget_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_textedit_qt::t_0 ... ok
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
QObject::setParent: Cannot set parent, new parent is in a different thread
test widgets_timepicker_qt::t_0 ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
```

The tests still don't run on macOS. I think this is because `test_driver_lib::collect_test_cases` only adds Qt as a style option if it is mentioned in the `SLINT_DEFAULT_STYLE.txt` file, which contains "cupertino" on macOS.