### PR TITLE
KeyboardShortcut: Use Display for platform string

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -546,7 +546,7 @@ fn gen_corelib(
         special_config.export.include = rust_types.iter().map(|s| s.to_string()).collect();
         special_config.export.exclude = [
             "slint_keyboard_shortcut_debug_string",
-            "slint_keyboard_shortcut_to_platform_string",
+            "slint_keyboard_shortcut_to_string",
             "slint_keyboard_shortcut_matches",
             "slint_keyboard_shortcut",
             "slint_visit_item_tree",

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -337,6 +337,13 @@ translate_from_bundle_with_plural(std::span<const char8_t *const> strs,
     return result;
 }
 
+inline SharedString keyboard_shortcut_to_string(const cbindgen_private::KeyboardShortcut &shortcut)
+{
+    SharedString result;
+    cbindgen_private::slint_keyboard_shortcut_to_string(&shortcut, &result);
+    return result;
+}
+
 template<typename Component>
 inline float get_resolved_default_font_size(const Component &component)
 {

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -211,7 +211,9 @@ pub mod re_exports {
     pub use i_slint_core::window::{
         InputMethodRequest, WindowAdapter, WindowAdapterRc, WindowInner,
     };
-    pub use i_slint_core::{Color, Coord, SharedString, SharedVector, format};
+    pub use i_slint_core::{
+        Color, Coord, SharedString, SharedVector, format, string::ToSharedString,
+    };
     pub use i_slint_core::{ItemTreeVTable_static, MenuVTable_static};
     pub use num_traits::float::Float;
     pub use num_traits::ops::euclid::Euclid;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3550,14 +3550,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                     )
                 }
                 (Type::KeyboardShortcutType, Type::String) => {
-                    format!(
-                        "[&](){{\
-                            slint::SharedString s;
-                            auto shortcut = {f};
-                            slint::cbindgen_private::slint_keyboard_shortcut_to_platform_string(&shortcut, &s);
-                            return s;
-                        }}()"
-                    )
+                    format!("slint::private_api::keyboard_shortcut_to_string({f})")
                 }
                 _ => f,
             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2517,7 +2517,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     quote!(match #f { #(#cases,)*  _ => sp::SharedString::default() })
                 }
                 (Type::KeyboardShortcutType, Type::String) => {
-                    quote!(#f.to_platform_string())
+                    quote!(sp::ToSharedString::to_shared_string(&#f))
                 }
                 (_, Type::Void) => {
                     quote!({#f;})

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -17,6 +17,7 @@ use alloc::rc::Rc;
 use alloc::vec::Vec;
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
+use core::fmt::Display;
 use core::pin::Pin;
 use core::time::Duration;
 
@@ -364,6 +365,8 @@ pub fn make_keyboard_shortcut(
 #[cfg(feature = "ffi")]
 #[allow(unsafe_code)]
 pub(crate) mod ffi {
+    use crate::api::ToSharedString as _;
+
     use super::*;
 
     #[unsafe(no_mangle)]
@@ -390,15 +393,15 @@ pub(crate) mod ffi {
         shortcut: &KeyboardShortcut,
         out: &mut SharedString,
     ) {
-        *out = crate::format!("{shortcut:?}")
+        *out = crate::format!("{shortcut:?}");
     }
 
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_keyboard_shortcut_to_platform_string(
+    pub unsafe extern "C" fn slint_keyboard_shortcut_to_string(
         shortcut: &KeyboardShortcut,
         out: &mut SharedString,
     ) {
-        *out = shortcut.to_platform_string();
+        *out = shortcut.to_shared_string();
     }
 
     #[unsafe(no_mangle)]
@@ -436,85 +439,7 @@ impl KeyboardShortcut {
         event_text.eq(self.key.chars()) && key_event.modifiers == expected_modifiers
     }
 
-    /// Convert the keyboard shortcut to a string that looks native on the current platform.
-    ///
-    /// For example, the shortcut created with @keys(Meta + Control + A)
-    /// will be converted like this:
-    /// - **macOS**: `⌃⌘A`
-    /// - **Windows**: `Super+Ctrl+A`
-    /// - **Linux**: `Super+Ctrl+A`
-    ///
-    /// Note that this functions output is best-effort and may be adjusted/improved at any time,
-    /// do not rely on this output to be stable!
-    //
-    // References for implementation
-    // - macOS: <https://developer.apple.com/design/human-interface-guidelines/keyboards>
-    // - Windows: <https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-accelerators>
-    // - Linux: <https://developer.gnome.org/hig/guidelines/keyboard.html>
-    pub fn to_platform_string(&self) -> SharedString {
-        if self.key.is_empty() {
-            return SharedString::default();
-        }
-
-        let mut parts = alloc::vec![];
-        let separator;
-
-        #[cfg(target_os = "macos")]
-        {
-            separator = "";
-
-            // Slint remaps modifiers on macOS: control → Command, meta → Control
-            // From Apple's documentation:
-            //
-            // List modifier keys in the correct order.
-            // If you use more than one modifier key in a custom shortcut, always list them in this order:
-            //  Control, Option, Shift, Command
-            if self.modifiers.meta {
-                parts.push("⌃");
-            }
-            if !self.ignore_alt && self.modifiers.alt {
-                parts.push("⌥");
-            }
-            if !self.ignore_shift && self.modifiers.shift {
-                parts.push("⇧");
-            }
-            if self.modifiers.control {
-                parts.push("⌘");
-            }
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            separator = "+";
-
-            // TODO: These should probably be translated, but better to have at least
-            // platform-local names than nothing.
-            #[cfg(target_os = "windows")]
-            let (ctrl_str, alt_str, shift_str, meta_str) = ("Ctrl", "Alt", "Shift", "Win");
-
-            #[cfg(not(target_os = "windows"))]
-            let (ctrl_str, alt_str, shift_str, meta_str) = ("Ctrl", "Alt", "Shift", "Super");
-
-            if self.modifiers.meta {
-                parts.push(meta_str);
-            }
-            if self.modifiers.control {
-                parts.push(ctrl_str);
-            }
-            if !self.ignore_alt && self.modifiers.alt {
-                parts.push(alt_str);
-            }
-            if !self.ignore_shift && self.modifiers.shift {
-                parts.push(shift_str);
-            }
-        }
-        let key_display = self.format_key_for_display();
-        parts.push(&key_display);
-
-        parts.join(separator).into()
-    }
-
-    fn format_key_for_display(&self) -> alloc::string::String {
+    fn format_key_for_display(&self) -> crate::SharedString {
         let key_str = self.key.as_str();
         let first_char = key_str.chars().next();
 
@@ -537,14 +462,87 @@ impl KeyboardShortcut {
         }
 
         if key_str.chars().count() == 1 {
-            return key_str.to_uppercase();
+            return key_str.to_uppercase().into();
         }
 
         key_str.into()
     }
 }
 
+impl Display for KeyboardShortcut {
+    /// Converts the keyboard shortcut to a string that looks native on the current platform.
+    ///
+    /// For example, the shortcut created with @keys(Meta + Control + A)
+    /// will be converted like this:
+    /// - **macOS**: `⌃⌘A`
+    /// - **Windows**: `Super+Ctrl+A`
+    /// - **Linux**: `Super+Ctrl+A`
+    ///
+    /// Note that this functions output is best-effort and may be adjusted/improved at any time,
+    /// do not rely on this output to be stable!
+    //
+    // References for implementation
+    // - macOS: <https://developer.apple.com/design/human-interface-guidelines/keyboards>
+    // - Windows: <https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-accelerators>
+    // - Linux: <https://developer.gnome.org/hig/guidelines/keyboard.html>
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if self.key.is_empty() {
+            return Ok(());
+        }
+
+        if cfg!(target_os = "macos") {
+            // Slint remaps modifiers on macOS: control → Command, meta → Control
+            // From Apple's documentation:
+            //
+            // List modifier keys in the correct order.
+            // If you use more than one modifier key in a custom shortcut, always list them in this order:
+            //  Control, Option, Shift, Command
+            if self.modifiers.meta {
+                f.write_str("⌃")?;
+            }
+            if !self.ignore_alt && self.modifiers.alt {
+                f.write_str("⌥")?;
+            }
+            if !self.ignore_shift && self.modifiers.shift {
+                f.write_str("⇧")?;
+            }
+            if self.modifiers.control {
+                f.write_str("⌘")?;
+            }
+        } else {
+            let separator = "+";
+
+            // TODO: These should probably be translated, but better to have at least
+            // platform-local names than nothing.
+            let (ctrl_str, alt_str, shift_str, meta_str) = if cfg!(target_os = "windows") {
+                ("Ctrl", "Alt", "Shift", "Win")
+            } else {
+                ("Ctrl", "Alt", "Shift", "Super")
+            };
+
+            if self.modifiers.meta {
+                f.write_str(meta_str)?;
+                f.write_str(separator)?;
+            }
+            if self.modifiers.control {
+                f.write_str(ctrl_str)?;
+                f.write_str(separator)?;
+            }
+            if !self.ignore_alt && self.modifiers.alt {
+                f.write_str(alt_str)?;
+                f.write_str(separator)?;
+            }
+            if !self.ignore_shift && self.modifiers.shift {
+                f.write_str(shift_str)?;
+                f.write_str(separator)?;
+            }
+        }
+        f.write_str(&self.format_key_for_display())
+    }
+}
+
 impl core::fmt::Debug for KeyboardShortcut {
+    /// Formats the keyboard shortcut so that the output would be accepted by the @keys macro in Slint.
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Make sure to keep this in sync with the implemenation in compiler/langtype.rs
         if self.key.is_empty() {
@@ -1316,7 +1314,7 @@ mod tests {
     extern crate alloc;
 
     #[test]
-    fn test_to_platform_string() {
+    fn test_to_string() {
         let test_cases = [
             (
                 "a",
@@ -1422,7 +1420,8 @@ mod tests {
         {
             let shortcut = make_keyboard_shortcut(key.into(), modifiers, ignore_shift, ignore_alt);
 
-            let result = shortcut.to_platform_string();
+            use crate::alloc::string::ToString;
+            let result = shortcut.to_string();
 
             #[cfg(target_os = "macos")]
             assert_eq!(result.as_str(), _expected_macos, "Failed for key: {:?}", key);

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -22,6 +22,7 @@ use i_slint_compiler::langtype::Type;
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_core as corelib;
+use i_slint_core::api::ToSharedString;
 use i_slint_core::items::KeyEvent;
 use smol_str::SmolStr;
 use std::collections::HashMap;
@@ -230,7 +231,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 (Value::Brush(brush), Type::Color) => brush.color().into(),
                 (Value::EnumerationValue(_, val), Type::String) => Value::String(val.into()),
                 (Value::KeyboardShortcut(shortcut), Type::String) => {
-                    Value::String(shortcut.to_platform_string())
+                    Value::String(shortcut.to_shared_string())
                 }
                 (v, _) => v,
             }


### PR DESCRIPTION
Follow-up on #10828
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
