### PR TITLE
Synthesize pinch/rotation gestures from raw multi-touch events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6397,6 +6397,7 @@ dependencies = [
 name = "native-gestures"
 version = "1.16.0"
 dependencies = [
+ "android_logger",
  "slint",
  "slint-build",
 ]

--- a/examples/native-gestures/Cargo.toml
+++ b/examples/native-gestures/Cargo.toml
@@ -9,12 +9,28 @@ edition.workspace = true
 publish = false
 license = "MIT"
 
+[lib]
+crate-type = ["lib", "cdylib"]
+path = "src/lib.rs"
+
 [[bin]]
-path = "main.rs"
 name = "native-gestures"
+path = "src/main.rs"
 
 [dependencies]
-slint = { path = "../../api/rs/slint" }
+slint = { path = "../../api/rs/slint", features = ["backend-android-activity-06"] }
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "0.14.1"
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+
+# Android settings
+[package.metadata.android]
+package = "dev.slint.examples.nativegestures"
+build_targets = ["aarch64-linux-android"]
+target_sdk_version = 33
+
+[package.metadata.android.application]
+label = "Native Gestures"

--- a/examples/native-gestures/main.rs
+++ b/examples/native-gestures/main.rs
@@ -1,8 +1,0 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: MIT
-
-slint::include_modules!();
-
-fn main() {
-    MainWindow::new().unwrap().run().unwrap();
-}

--- a/examples/native-gestures/native-gestures.slint
+++ b/examples/native-gestures/native-gestures.slint
@@ -27,10 +27,93 @@ component InfoItem inherits VerticalLayout {
     }
 }
 
+component ResetButton inherits Rectangle {
+    callback clicked();
+
+    height: 28px;
+    width: layout.preferred-width;
+    background: ta.has-hover ? #0f3460 : #16213e;
+    border-radius: 6px;
+    border-width: 1px;
+    border-color: #404060;
+
+    ta := TouchArea {
+        clicked => { root.clicked(); }
+    }
+
+    layout := HorizontalLayout {
+        padding-left: 12px;
+        padding-right: 12px;
+
+        Text {
+            text: "Reset";
+            color: #a0a0b0;
+            font-size: 13px;
+            vertical-alignment: center;
+            horizontal-alignment: center;
+        }
+    }
+}
+
+component GestureArea inherits Rectangle {
+    in property <length> image-size;
+    in property <float> current-scale;
+    in property <angle> current-rotation;
+    in property <bool> gesture-active;
+
+    background: root.gesture-active ? #1e2a4a : #16213e;
+    border-radius: 8px;
+    border-width: root.gesture-active ? 2px : 0px;
+    border-color: #e94560;
+    clip: true;
+
+    Image {
+        width: root.image-size * root.current-scale;
+        height: root.image-size * root.current-scale;
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
+        source: @image-url("../../logo/slint-logo-square-light.png");
+        transform-rotation: root.current-rotation;
+    }
+}
+
+component InfoPanel inherits VerticalLayout {
+    in property <float> current-scale;
+    in property <angle> current-rotation;
+    in property <string> status-text;
+    in property <bool> gesture-active;
+    in property <bool> has-gesture-occurred;
+    in property <length> center-x;
+    in property <length> center-y;
+
+    InfoItem {
+        label: "Scale";
+        value: round(root.current-scale * 100) + "%";
+    }
+
+    InfoItem {
+        label: "Rotation";
+        value: round(root.current-rotation / 1deg) + "°";
+    }
+
+    InfoItem {
+        label: "State";
+        value: root.status-text;
+        value-color: root.gesture-active ? #e94560 : #a0a0b0;
+    }
+
+    InfoItem {
+        label: "Center";
+        value: root.has-gesture-occurred
+            ? round(root.center-x / 1px) + ", " + round(root.center-y / 1px)
+            : "—";
+    }
+}
+
 export component MainWindow inherits Window {
     title: "Native Gestures Demo";
-    width: 800px;
-    height: 600px;
+    preferred-width: 800px;
+    preferred-height: 600px;
     background: #1a1a2e;
 
     property <float> current-scale: 1.0;
@@ -43,6 +126,14 @@ export component MainWindow inherits Window {
     property <length> center-y;
     property <bool> has-gesture-occurred: false;
     property <bool> gestures-enabled: true;
+    property <bool> is-landscape: root.width > root.height;
+
+    function reset() {
+        root.current-scale = 1.0;
+        root.current-rotation = 0deg;
+        root.status-text = "idle";
+        root.has-gesture-occurred = false;
+    }
 
     PinchGestureHandler {
         enabled: root.gestures-enabled;
@@ -85,11 +176,46 @@ export component MainWindow inherits Window {
         }
     }
 
+    // Safe-area inset container
     VerticalLayout {
-        padding: 20px;
-        spacing: 12px;
+        x: root.safe-area-insets.left;
+        y: root.safe-area-insets.top;
+        width: root.width - root.safe-area-insets.left - root.safe-area-insets.right;
+        height: root.height - root.safe-area-insets.top - root.safe-area-insets.bottom;
+        padding: root.is-landscape ? 12px : 16px;
+        spacing: 8px;
 
-        Text {
+        // Header + controls: single row in landscape, stacked in portrait
+        if root.is-landscape: HorizontalLayout {
+            spacing: 12px;
+            alignment: center;
+
+            Text {
+                text: "PinchGestureHandler Demo";
+                color: #e0e0f0;
+                font-size: 14px;
+                font-weight: 700;
+                vertical-alignment: center;
+            }
+
+            Text {
+                text: "Pinch • Rotate • Double-tap";
+                color: #606080;
+                font-size: 12px;
+                vertical-alignment: center;
+            }
+
+            Switch {
+                text: "Enabled";
+                checked <=> root.gestures-enabled;
+            }
+
+            ResetButton {
+                clicked => { root.reset(); }
+            }
+        }
+
+        if !root.is-landscape: Text {
             text: "PinchGestureHandler Demo";
             color: #e0e0f0;
             font-size: 18px;
@@ -97,15 +223,14 @@ export component MainWindow inherits Window {
             horizontal-alignment: center;
         }
 
-        Text {
+        if !root.is-landscape: Text {
             text: "Pinch to zoom  •  Rotate with two fingers  •  Double-tap to toggle zoom";
             color: #606080;
             font-size: 12px;
             horizontal-alignment: center;
         }
 
-        // Controls
-        HorizontalLayout {
+        if !root.is-landscape: HorizontalLayout {
             alignment: center;
             spacing: 20px;
 
@@ -114,58 +239,54 @@ export component MainWindow inherits Window {
                 checked <=> root.gestures-enabled;
             }
 
+            ResetButton {
+                clicked => { root.reset(); }
+            }
+        }
+
+        // Gesture area + info panel: side-by-side in landscape, stacked in portrait
+        if root.is-landscape: HorizontalLayout {
+            spacing: 8px;
+
+            GestureArea {
+                horizontal-stretch: 1;
+                image-size: 150px;
+                current-scale: root.current-scale;
+                current-rotation: root.current-rotation;
+                gesture-active: root.gesture-active;
+            }
+
             Rectangle {
-                height: 28px;
-                width: reset-layout.preferred-width;
-                background: reset-ta.has-hover ? #0f3460 : #16213e;
+                width: 100px;
+                background: #16213e;
                 border-radius: 6px;
-                border-width: 1px;
-                border-color: #404060;
 
-                reset-ta := TouchArea {
-                    clicked => {
-                        root.current-scale = 1.0;
-                        root.current-rotation = 0deg;
-                        root.status-text = "idle";
-                        root.has-gesture-occurred = false;
-                    }
-                }
+                VerticalLayout {
+                    alignment: space-around;
+                    padding: 8px;
 
-                reset-layout := HorizontalLayout {
-                    padding-left: 12px;
-                    padding-right: 12px;
-
-                    Text {
-                        text: "Reset";
-                        color: #a0a0b0;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        horizontal-alignment: center;
+                    InfoPanel {
+                        current-scale: root.current-scale;
+                        current-rotation: root.current-rotation;
+                        status-text: root.status-text;
+                        gesture-active: root.gesture-active;
+                        has-gesture-occurred: root.has-gesture-occurred;
+                        center-x: root.center-x;
+                        center-y: root.center-y;
                     }
                 }
             }
         }
 
-        // Gesture area
-        Rectangle {
-            background: root.gesture-active ? #1e2a4a : #16213e;
-            border-radius: 8px;
-            border-width: root.gesture-active ? 2px : 0px;
-            border-color: #e94560;
-            clip: true;
-
-            Image {
-                width: 200px * root.current-scale;
-                height: 200px * root.current-scale;
-                x: (parent.width - self.width) / 2;
-                y: (parent.height - self.height) / 2;
-                source: @image-url("../../logo/slint-logo-square-light.png");
-                transform-rotation: current-rotation;
-            }
+        if !root.is-landscape: GestureArea {
+            vertical-stretch: 1;
+            image-size: 200px;
+            current-scale: root.current-scale;
+            current-rotation: root.current-rotation;
+            gesture-active: root.gesture-active;
         }
 
-        // Info panel
-        Rectangle {
+        if !root.is-landscape: Rectangle {
             height: 60px;
             background: #16213e;
             border-radius: 6px;
@@ -174,27 +295,14 @@ export component MainWindow inherits Window {
                 alignment: space-around;
                 padding: 8px;
 
-                InfoItem {
-                    label: "Scale";
-                    value: round(root.current-scale * 100) + "%";
-                }
-
-                InfoItem {
-                    label: "Rotation";
-                    value: round(root.current-rotation / 1deg) + "°";
-                }
-
-                InfoItem {
-                    label: "State";
-                    value: root.status-text;
-                    value-color: root.gesture-active ? #e94560 : #a0a0b0;
-                }
-
-                InfoItem {
-                    label: "Center";
-                    value: root.has-gesture-occurred
-                        ? round(root.center-x / 1px) + ", " + round(root.center-y / 1px)
-                        : "—";
+                InfoPanel {
+                    current-scale: root.current-scale;
+                    current-rotation: root.current-rotation;
+                    status-text: root.status-text;
+                    gesture-active: root.gesture-active;
+                    has-gesture-occurred: root.has-gesture-occurred;
+                    center-x: root.center-x;
+                    center-y: root.center-y;
                 }
             }
         }

--- a/examples/native-gestures/src/lib.rs
+++ b/examples/native-gestures/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::include_modules!();
+
+pub fn app_main() -> Result<(), slint::PlatformError> {
+    MainWindow::new()?.run()
+}
+
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+fn android_main(app: slint::android::AndroidApp) -> Result<(), slint::PlatformError> {
+    slint::android::init(app).unwrap();
+    app_main()
+}

--- a/examples/native-gestures/src/main.rs
+++ b/examples/native-gestures/src/main.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() -> Result<(), slint::PlatformError> {
+    native_gestures::app_main()
+}

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -636,9 +636,7 @@ fn pointer_logical_position(
     offset: PhysicalPosition,
     scale_factor: f32,
 ) -> LogicalPosition {
-    let phys_x = x - offset.x as f32;
-    let phys_y = y - offset.y as f32;
-    LogicalPosition::new(phys_x / scale_factor, phys_y / scale_factor)
+    PhysicalPosition::new(x as i32 - offset.x, y as i32 - offset.y).to_logical(scale_factor)
 }
 
 fn position_for_event(

--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -154,7 +154,6 @@ impl<'a> LibInputHandler<'a> {
 
         Ok(mouse_pos_property)
     }
-
 }
 
 fn set_touch_pos(

--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -161,8 +161,7 @@ impl<'a> LibInputHandler<'a> {
     fn set_touch_pos(&mut self, slot: u64, pos: LogicalPosition) {
         if let Some(entry) = self.last_touch_positions.iter_mut().find(|(s, _)| *s == slot) {
             entry.1 = Some(pos);
-        } else if let Some(entry) =
-            self.last_touch_positions.iter_mut().find(|(_, p)| p.is_none())
+        } else if let Some(entry) = self.last_touch_positions.iter_mut().find(|(_, p)| p.is_none())
         {
             *entry = (slot, Some(pos));
         }

--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -116,8 +116,11 @@ pub struct LibInputHandler<'a> {
     libinput: input::Libinput,
     token: Option<calloop::Token>,
     mouse_pos: Pin<Rc<Property<Option<LogicalPosition>>>>,
-    /// Last known position per touch slot. Fixed-capacity to avoid heap
-    /// allocation — touchscreens rarely report more than 5 simultaneous contacts.
+    /// Last known position per touch slot. We must track positions because
+    /// touch-up events from libinput do not include coordinates — only the slot
+    /// identifier is available, so we replay the last known position.
+    /// Fixed-capacity to avoid heap allocation — touchscreens rarely report
+    /// more than 5 simultaneous contacts.
     last_touch_positions: [(u64, Option<LogicalPosition>); 5],
     window: &'a RefCell<Option<Rc<FullscreenWindowAdapter>>>,
     keystate: Option<xkb::State>,

--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -157,23 +157,29 @@ impl<'a> LibInputHandler<'a> {
 
         Ok(mouse_pos_property)
     }
+}
 
-    fn set_touch_pos(&mut self, slot: u64, pos: LogicalPosition) {
-        if let Some(entry) = self.last_touch_positions.iter_mut().find(|(s, _)| *s == slot) {
-            entry.1 = Some(pos);
-        } else if let Some(entry) = self.last_touch_positions.iter_mut().find(|(_, p)| p.is_none())
-        {
-            *entry = (slot, Some(pos));
-        }
+fn set_touch_pos(
+    positions: &mut [(u64, Option<LogicalPosition>); 5],
+    slot: u64,
+    pos: LogicalPosition,
+) {
+    if let Some(entry) = positions.iter_mut().find(|(s, _)| *s == slot) {
+        entry.1 = Some(pos);
+    } else if let Some(entry) = positions.iter_mut().find(|(_, p)| p.is_none()) {
+        *entry = (slot, Some(pos));
     }
+}
 
-    fn take_touch_pos(&mut self, slot: u64) -> LogicalPosition {
-        self.last_touch_positions
-            .iter_mut()
-            .find(|(s, _)| *s == slot)
-            .and_then(|entry| entry.1.take())
-            .unwrap_or_default()
-    }
+fn take_touch_pos(
+    positions: &mut [(u64, Option<LogicalPosition>); 5],
+    slot: u64,
+) -> LogicalPosition {
+    positions
+        .iter_mut()
+        .find(|(s, _)| *s == slot)
+        .and_then(|entry| entry.1.take())
+        .unwrap_or_default()
 }
 
 impl<'a> calloop::EventSource for LibInputHandler<'a> {
@@ -267,7 +273,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                             touch_down_event.y_transformed(screen_size.height as u32) as _,
                         );
                         let slot = touch_down_event.slot().unwrap_or(0) as u64;
-                        self.set_touch_pos(slot, pos);
+                        set_touch_pos(&mut self.last_touch_positions, slot, pos);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,
                             logical_point_from_api(pos),
@@ -276,7 +282,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                     }
                     input::event::TouchEvent::Up(touch_up_event) => {
                         let slot = touch_up_event.slot().unwrap_or(0) as u64;
-                        let pos = self.take_touch_pos(slot);
+                        let pos = take_touch_pos(&mut self.last_touch_positions, slot);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,
                             logical_point_from_api(pos),
@@ -289,7 +295,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                             touch_motion_event.y_transformed(screen_size.height as u32) as _,
                         );
                         let slot = touch_motion_event.slot().unwrap_or(0) as u64;
-                        self.set_touch_pos(slot, pos);
+                        set_touch_pos(&mut self.last_touch_positions, slot, pos);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,
                             logical_point_from_api(pos),
@@ -298,7 +304,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                     }
                     input::event::TouchEvent::Cancel(touch_cancel_event) => {
                         let slot = touch_cancel_event.slot().unwrap_or(0) as u64;
-                        let pos = self.take_touch_pos(slot);
+                        let pos = take_touch_pos(&mut self.last_touch_positions, slot);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,
                             logical_point_from_api(pos),

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -112,11 +112,10 @@ pub fn send_pinch_gesture<
     });
 }
 
-/// Send a platform rotation gesture event to the component's window.
+/// Send a rotation gesture event to the component's window.
 ///
-/// `delta` is the incremental rotation in degrees using the platform's sign convention
-/// (positive = counterclockwise on macOS). PinchGestureHandler negates this internally
-/// so that its `rotation` property uses positive = clockwise (CSS convention).
+/// `delta` is the incremental rotation in degrees using the Slint convention:
+/// positive = clockwise. The handler accumulates deltas into its `rotation` property.
 pub fn send_rotation_gesture<
     X: vtable::HasStaticVTable<ItemTreeVTable>,
     Component: Into<vtable::VRc<ItemTreeVTable, X>> + ComponentHandle,

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -389,7 +389,11 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
             WindowEvent::Touch(touch) => {
                 let location = touch.location.to_logical(runtime_window.scale_factor() as f64);
                 let position = euclid::point2(location.x, location.y);
-                runtime_window.process_touch_input(touch.id, position, winit_touch_phase(touch.phase));
+                runtime_window.process_touch_input(
+                    touch.id,
+                    position,
+                    winit_touch_phase(touch.phase),
+                );
             }
             WindowEvent::ScaleFactorChanged { scale_factor, inner_size_writer: _ } => {
                 if std::env::var("SLINT_SCALE_FACTOR").is_err() {

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -55,9 +55,9 @@ pub enum MouseEvent {
     /// `delta` is the incremental scale change; PinchGestureHandler accumulates it.
     PinchGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
     /// A platform-recognized rotation gesture (macOS/iOS trackpad, Qt).
-    /// `delta` is the incremental rotation in degrees using the platform's sign convention
-    /// (positive = counterclockwise on macOS). PinchGestureHandler negates this internally
-    /// so that its `rotation` property uses positive = clockwise (CSS convention).
+    /// `delta` is the incremental rotation in degrees using the Slint convention:
+    /// positive = clockwise. Backends must convert from their platform convention
+    /// before constructing this event.
     RotationGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
     /// A platform-recognized double-tap gesture ("smart magnify" on macOS trackpad).
     DoubleTapGesture { position: LogicalPoint },
@@ -73,9 +73,9 @@ impl MouseEvent {
             MouseEvent::Released { is_touch, .. } => Some(*is_touch),
             MouseEvent::Moved { is_touch, .. } => Some(*is_touch),
             MouseEvent::Wheel { .. } => None,
-            MouseEvent::PinchGesture { .. } => None,
-            MouseEvent::RotationGesture { .. } => None,
-            MouseEvent::DoubleTapGesture { .. } => None,
+            MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. }
+            | MouseEvent::DoubleTapGesture { .. } => Some(true),
             MouseEvent::DragMove(..) | MouseEvent::Drop(..) => None,
             MouseEvent::Exit => None,
         }

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -1057,9 +1057,7 @@ impl Item for PinchGestureHandler {
                         if !self.active() {
                             return InputEventResult::EventIgnored;
                         }
-                        // Negate: macOS/winit report positive = counterclockwise,
-                        // but our documented convention is positive = clockwise.
-                        let new_rotation = self.rotation() - delta;
+                        let new_rotation = self.rotation() + delta;
                         Self::FIELD_OFFSETS.rotation.apply_pin(self).set(new_rotation);
                         Self::FIELD_OFFSETS.center.apply_pin(self).set(center);
                         Self::FIELD_OFFSETS.updated.apply_pin(self).call(&());
@@ -1158,8 +1156,11 @@ impl PinchGestureHandler {
             return;
         }
         Self::FIELD_OFFSETS.active.apply_pin(self).set(false);
+        Self::FIELD_OFFSETS.cancelled.apply_pin(self).call(&());
+        // Reset after the callback so handlers can read the last known values
+        // to animate back smoothly, matching the pattern where `ended` leaves
+        // scale/rotation at their final values.
         Self::FIELD_OFFSETS.scale.apply_pin(self).set(1.0);
         Self::FIELD_OFFSETS.rotation.apply_pin(self).set(0.0);
-        Self::FIELD_OFFSETS.cancelled.apply_pin(self).call(&());
     }
 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -12,7 +12,7 @@ use crate::api::{
 };
 use crate::input::{
     ClickState, FocusEvent, FocusReason, InternalKeyboardModifierState, KeyEvent, KeyEventType,
-    MouseEvent, MouseInputState, PointerEventButton, TextCursorBlinker, key_codes,
+    MouseEvent, MouseInputState, PointerEventButton, TextCursorBlinker, TouchPhase, key_codes,
 };
 use crate::item_tree::{
     ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable, ItemTreeWeak, ItemWeak,
@@ -438,6 +438,1092 @@ struct WindowPinnedFields {
     text_input_focused: Property<bool>,
 }
 
+/// A single active touch point.
+#[derive(Clone, Copy, Default)]
+struct TouchPoint {
+    position: LogicalPoint,
+}
+
+/// Fixed-capacity map of touch IDs to touch points.
+///
+/// Touchscreens rarely report more than 5 simultaneous contacts, and gesture
+/// recognition only uses the first two. A linear-scan array avoids the heap
+/// allocation and pointer-chasing overhead of `BTreeMap` for this tiny collection.
+const MAX_TRACKED_TOUCHES: usize = 5;
+
+#[derive(Clone)]
+struct TouchMap {
+    entries: [(u64, TouchPoint); MAX_TRACKED_TOUCHES],
+    len: usize,
+}
+
+impl Default for TouchMap {
+    fn default() -> Self {
+        Self { entries: [(0, TouchPoint::default()); MAX_TRACKED_TOUCHES], len: 0 }
+    }
+}
+
+impl TouchMap {
+    fn get(&self, id: u64) -> Option<&TouchPoint> {
+        self.entries[..self.len].iter().find(|(k, _)| *k == id).map(|(_, v)| v)
+    }
+
+    fn get_mut(&mut self, id: u64) -> Option<&mut TouchPoint> {
+        self.entries[..self.len].iter_mut().find(|(k, _)| *k == id).map(|(_, v)| v)
+    }
+
+    fn insert(&mut self, id: u64, point: TouchPoint) {
+        if let Some(existing) = self.entries[..self.len].iter_mut().find(|(k, _)| *k == id) {
+            existing.1 = point;
+        } else if self.len < MAX_TRACKED_TOUCHES {
+            self.entries[self.len] = (id, point);
+            self.len += 1;
+        }
+    }
+
+    fn remove(&mut self, id: u64) {
+        if let Some(idx) = self.entries[..self.len].iter().position(|(k, _)| *k == id) {
+            self.len -= 1;
+            self.entries[idx] = self.entries[self.len];
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the first two distinct IDs, or `None` if fewer than 2 entries.
+    fn first_two_ids(&self) -> Option<(u64, u64)> {
+        if self.len >= 2 {
+            Some((self.entries[0].0, self.entries[1].0))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the first entry, if any.
+    fn first(&self) -> Option<(u64, &TouchPoint)> {
+        if self.len > 0 {
+            Some((self.entries[0].0, &self.entries[0].1))
+        } else {
+            None
+        }
+    }
+}
+
+/// State of the multi-touch gesture recognizer.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+enum GestureRecognitionState {
+    /// 0-1 fingers; forwarding as mouse events.
+    #[default]
+    Idle,
+    /// 2 fingers down, waiting for movement to exceed threshold.
+    TwoFingersDown,
+    /// Actively synthesizing PinchGesture/RotationGesture events.
+    Pinching,
+}
+
+/// Tracks all active touch points and recognizes pinch/rotation gestures.
+///
+/// When only one finger is down, touch events are forwarded as mouse events.
+/// When two fingers are down and move beyond a threshold, synthesized
+/// `PinchGesture` and `RotationGesture` events are emitted — the same events
+/// that Path A (platform gestures) produces.
+struct TouchState {
+    active_touches: TouchMap,
+    /// The finger forwarded as mouse events during single-touch.
+    primary_touch_id: Option<u64>,
+    /// The two finger IDs participating in the gesture (when in TwoFingersDown or Pinching).
+    gesture_finger_ids: Option<(u64, u64)>,
+    gesture_state: GestureRecognitionState,
+    /// Distance between the two fingers when the gesture started.
+    initial_distance: f32,
+    /// Last reported cumulative scale (for computing incremental deltas).
+    last_scale: f32,
+    /// Raw atan2 angle (degrees) from the previous frame, used for per-frame
+    /// rotation delta computation via `normalize_angle(current - last)`.
+    last_angle: f32,
+    /// Time of the last single-finger tap (for double-tap detection).
+    last_tap_time: Option<crate::animations::Instant>,
+    /// Position of the last single-finger tap (for double-tap detection).
+    last_tap_position: Option<LogicalPoint>,
+}
+
+impl Default for TouchState {
+    fn default() -> Self {
+        Self {
+            active_touches: TouchMap::default(),
+            primary_touch_id: None,
+            gesture_finger_ids: None,
+            gesture_state: GestureRecognitionState::Idle,
+            initial_distance: 0.0,
+            last_scale: 1.0,
+            last_angle: 0.0,
+            last_tap_time: None,
+            last_tap_position: None,
+        }
+    }
+}
+
+impl TouchState {
+    /// Minimum movement (in logical pixels) before two fingers are recognized as a pinch.
+    const PINCH_THRESHOLD: f32 = 8.0;
+
+    /// Minimum angular change (in degrees) before two fingers are recognized as a rotation.
+    const ROTATION_THRESHOLD: f32 = 5.0;
+
+    /// Maximum squared distance (in logical pixels) between two taps for a double-tap.
+    /// 100 px² ≈ 10px radius, matching [`ClickState::check_repeat`](crate::input::ClickState).
+    const DOUBLE_TAP_DISTANCE_SQ: f32 = 100.0;
+
+    /// Returns the positions of the two gesture fingers, or `None` if not available.
+    fn gesture_finger_positions(&self) -> Option<(&TouchPoint, &TouchPoint)> {
+        let (id_a, id_b) = self.gesture_finger_ids?;
+        let a = self.active_touches.get(id_a)?;
+        let b = self.active_touches.get(id_b)?;
+        Some((a, b))
+    }
+
+    /// Returns the midpoint between the two gesture fingers, or `None`.
+    fn gesture_midpoint(&self) -> Option<LogicalPoint> {
+        let (a, b) = self.gesture_finger_positions()?;
+        Some(euclid::point2(
+            (a.position.x + b.position.x) / 2.0,
+            (a.position.y + b.position.y) / 2.0,
+        ))
+    }
+
+    /// Returns (distance, angle_in_degrees) between the two gesture fingers.
+    fn gesture_geometry(&self) -> Option<(f32, f32)> {
+        let (a, b) = self.gesture_finger_positions()?;
+        let dx = b.position.x - a.position.x;
+        let dy = b.position.y - a.position.y;
+        let distance = (dx * dx + dy * dy).sqrt();
+        let angle = dy.atan2(dx).to_degrees();
+        Some((distance, angle))
+    }
+
+    /// Returns true if the given touch ID is one of the two gesture fingers.
+    fn is_gesture_finger(&self, id: u64) -> bool {
+        self.gesture_finger_ids.is_some_and(|(a, b)| id == a || id == b)
+    }
+
+    /// Snapshot the current two-finger geometry as the baseline for gesture deltas.
+    ///
+    /// Returns `true` if the snapshot succeeded. A `false` return means the
+    /// gesture finger IDs don't correspond to entries in `active_touches`,
+    /// which indicates a bug in the state machine.
+    fn snapshot_initial_geometry(&mut self) -> bool {
+        if let Some((dist, angle)) = self.gesture_geometry() {
+            self.initial_distance = dist;
+            self.last_scale = 1.0;
+            self.last_angle = angle;
+            true
+        } else {
+            debug_assert!(false, "snapshot_initial_geometry called but gesture fingers not in active_touches");
+            false
+        }
+    }
+
+    /// Normalize an angle difference to [-180, 180].
+    fn normalize_angle(degrees: f32) -> f32 {
+        let mut d = degrees % 360.0;
+        if d > 180.0 {
+            d -= 360.0;
+        } else if d < -180.0 {
+            d += 360.0;
+        }
+        d
+    }
+
+    /// Run the touch state machine for a single event and return the
+    /// [`MouseEvent`]s to dispatch.
+    ///
+    /// This is intentionally separated from [`WindowInner::process_touch_input`]
+    /// so that the `RefCell` borrow can be dropped *once* before dispatching,
+    /// rather than requiring a manual `drop` at every branch.
+    fn process(
+        &mut self,
+        id: u64,
+        position: LogicalPoint,
+        phase: TouchPhase,
+        click_interval: core::time::Duration,
+    ) -> alloc::vec::Vec<MouseEvent> {
+        let mut events = alloc::vec::Vec::new();
+
+        match phase {
+            TouchPhase::Started => {
+                let is_double_tap = if self.active_touches.len() == 0 {
+                    // Check for double-tap before inserting, so a second finger
+                    // arriving during the double-tap touch doesn't see a stale entry.
+                    if let (Some(last_time), Some(last_pos)) =
+                        (self.last_tap_time, self.last_tap_position)
+                    {
+                        let now = crate::animations::Instant::now();
+                        let elapsed = now - last_time;
+                        let dist_sq = (position - last_pos).square_length();
+                        elapsed < click_interval && dist_sq < Self::DOUBLE_TAP_DISTANCE_SQ
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
+                if is_double_tap {
+                    // Don't insert into active_touches: the finger-lift will
+                    // find nothing to remove and fall through harmlessly.
+                    self.last_tap_time = None;
+                    self.last_tap_position = None;
+                    events.push(MouseEvent::DoubleTapGesture { position });
+                    return events;
+                }
+
+                self.active_touches.insert(id, TouchPoint { position });
+
+                let total = self.active_touches.len();
+                if total == 1 {
+                    // First finger: become primary, forward as mouse press.
+                    self.primary_touch_id = Some(id);
+                    self.gesture_state = GestureRecognitionState::Idle;
+                    events.push(MouseEvent::Pressed {
+                        position,
+                        button: PointerEventButton::Left,
+                        click_count: 0,
+                        is_touch: true,
+                    });
+                } else if total == 2 {
+                    // Second finger: transition Idle → TwoFingersDown.
+                    if let Some((id_a, id_b)) = self.active_touches.first_two_ids() {
+                        self.gesture_finger_ids = Some((id_a, id_b));
+                    }
+
+                    // Synthesize a Release for the primary finger to clear any
+                    // Flickable grab / delay state.
+                    let primary_pos = self.primary_touch_id
+                        .and_then(|pid| self.active_touches.get(pid))
+                        .map(|tp| tp.position)
+                        .unwrap_or(position);
+
+                    self.snapshot_initial_geometry();
+                    self.gesture_state = GestureRecognitionState::TwoFingersDown;
+                    // Clear double-tap state: a two-finger gesture interrupts the sequence.
+                    self.last_tap_time = None;
+                    self.last_tap_position = None;
+
+                    events.push(MouseEvent::Released {
+                        position: primary_pos,
+                        button: PointerEventButton::Left,
+                        click_count: 0,
+                        is_touch: true,
+                    });
+                }
+                // 3+ fingers: tracked in active_touches but ignored for gesture.
+            }
+
+            TouchPhase::Moved => {
+                if let Some(tp) = self.active_touches.get_mut(id) {
+                    tp.position = position;
+                }
+
+                let is_gesture_finger = self.is_gesture_finger(id);
+
+                match self.gesture_state {
+                    GestureRecognitionState::Idle => {
+                        if self.primary_touch_id == Some(id) {
+                            // Clear double-tap state if the finger moved too far
+                            // from the last tap, preventing false double-taps
+                            // after drags.
+                            if let Some(last_pos) = self.last_tap_position {
+                                if (position - last_pos).square_length()
+                                    >= Self::DOUBLE_TAP_DISTANCE_SQ
+                                {
+                                    self.last_tap_time = None;
+                                    self.last_tap_position = None;
+                                }
+                            }
+                            events.push(MouseEvent::Moved {
+                                position,
+                                is_touch: true,
+                            });
+                        }
+                    }
+                    GestureRecognitionState::TwoFingersDown if is_gesture_finger => {
+                        if let Some((dist, angle)) = self.gesture_geometry() {
+                            let delta_dist = (dist - self.initial_distance).abs();
+                            let delta_angle =
+                                Self::normalize_angle(angle - self.last_angle).abs();
+                            if delta_dist > Self::PINCH_THRESHOLD
+                                || delta_angle > Self::ROTATION_THRESHOLD
+                            {
+                                self.gesture_state = GestureRecognitionState::Pinching;
+                                // Re-snapshot so the first gesture event starts from
+                                // the current geometry rather than accumulating the
+                                // threshold movement.
+                                self.snapshot_initial_geometry();
+
+                                let midpoint =
+                                    self.gesture_midpoint().unwrap_or(position);
+
+                                events.push(MouseEvent::PinchGesture {
+                                    position: midpoint,
+                                    delta: 0.0,
+                                    phase: TouchPhase::Started,
+                                });
+                                events.push(MouseEvent::RotationGesture {
+                                    position: midpoint,
+                                    delta: 0.0,
+                                    phase: TouchPhase::Started,
+                                });
+                            }
+                        }
+                    }
+                    GestureRecognitionState::Pinching if is_gesture_finger => {
+                        if let Some((dist, angle)) = self.gesture_geometry() {
+                            let midpoint =
+                                self.gesture_midpoint().unwrap_or(position);
+
+                            let current_scale = if self.initial_distance > 0.0 {
+                                dist / self.initial_distance
+                            } else {
+                                1.0
+                            };
+                            let scale_delta = current_scale - self.last_scale;
+                            self.last_scale = current_scale;
+
+                            // Per-frame rotation delta from the raw atan2 angle.
+                            // `normalize_angle` handles the ±180° wraparound so that
+                            // even a large frame-skip produces the correct small delta.
+                            // Negate because screen Y-down means atan2 gives increasing
+                            // angles for clockwise rotation, but PinchGestureHandler
+                            // expects positive = counterclockwise (macOS convention).
+                            let rotation_delta =
+                                -Self::normalize_angle(angle - self.last_angle);
+                            self.last_angle = angle;
+
+                            events.push(MouseEvent::PinchGesture {
+                                position: midpoint,
+                                delta: scale_delta,
+                                phase: TouchPhase::Moved,
+                            });
+                            events.push(MouseEvent::RotationGesture {
+                                position: midpoint,
+                                delta: rotation_delta,
+                                phase: TouchPhase::Moved,
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            TouchPhase::Ended | TouchPhase::Cancelled => {
+                let is_cancelled = phase == TouchPhase::Cancelled;
+                // Check gesture membership *before* removing from the map.
+                let is_gesture_finger = self.is_gesture_finger(id);
+                self.active_touches.remove(id);
+
+                match self.gesture_state {
+                    GestureRecognitionState::Idle => {
+                        if self.primary_touch_id == Some(id) {
+                            self.primary_touch_id = None;
+                            if !is_cancelled {
+                                self.last_tap_time =
+                                    Some(crate::animations::Instant::now());
+                                self.last_tap_position = Some(position);
+                            }
+                            events.push(MouseEvent::Released {
+                                position,
+                                button: PointerEventButton::Left,
+                                click_count: 0,
+                                is_touch: true,
+                            });
+                            events.push(MouseEvent::Exit);
+                        }
+                    }
+                    GestureRecognitionState::TwoFingersDown if is_gesture_finger => {
+                        self.gesture_state = GestureRecognitionState::Idle;
+                        self.gesture_finger_ids = None;
+                        if !is_cancelled {
+                            if let Some((remaining_id, remaining)) =
+                                self.active_touches.first()
+                            {
+                                let remaining_pos = remaining.position;
+                                self.primary_touch_id = Some(remaining_id);
+                                events.push(MouseEvent::Pressed {
+                                    position: remaining_pos,
+                                    button: PointerEventButton::Left,
+                                    click_count: 0,
+                                    is_touch: true,
+                                });
+                            } else {
+                                self.primary_touch_id = None;
+                                events.push(MouseEvent::Exit);
+                            }
+                        } else {
+                            self.primary_touch_id = None;
+                            events.push(MouseEvent::Exit);
+                        }
+                    }
+                    GestureRecognitionState::Pinching if is_gesture_finger => {
+                        let midpoint =
+                            self.gesture_midpoint().unwrap_or(position);
+                        self.gesture_state = GestureRecognitionState::Idle;
+                        self.gesture_finger_ids = None;
+
+                        let gesture_phase = if is_cancelled {
+                            TouchPhase::Cancelled
+                        } else {
+                            TouchPhase::Ended
+                        };
+
+                        let remaining = if !is_cancelled {
+                            self.active_touches
+                                .first()
+                                .map(|(rid, rp)| (rid, rp.position))
+                        } else {
+                            None
+                        };
+                        if let Some((rid, _)) = remaining {
+                            self.primary_touch_id = Some(rid);
+                        } else {
+                            self.primary_touch_id = None;
+                        }
+
+                        events.push(MouseEvent::PinchGesture {
+                            position: midpoint,
+                            delta: 0.0,
+                            phase: gesture_phase,
+                        });
+                        events.push(MouseEvent::RotationGesture {
+                            position: midpoint,
+                            delta: 0.0,
+                            phase: gesture_phase,
+                        });
+
+                        if let Some((_, rpos)) = remaining {
+                            events.push(MouseEvent::Pressed {
+                                position: rpos,
+                                button: PointerEventButton::Left,
+                                click_count: 0,
+                                is_touch: true,
+                            });
+                        } else {
+                            events.push(MouseEvent::Exit);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        events
+    }
+}
+
+#[cfg(test)]
+mod touch_tests {
+    extern crate alloc;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use super::*;
+    use crate::input::{MouseEvent, TouchPhase};
+    use crate::lengths::LogicalPoint;
+
+    fn pt(x: f32, y: f32) -> LogicalPoint {
+        euclid::point2(x, y)
+    }
+
+    /// Default click interval for tests (500ms, matching platform default).
+    const CLICK_INTERVAL: core::time::Duration = core::time::Duration::from_millis(500);
+
+    // -----------------------------------------------------------------------
+    // TouchMap tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn touch_map_insert_and_get() {
+        let mut map = TouchMap::default();
+        assert_eq!(map.len(), 0);
+        map.insert(1, TouchPoint { position: pt(10.0, 20.0) });
+        assert_eq!(map.len(), 1);
+        assert!(map.get(1).is_some());
+        assert!((map.get(1).unwrap().position.x - 10.0).abs() < f32::EPSILON);
+        assert!(map.get(2).is_none());
+    }
+
+    #[test]
+    fn touch_map_update_existing() {
+        let mut map = TouchMap::default();
+        map.insert(1, TouchPoint { position: pt(10.0, 20.0) });
+        map.insert(1, TouchPoint { position: pt(30.0, 40.0) });
+        assert_eq!(map.len(), 1);
+        assert!((map.get(1).unwrap().position.x - 30.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn touch_map_remove() {
+        let mut map = TouchMap::default();
+        map.insert(1, TouchPoint { position: pt(10.0, 20.0) });
+        map.insert(2, TouchPoint { position: pt(30.0, 40.0) });
+        assert_eq!(map.len(), 2);
+        map.remove(1);
+        assert_eq!(map.len(), 1);
+        assert!(map.get(1).is_none());
+        assert!(map.get(2).is_some());
+    }
+
+    #[test]
+    fn touch_map_remove_nonexistent() {
+        let mut map = TouchMap::default();
+        map.insert(1, TouchPoint { position: pt(10.0, 20.0) });
+        map.remove(99);
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn touch_map_capacity() {
+        let mut map = TouchMap::default();
+        for i in 0..MAX_TRACKED_TOUCHES {
+            map.insert(i as u64, TouchPoint { position: pt(i as f32, 0.0) });
+        }
+        assert_eq!(map.len(), MAX_TRACKED_TOUCHES);
+        // Inserting beyond capacity is silently ignored.
+        map.insert(99, TouchPoint { position: pt(99.0, 0.0) });
+        assert_eq!(map.len(), MAX_TRACKED_TOUCHES);
+        assert!(map.get(99).is_none());
+    }
+
+    #[test]
+    fn touch_map_first_two_ids() {
+        let mut map = TouchMap::default();
+        assert!(map.first_two_ids().is_none());
+        map.insert(5, TouchPoint { position: pt(0.0, 0.0) });
+        assert!(map.first_two_ids().is_none());
+        map.insert(10, TouchPoint { position: pt(0.0, 0.0) });
+        assert_eq!(map.first_two_ids(), Some((5, 10)));
+    }
+
+    #[test]
+    fn touch_map_first() {
+        let mut map = TouchMap::default();
+        assert!(map.first().is_none());
+        map.insert(7, TouchPoint { position: pt(1.0, 2.0) });
+        let (id, tp) = map.first().unwrap();
+        assert_eq!(id, 7);
+        assert!((tp.position.x - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn touch_map_get_mut() {
+        let mut map = TouchMap::default();
+        map.insert(1, TouchPoint { position: pt(0.0, 0.0) });
+        map.get_mut(1).unwrap().position = pt(5.0, 6.0);
+        assert!((map.get(1).unwrap().position.x - 5.0).abs() < f32::EPSILON);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: extract event types for readable assertions
+    // -----------------------------------------------------------------------
+
+    #[derive(Debug, PartialEq)]
+    enum Ev {
+        Pressed(f32, f32),
+        Released(f32, f32),
+        Moved(f32, f32),
+        Exit,
+        PinchStarted,
+        PinchMoved(f32),
+        PinchEnded,
+        PinchCancelled,
+        RotationStarted,
+        RotationMoved(f32),
+        RotationEnded,
+        RotationCancelled,
+        DoubleTap(f32, f32),
+    }
+
+    fn classify(events: &[MouseEvent]) -> Vec<Ev> {
+        events
+            .iter()
+            .map(|e| match e {
+                MouseEvent::Pressed { position, .. } => Ev::Pressed(position.x, position.y),
+                MouseEvent::Released { position, .. } => Ev::Released(position.x, position.y),
+                MouseEvent::Moved { position, .. } => Ev::Moved(position.x, position.y),
+                MouseEvent::Exit => Ev::Exit,
+                MouseEvent::PinchGesture { delta, phase, .. } => match phase {
+                    TouchPhase::Started => Ev::PinchStarted,
+                    TouchPhase::Moved => Ev::PinchMoved(*delta),
+                    TouchPhase::Ended => Ev::PinchEnded,
+                    TouchPhase::Cancelled => Ev::PinchCancelled,
+                },
+                MouseEvent::RotationGesture { delta, phase, .. } => match phase {
+                    TouchPhase::Started => Ev::RotationStarted,
+                    TouchPhase::Moved => Ev::RotationMoved(*delta),
+                    TouchPhase::Ended => Ev::RotationEnded,
+                    TouchPhase::Cancelled => Ev::RotationCancelled,
+                },
+                MouseEvent::DoubleTapGesture { position } => {
+                    Ev::DoubleTap(position.x, position.y)
+                }
+                _ => panic!("unexpected event: {:?}", e),
+            })
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // TouchState: single-finger forwarding
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn single_finger_press_move_release() {
+        let mut state = TouchState::default();
+
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Pressed(100.0, 200.0)]);
+
+        let evs = state.process(1, pt(110.0, 200.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Moved(110.0, 200.0)]);
+
+        let evs = state.process(1, pt(110.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Released(110.0, 200.0), Ev::Exit]);
+    }
+
+    #[test]
+    fn single_finger_cancel() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Cancelled, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Released(100.0, 200.0), Ev::Exit]);
+
+        // Cancelled touch should NOT record tap state for double-tap.
+        assert!(state.last_tap_time.is_none());
+    }
+
+    #[test]
+    fn non_primary_move_ignored() {
+        let mut state = TouchState::default();
+        // Touch 1 is primary.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        // Move for a different ID that was never started (edge case).
+        let evs = state.process(99, pt(50.0, 50.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert!(classify(&evs).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // TouchState: two-finger → gesture transition
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn two_fingers_synthesize_release_then_gesture() {
+        let mut state = TouchState::default();
+
+        // Finger 1 down.
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Pressed(100.0, 200.0)]);
+
+        // Finger 2 down → synthesized release for finger 1.
+        let evs = state.process(2, pt(200.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Released(100.0, 200.0)]);
+        assert_eq!(state.gesture_state, GestureRecognitionState::TwoFingersDown);
+
+        // Move finger 2 far enough to trigger pinch (> 8px threshold).
+        let evs = state.process(2, pt(220.0, 200.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert_eq!(
+            classify(&evs),
+            vec![Ev::PinchStarted, Ev::RotationStarted]
+        );
+        assert_eq!(state.gesture_state, GestureRecognitionState::Pinching);
+    }
+
+    #[test]
+    fn two_fingers_below_threshold_no_gesture() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(200.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        // Small movement within threshold.
+        let evs = state.process(2, pt(202.0, 200.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert!(classify(&evs).is_empty());
+        assert_eq!(state.gesture_state, GestureRecognitionState::TwoFingersDown);
+    }
+
+    #[test]
+    fn pinch_produces_scale_deltas() {
+        let mut state = TouchState::default();
+
+        // Set up: finger 1 at (0, 0), finger 2 at (100, 0) → distance = 100.
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(100.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        // Move finger 2 to (120, 0) to exceed threshold and start pinching.
+        state.process(2, pt(120.0, 0.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert_eq!(state.gesture_state, GestureRecognitionState::Pinching);
+
+        // Now move finger 2 further to (180, 0).
+        // New distance = 180, initial distance (re-snapshotted) = 120.
+        // Scale = 180/120 = 1.5, delta = 1.5 - 1.0 = 0.5.
+        let evs = state.process(2, pt(180.0, 0.0), TouchPhase::Moved, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        assert_eq!(classified.len(), 2);
+        if let Ev::PinchMoved(delta) = classified[0] {
+            assert!((delta - 0.5).abs() < 0.01, "expected ~0.5, got {}", delta);
+        } else {
+            panic!("expected PinchMoved, got {:?}", classified[0]);
+        }
+    }
+
+    #[test]
+    fn rotation_produces_correct_deltas() {
+        let mut state = TouchState::default();
+
+        // Finger 1 at origin, finger 2 on the X axis at (100, 0).
+        // Initial angle = atan2(0, 100) = 0°.
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(100.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        // Move finger 2 far enough to trigger gesture.
+        state.process(2, pt(120.0, 0.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert_eq!(state.gesture_state, GestureRecognitionState::Pinching);
+
+        // Rotate ~45° clockwise: move finger 2 from (120, 0) to roughly
+        // (70.7, 70.7) which is at 45° from origin.
+        // atan2(70.7, 70.7) ≈ 45°. Delta from re-snapshotted 0° = +45°.
+        // Negated for macOS convention → delta ≈ -45°.
+        let evs = state.process(2, pt(70.7, 70.7), TouchPhase::Moved, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        assert_eq!(classified.len(), 2);
+        if let Ev::RotationMoved(delta) = classified[1] {
+            assert!(
+                (delta - (-45.0)).abs() < 1.0,
+                "expected ~-45.0 (clockwise), got {}",
+                delta
+            );
+        } else {
+            panic!("expected RotationMoved, got {:?}", classified[1]);
+        }
+    }
+
+    #[test]
+    fn rotation_across_180_degree_boundary() {
+        let mut state = TouchState::default();
+
+        // Finger 1 at origin, finger 2 at (-100, -10).
+        // angle = atan2(-10, -100) ≈ -174.3°.
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(-100.0, -10.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        // Trigger gesture by moving far enough.
+        state.process(2, pt(-120.0, -10.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert_eq!(state.gesture_state, GestureRecognitionState::Pinching);
+
+        // Rotate across the ±180° boundary: move finger 2 to (-100, 10).
+        // New angle = atan2(10, -100) ≈ 174.3°.
+        // Raw angular change crosses ±180°, but per-frame delta should be
+        // small (~11.4° which is 2 * 5.7°), NOT a ~349° jump.
+        let evs = state.process(2, pt(-100.0, 10.0), TouchPhase::Moved, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        if let Ev::RotationMoved(delta) = classified[1] {
+            assert!(
+                delta.abs() < 20.0,
+                "rotation should be a small delta (~11°), got {} (discontinuity!)",
+                delta
+            );
+        } else {
+            panic!("expected RotationMoved, got {:?}", classified[1]);
+        }
+    }
+
+    #[test]
+    fn rotation_cumulative_over_multiple_frames() {
+        let mut state = TouchState::default();
+
+        // Finger 1 at origin, finger 2 at (100, 0).
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(100.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(120.0, 0.0), TouchPhase::Moved, CLICK_INTERVAL);
+        assert_eq!(state.gesture_state, GestureRecognitionState::Pinching);
+
+        // Rotate in 3 steps of ~30° each (clockwise).
+        // Step 1: 0° → 30°
+        let r = 120.0_f32;
+        let evs = state.process(
+            2,
+            pt(r * 30.0_f32.to_radians().cos(), r * 30.0_f32.to_radians().sin()),
+            TouchPhase::Moved,
+            CLICK_INTERVAL,
+        );
+        let d1 = if let Ev::RotationMoved(d) = classify(&evs)[1] { d } else { panic!() };
+
+        // Step 2: 30° → 60°
+        let evs = state.process(
+            2,
+            pt(r * 60.0_f32.to_radians().cos(), r * 60.0_f32.to_radians().sin()),
+            TouchPhase::Moved,
+            CLICK_INTERVAL,
+        );
+        let d2 = if let Ev::RotationMoved(d) = classify(&evs)[1] { d } else { panic!() };
+
+        // Step 3: 60° → 90°
+        let evs = state.process(
+            2,
+            pt(r * 90.0_f32.to_radians().cos(), r * 90.0_f32.to_radians().sin()),
+            TouchPhase::Moved,
+            CLICK_INTERVAL,
+        );
+        let d3 = if let Ev::RotationMoved(d) = classify(&evs)[1] { d } else { panic!() };
+
+        // Each delta should be ~-30° (clockwise, negated).
+        let total = d1 + d2 + d3;
+        assert!(
+            (total - (-90.0)).abs() < 2.0,
+            "cumulative rotation should be ~-90°, got {}",
+            total
+        );
+        // Each step should be roughly equal.
+        assert!((d1 - d2).abs() < 1.0, "deltas should be similar: {} vs {}", d1, d2);
+        assert!((d2 - d3).abs() < 1.0, "deltas should be similar: {} vs {}", d2, d3);
+    }
+
+    // -----------------------------------------------------------------------
+    // TouchState: gesture end transitions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pinch_end_with_remaining_finger() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(100.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        // Trigger pinch.
+        state.process(2, pt(120.0, 0.0), TouchPhase::Moved, CLICK_INTERVAL);
+
+        // Lift finger 2 → gesture ends, finger 1 gets re-pressed.
+        let evs = state.process(2, pt(120.0, 0.0), TouchPhase::Ended, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        assert_eq!(
+            classified,
+            vec![Ev::PinchEnded, Ev::RotationEnded, Ev::Pressed(0.0, 0.0)]
+        );
+        assert_eq!(state.gesture_state, GestureRecognitionState::Idle);
+        assert_eq!(state.primary_touch_id, Some(1));
+    }
+
+    #[test]
+    fn pinch_end_no_remaining_finger_emits_exit() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(100.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(120.0, 0.0), TouchPhase::Moved, CLICK_INTERVAL);
+
+        // Lift finger 1 first (it's also a gesture finger, so gesture ends).
+        // But finger 2 is still tracked → remaining finger gets Pressed.
+        let evs = state.process(1, pt(0.0, 0.0), TouchPhase::Ended, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        assert_eq!(
+            classified,
+            vec![Ev::PinchEnded, Ev::RotationEnded, Ev::Pressed(120.0, 0.0)]
+        );
+
+        // Now lift the remaining finger 2 (now primary, in Idle).
+        let evs = state.process(2, pt(120.0, 0.0), TouchPhase::Ended, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        assert_eq!(classified, vec![Ev::Released(120.0, 0.0), Ev::Exit]);
+    }
+
+    #[test]
+    fn pinch_cancel_emits_cancelled_and_exit() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(100.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(120.0, 0.0), TouchPhase::Moved, CLICK_INTERVAL);
+
+        // Cancel finger 2.
+        let evs = state.process(2, pt(120.0, 0.0), TouchPhase::Cancelled, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        assert_eq!(
+            classified,
+            vec![Ev::PinchCancelled, Ev::RotationCancelled, Ev::Exit]
+        );
+        assert!(state.primary_touch_id.is_none());
+    }
+
+    #[test]
+    fn two_fingers_down_lift_before_threshold_returns_to_idle() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(200.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(state.gesture_state, GestureRecognitionState::TwoFingersDown);
+
+        // Lift finger 2 without exceeding movement threshold.
+        let evs = state.process(2, pt(200.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+        let classified = classify(&evs);
+        // Remaining finger 1 gets re-pressed.
+        assert_eq!(classified, vec![Ev::Pressed(100.0, 200.0)]);
+        assert_eq!(state.gesture_state, GestureRecognitionState::Idle);
+        assert_eq!(state.primary_touch_id, Some(1));
+    }
+
+    #[test]
+    fn two_fingers_down_cancel_both_emits_exit() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(200.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        // Cancel finger 2 (gesture finger, no remaining → Exit).
+        let evs = state.process(2, pt(200.0, 200.0), TouchPhase::Cancelled, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Exit]);
+
+        // Cancel finger 1 (now in Idle, but not primary since cancel cleared it).
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Cancelled, CLICK_INTERVAL);
+        assert!(classify(&evs).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // TouchState: double-tap detection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn double_tap_within_interval() {
+        let mut state = TouchState::default();
+
+        // First tap.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(1, pt(100.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+        assert!(state.last_tap_time.is_some());
+
+        // Second tap at same position, within interval.
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::DoubleTap(100.0, 200.0)]);
+
+        // Tap state cleared after double-tap.
+        assert!(state.last_tap_time.is_none());
+    }
+
+    #[test]
+    fn double_tap_too_far() {
+        let mut state = TouchState::default();
+
+        // First tap.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(1, pt(100.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+
+        // Second tap too far away (> 10px radius → > 100 sq dist).
+        let evs = state.process(1, pt(200.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        // Should be a regular press, not a double-tap.
+        assert_eq!(classify(&evs), vec![Ev::Pressed(200.0, 200.0)]);
+    }
+
+    #[test]
+    fn double_tap_state_cleared_by_drag() {
+        let mut state = TouchState::default();
+
+        // First tap.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(1, pt(100.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+        assert!(state.last_tap_time.is_some());
+
+        // New touch + drag beyond threshold.
+        state.process(2, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(120.0, 200.0), TouchPhase::Moved, CLICK_INTERVAL);
+        // 20px > 10px radius, so tap state should be cleared.
+        assert!(state.last_tap_time.is_none());
+
+        state.process(2, pt(120.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+
+        // Next tap should be a regular press, not double-tap.
+        let evs = state.process(3, pt(120.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Pressed(120.0, 200.0)]);
+    }
+
+    #[test]
+    fn double_tap_state_cleared_by_two_finger_gesture() {
+        let mut state = TouchState::default();
+
+        // First tap.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(1, pt(100.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+        assert!(state.last_tap_time.is_some());
+
+        // Second finger arrives → clears tap state.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(200.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert!(state.last_tap_time.is_none());
+    }
+
+    #[test]
+    fn double_tap_finger_lift_harmless() {
+        let mut state = TouchState::default();
+
+        // First tap.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(1, pt(100.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+
+        // Double-tap detected.
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::DoubleTap(100.0, 200.0)]);
+
+        // The finger was never inserted into active_touches, so lifting it
+        // should produce no events (falls through _ => {} in Idle).
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Ended, CLICK_INTERVAL);
+        assert!(classify(&evs).is_empty());
+    }
+
+    #[test]
+    fn cancelled_tap_does_not_enable_double_tap() {
+        let mut state = TouchState::default();
+
+        // Cancelled touch should not record tap state.
+        state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(1, pt(100.0, 200.0), TouchPhase::Cancelled, CLICK_INTERVAL);
+        assert!(state.last_tap_time.is_none());
+
+        // Next tap should be regular press.
+        let evs = state.process(1, pt(100.0, 200.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert_eq!(classify(&evs), vec![Ev::Pressed(100.0, 200.0)]);
+    }
+
+    // -----------------------------------------------------------------------
+    // TouchState: 3+ fingers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn third_finger_ignored_for_gesture() {
+        let mut state = TouchState::default();
+
+        state.process(1, pt(0.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+        state.process(2, pt(100.0, 0.0), TouchPhase::Started, CLICK_INTERVAL);
+
+        // Third finger: no additional events.
+        let evs = state.process(3, pt(50.0, 50.0), TouchPhase::Started, CLICK_INTERVAL);
+        assert!(classify(&evs).is_empty());
+        assert_eq!(state.active_touches.len(), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // TouchState: normalize_angle
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn normalize_angle_values() {
+        assert!((TouchState::normalize_angle(0.0)).abs() < f32::EPSILON);
+        assert!((TouchState::normalize_angle(180.0) - 180.0).abs() < f32::EPSILON);
+        assert!((TouchState::normalize_angle(181.0) - (-179.0)).abs() < f32::EPSILON);
+        assert!((TouchState::normalize_angle(-181.0) - 179.0).abs() < f32::EPSILON);
+        assert!((TouchState::normalize_angle(360.0)).abs() < f32::EPSILON);
+        assert!((TouchState::normalize_angle(540.0) - 180.0).abs() < f32::EPSILON);
+    }
+}
+
 /// Inner datastructure for the [`crate::api::Window`]
 pub struct WindowInner {
     window_adapter_weak: Weak<dyn WindowAdapter>,
@@ -445,6 +1531,7 @@ pub struct WindowInner {
     /// When the window is visible, keep a strong reference
     strong_component_ref: RefCell<Option<ItemTreeRc>>,
     mouse_input_state: Cell<MouseInputState>,
+    touch_state: RefCell<TouchState>,
     pub(crate) modifiers: Cell<InternalKeyboardModifierState>,
 
     /// ItemRC that currently have the focus (possibly an instance of TextInput)
@@ -505,6 +1592,7 @@ impl WindowInner {
             component: Default::default(),
             strong_component_ref: Default::default(),
             mouse_input_state: Default::default(),
+            touch_state: Default::default(),
             modifiers: Default::default(),
             pinned_fields: Box::pin(WindowPinnedFields {
                 redraw_tracker,
@@ -537,6 +1625,7 @@ impl WindowInner {
         self.close_all_popups();
         self.focus_item.replace(Default::default());
         self.mouse_input_state.replace(Default::default());
+        self.touch_state.replace(Default::default());
         self.modifiers.replace(Default::default());
         self.component.replace(ItemTreeRc::downgrade(component));
         self.pinned_fields.window_properties_tracker.set_dirty(); // component changed, layout constraints for sure must be re-calculated
@@ -754,6 +1843,21 @@ impl WindowInner {
         }
 
         crate::properties::ChangeTracker::run_change_handlers();
+    }
+
+    /// Receive a raw touch event from a backend and either forward it as a mouse
+    /// event (single finger) or synthesize `PinchGesture`/`RotationGesture` events
+    /// (two fingers), which are the same events that Path A (platform gestures) produces.
+    ///
+    /// `position` must be in **logical coordinates** (i.e., already divided by the
+    /// scale factor). Passing physical coordinates will produce incorrect gesture
+    /// geometry and hit-testing.
+    pub fn process_touch_input(&self, id: u64, position: LogicalPoint, phase: TouchPhase) {
+        let click_interval = self.context().platform().click_interval();
+        let events = self.touch_state.borrow_mut().process(id, position, phase, click_interval);
+        for event in events {
+            self.process_mouse_input(event);
+        }
     }
 
     /// Called by the input code's internal timer to send an event that was delayed

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -543,11 +543,7 @@ enum GestureRecognitionState {
     #[default]
     Idle,
     /// 2 fingers down, waiting for movement to exceed threshold.
-    TwoFingersDown {
-        finger_ids: (u64, u64),
-        initial_distance: f32,
-        last_angle: euclid::Angle<f32>,
-    },
+    TwoFingersDown { finger_ids: (u64, u64), initial_distance: f32, last_angle: euclid::Angle<f32> },
     /// Actively synthesizing PinchGesture/RotationGesture events.
     Pinching {
         finger_ids: (u64, u64),
@@ -706,8 +702,7 @@ impl TouchState {
             });
         } else if total == 2 {
             // Second finger: transition Idle → TwoFingersDown.
-            let finger_ids = self.active_touches.first_two_ids()
-                .unwrap_or((0, 0));
+            let finger_ids = self.active_touches.first_two_ids().unwrap_or((0, 0));
 
             // Synthesize a Release for the primary finger to clear any
             // Flickable grab / delay state.
@@ -718,8 +713,8 @@ impl TouchState {
                 .unwrap_or(position);
 
             // Compute initial geometry for threshold detection.
-            let (initial_distance, last_angle) = self.geometry_for(finger_ids)
-                .unwrap_or((0.0, euclid::Angle::zero()));
+            let (initial_distance, last_angle) =
+                self.geometry_for(finger_ids).unwrap_or((0.0, euclid::Angle::zero()));
             self.gesture_state = GestureRecognitionState::TwoFingersDown {
                 finger_ids,
                 initial_distance,
@@ -762,14 +757,14 @@ impl TouchState {
                 }
             }
             GestureRecognitionState::TwoFingersDown {
-                finger_ids, initial_distance, last_angle,
+                finger_ids,
+                initial_distance,
+                last_angle,
             } if is_gesture_finger => {
                 if let Some((dist, angle)) = self.gesture_geometry() {
                     let delta_dist = (dist - initial_distance).abs();
-                    let delta_angle =
-                        (angle - last_angle).signed().to_degrees().abs();
-                    if delta_dist > Self::PINCH_THRESHOLD
-                        || delta_angle > Self::ROTATION_THRESHOLD
+                    let delta_angle = (angle - last_angle).signed().to_degrees().abs();
+                    if delta_dist > Self::PINCH_THRESHOLD || delta_angle > Self::ROTATION_THRESHOLD
                     {
                         // Re-snapshot so the first gesture event starts from
                         // the current geometry rather than accumulating the
@@ -802,22 +797,21 @@ impl TouchState {
                 if let Some((dist, angle)) = self.gesture_geometry() {
                     let midpoint = self.gesture_midpoint().unwrap_or(position);
 
-                    let current_scale = if initial_distance > 0.0 {
-                        dist / initial_distance
-                    } else {
-                        1.0
-                    };
+                    let current_scale =
+                        if initial_distance > 0.0 { dist / initial_distance } else { 1.0 };
                     let scale_delta = current_scale - last_scale;
 
                     // `.signed()` wraps to [-pi, pi] so crossing the ±180°
                     // atan2 boundary doesn't produce a full-revolution jump.
-                    let rotation_delta =
-                        (angle - last_angle).signed().to_degrees();
+                    let rotation_delta = (angle - last_angle).signed().to_degrees();
 
                     // Update the mutable state for next frame.
                     if let GestureRecognitionState::Pinching {
-                        last_scale: ref mut ls, last_angle: ref mut la, ..
-                    } = self.gesture_state {
+                        last_scale: ref mut ls,
+                        last_angle: ref mut la,
+                        ..
+                    } = self.gesture_state
+                    {
                         *ls = current_scale;
                         *la = angle;
                     }
@@ -854,8 +848,7 @@ impl TouchState {
                 if self.primary_touch_id == Some(id) {
                     self.primary_touch_id = None;
                     if !is_cancelled {
-                        self.last_tap =
-                            Some((crate::animations::Instant::now(), position));
+                        self.last_tap = Some((crate::animations::Instant::now(), position));
                     }
                     events.push(MouseEvent::Released {
                         position,

--- a/tests/cases/elements/pinchgesturehandler.slint
+++ b/tests/cases/elements/pinchgesturehandler.slint
@@ -202,15 +202,14 @@ slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Star
 assert_eq!(instance.get_active(), true);
 assert_eq!(instance.get_rotation(), 0.0);
 
-// Send rotation delta of 15 degrees (platform convention: positive = counterclockwise).
-// PinchGestureHandler negates to match CSS/Slint convention (positive = clockwise).
-slint_testing::send_rotation_gesture(&instance, 15.0, 300.0, 300.0, TouchPhase::Moved);
+// Send rotation delta of -15 degrees (counterclockwise).
+slint_testing::send_rotation_gesture(&instance, -15.0, 300.0, 300.0, TouchPhase::Moved);
 assert_eq!(instance.get_active(), true);
 assert_eq!(instance.get_rotation(), -15.0);
 assert_eq!(instance.get_r(), "started;updated(1);");
 
-// Send another rotation delta of -5 degrees (clockwise on platform → positive in our convention)
-slint_testing::send_rotation_gesture(&instance, -5.0, 300.0, 300.0, TouchPhase::Moved);
+// Send another rotation delta of +5 degrees (5° clockwise)
+slint_testing::send_rotation_gesture(&instance, 5.0, 300.0, 300.0, TouchPhase::Moved);
 assert_eq!(instance.get_rotation(), -10.0);
 assert_eq!(instance.get_r(), "started;updated(1);updated(1);");
 
@@ -224,7 +223,7 @@ use slint_testing::TouchPhase;
 
 // === Test 11: Rotation resets on new gesture start ===
 slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
-slint_testing::send_rotation_gesture(&instance, 45.0, 300.0, 300.0, TouchPhase::Moved);
+slint_testing::send_rotation_gesture(&instance, -45.0, 300.0, 300.0, TouchPhase::Moved);
 assert_eq!(instance.get_rotation(), -45.0);
 
 slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
@@ -266,7 +265,7 @@ assert_eq!(instance.get_active(), true);
 assert_eq!(instance.get_scale(), 1.0);
 assert_eq!(instance.get_rotation(), 0.0);
 
-slint_testing::send_rotation_gesture(&instance, 30.0, 300.0, 300.0, TouchPhase::Moved);
+slint_testing::send_rotation_gesture(&instance, -30.0, 300.0, 300.0, TouchPhase::Moved);
 assert_eq!(instance.get_rotation(), -30.0);
 // Scale unchanged because only rotation happened
 assert_eq!(instance.get_scale(), 1.0);
@@ -289,15 +288,15 @@ slint_testing::send_pinch_gesture(&instance, 0.5, 300.0, 300.0, TouchPhase::Move
 assert_eq!(instance.get_scale(), 1.5);
 assert_eq!(instance.get_rotation(), 0.0);
 
-slint_testing::send_rotation_gesture(&instance, 20.0, 300.0, 300.0, TouchPhase::Moved);
+slint_testing::send_rotation_gesture(&instance, -20.0, 300.0, 300.0, TouchPhase::Moved);
 assert_eq!(instance.get_scale(), 1.5);
 assert_eq!(instance.get_rotation(), -20.0);
 
 slint_testing::send_pinch_gesture(&instance, 0.3, 300.0, 300.0, TouchPhase::Moved);
-slint_testing::send_rotation_gesture(&instance, -10.0, 300.0, 300.0, TouchPhase::Moved);
+slint_testing::send_rotation_gesture(&instance, 10.0, 300.0, 300.0, TouchPhase::Moved);
 // scale = 1.5 * (1 + 0.3) = 1.95
 assert!((instance.get_scale() - 1.95).abs() < 0.001);
-// rotation = -20 - (-10) = -10
+// rotation = -20 + 10 = -10
 assert_eq!(instance.get_rotation(), -10.0);
 
 slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ended);
@@ -311,7 +310,7 @@ use slint_testing::TouchPhase;
 // === Test 16: Cancellation resets scale and rotation ===
 slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Started);
 slint_testing::send_pinch_gesture(&instance, 0.5, 300.0, 300.0, TouchPhase::Moved);
-slint_testing::send_rotation_gesture(&instance, 45.0, 300.0, 300.0, TouchPhase::Moved);
+slint_testing::send_rotation_gesture(&instance, -45.0, 300.0, 300.0, TouchPhase::Moved);
 assert_eq!(instance.get_scale(), 1.5);
 assert_eq!(instance.get_rotation(), -45.0);
 assert_eq!(instance.get_active(), true);


### PR DESCRIPTION
## Summary

- Synthesize `PinchGesture`, `RotationGesture`, and `DoubleTapGesture` events from raw multi-touch input on backends that lack native gesture recognition (Android, Linux KMS)
- Add a `TouchState` state machine in `window.rs` that tracks active touches and transitions through Idle → TwoFingersDown → Pinching, producing the same `MouseEvent` variants that the winit backend already emits for macOS platform gestures
- Update the `native-gestures` example with Android support and improved UI
- Review fixes: sign convention normalization, fixed-capacity data structures (no heap allocation), callback ordering, deduplication of coordinate conversion and phase mapping helpers, edge-case test coverage

## Details

The `TouchState` recognizer:
- Forwards single-finger touches as mouse press/move/release events
- Detects two-finger gestures with configurable thresholds (8px pinch, 5° rotation)
- Synthesizes a release for the primary finger before entering gesture mode
- Re-presses the remaining finger when a gesture ends with one finger still down
- Detects double-tap with distance and timing constraints
- Uses fixed-capacity data structures (`TouchMap`, `TouchEventBuffer`) to avoid heap allocation

Backend changes:
- **Android**: Unified coordinate conversion, calls `process_touch_input` for multi-pointer events
- **Linux KMS**: Replaced `BTreeMap` with fixed-capacity array for touch positions
- **Winit**: Extracted `winit_touch_phase` helper, negates rotation delta at the source to match Slint convention (positive = clockwise)

## Test plan

- [x] `cargo test -p i-slint-core -- touch` (27 unit tests for TouchState)
- [x] `cargo test -p test-driver-rust -- pinchgesturehandler` (15 element tests)
- [x] Manual test: macOS trackpad pinch/rotation via `native-gestures` example
- [ ] Manual test: Android touchscreen via `native-gestures` example
- [ ] Manual test: Linux touchscreen