### PR TITLE
figma_import: Make Effect deserialization more robust

### DIFF
--- a/tools/figma_import/src/figmatypes.rs
+++ b/tools/figma_import/src/figmatypes.rs
@@ -141,11 +141,12 @@ pub struct LayoutGrid {
     pub count: f32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
 pub struct Effect {
     pub r#type: String,
     pub visible: bool,
-    pub radius: f32,
+    pub radius: Option<f32>,
     pub color: Option<Color>,
     pub blendMode: Option<BlendMode>,
     pub offset: Option<Vector>,


### PR DESCRIPTION
Add Default derive and serde(default) to the Effect struct so that missing fields in the Figma API response don't cause deserialization failures. Change radius to Option<f32> since not all effect types (e.g. BACKGROUND_BLUR) include a radius field.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
