### PR TITLE
GridLayout: an empty layout didn't respect the padding, unlike BoxLayout

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -972,7 +972,10 @@ pub fn grid_layout_info(
         None,
     );
     if layout_data.is_empty() {
-        return Default::default();
+        let mut info = LayoutInfo::default();
+        info.min = padding.begin + padding.end;
+        info.preferred = info.min;
+        return info;
     }
     let spacing_w = spacing * (layout_data.len() - 1) as Coord + padding.begin + padding.end;
     let min = layout_data.iter().map(|data| data.min).sum::<Coord>() + spacing_w;

--- a/tests/cases/layout/empty_layout.slint
+++ b/tests/cases/layout/empty_layout.slint
@@ -21,6 +21,8 @@ export component TestCase inherits Window {
             padding-right: 80phx; padding-bottom: 70phx;
         }
     }
+    empty7 := Rectangle { GridLayout { } }
+    empty8 := Rectangle { GridLayout { spacing: 3px; padding: 5px; } }
 
     out property <bool> t1: empty1.min-height == 0 && empty1.min-width == 0 && empty1.preferred-height == 0 && empty1.preferred-width == 0 && empty1.max-height > 10000px && empty1.max-width == 0;
     out property <bool> t2: empty2.min-height == 4px && empty2.min-width == 4px && empty2.preferred-height == 4px && empty2.preferred-width == 4px && empty2.max-height == 4px && empty2.max-width > 100000px;
@@ -28,7 +30,9 @@ export component TestCase inherits Window {
     out property <bool> t4: empty4.min-height == 50phx && empty4.min-width == 10phx && empty4.preferred-height == 50phx && empty4.preferred-width == 10phx && empty4.max-height > 10000px && empty4.max-width > 10000px;
     out property <bool> t5: empty5.min-height == 50phx && empty5.min-width == 10phx && empty5.preferred-height == 50phx && empty5.preferred-width == 10phx && empty5.max-height > 10000px && empty5.max-width > 10000px;
     out property <bool> t6: empty6.min-height == 70phx && empty6.min-width == 80phx && empty6.preferred-height == 70phx && empty6.preferred-width == 80phx && empty6.max-height > 10000px && empty6.max-width == 80phx;
-    out property <bool> test: t1 && t2 && t3 && t4 && t5 && t6;
+    out property <bool> t7: empty7.min-height == 0 && empty7.min-width == 0 && empty7.preferred-height == 0 && empty7.preferred-width == 0 && empty7.max-height > 10000px && empty7.max-width > 10000px;
+    out property <bool> t8: empty8.min-height == 10px && empty8.min-width == 10px && empty8.preferred-height == 10px && empty8.preferred-width == 10px;
+    out property <bool> test: t1 && t2 && t3 && t4 && t5 && t6 && t7 && t8;
 }
 
 /*


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
