### PR TITLE
PinchGestureHandler: Add rotation and smart-magnify support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6375,6 +6375,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-gestures"
+version = "1.16.0"
+dependencies = [
+ "slint",
+ "slint-build",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   'examples/imagefilter/rust',
   'examples/maps',
   'examples/memory',
+  'examples/native-gestures',
   'examples/opengl_underlay',
   'examples/opengl_texture',
   'examples/wgpu_texture',

--- a/docs/astro/src/content/docs/reference/gestures/pinchgesturehandler.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/pinchgesturehandler.mdx
@@ -5,7 +5,7 @@ description: PinchGestureHandler element api.
 import SlintProperty  from '@slint/common-files/src/components/SlintProperty.astro';
 
 
-Use the `PinchGestureHandler` to handle pinch-to-zoom gestures from trackpads or touchscreens.
+Use the `PinchGestureHandler` to handle pinch, rotation, and smart-magnify gestures from trackpads or touchscreens.
 Recognition is limited to the element's geometry.
 
 ```slint playground
@@ -14,27 +14,31 @@ export component Example inherits Window {
     height: 400px;
 
     property <float> start-scale;
+    property <angle> start-rotation;
 
     pinch := PinchGestureHandler {
         started => {
-            start-scale = rect.scale;
+            start-scale = rect.current-scale;
+            start-rotation = rect.current-rotation;
         }
         updated => {
-            rect.scale = start-scale * self.scale;
+            rect.current-scale = start-scale * self.scale;
+            rect.current-rotation = start-rotation + self.rotation;
         }
 
         rect := Rectangle {
             background: @radial-gradient(circle, #4488ff, #224488);
             border-radius: 8px;
 
-            property <float> scale: 1.0;
-            width: 200px * self.scale;
-            height: 200px * self.scale;
+            property <float> current-scale: 1.0;
+            property <angle> current-rotation: 0deg;
+            width: 200px * self.current-scale;
+            height: 200px * self.current-scale;
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
 
             Text {
-                text: "Pinch to zoom";
+                text: "Pinch & rotate";
                 color: white;
             }
         }
@@ -43,10 +47,11 @@ export component Example inherits Window {
 ```
 
 The `scale` property provides a cumulative scale factor relative to the start of the gesture (starting at `1.0`).
-Use the `started` callback to capture your initial state, then multiply by `scale` in the `updated` callback to apply the gesture.
+The `rotation` property provides a cumulative rotation angle (starting at `0deg`).
+Use the `started` callback to capture your initial state, then multiply by `scale` and add `rotation` in the `updated` callback to apply the gesture.
 
-On macOS and iOS, the handler responds to trackpad pinch gestures (platform gesture events).
-On other platforms, it processes raw two-finger touch input.
+On macOS and iOS, the handler responds to trackpad pinch, rotation, and smart-magnify gestures (platform gesture events).
+On other platforms, it processes raw two-finger touch input for pinch and rotation.
 
 ## Properties
 
@@ -57,7 +62,7 @@ When disabled, the `PinchGestureHandler` doesn't recognize any gestures and any 
 
 ### active
 <SlintProperty propName="active" typeName="bool" propertyVisibility="out">
-`true` while a pinch gesture is being recognized, `false` otherwise.
+`true` while a gesture is being recognized, `false` otherwise.
 </SlintProperty>
 
 ### scale
@@ -67,22 +72,23 @@ A value greater than `1.0` means zooming in, less than `1.0` means zooming out.
 </SlintProperty>
 
 ### rotation
-<SlintProperty propName="rotation" typeName="float" propertyVisibility="out">
-The cumulative rotation angle of the gesture in degrees. Always starts at `0.0` when the gesture begins.
+<SlintProperty propName="rotation" typeName="angle" propertyVisibility="out">
+The cumulative rotation angle of the gesture. Always starts at `0deg` when the gesture begins.
 Positive values indicate clockwise rotation, negative values indicate counter-clockwise rotation.
-On platforms that don't support rotation gestures yet, this property remains `0.0`.
+On platforms that don't support rotation gestures yet, this property remains `0deg`.
 </SlintProperty>
 
 ### center
 <SlintProperty propName="center" typeName="struct" structName="Point" propertyVisibility="out">
-The center point of the pinch gesture, in the coordinate system of the `PinchGestureHandler`.
+The center point of the gesture, in the coordinate system of the `PinchGestureHandler`.
 For two-finger touch input, this is the midpoint between the two fingers.
 For trackpad gestures, this is the mouse cursor position.
 </SlintProperty>
 
 ## Callbacks
 
--   **`started()`**: Invoked when a pinch gesture begins. Use this to capture the initial state you want to scale.
--   **`updated()`**: Invoked whenever the `scale` or `center` changes during the gesture.
--   **`ended()`**: Invoked when the pinch gesture completes normally (fingers lifted).
+-   **`started()`**: Invoked when a gesture begins. Use this to capture the initial state you want to transform.
+-   **`updated()`**: Invoked whenever the `scale`, `rotation`, or `center` changes during the gesture.
+-   **`ended()`**: Invoked when the gesture completes normally (fingers lifted).
 -   **`cancelled()`**: Invoked when the gesture is cancelled, for example when the handler is disabled during an active gesture or the window loses focus.
+-   **`smart-magnify()`**: Invoked on a platform "smart magnify" gesture (two-finger double-tap on macOS/iOS trackpads). This does not activate the gesture or change `scale`/`rotation`.

--- a/examples/native-gestures/Cargo.toml
+++ b/examples/native-gestures/Cargo.toml
@@ -1,0 +1,20 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "native-gestures"
+version = "1.16.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+publish = false
+license = "MIT"
+
+[[bin]]
+path = "main.rs"
+name = "native-gestures"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }
+
+[build-dependencies]
+slint-build = { path = "../../api/rs/build" }

--- a/examples/native-gestures/build.rs
+++ b/examples/native-gestures/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    slint_build::compile("native-gestures.slint").unwrap();
+}

--- a/examples/native-gestures/main.rs
+++ b/examples/native-gestures/main.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::include_modules!();
+
+fn main() {
+    MainWindow::new().unwrap().run().unwrap();
+}

--- a/examples/native-gestures/native-gestures.slint
+++ b/examples/native-gestures/native-gestures.slint
@@ -1,0 +1,202 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Switch } from "std-widgets.slint";
+
+component InfoItem inherits VerticalLayout {
+    in property <string> label;
+    in property <string> value;
+    in property <brush> value-color: #e0e0f0;
+
+    alignment: center;
+    spacing: 2px;
+
+    Text {
+        text: root.label;
+        color: #606080;
+        font-size: 11px;
+        horizontal-alignment: center;
+    }
+
+    Text {
+        text: root.value;
+        color: root.value-color;
+        font-size: 16px;
+        font-weight: 700;
+        horizontal-alignment: center;
+    }
+}
+
+export component MainWindow inherits Window {
+    title: "Native Gestures Demo";
+    width: 800px;
+    height: 600px;
+    background: #1a1a2e;
+
+    property <float> current-scale: 1.0;
+    property <angle> current-rotation: 0deg;
+    property <float> base-scale: 1.0;
+    property <angle> base-rotation: 0deg;
+    property <bool> gesture-active: false;
+    property <string> status-text: "idle";
+    property <length> center-x;
+    property <length> center-y;
+    property <bool> has-gesture-occurred: false;
+    property <bool> gestures-enabled: true;
+
+    PinchGestureHandler {
+        enabled: root.gestures-enabled;
+
+        started => {
+            root.base-scale = root.current-scale;
+            root.base-rotation = root.current-rotation;
+            root.gesture-active = true;
+            root.status-text = "active";
+        }
+
+        updated => {
+            root.current-scale = max(0.1, root.base-scale * self.scale);
+            root.current-rotation = root.base-rotation + self.rotation;
+            root.center-x = self.center.x;
+            root.center-y = self.center.y;
+            root.has-gesture-occurred = true;
+        }
+
+        ended => {
+            root.gesture-active = false;
+            root.status-text = "ended";
+        }
+
+        cancelled => {
+            root.current-scale = root.base-scale;
+            root.current-rotation = root.base-rotation;
+            root.gesture-active = false;
+            root.status-text = "cancelled";
+        }
+
+        smart-magnify => {
+            if root.current-scale > 1.5 {
+                root.current-scale = 1.0;
+                root.current-rotation = 0deg;
+            } else {
+                root.current-scale = 2.5;
+            }
+            root.status-text = "smart magnify";
+        }
+    }
+
+    VerticalLayout {
+        padding: 20px;
+        spacing: 12px;
+
+        Text {
+            text: "PinchGestureHandler Demo";
+            color: #e0e0f0;
+            font-size: 18px;
+            font-weight: 700;
+            horizontal-alignment: center;
+        }
+
+        Text {
+            text: "Pinch to zoom  •  Rotate with two fingers  •  Double-tap to toggle zoom";
+            color: #606080;
+            font-size: 12px;
+            horizontal-alignment: center;
+        }
+
+        // Controls
+        HorizontalLayout {
+            alignment: center;
+            spacing: 20px;
+
+            Switch {
+                text: "Enabled";
+                checked <=> root.gestures-enabled;
+            }
+
+            Rectangle {
+                height: 28px;
+                width: reset-layout.preferred-width;
+                background: reset-ta.has-hover ? #0f3460 : #16213e;
+                border-radius: 6px;
+                border-width: 1px;
+                border-color: #404060;
+
+                reset-ta := TouchArea {
+                    clicked => {
+                        root.current-scale = 1.0;
+                        root.current-rotation = 0deg;
+                        root.status-text = "idle";
+                        root.has-gesture-occurred = false;
+                    }
+                }
+
+                reset-layout := HorizontalLayout {
+                    padding-left: 12px;
+                    padding-right: 12px;
+
+                    Text {
+                        text: "Reset";
+                        color: #a0a0b0;
+                        font-size: 13px;
+                        vertical-alignment: center;
+                        horizontal-alignment: center;
+                    }
+                }
+            }
+        }
+
+        // Gesture area
+        Rectangle {
+            background: root.gesture-active ? #1e2a4a : #16213e;
+            border-radius: 8px;
+            border-width: root.gesture-active ? 2px : 0px;
+            border-color: #e94560;
+            clip: true;
+
+            Image {
+                width: 200px * root.current-scale;
+                height: 200px * root.current-scale;
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                source: @image-url("../../logo/slint-logo-square-light.png");
+                transform-rotation: current-rotation;
+            }
+        }
+
+        // Info panel
+        Rectangle {
+            height: 60px;
+            background: #16213e;
+            border-radius: 6px;
+
+            HorizontalLayout {
+                alignment: space-around;
+                padding: 8px;
+
+                InfoItem {
+                    label: "Scale";
+                    value: round(root.current-scale * 100) + "%";
+                }
+
+                InfoItem {
+                    label: "Rotation";
+                    value: round(root.current-rotation / 1deg) + "°";
+                }
+
+                InfoItem {
+                    label: "State";
+                    value: root.status-text;
+                    value-color: root.gesture-active ? #e94560 : #a0a0b0;
+                }
+
+                InfoItem {
+                    label: "Center";
+                    value: root.has-gesture-occurred
+                        ? round(root.center-x / 1px) + ", " + round(root.center-y / 1px)
+                        : "—";
+                }
+            }
+        }
+    }
+}

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -291,7 +291,9 @@ impl Item for NativeButton {
                 };
             }
             MouseEvent::Wheel { .. } => return InputEventResult::EventIgnored,
-            MouseEvent::PinchGesture { .. } => return InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => return InputEventResult::EventIgnored,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
                 return InputEventResult::EventIgnored;
             }

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -103,6 +103,8 @@ impl Item for NativeCheckBox {
             MouseEvent::Drop(_)
             | MouseEvent::Wheel { .. }
             | MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. }
             | MouseEvent::DragMove(_) => InputEventResult::EventIgnored,
             // Make sure that generally mouse events are accepted, so that the hover state is
             // correctly updated

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -254,7 +254,9 @@ impl Item for NativeScrollView {
                     }
                     InputEventResult::EventAccepted
                 }
-                MouseEvent::PinchGesture { .. } => InputEventResult::EventIgnored,
+                MouseEvent::PinchGesture { .. }
+                | MouseEvent::RotationGesture { .. }
+                | MouseEvent::DoubleTapGesture { .. } => InputEventResult::EventIgnored,
                 MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
             };
             self.data.set(data);

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -264,7 +264,9 @@ impl Item for NativeSlider {
                 debug_assert_ne!(*button, PointerEventButton::Left);
                 InputEventResult::EventIgnored
             }
-            MouseEvent::PinchGesture { .. } => InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventResult::EventIgnored,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
             // Note: The Qt slider used to accept scroll events, however the other styles do not.
             // As the scroll event handling is problematic when a slider is placed in a Flickable,

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -238,7 +238,9 @@ impl Item for NativeSpinBox {
                     }
                     true
                 }
-                MouseEvent::PinchGesture { .. } => false,
+                MouseEvent::PinchGesture { .. }
+                | MouseEvent::RotationGesture { .. }
+                | MouseEvent::DoubleTapGesture { .. } => false,
                 MouseEvent::DragMove(..) | MouseEvent::Drop(..) => false,
             };
         data.active_controls = new_control;

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -474,7 +474,9 @@ impl Item for NativeTab {
                 };
             }
             MouseEvent::Wheel { .. } => return InputEventResult::EventIgnored,
-            MouseEvent::PinchGesture { .. } => return InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => return InputEventResult::EventIgnored,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
                 return InputEventResult::EventIgnored;
             }

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -112,6 +112,48 @@ pub fn send_pinch_gesture<
     });
 }
 
+/// Send a platform rotation gesture event to the component's window.
+///
+/// `delta` is the incremental rotation in degrees using the platform's sign convention
+/// (positive = counterclockwise on macOS). PinchGestureHandler negates this internally
+/// so that its `rotation` property uses positive = clockwise (CSS convention).
+pub fn send_rotation_gesture<
+    X: vtable::HasStaticVTable<ItemTreeVTable>,
+    Component: Into<vtable::VRc<ItemTreeVTable, X>> + ComponentHandle,
+>(
+    component: &Component,
+    delta: f32,
+    center_x: f32,
+    center_y: f32,
+    phase: i_slint_core::input::TouchPhase,
+) {
+    let inner = WindowInner::from_pub(component.window());
+    inner.process_mouse_input(i_slint_core::input::MouseEvent::RotationGesture {
+        position: i_slint_core::lengths::logical_point_from_api(
+            i_slint_core::api::LogicalPosition::new(center_x, center_y),
+        ),
+        delta,
+        phase,
+    });
+}
+
+/// Send a platform double-tap gesture ("smart magnify") event to the component's window.
+pub fn send_double_tap_gesture<
+    X: vtable::HasStaticVTable<ItemTreeVTable>,
+    Component: Into<vtable::VRc<ItemTreeVTable, X>> + ComponentHandle,
+>(
+    component: &Component,
+    center_x: f32,
+    center_y: f32,
+) {
+    let inner = WindowInner::from_pub(component.window());
+    inner.process_mouse_input(i_slint_core::input::MouseEvent::DoubleTapGesture {
+        position: i_slint_core::lengths::logical_point_from_api(
+            i_slint_core::api::LogicalPosition::new(center_x, center_y),
+        ),
+    });
+}
+
 pub fn access_testing_window<R>(
     window: &i_slint_core::api::Window,
     callback: impl FnOnce(&TestingWindow) -> R,

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -449,6 +449,24 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     phase,
                 });
             }
+            WindowEvent::RotationGesture { delta, phase, .. } => {
+                let phase = match phase {
+                    winit::event::TouchPhase::Started => corelib::input::TouchPhase::Started,
+                    winit::event::TouchPhase::Moved => corelib::input::TouchPhase::Moved,
+                    winit::event::TouchPhase::Ended => corelib::input::TouchPhase::Ended,
+                    winit::event::TouchPhase::Cancelled => corelib::input::TouchPhase::Cancelled,
+                };
+                runtime_window.process_mouse_input(corelib::input::MouseEvent::RotationGesture {
+                    position: self.cursor_pos,
+                    delta: delta as f32,
+                    phase,
+                });
+            }
+            WindowEvent::DoubleTapGesture { .. } => {
+                runtime_window.process_mouse_input(corelib::input::MouseEvent::DoubleTapGesture {
+                    position: self.cursor_pos,
+                });
+            }
             _ => {}
         }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -225,12 +225,14 @@ export component PinchGestureHandler {
 
     out property <bool> active;
     out property <float> scale;       // Cumulative factor: 1.0 = no change
+    out property <angle> rotation;    // Cumulative rotation: 0deg = no change
     out property <Point> center;
 
     callback started();
     callback updated();
     callback ended();
     callback cancelled();
+    callback smart-magnify();
 
     //-default_size_binding:expands_to_parent_geometry
 }

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -55,6 +55,13 @@ pub enum MouseEvent {
     /// A platform-recognized pinch gesture (macOS/iOS trackpad, Qt).
     /// `delta` is the incremental scale change; PinchGestureHandler accumulates it.
     PinchGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
+    /// A platform-recognized rotation gesture (macOS/iOS trackpad, Qt).
+    /// `delta` is the incremental rotation in degrees using the platform's sign convention
+    /// (positive = counterclockwise on macOS). PinchGestureHandler negates this internally
+    /// so that its `rotation` property uses positive = clockwise (CSS convention).
+    RotationGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
+    /// A platform-recognized double-tap gesture ("smart magnify" on macOS trackpad).
+    DoubleTapGesture { position: LogicalPoint },
     /// The mouse exited the item or component
     Exit,
 }
@@ -68,6 +75,8 @@ impl MouseEvent {
             MouseEvent::Moved { is_touch, .. } => Some(*is_touch),
             MouseEvent::Wheel { .. } => None,
             MouseEvent::PinchGesture { .. } => None,
+            MouseEvent::RotationGesture { .. } => None,
+            MouseEvent::DoubleTapGesture { .. } => None,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => None,
             MouseEvent::Exit => None,
         }
@@ -81,6 +90,8 @@ impl MouseEvent {
             MouseEvent::Moved { position, .. } => Some(*position),
             MouseEvent::Wheel { position, .. } => Some(*position),
             MouseEvent::PinchGesture { position, .. } => Some(*position),
+            MouseEvent::RotationGesture { position, .. } => Some(*position),
+            MouseEvent::DoubleTapGesture { position } => Some(*position),
             MouseEvent::DragMove(e) | MouseEvent::Drop(e) => {
                 Some(crate::lengths::logical_point_from_api(e.position))
             }
@@ -96,6 +107,8 @@ impl MouseEvent {
             MouseEvent::Moved { position, .. } => Some(position),
             MouseEvent::Wheel { position, .. } => Some(position),
             MouseEvent::PinchGesture { position, .. } => Some(position),
+            MouseEvent::RotationGesture { position, .. } => Some(position),
+            MouseEvent::DoubleTapGesture { position } => Some(position),
             MouseEvent::DragMove(e) | MouseEvent::Drop(e) => {
                 e.position = crate::api::LogicalPosition::from_euclid(
                     crate::lengths::logical_point_from_api(e.position) + vec,
@@ -117,6 +130,8 @@ impl MouseEvent {
             MouseEvent::Moved { position, .. } => Some(position),
             MouseEvent::Wheel { position, .. } => Some(position),
             MouseEvent::PinchGesture { position, .. } => Some(position),
+            MouseEvent::RotationGesture { position, .. } => Some(position),
+            MouseEvent::DoubleTapGesture { position } => Some(position),
             MouseEvent::DragMove(e) | MouseEvent::Drop(e) => {
                 e.position = crate::api::LogicalPosition::from_euclid(
                     transform

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -95,7 +95,9 @@ impl Item for DragArea {
             MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
-            MouseEvent::PinchGesture { .. } => InputEventFilterResult::ForwardAndIgnore,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventFilterResult::ForwardAndIgnore,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
                 InputEventFilterResult::ForwardAndIgnore
             }
@@ -136,7 +138,9 @@ impl Item for DragArea {
                 }
             }
             MouseEvent::Wheel { .. } => InputEventResult::EventIgnored,
-            MouseEvent::PinchGesture { .. } => InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventResult::EventIgnored,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }
     }

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -528,7 +528,9 @@ impl FlickableData {
             MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
-            MouseEvent::PinchGesture { .. } => InputEventFilterResult::ForwardEvent,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventFilterResult::ForwardEvent,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
                 InputEventFilterResult::ForwardAndIgnore
             }
@@ -626,7 +628,9 @@ impl FlickableData {
 
                 inner.process_wheel_event(flick, delta, *position, flick_rc)
             }
-            MouseEvent::PinchGesture { .. } => InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventResult::EventIgnored,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }
     }

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -207,7 +207,9 @@ impl Item for TouchArea {
                     }
                 }
             }
-            MouseEvent::PinchGesture { .. } => InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventResult::EventIgnored,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }
     }
@@ -537,7 +539,9 @@ impl Item for SwipeGestureHandler {
             MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
-            MouseEvent::PinchGesture { .. } => InputEventFilterResult::ForwardAndIgnore,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventFilterResult::ForwardAndIgnore,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
                 InputEventFilterResult::ForwardAndIgnore
             }
@@ -585,7 +589,9 @@ impl Item for SwipeGestureHandler {
                 if swiping { InputEventResult::GrabMouse } else { InputEventResult::EventAccepted }
             }
             MouseEvent::Wheel { .. } => InputEventResult::EventIgnored,
-            MouseEvent::PinchGesture { .. } => InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => InputEventResult::EventIgnored,
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }
     }
@@ -706,6 +712,9 @@ pub struct PinchGestureHandler {
     /// gesture starts, then updated as the gesture progresses (e.g., 2.0 means
     /// doubled, 0.5 means halved).
     pub scale: Property<f32>,
+    /// Cumulative rotation in degrees relative to gesture start. Always 0.0 when
+    /// the gesture starts.
+    pub rotation: Property<f32>,
     pub center: Property<LogicalPosition>,
 
     // Callbacks
@@ -713,6 +722,7 @@ pub struct PinchGestureHandler {
     pub updated: Callback<VoidArg>,
     pub ended: Callback<VoidArg>,
     pub cancelled: Callback<VoidArg>,
+    pub smart_magnify: Callback<VoidArg>,
 
     /// FIXME: remove this
     pub cached_rendering_data: CachedRenderingData,
@@ -738,11 +748,15 @@ impl Item for PinchGestureHandler {
         _: &mut MouseCursor,
     ) -> InputEventFilterResult {
         match event {
-            // Forward pinch gestures so inner handlers get first shot
-            MouseEvent::PinchGesture { .. } if self.enabled() => {
+            // Forward gesture events so inner handlers get first shot
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. }
+                if self.enabled() =>
+            {
                 InputEventFilterResult::ForwardEvent
             }
-            // While a pinch gesture is active, intercept non-pinch events to
+            // While a gesture is active, intercept non-gesture events to
             // prevent Flickable and other items from processing them concurrently.
             _ if self.active() => InputEventFilterResult::Intercept,
             _ => InputEventFilterResult::ForwardAndIgnore,
@@ -773,6 +787,7 @@ impl Item for PinchGestureHandler {
                         }
                         Self::FIELD_OFFSETS.active.apply_pin(self).set(true);
                         Self::FIELD_OFFSETS.scale.apply_pin(self).set(1.0);
+                        Self::FIELD_OFFSETS.rotation.apply_pin(self).set(0.0);
                         Self::FIELD_OFFSETS.center.apply_pin(self).set(center);
                         Self::FIELD_OFFSETS.started.apply_pin(self).call(&());
                         InputEventResult::GrabMouse
@@ -801,7 +816,63 @@ impl Item for PinchGestureHandler {
                     }
                 }
             }
-            // Grab mouse during active pinch to maintain exclusivity.
+            MouseEvent::RotationGesture { delta, phase, position } => {
+                if !self.enabled() {
+                    return InputEventResult::EventIgnored;
+                }
+                let center = crate::lengths::logical_position_to_api(*position);
+                match phase {
+                    TouchPhase::Started => {
+                        // Rotation often arrives alongside pinch. If we're
+                        // already active (pinch started first), just accept.
+                        // If not active yet, start the gesture from rotation.
+                        if !self.active() {
+                            Self::FIELD_OFFSETS.active.apply_pin(self).set(true);
+                            Self::FIELD_OFFSETS.scale.apply_pin(self).set(1.0);
+                            Self::FIELD_OFFSETS.rotation.apply_pin(self).set(0.0);
+                            Self::FIELD_OFFSETS.center.apply_pin(self).set(center);
+                            Self::FIELD_OFFSETS.started.apply_pin(self).call(&());
+                        }
+                        InputEventResult::GrabMouse
+                    }
+                    TouchPhase::Moved => {
+                        if !self.active() {
+                            return InputEventResult::EventIgnored;
+                        }
+                        // Negate: macOS/winit report positive = counterclockwise,
+                        // but our documented convention is positive = clockwise.
+                        let new_rotation = self.rotation() - delta;
+                        Self::FIELD_OFFSETS.rotation.apply_pin(self).set(new_rotation);
+                        Self::FIELD_OFFSETS.center.apply_pin(self).set(center);
+                        Self::FIELD_OFFSETS.updated.apply_pin(self).call(&());
+                        InputEventResult::GrabMouse
+                    }
+                    TouchPhase::Ended => {
+                        // On macOS/iOS, both PinchGesture::Ended and
+                        // RotationGesture::Ended arrive for the same physical
+                        // gesture. Whichever arrives second will see active=false
+                        // and return early.
+                        if !self.active() {
+                            return InputEventResult::EventIgnored;
+                        }
+                        Self::FIELD_OFFSETS.active.apply_pin(self).set(false);
+                        Self::FIELD_OFFSETS.ended.apply_pin(self).call(&());
+                        InputEventResult::EventAccepted
+                    }
+                    TouchPhase::Cancelled => {
+                        self.cancel_impl();
+                        InputEventResult::EventAccepted
+                    }
+                }
+            }
+            MouseEvent::DoubleTapGesture { .. } => {
+                if !self.enabled() {
+                    return InputEventResult::EventIgnored;
+                }
+                Self::FIELD_OFFSETS.smart_magnify.apply_pin(self).call(&());
+                InputEventResult::EventAccepted
+            }
+            // Grab mouse during active gesture to maintain exclusivity.
             _ if self.active() => InputEventResult::GrabMouse,
             _ => InputEventResult::EventIgnored,
         }
@@ -869,6 +940,8 @@ impl PinchGestureHandler {
             return;
         }
         Self::FIELD_OFFSETS.active.apply_pin(self).set(false);
+        Self::FIELD_OFFSETS.scale.apply_pin(self).set(1.0);
+        Self::FIELD_OFFSETS.rotation.apply_pin(self).set(0.0);
         Self::FIELD_OFFSETS.cancelled.apply_pin(self).call(&());
     }
 }

--- a/tests/cases/elements/pinchgesturehandler.slint
+++ b/tests/cases/elements/pinchgesturehandler.slint
@@ -9,7 +9,9 @@ export component TestCase inherits Window {
     in-out property <bool> enabled <=> pinch.enabled;
     out property <bool> active <=> pinch.active;
     out property <float> scale <=> pinch.scale;
+    out property <angle> rotation <=> pinch.rotation;
     out property <Point> center <=> pinch.center;
+    out property <bool> smart-magnified: false;
 
     pinch := PinchGestureHandler {
         started => {
@@ -23,6 +25,9 @@ export component TestCase inherits Window {
         }
         cancelled => {
             r += "cancelled;";
+        }
+        smart-magnify => {
+            root.smart-magnified = true;
         }
     }
 }
@@ -186,5 +191,136 @@ assert_eq!(instance.get_r(), "started;updated(1.5);cancelled;started;updated(2);
 slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
 assert_eq!(instance.get_active(), false);
 assert_eq!(instance.get_r(), "started;updated(1.5);cancelled;started;updated(2);ended;");
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+use slint_testing::TouchPhase;
+
+// === Test 10: Rotation gesture accumulates degrees ===
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
+assert_eq!(instance.get_active(), true);
+assert_eq!(instance.get_rotation(), 0.0);
+
+// Send rotation delta of 15 degrees (platform convention: positive = counterclockwise).
+// PinchGestureHandler negates to match CSS/Slint convention (positive = clockwise).
+slint_testing::send_rotation_gesture(&instance, 15.0, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_active(), true);
+assert_eq!(instance.get_rotation(), -15.0);
+assert_eq!(instance.get_r(), "started;updated(1);");
+
+// Send another rotation delta of -5 degrees (clockwise on platform → positive in our convention)
+slint_testing::send_rotation_gesture(&instance, -5.0, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_rotation(), -10.0);
+assert_eq!(instance.get_r(), "started;updated(1);updated(1);");
+
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
+assert_eq!(instance.get_active(), false);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+use slint_testing::TouchPhase;
+
+// === Test 11: Rotation resets on new gesture start ===
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
+slint_testing::send_rotation_gesture(&instance, 45.0, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_rotation(), -45.0);
+
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
+assert_eq!(instance.get_active(), false);
+
+// Start new gesture — rotation should be 0
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
+assert_eq!(instance.get_rotation(), 0.0);
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+
+// === Test 12: DoubleTapGesture fires smart-magnify callback ===
+assert_eq!(instance.get_smart_magnified(), false);
+slint_testing::send_double_tap_gesture(&instance, 300.0, 300.0);
+assert_eq!(instance.get_smart_magnified(), true);
+// DoubleTapGesture should not activate the gesture
+assert_eq!(instance.get_active(), false);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+
+// === Test 13: DoubleTapGesture ignored when disabled ===
+instance.set_enabled(false);
+slint_testing::send_double_tap_gesture(&instance, 300.0, 300.0);
+assert_eq!(instance.get_smart_magnified(), false);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+use slint_testing::TouchPhase;
+
+// === Test 14: Rotation-only gesture (no pinch) starts and ends independently ===
+slint_testing::send_rotation_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
+assert_eq!(instance.get_active(), true);
+assert_eq!(instance.get_scale(), 1.0);
+assert_eq!(instance.get_rotation(), 0.0);
+
+slint_testing::send_rotation_gesture(&instance, 30.0, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_rotation(), -30.0);
+// Scale unchanged because only rotation happened
+assert_eq!(instance.get_scale(), 1.0);
+
+// Rotation-only gesture can end without PinchGesture
+slint_testing::send_rotation_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
+assert_eq!(instance.get_active(), false);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+use slint_testing::TouchPhase;
+
+// === Test 15: Combined pinch + rotation in same gesture ===
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
+slint_testing::send_rotation_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
+
+// Interleave pinch and rotation updates
+slint_testing::send_pinch_gesture(&instance, 0.5, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_scale(), 1.5);
+assert_eq!(instance.get_rotation(), 0.0);
+
+slint_testing::send_rotation_gesture(&instance, 20.0, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_scale(), 1.5);
+assert_eq!(instance.get_rotation(), -20.0);
+
+slint_testing::send_pinch_gesture(&instance, 0.3, 300.0, 300.0, TouchPhase::Moved);
+slint_testing::send_rotation_gesture(&instance, -10.0, 300.0, 300.0, TouchPhase::Moved);
+// scale = 1.5 * (1 + 0.3) = 1.95
+assert!((instance.get_scale() - 1.95).abs() < 0.001);
+// rotation = -20 - (-10) = -10
+assert_eq!(instance.get_rotation(), -10.0);
+
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
+assert_eq!(instance.get_active(), false);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+use slint_testing::TouchPhase;
+
+// === Test 16: Cancellation resets scale and rotation ===
+slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
+slint_testing::send_pinch_gesture(&instance, 0.5, 300.0, 300.0, TouchPhase::Moved);
+slint_testing::send_rotation_gesture(&instance, 45.0, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_scale(), 1.5);
+assert_eq!(instance.get_rotation(), -45.0);
+assert_eq!(instance.get_active(), true);
+
+// Disable mid-gesture triggers cancellation
+instance.set_enabled(false);
+slint_testing::send_pinch_gesture(&instance, 0.1, 300.0, 300.0, TouchPhase::Moved);
+assert_eq!(instance.get_active(), false);
+assert_eq!(instance.get_scale(), 1.0);
+assert_eq!(instance.get_rotation(), 0.0);
 ```
 */


### PR DESCRIPTION
## Summary
- Add `rotation` property (cumulative degrees, positive = clockwise) and `smart-magnify` callback to `PinchGestureHandler`
- Forward winit's `RotationGesture` and `DoubleTapGesture` events through the input pipeline, extending the existing pinch gesture pattern
- Update documentation with rotation/smart-magnify coverage and improved playground example
- Add `native-gestures` example demonstrating full PinchGestureHandler API

## Details

**Rotation gesture:**
- New `MouseEvent::RotationGesture` variant with `{ position, delta, phase }` 
- Independent lifecycle handling so rotation-only gestures work correctly
- Sign convention: macOS reports positive = counterclockwise; PinchGestureHandler negates internally so `rotation` property uses positive = clockwise (CSS convention)

**Smart magnify:**
- New `MouseEvent::DoubleTapGesture` variant mapped from winit's `DoubleTapGesture` (two-finger double-tap on macOS/iOS trackpads)
- Fires `smart-magnify` callback without activating the gesture or changing `scale`/`rotation`

**Cancel behavior:**
- `cancel_impl` now resets both `scale` and `rotation` (previously only reset scale)

**Tests:**
- 7 new test cases: rotation accumulation, rotation reset, double-tap, disabled state, rotation-only gestures, combined pinch+rotation, cancellation resets both scale and rotation

## Test plan
- [x] All 15 PinchGestureHandler tests pass
- [x] `native-gestures` example builds and runs
- [x] Manual testing: pinch, rotation, smart-magnify on macOS trackpad