### PR TITLE
Fix clippy warnings in backends

### DIFF
--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -39,10 +39,10 @@ pub fn send_keyboard_shortcut<
 ) {
     let keys: Vec<_> = keys.into_iter().map(Into::into).collect();
     for key in &keys {
-        send_keyboard_char(component, key.clone(), true);
+        send_keyboard_char(component, *key, true);
     }
     for key in keys.iter().rev() {
-        send_keyboard_char(component, key.clone(), false);
+        send_keyboard_char(component, *key, false);
     }
 }
 

--- a/internal/backends/winit/README.md
+++ b/internal/backends/winit/README.md
@@ -32,10 +32,8 @@ winit = "0.w"
 To ensure that the runtime backend is selected, initialize the backend as the first step in the `main` function:
 
 ```rust
-fn main() {
-    slint::platform::set_platform(Box::new(i_slint_backend_winit::Backend::new().unwrap()));
-    // ...
-}
+slint::platform::set_platform(Box::new(i_slint_backend_winit::Backend::new().unwrap()));
+// ...
 ```
 
 Once you have a [`slint::Window`](i_slint_core::api::Window)

--- a/internal/backends/winit/frame_throttle.rs
+++ b/internal/backends/winit/frame_throttle.rs
@@ -12,9 +12,9 @@ pub fn create_frame_throttle(
     _is_wayland: bool,
 ) -> Box<dyn FrameThrottle> {
     if _is_wayland {
-        WinitBasedFrameThrottle::new(window_adapter)
+        WinitBasedFrameThrottle::create(window_adapter)
     } else {
-        TimerBasedFrameThrottle::new(window_adapter)
+        TimerBasedFrameThrottle::create(window_adapter)
     }
 }
 
@@ -28,7 +28,7 @@ struct TimerBasedFrameThrottle {
 }
 
 impl TimerBasedFrameThrottle {
-    fn new(window_adapter: Weak<WinitWindowAdapter>) -> Box<dyn FrameThrottle> {
+    fn create(window_adapter: Weak<WinitWindowAdapter>) -> Box<dyn FrameThrottle> {
         Box::new(Self { window_adapter, timer: Rc::new(Timer::default()) })
     }
 }
@@ -81,7 +81,7 @@ struct WinitBasedFrameThrottle {
 }
 
 impl WinitBasedFrameThrottle {
-    fn new(window_adapter: Weak<WinitWindowAdapter>) -> Box<dyn FrameThrottle> {
+    fn create(window_adapter: Weak<WinitWindowAdapter>) -> Box<dyn FrameThrottle> {
         Box::new(Self { window_adapter })
     }
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -119,9 +119,7 @@ fn icon_to_winit(
 ) -> Option<winit::window::Icon> {
     let image_inner: &ImageInner = (&icon).into();
 
-    let Some(pixel_buffer) = image_inner.render_to_buffer(Some(size.cast())) else {
-        return None;
-    };
+    let pixel_buffer = image_inner.render_to_buffer(Some(size.cast()))?;
 
     // This could become a method in SharedPixelBuffer...
     let rgba_pixels: Vec<u8> = match &pixel_buffer {
@@ -162,6 +160,7 @@ fn window_is_resizable(
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum WinitWindowOrNone {
     HasWindow {
         window: Arc<winit::window::Window>,


### PR DESCRIPTION
- removed the doctest fn main() wrapper and kept only the setup snippet to satisfy clippy::needless_doctest_main
- In frame_throttle.rs, renamed internal constructors from new(...) -> Box<dyn FrameThrottle> to create(...), because new is expected to return Self (clippy::new_ret_no_self).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
