### PR TITLE
Fix rem_euclid usage for non-std feature

### DIFF
--- a/internal/core/graphics/brush.rs
+++ b/internal/core/graphics/brush.rs
@@ -395,7 +395,7 @@ impl ConicGradientBrush {
                 #[cfg(feature = "std")]
                 let rotated_position = (stop.position + normalized_from_angle).rem_euclid(1.0);
                 #[cfg(not(feature = "std"))]
-                let rotated_position = (stop.position + normalized_from_angle).rem_euclid(&1.0);
+                let rotated_position = (stop.position + normalized_from_angle).rem_euclid(1.0);
                 GradientStop { position: rotated_position, color: stop.color }
             })
             .collect();


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
