### PR TITLE
Fix match_element_type_name_or_base to use match_inherits

### DIFF
--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -299,7 +299,7 @@ impl TestingClient {
                     query = query.match_type_name(type_name)
                 }
                 proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_type_name_or_base(type_name_or_base) => {
-                    query = query.match_type_name(type_name_or_base)
+                    query = query.match_inherits(type_name_or_base)
                 }
                 proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_accessible_role(role) => {
                     query = query.match_accessible_role(convert_from_proto_accessible_role(role).ok_or_else(|| "Unknown accessibility role used in element query".to_string())?)


### PR DESCRIPTION
## Summary
- Fix `match_element_type_name_or_base` query instruction in systest to call `query.match_inherits()` instead of `query.match_type_name()`, so it correctly matches inherited base types in addition to exact type names.

## Test plan
- [ ] Verify existing system tests pass
- [ ] Test `match_element_type_name_or_base` with an element that inherits from a base type (e.g. querying for `TouchArea` on a custom component that inherits it)