### PR TITLE
FlexBoxLayout: implement "align-content" property

### DIFF
--- a/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
@@ -110,6 +110,16 @@ The primary direction in which items are placed. Set to `row` to place items hor
 It also supports `row-reverse` and `column-reverse` which invert the flow: `row-reverse` places items right-to-left (starting at the right edge), and `column-reverse` places items bottom-to-top (starting at the bottom edge).
 </SlintProperty>
 
+### align-content
+<SlintProperty propName="align-content" typeName="enum" enumName="FlexAlignContent">
+Set the distribution of flex lines along the cross axis.
+- `stretch`: Lines are stretched to fill the container along the cross axis (default).
+- `start`: Lines are placed at the start of the cross axis.
+- `end`: Lines are placed at the end of the cross axis.
+- `center`: Lines are centered along the cross axis.
+The default value is `stretch`.
+</SlintProperty>
+
 ## Layout Behavior
 
 The layouting algorithm for FlexBoxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -26,6 +26,7 @@ export component MainWindow inherits Window {
     property <[string]> names: ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"];
     property <[string]> direction_options: ["Row", "RowReverse", "Column", "ColumnReverse"];
     property <[string]> alignment_options: ["Start", "End", "Center", "SpaceBetween", "SpaceAround", "SpaceEvenly"];
+    property <[string]> align_content_options: ["Stretch", "Start", "End", "Center"];
 
     VerticalLayout {
         padding: 20phx;
@@ -54,14 +55,29 @@ export component MainWindow inherits Window {
             }
         }
 
+        HorizontalLayout {
+            spacing: 10phx;
+            Text {
+                text: "Align Content:";
+                vertical-alignment: center;
+            }
+
+            align_content_combo := ComboBox {
+                model: align_content_options;
+                current-index: 0;
+            }
+        }
+
         flex_container := Rectangle {
             border-width: 2phx;
             border-color: #333;
             background: white;
+            vertical-stretch: 1;
 
             FlexBoxLayout {
                 flex-direction: direction_combo.current-index == 0 ? row : direction_combo.current-index == 1 ? row-reverse : direction_combo.current-index == 2 ? column : column-reverse;
                 alignment: alignment_combo.current-index == 0 ? start : alignment_combo.current-index == 1 ? end : alignment_combo.current-index == 2 ? center : alignment_combo.current-index == 3 ? space-between : alignment_combo.current-index == 4 ? space-around : space-evenly;
+                align-content: align_content_combo.current-index == 0 ? stretch : align_content_combo.current-index == 1 ? start : align_content_combo.current-index == 2 ? end : center;
                 padding: 10phx;
                 spacing: 10phx;
 

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -369,6 +369,19 @@ macro_rules! for_each_enums {
                 ColumnReverse,
             }
 
+            /// Controls the distribution of flex lines along the cross axis in a flex container.
+            #[non_exhaustive]
+            enum FlexAlignContent {
+                /// Lines are stretched to fill the container along the cross axis.
+                Stretch,
+                /// Lines are placed at the start of the cross axis.
+                Start,
+                /// Lines are placed at the end of the cross axis.
+                End,
+                /// Lines are centered along the cross axis.
+                Center,
+            }
+
             /// PathEvent is a low-level data structure describing the composition of a path. Typically it is
             /// generated at compile time from a higher-level description, such as SVG commands.
             #[non_exhaustive]

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -443,6 +443,7 @@ export component FlexBoxLayout {
     in property <length> spacing;
     in property <LayoutAlignment> alignment: LayoutAlignment.start;  // CSS default is flex-start
     in property <FlexDirection> flex-direction;
+    in property <FlexAlignContent> align-content: FlexAlignContent.stretch;  // CSS default
 }
 
 component MoveTo {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -554,6 +554,7 @@ pub struct FlexBoxLayout {
     pub elems: Vec<LayoutItem>,
     pub geometry: LayoutGeometry,
     pub direction: Option<NamedReference>,
+    pub align_content: Option<NamedReference>,
 }
 
 impl FlexBoxLayout {
@@ -563,6 +564,9 @@ impl FlexBoxLayout {
         }
         self.geometry.visit_named_references(visitor);
         if let Some(e) = self.direction.as_mut() {
+            visitor(&mut *e)
+        }
+        if let Some(e) = self.align_content.as_mut() {
             visitor(&mut *e)
         }
     }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -326,6 +326,12 @@ pub(super) fn solve_flexbox_layout(
                     .with(|e| Type::Enumeration(e.enums.FlexDirection.clone())),
                 fld.direction,
             ),
+            (
+                "align_content",
+                crate::typeregister::BUILTIN
+                    .with(|e| Type::Enumeration(e.enums.FlexAlignContent.clone())),
+                fld.align_content,
+            ),
             ("cells_h", fld.cells_h.ty(ctx), fld.cells_h),
             ("cells_v", fld.cells_v.ty(ctx), fld.cells_v),
         ],
@@ -550,6 +556,7 @@ fn compute_flexbox_layout_info_for_direction(
 struct FlexBoxLayoutDataResult {
     alignment: llr_Expression,
     direction: llr_Expression,
+    align_content: llr_Expression,
     cells_h: llr_Expression,
     cells_v: llr_Expression,
     /// When there are repeaters involved, we need to do a WithFlexBoxLayoutItemInfo with the
@@ -579,6 +586,16 @@ fn flexbox_layout_data(
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
         let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexDirection.clone());
+        llr_Expression::EnumerationValue(EnumerationValue {
+            value: e.default_value,
+            enumeration: e,
+        })
+    };
+
+    let align_content = if let Some(expr) = &layout.align_content {
+        llr_Expression::PropertyReference(ctx.map_property_reference(expr))
+    } else {
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexAlignContent.clone());
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -617,7 +634,14 @@ fn flexbox_layout_data(
             element_ty,
             output: llr_ArrayOutput::Slice,
         };
-        FlexBoxLayoutDataResult { alignment, direction, cells_h, cells_v, compute_cells: None }
+        FlexBoxLayoutDataResult {
+            alignment,
+            direction,
+            align_content,
+            cells_h,
+            cells_v,
+            compute_cells: None,
+        }
     } else {
         let mut elements = Vec::new();
         for item in &layout.elems {
@@ -654,6 +678,7 @@ fn flexbox_layout_data(
         FlexBoxLayoutDataResult {
             alignment,
             direction,
+            align_content,
             cells_h,
             cells_v,
             compute_cells: Some(("cells_h".into(), "cells_v".into(), elements)),

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -725,11 +725,13 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
     }
 
     let direction = crate::layout::binding_reference(layout_element, "flex-direction");
+    let align_content = crate::layout::binding_reference(layout_element, "align-content");
 
     let mut layout = crate::layout::FlexBoxLayout {
         elems: Default::default(),
         geometry: LayoutGeometry::new(layout_element),
         direction,
+        align_content,
     };
 
     // FlexBoxLayout needs 4 values per item: x, y, width, height

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -5,6 +5,7 @@ export component X inherits Rectangle {
 
     flex := FlexBoxLayout {
         alignment: center;
+        align-content: stretch;
         gap: 10px;
 //      > <error{Use spacing instead of gap}
         row-gap: 5px;

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -198,6 +198,12 @@ pub(crate) fn solve_flexbox_layout(
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
     let direction = flexbox_layout_direction(flexbox_layout, local_context);
+    let align_content = flexbox_layout
+        .align_content
+        .as_ref()
+        .map_or(i_slint_core::items::FlexAlignContent::default(), |nr| {
+            eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
+        });
 
     let (padding_h, spacing_h) =
         padding_and_spacing(&flexbox_layout.geometry, Orientation::Horizontal, &expr_eval);
@@ -214,6 +220,7 @@ pub(crate) fn solve_flexbox_layout(
             padding_v,
             alignment,
             direction,
+            align_content,
             cells_h: Slice::from(cells_h.as_slice()),
             cells_v: Slice::from(cells_v.as_slice()),
         },

--- a/tests/cases/layout/flexbox-preferred-width.slint
+++ b/tests/cases/layout/flexbox-preferred-width.slint
@@ -9,6 +9,7 @@ export component TestCase inherits Window {
     min-height: 300px;
 
     flex := FlexBoxLayout {
+        align-content: start;  // Don't stretch rows to fill the window height
         spacing: 10px;
         vertical-stretch: 0;
         horizontal-stretch: 0;

--- a/tests/cases/layout/flexbox_align_content.slint
+++ b/tests/cases/layout/flexbox_align_content.slint
@@ -1,0 +1,344 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test FlexBoxLayout align-content property for row and column directions
+// align-content controls how flex lines are distributed along the cross axis.
+
+component VisibleRect inherits Rectangle {
+    border-width: 1px;
+    border-color: black;
+}
+
+// === Row direction tests ===
+
+// Test 1: align-content: start (row) — rows packed at top
+component TestAlignContentStartRow inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+    FlexBoxLayout {
+        align-content: start;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: green;
+        }
+        // Row 1: r1 + r2 = 165 < 200, fits
+        r3 := Rectangle {
+            width: 150px;
+            height: 30px;
+            background: blue;
+        }
+        // Row 2: r3 alone
+    }
+
+    // With align-content: start, rows pack at y=0
+    // Row 1: y=0, Row 2: y=35 (30+5)
+    out property <bool> test: r1.y == 0px && r2.y == 0px && r3.y == 35px;
+}
+
+    // Test 2: align-content: end (row) — rows packed at bottom
+component TestAlignContentEndRow inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+
+    FlexBoxLayout {
+        align-content: end;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: green;
+        }
+
+        r3 := Rectangle {
+            width: 150px;
+            height: 30px;
+            background: blue;
+        }
+    }
+
+    // With align-content: end, rows pack at the bottom
+    // Total content height: 30+5+30 = 65
+    // Offset: 200-65 = 135
+    out property <bool> test: r1.y == 135px && r2.y == 135px && r3.y == 170px;
+}
+
+    // Test 3: align-content: center (row) — rows centered vertically
+component TestAlignContentCenterRow inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+
+    FlexBoxLayout {
+        align-content: center;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: green;
+        }
+
+        r3 := Rectangle {
+            width: 150px;
+            height: 30px;
+            background: blue;
+        }
+    }
+
+    // With align-content: center, rows centered
+    // Total content height: 30+5+30 = 65
+    // Offset: (200-65)/2 = 67.5 ≈ 68
+    out property <bool> test_r1: r1.y >= 67px && r1.y <= 68px;
+    out property <bool> test_r3: r3.y >= 102px && r3.y <= 103px;
+    out property <bool> test: test_r1 && test_r3;
+}
+
+    // Test 4: align-content: stretch (row, the default) — rows stretched to fill
+component TestAlignContentStretchRow inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+
+    FlexBoxLayout {
+        align-content: stretch;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 80px;
+            height: 30px;
+            background: green;
+        }
+
+        r3 := Rectangle {
+            width: 150px;
+            height: 30px;
+            background: blue;
+        }
+    }
+
+    // With align-content: stretch, rows are stretched to fill the 200px height.
+    // Row 2 starts well below row 1 since the remaining 135px is distributed.
+    out property <bool> test: r1.y == 0px && r3.y > 35px;
+}
+
+    // === Column direction tests ===
+
+// Test 5: align-content: start (column) — columns packed at left
+component TestAlignContentStartCol inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+
+    FlexBoxLayout {
+        flex-direction: column;
+        align-content: start;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: green;
+        }
+        // Col 1: r1 + r2 = 165 < 200, fits
+        r3 := Rectangle {
+            width: 30px;
+            height: 150px;
+            background: blue;
+        }
+        // Col 2: r3 alone
+    }
+
+    // With align-content: start, columns pack at x=0
+    // Col 1: x=0, Col 2: x=35 (30+5)
+    out property <bool> test: r1.x == 0px && r2.x == 0px && r3.x == 35px;
+}
+
+    // Test 6: align-content: end (column) — columns packed at right
+component TestAlignContentEndCol inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+
+    FlexBoxLayout {
+        flex-direction: column;
+        align-content: end;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: green;
+        }
+
+        r3 := Rectangle {
+            width: 30px;
+            height: 150px;
+            background: blue;
+        }
+    }
+
+    // With align-content: end, columns pack at the right
+    // Total content width: 30+5+30 = 65
+    // Offset: 200-65 = 135
+    out property <bool> test: r1.x == 135px && r2.x == 135px && r3.x == 170px;
+}
+
+    // Test 7: align-content: center (column) — columns centered horizontally
+component TestAlignContentCenterCol inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+
+    FlexBoxLayout {
+        flex-direction: column;
+        align-content: center;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: green;
+        }
+
+        r3 := Rectangle {
+            width: 30px;
+            height: 150px;
+            background: blue;
+        }
+    }
+
+    // With align-content: center, columns centered
+    // Total content width: 30+5+30 = 65
+    // Offset: (200-65)/2 = 67.5 ≈ 68
+    out property <bool> test_r1: r1.x >= 67px && r1.x <= 68px;
+    out property <bool> test_r3: r3.x >= 102px && r3.x <= 103px;
+    out property <bool> test: test_r1 && test_r3;
+}
+
+    // Test 8: align-content: stretch (column, the default) — columns stretched to fill
+component TestAlignContentStretchCol inherits VisibleRect {
+    width: 200px;
+    height: 200px;
+
+    FlexBoxLayout {
+        flex-direction: column;
+        align-content: stretch;
+        spacing: 5px;
+
+        r1 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: red;
+        }
+
+        r2 := Rectangle {
+            width: 30px;
+            height: 80px;
+            background: green;
+        }
+
+        r3 := Rectangle {
+            width: 30px;
+            height: 150px;
+            background: blue;
+        }
+    }
+
+    // With align-content: stretch, columns are stretched to fill the 200px width.
+    // Column 2 starts well to the right of column 1 since the remaining 135px is distributed.
+    out property <bool> test: r1.x == 0px && r3.x > 35px;
+}
+
+export component TestCase inherits Window {
+    width: 450px;
+    height: 860px;
+
+    HorizontalLayout {
+        spacing: 10px;
+        padding: 10px;
+        VerticalLayout {
+            spacing: 10px;
+            padding: 10px;
+            t1 := TestAlignContentStartRow { }
+
+            t2 := TestAlignContentEndRow { }
+
+            t3 := TestAlignContentCenterRow { }
+
+            t4 := TestAlignContentStretchRow { }
+        }
+
+        VerticalLayout {
+            spacing: 10px;
+            padding: 10px;
+
+            t5 := TestAlignContentStartCol { }
+
+            t6 := TestAlignContentEndCol { }
+
+            t7 := TestAlignContentCenterCol { }
+
+            t8 := TestAlignContentStretchCol { }
+        }
+    }
+
+    out property <bool> test: t1.test && t2.test && t3.test && t4.test && t5.test && t6.test && t7.test && t8.test;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_column_multiple_columns.slint
+++ b/tests/cases/layout/flexbox_column_multiple_columns.slint
@@ -24,11 +24,12 @@ export component TestCase inherits Window {
     // Column 1: r1 (50px) + r2 (50px) + spacing = 105px < 150px
     // Column 2: r3 (50px) + r4 (50px) + spacing = 105px < 150px
     // Column 3: r5 (50px)
+    // With align-content: stretch (CSS default), columns are stretched to fill the 250px width.
     out property <bool> test: r1.x == 0px && r1.y == 0px &&
                               r2.x == 0px && r2.y == 55px &&
-                              r3.x == 45px && r3.y == 0px &&
-                              r4.x == 45px && r4.y == 55px &&
-                              r5.x == 90px && r5.y == 0px;
+                              r3.x == 85px && r3.y == 0px &&
+                              r4.x == 85px && r4.y == 55px &&
+                              r5.x == 170px && r5.y == 0px;
 }
 
 /*

--- a/tests/cases/layout/flexbox_min_width.slint
+++ b/tests/cases/layout/flexbox_min_width.slint
@@ -49,8 +49,9 @@ export component TestCase inherits Window {
     out property <bool> test_r2: r2.x == 85px && r2.y == 0px && r2.width == 60px;
 
     // Row 2: r3 clamped to max-width (80px) + r4 (respects min/max)
-    out property <bool> test_r3: r3.x == 0px && r3.y == 55px && r3.width == 80px;
-    out property <bool> test_r4: r4.x == 85px && r4.y == 55px && r4.width >= 40px && r4.width <= 60px;
+    // With align-content: stretch (CSS default), rows are stretched to fill the 300px height.
+    out property <bool> test_r3: r3.x == 0px && r3.y == 153px && r3.width == 80px;
+    out property <bool> test_r4: r4.x == 85px && r4.y == 153px && r4.width >= 40px && r4.width <= 60px;
 
     out property <bool> test: test_r1 && test_r2 && test_r3 && test_r4;
 }

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -8,6 +8,7 @@ export component TestCase inherits Window {
     height: 300px;
 
     flex := FlexBoxLayout {
+        align-content: start;
         padding: 2px;
         spacing: 5px;
 

--- a/tests/cases/layout/flexbox_oversized.slint
+++ b/tests/cases/layout/flexbox_oversized.slint
@@ -10,6 +10,7 @@ export component TestCase inherits Window {
     // Test with wide items (one per row)
     FlexBoxLayout {
         spacing: 5px;
+        align-content: start;
 
         w1 := Rectangle { width: 100px; height: 30px; background: red; }
         w2 := Rectangle { width: 100px; height: 30px; background: green; }

--- a/tests/cases/layout/flexbox_spacing_and_padding.slint
+++ b/tests/cases/layout/flexbox_spacing_and_padding.slint
@@ -14,6 +14,7 @@ export component TestCase inherits Window {
         border-color: black;
         border-width: 1px;
         FlexBoxLayout {
+            align-content: start;
             spacing: 5px;
             padding: 2px;
 
@@ -45,6 +46,7 @@ export component TestCase inherits Window {
         border-width: 1px;
 
         FlexBoxLayout {
+            align-content: start;
             spacing-vertical: 50px;
             spacing-horizontal: 10px;
             padding-top: 10phx;

--- a/tests/cases/layout/flexbox_varying_heights.slint
+++ b/tests/cases/layout/flexbox_varying_heights.slint
@@ -8,6 +8,7 @@ export component TestCase inherits Window {
     height: 200px;
 
     FlexBoxLayout {
+        align-content: start;
         spacing: 10px;
 
         // Row 1: items with different heights, row height = max(30, 50, 40) = 50


### PR DESCRIPTION
Add FlexAlignContent enum with Stretch (default), Start, End, Center.
This controls the distribution of flex lines along the cross axis,
matching CSS flexbox "align-content".

The default changes from FlexStart (previous hardcoded value) to Stretch
(the CSS default), which distributes extra cross-axis space among flex
lines. This changes the layout of multi-row/multi-column flex containers:
rows/columns are now evenly stretched to fill the full container height/width.

Also fix a bug where only the main-axis container dimension was passed
to taffy — both width and height are now provided when available, which
is required for align-content to distribute extra space correctly.
