### PR TITLE
Add run_tests.sh script to allow a LLM in agent mode to run tests more easily

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ cargo test -p doctests                        # Documentation snippet tests
 
 ### Filtered Testing
 ```sh
-SLINT_TEST_FILTER=layout cargo test -p test-driver-rust  # Filter by name
+tests/run_tests.sh rust layout     # Filter by name
 ```
 
 ### Syntax Tests (Compiler Errors)

--- a/docs/agents/layout-system.md
+++ b/docs/agents/layout-system.md
@@ -216,7 +216,7 @@ Repeaters (dynamic item lists) in layouts use indirection:
 
 ```sh
 # Run layout-specific tests
-SLINT_TEST_FILTER=layout cargo test -p test-driver-rust
+tests/run_tests.sh rust layout
 
 # Run all interpreter tests (fast)
 cargo test -p test-driver-interpreter

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,12 +68,16 @@ export component Foo inherits Rectangle {
 The rust driver will compile each snippet of code and put it in a `slint!` macro in its own module
 In addition, if there are ```` ```rust ```` blocks in a comment, they are extracted into a `#[test]`
 function in the same module. This is useful to test the rust api.
-This is all compiled in a while program, so the `SLINT_TEST_FILTER` environment variable can be
-set while building to only build the test that matches the filter.
-Example: to test all the layout test:
+The `SLINT_TEST_FILTER` environment variable can be set while building to only build the tests
+that matches the filter.
+Example: to run all the layout tests:
 
 ```
 SLINT_TEST_FILTER=layout cargo test -p test-driver-rust
+```
+or
+```
+tests/run_tests.sh rust layout
 ```
 
 Instead of putting everything in a slint! macro, it's possible to tell the driver to do the
@@ -81,6 +85,10 @@ compilation in the build.rs, with the build-time feature:
 
 ```
 SLINT_TEST_FILTER=layout cargo test -p test-driver-rust --features build-time
+```
+or
+```
+tests/run_tests.sh rust layout --features build-time
 ```
 
 ### C++ driver

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,38 @@
+# Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#!/bin/sh
+set -eu
+
+usage() {
+  echo "Usage: $0 <rust|cpp|interpreter|nodejs> [<filter>] [<cargo test args>...]" >&2
+}
+
+fatal() {
+  printf '%s\n' "$1" >&2
+  usage
+  exit 1
+}
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+driver="$1"
+
+case "$driver" in
+  rust|cpp|interpreter|nodejs) ;;
+  *)
+    fatal "Invalid driver: $driver"
+    ;;
+esac
+
+shift
+filter=""
+if [ "$#" -ge 1 ]; then
+  filter="$1"
+  shift || true
+fi
+
+SLINT_TEST_FILTER="$filter" cargo test -p "test-driver-$driver" "$@"


### PR DESCRIPTION
A command like `SLINT_TEST_FILTER=layout cargo test...` cannot be added to an auto-approve rule (neither in vscode+copilot nor in Claude CLI). A command like tests/run_tests.sh can.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
