### PR TITLE
bevy-hosts-slint-gpu: Fix crash

### DIFF
--- a/examples/bevy-hosts-slint-gpu/Cargo.toml
+++ b/examples/bevy-hosts-slint-gpu/Cargo.toml
@@ -26,3 +26,4 @@ bevy = { git = "https://github.com/bevyengine/bevy", rev = "44ae8e24" }
 bevy_image = { git = "https://github.com/bevyengine/bevy", rev = "44ae8e24", features = ["zstd_rust"] }
 wgpu-28 = { package = "wgpu", version = "28", default-features = false, features = ["wgsl"] }
 femtovg = { version = "0.20.1", features = ["image-loading"] }
+spin_on = "0.1.1"


### PR DESCRIPTION
We can't extract the RenderInstance via
world.resource::<RenderInstance>(), as that's not set by bevy. Instead, initialize wgpu by hand and propagate the wgpu types to the init function.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
