### PR TITLE
Rename box_layout_cell_data_type to layout_item_info_type

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -622,7 +622,7 @@ fn flexbox_layout_data(
     let repeater_count =
         layout.elems.iter().filter(|i| i.element.borrow().repeated.is_some()).count();
 
-    let element_ty = crate::typeregister::box_layout_cell_data_type();
+    let element_ty = crate::typeregister::layout_item_info_type();
 
     if repeater_count == 0 {
         let cells_h = llr_Expression::Array {
@@ -738,7 +738,7 @@ fn box_layout_data(
     let repeater_count =
         layout.elems.iter().filter(|i| i.element.borrow().repeated.is_some()).count();
 
-    let element_ty = crate::typeregister::box_layout_cell_data_type();
+    let element_ty = crate::typeregister::layout_item_info_type();
 
     if repeater_count == 0 {
         let cells = llr_Expression::Array {
@@ -797,7 +797,7 @@ fn grid_layout_cell_constraints(
     let repeater_count =
         layout.elems.iter().filter(|i| i.item.element.borrow().repeated.is_some()).count();
 
-    let element_ty = crate::typeregister::box_layout_cell_data_type();
+    let element_ty = crate::typeregister::layout_item_info_type();
 
     if repeater_count == 0 {
         let cells = llr_Expression::Array {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -88,7 +88,7 @@ pub struct BuiltinTypes {
     pub layout_info_type: Rc<Struct>,
     pub gridlayout_input_data_type: Type,
     pub path_element_type: Type,
-    pub box_layout_cell_data_type: Type,
+    pub layout_item_info_type: Type,
 }
 
 impl BuiltinTypes {
@@ -148,7 +148,7 @@ impl BuiltinTypes {
                 fields: Default::default(),
                 name: BuiltinPrivateStruct::PathElement.into(),
             })),
-            box_layout_cell_data_type: Type::Struct(Rc::new(Struct {
+            layout_item_info_type: Type::Struct(Rc::new(Struct {
                 fields: IntoIterator::into_iter([("constraint".into(), layout_info_type.into())])
                     .collect(),
                 name: BuiltinPrivateStruct::LayoutItemInfo.into(),
@@ -826,6 +826,6 @@ pub fn path_element_type() -> Type {
 }
 
 /// The [`Type`] for a runtime LayoutItemInfo structure
-pub fn box_layout_cell_data_type() -> Type {
-    BUILTIN.with(|types| types.box_layout_cell_data_type.clone())
+pub fn layout_item_info_type() -> Type {
+    BUILTIN.with(|types| types.layout_item_info_type.clone())
 }


### PR DESCRIPTION
This was missed in the earlier renaming of BoxLayoutCellData to LayoutItemInfo.
