### PR TITLE
Rename BoxLayout-specific functions/enums with "box" in the name

### DIFF
--- a/docs/agents/layout-system.md
+++ b/docs/agents/layout-system.md
@@ -121,8 +121,8 @@ Child x/y/width/height bound to cache access expressions
 | Expression | Purpose |
 |------------|---------|
 | `OrganizeGridLayout` | Compute cell row/column assignments |
-| `SolveGridLayout` | Compute positions and sizes |
-| `SolveLayout` | Box layout solving |
+| `SolveBoxLayout`    | Compute positions and sizes for items in a box layout |
+| `SolveGridLayout`   | Compute positions and sizes for items in a grid layout |
 | `ComputeLayoutInfo` | Calculate combined constraints |
 | `LayoutCacheAccess` | Read position/size from cache |
 

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -783,15 +783,15 @@ pub enum Expression {
     /// Organize a grid layout, i.e. decide what goes where
     OrganizeGridLayout(crate::layout::GridLayout),
 
-    /// Compute the LayoutInfo for the given layout.
+    /// Compute the LayoutInfo for the given box layout.
     /// The orientation is the orientation of the cache, not the orientation of the layout
-    ComputeLayoutInfo(crate::layout::Layout, crate::layout::Orientation),
+    ComputeBoxLayoutInfo(crate::layout::BoxLayout, crate::layout::Orientation),
     ComputeGridLayoutInfo {
         layout_organized_data_prop: NamedReference,
         layout: crate::layout::GridLayout,
         orientation: crate::layout::Orientation,
     },
-    SolveLayout(crate::layout::Layout, crate::layout::Orientation),
+    SolveBoxLayout(crate::layout::BoxLayout, crate::layout::Orientation),
     SolveGridLayout {
         layout_organized_data_prop: NamedReference,
         layout: crate::layout::GridLayout,
@@ -925,9 +925,9 @@ impl Expression {
             Expression::ReturnStatement(_) => Type::Invalid,
             Expression::LayoutCacheAccess { .. } => Type::LogicalLength,
             Expression::OrganizeGridLayout(..) => Type::ArrayOfU16,
-            Expression::ComputeLayoutInfo(..) => typeregister::layout_info_type().into(),
+            Expression::ComputeBoxLayoutInfo(..) => typeregister::layout_info_type().into(),
             Expression::ComputeGridLayoutInfo { .. } => typeregister::layout_info_type().into(),
-            Expression::SolveLayout(..) => Type::LayoutCache,
+            Expression::SolveBoxLayout(..) => Type::LayoutCache,
             Expression::SolveGridLayout { .. } => Type::LayoutCache,
             Expression::MinMax { ty, .. } => ty.clone(),
             Expression::EmptyComponentFactory => Type::ComponentFactory,
@@ -1027,9 +1027,9 @@ impl Expression {
                 repeater_index.as_deref().map(visitor);
             }
             Expression::OrganizeGridLayout(..) => {}
-            Expression::ComputeLayoutInfo(..) => {}
+            Expression::ComputeBoxLayoutInfo(..) => {}
             Expression::ComputeGridLayoutInfo { .. } => {}
-            Expression::SolveLayout(..) => {}
+            Expression::SolveBoxLayout(..) => {}
             Expression::SolveGridLayout { .. } => {}
             Expression::MinMax { lhs, rhs, .. } => {
                 visitor(lhs);
@@ -1134,9 +1134,9 @@ impl Expression {
                 repeater_index.as_deref_mut().map(visitor);
             }
             Expression::OrganizeGridLayout(..) => {}
-            Expression::ComputeLayoutInfo(..) => {}
+            Expression::ComputeBoxLayoutInfo(..) => {}
             Expression::ComputeGridLayoutInfo { .. } => {}
-            Expression::SolveLayout(..) => {}
+            Expression::SolveBoxLayout(..) => {}
             Expression::SolveGridLayout { .. } => {}
             Expression::MinMax { lhs, rhs, .. } => {
                 visitor(lhs);
@@ -1231,9 +1231,9 @@ impl Expression {
             // TODO:  detect constant property within layouts
             Expression::LayoutCacheAccess { .. } => false,
             Expression::OrganizeGridLayout { .. } => false,
-            Expression::ComputeLayoutInfo(..) => false,
+            Expression::ComputeBoxLayoutInfo(..) => false,
             Expression::ComputeGridLayoutInfo { .. } => false,
-            Expression::SolveLayout(..) => false,
+            Expression::SolveBoxLayout(..) => false,
             Expression::SolveGridLayout { .. } => false,
             Expression::MinMax { lhs, rhs, .. } => lhs.is_constant(ga) && rhs.is_constant(ga),
             Expression::EmptyComponentFactory => true,
@@ -1919,9 +1919,9 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
             }
         }
         Expression::OrganizeGridLayout(..) => write!(f, "organize_grid_layout(..)"),
-        Expression::ComputeLayoutInfo(..) => write!(f, "layout_info(..)"),
+        Expression::ComputeBoxLayoutInfo(..) => write!(f, "layout_info(..)"),
         Expression::ComputeGridLayoutInfo { .. } => write!(f, "grid_layout_info(..)"),
-        Expression::SolveLayout(..) => write!(f, "solve_layout(..)"),
+        Expression::SolveBoxLayout(..) => write!(f, "solve_box_layout(..)"),
         Expression::SolveGridLayout { .. } => write!(f, "solve_grid_layout(..)"),
         Expression::MinMax { ty: _, op, lhs, rhs } => {
             match op {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -26,27 +26,6 @@ pub enum Layout {
 }
 
 impl Layout {
-    pub fn rect(&self) -> &LayoutRect {
-        match self {
-            Layout::GridLayout(g) => &g.geometry.rect,
-            Layout::BoxLayout(g) => &g.geometry.rect,
-        }
-    }
-    pub fn rect_mut(&mut self) -> &mut LayoutRect {
-        match self {
-            Layout::GridLayout(g) => &mut g.geometry.rect,
-            Layout::BoxLayout(g) => &mut g.geometry.rect,
-        }
-    }
-    pub fn geometry(&self) -> &LayoutGeometry {
-        match self {
-            Layout::GridLayout(l) => &l.geometry,
-            Layout::BoxLayout(l) => &l.geometry,
-        }
-    }
-}
-
-impl Layout {
     /// Call the visitor for each NamedReference stored in the layout
     pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
         match self {
@@ -546,7 +525,7 @@ pub struct BoxLayout {
 }
 
 impl BoxLayout {
-    fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
         for cell in &mut self.elems {
             cell.constraints.visit_named_references(visitor);
         }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2667,12 +2667,12 @@ pub fn visit_named_references_in_expression(
         } => vis(r),
         Expression::LayoutCacheAccess { layout_cache_prop, .. } => vis(layout_cache_prop),
         Expression::OrganizeGridLayout(l) => l.visit_named_references(vis),
-        Expression::ComputeLayoutInfo(l, _) => l.visit_named_references(vis),
+        Expression::ComputeBoxLayoutInfo(l, _) => l.visit_named_references(vis),
         Expression::ComputeGridLayoutInfo { layout_organized_data_prop, layout, .. } => {
             vis(layout_organized_data_prop);
             layout.visit_named_references(vis);
         }
-        Expression::SolveLayout(l, _) => l.visit_named_references(vis),
+        Expression::SolveBoxLayout(l, _) => l.visit_named_references(vis),
         Expression::SolveGridLayout { layout_organized_data_prop, layout, .. } => {
             vis(layout_organized_data_prop);
             layout.visit_named_references(vis);

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -520,23 +520,16 @@ fn recurse_expression(
         Expression::LayoutCacheAccess { layout_cache_prop, .. } => {
             vis(&layout_cache_prop.clone().into(), P)
         }
-        Expression::SolveLayout(l, o) | Expression::ComputeLayoutInfo(l, o) => {
+        Expression::SolveBoxLayout(l, o) | Expression::ComputeBoxLayoutInfo(l, o) => {
             // we should only visit the layout geometry for the orientation
-            if matches!(expr, Expression::SolveLayout(..))
-                && let Some(nr) = l.geometry().rect.size_reference(*o)
+            if matches!(expr, Expression::SolveBoxLayout(..))
+                && let Some(nr) = l.geometry.rect.size_reference(*o)
             {
                 vis(&nr.clone().into(), P);
             }
-            match l {
-                crate::layout::Layout::GridLayout(_) => {
-                    panic!("GridLayout should use SolveGridLayout/ComputeGridLayoutInfo")
-                }
-                crate::layout::Layout::BoxLayout(l) => {
-                    visit_layout_items_dependencies(l.elems.iter(), *o, vis)
-                }
-            }
+            visit_layout_items_dependencies(l.elems.iter(), *o, vis);
 
-            let mut g = l.geometry().clone();
+            let mut g = l.geometry.clone();
             g.rect = Default::default(); // already visited;
             g.visit_named_references(&mut |nr| vis(&nr.clone().into(), P))
         }

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -210,8 +210,8 @@ fn simplify_expression(expr: &mut Expression, ga: &GlobalAnalysis) -> bool {
         Expression::ElementReference { .. } => false,
         Expression::LayoutCacheAccess { .. } => false,
         Expression::OrganizeGridLayout { .. } => false,
-        Expression::SolveLayout { .. } => false,
-        Expression::ComputeLayoutInfo { .. } => false,
+        Expression::SolveBoxLayout { .. } => false,
+        Expression::ComputeBoxLayoutInfo { .. } => false,
         _ => {
             let mut result = true;
             expr.visit_mut(|expr| result &= simplify_expression(expr, ga));

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -588,18 +588,11 @@ fn fixup_element_references(expr: &mut Expression, mapping: &Mapping) {
     };
     match expr {
         Expression::ElementReference(element) => fx(element),
-        Expression::SolveLayout(l, _) | Expression::ComputeLayoutInfo(l, _) => match l {
-            crate::layout::Layout::GridLayout(l) => {
-                for e in &mut l.elems {
-                    fxe(&mut e.item.element);
-                }
+        Expression::SolveBoxLayout(l, _) | Expression::ComputeBoxLayoutInfo(l, _) => {
+            for e in &mut l.elems {
+                fxe(&mut e.element);
             }
-            crate::layout::Layout::BoxLayout(l) => {
-                for e in &mut l.elems {
-                    fxe(&mut e.element);
-                }
-            }
-        },
+        }
         Expression::SolveGridLayout { layout, .. }
         | Expression::OrganizeGridLayout(layout)
         | Expression::ComputeGridLayoutInfo { layout, .. } => {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -661,7 +661,7 @@ fn lower_box_layout(
     layout_cache_prop.element().borrow_mut().bindings.insert(
         layout_cache_prop.name().clone(),
         BindingExpression::new_with_span(
-            Expression::SolveLayout(Layout::BoxLayout(layout.clone()), orientation),
+            Expression::SolveBoxLayout(layout.clone(), orientation),
             span.clone(),
         )
         .into(),
@@ -669,10 +669,7 @@ fn lower_box_layout(
     layout_info_prop_h.element().borrow_mut().bindings.insert(
         layout_info_prop_h.name().clone(),
         BindingExpression::new_with_span(
-            Expression::ComputeLayoutInfo(
-                Layout::BoxLayout(layout.clone()),
-                Orientation::Horizontal,
-            ),
+            Expression::ComputeBoxLayoutInfo(layout.clone(), Orientation::Horizontal),
             span.clone(),
         )
         .into(),
@@ -680,7 +677,7 @@ fn lower_box_layout(
     layout_info_prop_v.element().borrow_mut().bindings.insert(
         layout_info_prop_v.name().clone(),
         BindingExpression::new_with_span(
-            Expression::ComputeLayoutInfo(Layout::BoxLayout(layout.clone()), Orientation::Vertical),
+            Expression::ComputeBoxLayoutInfo(layout.clone(), Orientation::Vertical),
             span,
         )
         .into(),

--- a/internal/compiler/passes/resolving/remove_noop.rs
+++ b/internal/compiler/passes/resolving/remove_noop.rs
@@ -102,10 +102,10 @@ fn without_side_effects(expression: &Expression) -> bool {
         // the current function stops at this point.
         Expression::ReturnStatement(_) => false,
         Expression::LayoutCacheAccess { .. } => false,
-        Expression::ComputeLayoutInfo(_, _) => false,
+        Expression::ComputeBoxLayoutInfo(_, _) => false,
         Expression::ComputeGridLayoutInfo { .. } => false,
         Expression::OrganizeGridLayout(_) => false,
-        Expression::SolveLayout(_, _) => false,
+        Expression::SolveBoxLayout(_, _) => false,
         Expression::SolveGridLayout { .. } => false,
         Expression::MinMax { ty: _, op: _, lhs, rhs } => {
             without_side_effects(lhs) && without_side_effects(rhs)

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -492,8 +492,8 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 panic!("invalid layout cache")
             }
         }
-        Expression::ComputeLayoutInfo(lay, o) => {
-            crate::eval_layout::compute_layout_info(lay, *o, local_context)
+        Expression::ComputeBoxLayoutInfo(lay, o) => {
+            crate::eval_layout::compute_box_layout_info(lay, *o, local_context)
         }
         Expression::ComputeGridLayoutInfo { layout_organized_data_prop, layout, orientation } => {
             let cache = load_property_helper(
@@ -516,7 +516,9 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         Expression::OrganizeGridLayout(lay) => {
             crate::eval_layout::organize_grid_layout(lay, local_context)
         }
-        Expression::SolveLayout(lay, o) => crate::eval_layout::solve_layout(lay, *o, local_context),
+        Expression::SolveBoxLayout(lay, o) => {
+            crate::eval_layout::solve_box_layout(lay, *o, local_context)
+        }
         Expression::SolveGridLayout { layout_organized_data_prop, layout, orientation } => {
             let cache = load_property_helper(
                 &ComponentInstance::InstanceRef(local_context.component_instance),


### PR DESCRIPTION
It's clear to me now (especially given that I'm starting to look at implementing a 3rd kind of layout) that those will only ever be useful for box layouts, so pass a BoxLayout instead of a Layout and remove the match() statements.

This also removes the need for the forwarding functions in Layout.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
