### PR TITLE
Add a feature to enable Path rendering with the software renderer in …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ read-fonts = { version = "0.35" }
 skrifa = { version = "0.37" }
 windows = { version = "0.62" }
 windows-core = { version = "0.62.0" }
+lyon_path = { version = "1.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -56,6 +56,10 @@ serde = ["i-slint-core/serde"]
 # Deprecated feature, this is now automatically enabled when the `renderer-software` and `std` features are enabled
 software-renderer-systemfonts = ["renderer-software"]
 
+# Enable support for Path element rendering with the software renderer. This is implicitly enabled by the
+# `std` feature, but can be enabled without `std` if you want to use the software renderer in a `#![no_std]` environment and need support for Path elements.
+software-renderer-path = ["i-slint-renderer-software/path"]
+
 ## Slint uses internally some `thread_local` state.
 ##
 ## When the `std` feature is enabled, Slint can use [`std::thread_local!`], but when in a `#![no_std]`

--- a/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
+++ b/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
@@ -83,7 +83,7 @@ The Qt renderer comes with the <Link type="QtBackend" label="Qt backend" /> and 
   * No support for `border-radius` in combination with `clip: true`.
   * No text stroking/outlining.
 - Text rendering currently limited to western scripts.
-- `Path` elements only available with the `std` feature.
+- `Path` elements in `no_std` environments requires enabling the `software-renderer-path` feature.
 - Available in `no_std` environments as well as in the <Link type="WinitBackend" label="Winit backend" /> and <Link type="LinuxkmsBackend" label="LinuxKMS backend" />.
 - Public <LangRefLink lang="rust-slint" relpath="platform/software_renderer/">Rust</LangRefLink> and <LangRefLink lang="cpp" relpath="api/classslint_1_1platform_1_1SoftwareRenderer">C++</LangRefLink> API.
 

--- a/internal/backends/qt/Cargo.toml
+++ b/internal/backends/qt/Cargo.toml
@@ -30,7 +30,7 @@ const-field-offset = { version = "0.1", path = "../../../helper_crates/const-fie
 vtable = { workspace = true }
 
 cpp = { version = "0.5.5", optional = true }
-lyon_path = { version = "1", optional = true }
+lyon_path = { workspace = true, optional = true }
 pin-project = { version = "1", optional = true }
 pin-weak = { version = "1", optional = true }
 qttypes = { version = "0.2.7", default-features = false, optional = true }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -70,7 +70,7 @@ i-slint-common = { workspace = true, features = ["default"] }
 
 cfg-if = "1"
 derive_more = { workspace = true }
-lyon_path = "1.0"
+lyon_path = { workspace = true }
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
 strum = { workspace = true }

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -52,7 +52,7 @@ derive_more = { workspace = true }
 annotate-snippets = { version = "0.12.9", optional = true }
 quote = { version = "1.0", optional = true }
 proc-macro2 = { version = "1.0.17", optional = true }
-lyon_path = { version = "1.0" }
+lyon_path = { workspace = true, features = ["std"] }
 lyon_extra = "1.0.1"
 by_address = { workspace = true }
 itertools = { workspace = true }

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -32,14 +32,6 @@ pub fn compile_paths(
             return;
         }
 
-        #[cfg(feature = "software-renderer")]
-        if _embed_resources == EmbedResourcesKind::EmbedTextures {
-            diag.push_warning(
-                "Path element is not supported with the software renderer".into(),
-                &*elem_.borrow(),
-            )
-        }
-
         let element_types = &path_type.additional_accepted_child_types;
 
         let commands_binding =
@@ -71,10 +63,20 @@ pub fn compile_paths(
                         }
                     }
                 }
-                expr if expr.ty() == Type::String => Expression::PathData(
-                    crate::expression_tree::Path::Commands(Box::new(commands_expr.expression)),
-                )
-                .into(),
+                expr if expr.ty() == Type::String => {
+                    #[cfg(feature = "software-renderer")]
+                    if _embed_resources == EmbedResourcesKind::EmbedTextures {
+                        diag.push_warning(
+                            "Bindings to the Path element's commands are not supported with the software renderer".into(),
+                            &*elem_.borrow(),
+                        )
+                    }
+
+                    Expression::PathData(crate::expression_tree::Path::Commands(Box::new(
+                        commands_expr.expression,
+                    )))
+                    .into()
+                }
                 _ => {
                     diag.push_error(
                         "The commands property only accepts strings".into(),

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -28,14 +28,11 @@ std = [
   "euclid/std",
   "once_cell/std",
   "dep:scoped-tls-hkt",
-  "dep:lyon_path",
-  "dep:lyon_algorithms",
-  "dep:lyon_geom",
-  "dep:lyon_extra",
-  "dep:auto_enums",
   "dep:web-time",
+  "dep:lyon_extra",
   "image-decoders",
   "svg",
+  "path",
   "raw-window-handle-06?/std",
   "chrono/std",
   "chrono/wasmbind",
@@ -75,6 +72,8 @@ default = ["std", "unicode", "shared-parley"]
 
 shared-parley = ["shared-fontique", "dep:parley", "dep:skrifa"]
 
+path = ["dep:auto_enums", "dep:lyon_path", "dep:lyon_geom", "dep:lyon_algorithms"]
+
 [dependencies]
 i-slint-common = { workspace = true, features = ["default"] }
 i-slint-core-macros = { workspace = true, features = ["default"] }
@@ -87,10 +86,10 @@ auto_enums = { version = "0.8.0", optional = true }
 cfg-if = "1"
 derive_more = { workspace = true, features = ["error"] }
 euclid = { workspace = true }
-lyon_algorithms = { version = "1.0", optional = true }
-lyon_geom = { version = "1.0", optional = true }
-lyon_path = { version = "1.0", optional = true }
-lyon_extra = { version = "1.0.1", optional = true }
+lyon_algorithms = { version = "1.0", optional = true, default-features = false }
+lyon_geom = { version = "1.0", optional = true, default-features = false }
+lyon_path = { workspace = true, optional = true, default-features = false }
+lyon_extra = { version = "1.0.1", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.5", default-features = false, features = ["critical-section"] }
 pin-project = "1"

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -32,11 +32,11 @@ pub type Transform = euclid::default::Transform2D<Coord>;
 pub(crate) mod color;
 pub use color::*;
 
-#[cfg(feature = "std")]
-mod path;
 #[cfg(feature = "shared-fontique")]
 use i_slint_common::sharedfontique::{self, fontique};
-#[cfg(feature = "std")]
+#[cfg(feature = "path")]
+mod path;
+#[cfg(feature = "path")]
 pub use path::*;
 
 mod brush;

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -5,6 +5,7 @@
 This module contains path related types and functions for the run-time library.
 */
 
+#[cfg(feature = "std")]
 use crate::debug_log;
 use crate::items::PathEvent;
 #[cfg(feature = "rtti")]
@@ -272,6 +273,7 @@ pub enum PathData {
     /// associated coordinates.
     Events(crate::SharedVector<PathEvent>, crate::SharedVector<lyon_path::math::Point>),
     /// The Commands variant describes the path as a series of SVG encoded path commands.
+    #[cfg(feature = "std")]
     Commands(crate::SharedString),
 }
 
@@ -293,6 +295,7 @@ impl PathData {
                 PathData::Events(events, coordinates) => {
                     LyonPathIteratorVariant::FromEvents(events, coordinates)
                 }
+                #[cfg(feature = "std")]
                 PathData::Commands(commands) => {
                     let mut builder = lyon_path::Path::builder();
                     let mut parser = lyon_extra::parser::PathParser::new();

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -428,7 +428,7 @@ pub trait ItemRenderer {
         _self_rc: &ItemRc,
         _size: LogicalSize,
     );
-    #[cfg(feature = "std")]
+    #[cfg(feature = "path")]
     fn draw_path(&mut self, path: Pin<&Path>, _self_rc: &ItemRc, _size: LogicalSize);
     fn draw_box_shadow(
         &mut self,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -59,9 +59,9 @@ mod image;
 pub use self::image::*;
 mod drag_n_drop;
 pub use drag_n_drop::*;
-#[cfg(feature = "std")]
+#[cfg(feature = "path")]
 mod path;
-#[cfg(feature = "std")]
+#[cfg(feature = "path")]
 pub use path::*;
 
 /// Alias for `&mut dyn ItemRenderer`. Required so cbindgen generates the ItemVTable
@@ -1793,7 +1793,7 @@ declare_item_vtable! {
     fn slint_get_ClippedImageVTable() -> ClippedImageVTable for ClippedImage
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "path")]
 declare_item_vtable! {
     fn slint_get_PathVTable() -> PathVTable for Path
 }

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -21,7 +21,7 @@ use crate::item_rendering::{
     RenderText,
 };
 use crate::item_tree::{ItemTreeRc, ItemTreeWeak, ItemVisitorResult};
-#[cfg(feature = "std")]
+#[cfg(feature = "path")]
 use crate::items::Path;
 use crate::items::{BoxShadow, Clip, ItemRc, ItemRef, Opacity, RenderingResult, TextInput};
 use crate::lengths::{
@@ -668,7 +668,7 @@ impl<T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRenderer<'_
     forward_rendering_call2!(fn draw_image(dyn RenderImage));
     forward_rendering_call2!(fn draw_text(dyn RenderText));
     forward_rendering_call!(fn draw_text_input(TextInput));
-    #[cfg(feature = "std")]
+    #[cfg(feature = "path")]
     forward_rendering_call!(fn draw_path(Path));
     forward_rendering_call!(fn draw_box_shadow(BoxShadow));
 

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -146,7 +146,7 @@ vtable = { workspace = true }
 
 derive_more = { workspace = true, features = ["std", "error"] }
 generativity = "1"
-lyon_path = { version = "1.0" }
+lyon_path = { workspace = true }
 once_cell = "1.5"
 serde_json = { workspace = true, optional = true }
 document-features = { version = "0.2.0", optional = true }

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -32,7 +32,7 @@ const-field-offset = { version = "0.1", path = "../../../helper_crates/const-fie
 
 cfg-if = "1"
 derive_more = { workspace = true }
-lyon_path = "1.0"
+lyon_path = { workspace = true }
 pin-weak = "1"
 femtovg = { version = "0.20.1", default-features = false, features = ["image-loading"] }
 ttf-parser = { workspace = true }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -56,7 +56,7 @@ vtable = { workspace = true }
 
 cfg-if = "1"
 derive_more = { workspace = true }
-lyon_path = "1.0"
+lyon_path = { workspace = true }
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.6", features = ["std"] }

--- a/internal/renderers/software/Cargo.toml
+++ b/internal/renderers/software/Cargo.toml
@@ -25,7 +25,7 @@ systemfonts = [
   "std",
   "dep:clru",
 ]
-path = ["dep:zeno", "dep:lyon_path"]
+path = ["dep:zeno", "dep:lyon_path", "i-slint-core/path"]
 std = ["zeno?/std", "num-traits/std", "euclid/std", "i-slint-core/std", "path", "systemfonts"]
 libm = ["zeno?/libm", "num-traits/libm", "euclid/libm", "i-slint-core/libm"]
 
@@ -44,7 +44,7 @@ num-traits = { version = "0.2", default-features = false }
 skrifa = { workspace = true, optional = true }
 fontdue = { workspace = true, optional = true }
 zeno = { version = "0.3.3", optional = true, default-features = false, features = ["eval"] }
-lyon_path = { version = "1.0", optional = true }
+lyon_path = { workspace = true, optional = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(cbindgen)", "cfg(slint_nightly_test)"] }

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -2918,7 +2918,7 @@ impl<T: ProcessScene> i_slint_core::item_rendering::ItemRenderer for SceneBuilde
         // Path rendering is disabled without the path feature
     }
 
-    #[cfg(all(feature = "std", feature = "path"))]
+    #[cfg(feature = "path")]
     fn draw_path(
         &mut self,
         path: Pin<&i_slint_core::items::Path>,

--- a/internal/renderers/software/path.rs
+++ b/internal/renderers/software/path.rs
@@ -12,7 +12,6 @@ use zeno::{Fill, Mask, Stroke};
 pub use zeno::Command;
 
 /// Convert Slint's PathDataIterator to zeno's Command format
-#[cfg(feature = "std")]
 pub fn convert_path_data_to_zeno(
     path_data: i_slint_core::graphics::PathDataIterator,
     rotation: crate::RotationInfo,


### PR DESCRIPTION
…no_std environments

This works, except for dynamic `commands`.

cc #4178

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
