### PR TITLE
Esp32S3Box: fix flash size and display size

### DIFF
--- a/examples/mcu-board-support/esp32_s3_box_3.rs
+++ b/examples/mcu-board-support/esp32_s3_box_3.rs
@@ -10,7 +10,6 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::cell::RefCell;
-use embedded_graphics_core::geometry::OriginDimensions;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal_bus::spi::ExclusiveDevice;
@@ -176,8 +175,7 @@ impl EspBackend {
         backlight.set_high();
 
         // Update the Slint window size from the display.
-        let size = display.size();
-        let size = slint::PhysicalSize::new(size.width, size.height);
+        let size = slint::PhysicalSize::new(320, 240);
         self.window.borrow().as_ref().unwrap().set_size(size);
 
         // --- End Display Initialization ---

--- a/examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
+++ b/examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
@@ -6,7 +6,7 @@ ESP_LOG = "INFO"
 ESP_HAL_CONFIG_PSRAM_MODE = "octal"
 
 [target.xtensa-esp32s3-none-elf]
-runner = "espflash flash --monitor"
+runner = "espflash flash --monitor --flash-size 16mb"
 rustflags = ["-C", "link-arg=-Wl,-Tlinkall.x"]
 
 [build]


### PR DESCRIPTION
The new printer demo doesn't fit in the 1MiB default partition from the esp32s3 hel crate.
But the device actualy has more flash, so tell espflash to use that.

Also the driver's hardcoded 320x480 size is not accurate. https://github.com/almindor/mipidsi/blob/6661d005daebaf00ed3dea003094ec55a77a3cc8/src/models/ili9486.rs#L20 The actual device has a 320x240 screen
(I guess that's bigger because it can implement scroll)
