### PR TITLE
Add platform-native string conversion for keyboard shortcuts

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -544,7 +544,8 @@ fn gen_corelib(
         let mut special_config = config.clone();
         special_config.export.include = rust_types.iter().map(|s| s.to_string()).collect();
         special_config.export.exclude = [
-            "slint_keyboard_shortcut_to_string",
+            "slint_keyboard_shortcut_debug_string",
+            "slint_keyboard_shortcut_to_platform_string",
             "slint_keyboard_shortcut_matches",
             "slint_keyboard_shortcut",
             "slint_visit_item_tree",

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -72,7 +72,7 @@ pub fn to_js_unknown(env: &Env, value: &Value) -> Result<JsUnknown> {
         }
         Value::KeyboardShortcut(shortcut) => {
             // TODO: Make this an actual JS object
-            env.create_string(&shortcut.to_string()).map(JsString::into_unknown)
+            env.create_string(&format!("{shortcut:?}")).map(JsString::into_unknown)
         }
         Value::Brush(brush) => {
             Ok(SlintBrush::from(brush.clone()).into_instance(*env)?.as_object(*env).into_unknown())

--- a/api/python/slint/value.rs
+++ b/api/python/slint/value.rs
@@ -47,7 +47,7 @@ impl<'py> IntoPyObject<'py> for SlintToPyValue {
             Value::EnumerationValue(enum_name, enum_value) => {
                 type_collection.enum_to_py(&enum_name, &enum_value, py)?.into_bound_py_any(py)
             }
-            Value::KeyboardShortcut(shortcut) => shortcut.to_string().into_bound_py_any(py),
+            Value::KeyboardShortcut(shortcut) => format!("{shortcut:?}").into_bound_py_any(py),
             v @ _ => {
                 eprintln!(
                     "Python: conversion from slint to python needed for {v:#?} and not implemented yet"

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -339,6 +339,7 @@ The following conversions are possible:
     but they can be divided by themselves to result in a number. Similarly, a number can be multiplied by one of
     these unit. The idea is that one would multiply by `1px` or divide by `1px` to do such conversions
 -   The literal `0` can be converted to any of these types that have associated unit.
+-   A `keyboard-shortcut` can be converted to `string`, which will return a platform-native description of the shortcut.
 -   Struct types convert with another struct type if they have the same property names and their types can be converted.
     The source struct can have either missing properties, or extra properties. But not both.
 -   Arrays generally don't convert between each other. Array literals can be converted if the element types are convertible.
@@ -364,5 +365,6 @@ export component Example {
     property<float> xxx1: xxx.to-float(); // 42.1
     property<bool> xxx2: xxx.is-float(); // true
     property<int> xxx3: 45.8; // 45
+    property<string> xxx4: @keys(Control + A); // "⌘A" on macOS, "Ctrl+A" on other platforms, etc.
 }
 ```

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -409,8 +409,7 @@ fn to_debug_string(
         | Type::Image
         | Type::Easing
         | Type::StyledText
-        | Type::Array(_)
-        | Type::KeyboardShortcutType => {
+        | Type::Array(_) => {
             Expression::StringLiteral("<debug-of-this-type-not-yet-implemented>".into())
         }
         Type::Duration
@@ -486,7 +485,9 @@ fn to_debug_string(
                 ]),
             }
         }
-        Type::Enumeration(_) => Expression::Cast { from: Box::new(expr), to: (Type::String) },
+        Type::Enumeration(_) | Type::KeyboardShortcutType => {
+            Expression::Cast { from: Box::new(expr), to: (Type::String) }
+        }
     }
 }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3549,6 +3549,16 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                         cases.join(" ")
                     )
                 }
+                (Type::KeyboardShortcutType, Type::String) => {
+                    format!(
+                        "[&](){{\
+                            slint::SharedString s;
+                            auto shortcut = {f};
+                            slint::cbindgen_private::slint_keyboard_shortcut_to_platform_string(&shortcut, &s);
+                            return s;
+                        }}()"
+                    )
+                }
                 _ => f,
             }
         }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2516,6 +2516,9 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     });
                     quote!(match #f { #(#cases,)*  _ => sp::SharedString::default() })
                 }
+                (Type::KeyboardShortcutType, Type::String) => {
+                    quote!(#f.to_platform_string())
+                }
                 (_, Type::Void) => {
                     quote!({#f;})
                 }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -279,7 +279,8 @@ impl Type {
             | (Type::PhysicalLength, Type::Rem)
             | (Type::Percent, Type::Float32)
             | (Type::Brush, Type::Color)
-            | (Type::Color, Type::Brush) => true,
+            | (Type::Color, Type::Brush)
+            | (Type::KeyboardShortcutType, Type::String) => true,
             (Type::Array(a), Type::Model) if a.is_property_type() => true,
             (Type::Struct(a), Type::Struct(b)) => can_convert_struct(&a.fields, &b.fields),
             (Type::UnitProduct(u), o) => match o.as_unit_product() {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -220,7 +220,7 @@ impl std::fmt::Debug for Value {
             Value::ArrayOfU16(data) => {
                 write!(f, "Value::ArrayOfU16({data:?})")
             }
-            Value::KeyboardShortcut(ks) => write!(f, "Value::KeyboardShortcut({ks})"),
+            Value::KeyboardShortcut(ks) => write!(f, "Value::KeyboardShortcut({ks:?})"),
         }
     }
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -229,6 +229,9 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 (Value::Number(n), Type::Color) => Color::from_argb_encoded(n as u32).into(),
                 (Value::Brush(brush), Type::Color) => brush.color().into(),
                 (Value::EnumerationValue(_, val), Type::String) => Value::String(val.into()),
+                (Value::KeyboardShortcut(shortcut), Type::String) => {
+                    Value::String(shortcut.to_platform_string())
+                }
                 (v, _) => v,
             }
         }

--- a/tests/cases/types/keyboard_shortcut.slint
+++ b/tests/cases/types/keyboard_shortcut.slint
@@ -12,6 +12,11 @@ export component TestCase inherits Window {
     // For access from NodeJS
     out property <keyboard-shortcut> first_shortcut: shortcuts[0];
 
+    // Test conversion from keyboard-shortcut to string
+    out property <string> shortcut_as_string: shortcuts[0];
+    out property <string> shortcut_a_as_string: shortcuts[1];
+    out property <string> shortcut_plus_as_string: shortcuts[2];
+
     out property <int> matches: 0;
 
     Text {
@@ -27,13 +32,22 @@ export component TestCase inherits Window {
             debug("Pressed: ", event);
             EventResult.reject
         }
+        function log_matches(shortcut: keyboard-shortcut, event: KeyEvent) -> bool {
+            if shortcut.matches(event) {
+                debug("MATCH: ", shortcut);
+                true
+            } else {
+                false
+            }
+        }
+
         key-released(event) => {
             debug("Released: ", event);
             let old-matches = root.matches;
 
-            if root.shortcuts[0].matches(event) { matches += 1; }
-            if root.shortcuts[1].matches(event) { matches += 1; }
-            if root.shortcuts[2].matches(event) { matches += 1; }
+            if log_matches(root.shortcuts[0], event) { matches += 1; }
+            if log_matches(root.shortcuts[1], event) { matches += 1; }
+            if log_matches(root.shortcuts[2], event) { matches += 1; }
 
             if old-matches != root.matches {
                 debug("MATCHES");
@@ -54,7 +68,7 @@ const TestCase &instance = *handle;
 const auto shortcuts = instance.get_shortcuts();
 const auto shortcut = shortcuts->row_data(0).value();
 slint::SharedString shortcut_string;
-slint::cbindgen_private::slint_keyboard_shortcut_to_string(&shortcut, &shortcut_string);
+slint::cbindgen_private::slint_keyboard_shortcut_debug_string(&shortcut, &shortcut_string);
 assert_eq(shortcut_string, "Control+Shift+\"\\u{1b}\"");
 
 using namespace slint::platform;
@@ -103,7 +117,7 @@ let expected = [
     "Control+IgnoreShift+\"+\"",
 ];
 for (shortcut, expected) in shortcuts.iter().zip(expected) {
-    assert_eq!(shortcut.to_string(), expected);
+    assert_eq!(format!("{:?}", shortcut), expected);
 }
 
 use slint::private_unstable_api::re_exports::Key;
@@ -129,6 +143,33 @@ slint_testing::send_keyboard_shortcut(&instance, [Key::Control, Key::Alt, Key::P
 slint_testing::send_keyboard_shortcut(&instance, [char::from(Key::Control), 'A']);
 slint_testing::send_keyboard_shortcut(&instance, [char::from(Key::Control), 'a']);
 assert_eq!(instance.get_matches(), 5);
+
+// Test platform string conversion - explicit comparison with expected values
+let shortcut_string = instance.get_shortcut_as_string();
+let shortcut_a_string = instance.get_shortcut_a_as_string();
+let shortcut_plus_string = instance.get_shortcut_plus_as_string();
+
+#[cfg(target_os = "macos")]
+{
+    assert_eq!(shortcut_string.as_str(), "⇧⌘Escape");
+    assert_eq!(shortcut_a_string.as_str(), "⇧⌘A");
+    assert_eq!(shortcut_plus_string.as_str(), "⌘+");
+}
+
+#[cfg(target_os = "windows")]
+{
+    assert_eq!(shortcut_string.as_str(), "Ctrl+Shift+Escape");
+    assert_eq!(shortcut_a_string.as_str(), "Ctrl+Shift+A");
+    assert_eq!(shortcut_plus_string.as_str(), "Ctrl++");
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+{
+    assert_eq!(shortcut_string.as_str(), "Ctrl+Shift+Escape");
+    assert_eq!(shortcut_a_string.as_str(), "Ctrl+Shift+A");
+    assert_eq!(shortcut_plus_string.as_str(), "Ctrl++");
+}
+
 ```
 
 ```js


### PR DESCRIPTION
Part of #102

- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [] ~If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`~
- [ ] ~If the change is noteworthy, the commit message should contain `ChangeLog: ...`~
