### PR TITLE
Custom wgsl fragment shaders for the femtovg+wgpu backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,8 +3308,7 @@ dependencies = [
 [[package]]
 name = "femtovg"
 version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35695993a8264f5dfa8facc135c003965cea40d83705b49e0f8c3a3b632a2171"
+source = "git+https://github.com/expenses/femtovg?branch=custom-shaders#f5877fba3372c1ba2d8ad332c5b8cbb00a735996"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -3321,7 +3320,6 @@ dependencies = [
  "rgb",
  "slotmap",
  "swash",
- "ttf-parser 0.25.1",
  "wasm-bindgen",
  "web-sys",
  "wgpu 28.0.0",

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -118,6 +118,7 @@ pub enum BuiltinFunction {
     RestartTimer,
     ParseMarkdown,
     StringToStyledText,
+    FragmentShader,
 }
 
 #[derive(Debug, Clone)]
@@ -261,6 +262,7 @@ declare_builtin_function_types!(
     Rgb: (Type::Int32, Type::Int32, Type::Int32, Type::Float32) -> Type::Color,
     Hsv: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
     Oklch: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
+    FragmentShader: (Type::String) -> Type::Brush,
     ColorScheme: () -> Type::Enumeration(
         typeregister::BUILTIN.with(|e| e.enums.ColorScheme.clone()),
     ),
@@ -398,6 +400,7 @@ impl BuiltinFunction {
             BuiltinFunction::RestartTimer => false,
             BuiltinFunction::ParseMarkdown => false,
             BuiltinFunction::StringToStyledText => true,
+            BuiltinFunction::FragmentShader => true,
         }
     }
 
@@ -480,6 +483,7 @@ impl BuiltinFunction {
             BuiltinFunction::RestartTimer => false,
             BuiltinFunction::ParseMarkdown => true,
             BuiltinFunction::StringToStyledText => true,
+            BuiltinFunction::FragmentShader => true,
         }
     }
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4131,6 +4131,10 @@ fn compile_builtin_function_call(
                 alpha = a.next().unwrap(),
             )
         }
+        BuiltinFunction::FragmentShader => {
+            let string = a.next().unwrap();
+            format!("slint::Brush(slint::private_api::FragmentShader({}))", string)
+        }
         BuiltinFunction::ColorScheme => {
             format!("{}.color_scheme()", access_window_field(ctx))
         }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3461,6 +3461,10 @@ fn compile_builtin_function_call(
                 sp::Color::from_oklch(l, c, #h as f32, alpha)
             })
         }
+        BuiltinFunction::FragmentShader => {
+            let string = a.next().unwrap();
+            quote!(sp::Brush::FragmentShader(#string.into()))
+        }
         BuiltinFunction::ColorScheme => {
             let window_adapter_tokens = access_window_adapter_field(ctx);
             quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).color_scheme())

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -163,6 +163,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::RestartTimer => 10,
         BuiltinFunction::ParseMarkdown => isize::MAX,
         BuiltinFunction::StringToStyledText => ALLOC_COST,
+        BuiltinFunction::FragmentShader => ALLOC_COST,
     }
 }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -768,6 +768,7 @@ impl LookupObject for MathFunctions {
             .or_else(|| f("pow", b(BuiltinFunction::Pow)))
             .or_else(|| f("exp", b(BuiltinFunction::Exp)))
             .or_else(|| f("sign", BuiltinMacroFunction::Sign.into()))
+            .or_else(|| f("fragment-shader", b(BuiltinFunction::FragmentShader)))
     }
 }
 

--- a/internal/core/graphics/brush.rs
+++ b/internal/core/graphics/brush.rs
@@ -34,6 +34,8 @@ pub enum Brush {
     /// The conical gradient variant of a brush describes a gradient that rotates around
     /// a center point, like the hands of a clock
     ConicGradient(ConicGradientBrush),
+    /// Uses a custom fragment shader for the fill.
+    FragmentShader(crate::SharedString),
 }
 
 /// Construct a brush with transparent color
@@ -58,6 +60,7 @@ impl Brush {
             Brush::ConicGradient(gradient) => {
                 gradient.stops().next().map(|stop| stop.color).unwrap_or_default()
             }
+            _ => Default::default(),
         }
     }
 
@@ -75,6 +78,7 @@ impl Brush {
             Brush::LinearGradient(_) => false,
             Brush::RadialGradient(_) => false,
             Brush::ConicGradient(_) => false,
+            _ => false,
         }
     }
 
@@ -92,6 +96,7 @@ impl Brush {
             Brush::LinearGradient(g) => g.stops().all(|s| s.color.alpha() == 255),
             Brush::RadialGradient(g) => g.stops().all(|s| s.color.alpha() == 255),
             Brush::ConicGradient(g) => g.stops().all(|s| s.color.alpha() == 255),
+            _ => true,
         }
     }
 
@@ -122,6 +127,7 @@ impl Brush {
                 }
                 Brush::ConicGradient(new_grad)
             }
+            other => other.clone(),
         }
     }
 
@@ -149,6 +155,7 @@ impl Brush {
                 }
                 Brush::ConicGradient(new_grad)
             }
+            other => other.clone(),
         }
     }
 
@@ -181,6 +188,7 @@ impl Brush {
                 }
                 Brush::ConicGradient(new_grad)
             }
+            other => other.clone(),
         }
     }
 
@@ -210,6 +218,7 @@ impl Brush {
                 }
                 Brush::ConicGradient(new_grad)
             }
+            other => other.clone(),
         }
     }
 }
@@ -665,6 +674,7 @@ impl InterpolatedPropertyValue for Brush {
                     Self::interpolate(&Brush::SolidColor(color), b, (t - 0.5) * 2.)
                 }
             }
+            (a, b) => a.clone(),
         }
     }
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1605,6 +1605,11 @@ fn call_builtin_function(
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
             Value::StyledText(corelib::styled_text::string_to_styled_text(string.to_string()))
         }
+        BuiltinFunction::FragmentShader => {
+            let string: SharedString =
+                eval_expression(&arguments[0], local_context).try_into().unwrap();
+            Value::Brush(corelib::graphics::Brush::FragmentShader(string))
+        }
     }
 }
 

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1"
 derive_more = { workspace = true }
 lyon_path = { workspace = true }
 pin-weak = "1"
-femtovg = { version = "0.20.4", default-features = false, features = ["swash"] }
+femtovg = { git = "https://github.com/expenses/femtovg", branch = "custom-shaders", default-features = false, features = ["swash"] }
 imgref = { version = "1.6.1" }
 rgb = { version = "0.8.27" }
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1520,6 +1520,9 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
 
                 femtovg::Paint::conic_gradient_stops(path_width / 2., path_height / 2., stops)
             }
+            Brush::FragmentShader(shader) => {
+                femtovg::Paint::custom_fragment_shader(shader.to_string())
+            }
             _ => return None,
         })
     }


### PR DESCRIPTION
Requires https://github.com/femtovg/femtovg/pull/263. 

Tested with the following:

```slint
export component App inherits Window {
    preferred-width: 700px;
    preferred-height: 500px;
    Rectangle {
        width: 50%;
        height: 50%;
        background: fragment_shader(
"@fragment fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {return vec4<f32>(position.xy/1000.0,1,1);}"
        );
    }
}
```

It's a little tricky to use currently given that multiline strings aren't supported.

<img width="1129" height="1466" alt="20260226_15h26m46s_grim" src="https://github.com/user-attachments/assets/5aaf72e2-cada-4050-856a-85097e9947fb" />
