### PR TITLE
Add external field to BorrowedOpenGLTexture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,8 +3362,7 @@ dependencies = [
 [[package]]
 name = "femtovg"
 version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727c5dd9d601f3f4ea133b8a6ba37d37ca67ed59781675dc1c9c9f1701e0d197"
+source = "git+https://github.com/expenses/femtovg?branch=canvas-external#398dbdc0515a3a8810d365348f461a7d447c5386"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",

--- a/api/cpp/include/private/slint_image.h
+++ b/api/cpp/include/private/slint_image.h
@@ -166,6 +166,7 @@ public:
                         texture_id,
                         size,
                         origin_private,
+                        false,
                 })
 
         );

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -4265,8 +4265,7 @@ dependencies = [
 [[package]]
 name = "femtovg"
 version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727c5dd9d601f3f4ea133b8a6ba37d37ca67ed59781675dc1c9c9f1701e0d197"
+source = "git+https://github.com/expenses/femtovg?branch=canvas-external#398dbdc0515a3a8810d365348f461a7d447c5386"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -7342,9 +7341,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -7439,9 +7438,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -8818,9 +8817,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -9647,9 +9646,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni 0.22.4",

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -995,7 +995,20 @@ impl BorrowedOpenGLTextureBuilder {
     /// different windows.
     #[allow(unsafe_code)]
     pub unsafe fn new_gl_2d_rgba_texture(texture_id: core::num::NonZeroU32, size: IntSize) -> Self {
-        Self(BorrowedOpenGLTexture { texture_id, size, origin: Default::default() })
+        Self(BorrowedOpenGLTexture {
+            texture_id,
+            size,
+            external: false,
+            origin: Default::default(),
+        })
+    }
+
+    #[allow(unsafe_code)]
+    pub unsafe fn new_gl_2d_external_rgba_texture(
+        texture_id: core::num::NonZeroU32,
+        size: IntSize,
+    ) -> Self {
+        Self(BorrowedOpenGLTexture { texture_id, size, external: true, origin: Default::default() })
     }
 
     /// Configures the texture to be rendered vertically mirrored.
@@ -1467,6 +1480,8 @@ pub struct BorrowedOpenGLTexture {
     pub size: IntSize,
     /// Origin of the texture when rendering.
     pub origin: BorrowedOpenGLTextureOrigin,
+    /// The texture is external to opengl (e.g. a DMA buffer)
+    pub external: bool,
 }
 
 #[cfg(test)]

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1003,6 +1003,7 @@ impl BorrowedOpenGLTextureBuilder {
         })
     }
 
+    /// Generates the base configuration for a borrowed OpenGL texture that is marked as external.
     #[allow(unsafe_code)]
     pub unsafe fn new_gl_2d_external_rgba_texture(
         texture_id: core::num::NonZeroU32,

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1004,6 +1004,22 @@ impl BorrowedOpenGLTextureBuilder {
     }
 
     /// Generates the base configuration for a borrowed OpenGL texture that is marked as external.
+    ///
+    /// The texture must be bindable against the `GL_TEXTURE_2D` target, have `GL_RGBA` as format
+    /// for the pixel data.
+    ///
+    /// By default, when Slint renders the texture, it assumes that the origin of the texture is at the top-left.
+    /// This is different from the default OpenGL coordinate system. Use the `mirror_vertically` function
+    /// to reconfigure this.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because invalid texture ids may lead to undefined behavior in OpenGL
+    /// drivers. A valid texture id is one that was created by the same OpenGL context that is
+    /// current during any of the invocations of the callback set on [`Window::set_rendering_notifier()`](crate::api::Window::set_rendering_notifier).
+    /// OpenGL contexts between instances of [`slint::Window`](crate::api::Window) are not sharing resources. Consequently
+    /// [`slint::Image`](Image) objects created from borrowed OpenGL textures cannot be shared between
+    /// different windows.
     #[allow(unsafe_code)]
     pub unsafe fn new_gl_2d_external_rgba_texture(
         texture_id: core::num::NonZeroU32,

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -36,7 +36,7 @@ cfg-if = "1"
 derive_more = { workspace = true }
 lyon_path = { workspace = true }
 pin-weak = "1"
-femtovg = { version = "0.23.2", default-features = false, features = ["swash"] }
+femtovg = { git = "https://github.com/expenses/femtovg", branch = "canvas-external", default-features = false, features = ["swash"] }
 imgref = { version = "1.6.1" }
 rgb = { version = "0.8.27" }
 

--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -21,6 +21,11 @@ where
     #[cfg(not(target_family = "wasm"))]
     fn convert_opengl_texture(opengl_texture: std::num::NonZero<u32>) -> Self::NativeTexture;
 
+    #[cfg(not(target_family = "wasm"))]
+    fn convert_external_opengl_texture(
+        opengl_texture: std::num::NonZero<u32>,
+    ) -> Self::ExternalTexture;
+
     #[cfg(feature = "unstable-wgpu-28")]
     fn convert_wgpu_28_texture(wgpu_texture: wgpu_28::Texture) -> Self::NativeTexture;
 }
@@ -28,6 +33,13 @@ where
 impl TextureImporter for femtovg::renderer::OpenGl {
     #[cfg(not(target_family = "wasm"))]
     fn convert_opengl_texture(opengl_texture: std::num::NonZero<u32>) -> Self::NativeTexture {
+        glow::NativeTexture(opengl_texture)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn convert_external_opengl_texture(
+        opengl_texture: std::num::NonZero<u32>,
+    ) -> Self::NativeTexture {
         glow::NativeTexture(opengl_texture)
     }
 
@@ -40,6 +52,12 @@ impl TextureImporter for femtovg::renderer::OpenGl {
 #[cfg(all(feature = "wgpu-28", not(target_family = "wasm")))]
 impl TextureImporter for femtovg::renderer::WGPURenderer {
     fn convert_opengl_texture(_opengl_texture: std::num::NonZero<u32>) -> Self::NativeTexture {
+        todo!()
+    }
+
+    fn convert_external_opengl_texture(
+        _opengl_texture: std::num::NonZero<u32>,
+    ) -> Self::ExternalTexture {
         todo!()
     }
 
@@ -159,7 +177,7 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                 texture_id,
                 size,
                 origin,
-                external: _,
+                external,
                 ..
             }) => {
                 let image_flags = match origin {
@@ -171,18 +189,29 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                         "internal error: missing implementation for BorrowedOpenGLTextureOrigin"
                     ),
                 };
-                canvas
-                    .borrow_mut()
-                    .create_image_from_native_texture(
-                        <R as TextureImporter>::convert_opengl_texture(*texture_id),
-                        femtovg::ImageInfo::new(
-                            image_flags,
-                            size.width as _,
-                            size.height as _,
-                            femtovg::PixelFormat::Rgba8,
-                        ),
-                    )
-                    .unwrap()
+                let image_info = femtovg::ImageInfo::new(
+                    image_flags,
+                    size.width as _,
+                    size.height as _,
+                    femtovg::PixelFormat::Rgba8,
+                );
+                if *external {
+                    canvas
+                        .borrow_mut()
+                        .create_image_from_external_texture(
+                            <R as TextureImporter>::convert_external_opengl_texture(*texture_id),
+                            image_info,
+                        )
+                        .unwrap()
+                } else {
+                    canvas
+                        .borrow_mut()
+                        .create_image_from_native_texture(
+                            <R as TextureImporter>::convert_opengl_texture(*texture_id),
+                            image_info,
+                        )
+                        .unwrap()
+                }
             }
             #[cfg(all(not(target_arch = "wasm32"), feature = "unstable-wgpu-28"))]
             ImageInner::WGPUTexture(i_slint_core::graphics::WGPUTexture::WGPU28Texture(

--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -159,6 +159,7 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                 texture_id,
                 size,
                 origin,
+                external: _,
                 ..
             }) => {
                 let image_flags = match origin {

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -175,11 +175,14 @@ impl super::Surface for OpenGLSurface {
     fn import_opengl_texture(
         &self,
         canvas: &skia_safe::Canvas,
-        BorrowedOpenGLTexture { texture_id, size, origin, .. }: &BorrowedOpenGLTexture,
+        BorrowedOpenGLTexture { texture_id, size, origin, external, .. }: &BorrowedOpenGLTexture,
     ) -> Option<skia_safe::Image> {
+        // https://registry.khronos.org/OpenGL/extensions/OES/OES_EGL_image_external.txt
+        const TEXTURE_EXTERNAL_OES: u32 = 0x8D65;
+
         unsafe {
             let mut texture_info = skia_safe::gpu::gl::TextureInfo::from_target_and_id(
-                glow::TEXTURE_2D,
+                if *external { TEXTURE_EXTERNAL_OES } else { glow::TEXTURE_2D },
                 texture_id.get(),
             );
             texture_info.format = glow::RGBA8;


### PR DESCRIPTION
I believe this is all that's required for DMA buffers to work with the Skia backend. C++ stuff not implemented yet. 