### PR TITLE
Fix all clippy warnings in i-slint-renderer-software

### DIFF
--- a/internal/renderers/software/draw_functions.rs
+++ b/internal/renderers/software/draw_functions.rs
@@ -63,7 +63,7 @@ pub(super) fn draw_texture_line(
             let o = (off_x + (delta * (extra_clip_end as i32 + len as i32 - 1)))
                 % Fixed::from_integer(source_size.width);
             pos = o;
-            tile_start = source_size.width as i32;
+            tile_start = source_size.width;
             end = (o / delta) as usize + 1;
             acc_err = -delta + o % delta;
             delta = -delta;

--- a/internal/renderers/software/fonts/vectorfont.rs
+++ b/internal/renderers/software/fonts/vectorfont.rs
@@ -115,8 +115,8 @@ impl VectorFont {
                 let alpha_map: Rc<[u8]> = alpha_map.into();
 
                 let glyph = super::RenderableVectorGlyph {
-                    x: Fixed::from_integer(metrics.xmin.try_into().unwrap()),
-                    y: Fixed::from_integer(metrics.ymin.try_into().unwrap()),
+                    x: Fixed::from_integer(metrics.xmin),
+                    y: Fixed::from_integer(metrics.ymin),
                     width: PhysicalLength::new(metrics.width.try_into().unwrap()),
                     height: PhysicalLength::new(metrics.height.try_into().unwrap()),
                     alpha_map,
@@ -160,15 +160,14 @@ impl TextShaper for VectorFont {
     }
 
     fn glyph_for_char(&self, ch: char) -> Option<Glyph<PhysicalLength>> {
-        NonZeroU16::try_from(self.fontdue_font.lookup_glyph_index(ch)).ok().map(|glyph_id| {
-            let mut out_glyph = Glyph::default();
-            out_glyph.glyph_id = Some(glyph_id);
-            out_glyph.advance = PhysicalLength::new(
+        NonZeroU16::try_from(self.fontdue_font.lookup_glyph_index(ch)).ok().map(|glyph_id| Glyph {
+            glyph_id: Some(glyph_id),
+            advance: PhysicalLength::new(
                 self.fontdue_font
                     .metrics_indexed(glyph_id.get(), self.pixel_size.get() as _)
                     .advance_width as _,
-            );
-            out_glyph
+            ),
+            ..Default::default()
         })
     }
 

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -364,18 +364,18 @@ fn region_line_ranges(
                             return true;
                         }
                         r.start = it.start;
-                        return false;
+                        false
                     } else if it.start <= r.end {
                         if it.end <= r.end {
-                            return false;
+                            false
                         } else {
                             it.start = r.start;
                             tmp = None;
-                            return true;
+                            true
                         }
                     } else {
                         core::mem::swap(it, r);
-                        return true;
+                        true
                     }
                 } else {
                     true
@@ -1108,17 +1108,16 @@ impl RendererSealed for SoftwareRenderer {
         let window = window_adapter.window();
         let size = window.size();
 
-        let Some((width, height)) = size.width.try_into().ok().zip(size.height.try_into().ok())
-        else {
+        if size.width == 0 || size.height == 0 {
             // Nothing to render
             return Err("take_snapshot() called on window with invalid size".into());
         };
 
         let mut target_buffer =
-            SharedPixelBuffer::<i_slint_core::graphics::Rgb8Pixel>::new(width, height);
+            SharedPixelBuffer::<i_slint_core::graphics::Rgb8Pixel>::new(size.width, size.height);
 
         self.set_repaint_buffer_type(RepaintBufferType::NewBuffer);
-        self.render(target_buffer.make_mut_slice(), width as usize);
+        self.render(target_buffer.make_mut_slice(), size.width as usize);
         // ensure that caches are clear for the next call
         self.set_repaint_buffer_type(RepaintBufferType::NewBuffer);
 
@@ -1600,12 +1599,11 @@ fn process_rectangle_impl(
         return;
     }
 
-    if color.alpha > 0 {
-        if let Some(r) =
+    if color.alpha > 0
+        && let Some(r) =
             geom.round().cast().inflate(-border.get(), -border.get()).intersection(clip)
-        {
-            processor.process_simple_rectangle(r, color);
-        }
+    {
+        processor.process_simple_rectangle(r, color);
     }
 
     if border_color.alpha > 0 {
@@ -1675,7 +1673,7 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
                     size: PhysicalSize::new(end - begin, next - line),
                 };
 
-                f(&mut self.buffer, region, extra_left_clip, extra_right_clip);
+                f(self.buffer, region, extra_left_clip, extra_right_clip);
             }
             if next == geometry.max_y() {
                 break;

--- a/internal/renderers/software/scene.rs
+++ b/internal/renderers/software/scene.rs
@@ -129,7 +129,7 @@ impl Scene {
                 .map(|i| i.z);
             let item = loop {
                 if tmp1 != tmp2 {
-                    if future_next_z.map_or(true, |z| self.items[tmp1].z > z) {
+                    if future_next_z.is_none_or(|z| self.items[tmp1].z > z) {
                         let idx = tmp1;
                         tmp1 += 1;
                         if tmp1 == tmp2 {
@@ -144,7 +144,7 @@ impl Scene {
                         j += 1;
                         continue;
                     }
-                    if future_next_z.map_or(true, |z| item.z > z) {
+                    if future_next_z.is_none_or(|z| item.z > z) {
                         j += 1;
                         break *item;
                     }
@@ -215,19 +215,19 @@ impl Scene {
             self.current_line.get(),
             &mut self.current_line_ranges,
         );
-        if self.current_line_ranges.is_empty() {
-            if let Some(next) = validity {
-                self.current_line = Length::new(next);
-                self.range_valid_until_line = Length::new(
-                    super::region_line_ranges(
-                        &self.dirty_region,
-                        self.current_line.get(),
-                        &mut self.current_line_ranges,
-                    )
-                    .unwrap_or_default(),
-                );
-                return true;
-            }
+        if self.current_line_ranges.is_empty()
+            && let Some(next) = validity
+        {
+            self.current_line = Length::new(next);
+            self.range_valid_until_line = Length::new(
+                super::region_line_ranges(
+                    &self.dirty_region,
+                    self.current_line.get(),
+                    &mut self.current_line_ranges,
+                )
+                .unwrap_or_default(),
+            );
+            return true;
         }
         self.range_valid_until_line = Length::new(validity.unwrap_or_default());
         false
@@ -384,8 +384,8 @@ impl SceneTextureExtra {
             offset -= euclid::vec2(tiling.offset_x, tiling.offset_y).cast();
 
             // FIXME: gap
-            tiling.gap_x;
-            tiling.gap_y;
+            let _ = tiling.gap_x;
+            let _ = tiling.gap_y;
 
             (Fixed::from_f32(tiling.scale_x)?, Fixed::from_f32(tiling.scale_y)?)
         } else {

--- a/internal/renderers/software/target_pixel_buffer.rs
+++ b/internal/renderers/software/target_pixel_buffer.rs
@@ -95,7 +95,7 @@ impl DrawTextureArgs {
             TextureDataContainer::Static(data) => data.clone(),
             TextureDataContainer::Shared { buffer, source_rect } => {
                 let stride = buffer.width();
-                let core::ops::Range { start, end } = compute_range_in_buffer(&source_rect, stride);
+                let core::ops::Range { start, end } = compute_range_in_buffer(source_rect, stride);
                 let size = source_rect.size.to_untyped().cast();
 
                 match &buffer {


### PR DESCRIPTION
Partly automated, partly manual.
The biggest changes are the for loop in path.rs
(https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#needless_range_loop)

and the logic change in take_snapshot (the conversions could never fail, so the error "invalid size" never happened - my guess is that it would make sense to return that error when the width or height is 0).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
