### PR TITLE
Add text input controller infrastructure for mobile IME support

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use crate::javahelper::{JavaHelper, print_jni_error};
+use crate::text_input::AndroidTextInputHandler;
 use android_activity::input::{
     ButtonState, InputEvent, KeyAction, Keycode, MotionAction, MotionEvent,
 };
@@ -48,6 +49,8 @@ pub struct AndroidWindowAdapter {
 
     long_press: RefCell<Option<LongPressDetection>>,
     last_pressed_state: Cell<ButtonState>,
+    /// Handler for text input / IME integration
+    text_input_handler: AndroidTextInputHandler,
 }
 
 impl WindowAdapter for AndroidWindowAdapter {
@@ -160,6 +163,17 @@ impl WindowAdapter for AndroidWindowAdapter {
             }),
         });
     }
+
+    fn text_input_focused(
+        &self,
+        controller: Rc<dyn i_slint_core::text_input_controller::TextInputController>,
+    ) {
+        self.text_input_handler.on_text_input_focused(controller);
+    }
+
+    fn text_input_unfocused(&self) {
+        self.text_input_handler.on_text_input_unfocused();
+    }
 }
 
 impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
@@ -206,6 +220,7 @@ impl AndroidWindowAdapter {
             show_cursor_handles: Cell::new(false),
             long_press: RefCell::default(),
             last_pressed_state: Cell::new(ButtonState(0)),
+            text_input_handler: AndroidTextInputHandler::new(),
         })
     }
 

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -81,11 +81,9 @@ impl WindowAdapter for AndroidWindowAdapter {
     ) -> Option<&dyn i_slint_core::window::WindowAdapterInternal> {
         Some(self)
     }
-}
 
-impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
     #[cfg(feature = "native-activity")]
-    fn input_method_request(&self, request: InputMethodRequest) {
+    fn handle_input_method_request(&self, request: InputMethodRequest) {
         match request {
             InputMethodRequest::Enable(props) => {
                 self.java_helper
@@ -131,7 +129,7 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
     }
 
     #[cfg(not(feature = "native-activity"))]
-    fn input_method_request(&self, request: InputMethodRequest) {
+    fn handle_input_method_request(&self, request: InputMethodRequest) {
         use android_activity::input::{TextInputState, TextSpan};
 
         let props = match request {
@@ -162,7 +160,9 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
             }),
         });
     }
+}
 
+impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
     fn color_scheme(&self) -> ColorScheme {
         self.color_scheme.as_ref().get()
     }

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -10,6 +10,7 @@
 
 mod androidwindowadapter;
 mod javahelper;
+mod text_input;
 
 #[cfg(all(not(feature = "aa-06"), feature = "aa-05"))]
 pub use android_activity_05 as android_activity;

--- a/internal/backends/android-activity/text_input.rs
+++ b/internal/backends/android-activity/text_input.rs
@@ -81,13 +81,7 @@ impl AndroidTextInputHandler {
     /// Returns None if no TextInput is focused or if the controller has been invalidated.
     pub fn controller(&self) -> Option<Rc<dyn TextInputController>> {
         let controller = self.controller.borrow();
-        controller.as_ref().and_then(|c| {
-            if c.is_valid() {
-                Some(c.clone())
-            } else {
-                None
-            }
-        })
+        controller.as_ref().and_then(|c| if c.is_valid() { Some(c.clone()) } else { None })
     }
 
     /// Checks if there is a valid focused text input.
@@ -267,8 +261,8 @@ impl AndroidTextInputHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use i_slint_core::lengths::LogicalRect;
     use i_slint_core::SharedString;
+    use i_slint_core::lengths::LogicalRect;
     use std::cell::Cell;
 
     /// Mock TextInputController for testing the handler.
@@ -294,7 +288,7 @@ mod tests {
             Self {
                 valid: Cell::new(true),
                 text: RefCell::new(String::from("Hello World")),
-                cursor: Cell::new(5), // After "Hello"
+                cursor: Cell::new(5),         // After "Hello"
                 selection: Cell::new((5, 5)), // No selection, cursor at 5
                 preedit: RefCell::new(String::new()),
                 preedit_cursor: Cell::new(None),

--- a/internal/backends/android-activity/text_input.rs
+++ b/internal/backends/android-activity/text_input.rs
@@ -1,0 +1,265 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Android text input handling scaffolding.
+//!
+//! This module provides the infrastructure for integrating with Android's IME system.
+//! The full InputConnection implementation is tracked in SLINT-ANDROID-TXT-001 through TXT-015.
+//!
+//! ## Current Status
+//!
+//! This is scaffolding only. The current implementation:
+//! - Stores the TextInputController when a TextInput gains focus
+//! - Clears the controller when focus is lost
+//! - Logs stub messages for unimplemented features
+//!
+//! ## Next Steps (from implementation plan)
+//!
+//! 1. **SLINT-ANDROID-TXT-001**: Create Java InputConnection implementation
+//! 2. **SLINT-ANDROID-TXT-002**: JNI bindings for InputConnection ↔ Rust
+//! 3. **SLINT-ANDROID-TXT-003**: Implement getTextBeforeCursor/getTextAfterCursor
+//! 4. **SLINT-ANDROID-TXT-004**: Implement commitText
+//! 5. **SLINT-ANDROID-TXT-005**: Implement setComposingText/setComposingRegion
+//! 6. **SLINT-ANDROID-TXT-006**: Implement deleteSurroundingText
+//! 7. **SLINT-ANDROID-TXT-007**: Implement getSelectedText/setSelection
+//! 8. **SLINT-ANDROID-TXT-008**: Implement performEditorAction (for IME action button)
+//! 9. **SLINT-ANDROID-TXT-009**: Handle keyboard visibility changes
+//! 10. **SLINT-ANDROID-TXT-010**: Integrate with soft keyboard state API
+//!
+//! ## Architecture Notes
+//!
+//! The Android IME system works as follows:
+//! 1. When TextInput gains focus, Slint calls `text_input_focused()` with a controller
+//! 2. The controller provides sync access to text state (via TextInputController trait)
+//! 3. Android's InputMethodManager creates an InputConnection to our view
+//! 4. InputConnection methods call through JNI to the stored controller
+//! 5. When TextInput loses focus, `text_input_unfocused()` clears the controller
+
+use i_slint_core::text_input_controller::TextInputController;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Handler for Android text input / IME integration.
+///
+/// This struct holds the TextInputController and provides methods for
+/// the Android InputConnection to interact with Slint's text input.
+pub struct AndroidTextInputHandler {
+    /// The current TextInputController, if a TextInput has focus.
+    /// This is used by the Android InputConnection to query and modify text state.
+    controller: RefCell<Option<Rc<dyn TextInputController>>>,
+}
+
+impl Default for AndroidTextInputHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AndroidTextInputHandler {
+    /// Creates a new AndroidTextInputHandler.
+    pub fn new() -> Self {
+        Self { controller: RefCell::new(None) }
+    }
+
+    /// Called when a TextInput gains focus.
+    ///
+    /// The controller provides synchronous access to the TextInput's state,
+    /// which is needed for Android's InputConnection interface.
+    pub fn on_text_input_focused(&self, controller: Rc<dyn TextInputController>) {
+        log::debug!("AndroidTextInputHandler: text input focused");
+        *self.controller.borrow_mut() = Some(controller);
+    }
+
+    /// Called when the focused TextInput loses focus or is destroyed.
+    pub fn on_text_input_unfocused(&self) {
+        log::debug!("AndroidTextInputHandler: text input unfocused");
+        *self.controller.borrow_mut() = None;
+    }
+
+    /// Returns the current controller, if any.
+    ///
+    /// Returns None if no TextInput is focused or if the controller has been invalidated.
+    pub fn controller(&self) -> Option<Rc<dyn TextInputController>> {
+        let controller = self.controller.borrow();
+        controller.as_ref().and_then(|c| {
+            if c.is_valid() {
+                Some(c.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Checks if there is a valid focused text input.
+    pub fn has_focus(&self) -> bool {
+        self.controller().is_some()
+    }
+
+    // ============================================================
+    // InputConnection method stubs
+    // These will be called from JNI when the full implementation is complete
+    // ============================================================
+
+    /// Gets text before the cursor. Called by InputConnection.getTextBeforeCursor().
+    ///
+    /// # Arguments
+    /// * `max_chars` - Maximum number of characters to return
+    ///
+    /// # Returns
+    /// The text before cursor, or empty string if no focus
+    pub fn get_text_before_cursor(&self, max_chars: usize) -> String {
+        if let Some(controller) = self.controller() {
+            // Convert max chars to approximate max bytes (assume worst case UTF-8)
+            let max_bytes = max_chars * 4;
+            controller.text_before_cursor(max_bytes).to_string()
+        } else {
+            log::warn!("get_text_before_cursor called with no focused text input");
+            String::new()
+        }
+    }
+
+    /// Gets text after the cursor. Called by InputConnection.getTextAfterCursor().
+    ///
+    /// # Arguments
+    /// * `max_chars` - Maximum number of characters to return
+    ///
+    /// # Returns
+    /// The text after cursor, or empty string if no focus
+    pub fn get_text_after_cursor(&self, max_chars: usize) -> String {
+        if let Some(controller) = self.controller() {
+            let max_bytes = max_chars * 4;
+            controller.text_after_cursor(max_bytes).to_string()
+        } else {
+            log::warn!("get_text_after_cursor called with no focused text input");
+            String::new()
+        }
+    }
+
+    /// Gets the currently selected text. Called by InputConnection.getSelectedText().
+    ///
+    /// # Returns
+    /// The selected text, or None if nothing selected or no focus
+    pub fn get_selected_text(&self) -> Option<String> {
+        self.controller()?.selected_text().map(|s| s.to_string())
+    }
+
+    /// Commits text at the cursor position. Called by InputConnection.commitText().
+    ///
+    /// # Arguments
+    /// * `text` - The text to commit
+    /// * `new_cursor_position` - Cursor position relative to text end (1 = after, 0 = at end)
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn commit_text(&self, text: &str, new_cursor_position: i32) -> bool {
+        if let Some(controller) = self.controller() {
+            // Android uses 1-based position relative to committed text end
+            // Convert to our offset from end of inserted text
+            let cursor_offset = new_cursor_position - 1;
+            controller.commit_text(text, cursor_offset)
+        } else {
+            log::warn!("commit_text called with no focused text input");
+            false
+        }
+    }
+
+    /// Sets composing (preedit) text. Called by InputConnection.setComposingText().
+    ///
+    /// # Arguments
+    /// * `text` - The composing text
+    /// * `new_cursor_position` - Cursor position within composing text
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn set_composing_text(&self, text: &str, new_cursor_position: i32) -> bool {
+        if let Some(controller) = self.controller() {
+            // Convert Android's 1-based position to 0-based byte offset
+            let cursor = if new_cursor_position > 0 {
+                Some(text.len()) // Position after text
+            } else {
+                Some(0) // Position at start
+            };
+            controller.set_preedit(text, cursor)
+        } else {
+            log::warn!("set_composing_text called with no focused text input");
+            false
+        }
+    }
+
+    /// Finishes the composing text. Called by InputConnection.finishComposingText().
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn finish_composing_text(&self) -> bool {
+        if let Some(controller) = self.controller() {
+            controller.finish_composing()
+        } else {
+            log::warn!("finish_composing_text called with no focused text input");
+            false
+        }
+    }
+
+    /// Deletes text around the cursor. Called by InputConnection.deleteSurroundingText().
+    ///
+    /// # Arguments
+    /// * `before_length` - Characters to delete before cursor
+    /// * `after_length` - Characters to delete after cursor
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn delete_surrounding_text(&self, before_length: usize, after_length: usize) -> bool {
+        if let Some(controller) = self.controller() {
+            // Convert character counts to byte counts (approximate)
+            // The controller will handle boundary validation
+            controller.delete_surrounding(before_length, after_length)
+        } else {
+            log::warn!("delete_surrounding_text called with no focused text input");
+            false
+        }
+    }
+
+    /// Sets the selection range. Called by InputConnection.setSelection().
+    ///
+    /// # Arguments
+    /// * `start` - Selection start (character offset)
+    /// * `end` - Selection end (character offset)
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn set_selection(&self, start: usize, end: usize) -> bool {
+        if let Some(controller) = self.controller() {
+            controller.set_selection(start, end)
+        } else {
+            log::warn!("set_selection called with no focused text input");
+            false
+        }
+    }
+
+    /// Sets the composing region on existing text. Called by InputConnection.setComposingRegion().
+    ///
+    /// # Arguments
+    /// * `start` - Region start (character offset)
+    /// * `end` - Region end (character offset)
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn set_composing_region(&self, start: usize, end: usize) -> bool {
+        if let Some(controller) = self.controller() {
+            controller.set_composing_region(Some((start, end)))
+        } else {
+            log::warn!("set_composing_region called with no focused text input");
+            false
+        }
+    }
+
+    /// Gets the cursor position. Called by InputConnection.getExtractedText().
+    ///
+    /// # Returns
+    /// (cursor_position, selection_start, selection_end) or None if no focus
+    pub fn get_cursor_and_selection(&self) -> Option<(usize, usize, usize)> {
+        let controller = self.controller()?;
+        let cursor = controller.cursor_position();
+        let (sel_start, sel_end) = controller.selection();
+        Some((cursor, sel_start, sel_end))
+    }
+}

--- a/internal/backends/android-activity/text_input.rs
+++ b/internal/backends/android-activity/text_input.rs
@@ -36,7 +36,7 @@
 //! 5. When TextInput loses focus, `text_input_unfocused()` clears the controller
 
 use i_slint_core::text_input_controller::{
-    byte_offset_to_utf16_offset, utf16_offset_to_byte_offset, TextInputController,
+    TextInputController, byte_offset_to_utf16_offset, utf16_offset_to_byte_offset,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -250,7 +250,10 @@ impl AndroidTextInputHandler {
             let start_bytes = match utf16_offset_to_byte_offset(&text, start) {
                 Some(offset) => offset,
                 None => {
-                    log::warn!("set_selection: invalid start offset {} (inside surrogate pair)", start);
+                    log::warn!(
+                        "set_selection: invalid start offset {} (inside surrogate pair)",
+                        start
+                    );
                     return false;
                 }
             };

--- a/internal/backends/android-activity/text_input.rs
+++ b/internal/backends/android-activity/text_input.rs
@@ -263,3 +263,468 @@ impl AndroidTextInputHandler {
         Some((cursor, sel_start, sel_end))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use i_slint_core::lengths::LogicalRect;
+    use i_slint_core::SharedString;
+    use std::cell::Cell;
+
+    /// Mock TextInputController for testing the handler.
+    struct MockTextInputController {
+        valid: Cell<bool>,
+        text: RefCell<String>,
+        cursor: Cell<usize>,
+        selection: Cell<(usize, usize)>,
+        preedit: RefCell<String>,
+        preedit_cursor: Cell<Option<usize>>,
+        composing_region: Cell<Option<(usize, usize)>>,
+        // Track method calls for verification
+        commit_text_calls: RefCell<Vec<(String, i32)>>,
+        set_preedit_calls: RefCell<Vec<(String, Option<usize>)>>,
+        finish_composing_calls: Cell<u32>,
+        delete_surrounding_calls: RefCell<Vec<(usize, usize)>>,
+        set_selection_calls: RefCell<Vec<(usize, usize)>>,
+        set_composing_region_calls: RefCell<Vec<Option<(usize, usize)>>>,
+    }
+
+    impl MockTextInputController {
+        fn new() -> Self {
+            Self {
+                valid: Cell::new(true),
+                text: RefCell::new(String::from("Hello World")),
+                cursor: Cell::new(5), // After "Hello"
+                selection: Cell::new((5, 5)), // No selection, cursor at 5
+                preedit: RefCell::new(String::new()),
+                preedit_cursor: Cell::new(None),
+                composing_region: Cell::new(None),
+                commit_text_calls: RefCell::new(Vec::new()),
+                set_preedit_calls: RefCell::new(Vec::new()),
+                finish_composing_calls: Cell::new(0),
+                delete_surrounding_calls: RefCell::new(Vec::new()),
+                set_selection_calls: RefCell::new(Vec::new()),
+                set_composing_region_calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_text(text: &str, cursor: usize) -> Self {
+            let mock = Self::new();
+            *mock.text.borrow_mut() = text.to_string();
+            mock.cursor.set(cursor);
+            mock.selection.set((cursor, cursor));
+            mock
+        }
+
+        fn with_selection(text: &str, sel_start: usize, sel_end: usize) -> Self {
+            let mock = Self::new();
+            *mock.text.borrow_mut() = text.to_string();
+            mock.cursor.set(sel_end);
+            mock.selection.set((sel_start, sel_end));
+            mock
+        }
+
+        fn set_invalid(&self) {
+            self.valid.set(false);
+        }
+    }
+
+    impl TextInputController for MockTextInputController {
+        fn is_valid(&self) -> bool {
+            self.valid.get()
+        }
+
+        fn text_before_cursor(&self, max_bytes: usize) -> SharedString {
+            let text = self.text.borrow();
+            let cursor = self.cursor.get().min(text.len());
+            let start = cursor.saturating_sub(max_bytes);
+            text[start..cursor].into()
+        }
+
+        fn text_after_cursor(&self, max_bytes: usize) -> SharedString {
+            let text = self.text.borrow();
+            let cursor = self.cursor.get().min(text.len());
+            let end = (cursor + max_bytes).min(text.len());
+            text[cursor..end].into()
+        }
+
+        fn selected_text(&self) -> Option<SharedString> {
+            let (start, end) = self.selection.get();
+            if start == end {
+                None
+            } else {
+                let text = self.text.borrow();
+                Some(text[start..end].into())
+            }
+        }
+
+        fn text(&self) -> SharedString {
+            self.text.borrow().as_str().into()
+        }
+
+        fn cursor_position(&self) -> usize {
+            self.cursor.get()
+        }
+
+        fn selection(&self) -> (usize, usize) {
+            self.selection.get()
+        }
+
+        fn composing_region(&self) -> Option<(usize, usize)> {
+            self.composing_region.get()
+        }
+
+        fn preedit_text(&self) -> SharedString {
+            self.preedit.borrow().as_str().into()
+        }
+
+        fn preedit_cursor(&self) -> Option<usize> {
+            self.preedit_cursor.get()
+        }
+
+        fn cursor_rect(&self) -> LogicalRect {
+            LogicalRect::default()
+        }
+
+        fn commit_text(&self, text: &str, cursor_offset: i32) -> bool {
+            self.commit_text_calls.borrow_mut().push((text.to_string(), cursor_offset));
+            true
+        }
+
+        fn set_preedit(&self, text: &str, cursor: Option<usize>) -> bool {
+            self.set_preedit_calls.borrow_mut().push((text.to_string(), cursor));
+            *self.preedit.borrow_mut() = text.to_string();
+            self.preedit_cursor.set(cursor);
+            true
+        }
+
+        fn clear_preedit(&self) -> bool {
+            *self.preedit.borrow_mut() = String::new();
+            self.preedit_cursor.set(None);
+            true
+        }
+
+        fn set_composing_region(&self, region: Option<(usize, usize)>) -> bool {
+            self.set_composing_region_calls.borrow_mut().push(region);
+            self.composing_region.set(region);
+            true
+        }
+
+        fn finish_composing(&self) -> bool {
+            self.finish_composing_calls.set(self.finish_composing_calls.get() + 1);
+            true
+        }
+
+        fn delete_surrounding(&self, before: usize, after: usize) -> bool {
+            self.delete_surrounding_calls.borrow_mut().push((before, after));
+            true
+        }
+
+        fn set_cursor(&self, position: usize) -> bool {
+            self.cursor.set(position);
+            self.selection.set((position, position));
+            true
+        }
+
+        fn set_selection(&self, start: usize, end: usize) -> bool {
+            self.set_selection_calls.borrow_mut().push((start, end));
+            self.selection.set((start, end));
+            self.cursor.set(end);
+            true
+        }
+
+        fn begin_batch_edit(&self) -> bool {
+            true
+        }
+
+        fn end_batch_edit(&self) -> bool {
+            true
+        }
+    }
+
+    // ===== Handler Lifecycle Tests =====
+
+    #[test]
+    fn test_new_handler_has_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(!handler.has_focus());
+        assert!(handler.controller().is_none());
+    }
+
+    #[test]
+    fn test_default_handler_has_no_focus() {
+        let handler = AndroidTextInputHandler::default();
+        assert!(!handler.has_focus());
+    }
+
+    #[test]
+    fn test_focus_unfocus_cycle() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        // Initially no focus
+        assert!(!handler.has_focus());
+
+        // Focus
+        handler.on_text_input_focused(mock.clone());
+        assert!(handler.has_focus());
+        assert!(handler.controller().is_some());
+
+        // Unfocus
+        handler.on_text_input_unfocused();
+        assert!(!handler.has_focus());
+        assert!(handler.controller().is_none());
+    }
+
+    #[test]
+    fn test_controller_returns_none_when_invalid() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+        assert!(handler.has_focus());
+
+        // Invalidate the controller
+        mock.set_invalid();
+        assert!(!handler.has_focus());
+        assert!(handler.controller().is_none());
+    }
+
+    #[test]
+    fn test_replacing_focus() {
+        let handler = AndroidTextInputHandler::new();
+        let mock1 = Rc::new(MockTextInputController::with_text("First", 5));
+        let mock2 = Rc::new(MockTextInputController::with_text("Second", 6));
+
+        handler.on_text_input_focused(mock1);
+        assert_eq!(handler.get_text_before_cursor(100), "First");
+
+        // Replace with new controller
+        handler.on_text_input_focused(mock2);
+        assert_eq!(handler.get_text_before_cursor(100), "Second");
+    }
+
+    // ===== Text Query Tests =====
+
+    #[test]
+    fn test_get_text_before_cursor() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello World", 5));
+
+        handler.on_text_input_focused(mock);
+
+        // Request more chars than available before cursor
+        assert_eq!(handler.get_text_before_cursor(100), "Hello");
+
+        // Request limited chars (max_chars * 4 = max_bytes)
+        assert_eq!(handler.get_text_before_cursor(2), "lo"); // 2*4=8 bytes, but only 5 available
+    }
+
+    #[test]
+    fn test_get_text_before_cursor_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert_eq!(handler.get_text_before_cursor(100), "");
+    }
+
+    #[test]
+    fn test_get_text_after_cursor() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello World", 5));
+
+        handler.on_text_input_focused(mock);
+
+        // Request more chars than available after cursor
+        assert_eq!(handler.get_text_after_cursor(100), " World");
+    }
+
+    #[test]
+    fn test_get_text_after_cursor_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert_eq!(handler.get_text_after_cursor(100), "");
+    }
+
+    #[test]
+    fn test_get_selected_text_with_selection() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_selection("Hello World", 0, 5));
+
+        handler.on_text_input_focused(mock);
+        assert_eq!(handler.get_selected_text(), Some("Hello".to_string()));
+    }
+
+    #[test]
+    fn test_get_selected_text_no_selection() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello World", 5));
+
+        handler.on_text_input_focused(mock);
+        assert_eq!(handler.get_selected_text(), None);
+    }
+
+    #[test]
+    fn test_get_selected_text_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert_eq!(handler.get_selected_text(), None);
+    }
+
+    #[test]
+    fn test_get_cursor_and_selection() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_selection("Hello World", 2, 7));
+
+        handler.on_text_input_focused(mock);
+
+        let result = handler.get_cursor_and_selection();
+        assert!(result.is_some());
+        let (cursor, sel_start, sel_end) = result.unwrap();
+        assert_eq!(cursor, 7); // Cursor at end of selection
+        assert_eq!(sel_start, 2);
+        assert_eq!(sel_end, 7);
+    }
+
+    #[test]
+    fn test_get_cursor_and_selection_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(handler.get_cursor_and_selection().is_none());
+    }
+
+    // ===== Text Mutation Tests =====
+
+    #[test]
+    fn test_commit_text_cursor_offset_conversion() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        // Android uses 1-based position, we convert to 0-based offset
+        // new_cursor_position = 1 means after text, offset = 0
+        assert!(handler.commit_text("test", 1));
+        let calls = mock.commit_text_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], ("test".to_string(), 0)); // 1 - 1 = 0
+
+        drop(calls);
+
+        // new_cursor_position = 0 means at end of text, offset = -1
+        assert!(handler.commit_text("more", 0));
+        let calls = mock.commit_text_calls.borrow();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1], ("more".to_string(), -1)); // 0 - 1 = -1
+    }
+
+    #[test]
+    fn test_commit_text_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(!handler.commit_text("test", 1));
+    }
+
+    #[test]
+    fn test_set_composing_text_cursor_after() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        // new_cursor_position > 0 means cursor at end of preedit
+        assert!(handler.set_composing_text("にほん", 1));
+        let calls = mock.set_preedit_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "にほん");
+        assert_eq!(calls[0].1, Some(9)); // len of "にほん" in bytes
+    }
+
+    #[test]
+    fn test_set_composing_text_cursor_at_start() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        // new_cursor_position <= 0 means cursor at start
+        assert!(handler.set_composing_text("test", 0));
+        let calls = mock.set_preedit_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, Some(0));
+    }
+
+    #[test]
+    fn test_set_composing_text_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(!handler.set_composing_text("test", 1));
+    }
+
+    #[test]
+    fn test_finish_composing_text() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.finish_composing_text());
+        assert_eq!(mock.finish_composing_calls.get(), 1);
+    }
+
+    #[test]
+    fn test_finish_composing_text_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(!handler.finish_composing_text());
+    }
+
+    #[test]
+    fn test_delete_surrounding_text() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.delete_surrounding_text(3, 2));
+        let calls = mock.delete_surrounding_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], (3, 2));
+    }
+
+    #[test]
+    fn test_delete_surrounding_text_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(!handler.delete_surrounding_text(1, 1));
+    }
+
+    #[test]
+    fn test_set_selection() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.set_selection(2, 8));
+        let calls = mock.set_selection_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], (2, 8));
+    }
+
+    #[test]
+    fn test_set_selection_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(!handler.set_selection(0, 5));
+    }
+
+    #[test]
+    fn test_set_composing_region() {
+        let handler = AndroidTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.set_composing_region(3, 7));
+        let calls = mock.set_composing_region_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], Some((3, 7)));
+    }
+
+    #[test]
+    fn test_set_composing_region_no_focus() {
+        let handler = AndroidTextInputHandler::new();
+        assert!(!handler.set_composing_region(0, 5));
+    }
+}

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1941,6 +1941,47 @@ impl WindowAdapter for QtWindow {
     fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {
         Some(self)
     }
+
+    fn handle_input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
+        let widget_ptr = self.widget_ptr();
+        let props = match request {
+            i_slint_core::window::InputMethodRequest::Enable(props) => {
+                cpp! {unsafe [widget_ptr as "QWidget*"] {
+                    widget_ptr->setAttribute(Qt::WA_InputMethodEnabled, true);
+                }};
+                props
+            }
+            i_slint_core::window::InputMethodRequest::Disable => {
+                cpp! {unsafe [widget_ptr as "SlintWidget*"] {
+                    widget_ptr->ime_text = "";
+                    widget_ptr->ime_cursor = 0;
+                    widget_ptr->ime_anchor = 0;
+                    widget_ptr->setAttribute(Qt::WA_InputMethodEnabled, false);
+                }};
+                return;
+            }
+            i_slint_core::window::InputMethodRequest::Update(props) => props,
+            _ => return,
+        };
+
+        let rect = qttypes::QRectF {
+            x: props.cursor_rect_origin.x as _,
+            y: props.cursor_rect_origin.y as _,
+            width: props.cursor_rect_size.width as _,
+            height: props.cursor_rect_size.height as _,
+        };
+        let cursor: i32 = props.text[..props.cursor_position].encode_utf16().count() as _;
+        let anchor: i32 =
+            props.anchor_position.map_or(cursor, |a| props.text[..a].encode_utf16().count() as _);
+        let text: qttypes::QString = props.text.as_str().into();
+        cpp! {unsafe [widget_ptr as "SlintWidget*", rect as "QRectF", cursor as "int", anchor as "int", text as "QString"]  {
+            widget_ptr->ime_position = rect.toRect();
+            widget_ptr->ime_text = text;
+            widget_ptr->ime_cursor = cursor;
+            widget_ptr->ime_anchor = anchor;
+            QGuiApplication::inputMethod()->update(Qt::ImQueryInput);
+        }};
+    }
 }
 
 fn into_qsize(logical_size: i_slint_core::api::LogicalSize) -> qttypes::QSize {
@@ -2016,47 +2057,6 @@ impl WindowAdapterInternal for QtWindow {
         };
         cpp! {unsafe [widget_ptr as "QWidget*", cursor_shape as "Qt::CursorShape"] {
             widget_ptr->setCursor(QCursor{cursor_shape});
-        }};
-    }
-
-    fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
-        let widget_ptr = self.widget_ptr();
-        let props = match request {
-            i_slint_core::window::InputMethodRequest::Enable(props) => {
-                cpp! {unsafe [widget_ptr as "QWidget*"] {
-                    widget_ptr->setAttribute(Qt::WA_InputMethodEnabled, true);
-                }};
-                props
-            }
-            i_slint_core::window::InputMethodRequest::Disable => {
-                cpp! {unsafe [widget_ptr as "SlintWidget*"] {
-                    widget_ptr->ime_text = "";
-                    widget_ptr->ime_cursor = 0;
-                    widget_ptr->ime_anchor = 0;
-                    widget_ptr->setAttribute(Qt::WA_InputMethodEnabled, false);
-                }};
-                return;
-            }
-            i_slint_core::window::InputMethodRequest::Update(props) => props,
-            _ => return,
-        };
-
-        let rect = qttypes::QRectF {
-            x: props.cursor_rect_origin.x as _,
-            y: props.cursor_rect_origin.y as _,
-            width: props.cursor_rect_size.width as _,
-            height: props.cursor_rect_size.height as _,
-        };
-        let cursor: i32 = props.text[..props.cursor_position].encode_utf16().count() as _;
-        let anchor: i32 =
-            props.anchor_position.map_or(cursor, |a| props.text[..a].encode_utf16().count() as _);
-        let text: qttypes::QString = props.text.as_str().into();
-        cpp! {unsafe [widget_ptr as "SlintWidget*", rect as "QRectF", cursor as "int", anchor as "int", text as "QString"]  {
-            widget_ptr->ime_position = rect.toRect();
-            widget_ptr->ime_text = text;
-            widget_ptr->ime_cursor = cursor;
-            widget_ptr->ime_anchor = anchor;
-            QGuiApplication::inputMethod()->update(Qt::ImQueryInput);
         }};
     }
 

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -69,6 +69,76 @@ pub fn set_window_scale_factor<
     component.window().dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor: factor });
 }
 
+/// Simulate IME preedit (composition) text input.
+///
+/// This simulates the behavior of an IME setting preedit text on the focused TextInput.
+/// The preedit text is displayed but not yet committed to the text field.
+///
+/// # Arguments
+/// * `component` - The component containing the focused TextInput
+/// * `preedit` - The preedit/composition text to display (empty string clears preedit)
+/// * `cursor` - Cursor position within the preedit text (byte offset), or None for end
+pub fn simulate_ime_preedit<
+    X: vtable::HasStaticVTable<i_slint_core::item_tree::ItemTreeVTable>,
+    Component: Into<vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, X>> + ComponentHandle,
+>(
+    component: &Component,
+    preedit: &str,
+    cursor: Option<usize>,
+) {
+    i_slint_core::tests::simulate_ime_preedit(
+        preedit,
+        cursor,
+        &WindowInner::from_pub(component.window()).window_adapter(),
+    );
+}
+
+/// Simulate IME commit (finalize composition).
+///
+/// This simulates the behavior of an IME committing text, replacing any active preedit
+/// with the final text.
+///
+/// # Arguments
+/// * `component` - The component containing the focused TextInput
+/// * `text` - The text to commit
+/// * `cursor_offset` - Where to place cursor relative to inserted text end
+///   (0 = at end, negative = before, positive = after)
+pub fn simulate_ime_commit<
+    X: vtable::HasStaticVTable<i_slint_core::item_tree::ItemTreeVTable>,
+    Component: Into<vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, X>> + ComponentHandle,
+>(
+    component: &Component,
+    text: &str,
+    cursor_offset: i32,
+) {
+    i_slint_core::tests::simulate_ime_commit(
+        text,
+        cursor_offset,
+        &WindowInner::from_pub(component.window()).window_adapter(),
+    );
+}
+
+/// Simulate setting a composing region on existing text.
+///
+/// The composing region marks a range of existing committed text as "being edited" by the IME.
+/// This is used by autocorrect features.
+///
+/// # Arguments
+/// * `component` - The component containing the focused TextInput
+/// * `region` - The (start, end) byte offsets, or None to clear the region
+pub fn simulate_ime_set_composing_region<
+    X: vtable::HasStaticVTable<i_slint_core::item_tree::ItemTreeVTable>,
+    Component: Into<vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, X>> + ComponentHandle,
+>(
+    component: &Component,
+    region: Option<(usize, usize)>,
+) {
+    i_slint_core::tests::simulate_ime_set_composing_region(
+        region,
+        &WindowInner::from_pub(component.window()).window_adapter(),
+    );
+}
+
 pub fn access_testing_window<R>(
     window: &i_slint_core::api::Window,
     callback: impl FnOnce(&TestingWindow) -> R,

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -139,6 +139,44 @@ pub fn simulate_ime_set_composing_region<
     );
 }
 
+/// Simulate setting the soft keyboard state.
+///
+/// This simulates the behavior of a platform reporting soft keyboard visibility changes.
+/// It updates the window's virtual keyboard properties which can affect layout.
+///
+/// # Arguments
+/// * `component` - The component whose window to update
+/// * `visible` - Whether the keyboard is visible
+/// * `height` - Height of the keyboard in logical pixels
+pub fn simulate_set_soft_keyboard_state<
+    X: vtable::HasStaticVTable<i_slint_core::item_tree::ItemTreeVTable>,
+    Component: Into<vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, X>> + ComponentHandle,
+>(
+    component: &Component,
+    visible: bool,
+    height: f32,
+) {
+    i_slint_core::tests::simulate_set_soft_keyboard_state(
+        visible,
+        height,
+        &WindowInner::from_pub(component.window()).window_adapter(),
+    );
+}
+
+/// Get the current soft keyboard state.
+///
+/// Returns (visible, height) tuple.
+pub fn get_soft_keyboard_state<
+    X: vtable::HasStaticVTable<i_slint_core::item_tree::ItemTreeVTable>,
+    Component: Into<vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, X>> + ComponentHandle,
+>(
+    component: &Component,
+) -> (bool, f32) {
+    i_slint_core::tests::get_soft_keyboard_state(
+        &WindowInner::from_pub(component.window()).window_adapter(),
+    )
+}
+
 pub fn access_testing_window<R>(
     window: &i_slint_core::api::Window,
     callback: impl FnOnce(&TestingWindow) -> R,

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -138,10 +138,6 @@ impl TestingWindow {
 }
 
 impl WindowAdapterInternal for TestingWindow {
-    fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
-        self.ime_requests.borrow_mut().push(request)
-    }
-
     fn set_mouse_cursor(&self, cursor: i_slint_core::items::MouseCursor) {
         self.mouse_cursor.set(cursor);
     }
@@ -194,6 +190,10 @@ impl WindowAdapter for TestingWindow {
 
     fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {
         Some(self)
+    }
+
+    fn handle_input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
+        self.ime_requests.borrow_mut().push(request)
     }
 }
 

--- a/internal/backends/winit/ios.rs
+++ b/internal/backends/winit/ios.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 mod keyboard_animator;
+mod text_input;
 mod virtual_keyboard;
 
 pub(crate) use keyboard_animator::KeyboardCurveSampler;
+pub(crate) use text_input::IOSTextInputHandler;
 pub(crate) use virtual_keyboard::{KeyboardNotifications, register_keyboard_notifications};

--- a/internal/backends/winit/ios/text_input.rs
+++ b/internal/backends/winit/ios/text_input.rs
@@ -46,7 +46,7 @@
 //! - `textRangeFromPosition:toPosition:` - Range creation
 
 use i_slint_core::text_input_controller::{
-    byte_offset_to_utf16_offset, utf16_offset_to_byte_offset, TextInputController,
+    TextInputController, byte_offset_to_utf16_offset, utf16_offset_to_byte_offset,
 };
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/internal/backends/winit/ios/text_input.rs
+++ b/internal/backends/winit/ios/text_input.rs
@@ -1,0 +1,294 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! iOS text input handling scaffolding.
+//!
+//! This module provides the infrastructure for integrating with iOS's UITextInput protocol.
+//! The full UITextInput implementation is tracked in SLINT-IOS-TXT-001 through TXT-015.
+//!
+//! ## Current Status
+//!
+//! This is scaffolding only. The current implementation:
+//! - Stores the TextInputController when a TextInput gains focus
+//! - Clears the controller when focus is lost
+//! - Logs stub messages for unimplemented features
+//!
+//! ## Next Steps (from implementation plan)
+//!
+//! 1. **SLINT-IOS-TXT-001**: Create SlintTextInputView (UIView subclass adopting UITextInput)
+//! 2. **SLINT-IOS-TXT-002**: Implement UITextInput protocol methods
+//! 3. **SLINT-IOS-TXT-003**: Bridge UITextInput calls to TextInputController
+//! 4. **SLINT-IOS-TXT-004**: Handle marked text (preedit/composition)
+//! 5. **SLINT-IOS-TXT-005**: Handle text position and text range conversions
+//! 6. **SLINT-IOS-TXT-006**: Implement UITextInputTokenizer for word/paragraph navigation
+//! 7. **SLINT-IOS-TXT-007**: Handle keyboard appearance notifications
+//! 8. **SLINT-IOS-TXT-008**: Integrate with soft keyboard state API
+//! 9. **SLINT-IOS-TXT-009**: Handle dictation and autocorrect
+//! 10. **SLINT-IOS-TXT-010**: Support secure text entry for password fields
+//!
+//! ## Architecture Notes
+//!
+//! The iOS text input system works as follows:
+//! 1. When TextInput gains focus, Slint calls `text_input_focused()` with a controller
+//! 2. A hidden UIView (SlintTextInputView) becomes first responder
+//! 3. iOS creates a UITextInputContext and queries the view via UITextInput protocol
+//! 4. UITextInput method calls are bridged to the stored TextInputController
+//! 5. When TextInput loses focus, the view resigns first responder
+//!
+//! ## UITextInput Protocol
+//!
+//! Key methods to implement:
+//! - `textInRange:` / `replaceRange:withText:` - Text access and modification
+//! - `selectedTextRange` / `setSelectedTextRange:` - Selection handling
+//! - `markedTextRange` / `setMarkedText:selectedRange:` - Composition/preedit
+//! - `positionFromPosition:offset:` - Cursor navigation
+//! - `comparePosition:toPosition:` - Position comparison
+//! - `textRangeFromPosition:toPosition:` - Range creation
+
+use i_slint_core::text_input_controller::TextInputController;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Handler for iOS text input / UITextInput integration.
+///
+/// This struct holds the TextInputController and provides methods for
+/// the iOS UITextInput protocol to interact with Slint's text input.
+pub struct IOSTextInputHandler {
+    /// The current TextInputController, if a TextInput has focus.
+    /// This is used by the UITextInput protocol implementation to query and modify text state.
+    controller: RefCell<Option<Rc<dyn TextInputController>>>,
+}
+
+impl Default for IOSTextInputHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IOSTextInputHandler {
+    /// Creates a new IOSTextInputHandler.
+    pub fn new() -> Self {
+        Self { controller: RefCell::new(None) }
+    }
+
+    /// Called when a TextInput gains focus.
+    ///
+    /// The controller provides synchronous access to the TextInput's state,
+    /// which is needed for iOS's UITextInput protocol.
+    pub fn on_text_input_focused(&self, controller: Rc<dyn TextInputController>) {
+        log::debug!("IOSTextInputHandler: text input focused");
+        *self.controller.borrow_mut() = Some(controller);
+        // TODO: Make SlintTextInputView become first responder
+    }
+
+    /// Called when the focused TextInput loses focus or is destroyed.
+    pub fn on_text_input_unfocused(&self) {
+        log::debug!("IOSTextInputHandler: text input unfocused");
+        *self.controller.borrow_mut() = None;
+        // TODO: Resign first responder from SlintTextInputView
+    }
+
+    /// Returns the current controller, if any.
+    ///
+    /// Returns None if no TextInput is focused or if the controller has been invalidated.
+    pub fn controller(&self) -> Option<Rc<dyn TextInputController>> {
+        let controller = self.controller.borrow();
+        controller.as_ref().and_then(|c| {
+            if c.is_valid() {
+                Some(c.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Checks if there is a valid focused text input.
+    pub fn has_focus(&self) -> bool {
+        self.controller().is_some()
+    }
+
+    // ============================================================
+    // UITextInput protocol method stubs
+    // These will be called from Objective-C when the full implementation is complete
+    // ============================================================
+
+    /// Gets text in the specified range. Called by UITextInput textInRange:.
+    ///
+    /// # Arguments
+    /// * `start` - Start position (UTF-16 offset in iOS)
+    /// * `end` - End position (UTF-16 offset in iOS)
+    ///
+    /// # Returns
+    /// The text in the range, or empty string if no focus
+    pub fn text_in_range(&self, start: usize, end: usize) -> String {
+        if let Some(controller) = self.controller() {
+            let text = controller.text();
+            // Convert UTF-16 offsets to byte offsets
+            // For now, assume 1:1 mapping (ASCII). Full implementation needs proper conversion.
+            let byte_start = start.min(text.len());
+            let byte_end = end.min(text.len());
+            if byte_start <= byte_end {
+                text[byte_start..byte_end].to_string()
+            } else {
+                String::new()
+            }
+        } else {
+            log::warn!("text_in_range called with no focused text input");
+            String::new()
+        }
+    }
+
+    /// Replaces text in the specified range. Called by UITextInput replaceRange:withText:.
+    ///
+    /// # Arguments
+    /// * `start` - Start position
+    /// * `end` - End position
+    /// * `text` - Replacement text
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn replace_range(&self, start: usize, end: usize, text: &str) -> bool {
+        if let Some(controller) = self.controller() {
+            // Set selection to the range, then commit the new text
+            controller.set_selection(start, end);
+            controller.commit_text(text, 0)
+        } else {
+            log::warn!("replace_range called with no focused text input");
+            false
+        }
+    }
+
+    /// Gets the selected text range. Called by UITextInput selectedTextRange.
+    ///
+    /// # Returns
+    /// (start, end) of selection, or None if no focus
+    pub fn selected_text_range(&self) -> Option<(usize, usize)> {
+        let controller = self.controller()?;
+        Some(controller.selection())
+    }
+
+    /// Sets the selected text range. Called by UITextInput setSelectedTextRange:.
+    ///
+    /// # Arguments
+    /// * `start` - Selection start
+    /// * `end` - Selection end
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn set_selected_text_range(&self, start: usize, end: usize) -> bool {
+        if let Some(controller) = self.controller() {
+            controller.set_selection(start, end)
+        } else {
+            log::warn!("set_selected_text_range called with no focused text input");
+            false
+        }
+    }
+
+    /// Gets the marked (composition/preedit) text range. Called by UITextInput markedTextRange.
+    ///
+    /// # Returns
+    /// (start, end) of marked text, or None if no marked text
+    pub fn marked_text_range(&self) -> Option<(usize, usize)> {
+        let controller = self.controller()?;
+        let preedit = controller.preedit_text();
+        if preedit.is_empty() {
+            None
+        } else {
+            let cursor = controller.cursor_position();
+            Some((cursor, cursor + preedit.len()))
+        }
+    }
+
+    /// Sets the marked (composition/preedit) text. Called by UITextInput setMarkedText:selectedRange:.
+    ///
+    /// # Arguments
+    /// * `text` - The marked text
+    /// * `selected_start` - Selection start within marked text
+    /// * `selected_end` - Selection end within marked text
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn set_marked_text(&self, text: &str, selected_start: usize, selected_end: usize) -> bool {
+        if let Some(controller) = self.controller() {
+            // The selected range within the marked text indicates the cursor position
+            let cursor = if selected_start == selected_end {
+                Some(selected_start)
+            } else {
+                Some(selected_end)
+            };
+            controller.set_preedit(text, cursor)
+        } else {
+            log::warn!("set_marked_text called with no focused text input");
+            false
+        }
+    }
+
+    /// Unmarks the current marked text (commits it). Called by UITextInput unmarkText.
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn unmark_text(&self) -> bool {
+        if let Some(controller) = self.controller() {
+            controller.finish_composing()
+        } else {
+            log::warn!("unmark_text called with no focused text input");
+            false
+        }
+    }
+
+    /// Gets the beginning of the document. Called by UITextInput beginningOfDocument.
+    ///
+    /// # Returns
+    /// Position 0 (always)
+    pub fn beginning_of_document(&self) -> usize {
+        0
+    }
+
+    /// Gets the end of the document. Called by UITextInput endOfDocument.
+    ///
+    /// # Returns
+    /// The text length, or 0 if no focus
+    pub fn end_of_document(&self) -> usize {
+        self.controller().map(|c| c.text().len()).unwrap_or(0)
+    }
+
+    /// Inserts text at the insertion point. Called by UITextInput insertText:.
+    ///
+    /// # Arguments
+    /// * `text` - The text to insert
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn insert_text(&self, text: &str) -> bool {
+        if let Some(controller) = self.controller() {
+            // First finish any composition
+            controller.finish_composing();
+            // Then commit the new text
+            controller.commit_text(text, 0)
+        } else {
+            log::warn!("insert_text called with no focused text input");
+            false
+        }
+    }
+
+    /// Deletes backward from the insertion point. Called by UITextInput deleteBackward.
+    ///
+    /// # Returns
+    /// true if successful
+    pub fn delete_backward(&self) -> bool {
+        if let Some(controller) = self.controller() {
+            // If there's a selection, delete it
+            let (start, end) = controller.selection();
+            if start != end {
+                controller.set_selection(start, end);
+                controller.commit_text("", 0)
+            } else {
+                // Delete one character before cursor
+                controller.delete_surrounding(1, 0)
+            }
+        } else {
+            log::warn!("delete_backward called with no focused text input");
+            false
+        }
+    }
+}

--- a/internal/backends/winit/ios/text_input.rs
+++ b/internal/backends/winit/ios/text_input.rs
@@ -292,3 +292,516 @@ impl IOSTextInputHandler {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use i_slint_core::lengths::LogicalRect;
+    use i_slint_core::SharedString;
+    use std::cell::Cell;
+
+    /// Mock TextInputController for testing the handler.
+    struct MockTextInputController {
+        valid: Cell<bool>,
+        text: RefCell<String>,
+        cursor: Cell<usize>,
+        selection: Cell<(usize, usize)>,
+        preedit: RefCell<String>,
+        preedit_cursor: Cell<Option<usize>>,
+        composing_region: Cell<Option<(usize, usize)>>,
+        // Track method calls for verification
+        commit_text_calls: RefCell<Vec<(String, i32)>>,
+        set_preedit_calls: RefCell<Vec<(String, Option<usize>)>>,
+        finish_composing_calls: Cell<u32>,
+        delete_surrounding_calls: RefCell<Vec<(usize, usize)>>,
+        set_selection_calls: RefCell<Vec<(usize, usize)>>,
+    }
+
+    impl MockTextInputController {
+        fn new() -> Self {
+            Self {
+                valid: Cell::new(true),
+                text: RefCell::new(String::from("Hello World")),
+                cursor: Cell::new(5), // After "Hello"
+                selection: Cell::new((5, 5)), // No selection, cursor at 5
+                preedit: RefCell::new(String::new()),
+                preedit_cursor: Cell::new(None),
+                composing_region: Cell::new(None),
+                commit_text_calls: RefCell::new(Vec::new()),
+                set_preedit_calls: RefCell::new(Vec::new()),
+                finish_composing_calls: Cell::new(0),
+                delete_surrounding_calls: RefCell::new(Vec::new()),
+                set_selection_calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_text(text: &str, cursor: usize) -> Self {
+            let mock = Self::new();
+            *mock.text.borrow_mut() = text.to_string();
+            mock.cursor.set(cursor);
+            mock.selection.set((cursor, cursor));
+            mock
+        }
+
+        fn with_selection(text: &str, sel_start: usize, sel_end: usize) -> Self {
+            let mock = Self::new();
+            *mock.text.borrow_mut() = text.to_string();
+            mock.cursor.set(sel_end);
+            mock.selection.set((sel_start, sel_end));
+            mock
+        }
+
+        fn with_preedit(text: &str, cursor: usize, preedit: &str) -> Self {
+            let mock = Self::with_text(text, cursor);
+            *mock.preedit.borrow_mut() = preedit.to_string();
+            mock
+        }
+
+        fn set_invalid(&self) {
+            self.valid.set(false);
+        }
+    }
+
+    impl TextInputController for MockTextInputController {
+        fn is_valid(&self) -> bool {
+            self.valid.get()
+        }
+
+        fn text_before_cursor(&self, max_bytes: usize) -> SharedString {
+            let text = self.text.borrow();
+            let cursor = self.cursor.get().min(text.len());
+            let start = cursor.saturating_sub(max_bytes);
+            text[start..cursor].into()
+        }
+
+        fn text_after_cursor(&self, max_bytes: usize) -> SharedString {
+            let text = self.text.borrow();
+            let cursor = self.cursor.get().min(text.len());
+            let end = (cursor + max_bytes).min(text.len());
+            text[cursor..end].into()
+        }
+
+        fn selected_text(&self) -> Option<SharedString> {
+            let (start, end) = self.selection.get();
+            if start == end {
+                None
+            } else {
+                let text = self.text.borrow();
+                Some(text[start..end].into())
+            }
+        }
+
+        fn text(&self) -> SharedString {
+            self.text.borrow().as_str().into()
+        }
+
+        fn cursor_position(&self) -> usize {
+            self.cursor.get()
+        }
+
+        fn selection(&self) -> (usize, usize) {
+            self.selection.get()
+        }
+
+        fn composing_region(&self) -> Option<(usize, usize)> {
+            self.composing_region.get()
+        }
+
+        fn preedit_text(&self) -> SharedString {
+            self.preedit.borrow().as_str().into()
+        }
+
+        fn preedit_cursor(&self) -> Option<usize> {
+            self.preedit_cursor.get()
+        }
+
+        fn cursor_rect(&self) -> LogicalRect {
+            LogicalRect::default()
+        }
+
+        fn commit_text(&self, text: &str, cursor_offset: i32) -> bool {
+            self.commit_text_calls.borrow_mut().push((text.to_string(), cursor_offset));
+            true
+        }
+
+        fn set_preedit(&self, text: &str, cursor: Option<usize>) -> bool {
+            self.set_preedit_calls.borrow_mut().push((text.to_string(), cursor));
+            *self.preedit.borrow_mut() = text.to_string();
+            self.preedit_cursor.set(cursor);
+            true
+        }
+
+        fn clear_preedit(&self) -> bool {
+            *self.preedit.borrow_mut() = String::new();
+            self.preedit_cursor.set(None);
+            true
+        }
+
+        fn set_composing_region(&self, region: Option<(usize, usize)>) -> bool {
+            self.composing_region.set(region);
+            true
+        }
+
+        fn finish_composing(&self) -> bool {
+            self.finish_composing_calls.set(self.finish_composing_calls.get() + 1);
+            true
+        }
+
+        fn delete_surrounding(&self, before: usize, after: usize) -> bool {
+            self.delete_surrounding_calls.borrow_mut().push((before, after));
+            true
+        }
+
+        fn set_cursor(&self, position: usize) -> bool {
+            self.cursor.set(position);
+            self.selection.set((position, position));
+            true
+        }
+
+        fn set_selection(&self, start: usize, end: usize) -> bool {
+            self.set_selection_calls.borrow_mut().push((start, end));
+            self.selection.set((start, end));
+            self.cursor.set(end);
+            true
+        }
+
+        fn begin_batch_edit(&self) -> bool {
+            true
+        }
+
+        fn end_batch_edit(&self) -> bool {
+            true
+        }
+    }
+
+    // ===== Handler Lifecycle Tests =====
+
+    #[test]
+    fn test_new_handler_has_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(!handler.has_focus());
+        assert!(handler.controller().is_none());
+    }
+
+    #[test]
+    fn test_default_handler_has_no_focus() {
+        let handler = IOSTextInputHandler::default();
+        assert!(!handler.has_focus());
+    }
+
+    #[test]
+    fn test_focus_unfocus_cycle() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        // Initially no focus
+        assert!(!handler.has_focus());
+
+        // Focus
+        handler.on_text_input_focused(mock.clone());
+        assert!(handler.has_focus());
+        assert!(handler.controller().is_some());
+
+        // Unfocus
+        handler.on_text_input_unfocused();
+        assert!(!handler.has_focus());
+        assert!(handler.controller().is_none());
+    }
+
+    #[test]
+    fn test_controller_returns_none_when_invalid() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+        assert!(handler.has_focus());
+
+        // Invalidate the controller
+        mock.set_invalid();
+        assert!(!handler.has_focus());
+        assert!(handler.controller().is_none());
+    }
+
+    // ===== Text Query Tests =====
+
+    #[test]
+    fn test_text_in_range() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello World", 5));
+
+        handler.on_text_input_focused(mock);
+
+        assert_eq!(handler.text_in_range(0, 5), "Hello");
+        assert_eq!(handler.text_in_range(6, 11), "World");
+        assert_eq!(handler.text_in_range(0, 11), "Hello World");
+    }
+
+    #[test]
+    fn test_text_in_range_clamped() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello", 5));
+
+        handler.on_text_input_focused(mock);
+
+        // Range beyond text length should be clamped
+        assert_eq!(handler.text_in_range(0, 100), "Hello");
+        assert_eq!(handler.text_in_range(3, 100), "lo");
+    }
+
+    #[test]
+    fn test_text_in_range_reversed() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello", 5));
+
+        handler.on_text_input_focused(mock);
+
+        // Reversed range should return empty
+        assert_eq!(handler.text_in_range(5, 0), "");
+    }
+
+    #[test]
+    fn test_text_in_range_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert_eq!(handler.text_in_range(0, 5), "");
+    }
+
+    #[test]
+    fn test_selected_text_range() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_selection("Hello World", 2, 7));
+
+        handler.on_text_input_focused(mock);
+
+        let range = handler.selected_text_range();
+        assert_eq!(range, Some((2, 7)));
+    }
+
+    #[test]
+    fn test_selected_text_range_no_selection() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello", 3));
+
+        handler.on_text_input_focused(mock);
+
+        // No selection means start == end
+        let range = handler.selected_text_range();
+        assert_eq!(range, Some((3, 3)));
+    }
+
+    #[test]
+    fn test_selected_text_range_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(handler.selected_text_range().is_none());
+    }
+
+    #[test]
+    fn test_marked_text_range_with_preedit() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_preedit("Hello", 5, "World"));
+
+        handler.on_text_input_focused(mock);
+
+        // Marked text range is (cursor, cursor + preedit.len())
+        let range = handler.marked_text_range();
+        assert_eq!(range, Some((5, 10))); // 5 + 5 bytes of "World"
+    }
+
+    #[test]
+    fn test_marked_text_range_no_preedit() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello", 5));
+
+        handler.on_text_input_focused(mock);
+
+        assert!(handler.marked_text_range().is_none());
+    }
+
+    #[test]
+    fn test_marked_text_range_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(handler.marked_text_range().is_none());
+    }
+
+    #[test]
+    fn test_beginning_of_document() {
+        let handler = IOSTextInputHandler::new();
+        // Always returns 0, even without focus
+        assert_eq!(handler.beginning_of_document(), 0);
+    }
+
+    #[test]
+    fn test_end_of_document() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello World", 5));
+
+        handler.on_text_input_focused(mock);
+        assert_eq!(handler.end_of_document(), 11);
+    }
+
+    #[test]
+    fn test_end_of_document_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert_eq!(handler.end_of_document(), 0);
+    }
+
+    // ===== Text Mutation Tests =====
+
+    #[test]
+    fn test_replace_range() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.replace_range(0, 5, "Hi"));
+
+        // Should first set selection, then commit
+        let sel_calls = mock.set_selection_calls.borrow();
+        assert_eq!(sel_calls.len(), 1);
+        assert_eq!(sel_calls[0], (0, 5));
+
+        let commit_calls = mock.commit_text_calls.borrow();
+        assert_eq!(commit_calls.len(), 1);
+        assert_eq!(commit_calls[0], ("Hi".to_string(), 0));
+    }
+
+    #[test]
+    fn test_replace_range_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(!handler.replace_range(0, 5, "test"));
+    }
+
+    #[test]
+    fn test_set_selected_text_range() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.set_selected_text_range(2, 8));
+        let calls = mock.set_selection_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], (2, 8));
+    }
+
+    #[test]
+    fn test_set_selected_text_range_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(!handler.set_selected_text_range(0, 5));
+    }
+
+    #[test]
+    fn test_set_marked_text_cursor_at_end() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        // selected_start == selected_end means cursor at that position
+        assert!(handler.set_marked_text("にほん", 3, 3));
+        let calls = mock.set_preedit_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "にほん");
+        assert_eq!(calls[0].1, Some(3));
+    }
+
+    #[test]
+    fn test_set_marked_text_with_selection() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        // When there's a selection in marked text, cursor goes to end
+        assert!(handler.set_marked_text("test", 1, 3));
+        let calls = mock.set_preedit_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, Some(3)); // selected_end
+    }
+
+    #[test]
+    fn test_set_marked_text_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(!handler.set_marked_text("test", 0, 0));
+    }
+
+    #[test]
+    fn test_unmark_text() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.unmark_text());
+        assert_eq!(mock.finish_composing_calls.get(), 1);
+    }
+
+    #[test]
+    fn test_unmark_text_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(!handler.unmark_text());
+    }
+
+    #[test]
+    fn test_insert_text() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::new());
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.insert_text("Hello"));
+
+        // Should finish composing first, then commit
+        assert_eq!(mock.finish_composing_calls.get(), 1);
+
+        let calls = mock.commit_text_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], ("Hello".to_string(), 0));
+    }
+
+    #[test]
+    fn test_insert_text_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(!handler.insert_text("test"));
+    }
+
+    #[test]
+    fn test_delete_backward_no_selection() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_text("Hello", 5));
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.delete_backward());
+
+        // Should delete 1 character before cursor
+        let calls = mock.delete_surrounding_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], (1, 0));
+    }
+
+    #[test]
+    fn test_delete_backward_with_selection() {
+        let handler = IOSTextInputHandler::new();
+        let mock = Rc::new(MockTextInputController::with_selection("Hello World", 0, 5));
+
+        handler.on_text_input_focused(mock.clone());
+
+        assert!(handler.delete_backward());
+
+        // Should set selection and commit empty string
+        let sel_calls = mock.set_selection_calls.borrow();
+        assert_eq!(sel_calls.len(), 1);
+        assert_eq!(sel_calls[0], (0, 5));
+
+        let commit_calls = mock.commit_text_calls.borrow();
+        assert_eq!(commit_calls.len(), 1);
+        assert_eq!(commit_calls[0], ("".to_string(), 0));
+    }
+
+    #[test]
+    fn test_delete_backward_no_focus() {
+        let handler = IOSTextInputHandler::new();
+        assert!(!handler.delete_backward());
+    }
+}

--- a/internal/backends/winit/ios/text_input.rs
+++ b/internal/backends/winit/ios/text_input.rs
@@ -93,13 +93,7 @@ impl IOSTextInputHandler {
     /// Returns None if no TextInput is focused or if the controller has been invalidated.
     pub fn controller(&self) -> Option<Rc<dyn TextInputController>> {
         let controller = self.controller.borrow();
-        controller.as_ref().and_then(|c| {
-            if c.is_valid() {
-                Some(c.clone())
-            } else {
-                None
-            }
-        })
+        controller.as_ref().and_then(|c| if c.is_valid() { Some(c.clone()) } else { None })
     }
 
     /// Checks if there is a valid focused text input.
@@ -296,8 +290,8 @@ impl IOSTextInputHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use i_slint_core::lengths::LogicalRect;
     use i_slint_core::SharedString;
+    use i_slint_core::lengths::LogicalRect;
     use std::cell::Cell;
 
     /// Mock TextInputController for testing the handler.
@@ -322,7 +316,7 @@ mod tests {
             Self {
                 valid: Cell::new(true),
                 text: RefCell::new(String::from("Hello World")),
-                cursor: Cell::new(5), // After "Hello"
+                cursor: Cell::new(5),         // After "Hello"
                 selection: Cell::new((5, 5)), // No selection, cursor at 5
                 preedit: RefCell::new(String::new()),
                 preedit_cursor: Cell::new(None),

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1313,49 +1313,8 @@ impl WindowAdapter for WinitWindowAdapter {
     fn internal(&self, _: corelib::InternalToken) -> Option<&dyn WindowAdapterInternal> {
         Some(self)
     }
-}
 
-impl WindowAdapterInternal for WinitWindowAdapter {
-    fn set_mouse_cursor(&self, cursor: MouseCursor) {
-        let winit_cursor = match cursor {
-            MouseCursor::Default => winit::window::CursorIcon::Default,
-            MouseCursor::None => winit::window::CursorIcon::Default,
-            MouseCursor::Help => winit::window::CursorIcon::Help,
-            MouseCursor::Pointer => winit::window::CursorIcon::Pointer,
-            MouseCursor::Progress => winit::window::CursorIcon::Progress,
-            MouseCursor::Wait => winit::window::CursorIcon::Wait,
-            MouseCursor::Crosshair => winit::window::CursorIcon::Crosshair,
-            MouseCursor::Text => winit::window::CursorIcon::Text,
-            MouseCursor::Alias => winit::window::CursorIcon::Alias,
-            MouseCursor::Copy => winit::window::CursorIcon::Copy,
-            MouseCursor::Move => winit::window::CursorIcon::Move,
-            MouseCursor::NoDrop => winit::window::CursorIcon::NoDrop,
-            MouseCursor::NotAllowed => winit::window::CursorIcon::NotAllowed,
-            MouseCursor::Grab => winit::window::CursorIcon::Grab,
-            MouseCursor::Grabbing => winit::window::CursorIcon::Grabbing,
-            MouseCursor::ColResize => winit::window::CursorIcon::ColResize,
-            MouseCursor::RowResize => winit::window::CursorIcon::RowResize,
-            MouseCursor::NResize => winit::window::CursorIcon::NResize,
-            MouseCursor::EResize => winit::window::CursorIcon::EResize,
-            MouseCursor::SResize => winit::window::CursorIcon::SResize,
-            MouseCursor::WResize => winit::window::CursorIcon::WResize,
-            MouseCursor::NeResize => winit::window::CursorIcon::NeResize,
-            MouseCursor::NwResize => winit::window::CursorIcon::NwResize,
-            MouseCursor::SeResize => winit::window::CursorIcon::SeResize,
-            MouseCursor::SwResize => winit::window::CursorIcon::SwResize,
-            MouseCursor::EwResize => winit::window::CursorIcon::EwResize,
-            MouseCursor::NsResize => winit::window::CursorIcon::NsResize,
-            MouseCursor::NeswResize => winit::window::CursorIcon::NeswResize,
-            MouseCursor::NwseResize => winit::window::CursorIcon::NwseResize,
-            _ => winit::window::CursorIcon::Default,
-        };
-        if let Some(winit_window) = self.winit_window_or_none.borrow().as_window() {
-            winit_window.set_cursor_visible(cursor != MouseCursor::None);
-            winit_window.set_cursor(winit_cursor);
-        }
-    }
-
-    fn input_method_request(&self, request: corelib::window::InputMethodRequest) {
+    fn handle_input_method_request(&self, request: corelib::window::InputMethodRequest) {
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(winit_window) = self.winit_window_or_none.borrow().as_window() {
             let props = match &request {
@@ -1403,6 +1362,47 @@ impl WindowAdapterInternal for WinitWindowAdapter {
             }
             _ => {}
         };
+    }
+}
+
+impl WindowAdapterInternal for WinitWindowAdapter {
+    fn set_mouse_cursor(&self, cursor: MouseCursor) {
+        let winit_cursor = match cursor {
+            MouseCursor::Default => winit::window::CursorIcon::Default,
+            MouseCursor::None => winit::window::CursorIcon::Default,
+            MouseCursor::Help => winit::window::CursorIcon::Help,
+            MouseCursor::Pointer => winit::window::CursorIcon::Pointer,
+            MouseCursor::Progress => winit::window::CursorIcon::Progress,
+            MouseCursor::Wait => winit::window::CursorIcon::Wait,
+            MouseCursor::Crosshair => winit::window::CursorIcon::Crosshair,
+            MouseCursor::Text => winit::window::CursorIcon::Text,
+            MouseCursor::Alias => winit::window::CursorIcon::Alias,
+            MouseCursor::Copy => winit::window::CursorIcon::Copy,
+            MouseCursor::Move => winit::window::CursorIcon::Move,
+            MouseCursor::NoDrop => winit::window::CursorIcon::NoDrop,
+            MouseCursor::NotAllowed => winit::window::CursorIcon::NotAllowed,
+            MouseCursor::Grab => winit::window::CursorIcon::Grab,
+            MouseCursor::Grabbing => winit::window::CursorIcon::Grabbing,
+            MouseCursor::ColResize => winit::window::CursorIcon::ColResize,
+            MouseCursor::RowResize => winit::window::CursorIcon::RowResize,
+            MouseCursor::NResize => winit::window::CursorIcon::NResize,
+            MouseCursor::EResize => winit::window::CursorIcon::EResize,
+            MouseCursor::SResize => winit::window::CursorIcon::SResize,
+            MouseCursor::WResize => winit::window::CursorIcon::WResize,
+            MouseCursor::NeResize => winit::window::CursorIcon::NeResize,
+            MouseCursor::NwResize => winit::window::CursorIcon::NwResize,
+            MouseCursor::SeResize => winit::window::CursorIcon::SeResize,
+            MouseCursor::SwResize => winit::window::CursorIcon::SwResize,
+            MouseCursor::EwResize => winit::window::CursorIcon::EwResize,
+            MouseCursor::NsResize => winit::window::CursorIcon::NsResize,
+            MouseCursor::NeswResize => winit::window::CursorIcon::NeswResize,
+            MouseCursor::NwseResize => winit::window::CursorIcon::NwseResize,
+            _ => winit::window::CursorIcon::Default,
+        };
+        if let Some(winit_window) = self.winit_window_or_none.borrow().as_window() {
+            winit_window.set_cursor_visible(cursor != MouseCursor::None);
+            winit_window.set_cursor(winit_cursor);
+        }
     }
 
     fn color_scheme(&self) -> ColorScheme {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -341,6 +341,9 @@ pub struct WinitWindowAdapter {
     #[cfg(target_arch = "wasm32")]
     virtual_keyboard_helper: RefCell<Option<super::wasm_input_helper::WasmInputHelper>>,
 
+    #[cfg(target_os = "ios")]
+    text_input_handler: super::ios::IOSTextInputHandler,
+
     #[cfg(any(enable_accesskit, muda))]
     event_loop_proxy: EventLoopProxy<SlintEvent>,
 
@@ -400,6 +403,8 @@ impl WinitWindowAdapter {
             renderer,
             #[cfg(target_arch = "wasm32")]
             virtual_keyboard_helper: Default::default(),
+            #[cfg(target_os = "ios")]
+            text_input_handler: super::ios::IOSTextInputHandler::new(),
             #[cfg(any(enable_accesskit, muda))]
             event_loop_proxy: proxy,
             window_event_filter: Cell::new(None),
@@ -1362,6 +1367,19 @@ impl WindowAdapter for WinitWindowAdapter {
             }
             _ => {}
         };
+    }
+
+    #[cfg(target_os = "ios")]
+    fn text_input_focused(
+        &self,
+        controller: Rc<dyn i_slint_core::text_input_controller::TextInputController>,
+    ) {
+        self.text_input_handler.on_text_input_focused(controller);
+    }
+
+    #[cfg(target_os = "ios")]
+    fn text_input_unfocused(&self) {
+        self.text_input_handler.on_text_input_unfocused();
     }
 }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -765,6 +765,123 @@ impl Window {
     pub fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         self.0.window_adapter().renderer().take_snapshot()
     }
+
+    // ===== Input Method (IME) APIs =====
+    //
+    // These methods allow platform backends to interact with text input fields.
+    // They are primarily designed for mobile platforms (Android, iOS) where the
+    // platform IME needs synchronous access to query and modify text state.
+
+    /// Returns the current input method properties if a TextInput has focus.
+    ///
+    /// This allows platforms to query the current state of the text input field,
+    /// which is the inverse of receiving `InputMethodRequest::Update` notifications.
+    ///
+    /// Returns `None` if no TextInput element is currently focused.
+    pub fn input_method_properties(
+        &self,
+    ) -> Option<crate::window::InputMethodProperties> {
+        self.0.input_method_properties()
+    }
+
+    /// Commits text at the cursor position, replacing any active preedit.
+    ///
+    /// This is called by platform IME when the user confirms text input
+    /// (e.g., tapping a word suggestion or pressing space).
+    ///
+    /// # Arguments
+    /// * `text` - The text to commit
+    /// * `cursor_offset` - Where to place cursor relative to inserted text end
+    ///   (0 = at end, negative = before, positive = after)
+    ///
+    /// # Errors
+    /// Returns `Err` if no TextInput is focused.
+    pub fn ime_commit_text(
+        &self,
+        text: &str,
+        cursor_offset: i32,
+    ) -> Result<(), crate::window::TextInputError> {
+        self.0.ime_commit_text(text, cursor_offset)
+    }
+
+    /// Sets preedit/composition text without committing.
+    ///
+    /// Preedit text is displayed at the cursor position but is not yet part of the
+    /// committed text. It's typically shown with special styling (underline).
+    ///
+    /// # Arguments
+    /// * `text` - The preedit text to display
+    /// * `cursor` - Cursor position within the preedit (byte offset), or None for end
+    ///
+    /// # Errors
+    /// Returns `Err` if no TextInput is focused or if `cursor` is not on a valid
+    /// UTF-8 character boundary.
+    pub fn ime_set_preedit(
+        &self,
+        text: &str,
+        cursor: Option<usize>,
+    ) -> Result<(), crate::window::TextInputError> {
+        self.0.ime_set_preedit(text, cursor)
+    }
+
+    /// Clears preedit text without committing.
+    ///
+    /// This is called when the user cancels composition (e.g., pressing Escape).
+    ///
+    /// # Errors
+    /// Returns `Err` if no TextInput is focused.
+    pub fn ime_clear_preedit(&self) -> Result<(), crate::window::TextInputError> {
+        self.0.ime_clear_preedit()
+    }
+
+    /// Sets the composing region on existing committed text.
+    ///
+    /// The composing region marks a range of existing text as "being edited" by the IME.
+    /// This is used by autocorrect features to highlight suggested corrections.
+    ///
+    /// # Arguments
+    /// * `region` - The (start, end) byte offsets, or None to clear the region
+    ///
+    /// # Errors
+    /// Returns `Err` if no TextInput is focused or if the byte offsets are invalid.
+    pub fn ime_set_composing_region(
+        &self,
+        region: Option<(usize, usize)>,
+    ) -> Result<(), crate::window::TextInputError> {
+        self.0.ime_set_composing_region(region)
+    }
+
+    /// Deletes text around the cursor.
+    ///
+    /// # Arguments
+    /// * `before` - Number of bytes to delete before the cursor
+    /// * `after` - Number of bytes to delete after the cursor
+    ///
+    /// # Errors
+    /// Returns `Err` if no TextInput is focused or if deletion would split a UTF-8 character.
+    pub fn ime_delete_surrounding(
+        &self,
+        before: usize,
+        after: usize,
+    ) -> Result<(), crate::window::TextInputError> {
+        self.0.ime_delete_surrounding(before, after)
+    }
+
+    /// Sets the selection range.
+    ///
+    /// # Arguments
+    /// * `start` - Start byte offset
+    /// * `end` - End byte offset. If start == end, this just moves the cursor.
+    ///
+    /// # Errors
+    /// Returns `Err` if no TextInput is focused or if the byte offsets are invalid.
+    pub fn ime_set_selection(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> Result<(), crate::window::TextInputError> {
+        self.0.ime_set_selection(start, end)
+    }
 }
 
 #[i_slint_core_macros::slint_doc]

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -882,6 +882,63 @@ impl Window {
     ) -> Result<(), crate::window::TextInputError> {
         self.0.ime_set_selection(start, end)
     }
+
+    // ===== Soft Keyboard APIs =====
+
+    /// Returns the current soft keyboard state.
+    ///
+    /// This returns the last state set by [`set_soft_keyboard_state()`](Self::set_soft_keyboard_state).
+    /// On desktop platforms without a soft keyboard, this returns a default state with
+    /// `visible: false` and `height: 0`.
+    pub fn soft_keyboard_state(&self) -> crate::window::SoftKeyboardState {
+        self.0.soft_keyboard_state()
+    }
+
+    /// Called by platform backends when soft keyboard visibility or size changes.
+    ///
+    /// This updates the internal keyboard state and triggers layout recalculation.
+    /// If a TextInput is focused and would be occluded by the keyboard, Slint will
+    /// attempt to scroll it into view.
+    ///
+    /// # Arguments
+    /// * `state` - The new keyboard state
+    ///
+    /// # Example
+    /// ```ignore
+    /// // Keyboard appearing with 300px height
+    /// window.set_soft_keyboard_state(SoftKeyboardState {
+    ///     visible: true,
+    ///     height: 300.0,
+    ///     animation_duration_ms: Some(250),
+    ///     animation_progress: Some(0.0),
+    /// });
+    ///
+    /// // During animation, update progress
+    /// window.set_soft_keyboard_state(SoftKeyboardState {
+    ///     visible: true,
+    ///     height: 300.0,
+    ///     animation_duration_ms: Some(250),
+    ///     animation_progress: Some(0.5),
+    /// });
+    ///
+    /// // Keyboard fully visible
+    /// window.set_soft_keyboard_state(SoftKeyboardState {
+    ///     visible: true,
+    ///     height: 300.0,
+    ///     animation_duration_ms: None,
+    ///     animation_progress: Some(1.0),
+    /// });
+    ///
+    /// // Keyboard hiding
+    /// window.set_soft_keyboard_state(SoftKeyboardState {
+    ///     visible: false,
+    ///     height: 0.0,
+    ///     ..Default::default()
+    /// });
+    /// ```
+    pub fn set_soft_keyboard_state(&self, state: crate::window::SoftKeyboardState) {
+        self.0.set_soft_keyboard_state(state);
+    }
 }
 
 #[i_slint_core_macros::slint_doc]

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -778,9 +778,7 @@ impl Window {
     /// which is the inverse of receiving `InputMethodRequest::Update` notifications.
     ///
     /// Returns `None` if no TextInput element is currently focused.
-    pub fn input_method_properties(
-        &self,
-    ) -> Option<crate::window::InputMethodProperties> {
+    pub fn input_method_properties(&self) -> Option<crate::window::InputMethodProperties> {
         self.0.input_method_properties()
     }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1180,10 +1180,8 @@ impl Item for TextInput {
                 // FIXME: This should be tracked by a PropertyTracker in window and toggled when read_only() toggles.
                 if !self.read_only() {
                     // Create and provide a TextInputController for platform IME integration
-                    let controller = alloc::rc::Rc::new(CoreTextInputController::new(
-                        self_rc,
-                        window_adapter,
-                    ));
+                    let controller =
+                        alloc::rc::Rc::new(CoreTextInputController::new(self_rc, window_adapter));
                     window_adapter.text_input_focused(controller);
 
                     window_adapter.handle_input_method_request(InputMethodRequest::Enable(
@@ -2224,11 +2222,8 @@ impl TextInput {
 
         // Get preedit styling properties, using None to indicate default (text_color)
         let preedit_color_prop = self.preedit_color();
-        let preedit_color = if preedit_color_prop == Brush::default() {
-            None
-        } else {
-            Some(preedit_color_prop)
-        };
+        let preedit_color =
+            if preedit_color_prop == Brush::default() { None } else { Some(preedit_color_prop) };
 
         let preedit_underline_color_prop = self.preedit_underline_color();
         let preedit_underline_color = if preedit_underline_color_prop == Brush::default() {

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -57,6 +57,7 @@ pub mod slice;
 pub mod string;
 pub mod styled_text;
 pub mod tests;
+pub mod text_input_controller;
 pub mod textlayout;
 pub mod timers;
 pub mod translations;

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -14,8 +14,8 @@ pub use crate::renderer::Renderer;
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::unsafe_single_threaded::OnceCell;
 pub use crate::window::{
-    InputMethodProperties, InputMethodRequest, LayoutConstraints, TextInputError, WindowAdapter,
-    WindowProperties,
+    InputMethodProperties, InputMethodRequest, LayoutConstraints, SoftKeyboardState,
+    TextInputError, WindowAdapter, WindowProperties,
 };
 pub use crate::text_input_controller::{
     byte_offset_to_char_count, ceil_byte_offset, char_count_to_byte_offset, floor_byte_offset,

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -12,8 +12,10 @@ pub use crate::api::PlatformError;
 use crate::api::{LogicalPosition, LogicalSize};
 pub use crate::renderer::Renderer;
 pub use crate::text_input_controller::{
-    CoreTextInputController, TextInputController, byte_offset_to_char_count, ceil_byte_offset,
+    byte_offset_to_char_count, byte_offset_to_utf16_offset, ceil_byte_offset,
     char_count_to_byte_offset, floor_byte_offset, is_valid_byte_offset,
+    utf16_offset_to_byte_offset, utf16_offset_to_byte_offset_clamped, CoreTextInputController,
+    TextInputController,
 };
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::unsafe_single_threaded::OnceCell;

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -11,15 +11,15 @@ use crate::SharedString;
 pub use crate::api::PlatformError;
 use crate::api::{LogicalPosition, LogicalSize};
 pub use crate::renderer::Renderer;
+pub use crate::text_input_controller::{
+    CoreTextInputController, TextInputController, byte_offset_to_char_count, ceil_byte_offset,
+    char_count_to_byte_offset, floor_byte_offset, is_valid_byte_offset,
+};
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::unsafe_single_threaded::OnceCell;
 pub use crate::window::{
     InputMethodProperties, InputMethodRequest, LayoutConstraints, SoftKeyboardState,
     TextInputError, WindowAdapter, WindowProperties,
-};
-pub use crate::text_input_controller::{
-    byte_offset_to_char_count, ceil_byte_offset, char_count_to_byte_offset, floor_byte_offset,
-    is_valid_byte_offset, CoreTextInputController, TextInputController,
 };
 use alloc::boxed::Box;
 use alloc::rc::Rc;

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -12,10 +12,9 @@ pub use crate::api::PlatformError;
 use crate::api::{LogicalPosition, LogicalSize};
 pub use crate::renderer::Renderer;
 pub use crate::text_input_controller::{
-    byte_offset_to_char_count, byte_offset_to_utf16_offset, ceil_byte_offset,
-    char_count_to_byte_offset, floor_byte_offset, is_valid_byte_offset,
-    utf16_offset_to_byte_offset, utf16_offset_to_byte_offset_clamped, CoreTextInputController,
-    TextInputController,
+    CoreTextInputController, TextInputController, byte_offset_to_char_count,
+    byte_offset_to_utf16_offset, ceil_byte_offset, char_count_to_byte_offset, floor_byte_offset,
+    is_valid_byte_offset, utf16_offset_to_byte_offset, utf16_offset_to_byte_offset_clamped,
 };
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::unsafe_single_threaded::OnceCell;

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -13,7 +13,10 @@ use crate::api::{LogicalPosition, LogicalSize};
 pub use crate::renderer::Renderer;
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::unsafe_single_threaded::OnceCell;
-pub use crate::window::{LayoutConstraints, WindowAdapter, WindowProperties};
+pub use crate::window::{
+    InputMethodProperties, InputMethodRequest, LayoutConstraints, TextInputError, WindowAdapter,
+    WindowProperties,
+};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::string::String;

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -17,6 +17,10 @@ pub use crate::window::{
     InputMethodProperties, InputMethodRequest, LayoutConstraints, TextInputError, WindowAdapter,
     WindowProperties,
 };
+pub use crate::text_input_controller::{
+    byte_offset_to_char_count, ceil_byte_offset, char_count_to_byte_offset, floor_byte_offset,
+    is_valid_byte_offset, CoreTextInputController, TextInputController,
+};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::string::String;

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -176,6 +176,47 @@ pub fn simulate_ime_set_composing_region(
     }
 }
 
+/// Simulate setting the soft keyboard state.
+///
+/// This simulates the behavior of a platform reporting soft keyboard visibility changes.
+/// It updates the window's virtual keyboard properties which can affect layout.
+///
+/// # Arguments
+/// * `visible` - Whether the keyboard is visible
+/// * `height` - Height of the keyboard in logical pixels
+#[cfg(feature = "std")]
+pub fn simulate_set_soft_keyboard_state(
+    visible: bool,
+    height: f32,
+    window_adapter: &crate::window::WindowAdapterRc,
+) {
+    use crate::window::{SoftKeyboardState, WindowInner};
+
+    let state = SoftKeyboardState {
+        visible,
+        height,
+        animation_duration_ms: None,
+        animation_progress: None,
+    };
+
+    let window_inner = WindowInner::from_pub(window_adapter.window());
+    window_inner.set_soft_keyboard_state(state);
+}
+
+/// Get the current soft keyboard state.
+///
+/// Returns (visible, height) tuple.
+#[cfg(feature = "std")]
+pub fn get_soft_keyboard_state(
+    window_adapter: &crate::window::WindowAdapterRc,
+) -> (bool, f32) {
+    use crate::window::WindowInner;
+
+    let window_inner = WindowInner::from_pub(window_adapter.window());
+    let state = window_inner.soft_keyboard_state();
+    (state.visible, state.height)
+}
+
 /// implementation details for debug_log()
 #[doc(hidden)]
 pub fn debug_log_impl(args: core::fmt::Arguments) {

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -115,7 +115,12 @@ pub fn simulate_ime_preedit(
             if preedit.is_empty() {
                 text_input.as_pin_ref().ime_clear_preedit(window_adapter, &focus_item);
             } else {
-                text_input.as_pin_ref().ime_set_preedit(preedit, cursor, window_adapter, &focus_item);
+                text_input.as_pin_ref().ime_set_preedit(
+                    preedit,
+                    cursor,
+                    window_adapter,
+                    &focus_item,
+                );
             }
         }
     }
@@ -145,7 +150,12 @@ pub fn simulate_ime_commit(
     if let Some(focus_item) = window_inner.focus_item.borrow().upgrade() {
         // Check if it's a TextInput
         if let Some(text_input) = focus_item.downcast::<TextInput>() {
-            text_input.as_pin_ref().ime_commit_text(text, cursor_offset, window_adapter, &focus_item);
+            text_input.as_pin_ref().ime_commit_text(
+                text,
+                cursor_offset,
+                window_adapter,
+                &focus_item,
+            );
         }
     }
 }
@@ -207,9 +217,7 @@ pub fn simulate_set_soft_keyboard_state(
 ///
 /// Returns (visible, height) tuple.
 #[cfg(feature = "std")]
-pub fn get_soft_keyboard_state(
-    window_adapter: &crate::window::WindowAdapterRc,
-) -> (bool, f32) {
+pub fn get_soft_keyboard_state(window_adapter: &crate::window::WindowAdapterRc) -> (bool, f32) {
     use crate::window::WindowInner;
 
     let window_inner = WindowInner::from_pub(window_adapter.window());

--- a/internal/core/text_input_controller.rs
+++ b/internal/core/text_input_controller.rs
@@ -1,0 +1,527 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Text Input Controller for platform IME integration.
+//!
+//! This module provides the [`TextInputController`] trait that abstracts text input
+//! handling for mobile platforms (Android InputConnection, iOS UITextInput).
+
+use crate::item_tree::{ItemRc, ItemWeak};
+use crate::items::TextInput;
+use crate::lengths::LogicalRect;
+use crate::window::WindowAdapter;
+use crate::SharedString;
+use alloc::rc::{Rc, Weak};
+use core::cell::Cell;
+
+/// Trait for platform-specific text input handling.
+///
+/// Implementations bridge between Slint's TextInput element and platform IME
+/// protocols (Android InputConnection, iOS UITextInput).
+///
+/// # Thread Safety
+///
+/// All methods must be called on the main/UI thread. This trait does NOT require
+/// `Send + Sync`. Platform backends must ensure all calls happen on the correct thread.
+///
+/// # Byte Offsets
+///
+/// All position parameters are **byte offsets** into UTF-8 strings, not character
+/// counts. Platform code must convert to/from native offset systems (e.g., Java
+/// char offsets for Android). Use the byte offset utility functions in this module
+/// for conversions.
+///
+/// # Lifetime
+///
+/// Controllers are valid only while the associated TextInput has focus. Calling
+/// methods after the TextInput loses focus returns errors or default values.
+/// Use [`is_valid()`](TextInputController::is_valid) to check.
+pub trait TextInputController {
+    // ===== Validity =====
+
+    /// Returns true if this controller is still valid (TextInput still focused).
+    ///
+    /// Platform should check this before using the controller. After a TextInput
+    /// loses focus or is destroyed, this returns false.
+    fn is_valid(&self) -> bool;
+
+    // ===== Queries (Platform calls these) =====
+
+    /// Returns up to `max_bytes` of text before the cursor.
+    ///
+    /// Used by Android's `InputConnection.getTextBeforeCursor()`.
+    /// May return fewer bytes to avoid splitting a UTF-8 character.
+    fn text_before_cursor(&self, max_bytes: usize) -> SharedString;
+
+    /// Returns up to `max_bytes` of text after the cursor.
+    ///
+    /// Used by Android's `InputConnection.getTextAfterCursor()`.
+    /// May return fewer bytes to avoid splitting a UTF-8 character.
+    fn text_after_cursor(&self, max_bytes: usize) -> SharedString;
+
+    /// Returns currently selected text, if any.
+    fn selected_text(&self) -> Option<SharedString>;
+
+    /// Returns full text content (excluding preedit).
+    fn text(&self) -> SharedString;
+
+    /// Returns cursor position as byte offset.
+    fn cursor_position(&self) -> usize;
+
+    /// Returns selection range (start, end) as byte offsets.
+    ///
+    /// If no selection, start == end == cursor position.
+    fn selection(&self) -> (usize, usize);
+
+    /// Returns current composing region on committed text, if any.
+    ///
+    /// This is different from preedit — it marks existing text as "being edited"
+    /// (e.g., for autocorrect suggestions).
+    fn composing_region(&self) -> Option<(usize, usize)>;
+
+    /// Returns current preedit/composition text (empty if not composing).
+    fn preedit_text(&self) -> SharedString;
+
+    /// Returns cursor position within preedit, if any.
+    fn preedit_cursor(&self) -> Option<usize>;
+
+    /// Returns cursor rect in window coordinates (for IME popup positioning).
+    fn cursor_rect(&self) -> LogicalRect;
+
+    // ===== Mutations (Platform calls these) =====
+    // All mutations return false if controller is invalid or operation failed.
+
+    /// Commits text at cursor position, replacing any preedit.
+    ///
+    /// # Arguments
+    /// * `text` - The text to commit
+    /// * `cursor_offset` - Where to place cursor relative to inserted text end
+    ///   (0 = at end, negative = before, positive = after)
+    ///
+    /// Returns false if controller is invalid or operation failed.
+    fn commit_text(&self, text: &str, cursor_offset: i32) -> bool;
+
+    /// Sets preedit/composition text (not yet committed).
+    ///
+    /// # Arguments
+    /// * `text` - The composition text to display
+    /// * `cursor` - Byte offset within preedit for cursor, or None for end
+    ///
+    /// Returns false if controller is invalid or operation failed.
+    fn set_preedit(&self, text: &str, cursor: Option<usize>) -> bool;
+
+    /// Clears preedit without committing.
+    ///
+    /// Returns false if controller is invalid.
+    fn clear_preedit(&self) -> bool;
+
+    /// Sets the composing region on existing committed text.
+    ///
+    /// Used when IME wants to mark existing text as "being edited".
+    /// Pass None to clear the composing region.
+    ///
+    /// Returns false if controller is invalid or offsets are invalid.
+    fn set_composing_region(&self, region: Option<(usize, usize)>) -> bool;
+
+    /// Commits (finalizes) any active preedit, keeping its text.
+    ///
+    /// Returns false if controller is invalid.
+    fn finish_composing(&self) -> bool;
+
+    /// Deletes bytes around cursor.
+    ///
+    /// # Arguments
+    /// * `before` - Bytes to delete before cursor
+    /// * `after` - Bytes to delete after cursor
+    ///
+    /// Returns false if this would split a UTF-8 character or controller is invalid.
+    fn delete_surrounding(&self, before: usize, after: usize) -> bool;
+
+    /// Sets cursor position (byte offset). Clears selection.
+    ///
+    /// Returns false if offset is invalid or controller is invalid.
+    fn set_cursor(&self, position: usize) -> bool;
+
+    /// Sets selection range (byte offsets).
+    ///
+    /// Returns false if offsets are invalid or controller is invalid.
+    fn set_selection(&self, start: usize, end: usize) -> bool;
+
+    // ===== Batch editing =====
+
+    /// Begins a batch edit. Multiple mutations are accumulated.
+    ///
+    /// Batch edits can be nested — the implementation counts calls and only
+    /// applies changes when the final `end_batch_edit()` is called.
+    ///
+    /// Returns false if controller is invalid.
+    fn begin_batch_edit(&self) -> bool;
+
+    /// Ends batch edit. Apply all accumulated changes atomically.
+    ///
+    /// Triggers a single `edited` callback even for multiple changes.
+    /// Returns false if no batch edit was in progress or controller is invalid.
+    fn end_batch_edit(&self) -> bool;
+}
+
+/// Default implementation of [`TextInputController`] for Slint's TextInput element.
+///
+/// This struct bridges the platform IME to the core TextInput item.
+pub struct CoreTextInputController {
+    /// Weak reference to the TextInput item — becomes invalid when item loses focus
+    text_input: ItemWeak,
+    /// Weak reference to window for triggering updates
+    window_adapter: Weak<dyn WindowAdapter>,
+    /// Batch edit nesting counter
+    batch_edit_count: Cell<u32>,
+}
+
+impl CoreTextInputController {
+    /// Creates a new controller for the given TextInput.
+    ///
+    /// The controller holds weak references and will become invalid when the
+    /// TextInput loses focus or is destroyed.
+    pub fn new(text_input: &ItemRc, window_adapter: &Rc<dyn WindowAdapter>) -> Self {
+        Self {
+            text_input: text_input.downgrade(),
+            window_adapter: Rc::downgrade(window_adapter),
+            batch_edit_count: Cell::new(0),
+        }
+    }
+
+    /// Helper to get the TextInput if still valid.
+    fn with_text_input<R>(&self, f: impl FnOnce(core::pin::Pin<&TextInput>, &ItemRc, &Rc<dyn WindowAdapter>) -> R) -> Option<R> {
+        let item_rc = self.text_input.upgrade()?;
+        let window_adapter = self.window_adapter.upgrade()?;
+        let text_input = item_rc.downcast::<TextInput>()?;
+        Some(f(text_input.as_pin_ref(), &item_rc, &window_adapter))
+    }
+
+    /// Validates a byte offset is on a UTF-8 character boundary.
+    fn is_valid_offset(text: &str, offset: usize) -> bool {
+        offset <= text.len() && text.is_char_boundary(offset)
+    }
+}
+
+impl TextInputController for CoreTextInputController {
+    fn is_valid(&self) -> bool {
+        self.text_input.upgrade().is_some() && self.window_adapter.upgrade().is_some()
+    }
+
+    fn text_before_cursor(&self, max_bytes: usize) -> SharedString {
+        self.with_text_input(|ti, _, _| {
+            let text = ti.text();
+            let cursor = ti.cursor_position(&text);
+            let start = cursor.saturating_sub(max_bytes);
+            // Adjust to valid UTF-8 boundary
+            let start = floor_byte_offset(&text, start);
+            text[start..cursor].into()
+        }).unwrap_or_default()
+    }
+
+    fn text_after_cursor(&self, max_bytes: usize) -> SharedString {
+        self.with_text_input(|ti, _, _| {
+            let text = ti.text();
+            let cursor = ti.cursor_position(&text);
+            let end = (cursor + max_bytes).min(text.len());
+            // Adjust to valid UTF-8 boundary
+            let end = ceil_byte_offset(&text, end);
+            text[cursor..end].into()
+        }).unwrap_or_default()
+    }
+
+    fn selected_text(&self) -> Option<SharedString> {
+        self.with_text_input(|ti, _, _| {
+            let (start, end) = ti.selection_anchor_and_cursor();
+            if start == end {
+                None
+            } else {
+                let text = ti.text();
+                Some(text[start..end].into())
+            }
+        }).flatten()
+    }
+
+    fn text(&self) -> SharedString {
+        self.with_text_input(|ti, _, _| ti.text()).unwrap_or_default()
+    }
+
+    fn cursor_position(&self) -> usize {
+        self.with_text_input(|ti, _, _| {
+            let text = ti.text();
+            ti.cursor_position(&text)
+        }).unwrap_or(0)
+    }
+
+    fn selection(&self) -> (usize, usize) {
+        self.with_text_input(|ti, _, _| ti.selection_anchor_and_cursor()).unwrap_or((0, 0))
+    }
+
+    fn composing_region(&self) -> Option<(usize, usize)> {
+        self.with_text_input(|ti, _, _| ti.composing_region.get()).flatten()
+    }
+
+    fn preedit_text(&self) -> SharedString {
+        self.with_text_input(|ti, _, _| ti.preedit_text()).unwrap_or_default()
+    }
+
+    fn preedit_cursor(&self) -> Option<usize> {
+        self.with_text_input(|ti, _, _| {
+            ti.preedit_selection().as_option().map(|sel| sel.end as usize)
+        }).flatten()
+    }
+
+    fn cursor_rect(&self) -> LogicalRect {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            let text = ti.text();
+            let cursor_pos = ti.cursor_position(&text);
+            let rect = window_adapter.renderer().text_input_cursor_rect_for_byte_offset(ti, item_rc, cursor_pos);
+            let origin = item_rc.map_to_window(rect.origin);
+            LogicalRect::new(origin, rect.size)
+        }).unwrap_or_default()
+    }
+
+    fn commit_text(&self, text: &str, cursor_offset: i32) -> bool {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            ti.ime_commit_text(text, cursor_offset, window_adapter, item_rc);
+        }).is_some()
+    }
+
+    fn set_preedit(&self, text: &str, cursor: Option<usize>) -> bool {
+        // Validate cursor offset if provided
+        if let Some(pos) = cursor {
+            if !Self::is_valid_offset(text, pos) {
+                return false;
+            }
+        }
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            ti.ime_set_preedit(text, cursor, window_adapter, item_rc);
+        }).is_some()
+    }
+
+    fn clear_preedit(&self) -> bool {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            ti.ime_clear_preedit(window_adapter, item_rc);
+        }).is_some()
+    }
+
+    fn set_composing_region(&self, region: Option<(usize, usize)>) -> bool {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            // Validate offsets if region is provided
+            if let Some((start, end)) = region {
+                let text = ti.text();
+                if !Self::is_valid_offset(&text, start) || !Self::is_valid_offset(&text, end) {
+                    return false;
+                }
+            }
+            ti.ime_set_composing_region(region, window_adapter, item_rc);
+            true
+        }).unwrap_or(false)
+    }
+
+    fn finish_composing(&self) -> bool {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            let preedit = ti.preedit_text();
+            if !preedit.is_empty() {
+                // Commit the preedit text
+                ti.ime_commit_text(&preedit, 0, window_adapter, item_rc);
+            }
+            // Clear composing region
+            ti.ime_set_composing_region(None, window_adapter, item_rc);
+        }).is_some()
+    }
+
+    fn delete_surrounding(&self, before: usize, after: usize) -> bool {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            let text = ti.text();
+            let cursor = ti.cursor_position(&text);
+            let start = cursor.saturating_sub(before);
+            let end = (cursor + after).min(text.len());
+
+            // Validate UTF-8 boundaries
+            if !Self::is_valid_offset(&text, start) || !Self::is_valid_offset(&text, end) {
+                return false;
+            }
+
+            ti.ime_delete_surrounding(before, after, window_adapter, item_rc);
+            true
+        }).unwrap_or(false)
+    }
+
+    fn set_cursor(&self, position: usize) -> bool {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            let text = ti.text();
+            if !Self::is_valid_offset(&text, position) {
+                return false;
+            }
+            ti.ime_set_selection(position, position, window_adapter, item_rc);
+            true
+        }).unwrap_or(false)
+    }
+
+    fn set_selection(&self, start: usize, end: usize) -> bool {
+        self.with_text_input(|ti, item_rc, window_adapter| {
+            let text = ti.text();
+            if !Self::is_valid_offset(&text, start) || !Self::is_valid_offset(&text, end) {
+                return false;
+            }
+            ti.ime_set_selection(start, end, window_adapter, item_rc);
+            true
+        }).unwrap_or(false)
+    }
+
+    fn begin_batch_edit(&self) -> bool {
+        if !self.is_valid() {
+            return false;
+        }
+        self.batch_edit_count.set(self.batch_edit_count.get() + 1);
+        true
+    }
+
+    fn end_batch_edit(&self) -> bool {
+        let count = self.batch_edit_count.get();
+        if count == 0 {
+            return false;
+        }
+        self.batch_edit_count.set(count - 1);
+        // When count reaches 0, all changes have been applied individually
+        // (batch edit optimization is a future enhancement)
+        true
+    }
+}
+
+// ===== Byte Offset Utility Functions =====
+
+/// Validates that a byte offset is on a UTF-8 character boundary.
+///
+/// # Arguments
+/// * `text` - The UTF-8 string
+/// * `offset` - The byte offset to validate
+///
+/// # Returns
+/// `true` if the offset is valid (within bounds and on a character boundary)
+pub fn is_valid_byte_offset(text: &str, offset: usize) -> bool {
+    offset <= text.len() && text.is_char_boundary(offset)
+}
+
+/// Finds the nearest valid byte offset at or before the given offset.
+///
+/// If the offset is already valid, returns it unchanged.
+/// If the offset is beyond the string length, returns the string length.
+/// If the offset is in the middle of a UTF-8 character, returns the start of that character.
+pub fn floor_byte_offset(text: &str, offset: usize) -> usize {
+    if offset >= text.len() {
+        return text.len();
+    }
+    // Walk backwards to find a valid boundary
+    let mut pos = offset;
+    while pos > 0 && !text.is_char_boundary(pos) {
+        pos -= 1;
+    }
+    pos
+}
+
+/// Finds the nearest valid byte offset at or after the given offset.
+///
+/// If the offset is already valid, returns it unchanged.
+/// If the offset is beyond the string length, returns the string length.
+/// If the offset is in the middle of a UTF-8 character, returns the start of the next character.
+pub fn ceil_byte_offset(text: &str, offset: usize) -> usize {
+    if offset >= text.len() {
+        return text.len();
+    }
+    // Walk forwards to find a valid boundary
+    let mut pos = offset;
+    while pos < text.len() && !text.is_char_boundary(pos) {
+        pos += 1;
+    }
+    pos
+}
+
+/// Converts a byte offset to a character (Unicode scalar value) count.
+///
+/// Useful for platforms that need character-based offsets (e.g., Java strings).
+///
+/// # Arguments
+/// * `text` - The UTF-8 string
+/// * `byte_offset` - The byte offset to convert
+///
+/// # Returns
+/// The number of characters before the byte offset
+///
+/// # Panics
+/// Panics if `byte_offset` is not on a valid UTF-8 character boundary.
+pub fn byte_offset_to_char_count(text: &str, byte_offset: usize) -> usize {
+    text[..byte_offset].chars().count()
+}
+
+/// Converts a character count to a byte offset.
+///
+/// # Arguments
+/// * `text` - The UTF-8 string
+/// * `char_count` - The number of characters
+///
+/// # Returns
+/// The byte offset after `char_count` characters, or the string length if
+/// `char_count` exceeds the number of characters in the string.
+pub fn char_count_to_byte_offset(text: &str, char_count: usize) -> usize {
+    text.char_indices()
+        .nth(char_count)
+        .map(|(idx, _)| idx)
+        .unwrap_or(text.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_byte_offset() {
+        let text = "héllo";  // é is 2 bytes
+        assert!(is_valid_byte_offset(text, 0));
+        assert!(is_valid_byte_offset(text, 1));
+        assert!(!is_valid_byte_offset(text, 2)); // middle of é
+        assert!(is_valid_byte_offset(text, 3));
+        assert!(is_valid_byte_offset(text, 6)); // end of string
+        assert!(!is_valid_byte_offset(text, 7)); // beyond string
+    }
+
+    #[test]
+    fn test_floor_byte_offset() {
+        let text = "héllo";
+        assert_eq!(floor_byte_offset(text, 0), 0);
+        assert_eq!(floor_byte_offset(text, 1), 1);
+        assert_eq!(floor_byte_offset(text, 2), 1); // middle of é → start of é
+        assert_eq!(floor_byte_offset(text, 3), 3);
+        assert_eq!(floor_byte_offset(text, 10), 6); // beyond → end
+    }
+
+    #[test]
+    fn test_ceil_byte_offset() {
+        let text = "héllo";
+        assert_eq!(ceil_byte_offset(text, 0), 0);
+        assert_eq!(ceil_byte_offset(text, 1), 1);
+        assert_eq!(ceil_byte_offset(text, 2), 3); // middle of é → after é
+        assert_eq!(ceil_byte_offset(text, 3), 3);
+        assert_eq!(ceil_byte_offset(text, 10), 6); // beyond → end
+    }
+
+    #[test]
+    fn test_byte_offset_to_char_count() {
+        let text = "héllo";
+        assert_eq!(byte_offset_to_char_count(text, 0), 0);
+        assert_eq!(byte_offset_to_char_count(text, 1), 1); // after 'h'
+        assert_eq!(byte_offset_to_char_count(text, 3), 2); // after 'é'
+        assert_eq!(byte_offset_to_char_count(text, 6), 5); // end
+    }
+
+    #[test]
+    fn test_char_count_to_byte_offset() {
+        let text = "héllo";
+        assert_eq!(char_count_to_byte_offset(text, 0), 0);
+        assert_eq!(char_count_to_byte_offset(text, 1), 1); // after 'h'
+        assert_eq!(char_count_to_byte_offset(text, 2), 3); // after 'é'
+        assert_eq!(char_count_to_byte_offset(text, 5), 6); // end
+        assert_eq!(char_count_to_byte_offset(text, 10), 6); // beyond → end
+    }
+}

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -189,6 +189,38 @@ pub trait WindowAdapter {
     /// }
     /// ```
     fn handle_input_method_request(&self, _request: InputMethodRequest) {}
+
+    /// Called when a TextInput gains focus and IME should be activated.
+    ///
+    /// Platform backends should:
+    /// 1. Store the controller reference for IME protocol handling
+    /// 2. Show the soft keyboard (on mobile)
+    /// 3. Configure IME based on input type
+    ///
+    /// The controller provides methods for the platform to query and modify text state
+    /// synchronously, which is required by mobile IME protocols (Android InputConnection,
+    /// iOS UITextInput).
+    ///
+    /// The controller is valid until [`text_input_unfocused()`](Self::text_input_unfocused)
+    /// is called. After that, controller methods return errors/defaults.
+    ///
+    /// The default implementation does nothing, which is appropriate for desktop platforms
+    /// that use `handle_input_method_request()` for IME integration.
+    fn text_input_focused(&self, _controller: Rc<dyn crate::text_input_controller::TextInputController>) {
+        // Default: ignore (backwards compatible for desktop)
+    }
+
+    /// Called when TextInput loses focus or is destroyed.
+    ///
+    /// Platform backends should:
+    /// 1. Clear stored controller reference
+    /// 2. Hide soft keyboard (on mobile)
+    /// 3. Commit or cancel any pending IME composition
+    ///
+    /// The default implementation does nothing.
+    fn text_input_unfocused(&self) {
+        // Default: ignore
+    }
 }
 
 /// Implementation details behind [`WindowAdapter`], but since this

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -206,7 +206,10 @@ pub trait WindowAdapter {
     ///
     /// The default implementation does nothing, which is appropriate for desktop platforms
     /// that use `handle_input_method_request()` for IME integration.
-    fn text_input_focused(&self, _controller: Rc<dyn crate::text_input_controller::TextInputController>) {
+    fn text_input_focused(
+        &self,
+        _controller: Rc<dyn crate::text_input_controller::TextInputController>,
+    ) {
         // Default: ignore (backwards compatible for desktop)
     }
 
@@ -1802,11 +1805,12 @@ impl WindowInner {
     /// Returns a reference to the currently focused TextInput, if any.
     ///
     /// This is a helper function for the IME methods.
-    fn focused_text_input(&self) -> Result<VRcMapped<crate::item_tree::ItemTreeVTable, TextInput>, TextInputError> {
-        let focus_item = self.focus_item.borrow().upgrade()
-            .ok_or(TextInputError::NoFocusedTextInput)?;
-        focus_item.downcast::<TextInput>()
-            .ok_or(TextInputError::NoFocusedTextInput)
+    fn focused_text_input(
+        &self,
+    ) -> Result<VRcMapped<crate::item_tree::ItemTreeVTable, TextInput>, TextInputError> {
+        let focus_item =
+            self.focus_item.borrow().upgrade().ok_or(TextInputError::NoFocusedTextInput)?;
+        focus_item.downcast::<TextInput>().ok_or(TextInputError::NoFocusedTextInput)
     }
 
     /// Validates that a byte offset is on a UTF-8 character boundary.
@@ -1828,8 +1832,8 @@ impl WindowInner {
     ///   (0 = at end, negative = before, positive = after)
     pub fn ime_commit_text(&self, text: &str, cursor_offset: i32) -> Result<(), TextInputError> {
         let text_input = self.focused_text_input()?;
-        let focus_item = self.focus_item.borrow().upgrade()
-            .ok_or(TextInputError::NoFocusedTextInput)?;
+        let focus_item =
+            self.focus_item.borrow().upgrade().ok_or(TextInputError::NoFocusedTextInput)?;
         let window_adapter = self.window_adapter();
 
         text_input.as_pin_ref().ime_commit_text(text, cursor_offset, &window_adapter, &focus_item);
@@ -1850,8 +1854,8 @@ impl WindowInner {
         }
 
         let text_input = self.focused_text_input()?;
-        let focus_item = self.focus_item.borrow().upgrade()
-            .ok_or(TextInputError::NoFocusedTextInput)?;
+        let focus_item =
+            self.focus_item.borrow().upgrade().ok_or(TextInputError::NoFocusedTextInput)?;
         let window_adapter = self.window_adapter();
 
         text_input.as_pin_ref().ime_set_preedit(text, cursor, &window_adapter, &focus_item);
@@ -1863,8 +1867,8 @@ impl WindowInner {
     /// This is called when the user cancels composition (e.g., pressing Escape).
     pub fn ime_clear_preedit(&self) -> Result<(), TextInputError> {
         let text_input = self.focused_text_input()?;
-        let focus_item = self.focus_item.borrow().upgrade()
-            .ok_or(TextInputError::NoFocusedTextInput)?;
+        let focus_item =
+            self.focus_item.borrow().upgrade().ok_or(TextInputError::NoFocusedTextInput)?;
         let window_adapter = self.window_adapter();
 
         text_input.as_pin_ref().ime_clear_preedit(&window_adapter, &focus_item);
@@ -1878,10 +1882,13 @@ impl WindowInner {
     ///
     /// # Arguments
     /// * `region` - The (start, end) byte offsets, or None to clear the region
-    pub fn ime_set_composing_region(&self, region: Option<(usize, usize)>) -> Result<(), TextInputError> {
+    pub fn ime_set_composing_region(
+        &self,
+        region: Option<(usize, usize)>,
+    ) -> Result<(), TextInputError> {
         let text_input = self.focused_text_input()?;
-        let focus_item = self.focus_item.borrow().upgrade()
-            .ok_or(TextInputError::NoFocusedTextInput)?;
+        let focus_item =
+            self.focus_item.borrow().upgrade().ok_or(TextInputError::NoFocusedTextInput)?;
         let window_adapter = self.window_adapter();
 
         // Validate byte offsets if region is provided
@@ -1900,10 +1907,14 @@ impl WindowInner {
     /// # Arguments
     /// * `before` - Number of bytes to delete before the cursor
     /// * `after` - Number of bytes to delete after the cursor
-    pub fn ime_delete_surrounding(&self, before: usize, after: usize) -> Result<(), TextInputError> {
+    pub fn ime_delete_surrounding(
+        &self,
+        before: usize,
+        after: usize,
+    ) -> Result<(), TextInputError> {
         let text_input = self.focused_text_input()?;
-        let focus_item = self.focus_item.borrow().upgrade()
-            .ok_or(TextInputError::NoFocusedTextInput)?;
+        let focus_item =
+            self.focus_item.borrow().upgrade().ok_or(TextInputError::NoFocusedTextInput)?;
         let window_adapter = self.window_adapter();
 
         // Validate that deletion won't split UTF-8 characters
@@ -1926,8 +1937,8 @@ impl WindowInner {
     /// * `end` - End byte offset. If start == end, this just moves the cursor.
     pub fn ime_set_selection(&self, start: usize, end: usize) -> Result<(), TextInputError> {
         let text_input = self.focused_text_input()?;
-        let focus_item = self.focus_item.borrow().upgrade()
-            .ok_or(TextInputError::NoFocusedTextInput)?;
+        let focus_item =
+            self.focus_item.borrow().upgrade().ok_or(TextInputError::NoFocusedTextInput)?;
         let window_adapter = self.window_adapter();
 
         let text = text_input.as_pin_ref().text();

--- a/tests/cases/text/preedit.slint
+++ b/tests/cases/text/preedit.slint
@@ -1,0 +1,203 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Tests for preedit/composition text functionality used by IME systems.
+//
+// Preedit (also called "composition" or "marked text") is the uncommitted text
+// shown during IME input. For example, when typing Japanese with romaji input:
+// - Type "nihon" → preedit shows "にほん"
+// - Press Enter → preedit commits to "日本"
+
+export component TestCase inherits Window {
+    width: 300phx;
+    height: 100phx;
+
+    ti := TextInput {
+        width: 100%;
+        height: 100%;
+        text: "Hello";
+    }
+
+    // Expose preedit-text for testing (internal property)
+    out property <string> preedit_text <=> ti.preedit-text;
+    in-out property <string> text <=> ti.text;
+    out property <int> cursor_pos: ti.cursor-position-byte-offset;
+    out property <bool> has_focus: ti.has-focus;
+
+    // Focus the text input for testing
+    callback focus_input();
+    focus_input => {
+        ti.focus();
+    }
+
+    // Move cursor to end for predictable test state
+    callback move_cursor_to_end();
+    move_cursor_to_end => {
+        ti.set-selection-offsets(ti.text.character-count, ti.text.character-count);
+    }
+}
+
+/*
+```rust
+// Test: Preedit text property is accessible and initially empty
+let instance = TestCase::new().unwrap();
+instance.invoke_focus_input();
+slint_testing::mock_elapsed_time(50);
+
+// Initially, preedit should be empty
+assert_eq!(instance.get_preedit_text(), "");
+assert_eq!(instance.get_text(), "Hello");
+assert!(instance.get_has_focus());
+
+// Move cursor to end before typing
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+// Test: Normal keyboard input doesn't set preedit
+slint_testing::send_keyboard_string_sequence(&instance, " World");
+assert_eq!(instance.get_text(), "Hello World");
+assert_eq!(instance.get_preedit_text(), ""); // No preedit with direct input
+
+// Test: IME preedit simulation
+instance.set_text("Test".into());
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+// Simulate IME setting preedit text (like typing "nihon" in Japanese IME)
+slint_testing::simulate_ime_preedit(&instance, "にほん", None);
+slint_testing::mock_elapsed_time(16);
+
+// Preedit should be set, but text should be unchanged
+assert_eq!(instance.get_preedit_text(), "にほん");
+assert_eq!(instance.get_text(), "Test"); // Text unchanged until commit
+
+// Test: IME commit replaces preedit with final text
+slint_testing::simulate_ime_commit(&instance, "日本", 0);
+slint_testing::mock_elapsed_time(16);
+
+// After commit, preedit should be cleared and text should include committed text
+assert_eq!(instance.get_preedit_text(), "");
+assert_eq!(instance.get_text(), "Test日本");
+
+// Test: Clear preedit without committing
+instance.set_text("Start".into());
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+slint_testing::simulate_ime_preedit(&instance, "draft", None);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "draft");
+assert_eq!(instance.get_text(), "Start");
+
+// Clear preedit (simulates user pressing Escape during composition)
+slint_testing::simulate_ime_preedit(&instance, "", None);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "");
+assert_eq!(instance.get_text(), "Start"); // Text unchanged
+
+// Test: Preedit with cursor position
+instance.set_text("ABC".into());
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+// Set preedit with cursor at position 2 (between "に" and "ほ")
+slint_testing::simulate_ime_preedit(&instance, "にほん", Some(3)); // 3 bytes = after first char
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "にほん");
+
+// Test: Multiple preedit updates (simulates incremental composition)
+instance.set_text("".into());
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+slint_testing::simulate_ime_preedit(&instance, "n", None);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "n");
+
+slint_testing::simulate_ime_preedit(&instance, "ni", None);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "ni");
+
+slint_testing::simulate_ime_preedit(&instance, "にh", None);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "にh");
+
+slint_testing::simulate_ime_preedit(&instance, "にほ", None);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "にほ");
+
+// Commit final text
+slint_testing::simulate_ime_commit(&instance, "日本", 0);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_preedit_text(), "");
+assert_eq!(instance.get_text(), "日本");
+
+// Test: Commit with cursor offset
+instance.set_text("prefix".into());
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+slint_testing::simulate_ime_preedit(&instance, "test", None);
+slint_testing::mock_elapsed_time(16);
+
+// Commit with cursor_offset = -2 (cursor 2 positions before end of inserted text)
+slint_testing::simulate_ime_commit(&instance, "XY", -2);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_text(), "prefixXY");
+// Cursor should be at position 6 (after "prefix", before "XY")
+assert_eq!(instance.get_cursor_pos(), 6);
+```
+*/
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+instance.invoke_focus_input();
+slint_testing::mock_elapsed_time(50);
+
+// Initially, preedit should be empty
+assert_eq(instance.get_preedit_text(), "");
+assert_eq(instance.get_text(), "Hello");
+assert(instance.get_has_focus());
+
+// Test: Normal keyboard input doesn't set preedit
+slint_testing::send_keyboard_string_sequence(&instance, " World");
+assert_eq(instance.get_text(), "Hello World");
+assert_eq(instance.get_preedit_text(), ""); // No preedit with direct input
+
+// Test: IME preedit simulation
+instance.set_text("Test");
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+// Simulate IME setting preedit text
+slint_testing::simulate_ime_preedit(&instance, "にほん", {});
+slint_testing::mock_elapsed_time(16);
+
+// Preedit should be set, but text should be unchanged
+assert_eq(instance.get_preedit_text(), "にほん");
+assert_eq(instance.get_text(), "Test");
+
+// Test: IME commit replaces preedit with final text
+slint_testing::simulate_ime_commit(&instance, "日本", 0);
+slint_testing::mock_elapsed_time(16);
+
+assert_eq(instance.get_preedit_text(), "");
+assert_eq(instance.get_text(), "Test日本");
+
+// Test: Clear preedit without committing
+instance.set_text("Start");
+instance.invoke_move_cursor_to_end();
+slint_testing::mock_elapsed_time(16);
+
+slint_testing::simulate_ime_preedit(&instance, "draft", {});
+slint_testing::mock_elapsed_time(16);
+assert_eq(instance.get_preedit_text(), "draft");
+
+slint_testing::simulate_ime_preedit(&instance, "", {});
+slint_testing::mock_elapsed_time(16);
+assert_eq(instance.get_preedit_text(), "");
+assert_eq(instance.get_text(), "Start");
+```
+*/

--- a/tests/cases/text/soft_keyboard.slint
+++ b/tests/cases/text/soft_keyboard.slint
@@ -1,0 +1,206 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Tests for SoftKeyboardState functionality used on mobile platforms.
+//
+// SoftKeyboardState allows platform backends to report soft keyboard visibility
+// and geometry. When the keyboard appears, Slint updates virtual keyboard
+// properties that layouts can use to adjust.
+
+export component TestCase inherits Window {
+    width: 400phx;
+    height: 600phx;
+
+    // Content area that should resize when keyboard appears
+    content := Rectangle {
+        x: 0;
+        y: 0;
+        width: parent.width;
+        height: parent.height - parent.virtual-keyboard-height;
+        background: lightgray;
+
+        ti := TextInput {
+            width: 100%;
+            height: 40phx;
+            y: parent.height - 50phx;
+            text: "Input field";
+        }
+    }
+
+    // Expose virtual keyboard properties for testing
+    out property <length> vk_x: self.virtual-keyboard-x;
+    out property <length> vk_y: self.virtual-keyboard-y;
+    out property <length> vk_width: self.virtual-keyboard-width;
+    out property <length> vk_height: self.virtual-keyboard-height;
+    out property <length> content_height: content.height;
+
+    // Focus helper
+    callback focus_input();
+    focus_input => {
+        ti.focus();
+    }
+}
+
+/*
+```rust
+// Test: Default state - keyboard not visible
+let instance = TestCase::new().unwrap();
+slint_testing::mock_elapsed_time(50);
+
+// Initially, virtual keyboard should have zero dimensions
+assert_eq!(instance.get_vk_height(), 0.0);
+assert_eq!(instance.get_vk_width(), 0.0);
+assert_eq!(instance.get_vk_x(), 0.0);
+assert_eq!(instance.get_vk_y(), 0.0);
+
+// Content should fill the full height
+assert_eq!(instance.get_content_height(), 600.0);
+
+// Test: Check soft keyboard state getter
+let (visible, height) = slint_testing::get_soft_keyboard_state(&instance);
+assert!(!visible);
+assert_eq!(height, 0.0);
+
+// Test: Set keyboard visible with height
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 300.0);
+slint_testing::mock_elapsed_time(16);
+
+// Virtual keyboard properties should be updated
+assert_eq!(instance.get_vk_height(), 300.0);
+assert_eq!(instance.get_vk_width(), 400.0); // Full window width
+assert_eq!(instance.get_vk_x(), 0.0);
+assert_eq!(instance.get_vk_y(), 300.0); // 600 - 300 = 300
+
+// Content should resize to avoid keyboard
+assert_eq!(instance.get_content_height(), 300.0); // 600 - 300
+
+// Verify state getter
+let (visible, height) = slint_testing::get_soft_keyboard_state(&instance);
+assert!(visible);
+assert_eq!(height, 300.0);
+
+// Test: Change keyboard height (e.g., switching keyboard layouts)
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 250.0);
+slint_testing::mock_elapsed_time(16);
+
+assert_eq!(instance.get_vk_height(), 250.0);
+assert_eq!(instance.get_vk_y(), 350.0); // 600 - 250
+assert_eq!(instance.get_content_height(), 350.0);
+
+// Test: Hide keyboard
+slint_testing::simulate_set_soft_keyboard_state(&instance, false, 0.0);
+slint_testing::mock_elapsed_time(16);
+
+// Virtual keyboard should be cleared
+assert_eq!(instance.get_vk_height(), 0.0);
+assert_eq!(instance.get_vk_width(), 0.0);
+assert_eq!(instance.get_vk_x(), 0.0);
+assert_eq!(instance.get_vk_y(), 0.0);
+
+// Content should fill full height again
+assert_eq!(instance.get_content_height(), 600.0);
+
+let (visible, _) = slint_testing::get_soft_keyboard_state(&instance);
+assert!(!visible);
+
+// Test: Keyboard with different heights
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 200.0);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_vk_height(), 200.0);
+assert_eq!(instance.get_content_height(), 400.0);
+
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 350.0);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_vk_height(), 350.0);
+assert_eq!(instance.get_content_height(), 250.0);
+
+// Test: Very small keyboard
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 50.0);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_vk_height(), 50.0);
+assert_eq!(instance.get_content_height(), 550.0);
+
+// Test: Keyboard height equal to window height (edge case)
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 600.0);
+slint_testing::mock_elapsed_time(16);
+assert_eq!(instance.get_vk_height(), 600.0);
+assert_eq!(instance.get_vk_y(), 0.0);
+assert_eq!(instance.get_content_height(), 0.0);
+
+// Clean up
+slint_testing::simulate_set_soft_keyboard_state(&instance, false, 0.0);
+slint_testing::mock_elapsed_time(16);
+
+// Test: Focus text input then show keyboard (typical mobile flow)
+instance.invoke_focus_input();
+slint_testing::mock_elapsed_time(50);
+
+// Keyboard appears
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 280.0);
+slint_testing::mock_elapsed_time(16);
+
+assert_eq!(instance.get_vk_height(), 280.0);
+assert_eq!(instance.get_content_height(), 320.0);
+```
+*/
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::mock_elapsed_time(50);
+
+// Initially, virtual keyboard should have zero dimensions
+assert_eq(instance.get_vk_height(), 0.0f);
+assert_eq(instance.get_vk_width(), 0.0f);
+assert_eq(instance.get_vk_x(), 0.0f);
+assert_eq(instance.get_vk_y(), 0.0f);
+
+// Content should fill the full height
+assert_eq(instance.get_content_height(), 600.0f);
+
+// Test: Check soft keyboard state getter
+auto [visible, height] = slint_testing::get_soft_keyboard_state(&instance);
+assert(!visible);
+assert_eq(height, 0.0f);
+
+// Test: Set keyboard visible with height
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 300.0f);
+slint_testing::mock_elapsed_time(16);
+
+// Virtual keyboard properties should be updated
+assert_eq(instance.get_vk_height(), 300.0f);
+assert_eq(instance.get_vk_width(), 400.0f);
+assert_eq(instance.get_vk_x(), 0.0f);
+assert_eq(instance.get_vk_y(), 300.0f);
+
+// Content should resize to avoid keyboard
+assert_eq(instance.get_content_height(), 300.0f);
+
+// Verify state getter
+auto [visible2, height2] = slint_testing::get_soft_keyboard_state(&instance);
+assert(visible2);
+assert_eq(height2, 300.0f);
+
+// Test: Hide keyboard
+slint_testing::simulate_set_soft_keyboard_state(&instance, false, 0.0f);
+slint_testing::mock_elapsed_time(16);
+
+// Virtual keyboard should be cleared
+assert_eq(instance.get_vk_height(), 0.0f);
+assert_eq(instance.get_vk_width(), 0.0f);
+
+// Content should fill full height again
+assert_eq(instance.get_content_height(), 600.0f);
+
+// Test: Focus text input then show keyboard
+instance.invoke_focus_input();
+slint_testing::mock_elapsed_time(50);
+
+slint_testing::simulate_set_soft_keyboard_state(&instance, true, 280.0f);
+slint_testing::mock_elapsed_time(16);
+
+assert_eq(instance.get_vk_height(), 280.0f);
+assert_eq(instance.get_content_height(), 320.0f);
+```
+*/

--- a/tools/docsnapper/headless.rs
+++ b/tools/docsnapper/headless.rs
@@ -99,11 +99,7 @@ pub struct HeadlessWindow {
     renderer: SkiaRenderer,
 }
 
-impl WindowAdapterInternal for HeadlessWindow {
-    fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
-        self.ime_requests.borrow_mut().push(request)
-    }
-}
+impl WindowAdapterInternal for HeadlessWindow {}
 
 impl WindowAdapter for HeadlessWindow {
     fn window(&self) -> &i_slint_core::api::Window {
@@ -134,6 +130,10 @@ impl WindowAdapter for HeadlessWindow {
 
     fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {
         Some(self)
+    }
+
+    fn handle_input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
+        self.ime_requests.borrow_mut().push(request)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds foundational infrastructure for mobile text input (IME) support on Android and iOS. It establishes the architecture and interfaces that platform-specific implementations will build upon.

### What's included:

**Core Infrastructure:**
- `TextInputController` trait - Platform-agnostic abstraction for IME integration
- `CoreTextInputController` - Default implementation that bridges to Slint's TextInput
- `SoftKeyboardState` - Reports keyboard visibility and geometry for layout adjustment
- Public Window APIs: `ime_set_preedit()`, `ime_commit_text()`, `ime_set_selection()`, `soft_keyboard_state()`

**TextInput Enhancements:**
- Preedit (composition) text support with `preedit-text` property
- Composing region tracking for autocorrect scenarios
- Styling properties: `preedit-foreground`, `preedit-underline-color`, `composing-underline-color`
- IME-specific methods: `ime_set_preedit()`, `ime_commit_text()`, `ime_clear_preedit()`, `ime_set_composing_region()`

**Platform Scaffolding:**
- `AndroidTextInputHandler` - Scaffolding for Android InputConnection integration
- `IOSTextInputHandler` - Scaffolding for iOS UITextInput protocol integration

**Testing Infrastructure:**
- `simulate_ime_preedit()`, `simulate_ime_commit()`, `simulate_ime_set_composing_region()`
- `simulate_set_soft_keyboard_state()`, `get_soft_keyboard_state()`
- Integration tests for preedit and soft keyboard functionality

### Stats:
- 19 files changed, ~4000 lines added
- 44 unit tests for TextInputController
- Platform handler tests (run on respective platforms)
- Integration tests for preedit and soft keyboard

## Known Limitations (follow-up work needed)

This is **scaffolding** - the platform handlers are not yet wired to actual platform APIs.

1. **UTF-16 ↔ UTF-8 offset conversion** - Both Android (Java) and iOS (NSString) use UTF-16 code unit offsets, while Rust uses UTF-8 byte offsets. The scaffolding currently passes offsets directly without conversion, which will cause issues with non-ASCII text (emoji, CJK, etc.).

2. **Composing text cursor positioning** - `AndroidTextInputHandler::set_composing_text` uses simplified cursor logic (`> 0 → end`, `<= 0 → start`). Android's `newCursorPosition` has more nuanced semantics for positioning relative to surrounding text.

3. **Platform handler tests** - Tests are gated by `#[cfg(target_os = "...")]` and will only run on actual Android/iOS devices or emulators.

## Test plan

- [x] `cargo test -p test-driver-rust text_preedit` - Preedit integration tests pass
- [x] `cargo test -p test-driver-rust text_soft_keyboard` - Soft keyboard tests pass
- [x] Unit tests for TextInputController byte offset utilities
- [ ] Manual testing on Android device (future)
- [ ] Manual testing on iOS device (future)