### PR TITLE
Fix clippy warnings for printerdemo_mcu/pico-st7789 target

### DIFF
--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -140,7 +140,7 @@ pub fn init() {
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
         SPI_ST7789VW_MAX_FREQ,
-        &embedded_hal::spi::MODE_3,
+        embedded_hal::spi::MODE_3,
     );
 
     // SAFETY: This is not safe :-(  But we need to access the SPI and its control pins for the PIO
@@ -438,7 +438,7 @@ impl<
         // After the DMA operated, we need to empty the receive FIFO, otherwise the touch screen
         // driver will pick wrong values.
         // Continue to read as long as we don't get a Err(WouldBlock)
-        while !spi.read().is_err() {}
+        while spi.read().is_ok() {}
 
         self.pio = Some(PioTransfer::Idle(ch, b, spi));
     }
@@ -450,7 +450,7 @@ unsafe impl embedded_dma::ReadBuffer for PartialReadBuffer {
 
     unsafe fn read_buffer(&self) -> (*const <Self as embedded_dma::ReadBuffer>::Word, usize) {
         let act_slice = &self.0[self.1.clone()];
-        (act_slice.as_ptr() as *const u8, act_slice.len() * core::mem::size_of::<Rgb565Pixel>())
+        (act_slice.as_ptr() as *const u8, core::mem::size_of_val(act_slice))
     }
 }
 
@@ -599,7 +599,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
         4_000_000u32.Hz(),
-        &embedded_hal::spi::MODE_3,
+        embedded_hal::spi::MODE_3,
     );
 
     let mut timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1192,7 +1192,7 @@ trait RemEuclid {
 #[cfg(not(feature = "std"))]
 impl RemEuclid for f32 {
     fn rem_euclid(self, b: f32) -> f32 {
-        return num_traits::Euclid::rem_euclid(&self, &b);
+        num_traits::Euclid::rem_euclid(&self, &b)
     }
 }
 

--- a/internal/core/unsafe_single_threaded.rs
+++ b/internal/core/unsafe_single_threaded.rs
@@ -54,6 +54,7 @@ impl<T> FakeThreadStorage<T> {
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
         f(self.0.get_or_init(self.1))
     }
+    #[allow(clippy::result_unit_err)]
     pub fn try_with<R>(&self, f: impl FnOnce(&T) -> R) -> Result<R, ()> {
         Ok(self.with(f))
     }
@@ -65,6 +66,11 @@ unsafe impl<T, F> Sync for FakeThreadStorage<T, F> {}
 pub use thread_local_ as thread_local;
 
 pub struct OnceCell<T>(once_cell::unsync::OnceCell<T>);
+impl<T> Default for OnceCell<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl<T> OnceCell<T> {
     pub const fn new() -> Self {
         Self(once_cell::unsync::OnceCell::new())


### PR DESCRIPTION
- unsafe_single_threaded.rs: add Default impl for OnceCell, allow result_unit_err on try_with
- image.rs: remove needless return

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
