### PR TITLE
Femtovg: Switch to swash as glyph rasterizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,20 +3194,20 @@ dependencies = [
 
 [[package]]
 name = "femtovg"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a125295d4de2b2473e731c4612599ba3cdf7e05af6bba16f324ba8ffbf093436"
+checksum = "878199c9bc73ac922ddbd4e2b22c3f14f0b6b1d711709da88d00cbd804870db5"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "fnv",
  "glow",
- "image",
  "imgref",
  "itertools 0.14.0",
  "log",
  "rgb",
  "slotmap",
+ "swash",
  "ttf-parser 0.25.1",
  "wasm-bindgen",
  "web-sys",

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1"
 derive_more = { workspace = true }
 lyon_path = "1.0"
 pin-weak = "1"
-femtovg = { version = "0.20.1", default-features = false, features = ["image-loading"] }
+femtovg = { version = "0.20.3", default-features = false, features = ["swash"] }
 ttf-parser = { workspace = true }
 imgref = { version = "1.6.1" }
 rgb = { version = "0.8.27" }


### PR DESCRIPTION
This provides a better quality anti-aliasing.

cc #6215
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
