### PR TITLE
CI: switch nightly back to master

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -674,7 +674,7 @@ jobs:
                   tag: v${{ steps.version.outputs.VERSION }}
                   commit: ${{ github.sha }}
             - uses: ncipollo/release-action@v1
-              if: github.event.inputs.release != 'true'
+              if: github.event.inputs.release != 'true' && github.ref == 'refs/heads/master'
               with:
                   allowUpdates: true
                   prerelease: true
@@ -686,6 +686,7 @@ jobs:
                   tag: nightly
                   commit: ${{ github.sha }}
             - name: trigger stm32 build
+              if: github.ref == 'refs/heads/master'
               run: |
                 curl -L \
                 -X POST \

--- a/.github/workflows/schedule_nightly_snapshot.yaml
+++ b/.github/workflows/schedule_nightly_snapshot.yaml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         branch:
           - pre-release/1.15
+          - master
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Keep the pre-release/1.15 banch tested if it has commits, but do not overwrite the nightly artifacts

