### PR TITLE
enable Float to percentage conversions

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1351,6 +1351,11 @@ impl Expression {
                     rhs: Box::new(Expression::NumberLiteral(0.01, Unit::None)),
                     op: '*',
                 },
+                (Type::Float32, Type::Percent) => Expression::BinaryExpression {
+                    lhs: Box::new(self),
+                    rhs: Box::new(Expression::NumberLiteral(100., Unit::None)),
+                    op: '*',
+                },
                 (ref from_ty @ Type::Struct(ref left), Type::Struct(right))
                     if left.fields != right.fields =>
                 {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -267,6 +267,7 @@ impl Type {
             | (_, Type::Void)
             | (Type::Float32, Type::Int32)
             | (Type::Float32, Type::String)
+            | (Type::Float32, Type::Percent)
             | (Type::Int32, Type::Float32)
             | (Type::Int32, Type::String)
             | (Type::Float32, Type::Model)

--- a/internal/compiler/tests/syntax/basic/percent.slint
+++ b/internal/compiler/tests/syntax/basic/percent.slint
@@ -8,6 +8,9 @@ Foo := Rectangle {
     preferred-width: 50%;
 //                   >  <error{preferred-width must either be a length, or the literal '100%'}
 
+    property <percent> percent_property: 5;
+//                                       > <error{Cannot convert float to percent}
+
 
     Rectangle {
         height: 111%;

--- a/internal/compiler/tests/syntax/basic/percent.slint
+++ b/internal/compiler/tests/syntax/basic/percent.slint
@@ -8,6 +8,7 @@ Foo := Rectangle {
     preferred-width: 50%;
 //                   >  <error{preferred-width must either be a length, or the literal '100%'}
 
+    // We don't wanna have implicit conversion from float to percent, because this 5 would be 500% and not 5%
     property <percent> percent_property: 5;
 //                                       > <error{Cannot convert float to percent}
 


### PR DESCRIPTION
Description: This allows to do calculations on relative values by using Floats and converting then to percentage by *1% or by dividing by 100. Example:
```slint
private property <float> f: 50;
private property <percent> p: (f / 2) * 1%;
```

```slint
private property <float> f: 50;
private property <percent> p: (f / 2) / 100;
```
Fixes: #3785

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
