### PR TITLE
AGENTS.md: don't suggest --release for running examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,15 +11,15 @@ Slint is a declarative GUI toolkit for building native user interfaces across em
 ### Rust (Primary)
 ```sh
 cargo build                                    # Build the workspace
-cargo build --release                          # Release build
+cargo build --release                          # Release build (use this flag whenever testing performance)
 cargo test                                     # Run tests (requires cargo build first!)
-cargo build --workspace --exclude uefi-demo --release  # Build all examples
+cargo build --workspace --exclude uefi-demo    # Build all examples
 ```
 
 ### Running Examples
 ```sh
-cargo run --release -p gallery                 # Run the gallery example
-cargo run --release --bin slint-viewer -- path/to/file.slint  # View a .slint file
+cargo run -p gallery                 # Run the gallery example
+cargo run --bin slint-viewer -- path/to/file.slint  # View a .slint file
 ```
 
 ### C++ Build


### PR DESCRIPTION
cargo run --release --bin slint-viewer -- path/to/file.slint takes 4 minutes to build tools/viewer/main.rs,
while it takes only 3s in debug mode.

Add a note to use --release when testing performance, but don't default to that.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
