### PR TITLE
compiler: element_implements_interface supports native elements

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2570,7 +2570,7 @@ fn element_implements_interface(
             errors.push(format!("visibility: '{}'", interface_declaration.visibility));
         }
 
-        if property.declared_pure != interface_declaration.pure {
+        if property.declared_pure.unwrap_or(false) != interface_declaration.pure.unwrap_or(false) {
             errors.push(format!(
                 "purity declaration: '{}'",
                 interface_declaration.pure.unwrap_or(false)

--- a/internal/compiler/tests/syntax/interfaces/uses_errors.slint
+++ b/internal/compiler/tests/syntax/interfaces/uses_errors.slint
@@ -96,7 +96,7 @@ component IncorrectSpeakType {
 }
 
 export component ChildDoesNotImplementInterfaceCallback uses { ValidInterface from impl } {
-//                                                                                 >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void', visibility: 'input output', purity declaration: 'false'}
+//                                                                                 >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void', visibility: 'input output'}
     impl := IncorrectSpeakType { }
 }
 


### PR DESCRIPTION
The Qt style uses native elements such as `qt_widgets::NativeButton`. These provide callbacks that do not have any purity declaration in their `PropertyLookupResult`. Improve `element_implements_interface` handling of this case by treating missing property declarations as implicitly impure.

This allows the Qt std-widgets Button implementation to declare that the `native` child element provides the button interface that is added in a future commit.

Update `ChildDoesNotImplementInterfaceCallback` syntax test because now we only print the expected purity if the callback/function is declared pure (as shown in other tests).