### PR TITLE
CI: Remove the build of the material gallery from the nightly snapshot

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -770,8 +770,6 @@ jobs:
               run: cargo apk build -p weather-demo --target aarch64-linux-android --lib --release
             - name: Build usecases demo
               run: cargo apk build -p usecases --target aarch64-linux-android --lib --release
-            - name: Build material gallery
-              run: cargo apk build -p material-gallery --target aarch64-linux-android --lib --release
             - name: Build home automation demo
               run: cargo apk build -p home-automation --target aarch64-linux-android --lib --release
             - name: "upload APK artifact"
@@ -784,5 +782,4 @@ jobs:
                     target/release/apk/weather_demo.apk
                     target/release/apk/usecases_lib.apk
                     target/release/apk/usecases_lib.apk
-                    target/release/apk/slint_material.apk
                     target/release/apk/home_automation_lib.apk


### PR DESCRIPTION
The gallery is built - with all bells and whistels - in material_gallery.yaml as part of the material components website.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
