### PR TITLE
Fix warning when building a library with multiple exported components

### DIFF
--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -39,10 +39,17 @@ pub fn check_public_api(
             if let Either::Left(c) = &export.1
                 && !c.is_global() && !super::windows::inherits_window(c) {
                     let is_last = last.as_ref().is_some_and(|last| !Rc::ptr_eq(last, c));
+
+                    if cfg!(feature = "experimental-library-module") && config.library_name.is_some() {
+                        // In library mode, we want to allow exporting for all Slintcomponents, as they might be used
+                        // as base components for the users of the library.
+                        return !is_last;
+                    }
+
                     if is_last {
                         diag.push_warning(format!("Exported component '{}' doesn't inherit Window. No code will be generated for it", export.0.name), &export.0.name_ident);
                         return false;
-                    } else if config.library_name.is_none () {
+                    } else {
                         diag.push_warning(format!("Exported component '{}' doesn't inherit Window. This is deprecated", export.0.name), &export.0.name_ident);
                     }
                 }

--- a/tests/manual/module-builds/blogicb/ui/blogicb.slint
+++ b/tests/manual/module-builds/blogicb/ui/blogicb.slint
@@ -106,3 +106,17 @@ export component BLogicB {
         }
     }
 }
+
+
+/// This component only exists to test that exporting non-Window components from libraries
+/// does not trigger a warning (see #10881)
+export component BLogicB2 {
+    width: 600px; height: 240px;
+    Text {
+        text: "B2 component";
+        color: black;
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}


### PR DESCRIPTION
For the moment this is only relevant fith the experimentatl feature "experimental-module-builds" enabled.

CC #7060

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
