### PR TITLE
Fix the "redo" shortcut with winit

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -353,7 +353,7 @@ impl KeyEvent {
         } else if self.modifiers.control && self.modifiers.shift {
             match self.text.as_str() {
                 #[cfg(not(target_os = "windows"))]
-                "z" => Some(StandardShortcut::Redo),
+                "z" | "Z" => Some(StandardShortcut::Redo),
                 _ => None,
             }
         } else {


### PR DESCRIPTION
Ctrl+Shift+Z will match against "Z" because shift+Z is "Z" and not "z". Note that the difference is different with the Qt backend. The Qt backend  always give us lowercase letters when ctrl is pressed.
