### PR TITLE
refactor: Remove redundant `# type: ignore` comments

### DIFF
--- a/api/python/slint/slint/__init__.py
+++ b/api/python/slint/slint/__init__.py
@@ -473,7 +473,7 @@ def _callback_decorator(
 
         if inspect.iscoroutinefunction(callable):
 
-            def run_as_task(*args, **kwargs) -> None:  # type: ignore
+            def run_as_task(*args, **kwargs) -> None:
                 loop = asyncio.get_event_loop()
                 loop.create_task(callable(*args, **kwargs))
 

--- a/api/python/slint/slint/loop.py
+++ b/api/python/slint/slint/loop.py
@@ -28,7 +28,7 @@ class _SlintSelectorMapping(Mapping[typing.Any, selectors.SelectorKey]):
     def __len__(self) -> int:
         return len(self.slint_selector.fd_to_selector_key)
 
-    def get(self, fileobj, default=None):  # type: ignore
+    def get(self, fileobj, default=None):
         fd = fd_for_fileobj(fileobj)
         return self.slint_selector.fd_to_selector_key.get(fd, default)
 
@@ -36,7 +36,7 @@ class _SlintSelectorMapping(Mapping[typing.Any, selectors.SelectorKey]):
         fd = fd_for_fileobj(fileobj)
         return self.slint_selector.fd_to_selector_key[fd]
 
-    def __iter__(self):  # type: ignore
+    def __iter__(self):
         return iter(self.slint_selector.fd_to_selector_key)
 
 
@@ -134,7 +134,7 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
             self._is_running = False
             asyncio.events._set_running_loop(None)
 
-    def run_until_complete[T](self, future: typing.Awaitable[T]) -> T | None:  # type: ignore[override]
+    def run_until_complete[T](self, future: typing.Awaitable[T]) -> T | None:
         def stop_loop(future: typing.Any) -> None:
             self.stop()
 
@@ -177,7 +177,7 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
     def is_closed(self) -> bool:
         return False
 
-    def call_later(self, delay, callback, *args, context=None) -> asyncio.TimerHandle:  # type: ignore
+    def call_later(self, delay, callback, *args, context=None) -> asyncio.TimerHandle:
         timer = native.Timer()
 
         handle = asyncio.TimerHandle(
@@ -205,10 +205,10 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
 
         return handle
 
-    def call_at(self, when, callback, *args, context=None) -> asyncio.TimerHandle:  # type: ignore
+    def call_at(self, when, callback, *args, context=None) -> asyncio.TimerHandle:
         return self.call_later(when - self.time(), callback, *args, context=context)
 
-    def call_soon(self, callback, *args, context=None) -> asyncio.TimerHandle:  # type: ignore
+    def call_soon(self, callback, *args, context=None) -> asyncio.TimerHandle:
         # Collect call-soon tasks in a separate list to ensure FIFO order, as there's no guarantee
         # that multiple single-shot timers in Slint are run in order.
         handle = asyncio.TimerHandle(
@@ -225,7 +225,7 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
             if not handle._cancelled:
                 handle._run()
 
-    def call_soon_threadsafe(self, callback, *args, context=None) -> asyncio.Handle:  # type: ignore
+    def call_soon_threadsafe(self, callback, *args, context=None) -> asyncio.Handle:
         handle = asyncio.Handle(
             callback=callback,
             args=args,

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -206,8 +206,8 @@ def test_subprocess() -> None:
             proc = await asyncio.create_subprocess_exec(
                 sys.executable,
                 "--version",
-                stdout=asyncio.subprocess.PIPE,  # type: ignore
-                stderr=asyncio.subprocess.STDOUT,  # type: ignore
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
             )
 
             stdout, _ = await proc.communicate()

--- a/api/python/slint/tests/test_callback_decorators.py
+++ b/api/python/slint/tests/test_callback_decorators.py
@@ -20,7 +20,7 @@ def base_dir() -> Path:
 def test_callback_decorators(caplog: pytest.LogCaptureFixture) -> None:
     module = load_file(base_dir() / "test-load-file.slint", quiet=False)
 
-    class SubClass(module.App):  # type: ignore
+    class SubClass(module.App):
         @slint.callback()
         def say_hello_again(self, arg: str) -> str:
             return "say_hello_again:" + arg
@@ -43,7 +43,7 @@ def test_callback_decorators(caplog: pytest.LogCaptureFixture) -> None:
 def test_callback_decorators_async() -> None:
     module = load_file(base_dir() / "test-load-file.slint", quiet=False)
 
-    class SubClass(module.App):  # type: ignore
+    class SubClass(module.App):
         def __init__(self, in_queue: asyncio.Queue[int], out_queue: asyncio.Queue[int]):
             super().__init__()
             self.in_queue = in_queue
@@ -79,7 +79,7 @@ def test_callback_decorators_async() -> None:
 def test_callback_decorators_async_err() -> None:
     module = load_file(base_dir() / "test-load-file.slint", quiet=False)
 
-    class SubClass(module.App):  # type: ignore
+    class SubClass(module.App):
         def __init__(self) -> None:
             super().__init__()
 

--- a/api/python/slint/tests/test_models.py
+++ b/api/python/slint/tests/test_models.py
@@ -48,7 +48,7 @@ def test_model_notify() -> None:
     assert instance.get_property("layout-height") == 150
     model.append(75)
     assert instance.get_property("layout-height") == 225
-    del model[1:]  # type: ignore
+    del model[1:]
     assert instance.get_property("layout-height") == 100
 
     assert isinstance(instance.get_property("fixed-height-model"), models.ListModel)


### PR DESCRIPTION
Remove redundant `# type: ignore` comments from various type-hinted code sections.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
