### PR TITLE
CI: use a different workflow to schedule the nightly snapshot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/workflows/build_and_test_reusable.yaml
         with:
             os: ${{ matrix.os }}
-            name: ${{ matrix.name }}
+            name: build_and_test ${{ matrix.name }}
             rust_version: ${{ matrix.rust_version }}
             extra_args: ${{ matrix.extra_args }} --exclude material-gallery
             save_if: ${{ matrix.save_if }}

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -18,9 +18,6 @@ on:
                 required: false
                 description: "Release? Enable options for building binaries for a release (i.e. don't have a -nightly suffix for the extension)"
 
-    schedule:
-        - cron: "0 2 * * *"
-
 env:
     # Keep in sync with features in slint_tool_binary.yaml, cpp_package.yaml, api/node/Cargo.toml, and api/python/slint/Cargo.toml
     SLINT_BINARY_FEATURES: "backend-linuxkms-noseat,backend-winit,renderer-femtovg,renderer-skia,renderer-software"

--- a/.github/workflows/schedule_nightly_snapshot.yaml
+++ b/.github/workflows/schedule_nightly_snapshot.yaml
@@ -1,0 +1,39 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+# We have a different workflow to schedule the nightly snapshot because we want to be able to run
+# it from a different branch
+name: Schedule Nightly snapshot
+
+on:
+  schedule:
+    - cron: "18 2 * * *"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch:
+          - master
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      - name: Check for recent commits
+        id: recent
+        run: |
+          if git log origin/${{ matrix.branch }} --since="24 hours ago" --oneline | grep .; then
+            echo "has_commits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_commits=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger nightly workflow
+        if: steps.recent.outputs.has_commits == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run "Nightly snapshot" --ref ${{ matrix.branch }} --repo ${{ github.repository }} -f private=false


### PR DESCRIPTION
So it can be run with a different branch
