### PR TITLE
sdf fonts: Fix space characters not working

### DIFF
--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -459,7 +459,6 @@ fn generate_sdf_for_glyph(
     let face =
         fdsm_ttf_parser::ttf_parser::Face::parse(font.font.blob.data(), font.font.index).unwrap();
     let glyph_id = face.glyph_index(code_point).unwrap_or_default();
-    let mut shape = fdsm_ttf_parser::load_shape_from_face(&face, glyph_id)?;
 
     let metrics = sharedfontique::DesignFontMetrics::new(&font.font);
     let target_pixel_size = target_pixel_size as f64;
@@ -473,6 +472,8 @@ fn generate_sdf_for_glyph(
             ..Default::default()
         });
     };
+
+    let mut shape = fdsm_ttf_parser::load_shape_from_face(&face, glyph_id)?;
 
     let width = ((bbox.x_max as f64 - bbox.x_min as f64) * scale + 2.).ceil() as u32;
     let height = ((bbox.y_max as f64 - bbox.y_min as f64) * scale + 2.).ceil() as u32;


### PR DESCRIPTION
For spaces we don't have an outline in the font, so load_shape_from_face() will fail. That however was a return too early, we must enter the code path that handles this property, by returning a glyph with the reported advance.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
