### PR TITLE
Skia: only align to the grid if the transformation is purely translation

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -414,6 +414,9 @@ impl<'a> SkiaItemRenderer<'a> {
 
     fn pixel_align_origin_auto_restore(&self) -> Option<skia_safe::canvas::AutoRestoredCanvas<'_>> {
         let local_to_device = self.canvas.local_to_device_as_3x3();
+        if !local_to_device.is_translate() || local_to_device.is_identity() {
+            return None;
+        }
         let Some(device_to_local) = local_to_device.invert() else {
             return None;
         };


### PR DESCRIPTION
Any other operation prevents perfect alignment anyway

Fixes #10620
