### PR TITLE
Feature: Named Slots (@children extension)

### DIFF
--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -115,7 +115,16 @@ fn fill_token_vec(stream: impl Iterator<Item = TokenTree>, vec: &mut Vec<parser:
                     }
                     '*' => SyntaxKind::Star,
                     '/' => SyntaxKind::Div,
-                    '<' => SyntaxKind::LAngle,
+                    '<' => {
+                        if let Some(last) = vec.last_mut() {
+                            if last.kind == SyntaxKind::LAngle && prev_spacing == Spacing::Joint {
+                                last.kind = SyntaxKind::DoubleLess;
+                                last.text = "<<".into();
+                                continue;
+                            }
+                        }
+                        SyntaxKind::LAngle
+                    }
                     '>' => {
                         if let Some(last) = vec.last_mut() {
                             if last.kind == SyntaxKind::LessEqual && prev_spacing == Spacing::Joint

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -523,7 +523,7 @@ impl ElementType {
     ) -> Result<ElementType, String> {
         match self {
             Self::Component(component) => {
-                let base_type = match &*component.child_insertion_point.borrow() {
+                let base_type = match component.child_insertion_points.borrow().get("_children") {
                     Some(insert_in) => insert_in.parent.borrow().base_type.clone(),
                     None => {
                         let base_type = component.root_element.borrow().base_type.clone();

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -5,7 +5,7 @@
     Parse the contents of builtins.slint and fill the builtin type registry
 */
 
-use smol_str::{SmolStr, ToSmolStr};
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -124,10 +124,10 @@ fn create_viewport_element(flickable: &ElementRc, native_empty: &Rc<NativeClass>
         .is_set_externally = true;
 
     let enclosing_component = flickable.borrow().enclosing_component.upgrade().unwrap();
-    if let Some(insertion_point) = &mut *enclosing_component.child_insertion_point.borrow_mut()
-        && std::rc::Rc::ptr_eq(&insertion_point.parent, flickable)
-    {
-        insertion_point.parent = viewport.clone()
+    for insertion_point in enclosing_component.child_insertion_points.borrow_mut().values_mut() {
+        if std::rc::Rc::ptr_eq(&insertion_point.parent, flickable) {
+            insertion_point.parent = viewport.clone()
+        }
     }
 
     flickable.borrow_mut().children.push(viewport);

--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -50,14 +50,19 @@ fn diagnose_component_container(element: &ElementRc, diag: &mut BuildDiagnostics
     if !elem.children.is_empty() {
         diag.push_error("ComponentContainers may not have children".into(), &*element.borrow());
     }
-    if let Some(cip) =
-        elem.enclosing_component.upgrade().unwrap().child_insertion_point.borrow().clone()
-        && Rc::ptr_eq(&cip.parent, element)
+    for (name, cip) in &*elem.enclosing_component.upgrade().unwrap().child_insertion_points.borrow()
     {
-        diag.push_error(
-            "The @children placeholder cannot appear in a ComponentContainer".into(),
-            &*element.borrow(),
-        );
+        if Rc::ptr_eq(&cip.parent, element) {
+            let slot_name = if name == "_children" {
+                "The @children placeholder".into()
+            } else {
+                format!("the slot '{name}'")
+            };
+            diag.push_error(
+                format!("{} cannot appear in a ComponentContainer", slot_name),
+                &*element.borrow(),
+            );
+        }
     }
 }
 

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -105,11 +105,10 @@ fn lower_popup_window(
     parent_element_borrowed.children.remove(index);
     parent_element_borrowed.has_popup_child = true;
     drop(parent_element_borrowed);
-    if let Some(parent_cip) = &mut *parent_component.child_insertion_point.borrow_mut()
-        && Rc::ptr_eq(&parent_cip.parent, parent_element)
-        && parent_cip.insertion_index > index
-    {
-        parent_cip.insertion_index -= 1;
+    for parent_cip in parent_component.child_insertion_points.borrow_mut().values_mut() {
+        if Rc::ptr_eq(&parent_cip.parent, parent_element) && parent_cip.insertion_index > index {
+            parent_cip.insertion_index -= 1;
+        }
     }
 
     let map_close_on_click_value = |b: &BindingExpression| {

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -84,11 +84,10 @@ fn lower_timer(
     let removed = parent_element_borrowed.children.remove(index);
     parent_component.optimized_elements.borrow_mut().push(removed);
     drop(parent_element_borrowed);
-    if let Some(parent_cip) = &mut *parent_component.child_insertion_point.borrow_mut()
-        && Rc::ptr_eq(&parent_cip.parent, parent_element)
-        && parent_cip.insertion_index > index
-    {
-        parent_cip.insertion_index -= 1;
+    for parent_cip in parent_component.child_insertion_points.borrow_mut().values_mut() {
+        if Rc::ptr_eq(&parent_cip.parent, parent_element) && parent_cip.insertion_index > index {
+            parent_cip.insertion_index -= 1;
+        }
     }
 
     let running = NamedReference::new(timer_element, SmolStr::new_static("running"));

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -63,6 +63,8 @@ fn create_repeater_components(component: &Rc<Component>) {
                 item_index_of_first_children: Default::default(),
                 is_legacy_syntax: elem.is_legacy_syntax,
                 inline_depth: 0,
+                slot_target: elem.slot_target.clone(),
+                forwarded_slots: elem.forwarded_slots.clone(),
                 grid_layout_cell: elem.grid_layout_cell.clone(),
             })),
             parent_element,

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -65,6 +65,8 @@ pub fn ensure_window(
 
         inline_depth: 0,
         is_legacy_syntax: false,
+        slot_target: None,
+        forwarded_slots: Vec::new(),
     };
     let new_root = new_root.make_rc();
     win_elem_mut.children.push(new_root.clone());

--- a/internal/compiler/tests/syntax/basic/children_placeholder.slint
+++ b/internal/compiler/tests/syntax/basic/children_placeholder.slint
@@ -34,7 +34,7 @@ export TestBox2 := Rectangle {
         @children
     }
     @children
-//  >       <error{The @children placeholder can only appear once in an element hierarchy}
+//  >       <error{The @children placeholder can only appear once in an element}
 }
 
 export Final := TestBox {

--- a/internal/compiler/tests/syntax/component_slots/component_slots.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots.slint
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Base inherits Rectangle {
+    slot header;
+    slot footer;
+
+    VerticalLayout {
+        header {}
+        @children
+        footer {}
+    }
+}
+
+export component Test inherits Rectangle {
+    Base {
+        header << Rectangle {
+            background: blue;
+        }
+        Text { text: "Main Content"; }
+        footer << Rectangle {
+            background: gray;
+        }
+    }
+}
+
+export component FailDuplicateUse inherits Rectangle {
+    slot header;
+    header {}
+    header {}
+//  >       <error{The slot 'header' can only appear once in an element hierarchy}
+}
+
+export component FailDuplicateUse2 inherits Rectangle {
+    slot header;
+    header {}
+    Rectangle {
+        header {}
+//      >       <error{The slot 'header' can only appear once in an element hierarchy}
+    }
+}
+
+export component FailReservedSlotName inherits Rectangle {
+    slot _children;
+//       >       <error{The name '_children' is reserved for the default slot. Use @children instead}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -1,0 +1,108 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot header;
+
+    VerticalLayout {
+        header {}
+    }
+}
+
+export component UseOk inherits Rectangle {
+    SlotHost {
+        header << Rectangle {
+            background: blue;
+        }
+    }
+}
+
+export component FailDuplicateAssignment inherits Rectangle {
+    SlotHost {
+        header << Rectangle { background: red; }
+        header << Rectangle { background: green; }
+//      >                                        <error{Duplicate assignment to slot 'header'}
+    }
+}
+
+export component FailUnknownSlot inherits Rectangle {
+    SlotHost {
+        footer << Rectangle { }
+//      >                     <error{Unknown slot 'footer' in 'SlotHost'}
+    }
+}
+
+export component ForwardTargetHost inherits Rectangle {
+    slot hostHeader;
+
+    Rectangle {
+        hostHeader {}
+    }
+}
+
+export component FailUnknownForwardTarget inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        footer << header;
+//      >    <error{Unknown slot 'footer' in 'ForwardTargetHost'}
+    }
+
+    header {}
+}
+
+export component FailDuplicateForwardingTarget inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header;
+        hostHeader << header;
+//      >        <error{Duplicate forwarding to slot 'hostHeader'}
+    }
+}
+
+export component FailForwardAndAssignConflict inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header;
+        hostHeader << Rectangle { }
+//      >                         <error{Slot 'hostHeader' cannot be both forwarded and assigned}
+    }
+}
+
+export component FailForwardAndPlaceholderConflict inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header;
+    }
+
+    header {}
+//  >       <error{The slot 'header' cannot be forwarded and used as a placeholder in the same component}
+}
+
+export component FailForwardUnknownSource inherits Rectangle {
+    ForwardTargetHost {
+        hostHeader << header;
+//                    >    <error{The slot 'header' is used but not declared}
+    }
+}
+
+export component FailForwardInvalidRhs inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header + 1;
+//                    >        <error{Slot forwarding requires a slot identifier on the right-hand side}
+    }
+
+    header {}
+}
+
+export component FailUnassignedSlotReference inherits Rectangle {
+    SlotHost {
+        out property <length> header_y: header.absolute-position.y;
+//                                      >                        <error{Slot 'header' is not assigned in this instance}
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_parse_error.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_parse_error.slint
@@ -1,0 +1,7 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Fail inherits Rectangle {
+    header << ;
+//            ^error{invalid expression}
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -343,8 +343,9 @@ impl Snapshotter {
                     .collect(),
             );
 
-            let child_insertion_point =
-                RefCell::new(component.child_insertion_point.borrow().clone());
+            let child_insertion_points =
+                RefCell::new(component.child_insertion_points.borrow().clone());
+            let declared_slots = component.declared_slots.clone();
 
             let popup_windows = RefCell::new(
                 component
@@ -370,7 +371,8 @@ impl Snapshotter {
             object_tree::Component {
                 node: component.node.clone(),
                 id: component.id.clone(),
-                child_insertion_point,
+                child_insertion_points,
+                declared_slots,
                 exported_global_names: RefCell::new(
                     component.exported_global_names.borrow().clone(),
                 ),

--- a/tests/cases/component_slots/component_slots_basic.slint
+++ b/tests/cases/component_slots/component_slots_basic.slint
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotContent inherits Rectangle {
+    in-out property <int> value;
+    width: 10px;
+    height: 10px;
+    background: red;
+}
+
+export component Host inherits Rectangle {
+    slot header;
+    VerticalLayout {
+        header {}
+
+
+    }
+}
+
+export component TestCase inherits Rectangle {
+    host := Host {
+        header << SlotContent {
+            value: 42;
+        }
+
+        out property <int> header_value: header.value;
+    }
+
+    out property <int> header_value: host.header_value;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_header_value(), 42);
+```
+*/

--- a/tests/cases/component_slots/component_slots_branching_children.slint
+++ b/tests/cases/component_slots/component_slots_branching_children.slint
@@ -1,0 +1,123 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component HeaderComponent inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 1px;
+        }
+
+        @children
+        Rectangle {
+            height: 2px;
+        }
+    }
+}
+
+export component ContentBlock inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 1px;
+        }
+
+        @children
+        Rectangle {
+            height: 2px;
+        }
+    }
+}
+
+export component FooterComponent inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 1px;
+        }
+
+        @children
+        Rectangle {
+            height: 2px;
+        }
+    }
+}
+
+export component Panel inherits Rectangle {
+    slot header;
+    slot footer;
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+        @children
+        footer {}
+
+
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 160px;
+
+    panel := Panel {
+        width: 200px;
+        height: 160px;
+
+        header << HeaderComponent {
+            h1 := Rectangle {
+                height: 5px;
+            }
+
+            h2 := Rectangle {
+                height: 7px;
+            }
+        }
+
+        ContentBlock {
+            b1 := Rectangle {
+                height: 11px;
+            }
+        }
+
+        ContentBlock {
+            b2 := Rectangle {
+                height: 13px;
+            }
+        }
+
+        ContentBlock {
+            b3 := Rectangle {
+                height: 17px;
+            }
+        }
+
+        footer << FooterComponent {
+            f1 := Rectangle {
+                height: 19px;
+            }
+
+            f2 := Rectangle {
+                height: 23px;
+            }
+        }
+
+        out property <length> h1y: h1.absolute-position.y;
+        out property <length> h2y: h2.absolute-position.y;
+        out property <length> b1y: b1.absolute-position.y;
+        out property <length> b2y: b2.absolute-position.y;
+        out property <length> b3y: b3.absolute-position.y;
+        out property <length> f1y: f1.absolute-position.y;
+        out property <length> f2y: f2.absolute-position.y;
+    }
+
+    out property <bool> test:
+        panel.h1y == 1px && panel.h2y == 6px && panel.b1y == 16px && panel.b2y == 30px && panel.b3y == 46px && panel.f1y == 66px && panel.f2y == 85px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_layout.slint
+++ b/tests/cases/component_slots/component_slots_layout.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot header;
+    slot footer;
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+        @children
+        footer {}
+
+
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 60px;
+
+    host := SlotHost {
+        width: 200px;
+        height: 60px;
+
+        header << Rectangle {
+            height: 10px;
+        }
+
+        body_rect := Rectangle {
+            height: 20px;
+        }
+
+        footer << Rectangle {
+            height: 30px;
+        }
+
+        out property <length> header_y: header.absolute-position.y;
+        out property <length> body_y: body_rect.absolute-position.y;
+        out property <length> footer_y: footer.absolute-position.y;
+    }
+
+    out property <bool> test: host.header_y == 0px && host.body_y == 10px && host.footer_y == 30px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_optional_header.slint
+++ b/tests/cases/component_slots/component_slots_optional_header.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot header;
+
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+        @children
+    }
+}
+
+export component TestCase inherits Window {
+    width: 120px;
+    height: 30px;
+
+    host := SlotHost {
+        width: 120px;
+        height: 30px;
+
+        body_rect := Rectangle {
+            height: 30px;
+        }
+    }
+
+    out property <length> body_y: body_rect.absolute-position.y;
+    out property <bool> test: body_y == 0px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_slot_assignment_children.slint
+++ b/tests/cases/component_slots/component_slots_slot_assignment_children.slint
@@ -1,0 +1,63 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component NestedHost inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 2px;
+        }
+
+        @children
+        Rectangle {
+            height: 3px;
+        }
+    }
+}
+
+export component SlotHost inherits Rectangle {
+    slot header;
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+
+
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 60px;
+
+    host := SlotHost {
+        width: 100px;
+        height: 60px;
+
+        header << NestedHost {
+            a := Rectangle {
+                height: 5px;
+            }
+
+            b := Rectangle {
+                height: 7px;
+            }
+
+            c := Rectangle {
+                height: 11px;
+            }
+        }
+
+        out property <length> ay: a.absolute-position.y;
+        out property <length> by: b.absolute-position.y;
+        out property <length> cy: c.absolute-position.y;
+    }
+
+    out property <bool> test: host.ay == 2px && host.by == 7px && host.cy == 14px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_two_levels.slint
+++ b/tests/cases/component_slots/component_slots_two_levels.slint
@@ -1,0 +1,58 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot hostHeader;
+
+    VerticalLayout {
+        spacing: 0px;
+        hostHeader {}
+        @children
+    }
+}
+
+export component Outer inherits Rectangle {
+    slot header;
+
+    SlotHost {
+        hostHeader << header;
+        @children
+    }
+}
+
+export component TestCase inherits Window {
+    width: 120px;
+    height: 20px;
+
+    outer := Outer {
+        width: 120px;
+        height: 20px;
+
+        header << Rectangle {
+            height: 8px;
+        }
+
+        body_rect := Rectangle {
+            height: 12px;
+        }
+
+        out property <length> header_y: header.absolute-position.y;
+        out property <length> body_y: body_rect.absolute-position.y;
+    }
+
+    out property <bool> test: outer.header_y == 0px && outer.body_y == 8px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/driver/rust/tests/component_slots.rs
+++ b/tests/driver/rust/tests/component_slots.rs
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// NOTE: The files under tests/driver/rust/tests/ are generated and validated against this template.
+// Do not edit them directly, instead edit the template.rs file!
+
+// needs to be crate-level
+#![deny(rust_2024_compatibility)]
+
+include!(concat!(env!("OUT_DIR"), "/component_slots.rs"));

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -575,7 +575,8 @@ fn resolve_element_scope(
         ) -> (bool, bool, Vec<SmolStr>) {
             match element_type {
                 ElementType::Component(component) => {
-                    let base_type = match &*component.child_insertion_point.borrow() {
+                    let base_type = match component.child_insertion_points.borrow().get("_children")
+                    {
                         Some(insert_in) => insert_in.parent.borrow().base_type.clone(),
                         None => {
                             let base_type = component.root_element.borrow().base_type.clone();

--- a/tools/updater/experiments/geometry_changes.rs
+++ b/tools/updater/experiments/geometry_changes.rs
@@ -87,7 +87,7 @@ fn is_layout_base(elem: &ElementRc) -> bool {
             if c.id == "ListView" {
                 return true;
             }
-            if let Some(ins) = &*c.child_insertion_point.borrow() {
+            if let Some(ins) = c.child_insertion_points.borrow().get("_children") {
                 is_layout_base(&ins.parent)
             } else {
                 is_layout_base(&c.root_element)


### PR DESCRIPTION
This PR is a proposal to extend Slint’s existing `@children` mechanism with **named slots**, in response to #6258.

The current implementation introduces **structural, compile-time named slots** using the `@[slot-name]` syntax (e.g. `@header { ... }`), while preserving the existing `@children` behavior to avoid breaking changes for existing users. Conceptually, this is an extension of the current children-slot model rather than a replacement.

* Slots are inlined at compile time.
* Existing `@children` continues to work unchanged.
* Slots can expose properties to the parent.
* No support for dynamic / non-inlined slot content in this iteration. Supporting that would require runtime component factories, embedding, and additional backend/runtime support, which is intentionally out of scope for this proposal.

I’m open to feedback, both on syntax and on the overall design direction.
