### PR TITLE
safe-ui-core: disable std by default to fix no_std MCU builds

### DIFF
--- a/examples/safe-ui/core/Cargo.toml
+++ b/examples/safe-ui/core/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 crate-type = ["rlib", "staticlib"]
 
 [features]
-default = ["std"]
+default = []
 libm = ["slint/libm"]
 std = ["slint/std"]
 panic-handler = []


### PR DESCRIPTION
Setting "std" as a default feature in the core crate caused compilation failures on no_std targets.

This change reverts the default features to empty. The simulator remains unaffected as it explicitly enables the "std" feature in its own Cargo.toml.

This fixes an error that I accidentally introduced in [this](https://github.com/slint-ui/slint/commit/2b9cf15b1e35dfb87658e5ad9a78f28f10779c08) commit.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
