### PR TITLE
figma_import: Update generated Slint syntax to current format

### DIFF
--- a/tools/figma_import/src/rendered.rs
+++ b/tools/figma_import/src/rendered.rs
@@ -120,7 +120,7 @@ pub fn render(
     };
 
     let mut ctx = Ctx::default();
-    writeln!(ctx, "App := Window {{")?;
+    writeln!(ctx, "export component App inherits Window {{")?;
     ctx.indent += 1;
     writeln!(ctx, "background: {background};")?;
     writeln!(ctx, "width: {}px;", frame.absoluteBoundingBox.width)?;


### PR DESCRIPTION
Use `export component App inherits Window` instead of the legacy `App := Window` syntax.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
