### PR TITLE
CI: Add a job at the end of CI so we can merge the PR

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -66,3 +66,10 @@ jobs:
             CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
             CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
             READ_WRITE_PRIVATE_KEY: ${{ secrets.READ_WRITE_PRIVATE_KEY }}
+
+    done:
+        needs: [ci]
+        name: done
+        runs-on: ubuntu-latest
+        steps:
+            - run: echo "All checks passed."


### PR DESCRIPTION
We need a job to match on success to we can match that in the GitHub interface to enable the auto-merge

