### PR TITLE
winit: fix build without renderer-femtovg-wgpu 

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -480,8 +480,10 @@ impl BackendBuilder {
                 cfg_if::cfg_if! {
                     if #[cfg(enable_skia_renderer)] {
                         renderer::skia::WinitSkiaRenderer::new_wgpu_28_suspended
-                    } else {
+                    } else if #[cfg(feature = "renderer-femtovg-wgpu")] {
                         renderer::femtovg::WGPUFemtoVGRenderer::new_suspended
+                    } else {
+                        return Err("unstable-wgpu-28 was enabled but no renderer was selected. Please select either renderer-skia* or renderer-femtovg-wgpu".into())
                     }
                 }
             }

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -166,13 +166,13 @@ impl GlutinFemtoVGRenderer {
     }
 }
 
-#[cfg(all(feature = "unstable-wgpu-28", not(target_family = "wasm")))]
+#[cfg(all(feature = "renderer-femtovg-wgpu", not(target_family = "wasm")))]
 pub struct WGPUFemtoVGRenderer {
     renderer: FemtoVGRenderer<i_slint_renderer_femtovg::wgpu::WGPUBackend>,
     requested_graphics_api: Option<RequestedGraphicsAPI>,
 }
 
-#[cfg(all(feature = "unstable-wgpu-28", not(target_family = "wasm")))]
+#[cfg(all(feature = "renderer-femtovg-wgpu", not(target_family = "wasm")))]
 impl WGPUFemtoVGRenderer {
     pub fn new_suspended(
         shared_backend_data: &Rc<crate::SharedBackendData>,
@@ -190,7 +190,7 @@ impl WGPUFemtoVGRenderer {
     }
 }
 
-#[cfg(all(feature = "unstable-wgpu-28", not(target_family = "wasm")))]
+#[cfg(all(feature = "renderer-femtovg-wgpu", not(target_family = "wasm")))]
 impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
     fn render(&self, _window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
         self.renderer.render()


### PR DESCRIPTION
error: struct `WGPUFemtoVGRenderer` is never constructed
   --> internal/backends/winit/renderer/femtovg.rs:170:12
error: associated function `new_suspended` is never used
   --> internal/backends/winit/renderer/femtovg.rs:177:12

WGPUFemtoVGRenderer should be gated on renderer-femtovg-wgpu (which implies unstable-wgpu-28) rather than unstable-wgpu-28 alone, since the struct is only meaningful when the femtovg-wgpu renderer is actually selected.

lib.rs: the unreachable is for the impossible config of unstable-wgpu-28 without either renderer.