### PR TITLE
Fix malformed item trees when using repeaters and models with gaps

### DIFF
--- a/api/cpp/include/slint_models.h
+++ b/api/cpp/include/slint_models.h
@@ -922,9 +922,8 @@ class Repeater
             }
             auto &c = data[index];
             if (model && c.ptr) {
-                if (auto data = model->row_data(index)) {
-                    (*c.ptr)->update_data(index, *data);
-                }
+                std::optional<ModelData> data = model->row_data(index);
+                (*c.ptr)->update_data(index, data ? *data : ModelData {});
                 c.state = State::Clean;
             } else {
                 c.state = State::Dirty;
@@ -994,9 +993,8 @@ public:
                         created = true;
                     }
                     if (c.state == RepeaterInner::State::Dirty) {
-                        if (auto data = m->row_data(i)) {
-                            (*c.ptr)->update_data(i, *data);
-                        }
+                        std::optional<ModelData> data = m->row_data(i);
+                        (*c.ptr)->update_data(i, data ? *data : ModelData {});
                     }
                     if (created) {
                         (*c.ptr)->init();

--- a/tests/cases/issues/issue_10544_model_gaps.slint
+++ b/tests/cases/issues/issue_10544_model_gaps.slint
@@ -1,0 +1,89 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Can't create a default-constructed ModelData
+//ignore: live-preview
+
+export component TestCase inherits Window {
+    width: 300phx;
+    height: 300phx;
+    in-out property <[int]> model;
+
+    out property <int> focus-index: -1;
+
+    for item[index] in model: FocusScope {
+        focus-gained(reason) => {
+            root.focus-index = index;
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+type ModelData = i32;
+struct BrokenModel;
+
+impl slint::Model for BrokenModel {
+    type Data = ModelData;
+    fn row_count(&self) -> usize { 3 }
+
+    fn row_data(&self, row: usize) -> Option<Self::Data> {
+        // The model is "broken" because it doesn't return anything for when row == 1
+        if row == 0 || row == 2 {
+            Some(row as i32)
+        } else {
+            None
+        }
+    }
+    fn model_tracker(&self) -> &dyn slint::ModelTracker {
+        &()
+    }
+}
+
+assert_eq!(instance.get_focus_index(), -1);
+
+instance.set_model(slint::ModelRc::new(BrokenModel));
+
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq!(instance.get_focus_index(), 0);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq!(instance.get_focus_index(), 1);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq!(instance.get_focus_index(), 2);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq!(instance.get_focus_index(), 0);
+
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+struct BrokenModel : slint::Model<int> {
+    std::size_t row_count() const override { return 3; }
+    std::optional<int> row_data(std::size_t row) const override {
+        // The model is "broken" because it doesn't return anything for when row == 1
+        if (row == 0 || row == 2) {
+            return row;
+        } else {
+            return std::nullopt;
+        }
+    }
+};
+
+auto model = std::make_shared<BrokenModel>();
+instance.set_model(model);
+
+assert_eq(instance.get_focus_index(), -1);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq(instance.get_focus_index(), 0);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq(instance.get_focus_index(), 1);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq(instance.get_focus_index(), 2);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert_eq(instance.get_focus_index(), 0);
+```
+*/

--- a/tests/cases/models/model.slint
+++ b/tests/cases/models/model.slint
@@ -137,7 +137,7 @@ assert_eq!(instance.get_clicked_score(), 44000);
 
 // At position 0 there is the invalid item
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert_eq!(instance.get_clicked_score(), 0);
+assert_eq!(instance.get_clicked_score(), 42000);
 assert_eq!(instance.get_clicked_index(), 0);
 
 ```
@@ -229,7 +229,7 @@ assert_eq(instance.get_clicked_score(), 44000);
 
 // At position 0 there is the invalid item
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert_eq(instance.get_clicked_score(), 0);
+assert_eq(instance.get_clicked_score(), 42000);
 assert_eq(instance.get_clicked_index(), 0);
 ```
 


### PR DESCRIPTION
When a model returns None for a valid row index, it would happen so that we don't call RepeatedItemTree::update (or update_data in C++) for the corresponding entry in RepeatedItemTree::instances. That in turn meant that the index property would always remain zero, which then may cause infinite loops:

When iterating with ItemRc::next_sibling() through such a repeater and we'd reach a row with a gap, we'd always get an ItemTreeRc back that returns 0 for the subtree_index(), and then we'd always go back to the beginning of the repeater.

In the worst case, this may cause an infinite loop when the accessibility subsystem of the operating system queries our accessibility tree and we'd use `accessible_dependents()` to traverse the tree with `first_child()` and `next_sibling()`, as observed in LibrePCB.

Fixes #10544

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
