### PR TITLE
Add bevy-hosts-slint-gpu example to nightly tests

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -290,6 +290,9 @@ jobs:
             - name: Build bevy-hosts-slint Example
               run: cargo build
               working-directory: examples/bevy-hosts-slint
+            - name: Build bevy-hosts-slint-gpu Example
+              run: cargo build
+              working-directory: examples/bevy-hosts-slint-gpu
 
     android_wgpu:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add the newly merged `bevy-hosts-slint-gpu` example to the nightly CI workflow
- Ensures the example builds on all three platforms (Ubuntu, macOS, Windows)

## Test plan
- CI will verify the example builds on nightly runs