### PR TITLE
Expose layout_kind() in the C++ ui-testing API

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -19,6 +19,7 @@
 namespace slint::testing {
 
 using slint::cbindgen_private::AccessibleRole;
+using slint::cbindgen_private::LayoutKind;
 
 /// Init the testing backend.
 /// Should be called before any other Slint function that can access the platform.
@@ -207,6 +208,18 @@ public:
         SharedVector<SharedString> bases;
         if (cbindgen_private::slint_testing_element_bases(&inner, &bases)) {
             return bases;
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    /// Returns the layout kind if this element is a layout container;
+    /// std::nullopt if the element is not a layout or is not valid anymore.
+    std::optional<slint::testing::LayoutKind> layout_kind() const
+    {
+        LayoutKind kind {};
+        if (cbindgen_private::slint_testing_element_layout_kind(&inner, &kind)) {
+            return kind;
         } else {
             return std::nullopt;
         }

--- a/api/cpp/tests/testing.cpp
+++ b/api/cpp/tests/testing.cpp
@@ -112,16 +112,14 @@ SCENARIO("LayoutKind")
     {
         auto elements = slint::testing::ElementHandle::find_by_element_id(instance, "App::vl");
         REQUIRE(elements.size() == 1);
-        REQUIRE(*elements[0].layout_kind()
-                == slint::testing::LayoutKind::VerticalLayout);
+        REQUIRE(*elements[0].layout_kind() == slint::testing::LayoutKind::VerticalLayout);
     }
 
     SECTION("GridLayout")
     {
         auto elements = slint::testing::ElementHandle::find_by_element_id(instance, "App::gl");
         REQUIRE(elements.size() == 1);
-        REQUIRE(*elements[0].layout_kind()
-                == slint::testing::LayoutKind::GridLayout);
+        REQUIRE(*elements[0].layout_kind() == slint::testing::LayoutKind::GridLayout);
     }
 
     SECTION("Non-layout element")

--- a/api/cpp/tests/testing.cpp
+++ b/api/cpp/tests/testing.cpp
@@ -70,3 +70,64 @@ SCENARIO("ElementHandle")
         REQUIRE(*elements[1].id() == "App::second");
     }
 }
+
+SCENARIO("LayoutKind")
+{
+    using namespace slint::interpreter;
+    using namespace slint;
+
+    ComponentCompiler compiler;
+
+    auto result = compiler.build_from_source(
+            R"(
+        export component App {
+            hl := HorizontalLayout {
+                vl := VerticalLayout {
+                    Rectangle {}
+                }
+            }
+            gl := GridLayout {
+                Rectangle {}
+            }
+            rect := Rectangle {}
+        }
+    )",
+            "");
+    REQUIRE(result.has_value());
+    auto component_definition = *result;
+
+    auto instance = component_definition.create();
+
+    SECTION("HorizontalLayout")
+    {
+        auto elements = slint::testing::ElementHandle::find_by_element_id(instance, "App::hl");
+        REQUIRE(elements.size() == 1);
+        const auto lk = elements[0].layout_kind();
+        REQUIRE(lk.has_value());
+        REQUIRE(*lk == slint::testing::LayoutKind::HorizontalLayout);
+        REQUIRE(*elements[0].type_name() == "HorizontalLayout");
+    }
+
+    SECTION("VerticalLayout nested in HorizontalLayout")
+    {
+        auto elements = slint::testing::ElementHandle::find_by_element_id(instance, "App::vl");
+        REQUIRE(elements.size() == 1);
+        REQUIRE(*elements[0].layout_kind()
+                == slint::testing::LayoutKind::VerticalLayout);
+    }
+
+    SECTION("GridLayout")
+    {
+        auto elements = slint::testing::ElementHandle::find_by_element_id(instance, "App::gl");
+        REQUIRE(elements.size() == 1);
+        REQUIRE(*elements[0].layout_kind()
+                == slint::testing::LayoutKind::GridLayout);
+    }
+
+    SECTION("Non-layout element")
+    {
+        auto elements = slint::testing::ElementHandle::find_by_element_id(instance, "App::rect");
+        REQUIRE(elements.size() == 1);
+        REQUIRE_FALSE(elements[0].layout_kind().has_value());
+    }
+}

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use crate::{ElementHandle, ElementRoot};
+use crate::{ElementHandle, ElementRoot, LayoutKind};
 use i_slint_core::item_tree::ItemTreeRc;
 use i_slint_core::slice::Slice;
 use i_slint_core::{SharedString, SharedVector};
@@ -105,6 +105,19 @@ pub extern "C" fn slint_testing_element_bases(
 ) -> bool {
     if let Some(bases_it) = element.bases() {
         out.extend(bases_it);
+        true
+    } else {
+        false
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_testing_element_layout_kind(
+    element: &ElementHandle,
+    out: &mut LayoutKind,
+) -> bool {
+    if let Some(kind) = element.layout_kind() {
+        *out = kind;
         true
     } else {
         false

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -26,6 +26,7 @@ mod internal {
 
 /// Describes the kind of layout an element represents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum LayoutKind {
     /// A `HorizontalLayout`.


### PR DESCRIPTION
## Summary

- Expose the existing Rust `LayoutKind` enum and `ElementHandle::layout_kind()` method to the C++ ui-testing API via FFI
- Add `#[repr(u8)]` to `LayoutKind` for cbindgen compatibility
- Add `slint_testing_element_layout_kind` FFI bridge function
- Add C++ tests covering all layout kinds, nested layouts, and non-layout elements

Follow-up to #10910 as suggested by @tronical.

## Test plan

- [x] Rust tests pass (`cargo test -p i-slint-backend-testing`)
- [x] C++ tests pass (`test_testing` target with `SLINT_FEATURE_EXPERIMENTAL=ON` and `SLINT_FEATURE_TESTING=ON`)