### PR TITLE
Shortcut: Add enabled property

### DIFF
--- a/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
@@ -129,6 +129,11 @@ See <Link type="KeyboardShortcuts" label="Keyboard Shortcuts"/> for details.
 The <Link type="keyboard-shortcut" label="keyboard-shortcut" /> to match against incoming key events.
 </SlintProperty>
 
+#### enabled
+<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
+Whether this Shortcut is currently enabled. Disabled Shortcut elements don't consume key events and never invoke their `activated()` callback.
+</SlintProperty>
+
 ### Callbacks of `Shortcut`
 
 #### activated()

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -181,6 +181,7 @@ export component FocusScope {
 }
 
 component Shortcut {
+    in property <bool> enabled: true;
     in property <keyboard-shortcut> keys;
     callback activated();
     //-is_non_item_type

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -287,6 +287,7 @@ impl ItemConsts for Shortcut {
 #[pin]
 pub struct Shortcut {
     pub keys: Property<KeyboardShortcut>,
+    pub enabled: Property<bool>,
     pub activated: Callback<VoidArg>,
     pub cached_rendering_data: CachedRenderingData,
 }
@@ -437,7 +438,7 @@ pub struct FocusScope {
 }
 
 impl FocusScope {
-    fn visit_shortcuts<R>(
+    fn visit_enabled_shortcuts<R>(
         self: Pin<&Self>,
         self_rc: &ItemRc,
         mut fun: impl FnMut(&VRcMapped<ItemTreeVTable, Shortcut>) -> Option<R>,
@@ -451,7 +452,9 @@ impl FocusScope {
 
             let mut next = self_rc.first_child();
             while let Some(child) = next {
-                if let Some(shortcut) = ItemRc::downcast::<Shortcut>(&child) {
+                if let Some(shortcut) = ItemRc::downcast::<Shortcut>(&child)
+                    && shortcut.as_pin_ref().enabled()
+                {
                     found.push(VRcMapped::downgrade(&shortcut));
                 }
                 next = child.next_sibling();
@@ -552,7 +555,7 @@ impl Item for FocusScope {
                 Self::FIELD_OFFSETS.key_pressed.apply_pin(self).call(&(event.clone(),))
             }
             KeyEventType::KeyReleased => {
-                let shortcut = self.visit_shortcuts(self_rc, |shortcut| {
+                let shortcut = self.visit_enabled_shortcuts(self_rc, |shortcut| {
                     let keys = Shortcut::FIELD_OFFSETS.keys.apply_pin(shortcut.as_pin_ref()).get();
                     if keys.matches(event) { Some(VRcMapped::clone(shortcut)) } else { None }
                 });

--- a/tests/cases/elements/shortcut.slint
+++ b/tests/cases/elements/shortcut.slint
@@ -9,6 +9,7 @@ export component TestCase inherits Window {
         @keys(Control + D),
     ];
     out property has-focus <=> scope.has-focus;
+    in-out property <bool> enable-ctrl-a: true;
 
     forward-focus: scope;
 
@@ -17,6 +18,7 @@ export component TestCase inherits Window {
 
         scope := FocusScope {
             Shortcut {
+                enabled: root.enable-ctrl-a;
                 keys: @keys(Control + A);
                 activated => { matches += 1; }
             }
@@ -48,6 +50,10 @@ assert_matches(0);
 use slint::private_unstable_api::re_exports::Key;
 use slint_testing::send_keyboard_shortcut;
 
+send_keyboard_shortcut(&instance, [Key::Control, Key::A]);
+assert_matches(1);
+
+instance.set_enable_ctrl_a(false);
 send_keyboard_shortcut(&instance, [Key::Control, Key::A]);
 assert_matches(1);
 


### PR DESCRIPTION
During discussion in issue #102 it was agreed that this property should
exist as an alternative to putting the shortcut in an if statement.

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
