### PR TITLE
Fix dead_code warning by propagating unstable-wgpu-28 feature to femtovg

### DIFF
--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -61,6 +61,7 @@ unstable-wgpu-27 = [
 unstable-wgpu-28 = [
   "i-slint-core/unstable-wgpu-28",
   "i-slint-renderer-skia?/unstable-wgpu-28",
+  "i-slint-renderer-femtovg?/unstable-wgpu-28",
   "i-slint-backend-winit?/unstable-wgpu-28",
 ]
 


### PR DESCRIPTION
## Summary
- Fixes dead_code warning in `internal/renderers/femtovg/wgpu.rs` about unused `instance` and `device` fields
- Propagates the `unstable-wgpu-28` feature from the `slint` crate to `i-slint-renderer-femtovg`

## Problem
When building the `bevy-hosts-slint-gpu` example with the `unstable-wgpu-28` feature enabled, the compiler warned that the `instance` and `device` fields in the `WgpuTextureBackend` struct were never read:

```
warning: fields `instance` and `device` are never read
   --> internal/renderers/femtovg/wgpu.rs:194:5
```

## Root Cause
The `unstable-wgpu-28` feature definition in `api/rs/slint/Cargo.toml` was not propagating the feature to the `i-slint-renderer-femtovg` dependency. This meant the `#[cfg(feature = "unstable-wgpu-28")]` guarded code in `with_graphics_api` (which uses these fields) was not being compiled, making the fields appear unused.

## Solution
Added `i-slint-renderer-femtovg?/unstable-wgpu-28` to the feature propagation list. The `?/` syntax ensures the feature is only propagated when the optional dependency is present.

## Test plan
- [x] Build `bevy-hosts-slint-gpu` example with `unstable-wgpu-28` feature - no warnings
- [x] Build `i-slint-renderer-femtovg` with the feature enabled - no warnings