### PR TITLE
Skia: Enable subpixel glyph positioning to fix uneven text spacing

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -1017,7 +1017,8 @@ impl GlyphRenderer for SkiaItemRenderer<'_> {
         else {
             return;
         };
-        let font = skia_safe::Font::from_typeface(type_face, font_size.get());
+        let mut font = skia_safe::Font::from_typeface(type_face, font_size.get());
+        font.set_subpixel(true);
 
         let (glyph_ids, glyph_positions): (Vec<_>, Vec<_>) = glyphs_it
             .into_iter()


### PR DESCRIPTION
Without subpixel positioning, Skia rounds each glyph position to the nearest integer pixel. Since parley provides fractional glyph positions, this rounding caused visible spacing issues at low resolutions.

The old Skia Paragraph::paint() path handled subpixel positioning internally, so this was a regression introduced when switching to parley for text layout.

Fixes #10752

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
