### PR TITLE
Unify global and component Weak type

### DIFF
--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -18,6 +18,7 @@ pub mod generated_code {
 
     use crate::ComponentHandle;
     use crate::Global;
+    use crate::StrongHandle;
     use crate::Weak;
     use crate::Window;
 
@@ -91,10 +92,17 @@ pub mod generated_code {
         }
     }
 
-    impl ComponentHandle for SampleComponent {
+    impl StrongHandle for SampleComponent {
         #[doc(hidden)]
         type WeakInner = ();
 
+        #[doc(hidden)]
+        fn upgrade_from_weak_inner(_: &Self::WeakInner) -> Option<Self> {
+            unimplemented!();
+        }
+    }
+
+    impl ComponentHandle for SampleComponent {
         /// Returns a new weak pointer.
         fn as_weak(&self) -> Weak<Self> {
             unimplemented!()
@@ -102,11 +110,6 @@ pub mod generated_code {
 
         /// Returns a clone of this handle that's a strong reference.
         fn clone_strong(&self) -> Self {
-            unimplemented!();
-        }
-
-        #[doc(hidden)]
-        fn upgrade_from_weak_inner(_: &Self::WeakInner) -> Option<Self> {
             unimplemented!();
         }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -264,7 +264,7 @@ pub fn generate(
         #[allow(unused_imports)]
         pub use #generated_mod::{#(#compo_ids,)* #(#structs_and_enums_ids,)* #(#globals_ids,)* #(#named_exports,)* #(#global_exports,)*};
         #[allow(unused_imports)]
-        pub use slint::{ComponentHandle as _, Global as _, GlobalComponentHandle as _, ModelExt as _};
+        pub use slint::{ComponentHandle as _, Global as _, ModelExt as _};
     })
 }
 
@@ -383,18 +383,21 @@ fn generate_public_component(
             }
         }
 
-        impl slint::ComponentHandle for #public_component_id {
+        impl slint::StrongHandle for #public_component_id {
             type WeakInner = sp::VWeak<sp::ItemTreeVTable, #inner_component_id>;
+
+            fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> sp::Option<Self> {
+                sp::Some(Self(inner.upgrade()?))
+            }
+        }
+
+        impl slint::ComponentHandle for #public_component_id {
             fn as_weak(&self) -> slint::Weak<Self> {
                 slint::Weak::new(sp::VRc::downgrade(&self.0))
             }
 
             fn clone_strong(&self) -> Self {
                 Self(self.0.clone())
-            }
-
-            fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> sp::Option<Self> {
-                sp::Some(Self(inner.upgrade()?))
             }
 
             fn run(&self) -> ::core::result::Result<(), slint::PlatformError> {
@@ -1580,35 +1583,16 @@ fn generate_global(
         let aliases = global.aliases.iter().map(|name| ident(name));
         let getters = generate_global_getters(global, root);
 
-        let (as_weak_fn, global_component_handle) = if !global.is_builtin {
-            (
-                quote!(
-                    #[allow(unused)]
-                    pub fn as_weak(&self) -> slint::GlobalWeak<#inner_component_id> {
-                        let inner = ::core::pin::Pin::into_inner(self.0.clone());
-                        slint::GlobalWeak::new(sp::Rc::downgrade(&inner))
-                    }
-                ),
-                quote!(
-                    impl slint::GlobalComponentHandle for #inner_component_id {
-                        type Global<'a> = #public_component_id<'a>;
-                        type WeakInner = sp::Weak<#inner_component_id>;
-                        type PinnedInner = ::core::pin::Pin<sp::Rc<#inner_component_id>>;
+        let strong_handle_impl = quote!(
+            impl slint::StrongHandle for #public_component_id<'static> {
+                type WeakInner = sp::Weak<#inner_component_id>;
 
-                        fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> sp::Option<Self::PinnedInner> {
-                            let inner = ::core::pin::Pin::new(inner.upgrade()?);
-                            Some(inner)
-                        }
-
-                        fn to_self(inner: Self::PinnedInner) -> Self::Global<'static> {
-                            #public_component_id(inner.clone(), ::core::marker::PhantomData::default())
-                        }
-                    }
-                )
-            )
-        } else {
-            (quote!(), quote!())
-        };
+                fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> ::core::option::Option<Self> {
+                    let inner = ::core::pin::Pin::new(inner.upgrade()?);
+                    ::core::option::Option::Some(Self(inner, ::core::marker::PhantomData::default()))
+                }
+            }
+        );
 
         quote!(
             #[allow(unused)]
@@ -1616,13 +1600,11 @@ fn generate_global(
 
             impl<'a> #public_component_id<'a> {
                 #property_and_callback_accessors
-
-                #as_weak_fn
             }
             #(pub type #aliases<'a> = #public_component_id<'a>;)*
             #getters
 
-            #global_component_handle
+            #strong_handle_impl
         )
     });
 
@@ -1670,8 +1652,15 @@ fn generate_global_getters(
         let root_component_id = ident(&c.name);
         quote! {
             impl<'a> slint::Global<'a, #root_component_id> for #public_component_id<'a> {
+                type StaticSelf = #public_component_id<'static>;
+
                 fn get(component: &'a #root_component_id) -> Self {
                     Self(component.0.globals.get().unwrap().#global_id.clone(), ::core::marker::PhantomData::default())
+                }
+
+                fn as_weak(&self) -> slint::Weak<Self::StaticSelf> {
+                    let inner = ::core::pin::Pin::into_inner(self.0.clone());
+                    slint::Weak::new(sp::Rc::downgrade(&inner))
                 }
             }
         }

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -195,20 +195,23 @@ fn generate_public_component(
             #(#property_and_callback_accessors)*
         }
 
-        impl slint::ComponentHandle for #public_component_id {
+        impl slint::StrongHandle for #public_component_id {
             type WeakInner = sp::Weak<::core::cell::RefCell<sp::live_preview::LiveReloadingComponent>>;
+
+            fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> sp::Option<Self> {
+                let rc = inner.upgrade()?;
+                let window_adapter = sp::WindowInner::from_pub(slint::ComponentHandle::window(rc.borrow().instance())).window_adapter();
+                sp::Some(Self(rc, window_adapter))
+            }
+        }
+
+        impl slint::ComponentHandle for #public_component_id {
             fn as_weak(&self) -> slint::Weak<Self> {
                 slint::Weak::new(sp::Rc::downgrade(&self.0))
             }
 
             fn clone_strong(&self) -> Self {
                 Self(self.0.clone(), self.1.clone())
-            }
-
-            fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> sp::Option<Self> {
-                let rc = inner.upgrade()?;
-                let window_adapter = sp::WindowInner::from_pub(slint::ComponentHandle::window(rc.borrow().instance())).window_adapter();
-                sp::Some(Self(rc, window_adapter))
             }
 
             fn run(&self) -> ::core::result::Result<(), slint::PlatformError> {
@@ -330,22 +333,48 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
         let root_component_id = ident(&c.name);
         quote! {
             impl<'a> slint::Global<'a, #root_component_id> for #public_component_id<'a> {
+                type StaticSelf = #public_component_id<'static>;
+
                 fn get(component: &'a #root_component_id) -> Self {
-                    Self(&component.0)
+                    Self(
+                        sp::Rc::clone(&component.0),
+                        ::core::marker::PhantomData::default(),
+                    )
+                }
+
+                fn as_weak(&self) -> slint::Weak<Self::StaticSelf> {
+                    slint::Weak::new(sp::Rc::downgrade(&self.0))
                 }
             }
         }
     });
 
+    let strong_handle_impl = quote!(
+        impl slint::StrongHandle for #public_component_id<'static> {
+            type WeakInner = sp::Weak<::core::cell::RefCell<sp::live_preview::LiveReloadingComponent>>;
+
+            fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> ::core::option::Option<Self> {
+                let rc = inner.upgrade()?;
+                ::core::option::Option::Some(Self(rc, ::core::marker::PhantomData::default()))
+            }
+        }
+    );
+
     quote!(
         #[allow(unused)]
-        pub struct #public_component_id<'a>(&'a ::core::cell::RefCell<sp::live_preview::LiveReloadingComponent>);
+        pub struct #public_component_id<'a>(
+            sp::Rc<::core::cell::RefCell<sp::live_preview::LiveReloadingComponent>>,
+            ::core::marker::PhantomData<&'a sp::live_preview::LiveReloadingComponent>,
+
+        );
 
         impl<'a> #public_component_id<'a> {
             #(#property_and_callback_accessors)*
         }
         #(pub type #aliases<'a> = #public_component_id<'a>;)*
         #(#getters)*
+
+        #strong_handle_impl
     )
 }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -805,8 +805,35 @@ impl Window {
 /// **Note:** Only globals that are exported or re-exported from the main .slint file will
 /// be exposed in the API
 pub trait Global<'a, Component> {
-    /// Returns a reference that's tied to the life time of the provided component.
+    /// The `Self` type, with a `'static` lifetime.
+    type StaticSelf: 'static + StrongHandle;
+
+    /// Returns a reference to the global.
     fn get(component: &'a Component) -> Self;
+
+    /// Convert this Global reference into a weak reference.
+    ///
+    /// As a side-effect, this will also extend the lifetime of this global to `'static`.
+    fn as_weak(&self) -> Weak<Self::StaticSelf>;
+}
+
+/// This trait is automatically implemented on all strongly referenced Slint components.
+/// All of these types can be used in a [`Weak`] reference.
+///
+/// This includes all types that implement the [`ComponentHandle`] trait, as well as all types
+/// implementing the [`Global`] trait.
+///
+/// Note: Slint implements this trait automatically, it should not be implemented manually.
+pub trait StrongHandle {
+    /// The internal Inner type for `Weak<Self>::inner`.
+    #[doc(hidden)]
+    type WeakInner: Clone + Default;
+
+    /// Internal function used when upgrading a weak reference to a strong one.
+    #[doc(hidden)]
+    fn upgrade_from_weak_inner(_: &Self::WeakInner) -> Option<Self>
+    where
+        Self: Sized;
 }
 
 /// This trait describes the common public API of a strongly referenced Slint component.
@@ -814,11 +841,10 @@ pub trait Global<'a, Component> {
 /// as other convenience functions.
 ///
 /// This trait is implemented by the [generated component](index.html#generated-components)
-pub trait ComponentHandle {
-    /// The internal Inner type for `Weak<Self>::inner`.
-    #[doc(hidden)]
-    type WeakInner: Clone + Default;
+pub trait ComponentHandle: StrongHandle {
     /// Returns a new weak pointer.
+    // Note: It would be great if we could move this function into the StrongHandle trait. But
+    // that would be a backwards-incompatible change.
     fn as_weak(&self) -> Weak<Self>
     where
         Self: Sized;
@@ -826,12 +852,6 @@ pub trait ComponentHandle {
     /// Returns a clone of this handle that's a strong reference.
     #[must_use]
     fn clone_strong(&self) -> Self;
-
-    /// Internal function used when upgrading a weak reference to a strong one.
-    #[doc(hidden)]
-    fn upgrade_from_weak_inner(_: &Self::WeakInner) -> Option<Self>
-    where
-        Self: Sized;
 
     /// Convenience function for [`crate::Window::show()`](struct.Window.html#method.show).
     /// This shows the window on the screen and maintains an extra strong reference while
@@ -877,13 +897,13 @@ mod weak_handle {
     /// but the upgrade function will only return a valid component from the same thread
     /// as the one it has been created from.
     /// This is useful to use with [`invoke_from_event_loop()`] or [`Self::upgrade_in_event_loop()`].
-    pub struct Weak<T: ComponentHandle> {
+    pub struct Weak<T: StrongHandle> {
         inner: T::WeakInner,
         #[cfg(feature = "std")]
         thread: std::thread::ThreadId,
     }
 
-    impl<T: ComponentHandle> Default for Weak<T> {
+    impl<T: StrongHandle> Default for Weak<T> {
         fn default() -> Self {
             Self {
                 inner: T::WeakInner::default(),
@@ -893,7 +913,7 @@ mod weak_handle {
         }
     }
 
-    impl<T: ComponentHandle> Clone for Weak<T> {
+    impl<T: StrongHandle> Clone for Weak<T> {
         fn clone(&self) -> Self {
             Self {
                 inner: self.inner.clone(),
@@ -903,7 +923,7 @@ mod weak_handle {
         }
     }
 
-    impl<T: ComponentHandle> Weak<T> {
+    impl<T: StrongHandle> Weak<T> {
         #[doc(hidden)]
         pub fn new(inner: T::WeakInner) -> Self {
             Self {
@@ -918,10 +938,7 @@ mod weak_handle {
         ///
         /// This also returns None if the current thread is not the thread that created
         /// the component
-        pub fn upgrade(&self) -> Option<T>
-        where
-            T: ComponentHandle,
-        {
+        pub fn upgrade(&self) -> Option<T> {
             #[cfg(feature = "std")]
             if std::thread::current().id() != self.thread {
                 return None;
@@ -997,10 +1014,10 @@ mod weak_handle {
     // and the VWeak only use atomic pointer so it is safe to clone and drop in another thread
     #[allow(unsafe_code)]
     #[cfg(any(feature = "std", feature = "unsafe-single-threaded"))]
-    unsafe impl<T: ComponentHandle> Send for Weak<T> {}
+    unsafe impl<T: StrongHandle> Send for Weak<T> {}
     #[allow(unsafe_code)]
     #[cfg(any(feature = "std", feature = "unsafe-single-threaded"))]
-    unsafe impl<T: ComponentHandle> Sync for Weak<T> {}
+    unsafe impl<T: StrongHandle> Sync for Weak<T> {}
 }
 
 pub use weak_handle::*;
@@ -1009,159 +1026,6 @@ pub use weak_handle::*;
 /// clones and conversion into a weak pointer for a Global slint component.
 ///
 /// This trait is implemented by the [generated component](index.html#generated-components)
-pub trait GlobalComponentHandle {
-    /// The type for the public global component interface.
-    #[doc(hidden)]
-    type Global<'a>;
-    /// The internal Inner type for `Weak<Self>::inner`.
-    #[doc(hidden)]
-    type WeakInner: Clone + Default;
-    /// The internal Inner type for the 'Pin<sp::Rc<InnerSelf>'.
-    #[doc(hidden)]
-    type PinnedInner: Clone;
-
-    /// Internal function used when upgrading a weak reference to a strong one.
-    #[doc(hidden)]
-    fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> Option<Self::PinnedInner>
-    where
-        Self: Sized;
-
-    /// Internal function used when upgrading a weak reference to a strong one.
-    fn to_self(inner: Self::PinnedInner) -> Self::Global<'static>
-    where
-        Self: Sized;
-}
-
-pub use global_weak_handle::*;
-
-mod global_weak_handle {
-    use super::*;
-
-    /// Struct that's used to hold weak references of a [Slint global component](index.html#generated-components)
-    ///
-    /// In order to create a GlobalWeak, you should call .as_weak() on the global component instance.
-    pub struct GlobalWeak<T: GlobalComponentHandle> {
-        inner: T::WeakInner,
-        #[cfg(feature = "std")]
-        thread: std::thread::ThreadId,
-    }
-
-    impl<T: GlobalComponentHandle> Default for GlobalWeak<T> {
-        fn default() -> Self {
-            Self {
-                inner: T::WeakInner::default(),
-                #[cfg(feature = "std")]
-                thread: std::thread::current().id(),
-            }
-        }
-    }
-
-    impl<T: GlobalComponentHandle> Clone for GlobalWeak<T> {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-                #[cfg(feature = "std")]
-                thread: self.thread,
-            }
-        }
-    }
-
-    impl<T: GlobalComponentHandle> GlobalWeak<T> {
-        #[doc(hidden)]
-        pub fn new(inner: T::WeakInner) -> Self {
-            Self {
-                inner,
-                #[cfg(feature = "std")]
-                thread: std::thread::current().id(),
-            }
-        }
-
-        /// Returns a new GlobalStrong struct, where it's possible to get the global component
-        /// struct interface. If some other instance still holds a strong reference.
-        /// Otherwise, returns None.
-        ///
-        /// This also returns None if the current thread is not the thread that created
-        /// the component
-        pub fn upgrade(&self) -> Option<T::Global<'static>> {
-            #[cfg(feature = "std")]
-            if std::thread::current().id() != self.thread {
-                return None;
-            }
-            let inner = T::upgrade_from_weak_inner(&self.inner)?;
-            Some(T::to_self(inner))
-        }
-
-        /// Convenience function where a given functor is called with the global component
-        ///
-        /// If the current thread is not the thread that created the component the functor
-        /// will not be called and this function will do nothing.
-        pub fn upgrade_in(&self, func: impl FnOnce(T::Global<'_>)) {
-            #[cfg(feature = "std")]
-            if std::thread::current().id() != self.thread {
-                return;
-            }
-
-            if let Some(inner) = T::upgrade_from_weak_inner(&self.inner) {
-                func(T::to_self(inner));
-            }
-        }
-
-        /// Convenience function that combines [`invoke_from_event_loop()`] with [`Self::upgrade()`]
-        ///
-        /// The given functor will be added to an internal queue and will wake the event loop.
-        /// On the next iteration of the event loop, the functor will be executed with a `T` as an argument.
-        ///
-        /// If the component was dropped because there are no more strong reference to the component,
-        /// the functor will not be called.
-        /// # Example
-        /// ```rust
-        /// # i_slint_backend_testing::init_no_event_loop();
-        /// slint::slint! {
-        ///     export global MyAppData { in property<int> foo; }
-        ///     export component MyApp inherits Window { /* ... */ }
-        /// }
-        /// let ui = MyApp::new().unwrap();
-        /// let my_app_data = ui.global::<MyAppData>();
-        /// let my_app_data_weak = my_app_data.as_weak();
-        ///
-        /// let thread = std::thread::spawn(move || {
-        ///     // ... Do some computation in the thread
-        ///     let foo = 42;
-        ///     # assert!(my_app_data_weak.upgrade().is_none()); // note that upgrade fails in a thread
-        ///     # return; // don't upgrade_in_event_loop in our examples
-        ///     // now forward the data to the main thread using upgrade_in_event_loop
-        ///     my_app_data_weak.upgrade_in_event_loop(move |my_app_data| my_app_data.set_foo(foo));
-        /// });
-        /// # thread.join().unwrap(); return; // don't run the event loop in examples
-        /// ui.run().unwrap();
-        /// ```
-        #[cfg(any(feature = "std", feature = "unsafe-single-threaded"))]
-        pub fn upgrade_in_event_loop(
-            &self,
-            func: impl FnOnce(T::Global<'_>) + Send + 'static,
-        ) -> Result<(), EventLoopError>
-        where
-            T: 'static,
-        {
-            let weak_handle = self.clone();
-            super::invoke_from_event_loop(move || {
-                if let Some(h) = weak_handle.upgrade() {
-                    func(h);
-                }
-            })
-        }
-    }
-
-    // Safety: we make sure in upgrade that the thread is the proper one,
-    // and the Weak only use atomic pointer so it is safe to clone and drop in another thread
-    #[allow(unsafe_code)]
-    #[cfg(any(feature = "std", feature = "unsafe-single-threaded"))]
-    unsafe impl<T: GlobalComponentHandle> Send for GlobalWeak<T> {}
-    #[allow(unsafe_code)]
-    #[cfg(any(feature = "std", feature = "unsafe-single-threaded"))]
-    unsafe impl<T: GlobalComponentHandle> Sync for GlobalWeak<T> {}
-}
-
 /// Adds the specified function to an internal queue, notifies the event loop to wake up.
 /// Once woken up, any queued up functors will be invoked.
 ///

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1688,9 +1688,15 @@ impl ComponentInstance {
     }
 }
 
-impl ComponentHandle for ComponentInstance {
+impl StrongHandle for ComponentInstance {
     type WeakInner = vtable::VWeak<ItemTreeVTable, crate::dynamic_item_tree::ErasedItemTreeBox>;
 
+    fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> Option<Self> {
+        Some(Self { inner: inner.upgrade()? })
+    }
+}
+
+impl ComponentHandle for ComponentInstance {
     fn as_weak(&self) -> Weak<Self>
     where
         Self: Sized,
@@ -1700,10 +1706,6 @@ impl ComponentHandle for ComponentInstance {
 
     fn clone_strong(&self) -> Self {
         Self { inner: self.inner.clone() }
-    }
-
-    fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> Option<Self> {
-        Some(Self { inner: inner.upgrade()? })
     }
 
     fn show(&self) -> Result<(), PlatformError> {

--- a/tests/manual/module-builds/app/src/main.rs
+++ b/tests/manual/module-builds/app/src/main.rs
@@ -12,10 +12,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let ui = AppWindow::new()?;
 
     let blociga_api = ui.global::<blogica::backend::BLogicAAPI>();
-    blogica::backend::init(&blociga_api);
+    blogica::backend::init(blociga_api);
 
     let blogicb_api = ui.global::<blogicb::BLogicBAPI>();
-    blogicb::init(&blogicb_api);
+    blogicb::init(blogicb_api);
 
     ui.on_update_blogic_data({
         let ui_handle = ui.as_weak();

--- a/tests/manual/module-builds/blogica/src/lib.rs
+++ b/tests/manual/module-builds/blogica/src/lib.rs
@@ -2,38 +2,45 @@
 // SPDX-License-Identifier: MIT
 
 pub mod backend {
-    use slint::{Model, SharedString};
+    use slint::{Model, SharedString, Weak};
 
     slint::include_modules!();
 
-    pub fn init(blogica_api: &BLogicAAPI) {
+    struct Backend {
+        api: Weak<BLogicAAPI<'static>>,
+    }
+
+    impl Backend {
+        fn update(&self, bdata: BData) {
+            let blogica_api = self.api.upgrade().unwrap();
+
+            if bdata.colors.row_count() >= 4 {
+                blogica_api.set_color1(bdata.colors.row_data(0).unwrap());
+                blogica_api.set_color2(bdata.colors.row_data(1).unwrap());
+                blogica_api.set_color3(bdata.colors.row_data(2).unwrap());
+                blogica_api.set_color4(bdata.colors.row_data(3).unwrap());
+            }
+
+            if bdata.codes.row_count() >= 4 {
+                blogica_api.set_code1(bdata.codes.row_data(0).unwrap());
+                blogica_api.set_code2(bdata.codes.row_data(1).unwrap());
+                blogica_api.set_code3(bdata.codes.row_data(2).unwrap());
+                blogica_api.set_code4(bdata.codes.row_data(3).unwrap());
+            }
+        }
+    }
+
+    pub fn init(blogica_api: BLogicAAPI) {
         blogica_api.set_code1(SharedString::from("Important thing"));
         blogica_api.set_code2(SharedString::from("Another important thing"));
         blogica_api.set_code3(SharedString::from("Yet another important thing"));
         blogica_api.set_code4(SharedString::from("One more important thing"));
 
+        let backend = Backend { api: blogica_api.as_weak() };
+
         blogica_api.on_update({
-            let blogica_api = blogica_api.as_weak();
             move |bdata| {
-                {
-                    let blogica_api = blogica_api.upgrade().unwrap();
-
-                    if bdata.colors.row_count() >= 4 {
-                        blogica_api.set_color1(bdata.colors.row_data(0).unwrap());
-                        blogica_api.set_color2(bdata.colors.row_data(1).unwrap());
-                        blogica_api.set_color3(bdata.colors.row_data(2).unwrap());
-                        blogica_api.set_color4(bdata.colors.row_data(3).unwrap());
-                    }
-                }
-
-                blogica_api.upgrade_in(move |blogica_api| {
-                    if bdata.codes.row_count() >= 4 {
-                        blogica_api.set_code1(bdata.codes.row_data(0).unwrap());
-                        blogica_api.set_code2(bdata.codes.row_data(1).unwrap());
-                        blogica_api.set_code3(bdata.codes.row_data(2).unwrap());
-                        blogica_api.set_code4(bdata.codes.row_data(3).unwrap());
-                    }
-                });
+                backend.update(bdata);
             }
         });
 

--- a/tests/manual/module-builds/blogicb/src/lib.rs
+++ b/tests/manual/module-builds/blogicb/src/lib.rs
@@ -5,7 +5,7 @@ use slint::{Model, SharedString};
 
 slint::include_modules!();
 
-pub fn init(blogicb_api: &BLogicBAPI) {
+pub fn init(blogicb_api: BLogicBAPI) {
     blogicb_api.set_crank1(SharedString::from("1"));
     blogicb_api.set_crank2(SharedString::from("2"));
     blogicb_api.set_crank3(SharedString::from("3"));


### PR DESCRIPTION
This unifies the `Weak` handle to support both `Global` and `ComponentHandle` types.

@bennysj Note that for now this means the `upgrade_in` function has been reverted, as this would need to be added to the main `Weak` handle and that should be a separate PR from the weak/strong globals.
For the moment you can use `upgrade().map(...)` instead.

@tronical @ogoffart I experimented with making the `global` function return a `'static` global, but didn't end up implementing this because:

1. Unsure backward compatibility - I'm unsure if `'static` is really supported everywhere `'a` was before
2. Too easy to create memory leaks - you could just move a `'static` global into a callback, which immediately creates a memory leak.

Because of the second concern, the API now forces you to at least convert it to a weak, at which point the lifetime is extended to `'static`.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
