### PR TITLE
Apply default values for interface properties

### DIFF
--- a/tests/cases/interfaces/implements_defaults.slint
+++ b/tests/cases/interfaces/implements_defaults.slint
@@ -1,0 +1,53 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface InterfaceWithDefaults {
+    in-out property <string> text: "Hello";
+    out property <bool> enabled: true;
+    in property <int> precision: 2;
+    in property <float> confidence: 1.0;
+
+    public pure function length(text: string) -> int;
+    callback checked();
+}
+
+export component TestCase implements InterfaceWithDefaults {
+
+    confidence: 0.5;
+
+    out property <bool> test: self.text == "Hello" && self.enabled && self.precision == 2 && self.confidence == 0.5;
+
+    public pure function length(text: string) -> int {
+        text.character-count
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_text(), "Hello");
+assert_eq!(instance.get_enabled(), true);
+assert_eq!(instance.get_precision(), 2);
+assert_eq!(instance.get_confidence(), 0.5);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_text(), "Hello");
+assert_eq(instance.get_enabled(), true);
+assert_eq(instance.get_precision(), 2);
+assert_eq(instance.get_confidence(), 0.5);
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.text, "Hello");
+assert.equal(instance.enabled, true);
+assert.equal(instance.precision, 2);
+assert.equal(instance.confidence, 0.5);
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
Previously we would only copy the property declarations to the element, not the default bindings. This meant that the default values were not provided to the element. Provide the default property values as a separate step at the end of the element parsing so that we can only apply property defaults if the implementing element has not already provided a default.