### PR TITLE
Tree-sitter: Add tree-sitter.json

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -175,6 +175,7 @@ path = [
   "editors/**.md",
   "editors/sublime/LSP.sublime-settings",
   "editors/tree-sitter-slint/corpus/**.txt",
+  "editors/tree-sitter-slint/tree-sitter.json",
   "editors/vscode/**.json",
   "editors/vscode/css/**.css",
   "editors/vscode/tests/grammar/**.slint",

--- a/editors/tree-sitter-slint/.gitignore
+++ b/editors/tree-sitter-slint/.gitignore
@@ -8,3 +8,4 @@ Makefile
 package.json
 package-lock.json
 libtree-sitter-slint.*
+tree-sitter-slint.wasm

--- a/editors/tree-sitter-slint/tree-sitter.json
+++ b/editors/tree-sitter-slint/tree-sitter.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
+  "grammars": [
+    {
+      "name": "slint",
+      "camelcase": "Slint",
+      "title": "Slint",
+      "scope": "source.slint",
+      "file-types": [
+        "slint"
+      ],
+      "injection-regex": "^slint$",
+      "class-name": "TreeSitterSlint"
+    }
+  ],
+  "metadata": {
+    "version": "1.16.0",
+    "license": "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0",
+    "description": "Parser for the Slint language used by the Slint UI Toolkit.",
+    "authors": [
+      {
+        "name": "Slint Team",
+        "email": "info@slint.dev",
+        "url": "https://slint.dev/"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/slint-ui/slint"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true,
+    "zig": false
+  }
+}


### PR DESCRIPTION
This is required to support tree-sitter CLI with ABI 15.

Adding the config file allows you to run:
```bash
tree-sitter generate
tree-sitter build --wasm
tree-sitter playground
```
to generate an interactive website where you can test and iterate on the tree-sitter grammar.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
