### PR TITLE
Expose layout kind through the test protocol

### DIFF
--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -499,6 +499,12 @@ impl ElementHandle {
         })
     }
 
+    /// Returns the layout kind if this element is a layout (`h-box`, `v-box`, `grid`, or `flex-box`);
+    /// None if the element is not a layout or is not valid anymore.
+    pub fn layout_kind(&self) -> Option<SharedString> {
+        self.item.upgrade().and_then(|item| item.element_layout_kind(self.element_index))
+    }
+
     /// Returns the value of the element's `accessible-role` property, if present. Use this property to
     /// locate elements by their type/role, i.e. buttons, checkboxes, etc.
     pub fn accessible_role(&self) -> Option<crate::AccessibleRole> {

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -24,6 +24,32 @@ mod internal {
     pub trait Sealed {}
 }
 
+/// Describes the kind of layout an element represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LayoutKind {
+    /// A `HorizontalLayout`.
+    HorizontalLayout,
+    /// A `VerticalLayout`.
+    VerticalLayout,
+    /// A `GridLayout`.
+    GridLayout,
+    /// A flex box layout.
+    FlexBox,
+}
+
+impl LayoutKind {
+    fn from_encoded(s: &str) -> Option<Self> {
+        match s {
+            "h-box" => Some(Self::HorizontalLayout),
+            "v-box" => Some(Self::VerticalLayout),
+            "grid" => Some(Self::GridLayout),
+            "flex-box" => Some(Self::FlexBox),
+            _ => None,
+        }
+    }
+}
+
 pub(crate) use internal::Sealed;
 
 /// Trait for type that can be searched for element. This is implemented for everything that implements [`ComponentHandle`]
@@ -499,10 +525,13 @@ impl ElementHandle {
         })
     }
 
-    /// Returns the layout kind if this element is a layout (`h-box`, `v-box`, `grid`, or `flex-box`);
+    /// Returns the layout kind if this element is a layout container;
     /// None if the element is not a layout or is not valid anymore.
-    pub fn layout_kind(&self) -> Option<SharedString> {
-        self.item.upgrade().and_then(|item| item.element_layout_kind(self.element_index))
+    pub fn layout_kind(&self) -> Option<LayoutKind> {
+        self.item.upgrade().and_then(|item| {
+            item.element_layout_kind(self.element_index)
+                .and_then(|s| LayoutKind::from_encoded(s.as_str()))
+        })
     }
 
     /// Returns the value of the element's `accessible-role` property, if present. Use this property to

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -81,6 +81,14 @@ message WindowEvent {
 // Copied from enums.rs - can't be auto-generated :(
 // with one difference: None became Unknown, because None doesn't compile.
 // Upside: AccessKit also uses Unknown :)
+enum LayoutKind {
+    NotALayout = 0;
+    HorizontalBox = 1;
+    VerticalBox = 2;
+    Grid = 3;
+    FlexBox = 4;
+}
+
 enum AccessibleRole {
     Unknown = 0;
     Button = 1;
@@ -244,6 +252,7 @@ message ElementPropertiesResponse {
     string accessible_placeholder_text = 14;
     bool accessible_enabled = 15;
     bool accessible_read_only = 16;
+    LayoutKind layout_kind = 17;
 }
 
 message InvokeElementAccessibilityActionResponse {

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -83,9 +83,9 @@ message WindowEvent {
 // Upside: AccessKit also uses Unknown :)
 enum LayoutKind {
     NotALayout = 0;
-    HorizontalBox = 1;
-    VerticalBox = 2;
-    Grid = 3;
+    HorizontalLayout = 1;
+    VerticalLayout = 2;
+    GridLayout = 3;
     FlexBox = 4;
 }
 

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -379,6 +379,13 @@ impl TestingClient {
                 .to_string(),
             accessible_enabled: element.accessible_enabled().unwrap_or_default(),
             accessible_read_only: element.accessible_read_only().unwrap_or_default(),
+            layout_kind: match element.layout_kind().as_ref().map(|s| s.as_str()) {
+                Some("h-box") => proto::LayoutKind::HorizontalBox.into(),
+                Some("v-box") => proto::LayoutKind::VerticalBox.into(),
+                Some("grid") => proto::LayoutKind::Grid.into(),
+                Some("flex-box") => proto::LayoutKind::FlexBox.into(),
+                _ => proto::LayoutKind::NotALayout.into(),
+            },
         })
     }
 

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -14,7 +14,7 @@ use std::cell::RefCell;
 use std::io::Cursor;
 use std::rc::{Rc, Weak};
 
-use crate::{ElementHandle, ElementRoot};
+use crate::{ElementHandle, ElementRoot, LayoutKind};
 
 struct RootWrapper<'a>(&'a ItemTreeRc);
 
@@ -379,12 +379,12 @@ impl TestingClient {
                 .to_string(),
             accessible_enabled: element.accessible_enabled().unwrap_or_default(),
             accessible_read_only: element.accessible_read_only().unwrap_or_default(),
-            layout_kind: match element.layout_kind().as_ref().map(|s| s.as_str()) {
-                Some("h-box") => proto::LayoutKind::HorizontalBox.into(),
-                Some("v-box") => proto::LayoutKind::VerticalBox.into(),
-                Some("grid") => proto::LayoutKind::Grid.into(),
-                Some("flex-box") => proto::LayoutKind::FlexBox.into(),
-                _ => proto::LayoutKind::NotALayout.into(),
+            layout_kind: match element.layout_kind() {
+                Some(LayoutKind::HorizontalLayout) => proto::LayoutKind::HorizontalLayout.into(),
+                Some(LayoutKind::VerticalLayout) => proto::LayoutKind::VerticalLayout.into(),
+                Some(LayoutKind::GridLayout) => proto::LayoutKind::GridLayout.into(),
+                Some(LayoutKind::FlexBox) => proto::LayoutKind::FlexBox.into(),
+                None => proto::LayoutKind::NotALayout.into(),
             },
         })
     }

--- a/internal/backends/testing/tests/layout_kind.rs
+++ b/internal/backends/testing/tests/layout_kind.rs
@@ -1,0 +1,103 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use core::ops::ControlFlow;
+use i_slint_backend_testing::{ElementHandle, LayoutKind};
+
+#[test]
+fn test_layout_kind() {
+    i_slint_backend_testing::init_integration_test_with_system_time();
+
+    slint::slint! {
+        export component App inherits Window {
+            hl := HorizontalLayout {
+                Rectangle {}
+            }
+            vl := VerticalLayout {
+                Rectangle {}
+            }
+            gl := GridLayout {
+                Rectangle {}
+            }
+            rect := Rectangle {}
+        }
+    }
+
+    let app = App::new().unwrap();
+
+    let elems: Vec<_> = ElementHandle::find_by_element_id(&app, "App::hl").collect();
+    assert_eq!(elems.len(), 1);
+    assert_eq!(elems[0].layout_kind(), Some(LayoutKind::HorizontalLayout));
+
+    let elems: Vec<_> = ElementHandle::find_by_element_id(&app, "App::vl").collect();
+    assert_eq!(elems.len(), 1);
+    assert_eq!(elems[0].layout_kind(), Some(LayoutKind::VerticalLayout));
+
+    let elems: Vec<_> = ElementHandle::find_by_element_id(&app, "App::gl").collect();
+    assert_eq!(elems.len(), 1);
+    assert_eq!(elems[0].layout_kind(), Some(LayoutKind::GridLayout));
+
+    let elems: Vec<_> = ElementHandle::find_by_element_id(&app, "App::rect").collect();
+    assert_eq!(elems.len(), 1);
+    assert_eq!(elems[0].layout_kind(), None);
+
+    // Nested layouts: inner layout reports its own kind
+    slint::slint! {
+        export component Nested inherits Window {
+            outer := VerticalLayout {
+                inner := HorizontalLayout {
+                    Rectangle {}
+                }
+            }
+        }
+    }
+
+    let nested = Nested::new().unwrap();
+
+    let outer: Vec<_> = ElementHandle::find_by_element_id(&nested, "Nested::outer").collect();
+    assert_eq!(outer.len(), 1);
+    assert_eq!(outer[0].layout_kind(), Some(LayoutKind::VerticalLayout));
+
+    let inner: Vec<_> = ElementHandle::find_by_element_id(&nested, "Nested::inner").collect();
+    assert_eq!(inner.len(), 1);
+    assert_eq!(inner[0].layout_kind(), Some(LayoutKind::HorizontalLayout));
+
+    // Verify hierarchy: inner HorizontalLayout is a descendant of outer VerticalLayout
+    let found_inner = outer[0].visit_descendants(|descendant| {
+        if descendant.id() == Some(slint::SharedString::from("Nested::inner")) {
+            ControlFlow::Break(descendant)
+        } else {
+            ControlFlow::Continue(())
+        }
+    });
+    assert!(found_inner.is_some());
+    assert_eq!(found_inner.unwrap().layout_kind(), Some(LayoutKind::HorizontalLayout));
+
+    // type_name() is consistent with layout_kind()
+    assert_eq!(inner[0].type_name(), Some(slint::SharedString::from("HorizontalLayout")));
+
+    // HorizontalBox / VerticalBox (styled widget variants)
+    slint::slint! {
+        import { HorizontalBox, VerticalBox } from "std-widgets.slint";
+        export component Boxes inherits Window {
+            hb := HorizontalBox {
+                Rectangle {}
+            }
+            vb := VerticalBox {
+                Rectangle {}
+            }
+        }
+    }
+
+    let boxes = Boxes::new().unwrap();
+
+    let elems: Vec<_> = ElementHandle::find_by_element_id(&boxes, "Boxes::hb").collect();
+    assert_eq!(elems.len(), 1);
+    assert_eq!(elems[0].layout_kind(), Some(LayoutKind::HorizontalLayout));
+    assert_eq!(elems[0].type_name(), Some(slint::SharedString::from("HorizontalBox")));
+
+    let elems: Vec<_> = ElementHandle::find_by_element_id(&boxes, "Boxes::vb").collect();
+    assert_eq!(elems.len(), 1);
+    assert_eq!(elems[0].layout_kind(), Some(LayoutKind::VerticalLayout));
+    assert_eq!(elems[0].type_name(), Some(slint::SharedString::from("VerticalBox")));
+}

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -731,13 +731,26 @@ pub struct ElementDebugInfo {
 }
 
 impl ElementDebugInfo {
-    // Returns a comma separate string that encodes the element type name (`Rectangle`, `MyButton`, etc.)
-    // and the qualified id (`SurroundingComponent::my-id`).
+    // Returns a comma separate string that encodes the element type name (`Rectangle`, `MyButton`, etc.),
+    // the qualified id (`SurroundingComponent::my-id`), and optionally the layout kind
+    // (`h-box`, `v-box`, `grid`, `flex-box`).
     fn encoded_element_info(&self) -> String {
         let mut info = self.type_name.clone();
         info.push(',');
         if let Some(id) = self.qualified_id.as_ref() {
             info.push_str(id);
+        }
+        info.push(',');
+        if let Some(layout) = &self.layout {
+            use crate::layout::{Layout, Orientation};
+            match layout {
+                Layout::BoxLayout(b) => match b.orientation {
+                    Orientation::Horizontal => info.push_str("h-box"),
+                    Orientation::Vertical => info.push_str("v-box"),
+                },
+                Layout::GridLayout(_) => info.push_str("grid"),
+                Layout::FlexBoxLayout(_) => info.push_str("flex-box"),
+            }
         }
         info
     }


### PR DESCRIPTION
## Summary

- Encodes layout kind (`h-box`, `v-box`, `grid`, `flex-box`) as a third field in the compiler's debug info string, making layout information available at runtime
- Adds `element_layout_kind()` to `ItemRc` and `layout_kind()` to `ElementHandle` for querying layout kind
- Extends the systest protobuf protocol with a `LayoutKind` enum and `layout_kind` field on `ElementPropertiesResponse`
- Refactors `ItemRc` debug info parsing to share a `raw_element_infos()` helper across `element_count`, `element_type_names_and_ids`, and the new `element_layout_kind`

## Motivation

When inspecting a Slint app via the test protocol, layout information is invisible: a `HorizontalLayout` gets lowered to a `Rectangle` during compilation, and there's no way to see how children are arranged. This change surfaces layout kind so tooling can distinguish layout elements from plain rectangles.

## Test plan

- [x] `cargo build -p slint-compiler` — clean
- [x] `cargo build -p i-slint-backend-testing` — clean
- [x] `cargo test -p i-slint-core` — all tests pass
- [ ] Integration test with `SLINT_EMIT_DEBUG_INFO=1` verifying `layout_kind()` returns expected values for `HorizontalLayout`, `VerticalLayout`, `GridLayout`, and `None` for plain elements

This anticipates https://github.com/slint-ui/slint/pull/10905 and future extension thereof to make layout information introspectable at runtime.