### PR TITLE
Fix cross-compilation when the target environment doens't provide a h…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9140,7 +9140,6 @@ dependencies = [
  "bytemuck",
  "const-field-offset",
  "document-features",
- "fontique",
  "i-slint-backend-android-activity",
  "i-slint-backend-qt",
  "i-slint-backend-selector",
@@ -9174,6 +9173,7 @@ name = "slint-build"
 version = "1.15.0"
 dependencies = [
  "derive_more",
+ "fontique",
  "i-slint-compiler",
  "spin_on",
  "toml_edit 0.24.0+spec-1.1.0",

--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -34,6 +34,11 @@ spin_on = { workspace = true }
 toml_edit = { workspace = true }
 derive_more = { workspace = true, features = ["std", "error"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Workaround cross compiling on linux where here in slint-build we depend on fontique through the software
+# renderer compiler feature but fontconfig's build script find the target library via pkg-config and causes link errors
+fontique = { workspace = true, features = ["fontconfig-dlopen"] }
+
 [package.metadata.docs.rs]
 features = ["sdf-fonts"]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -168,7 +168,7 @@ renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "std"]
 renderer-skia-vulkan = ["i-slint-backend-selector/renderer-skia-vulkan", "std"]
 
 ## Render using the software renderer.
-renderer-software = ["i-slint-backend-selector/renderer-software", "dep:i-slint-renderer-software", "dep:fontique"]
+renderer-software = ["i-slint-backend-selector/renderer-software", "dep:i-slint-renderer-software"]
 
 ## KMS with Vulkan or EGL and libinput on Linux are used to render the application in full screen mode, without any
 ## windowing system. Requires libseat. If you don't have libseat, select `backend-linuxkms-noseat` instead.
@@ -303,11 +303,6 @@ i-slint-renderer-femtovg = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-backend-android-activity = { workspace = true, optional = true }
-
-[target.'cfg(target_os = "linux")'.build-dependencies]
-# Workaround cross compiling on linux where the build dependencies depends on fontique through slint-build
-# but fontconfig build script find the target library via pkg-config and causes link errors
-fontique = { workspace = true, optional = true, features = ["fontconfig-dlopen"] }
 
 [dev-dependencies]
 slint-build = { path = "../build" }


### PR DESCRIPTION
…ost fontconfig via pkg-config

Commit 2dd3da6e4535ec3deba8adfe1c905a3abbc27cea introduced the workaround of enabling dlopen via the software renderer feature in the slint crate, which stops working when using default-features = false and picking a different renderer. Apply the workaround in the crate that triggers it, slint-build.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
