### PR TITLE
servo: Update servo dependencies to use tag `v0.0.5`

### DIFF
--- a/examples/servo/Cargo.toml
+++ b/examples/servo/Cargo.toml
@@ -44,8 +44,8 @@ wgpu-core = "28.0.0"
 wgpu = { version = "28.0.0", features = ["metal"] }
 
 surfman = { version = "0.11.0", features = ["chains"] }
-libservo = { git = "https://github.com/servo/servo", rev = "e8aa7d5" }
-embedder_traits = { git = "https://github.com/servo/servo", rev = "e8aa7d5", features = ["baked-default-resources"] }
+libservo = { git = "https://github.com/servo/servo", tag = "v0.0.5" }
+embedder_traits = { git = "https://github.com/servo/servo", tag = "v0.0.5", features = ["baked-default-resources"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 ash = "0.38.0"


### PR DESCRIPTION
Update servo dependencies to use tag `v0.0.5` instead of a specific Git revision.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
