### PR TITLE
Fix copy-paste error in testing backend package description

### DIFF
--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "i-slint-backend-testing"
-description = "OpenGL rendering backend for Slint"
+description = "Testing backend for Slint"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary
- Fix incorrect package description in `internal/backends/testing/Cargo.toml` that said "OpenGL rendering backend for Slint" instead of "Testing backend for Slint" (copy-paste error)

## Test plan
- No functional changes; metadata-only fix