### PR TITLE
CI: prefix the material jobs with the name "material"

### DIFF
--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -32,15 +32,15 @@ permissions:
   contents: read
 
 jobs:
-  wasm_demo:
-      uses: ./.github/workflows/wasm_gallery.yaml
-  apk_demo:
+  material_wasm_demo:
+      uses: ./.github/workflows/material_wasm_gallery.yaml
+  material_apk_demo:
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       uses: ./.github/workflows/material_gallery.yaml
       secrets:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-  tests:
+  material_tests:
       env:
           CARGO_PROFILE_RELEASE_OPT_LEVEL: s
           CARGO_INCREMENTAL: false
@@ -67,7 +67,7 @@ jobs:
   deploy:
     if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') || (github.event_name == 'workflow_call' && inputs.publish == true) || github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-latest
-    needs: [wasm_demo, apk_demo]
+    needs: [material_wasm_demo, material_apk_demo]
     permissions:
       contents: read
       deployments: write
@@ -97,7 +97,7 @@ jobs:
         run: pnpm build
       - uses: actions/download-artifact@v7
         with:
-          name: wasm_gallery
+          name: material_wasm_gallery
           path: ui-libraries/material/docs/dist/wasm
       - uses: actions/download-artifact@v7
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/material_gallery.yaml
+++ b/.github/workflows/material_gallery.yaml
@@ -13,7 +13,7 @@ on:
         required: true
 
 jobs:
-  build:
+  material_gallery_android:
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: s
       CARGO_INCREMENTAL: false

--- a/.github/workflows/material_wasm_gallery.yaml
+++ b/.github/workflows/material_wasm_gallery.yaml
@@ -8,7 +8,7 @@ on:
     workflow_call:
 
 jobs:
-    wasm_build:
+    material_wasm_build:
         env:
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             CARGO_INCREMENTAL: false
@@ -47,7 +47,7 @@ jobs:
             - name: "Upload Artifacts"
               uses: actions/upload-artifact@v6
               with:
-                  name: wasm_gallery
+                  name: material_wasm_gallery
                   path: |
                       ui-libraries/material/examples/gallery/index.html
                       ui-libraries/material/examples/gallery/frame-tablet.webp


### PR DESCRIPTION
So we have more context when looking at the job list than "build", or "test"
