### PR TITLE
fix clippy warnings in core/graphics

### DIFF
--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -607,9 +607,9 @@ impl From<RgbaColor<f32>> for OklabColor {
         let b = srgb_to_linear(col.blue);
 
         // Linear RGB to LMS (using Oklab M1 matrix)
-        let l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
-        let m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
-        let s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+        let l = 0.41222146 * r + 0.53633255 * g + 0.051445995 * b;
+        let m = 0.2119035 * r + 0.6806995 * g + 0.10739696 * b;
+        let s = 0.08830246 * r + 0.28171885 * g + 0.6299787 * b;
 
         // Cube root
         let l_ = l.cbrt();
@@ -618,9 +618,9 @@ impl From<RgbaColor<f32>> for OklabColor {
 
         // LMS' to Oklab (using M2 matrix)
         Self {
-            l: 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
-            a: 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
-            b: 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_,
+            l: 0.21045426 * l_ + 0.7936178 * m_ - 0.004072047 * s_,
+            a: 1.9779985 * l_ - 2.4285922 * m_ + 0.4505937 * s_,
+            b: 0.025904037 * l_ + 0.78277177 * m_ - 0.80867577 * s_,
             alpha: col.alpha,
         }
     }
@@ -629,9 +629,9 @@ impl From<RgbaColor<f32>> for OklabColor {
 impl From<OklabColor> for RgbaColor<f32> {
     fn from(oklab: OklabColor) -> Self {
         // Oklab to LMS' (inverse of M2 matrix)
-        let l_ = oklab.l + 0.3963377774 * oklab.a + 0.2158037573 * oklab.b;
-        let m_ = oklab.l - 0.1055613458 * oklab.a - 0.0638541728 * oklab.b;
-        let s_ = oklab.l - 0.0894841775 * oklab.a - 1.2914855480 * oklab.b;
+        let l_ = oklab.l + 0.39633778 * oklab.a + 0.21580376 * oklab.b;
+        let m_ = oklab.l - 0.105561346 * oklab.a - 0.06385417 * oklab.b;
+        let s_ = oklab.l - 0.08948418 * oklab.a - 1.2914855 * oklab.b;
 
         // Cube to get LMS
         let l = l_ * l_ * l_;
@@ -639,9 +639,9 @@ impl From<OklabColor> for RgbaColor<f32> {
         let s = s_ * s_ * s_;
 
         // LMS to linear RGB (inverse of M1 matrix)
-        let r = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
-        let g = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
-        let b = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+        let r = 4.0767417 * l - 3.3077116 * m + 0.23096994 * s;
+        let g = -1.268438 * l + 2.6097574 * m - 0.34131938 * s;
+        let b = -0.0041960863 * l - 0.7034186 * m + 1.7076147 * s;
 
         // Convert linear RGB to sRGB and clamp
         Self {

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -264,8 +264,10 @@ impl PathDataIterator {
 #[derive(Clone, Debug, PartialEq)]
 /// PathData represents a path described by either high-level elements or low-level
 /// events and coordinates.
+#[derive(Default)]
 pub enum PathData {
     /// None is the variant when the path is empty.
+    #[default]
     None,
     /// The Elements variant is used to make a Path from shared arrays of elements.
     Elements(crate::SharedVector<PathElement>),
@@ -275,12 +277,6 @@ pub enum PathData {
     /// The Commands variant describes the path as a series of SVG encoded path commands.
     #[cfg(feature = "std")]
     Commands(crate::SharedString),
-}
-
-impl Default for PathData {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl PathData {


### PR DESCRIPTION
The float changes are due to
warning: float has excessive precision
   --> internal/core/graphics/color.rs:610:17
    |
610 |         let l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
    |                 ^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#excessive_precision

All automated by clippy --fix, except that I turned 0.412_221_46 back into 0.41222146

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
