### PR TITLE
DRAFT - Medcelerate skia alpha window

### DIFF
--- a/internal/renderers/skia/wgpu_27_surface.rs
+++ b/internal/renderers/skia/wgpu_27_surface.rs
@@ -66,6 +66,7 @@ impl super::Surface for WGPUSurface {
             .copied()
             .unwrap_or_else(|| swapchain_capabilities.formats[0]);
         surface_config.format = swapchain_format;
+        surface_config.alpha_mode = wgpu::CompositeAlphaMode::Auto;
         surface.configure(&device, &surface_config);
 
         let backend: Backend = adapter.get_info().backend.try_into()?;

--- a/internal/renderers/skia/wgpu_28_surface.rs
+++ b/internal/renderers/skia/wgpu_28_surface.rs
@@ -66,6 +66,7 @@ impl super::Surface for WGPUSurface {
             .copied()
             .unwrap_or_else(|| swapchain_capabilities.formats[0]);
         surface_config.format = swapchain_format;
+        surface_config.alpha_mode = wgpu::CompositeAlphaMode::Auto;
         surface.configure(&device, &surface_config);
 
         let backend: Backend = adapter.get_info().backend.try_into()?;


### PR DESCRIPTION
Adds surface alpha support for skia. This is draft as automatic does not resolved alpha transparency for a window on mac. Only Postmultiplied
