### PR TITLE
software_renderer: fix tracking geometry of invisible item

### DIFF
--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -919,11 +919,20 @@ fn position_tracking_without_partial_rendering() {
     }));
 
     ui.set_rect_x(20.);
-    assert!(
-        window.draw_if_needed(|renderer| {
-            do_test_render_region(renderer, 0, 0, 180, 260);
-        }),
-        "change of x should trigger a redraw"
-    );
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 180, 260);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+
+    ui.set_rect_x(-500.);
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 180, 260);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+
+    ui.set_rect_x(20.);
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 180, 260);
+    }));
     assert!(!window.draw_if_needed(|_| { unreachable!() }));
 }


### PR DESCRIPTION
This is a regression from 1b9d8454e3c216499c83fbc63bff5ff048ad3a7b (PR #10677) The partial renderer doesn't track the geometry of item since that is tracked by the code that compute the dirty region. However, since we are not computing the dirty region for NewBuffer, we don't do dependency tracking for the geometry unless the partial renderer adds it to the cache.

The solution is to not use the partial renderer at all for the NewBuffer. This should save even more memory.

Fixes #10714
