### PR TITLE
upgrade_version.yaml: Update versions.json only for the master branch

### DIFF
--- a/.github/workflows/upgrade_version.yaml
+++ b/.github/workflows/upgrade_version.yaml
@@ -70,7 +70,7 @@ jobs:
                   branch: wip/version-bump
 
     # update https://releases.slint.dev/versions.json
-    update_verions_json:
+    update_versions_json:
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/master'
         steps:


### PR DESCRIPTION
This avoids things like what was fixed by
https://github.com/slint-ui/www-releases/commit/173ce1a474fddfe4c67f10e51de5d7be48987674 when the version is updated on the pre-release branch
