### PR TITLE
Improve Diagnostics of the @keys macro

### DIFF
--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -541,7 +541,10 @@ fn parse_keys(p: &mut impl Parser) {
                     state = State::NeedKey;
                     p.consume();
                 } else {
-                    bail(&mut p, "Unexpected '+' in keyboard shortcut");
+                    bail(
+                        &mut p,
+                        "Unexpected '+' in keyboard shortcut (use Plus to refer to the key)",
+                    );
                     break;
                 }
                 continue;
@@ -560,10 +563,7 @@ fn parse_keys(p: &mut impl Parser) {
                     match text {
                         "Alt" => alt_count += 1,
                         "Ctrl" => {
-                            bail(
-                                &mut p,
-                                "`Ctrl` is not in the Key namespace (Use `Control` instead)",
-                            );
+                            bail(&mut p, "Ctrl is not in the Key namespace (Use Control instead)");
                             break;
                         }
                         "Control" => control_count += 1,
@@ -585,7 +585,7 @@ fn parse_keys(p: &mut impl Parser) {
                                 // \x20 equals to a space (needed to avoid the trailing \ eating
                                 // the indentation)
                                 &format!(
-                                    "`{text}` is not a cross-platform modifier\n\
+                                    "{text} is not a cross-platform modifier\n\
                                     Use cross-platform modifier names instead:\n\
                                     \x20   ⌘ command -> Control\n\
                                     \x20   ⌥ option -> Alt\n\
@@ -599,7 +599,7 @@ fn parse_keys(p: &mut impl Parser) {
                             bail(
                                 &mut p,
                                 &format!(
-                                    "`{text}` is not a cross-platform modifier (Use `Meta` instead)"
+                                    "{text} is not a cross-platform modifier (Use `Meta` instead)"
                                 ),
                             );
                             break;
@@ -645,9 +645,16 @@ fn parse_keys(p: &mut impl Parser) {
                 continue;
             }
             _ => {
+                let hint = if state == State::NeedKey {
+                    format!("\n(Consider using \"{}\")", p.peek().as_str())
+                } else {
+                    "".into()
+                };
                 bail(
                     &mut p,
-                    "Expected '+', a string literal, or an identifier in the Keys namespace",
+                    &format!(
+                        "Expected '+', a string literal, or an identifier in the Keys namespace{hint}"
+                    ),
                 );
                 break;
             }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -993,11 +993,16 @@ impl Expression {
                             identifier.clone(),
                         ))
                     } else {
-                        // TODO: This should suggest close matches
+                        // TODO: This should suggest more kinds of close matches
+                        let uppercased = key_name.to_uppercase();
+                        let hint = if lookup_key(&uppercased).is_some() {
+                            // common case: @keys(Control+a) instead of @keys(Control+A)
+                            format!("Use uppercase {uppercased} instead")
+                        } else {
+                            format!("Consider using \"{key_name}\"")
+                        };
                         ctx.diag.push_error(
-                            format!(
-                                "`{key_name}` not defined in the `Keys` namespace\n(Consider using \"{key_name}\")"
-                            ),
+                            format!("{key_name} not defined in the Keys namespace\n({hint})"),
                             &identifier,
                         );
                         shortcut.modifiers = KeyboardModifiers::default();

--- a/internal/compiler/tests/syntax/expressions/at_keys_parser.slint
+++ b/internal/compiler/tests/syntax/expressions/at_keys_parser.slint
@@ -51,7 +51,7 @@ export component SuperSimple {
         @keys(Alt + Shift),
 //                       ^error{A keyboard shortcut must be empty or contain exactly one key (with modifiers)}
         @keys(Alt ++ a),
-//                 ^error{Unexpected '+' in keyboard shortcut}
+//                 ^error{Unexpected '+' in keyboard shortcut (use Plus to refer to the key)}
         @keys("a" +),
 //                 ^error{Expected another identifier or string literal}
         @keys(Shift +),
@@ -59,15 +59,21 @@ export component SuperSimple {
 
         // Hints about common misunderstandings
         @keys(Ctrl + A),
-//            >  <error{`Ctrl` is not in the Key namespace (Use `Control` instead)}
+//            >  <error{Ctrl is not in the Key namespace (Use Control instead)}
         @keys(Command + A),
-//            >     <error{`Command` is not a cross-platform modifier↵Use cross-platform modifier names instead:↵    ⌘ command -> Control↵    ⌥ option -> Alt↵    ^ control -> Meta↵    ⇧ shift -> Shift}
+//            >     <error{Command is not a cross-platform modifier↵Use cross-platform modifier names instead:↵    ⌘ command -> Control↵    ⌥ option -> Alt↵    ^ control -> Meta↵    ⇧ shift -> Shift}
         @keys(Cmd + A),
-//            > <error{`Cmd` is not a cross-platform modifier↵Use cross-platform modifier names instead:↵    ⌘ command -> Control↵    ⌥ option -> Alt↵    ^ control -> Meta↵    ⇧ shift -> Shift}
+//            > <error{Cmd is not a cross-platform modifier↵Use cross-platform modifier names instead:↵    ⌘ command -> Control↵    ⌥ option -> Alt↵    ^ control -> Meta↵    ⇧ shift -> Shift}
         @keys(Win + A),
-//            > <error{`Win` is not a cross-platform modifier (Use `Meta` instead)}
-        @keys(Windows + A)
-//            >     <error{`Windows` is not a cross-platform modifier (Use `Meta` instead)}
+//            > <error{Win is not a cross-platform modifier (Use `Meta` instead)}
+        @keys(Windows + A),
+//            >     <error{Windows is not a cross-platform modifier (Use `Meta` instead)}
 
+
+        // Hints about weird characters
+        @keys(Control + €),
+//                      > <error{Expected '+', a string literal, or an identifier in the Keys namespace↵(Consider using "€")}
+        @keys(Control + +),
+//                      ^error{Unexpected '+' in keyboard shortcut (use Plus to refer to the key)}
     ];
 }

--- a/internal/compiler/tests/syntax/expressions/at_keys_resolving.slint
+++ b/internal/compiler/tests/syntax/expressions/at_keys_resolving.slint
@@ -4,11 +4,11 @@
 export component SuperSimple {
     property <[keyboard-shortcut]> unknown_keys_list: [
         @keys(a),
-//            ^error{`a` not defined in the `Keys` namespace↵(Consider using "a")}
+//            ^error{a not defined in the Keys namespace↵(Use uppercase A instead)}
         @keys(Alt + Control + Shift + Meta + a),
-//                                           ^error{`a` not defined in the `Keys` namespace↵(Consider using "a")}
+//                                           ^error{a not defined in the Keys namespace↵(Use uppercase A instead)}
         @keys(    Alt + Control + Shift + Meta + FooBar    ),
-//                                               >    <error{`FooBar` not defined in the `Keys` namespace↵(Consider using "FooBar")}
+//                                               >    <error{FooBar not defined in the Keys namespace↵(Consider using "FooBar")}
         @keys(Shift+Plus),
 //                  >  <error{Shortcuts involving Plus ignore Shift to support different keyboard layouts↵Remove Shift and consider using e.g. Equal (for U.S. Keyboard layout)}
         @keys(Shift+Asterisk),


### PR DESCRIPTION
This should address some more stumbling blocks that a friend of mine encountered when I asked him to test the new keyboard-shortcut macro.
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
