### PR TITLE
Fix the remaining clippy warnings in i-slint-interpreter

### DIFF
--- a/internal/interpreter/dynamic_type.rs
+++ b/internal/interpreter/dynamic_type.rs
@@ -168,6 +168,8 @@ impl<'id> TypeInfo<'id> {
     /// Safety, the instance must have been created by `TypeInfo::create_instance`
     unsafe fn delete_instance(instance: *mut Instance) {
         unsafe {
+            // removing the & causes a dangerous_implicit_autorefs error
+            #[allow(clippy::needless_borrow)]
             let mem_layout = (&(*instance).type_info).mem_layout;
             Self::drop_in_place(instance);
             let mem = instance as *mut u8;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
