### PR TITLE
Qt backend: Add pinch/rotation gesture support via QPinchGesture

### DIFF
--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -5,7 +5,9 @@
 
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
-#![recursion_limit = "2048"]
+// Bumped from 2048 to accommodate the number of rust!() invocations inside
+// the large cpp! {{ }} block in qt_window.rs (gesture/input event handling).
+#![recursion_limit = "4096"]
 #![cfg_attr(slint_nightly_test, feature(non_exhaustive_omitted_patterns_lint))]
 #![cfg_attr(slint_nightly_test, warn(non_exhaustive_omitted_patterns))]
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -65,6 +65,7 @@ cpp! {{
     #include <QtGui/QResizeEvent>
     #include <QtGui/QTextLayout>
     #include <QtGui/QWindow>
+    #include <QtWidgets/QGesture>
     #include <QtWidgets/QCheckBox>
     #include <QtWidgets/QComboBox>
     #include <QtWidgets/QGraphicsBlurEffect>

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -118,6 +118,7 @@ cpp! {{
             // to draw the window background which is set on the palette.
             // (But the window background might not be opaque)
             setAttribute(Qt::WA_NoSystemBackground, false);
+            grabGesture(Qt::PinchGesture);
         }
 
         void paintEvent(QPaintEvent *) override {
@@ -381,6 +382,71 @@ cpp! {{
                     };
                     runtime_window.process_key_input(event);
                 });
+        }
+        static int gesture_phase(Qt::GestureState state) {
+            // 0=Started, 1=Moved, 2=Ended, 3=Cancelled
+            switch (state) {
+                case Qt::GestureStarted:   return 0;
+                case Qt::GestureUpdated:   return 1;
+                case Qt::GestureFinished:  return 2;
+                case Qt::GestureCanceled:  return 3;
+                default:                   return 3;
+            }
+        }
+
+        bool event(QEvent *event) override {
+            if (event->type() == QEvent::Gesture) {
+                auto *ge = static_cast<QGestureEvent*>(event);
+                if (auto *pinch = static_cast<QPinchGesture*>(ge->gesture(Qt::PinchGesture))) {
+                    if (!rust_window) return true;
+
+                    int phase = gesture_phase(pinch->state());
+
+                    // scaleFactor() is the per-step multiplier (e.g. 1.02 = 2% growth
+                    // since last event). totalScaleFactor() is the cumulative product.
+                    // Subtract 1.0 to get an incremental delta matching winit semantics.
+                    float scale_delta = pinch->scaleFactor() - 1.0f;
+
+                    // rotationAngle() is cumulative; compute incremental delta.
+                    // Negate to match Slint convention (positive = clockwise),
+                    // same as the winit backend does for macOS.
+                    float rotation_delta = -(pinch->rotationAngle() - pinch->lastRotationAngle());
+
+                    // centerPoint() is in widget-local coordinates when delivered
+                    // via QWidget::event() (not scene coordinates as the QGraphicsObject
+                    // docs might suggest).
+                    QPointF center = pinch->centerPoint();
+
+                    rust!(Slint_pinchGesture [rust_window: &QtWindow as "void*",
+                            scale_delta: f32 as "float", rotation_delta: f32 as "float",
+                            center: qttypes::QPointF as "QPointF",
+                            phase: i32 as "int"] {
+                        let position = LogicalPoint::new(center.x as _, center.y as _);
+                        let phase = match phase {
+                            0 => i_slint_core::input::TouchPhase::Started,
+                            1 => i_slint_core::input::TouchPhase::Moved,
+                            2 => i_slint_core::input::TouchPhase::Ended,
+                            _ => i_slint_core::input::TouchPhase::Cancelled,
+                        };
+                        rust_window.mouse_event(MouseEvent::PinchGesture {
+                            position, delta: scale_delta, phase,
+                        });
+                        if rotation_delta != 0.0 || matches!(phase,
+                            i_slint_core::input::TouchPhase::Started
+                            | i_slint_core::input::TouchPhase::Ended
+                            | i_slint_core::input::TouchPhase::Cancelled)
+                        {
+                            rust_window.mouse_event(MouseEvent::RotationGesture {
+                                position, delta: rotation_delta, phase,
+                            });
+                        }
+                    });
+
+                    ge->accept();
+                    return true;
+                }
+            }
+            return QWidget::event(event);
         }
     };
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -408,9 +408,7 @@ cpp! {{
                     float scale_delta = pinch->scaleFactor() - 1.0f;
 
                     // rotationAngle() is cumulative; compute incremental delta.
-                    // Negate to match Slint convention (positive = clockwise),
-                    // same as the winit backend does for macOS.
-                    float rotation_delta = -(pinch->rotationAngle() - pinch->lastRotationAngle());
+                    float rotation_delta = pinch->rotationAngle() - pinch->lastRotationAngle();
 
                     // centerPoint() is in widget-local coordinates when delivered
                     // via QWidget::event() (not scene coordinates as the QGraphicsObject


### PR DESCRIPTION
## Summary

- Adds pinch and rotation gesture support to the Qt backend using `QPinchGesture`
- Calls `grabGesture(Qt::PinchGesture)` in the `SlintWidget` constructor
- Overrides `event()` to handle `QEvent::Gesture`, extracting incremental scale and rotation deltas and forwarding them as `MouseEvent::PinchGesture` / `MouseEvent::RotationGesture`
- Bumps `recursion_limit` from 2048 to 4096 to accommodate the additional `rust!()` macro invocations

## Notes

- `grabGesture(Qt::PinchGesture)` relies on OS-level gesture synthesis, which works reliably on **macOS** (native trackpad gestures). On Linux (X11/Wayland), the call is harmless but won't deliver events since there's no native gesture synthesis — Linux touchscreen support would require raw touch forwarding as a separate follow-up.
- Gesture events do **not** use `adjust_mouse_event_to_popup_parent`, consistent with `wheelEvent` behavior.

## Test plan

- [ ] Verify pinch-to-zoom and rotation gestures work on macOS with the `native-gestures` example
- [ ] Verify no regressions on Linux (gesture grab is a no-op, normal mouse/touch input unaffected)
- [ ] Verify the Qt backend compiles cleanly with the bumped recursion limit