### PR TITLE
swrenderer: skip partial rendering cache for NewBuffer mode

### DIFF
--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -599,23 +599,29 @@ impl SoftwareRenderer {
             .draw_contents(|components| {
                 let logical_size = (size.cast() / factor).cast();
 
-                let dirty_region_of_existing_buffer = match self.repaint_buffer_type.get() {
+                match self.repaint_buffer_type.get() {
                     RepaintBufferType::NewBuffer => {
-                        Some(LogicalRect::from_size(logical_size).into())
+                        renderer.dirty_region = LogicalRect::from_size(logical_size).into();
+                        self.partial_rendering_state.clear_cache();
                     }
-                    RepaintBufferType::ReusedBuffer => None,
-                    RepaintBufferType::SwappedBuffers => Some(self.prev_frame_dirty.take()),
-                };
-
-                let dirty_region_for_this_frame = self.partial_rendering_state.apply_dirty_region(
-                    &mut renderer,
-                    components,
-                    logical_size,
-                    dirty_region_of_existing_buffer,
-                );
-
-                if self.repaint_buffer_type.get() == RepaintBufferType::SwappedBuffers {
-                    self.prev_frame_dirty.set(dirty_region_for_this_frame);
+                    RepaintBufferType::ReusedBuffer => {
+                        self.partial_rendering_state.apply_dirty_region(
+                            &mut renderer,
+                            components,
+                            logical_size,
+                            None,
+                        );
+                    }
+                    RepaintBufferType::SwappedBuffers => {
+                        let dirty_region_for_this_frame =
+                            self.partial_rendering_state.apply_dirty_region(
+                                &mut renderer,
+                                components,
+                                logical_size,
+                                Some(self.prev_frame_dirty.take()),
+                            );
+                        self.prev_frame_dirty.set(dirty_region_for_this_frame);
+                    }
                 }
 
                 let rotation = RotationInfo { orientation: rotation, screen_size: size };
@@ -1301,22 +1307,31 @@ fn prepare_scene(
     window.draw_contents(|components| {
         let logical_size = (size.cast() / factor).cast();
 
-        let dirty_region_of_existing_buffer = match software_renderer.repaint_buffer_type.get() {
-            RepaintBufferType::NewBuffer => Some(LogicalRect::from_size(logical_size).into()),
-            RepaintBufferType::ReusedBuffer => None,
-            RepaintBufferType::SwappedBuffers => Some(software_renderer.prev_frame_dirty.take()),
-        };
-
-        let dirty_region_for_this_frame =
-            software_renderer.partial_rendering_state.apply_dirty_region(
-                &mut renderer,
-                components,
-                logical_size,
-                dirty_region_of_existing_buffer,
-            );
-
-        if software_renderer.repaint_buffer_type.get() == RepaintBufferType::SwappedBuffers {
-            software_renderer.prev_frame_dirty.set(dirty_region_for_this_frame);
+        match software_renderer.repaint_buffer_type.get() {
+            RepaintBufferType::NewBuffer => {
+                // NewBuffer always redraws the full screen, so skip dirty region
+                // tracking to avoid unbounded growth of the partial rendering cache.
+                renderer.dirty_region = LogicalRect::from_size(logical_size).into();
+                software_renderer.partial_rendering_state.clear_cache();
+            }
+            RepaintBufferType::ReusedBuffer => {
+                software_renderer.partial_rendering_state.apply_dirty_region(
+                    &mut renderer,
+                    components,
+                    logical_size,
+                    None,
+                );
+            }
+            RepaintBufferType::SwappedBuffers => {
+                let dirty_region_for_this_frame =
+                    software_renderer.partial_rendering_state.apply_dirty_region(
+                        &mut renderer,
+                        components,
+                        logical_size,
+                        Some(software_renderer.prev_frame_dirty.take()),
+                    );
+                software_renderer.prev_frame_dirty.set(dirty_region_for_this_frame);
+            }
         }
 
         let rotation =


### PR DESCRIPTION
When RepaintBufferType::NewBuffer is used, the entire screen is redrawn every frame. Despite this, prepare_scene() was still calling apply_dirty_region() which runs compute_dirty_regions(), populating the PartialRendererCache with PropertyTracker allocations for each item in the component tree.

On memory-constrained targets (e.g., 32KB heap on Cortex-M), this cache growth leads to OOM after interacting with UIs containing many conditional components. The resulting Rust allocation failure triggers a panic, which in freestanding (no_std) builds appears as a silent hang.

Skip dirty region computation for NewBuffer and clear the cache, since the full screen is always repainted regardless.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
