### PR TITLE
Add #[allow(...)] attributes to suppress clippy warnings

### DIFF
--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -37,6 +37,7 @@ struct SeatWrap {
 
 #[cfg(feature = "libseat")]
 impl SeatWrap {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(seat: &Rc<RefCell<libseat::Seat>>) -> input::Libinput {
         let seat_name = seat.borrow_mut().name().to_string();
         let mut libinput = input::Libinput::new_with_udev(Self {
@@ -82,6 +83,7 @@ struct DirectDeviceAccess {}
 
 #[cfg(not(feature = "libseat"))]
 impl DirectDeviceAccess {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> input::Libinput {
         let mut libinput = input::Libinput::new_with_udev(Self {});
         libinput.udev_assign_seat("seat0").unwrap();

--- a/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
+++ b/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
@@ -19,6 +19,7 @@ pub struct DumbBufferDisplay {
 }
 
 impl DumbBufferDisplay {
+    #[allow(clippy::new_ret_no_self, clippy::arc_with_non_send_sync)]
     pub fn new(
         device_opener: &crate::DeviceOpener,
         renderer_formats: &[drm::buffer::DrmFourcc],

--- a/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
+++ b/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
@@ -24,6 +24,7 @@ pub struct LinuxFBDisplay {
 }
 
 impl LinuxFBDisplay {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         device_opener: &crate::DeviceOpener,
         renderer_formats: &[drm::buffer::DrmFourcc],
@@ -47,6 +48,7 @@ impl LinuxFBDisplay {
         )))
     }
 
+    #[allow(clippy::arc_with_non_send_sync)]
     fn new_with_path(
         device_opener: &crate::DeviceOpener,
         path: &std::path::Path,

--- a/internal/backends/linuxkms/renderer/femtovg.rs
+++ b/internal/backends/linuxkms/renderer/femtovg.rs
@@ -154,6 +154,7 @@ unsafe impl i_slint_renderer_femtovg::opengl::OpenGLInterface for GlContextWrapp
 }
 
 impl FemtoVGRendererAdapter {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -88,6 +88,7 @@ impl SkiaRendererAdapter {
     }
 
     #[cfg(feature = "renderer-skia-opengl")]
+    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new_opengl(
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {

--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -146,6 +146,7 @@ impl TargetPixel for DumbBufferPixelBgra8888 {
 }
 
 impl SoftwareRendererAdapter {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -26,7 +26,7 @@ impl ElementRoot for RootWrapper<'_> {
 
 impl super::Sealed for RootWrapper<'_> {}
 
-#[allow(non_snake_case, unused_imports, non_camel_case_types)]
+#[allow(non_snake_case, unused_imports, non_camel_case_types, clippy::all)]
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/proto.rs"));
 }

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -161,6 +161,7 @@ pub enum RequestedOpenGLVersion {
 /// Internal enum specify which graphics API should be used, when
 /// the backend selector requests that from a built-in backend.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum RequestedGraphicsAPI {
     /// OpenGL (ES)
     OpenGL(RequestedOpenGLVersion),

--- a/internal/core/graphics/wgpu_27.rs
+++ b/internal/core/graphics/wgpu_27.rs
@@ -88,6 +88,7 @@ pub mod api {
     /// This enum describes the different ways to configure WGPU for rendering.
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    #[allow(clippy::large_enum_variant)]
     pub enum WGPUConfiguration {
         /// Use `Manual` if you've initialized WGPU and want to supply the instance, adapter,
         /// device, and queue for use.

--- a/internal/core/graphics/wgpu_28.rs
+++ b/internal/core/graphics/wgpu_28.rs
@@ -88,6 +88,7 @@ pub mod api {
     /// This enum describes the different ways to configure WGPU for rendering.
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    #[allow(clippy::large_enum_variant)]
     pub enum WGPUConfiguration {
         /// Use `Manual` if you've initialized WGPU and want to supply the instance, adapter,
         /// device, and queue for use.

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -7,6 +7,7 @@
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(unsafe_code)]
+#![allow(clippy::missing_safety_doc)] // FFI surface has many exported unsafe entry points
 #![cfg_attr(slint_nightly_test, feature(non_exhaustive_omitted_patterns_lint))]
 #![cfg_attr(slint_nightly_test, warn(non_exhaustive_omitted_patterns))]
 #![no_std]

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -141,13 +141,14 @@ pub extern "C" fn slint_interpreter_value_to_bool(val: &Value) -> Option<&bool> 
 /// `out` parameter and returns true; returns false if the value does not hold an extractable
 /// array.
 #[unsafe(no_mangle)]
+#[allow(clippy::borrowed_box)]
 pub extern "C" fn slint_interpreter_value_to_array(
     val: &Box<Value>,
     out: &mut SharedVector<Box<Value>>,
 ) -> bool {
     match val.as_ref() {
         Value::Model(m) => {
-            let vec = m.iter().map(|vb| Box::new(vb)).collect::<SharedVector<_>>();
+            let vec = m.iter().map(Box::new).collect::<SharedVector<_>>();
             *out = vec;
             true
         }

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -104,6 +104,8 @@ pub(crate) fn as_skia_image(
         ImageInner::WGPUTexture(any_wgpu_texture) => {
             surface.and_then(|surface| surface.import_wgpu_texture(canvas, any_wgpu_texture))
         }
+        #[allow(unreachable_patterns)]
+        _ => None,
     }
 }
 

--- a/tools/figma_import/src/figmatypes.rs
+++ b/tools/figma_import/src/figmatypes.rs
@@ -279,6 +279,7 @@ pub struct VectorNode {
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
+#[allow(clippy::large_enum_variant)]
 pub enum Node {
     DOCUMENT(NodeCommon),
     CANVAS {

--- a/tools/lsp/fmt.rs
+++ b/tools/lsp/fmt.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+#[allow(clippy::module_inception)]
 pub mod fmt;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod tool;

--- a/tools/updater/experiments/lookup_changes.rs
+++ b/tools/updater/experiments/lookup_changes.rs
@@ -312,6 +312,7 @@ pub(crate) fn collect_movable_properties(state: &mut crate::State) {
     }
 }
 
+#[allow(clippy::mutable_key_type)] // identity map keyed by ElementRc is intentional
 fn ensure_element_has_id(
     element: &ElementRc,
     elements_id: &mut HashMap<ByAddress<ElementRc>, SmolStr>,


### PR DESCRIPTION
For skia/cached_image.rs:
When i-slint-core has WGPUTexture but the skia renderer doesn't have wgpu features, the match arm above is not compiled yet the variant may exist. The wildcard provides coverage; it is unreachable when all variants are already handled above.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
