### PR TITLE
Fix cfg guard for testing backend selection in selector

### DIFF
--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -108,7 +108,7 @@ cfg_if::cfg_if! {
                     }
                     return builder.build().map(|b| Box::new(b) as Box<dyn Platform + 'static>)
                 },
-                #[cfg(feature = "i-slint-backend-testing")]
+                #[cfg(feature = "backend-testing")]
                 "testing" => return Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
                     i_slint_backend_testing::TestingBackendOptions { mock_time: false, threading: true },
                 ))),


### PR DESCRIPTION
## Summary
- Fix the `#[cfg]` guard on the `SLINT_BACKEND=testing` selection block from `feature = "i-slint-backend-testing"` to `feature = "backend-testing"`. The block references `TestingBackendOptions` which requires the `internal` sub-feature, but the implicit optional dependency feature `i-slint-backend-testing` activates whenever the crate is pulled in by any feature (e.g. `system-testing`, `mcp`), not just `backend-testing` which is the one that enables `internal`.

## Test plan
- [ ] Build with `system-testing` feature enabled (without `backend-testing`) — previously would fail to compile
- [ ] Build with `backend-testing` feature enabled — `SLINT_BACKEND=testing` selection still works