### PR TITLE
compiler: make using `row` on `Row` a warning instead of an error.

### DIFF
--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -228,7 +228,7 @@ fn lower_grid_layout(
             for row_child in row_children {
                 if let Some(binding) = row_child.borrow_mut().bindings.get("row") {
                     diag.push_warning(
-                        "The 'row' property cannot be used for elements inside a Row. (This was accepted by previous versions of Slint, but may become an error in the future.)".to_string(),
+                        "The 'row' property cannot be used for elements inside a Row. This was accepted by previous versions of Slint, but may become an error in the future".to_string(),
                         &*binding.borrow(),
                     );
                 }

--- a/internal/compiler/tests/syntax/layout/grid_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/grid_layout_properties.slint
@@ -15,7 +15,7 @@ export X := Rectangle {
             }
             Text {
                 row: 3;
-//                   ><warning{The 'row' property cannot be used for elements inside a Row. (This was accepted by previous versions of Slint, but may become an error in the future.)}
+//                   ><warning{The 'row' property cannot be used for elements inside a Row. This was accepted by previous versions of Slint, but may become an error in the future}
                 col: -2;
 //                   > <error{'col' must be a positive integer}
                 rowspan: 2.2;


### PR DESCRIPTION
This is otherwise a breaking change.

Fixes #10547
