### PR TITLE
Minor clippy fixes: comment typos, &'static, Error::other, is_err, unwrap_or_default, etc.

### DIFF
--- a/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
+++ b/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
@@ -331,7 +331,6 @@ const FBIOGET_VSCREENINFO: u32 = 0x4600;
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-
 pub struct fb_bitfield {
     offset: u32,
     length: u32,

--- a/internal/backends/linuxkms/display/vulkandisplay.rs
+++ b/internal/backends/linuxkms/display/vulkandisplay.rs
@@ -88,7 +88,7 @@ pub fn create_vulkan_display() -> Result<VulkanDisplay, PlatformError> {
                         format!(
                             "Index: {} Name: {}",
                             index,
-                            display.name().unwrap_or_else(|| "unknown")
+                            display.name().unwrap_or("unknown")
                         )
                     })
                     .collect();

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -140,13 +140,9 @@ impl WinitSkiaRenderer {
                         );
                     }
                     #[cfg(feature = "unstable-wgpu-27")]
-                    RequestedGraphicsAPI::WGPU27(..) => {
-                        return Ok(Self::new_wgpu_27_suspended);
-                    }
+                    RequestedGraphicsAPI::WGPU27(..) => Ok(Self::new_wgpu_27_suspended),
                     #[cfg(feature = "unstable-wgpu-28")]
-                    RequestedGraphicsAPI::WGPU28(..) => {
-                        return Ok(Self::new_wgpu_28_suspended);
-                    }
+                    RequestedGraphicsAPI::WGPU28(..) => Ok(Self::new_wgpu_28_suspended),
                 }
             }
             None => Ok(Self::new_suspended),

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1338,8 +1338,7 @@ pub(crate) mod ffi {
         unsafe {
             core::ptr::write(
                 image,
-                Image::load_from_path(std::path::Path::new(path.as_str()))
-                    .unwrap_or(Image::default()),
+                Image::load_from_path(std::path::Path::new(path.as_str())).unwrap_or_default(),
             )
         }
     }

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -108,6 +108,7 @@ fn make_c_function_binding(
 /// The current implementation will do usually two memory allocation:
 ///  1. the allocation from the calling code to allocate user_data
 ///  2. the box allocation within this binding
+///
 /// It might be possible to reduce that by passing something with a
 /// vtable, so there is the need for less memory allocation.
 #[unsafe(no_mangle)]
@@ -135,7 +136,7 @@ pub unsafe extern "C" fn slint_property_set_binding(
 
 /// Set a binding using an already allocated building holder
 ///
-//// (take ownership of the binding)
+/// (take ownership of the binding)
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_binding_internal(
     handle: &PropertyHandleOpaque,
@@ -528,7 +529,7 @@ pub unsafe extern "C" fn slint_change_tracker_init(
         BindingResult::KeepBinding
     }
 
-    const VT: &'static BindingVTable = &BindingVTable {
+    const VT: &BindingVTable = &BindingVTable {
         drop,
         evaluate,
         mark_dirty: ChangeTracker::mark_dirty,

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -278,6 +278,7 @@ const _: [(); std::mem::align_of::<StructIteratorOpaque>()] =
 pub unsafe extern "C" fn slint_interpreter_struct_iterator_destructor(
     val: *mut StructIteratorOpaque,
 ) {
+    #[allow(clippy::drop_non_drop)] // the drop is a no-op but we still want to be explicit
     drop(unsafe { std::ptr::read(val as *mut StructIterator) })
 }
 
@@ -513,10 +514,8 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_invoke_global(
                     .property_type,
                 i_slint_compiler::langtype::Type::Function { .. }
             ) {
-                g.as_ref().eval_function(
-                    &normalize_identifier(callable_name),
-                    args.as_slice().iter().cloned().collect(),
-                )
+                g.as_ref()
+                    .eval_function(&normalize_identifier(callable_name), args.as_slice().to_vec())
             } else {
                 g.as_ref().invoke_callback(&normalize_identifier(callable_name), args.as_slice())
             }

--- a/internal/interpreter/live_preview.rs
+++ b/internal/interpreter/live_preview.rs
@@ -272,7 +272,7 @@ impl Watcher {
         }));
 
         // no event loop, no need to start a watcher
-        if !result.is_ok() {
+        if result.is_err() {
             return arc;
         }
 

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -279,10 +279,7 @@ fn generate_source(
 
     if diag.has_errors() {
         diag.print_warnings_and_exit_on_error();
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("build error in {:?}", testcase.absolute_path),
-        ));
+        return Err(std::io::Error::other(format!("build error in {:?}", testcase.absolute_path)));
     } else {
         diag.print();
     }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -226,7 +226,7 @@ pub(crate) fn completion_at(
             resolve_expression_scope(ctx, document_cache, snippet_support)
         })?;
     } else if node.kind() == SyntaxKind::AtKeys {
-        return with_lookup_ctx(document_cache, node, Some(offset), |ctx| at_keys_completions(ctx));
+        return with_lookup_ctx(document_cache, node, Some(offset), at_keys_completions);
     } else if let Some(q) = syntax_nodes::QualifiedName::new(node.clone()) {
         match q.parent()?.kind() {
             SyntaxKind::Element => {

--- a/tools/lsp/preview/connector/native.rs
+++ b/tools/lsp/preview/connector/native.rs
@@ -170,7 +170,7 @@ impl SwitchableLspToPreview {
 
 impl common::LspToPreview for SwitchableLspToPreview {
     fn send(&self, message: &common::LspToPreviewMessage) {
-        let _ = self.lsp_to_previews.get(&self.current_target.borrow()).unwrap().send(message);
+        self.lsp_to_previews.get(&self.current_target.borrow()).unwrap().send(message);
     }
 
     fn preview_target(&self) -> common::PreviewTarget {

--- a/tools/lsp/preview/undo_redo.rs
+++ b/tools/lsp/preview/undo_redo.rs
@@ -151,7 +151,7 @@ pub fn setup(ui: &ui::PreviewUi) {
 pub fn set_undo_redo_enabled(state: &super::PreviewState) {
     if let Some(ui) = state.ui.as_ref() {
         let api = ui.global::<ui::Api>();
-        api.set_undo_enabled(state.undo_redo_stack.undo_stack.len() > 0);
-        api.set_redo_enabled(state.undo_redo_stack.redo_stack.len() > 0);
+        api.set_undo_enabled(!state.undo_redo_stack.undo_stack.is_empty());
+        api.set_redo_enabled(!state.undo_redo_stack.redo_stack.is_empty());
     }
 }

--- a/tools/tr-extractor/main.rs
+++ b/tools/tr-extractor/main.rs
@@ -62,8 +62,7 @@ fn main() -> std::io::Result<()> {
         .unwrap_or_else(|| format!("{}.po", args.domain.as_deref().unwrap_or("messages")).into());
 
     let mut messages = if args.join_existing {
-        let po = rspolib::pofile(&*output).map_err(|x| std::io::Error::other(x))?;
-        po
+        rspolib::pofile(&*output).map_err(std::io::Error::other)?
     } else {
         let package = args.package_name.as_ref().map(|x| x.as_ref()).unwrap_or("PACKAGE");
         let version = args.package_version.as_ref().map(|x| x.as_ref()).unwrap_or("VERSION");

--- a/tools/updater/experiments/lookup_changes.rs
+++ b/tools/updater/experiments/lookup_changes.rs
@@ -281,8 +281,8 @@ pub(crate) fn collect_movable_properties(state: &mut crate::State) {
             vec.extend(
                 c.borrow()
                     .property_declarations
-                    .iter()
-                    .map(|(name, _)| NamedReference::new(c, name.clone())),
+                    .keys()
+                    .map(|name| NamedReference::new(c, name.clone())),
             );
             collect_movable_properties_recursive(vec, c);
         }

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
     #[cfg(feature = "gettext")]
     if let Some(dirname) = args.translation_dir.clone() {
         i_slint_core::translations::gettext_bindtextdomain(
-            args.translation_domain.as_ref().map(String::as_str).unwrap_or_default(),
+            args.translation_domain.as_deref().unwrap_or_default(),
             dirname,
         )?;
     };


### PR DESCRIPTION
This commit has the ones that are trivial to review. Next one will have those a bit more "interesting".