### PR TITLE
Fix: correct syntax highlighting for single-function callbacks

### DIFF
--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -351,6 +351,9 @@
                     "include": "#callback-setup"
                 },
                 {
+                    "include": "#function-call"
+                },
+                {
                     "include": "#expression"
                 },
                 {

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -521,7 +521,7 @@ module.exports = grammar({
       seq(
         field("name", choice($.function_call, $.simple_identifier)),
         "=>",
-        field("action", $.imperative_block),
+        field("action", $._binding),
       ),
 
     changed_callback: ($) =>
@@ -529,7 +529,7 @@ module.exports = grammar({
         "changed",
         field("name", $.simple_identifier),
         "=>",
-        field("action", $.imperative_block),
+        field("action", $._binding),
       ),
 
     function_call: ($) =>


### PR DESCRIPTION
This PR fixes a bug in the syntax grammar where callbacks containing only a single function call were not highlighted correctly.

## Example
Previously, code like the following broke the text highlighting:

```slint
my_callback => parent.my_other_callback();
```