### PR TITLE
Flickable: Capture events after first scroll

### DIFF
--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -107,7 +107,7 @@ impl Item for Flickable {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: &MouseEvent,
-        _window_adapter: &Rc<dyn WindowAdapter>,
+        window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
         _: &mut super::MouseCursor,
     ) -> InputEventFilterResult {
@@ -126,7 +126,7 @@ impl Item for Flickable {
         if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {
             return InputEventFilterResult::ForwardAndIgnore;
         }
-        self.data.handle_mouse_filter(self, event, self_rc)
+        self.data.handle_mouse_filter(self, event, window_adapter, self_rc)
     }
 
     fn input_event(
@@ -336,6 +336,17 @@ pub(super) const DISTANCE_THRESHOLD: LogicalLength = LogicalLength::new(8 as _);
 pub(super) const DURATION_THRESHOLD: Duration = Duration::from_millis(500);
 /// The delay to which press are forwarded to the inner item
 pub(super) const FORWARD_DELAY: Duration = Duration::from_millis(100);
+/// Duration to filter scroll events from children after receiving a scroll event
+/// Note: This needs to be rather long, as that makes it more intuitive when scrolling with the
+/// mouse in concrete steps.
+/// The user can always override this by moving the mouse
+/// The value was tuned by hand, could be adjusted with further user feedback
+pub(super) const SCROLL_FILTER_DURATION: Duration = Duration::from_millis(800);
+/// Short duration for scroll event filtering, used when the end of the flickable is reached.
+pub(super) const SHORT_SCROLL_FILTER_DURATION: Duration =
+    Duration::from_millis(SCROLL_FILTER_DURATION.as_millis() as u64 / 2);
+/// How far the user has to move the mouse to stop filtering scroll event from children after receiving a scroll event
+pub(super) const SCROLL_FILTER_DISTANCE_SQUARED: LogicalLength = LogicalLength::new(4 as _);
 
 #[derive(Default, Debug)]
 struct FlickableDataInner {
@@ -346,6 +357,73 @@ struct FlickableDataInner {
     pressed_viewport_size: LogicalSize,
     /// Set to true if the flickable is flicking and capturing all mouse event, not forwarding back to the children
     capture_events: bool,
+    /// Heuristics for filtering scroll events from children after we have scrolled ourselves.
+    /// We want to filter those to prevent the case where the user scrolls with the mouse wheel,
+    /// but the mouse now moves over a child item, and that item captures the scroll event.
+    /// We use two heurstics: First, a timeout after we received a scroll event, and second, if the mouse moves we
+    /// stop filtering scroll event until the next scroll event.
+    last_scroll_event: Option<(Instant, LogicalPoint)>,
+}
+
+impl FlickableDataInner {
+    fn should_capture_scroll(&self, timeout: Duration, position: LogicalPoint) -> bool {
+        self.last_scroll_event.is_some_and(|(last_time, last_position)| {
+            // Note: Squared length for MCU support, which use i32 coords.
+            crate::animations::current_tick() - last_time < timeout
+                && LogicalLength::new((last_position - position).square_length().abs())
+                    < SCROLL_FILTER_DISTANCE_SQUARED
+        })
+    }
+
+    /// Whether the delta is a scroll in a orthogonal direction than what is allowed by the Flickable
+    fn is_allowed_scroll_direction(
+        flick: Pin<&Flickable>,
+        delta: LogicalVector,
+        flick_rc: &ItemRc,
+    ) -> bool {
+        let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
+        !(delta.x == 0 as Coord && flick.viewport_height() <= geo.height_length())
+            && !(delta.y == 0 as Coord && flick.viewport_width() <= geo.width_length())
+    }
+
+    fn process_wheel_event(
+        &mut self,
+        flick: Pin<&Flickable>,
+        delta: LogicalVector,
+        position: LogicalPoint,
+        flick_rc: &ItemRc,
+    ) -> InputEventResult {
+        if !Self::is_allowed_scroll_direction(flick, delta, flick_rc) {
+            // Release the capture immediately, this event is not meant for this Flickable.
+            self.last_scroll_event = None;
+            return InputEventResult::EventIgnored;
+        }
+
+        let old_pos = LogicalPoint::from_lengths(
+            (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick).get(),
+            (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick).get(),
+        );
+        let new_pos = ensure_in_bound(flick, old_pos + delta, flick_rc);
+
+        let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick);
+        let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick);
+        let old_pos = (viewport_x.get(), viewport_y.get());
+        viewport_x.set(new_pos.x_length());
+        viewport_y.set(new_pos.y_length());
+        let flicked = old_pos.0 != new_pos.x_length() || old_pos.1 != new_pos.y_length();
+        if flicked {
+            (Flickable::FIELD_OFFSETS.flicked).apply_pin(flick).call(&());
+            self.last_scroll_event = Some((crate::animations::current_tick(), position));
+            InputEventResult::EventAccepted
+        } else if self.should_capture_scroll(SHORT_SCROLL_FILTER_DURATION, position) {
+            // After reaching the end, keep accepting the input event for a while longer, then time
+            // out (by not updating the last_scroll_event)
+            InputEventResult::EventAccepted
+        } else {
+            self.last_scroll_event = None;
+            InputEventResult::EventIgnored
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -356,10 +434,25 @@ pub struct FlickableData {
 }
 
 impl FlickableData {
+    fn scroll_delta(
+        window_adapter: &Rc<dyn WindowAdapter>,
+        delta_x: Coord,
+        delta_y: Coord,
+    ) -> LogicalVector {
+        if window_adapter.window().0.modifiers.get().shift() && !cfg!(target_os = "macos") {
+            // Shift invert coordinate for the purpose of scrolling.
+            // But not on macOs because there the OS already take care of the change
+            LogicalVector::new(delta_y, delta_x)
+        } else {
+            LogicalVector::new(delta_x, delta_y)
+        }
+    }
+
     fn handle_mouse_filter(
         &self,
         flick: Pin<&Flickable>,
         event: &MouseEvent,
+        window_adapter: &Rc<dyn WindowAdapter>,
         flick_rc: &ItemRc,
     ) -> InputEventFilterResult {
         let mut inner = self.inner.borrow_mut();
@@ -418,7 +511,19 @@ impl FlickableData {
                     InputEventFilterResult::ForwardEvent
                 }
             }
-            MouseEvent::Wheel { .. } => InputEventFilterResult::ForwardEvent,
+            MouseEvent::Wheel { position, delta_x, delta_y } => {
+                // If we recently handled a wheel event, intercept it to prevent children from grabbing
+                // the scroll event
+                let delta = Self::scroll_delta(window_adapter, *delta_x, *delta_y);
+                if FlickableDataInner::is_allowed_scroll_direction(flick, delta, flick_rc)
+                    && inner.should_capture_scroll(SCROLL_FILTER_DURATION, *position)
+                {
+                    InputEventFilterResult::Intercept
+                } else {
+                    inner.last_scroll_event = None;
+                    InputEventFilterResult::ForwardEvent
+                }
+            }
             // Not the left button
             MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
@@ -515,40 +620,10 @@ impl FlickableData {
                     InputEventResult::EventIgnored
                 }
             }
-            MouseEvent::Wheel { delta_x, delta_y, .. } => {
-                let delta = if window_adapter.window().0.modifiers.get().shift()
-                    && !cfg!(target_os = "macos")
-                {
-                    // Shift invert coordinate for the purpose of scrolling. But not on macOs because there the OS already take care of the change
-                    LogicalVector::new(*delta_y, *delta_x)
-                } else {
-                    LogicalVector::new(*delta_x, *delta_y)
-                };
+            MouseEvent::Wheel { delta_x, delta_y, position } => {
+                let delta = Self::scroll_delta(window_adapter, *delta_x, *delta_y);
 
-                let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
-
-                if (delta.x == 0 as Coord && flick.viewport_height() <= geo.height_length())
-                    || (delta.y == 0 as Coord && flick.viewport_width() <= geo.width_length())
-                {
-                    // Scroll in a orthogonal direction than what is allowed by the flickable
-                    return InputEventResult::EventIgnored;
-                }
-
-                let old_pos = LogicalPoint::from_lengths(
-                    (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick).get(),
-                    (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick).get(),
-                );
-                let new_pos = ensure_in_bound(flick, old_pos + delta, flick_rc);
-
-                let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick);
-                let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick);
-                let old_pos = (viewport_x.get(), viewport_y.get());
-                viewport_x.set(new_pos.x_length());
-                viewport_y.set(new_pos.y_length());
-                if old_pos.0 != new_pos.x_length() || old_pos.1 != new_pos.y_length() {
-                    (Flickable::FIELD_OFFSETS.flicked).apply_pin(flick).call(&());
-                }
-                InputEventResult::EventAccepted
+                inner.process_wheel_event(flick, delta, *position, flick_rc)
             }
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }

--- a/tests/cases/widgets/scroll_event_propagation.slint
+++ b/tests/cases/widgets/scroll_event_propagation.slint
@@ -28,7 +28,6 @@ export component TestCase inherits Window {
     flickable := Flickable {
         width: 100%;
         height: 100%;
-        viewport_height: 1000px;
         // Test scroll behavior for all widgets in here
         VerticalLayout {
             checkbox := CheckBox {
@@ -54,7 +53,7 @@ export component TestCase inherits Window {
             }
 
             text-edit := TextEdit {
-                height: 60px;
+                height: 100px;
                 text: "TextEdit";
             }
 
@@ -87,6 +86,18 @@ export component TestCase inherits Window {
 
             // Add items after to make scrolling necessary
             Rectangle {
+                height: 400px;
+                background: lightyellow;
+            }
+
+            // add another "stumbling block" to test that we can scroll "over" this text edit when scroll events are cpatured
+            // by the flickable.
+            lower-text := TextEdit {
+                height: 100px;
+                text: "many\nlines\nof\ntext\nthat\nscrolls\nfoo\nbar\nbarfoo\nmore\nlines";
+            }
+
+            Rectangle {
                 height: 8000px;
                 background: lightyellow;
             }
@@ -104,7 +115,7 @@ let instance = TestCase::new().unwrap();
 let flickable = ElementHandle::find_by_element_id(&instance, "TestCase::flickable").next().unwrap();
 
 let reset = || {
-    flickable.scroll(0., 100.);
+    flickable.scroll(0., 10_000.);
     assert_eq!(instance.get_flickable_viewport_y(), 0.0);
 };
 
@@ -147,8 +158,13 @@ let scrolls = [
     "TestCase::text-edit",
 ];
 
+// The Flickable will start capturing scroll events, make sure to time this out.
+const SCROLL_CAPTURE_TIMEOUT_MS: u64 = 1_500;
+let timeout_scroll_capture = || slint_testing::mock_elapsed_time(SCROLL_CAPTURE_TIMEOUT_MS);
+
 for scroll in scrolls {
     assert_scrolls(scroll);
+    timeout_scroll_capture();
 }
 
 instance.invoke_focus_combobox(true);
@@ -163,8 +179,39 @@ instance.invoke_focus_combobox(false);
 assert_does_not_scroll("TestCase::spin-box");
 
 // TextEdit only consumes scroll events if it needs to
-instance.invoke_set_text_edit("Multi\nLine\nText\nThat\nScrolls".into());
-
+assert_scrolls("TestCase::text-edit");
+instance.invoke_set_text_edit("Multi\nLine\nText\nThat\nScrolls\nfoo\nbar\nmany\nlines".into());
 assert_does_not_scroll("TestCase::text-edit");
+
+// Test that we can scroll over the lower text edit if the scroll events are within the timeout
+// Also needs to ensure that the mouse position does not change -> always fire the scroll event in the
+// center of the flickable.
+for _ in 0..100 {
+    let before = instance.get_flickable_viewport_y();
+    flickable.scroll(0., -10.);
+    let after = instance.get_flickable_viewport_y();
+    assert!(
+        after < before,
+        "Should be able to scroll over the lower text edit if the scroll events are within the timeout.\
+         Before viewport-y: {before}, after scroll: {after}"
+    );
+}
+
+reset();
+
+// If scrolling with a slow timeout, the lower textedit will start consuming scroll events
+let mut found = false;
+for _ in 0..100 {
+    let before = instance.get_flickable_viewport_y();
+    timeout_scroll_capture();
+    flickable.scroll(0., -10.);
+    let after = instance.get_flickable_viewport_y();
+    eprintln!("{before} -> {after}");
+    if after == before {
+        found = true;
+        break;
+    }
+}
+assert!(found, "With a timeout, the lower text edit should start consuming scroll events, preventing the flickable from scrolling further.");
 ```
 */


### PR DESCRIPTION
Flickables and ScrollViews will now start capturing scroll events, as
soon as they first receive a scroll.
This allows scrolling over other inner ScrollViews/Flickables
(e.g. TextEdits) without interruption.
As soon as the mouse is moved or a timeout is reached, the flickable
stops capturing.
This results in a more intuitive scrolling behavior, as no child
elements suddenly grab the scroll events when scrolling over a list of
items.

ChangeLog: Improved scroll behavior with nested Flickables/ScrollViews - children can no longer grab scroll events from a surround Flickable that is already scrolling

Thanks to @brauntom for suggesting this. 

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
