### PR TITLE
fix clippy warnings in core/textlayout

### DIFF
--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -184,20 +184,20 @@ impl<Length> ShapeBuffer<Length> {
 
                 layout.font.shape_text(&text[*run_start..run_end], &mut glyphs);
 
-                if let Some(letter_spacing) = layout.letter_spacing {
-                    if glyphs.len() > glyphs_start {
-                        let mut last_byte_offset = glyphs[glyphs_start].text_byte_offset;
-                        for index in glyphs_start + 1..glyphs.len() {
-                            let current_glyph_byte_offset = glyphs[index].text_byte_offset;
-                            if current_glyph_byte_offset != last_byte_offset {
-                                let previous_glyph = &mut glyphs[index - 1];
-                                previous_glyph.advance += letter_spacing;
-                            }
-                            last_byte_offset = current_glyph_byte_offset;
+                if let Some(letter_spacing) = layout.letter_spacing
+                    && glyphs.len() > glyphs_start
+                {
+                    let mut last_byte_offset = glyphs[glyphs_start].text_byte_offset;
+                    for index in glyphs_start + 1..glyphs.len() {
+                        let current_glyph_byte_offset = glyphs[index].text_byte_offset;
+                        if current_glyph_byte_offset != last_byte_offset {
+                            let previous_glyph = &mut glyphs[index - 1];
+                            previous_glyph.advance += letter_spacing;
                         }
-
-                        glyphs.last_mut().unwrap().advance += letter_spacing;
+                        last_byte_offset = current_glyph_byte_offset;
                     }
+
+                    glyphs.last_mut().unwrap().advance += letter_spacing;
                 }
 
                 let run = TextRun {


### PR DESCRIPTION
The "while let" to "for" port comes from:
warning: this loop could be written as a `for` loop
   --> internal/core/textlayout/sharedparley.rs:378:21
    |
378 |                     while let Some((idx, ch)) = char_it.next() {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for (idx, ch) in char_it.by_ref()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#while_let_on_iterator

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
