### PR TITLE
OpenBSD: Disable jemalloc.

### DIFF
--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -35,5 +35,5 @@ proc-macro2 = "1.0.11"
 spin_on = { workspace = true }
 itertools = { workspace = true }
 
-[target.'cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
+[target.'cfg(not(any(target_os = "openbsd", target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -9,13 +9,21 @@ use std::io::{BufWriter, Write};
 
 #[cfg(all(
     feature = "jemalloc",
-    not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux")))
+    not(any(
+        target_os = "openbsd",
+        target_os = "windows",
+        all(target_arch = "aarch64", target_os = "linux")
+    ))
 ))]
 use tikv_jemallocator::Jemalloc;
 
 #[cfg(all(
     feature = "jemalloc",
-    not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux")))
+    not(any(
+        target_os = "openbsd",
+        target_os = "windows",
+        all(target_arch = "aarch64", target_os = "linux")
+    ))
 ))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -108,7 +108,7 @@ slint = { workspace = true, features = ["compat-1-2"], optional = true }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "internal", "internal-highlight", "internal-json", "image-default-formats"], optional = true }
 nucleo-matcher = "0.3.1"
 
-[target.'cfg(not(any(target_os = "windows", target_arch = "wasm32", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
+[target.'cfg(not(any(target_os = "openbsd", target_os = "windows", target_arch = "wasm32", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -43,6 +43,7 @@ use std::task::{Poll, Waker};
 use crate::common::document_cache::CompilerConfiguration;
 
 #[cfg(not(any(
+    target_os = "openbsd",
     target_os = "windows",
     target_arch = "wasm32",
     all(target_arch = "aarch64", target_os = "linux")
@@ -50,6 +51,7 @@ use crate::common::document_cache::CompilerConfiguration;
 use tikv_jemallocator::Jemalloc;
 
 #[cfg(not(any(
+    target_os = "openbsd",
     target_os = "windows",
     target_arch = "wasm32",
     all(target_arch = "aarch64", target_os = "linux")

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -66,7 +66,7 @@ itertools = { workspace = true }
 serde_json = { workspace = true }
 smol_str = { workspace = true }
 
-[target.'cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
+[target.'cfg(not(any(target_os = "openbsd", target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [[bin]]

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -15,10 +15,18 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
-#[cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "windows",
+    all(target_arch = "aarch64", target_os = "linux")
+)))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "windows",
+    all(target_arch = "aarch64", target_os = "linux")
+)))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
The internal LibrePCB Slint build is broken
under OpenBSD 7.8 in LibrePCB commit:
'830054f4e50269cb40bc83df1bc0a4d7d37bb3a0'.

Disable jemalloc under OpenBSD.

The commit is done like Slint commit:
'b625ad97227504d1af9296759e12e059162ac5a9'.

'examples/servo/' was ignored since this
dependency does not build on OpenBSD.