### PR TITLE
`lsp`: include `@library` into path resolution

### DIFF
--- a/tools/lsp/common/token_info.rs
+++ b/tools/lsp/common/token_info.rs
@@ -177,13 +177,32 @@ pub fn token_info(document_cache: &common::DocumentCache, token: SyntaxToken) ->
                 itertools::Either::Right(ty) => Some(TokenInfo::Type(ty)),
             };
         } else if matches!(node.kind(), SyntaxKind::ImportSpecifier | SyntaxKind::ExportModule) {
-            let import_file = node
-                .source_file
-                .path()
-                .parent()
-                .unwrap_or_else(|| Path::new("/"))
-                .join(node.child_text(SyntaxKind::StringLiteral)?.trim_matches('\"'));
-            let import_file = clean_path(&import_file);
+            let import_text =
+                node.child_text(SyntaxKind::StringLiteral)?.trim_matches('\"').to_string();
+            let import_file = if import_text.starts_with('@') {
+                document_cache
+                    .resolve_import_path(Some(&token.clone().into()), &import_text)
+                    .map(|(path, _)| path)
+                    .unwrap_or_else(|| {
+                        clean_path(
+                            &node
+                                .source_file
+                                .path()
+                                .parent()
+                                .unwrap_or_else(|| Path::new("/"))
+                                .join(&import_text),
+                        )
+                    })
+            } else {
+                clean_path(
+                    &node
+                        .source_file
+                        .path()
+                        .parent()
+                        .unwrap_or_else(|| Path::new("/"))
+                        .join(&import_text),
+                )
+            };
             return Some(TokenInfo::FileName(import_file));
         } else if syntax_nodes::BindingExpression::new(node.clone()).is_some() {
             // don't fallback to the Binding


### PR DESCRIPTION
This helps with resolving paths that include a custom `@library`. When hovered, a proper path will be shown. This also makes it possible to navigate to an imported .slint file in the editor.


An example with `-L ui=ui/ui`:
<img width="747" height="92" alt="image" src="https://github.com/user-attachments/assets/d7091072-bb9e-4180-9347-ea4bd4ad9650" />

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
