### PR TITLE
Minor cleanup: Remove explicit ttf-parser API usage in sharedparley

### DIFF
--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1242,9 +1242,8 @@ pub fn font_metrics(
     else {
         return crate::items::FontMetrics::default();
     };
-    let face = sharedfontique::ttf_parser::Face::parse(font.blob.data(), font.index).unwrap();
 
-    let metrics = sharedfontique::DesignFontMetrics::new_from_face(&face);
+    let metrics = sharedfontique::DesignFontMetrics::new(&font);
 
     crate::items::FontMetrics {
         ascent: metrics.ascent * logical_pixel_size / metrics.units_per_em,


### PR DESCRIPTION
We can keep that contained in sharedfontique

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
