### PR TITLE
Docs: function return value documentation is more explicit

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
@@ -32,8 +32,9 @@ value.
 
 Functions can also return a value. The return type is specified after `->` in the function
 signature. The return type is `void` if no return type is specified. The `return` keyword is used
-within the function body to return an expression of the declared type. If a function does not have
-an explicit return statement, the value of the last statement is returned by default.
+within the function body to return an expression of the declared type. If a function expects a
+return value and does not have an explicit return statement then the value of the last statement is
+returned by default.
 
 Functions can be annotated with the `pure` keyword.
 This indicates that the function does not cause any side effects.


### PR DESCRIPTION
These changes make it clearer what happens when a return type is expected, but no return statement is provided.

(Sorry - I missed these changes in my last PR).
