### PR TITLE
iOS: Mention that renderer-skia-opengl is not supported

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -161,6 +161,7 @@ renderer-femtovg-wgpu = ["i-slint-backend-selector/renderer-femtovg-wgpu", "i-sl
 renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use OpenGL.
+## Note: This is not supported on iOS. Use `renderer-skia` on iOS to enable Meta based rendering.
 renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use Vulkan.

--- a/docs/astro/src/content/docs/guide/backends-and-renderers/backend_winit.md
+++ b/docs/astro/src/content/docs/guide/backends-and-renderers/backend_winit.md
@@ -14,14 +14,14 @@ macOS, Windows, Linux with Wayland and X11.
 The Winit backend supports different renderers. They can be explicitly selected for use through the
 `SLINT_BACKEND` environment variable.
 
-| Renderer name  | Supported/Required Graphics APIs              | `SLINT_BACKEND` value to select renderer |
-|----------------|-----------------------------------------------|------------------------------------------|
-| FemtoVG        | OpenGL                                        | `winit-femtovg`                          |
-| FemtoVG (WGPU) | Metal, Direct3D, Vulkan with (http://wgpu.rs) | `winit-femtovg-wgpu`                     |
-| Skia           | OpenGL, Metal, Direct3D, Software-rendering   | `winit-skia`                             |
-| Skia Software  | Software-only rendering with Skia             | `winit-skia-software`                    |
-| Skia OpenGL    | OpenGL rendering with Skia                    | `winit-skia-opengl`                      |
-| software       | Software-rendering, no GPU required           | `winit-software`                         |
+| Renderer name  | Supported/Required Graphics APIs                  | `SLINT_BACKEND` value to select renderer |
+|----------------|---------------------------------------------------|------------------------------------------|
+| FemtoVG        | OpenGL                                            | `winit-femtovg`                          |
+| FemtoVG (WGPU) | Metal, Direct3D, Vulkan with (http://wgpu.rs)     | `winit-femtovg-wgpu`                     |
+| Skia           | OpenGL, Metal, Direct3D, Software-rendering       | `winit-skia`                             |
+| Skia Software  | Software-only rendering with Skia                 | `winit-skia-software`                    |
+| Skia OpenGL    | OpenGL rendering with Skia (not supported on iOS) | `winit-skia-opengl`                      |
+| software       | Software-rendering, no GPU required               | `winit-software`                         |
 
 If no renderer is explicitly set, the backend will first try to use the Skia renderer, if it was enabled at compile time.
 If that fails, it will fall back to the FemtoVG renderer, and if that also fails, it will use the software renderer.

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -91,6 +91,7 @@ renderer-femtovg-wgpu = ["i-slint-backend-selector/renderer-femtovg-wgpu", "std"
 renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use OpenGL.
+## Note: This is not supported on iOS. Use `renderer-skia` on iOS to enable Meta based rendering.
 renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use Vulkan.


### PR DESCRIPTION
This was previously just a run-time error, now it's also documented.

cc #10619

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
