### PR TITLE
Add embedded MCP server for in-process UI introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4942,6 +4942,7 @@ dependencies = [
  "include_dir",
  "pb-rs",
  "quick-protobuf",
+ "serde",
  "serde_json",
  "slint",
  "vtable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,9 +4930,11 @@ name = "i-slint-backend-testing"
 version = "1.16.0"
 dependencies = [
  "async-net",
+ "base64 0.22.1",
  "byteorder",
  "futures-lite",
  "generational-arena",
+ "httparse",
  "i-slint-common",
  "i-slint-core",
  "i-slint-core-macros",
@@ -4940,6 +4942,7 @@ dependencies = [
  "include_dir",
  "pb-rs",
  "quick-protobuf",
+ "serde_json",
  "slint",
  "vtable",
 ]

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -75,6 +75,16 @@ unsafe-single-threaded = ["i-slint-core/unsafe-single-threaded"]
 ## APIs to support screen readers and other assistive technologies.
 accessibility = ["i-slint-backend-selector/accessibility"]
 
+## Enable the embedded MCP (Model Context Protocol) server for runtime UI introspection.
+##
+## When this feature is enabled and the `SLINT_MCP_PORT` environment variable is set at runtime,
+## the application starts an HTTP server that exposes the UI element tree, properties, and
+## interaction capabilities via the MCP protocol. This allows MCP clients (e.g. coding assistants)
+## to inspect and interact with the running application.
+##
+## Requires `SLINT_EMIT_DEBUG_INFO=1` at build time for full element information.
+mcp = ["i-slint-backend-selector/mcp"]
+
 ## Enable integration with [raw-window-handle](raw_window_handle_06) version 0.6. This provides a
 ## [`Window::window_handle()`] function that returns a struct that implements
 ## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -50,6 +50,7 @@ accessibility = ["i-slint-backend-winit?/accessibility"]
 raw-window-handle-06 = ["i-slint-core/raw-window-handle-06", "i-slint-backend-winit?/raw-window-handle-06"]
 
 system-testing = ["i-slint-backend-testing/system-testing"]
+mcp = ["i-slint-backend-testing/mcp"]
 
 unstable-wgpu-27 = [
   "i-slint-core/unstable-wgpu-27",

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -172,6 +172,13 @@ pub fn with_global_context<R>(f: impl FnOnce(&SlintContext) -> R) -> Result<R, P
         i_slint_backend_testing::systest::init();
     }
 
+    #[cfg(feature = "mcp")]
+    if result.is_ok() && platform_created {
+        if let Err(e) = i_slint_backend_testing::mcp_server::init() {
+            i_slint_core::debug_log!("MCP server init failed: {e:?}");
+        }
+    }
+
     result
 }
 

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -22,7 +22,7 @@ internal = ["include_dir"]
 # ffi for C++ bindings
 ffi = []
 system-testing = ["quick-protobuf", "pb-rs", "generational-arena", "async-net", "futures-lite", "byteorder", "image"]
-mcp = ["generational-arena", "async-net", "futures-lite", "image", "serde_json", "base64", "httparse"]
+mcp = ["generational-arena", "async-net", "futures-lite", "image", "serde", "serde_json", "base64", "httparse"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["std", "shared-parley"] }
@@ -34,6 +34,7 @@ async-net = { version = "2.0.0", optional = true }
 futures-lite = { version = "2.3.0", optional = true }
 byteorder = { version = "1.5.0", optional = true }
 image = { workspace = true, optional = true, features = ["png"] }
+serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 base64 = { version = "0.22", optional = true }
 httparse = { version = "1", optional = true }

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -22,6 +22,7 @@ internal = ["include_dir"]
 # ffi for C++ bindings
 ffi = []
 system-testing = ["quick-protobuf", "pb-rs", "generational-arena", "async-net", "futures-lite", "byteorder", "image"]
+mcp = ["generational-arena", "async-net", "futures-lite", "image", "serde_json", "base64", "httparse"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["std", "shared-parley"] }
@@ -33,6 +34,9 @@ async-net = { version = "2.0.0", optional = true }
 futures-lite = { version = "2.3.0", optional = true }
 byteorder = { version = "1.5.0", optional = true }
 image = { workspace = true, optional = true, features = ["png"] }
+serde_json = { workspace = true, optional = true }
+base64 = { version = "0.22", optional = true }
+httparse = { version = "1", optional = true }
 include_dir = { version = "0.7", optional = true }
 
 [build-dependencies]

--- a/internal/backends/testing/introspection.rs
+++ b/internal/backends/testing/introspection.rs
@@ -1,0 +1,455 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Shared introspection state and logic used by both the systest (protobuf) and
+//! MCP (HTTP/JSON-RPC) transports.
+
+use i_slint_core::item_tree::ItemTreeRc;
+use i_slint_core::window::WindowAdapter;
+use i_slint_core::window::WindowInner;
+use std::cell::{Cell, RefCell};
+use std::rc::{Rc, Weak};
+
+use crate::{ElementHandle, ElementRoot, LayoutKind};
+
+thread_local! {
+    static SHARED_STATE: RefCell<Option<Rc<IntrospectionState>>> = const { RefCell::new(None) };
+    static HOOK_INSTALLED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Returns the shared introspection state, creating it if needed.
+/// Both `systest` and `mcp_server` use this to share window/element tracking.
+pub(crate) fn shared_state() -> Rc<IntrospectionState> {
+    SHARED_STATE.with(|s| {
+        let mut borrow = s.borrow_mut();
+        if let Some(state) = borrow.as_ref() {
+            return state.clone();
+        }
+        let state = Rc::new(IntrospectionState::new());
+        *borrow = Some(state.clone());
+        state
+    })
+}
+
+/// Ensures the window-shown hook is installed for window tracking.
+/// Safe to call multiple times — only installs once.
+/// Chains with any previously installed hook.
+///
+/// **Init order**: Both `systest::init()` and `mcp_server::init()` call this function
+/// first, then layer their own hooks on top via the same capture-and-chain pattern.
+/// The current call order (from `selector/lib.rs`) is: systest first, then mcp_server.
+/// This order is safe because `ensure_window_tracking` is idempotent and each subsequent
+/// caller chains onto the previous hook. Changing the init order in the selector is safe
+/// as long as `ensure_window_tracking()` is always called before installing additional hooks.
+pub(crate) fn ensure_window_tracking() -> Result<(), i_slint_core::api::EventLoopError> {
+    HOOK_INSTALLED.with(|installed| {
+        if installed.get() {
+            return Ok(());
+        }
+        installed.set(true);
+
+        let state = shared_state();
+
+        // Capture and chain any existing hook (e.g. from systest if it ran first)
+        let previous_hook = i_slint_core::context::set_window_shown_hook(None)
+            .map_err(|_| i_slint_core::api::EventLoopError::NoEventLoopProvider)?;
+        let previous_hook = RefCell::new(previous_hook);
+
+        i_slint_core::context::set_window_shown_hook(Some(Box::new(move |adapter| {
+            if let Some(prev) = previous_hook.borrow_mut().as_mut() {
+                prev(adapter);
+            }
+            state.add_window(adapter);
+        })))
+        .map_err(|_| i_slint_core::api::EventLoopError::NoEventLoopProvider)?;
+
+        Ok(())
+    })
+}
+
+pub(crate) struct RootWrapper<'a>(pub &'a ItemTreeRc);
+
+impl ElementRoot for RootWrapper<'_> {
+    fn item_tree(&self) -> ItemTreeRc {
+        self.0.clone()
+    }
+}
+
+impl super::Sealed for RootWrapper<'_> {}
+
+/// A tracked window with its adapter and cached root element handle.
+pub(crate) struct TrackedWindow {
+    pub window_adapter: Weak<dyn WindowAdapter>,
+    pub root_element_handle: generational_arena::Index,
+}
+
+/// Shared introspection state: window and element handle arenas.
+///
+/// Used by both `systest` (protobuf over TCP) and `mcp_server` (JSON-RPC over HTTP).
+pub(crate) struct IntrospectionState {
+    pub windows: RefCell<generational_arena::Arena<TrackedWindow>>,
+    pub element_handles: RefCell<generational_arena::Arena<ElementHandle>>,
+}
+
+impl IntrospectionState {
+    pub fn new() -> Self {
+        Self {
+            windows: Default::default(),
+            element_handles: Default::default(),
+        }
+    }
+
+    pub fn add_window(&self, adapter: &Rc<dyn WindowAdapter>) {
+        let root_element_handle = {
+            let window = adapter.window();
+            let item_tree = WindowInner::from_pub(window).component();
+            let root_wrapper = RootWrapper(&item_tree);
+            self.element_to_handle(root_wrapper.root_element())
+        };
+        self.windows.borrow_mut().insert(TrackedWindow {
+            window_adapter: Rc::downgrade(adapter),
+            root_element_handle,
+        });
+    }
+
+    pub fn window_handles(&self) -> Vec<generational_arena::Index> {
+        self.windows.borrow().iter().map(|(index, _)| index).collect()
+    }
+
+    pub fn window_adapter(
+        &self,
+        window_index: generational_arena::Index,
+    ) -> Result<Rc<dyn WindowAdapter>, String> {
+        self.windows
+            .borrow()
+            .get(window_index)
+            .ok_or_else(|| "Invalid window handle".to_string())?
+            .window_adapter
+            .upgrade()
+            .ok_or_else(|| "Attempting to access deleted window".to_string())
+    }
+
+    pub fn root_element_handle(
+        &self,
+        window_index: generational_arena::Index,
+    ) -> Result<generational_arena::Index, String> {
+        Ok(self
+            .windows
+            .borrow()
+            .get(window_index)
+            .ok_or_else(|| "Invalid window handle".to_string())?
+            .root_element_handle)
+    }
+
+    pub fn element_to_handle(&self, element: ElementHandle) -> generational_arena::Index {
+        self.element_handles.borrow_mut().insert(element)
+    }
+
+    pub fn element(
+        &self,
+        request: &str,
+        index: generational_arena::Index,
+    ) -> Result<ElementHandle, String> {
+        let element = self
+            .element_handles
+            .borrow()
+            .get(index)
+            .ok_or_else(|| format!("Invalid element handle for {request}"))?
+            .clone();
+        if !element.is_valid() {
+            self.element_handles.borrow_mut().remove(index);
+            return Err(format!(
+                "Element handle for {request} refers to element that was destroyed"
+            ));
+        }
+        Ok(element)
+    }
+
+    pub fn find_elements_by_id(
+        &self,
+        window_index: generational_arena::Index,
+        elements_id: &str,
+    ) -> Result<Vec<ElementHandle>, String> {
+        let adapter = self.window_adapter(window_index)?;
+        let window = adapter.window();
+        let item_tree = WindowInner::from_pub(window).component();
+        Ok(ElementHandle::find_by_element_id(&RootWrapper(&item_tree), elements_id)
+            .collect::<Vec<_>>())
+    }
+
+    pub fn element_properties(&self, element: &ElementHandle) -> ElementProperties {
+        let type_names_and_ids: Vec<(String, String)> =
+            core::iter::once((
+                element.type_name().unwrap_or_default().to_string(),
+                element.id().unwrap_or_default().to_string(),
+            ))
+            .chain(
+                element
+                    .bases()
+                    .into_iter()
+                    .flatten()
+                    .map(|base_type_name| (base_type_name.to_string(), "root".to_string())),
+            )
+            .collect();
+
+        ElementProperties {
+            type_names_and_ids,
+            accessible_role: accessible_role_to_string(
+                element.accessible_role().unwrap_or(i_slint_core::items::AccessibleRole::None),
+            ),
+            accessible_label: element.accessible_label().map(|s| s.to_string()),
+            accessible_value: non_empty(
+                element.accessible_value().unwrap_or_default().to_string(),
+            ),
+            accessible_description: non_empty(
+                element.accessible_description().unwrap_or_default().to_string(),
+            ),
+            accessible_placeholder_text: non_empty(
+                element.accessible_placeholder_text().unwrap_or_default().to_string(),
+            ),
+            accessible_checked: element.accessible_checked().unwrap_or_default(),
+            accessible_checkable: element.accessible_checkable().unwrap_or_default(),
+            accessible_enabled: element.accessible_enabled().unwrap_or_default(),
+            accessible_read_only: element.accessible_read_only().unwrap_or_default(),
+            accessible_value_minimum: element.accessible_value_minimum().unwrap_or_default(),
+            accessible_value_maximum: element.accessible_value_maximum().unwrap_or_default(),
+            accessible_value_step: element.accessible_value_step().unwrap_or_default(),
+            size: element.size(),
+            absolute_position: element.absolute_position(),
+            computed_opacity: element.computed_opacity(),
+            layout_kind: element.layout_kind(),
+        }
+    }
+
+    pub fn query_element_descendants(
+        &self,
+        element: ElementHandle,
+        instructions: Vec<QueryInstruction>,
+        find_all: bool,
+    ) -> Result<Vec<ElementHandle>, String> {
+        let mut query = element.query_descendants();
+        for instruction in instructions {
+            match instruction {
+                QueryInstruction::MatchDescendants => {
+                    query = query.match_descendants();
+                }
+                QueryInstruction::MatchId(id) => {
+                    query = query.match_id(id);
+                }
+                QueryInstruction::MatchTypeName(name) => {
+                    query = query.match_type_name(name);
+                }
+                QueryInstruction::MatchTypeNameOrBase(name) => {
+                    query = query.match_inherits(name);
+                }
+                QueryInstruction::MatchAccessibleRole(role) => {
+                    query = query.match_accessible_role(role);
+                }
+            }
+        }
+        Ok(if find_all { query.find_all() } else { query.find_first().into_iter().collect() })
+    }
+
+    /// Take a screenshot of a window, encoding it in the given MIME type.
+    /// Pass an empty string or "image/png" for PNG (the default).
+    pub fn take_snapshot(
+        &self,
+        window_index: generational_arena::Index,
+        image_mime_type: &str,
+    ) -> Result<Vec<u8>, String> {
+        let adapter = self.window_adapter(window_index)?;
+        let window = adapter.window();
+        let buffer =
+            window.take_snapshot().map_err(|e| format!("Error grabbing window screenshot: {e}"))?;
+        let format = if image_mime_type.is_empty() {
+            image::ImageFormat::Png
+        } else {
+            image::ImageFormat::from_mime_type(image_mime_type).ok_or_else(|| {
+                format!(
+                    "Unsupported image format {image_mime_type} requested for window snapshotting"
+                )
+            })?
+        };
+        let mut encoded: Vec<u8> = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut encoded);
+        image::write_buffer_with_format(
+            &mut cursor,
+            buffer.as_bytes(),
+            buffer.width(),
+            buffer.height(),
+            image::ExtendedColorType::Rgba8,
+            format,
+        )
+        .map_err(|e| {
+            format!("error encoding {image_mime_type} image after screenshot: {e}")
+        })?;
+        Ok(encoded)
+    }
+
+    pub fn dispatch_window_event(
+        &self,
+        window_index: generational_arena::Index,
+        event: i_slint_core::platform::WindowEvent,
+    ) -> Result<(), String> {
+        let adapter = self.window_adapter(window_index)?;
+        let window = adapter.window();
+        window.dispatch_event(event);
+        Ok(())
+    }
+
+    pub fn window_properties(
+        &self,
+        window_index: generational_arena::Index,
+    ) -> Result<WindowProperties, String> {
+        let adapter = self.window_adapter(window_index)?;
+        let window = adapter.window();
+        Ok(WindowProperties {
+            is_fullscreen: window.is_fullscreen(),
+            is_maximized: window.is_maximized(),
+            is_minimized: window.is_minimized(),
+            size: window.size(),
+            position: window.position(),
+            root_element_handle: self.root_element_handle(window_index)?,
+        })
+    }
+
+    pub fn invoke_element_accessibility_action(
+        &self,
+        element: &ElementHandle,
+        action: AccessibilityAction,
+    ) -> Result<(), String> {
+        match action {
+            AccessibilityAction::Default => element.invoke_accessible_default_action(),
+            AccessibilityAction::Increment => element.invoke_accessible_increment_action(),
+            AccessibilityAction::Decrement => element.invoke_accessible_decrement_action(),
+            AccessibilityAction::Expand => element.invoke_accessible_expand_action(),
+        }
+        Ok(())
+    }
+}
+
+fn non_empty(s: String) -> Option<String> {
+    if s.is_empty() { None } else { Some(s) }
+}
+
+// ============================================================================
+// Transport-independent types
+// ============================================================================
+
+pub(crate) struct WindowProperties {
+    pub is_fullscreen: bool,
+    pub is_maximized: bool,
+    pub is_minimized: bool,
+    pub size: i_slint_core::api::PhysicalSize,
+    pub position: i_slint_core::api::PhysicalPosition,
+    pub root_element_handle: generational_arena::Index,
+}
+
+pub(crate) struct ElementProperties {
+    pub type_names_and_ids: Vec<(String, String)>,
+    pub accessible_role: &'static str,
+    pub accessible_label: Option<String>,
+    pub accessible_value: Option<String>,
+    pub accessible_description: Option<String>,
+    pub accessible_placeholder_text: Option<String>,
+    pub accessible_checked: bool,
+    pub accessible_checkable: bool,
+    pub accessible_enabled: bool,
+    pub accessible_read_only: bool,
+    pub accessible_value_minimum: f32,
+    pub accessible_value_maximum: f32,
+    pub accessible_value_step: f32,
+    pub size: i_slint_core::api::LogicalSize,
+    pub absolute_position: i_slint_core::api::LogicalPosition,
+    pub computed_opacity: f32,
+    pub layout_kind: Option<LayoutKind>,
+}
+
+pub(crate) enum QueryInstruction {
+    MatchDescendants,
+    MatchId(String),
+    MatchTypeName(String),
+    MatchTypeNameOrBase(String),
+    MatchAccessibleRole(i_slint_core::items::AccessibleRole),
+}
+
+pub(crate) enum AccessibilityAction {
+    Default,
+    Increment,
+    Decrement,
+    Expand,
+}
+
+pub(crate) fn accessible_role_to_string(role: i_slint_core::items::AccessibleRole) -> &'static str {
+    match role {
+        i_slint_core::items::AccessibleRole::None => "unknown",
+        i_slint_core::items::AccessibleRole::Button => "button",
+        i_slint_core::items::AccessibleRole::Checkbox => "checkbox",
+        i_slint_core::items::AccessibleRole::Combobox => "combobox",
+        i_slint_core::items::AccessibleRole::List => "list",
+        i_slint_core::items::AccessibleRole::Slider => "slider",
+        i_slint_core::items::AccessibleRole::Spinbox => "spinbox",
+        i_slint_core::items::AccessibleRole::Tab => "tab",
+        i_slint_core::items::AccessibleRole::TabList => "tab-list",
+        i_slint_core::items::AccessibleRole::Text => "text",
+        i_slint_core::items::AccessibleRole::Table => "table",
+        i_slint_core::items::AccessibleRole::Tree => "tree",
+        i_slint_core::items::AccessibleRole::ProgressIndicator => "progress-indicator",
+        i_slint_core::items::AccessibleRole::TextInput => "text-input",
+        i_slint_core::items::AccessibleRole::Switch => "switch",
+        i_slint_core::items::AccessibleRole::ListItem => "list-item",
+        i_slint_core::items::AccessibleRole::TabPanel => "tab-panel",
+        i_slint_core::items::AccessibleRole::Groupbox => "groupbox",
+        i_slint_core::items::AccessibleRole::Image => "image",
+        i_slint_core::items::AccessibleRole::RadioButton => "radio-button",
+        _ => "unknown",
+    }
+}
+
+pub(crate) fn string_to_accessible_role(
+    s: &str,
+) -> Option<i_slint_core::items::AccessibleRole> {
+    Some(match s {
+        "unknown" => i_slint_core::items::AccessibleRole::None,
+        "button" => i_slint_core::items::AccessibleRole::Button,
+        "checkbox" => i_slint_core::items::AccessibleRole::Checkbox,
+        "combobox" => i_slint_core::items::AccessibleRole::Combobox,
+        "list" => i_slint_core::items::AccessibleRole::List,
+        "slider" => i_slint_core::items::AccessibleRole::Slider,
+        "spinbox" => i_slint_core::items::AccessibleRole::Spinbox,
+        "tab" => i_slint_core::items::AccessibleRole::Tab,
+        "tab-list" => i_slint_core::items::AccessibleRole::TabList,
+        "text" => i_slint_core::items::AccessibleRole::Text,
+        "table" => i_slint_core::items::AccessibleRole::Table,
+        "tree" => i_slint_core::items::AccessibleRole::Tree,
+        "progress-indicator" => i_slint_core::items::AccessibleRole::ProgressIndicator,
+        "text-input" => i_slint_core::items::AccessibleRole::TextInput,
+        "switch" => i_slint_core::items::AccessibleRole::Switch,
+        "list-item" => i_slint_core::items::AccessibleRole::ListItem,
+        "tab-panel" => i_slint_core::items::AccessibleRole::TabPanel,
+        "groupbox" => i_slint_core::items::AccessibleRole::Groupbox,
+        "image" => i_slint_core::items::AccessibleRole::Image,
+        "radio-button" => i_slint_core::items::AccessibleRole::RadioButton,
+        _ => return None,
+    })
+}
+
+/// Converts an arena Index to a (index, generation) pair for serialization.
+pub(crate) fn index_to_parts(index: generational_arena::Index) -> (u64, u64) {
+    let (idx, generation) = index.into_raw_parts();
+    (idx as u64, generation)
+}
+
+/// Converts a (index, generation) pair back to an arena Index.
+pub(crate) fn parts_to_index(index: u64, generation: u64) -> generational_arena::Index {
+    generational_arena::Index::from_raw_parts(index as usize, generation)
+}
+
+pub(crate) fn layout_kind_to_string(lk: &crate::LayoutKind) -> &'static str {
+    match lk {
+        crate::LayoutKind::HorizontalLayout => "horizontal",
+        crate::LayoutKind::VerticalLayout => "vertical",
+        crate::LayoutKind::GridLayout => "grid",
+        crate::LayoutKind::FlexBox => "flex-box",
+    }
+}

--- a/internal/backends/testing/introspection.rs
+++ b/internal/backends/testing/introspection.rs
@@ -113,10 +113,9 @@ impl IntrospectionState {
             let root_wrapper = RootWrapper(&item_tree);
             self.element_to_handle(root_wrapper.root_element())
         };
-        self.windows.borrow_mut().insert(TrackedWindow {
-            window_adapter: Rc::downgrade(adapter),
-            root_element_handle,
-        });
+        self.windows
+            .borrow_mut()
+            .insert(TrackedWindow { window_adapter: Rc::downgrade(adapter), root_element_handle });
     }
 
     pub fn window_handles(&self) -> Vec<generational_arena::Index> {
@@ -221,19 +220,18 @@ impl IntrospectionState {
     }
 
     pub fn element_properties(&self, element: &ElementHandle) -> ElementProperties {
-        let type_names_and_ids: Vec<(String, String)> =
-            core::iter::once((
-                element.type_name().unwrap_or_default().to_string(),
-                element.id().unwrap_or_default().to_string(),
-            ))
-            .chain(
-                element
-                    .bases()
-                    .into_iter()
-                    .flatten()
-                    .map(|base_type_name| (base_type_name.to_string(), "root".to_string())),
-            )
-            .collect();
+        let type_names_and_ids: Vec<(String, String)> = core::iter::once((
+            element.type_name().unwrap_or_default().to_string(),
+            element.id().unwrap_or_default().to_string(),
+        ))
+        .chain(
+            element
+                .bases()
+                .into_iter()
+                .flatten()
+                .map(|base_type_name| (base_type_name.to_string(), "root".to_string())),
+        )
+        .collect();
 
         ElementProperties {
             type_names_and_ids,
@@ -241,9 +239,7 @@ impl IntrospectionState {
                 element.accessible_role().unwrap_or(i_slint_core::items::AccessibleRole::None),
             ),
             accessible_label: element.accessible_label().map(|s| s.to_string()),
-            accessible_value: non_empty(
-                element.accessible_value().unwrap_or_default().to_string(),
-            ),
+            accessible_value: non_empty(element.accessible_value().unwrap_or_default().to_string()),
             accessible_description: non_empty(
                 element.accessible_description().unwrap_or_default().to_string(),
             ),
@@ -323,9 +319,7 @@ impl IntrospectionState {
             image::ExtendedColorType::Rgba8,
             format,
         )
-        .map_err(|e| {
-            format!("error encoding {image_mime_type} image after screenshot: {e}")
-        })?;
+        .map_err(|e| format!("error encoding {image_mime_type} image after screenshot: {e}"))?;
         Ok(encoded)
     }
 
@@ -449,9 +443,7 @@ pub(crate) fn accessible_role_to_string(role: i_slint_core::items::AccessibleRol
     }
 }
 
-pub(crate) fn string_to_accessible_role(
-    s: &str,
-) -> Option<i_slint_core::items::AccessibleRole> {
+pub(crate) fn string_to_accessible_role(s: &str) -> Option<i_slint_core::items::AccessibleRole> {
     Some(match s {
         "unknown" => i_slint_core::items::AccessibleRole::None,
         "button" => i_slint_core::items::AccessibleRole::Button,

--- a/internal/backends/testing/introspection.rs
+++ b/internal/backends/testing/introspection.rs
@@ -8,9 +8,13 @@ use i_slint_core::item_tree::ItemTreeRc;
 use i_slint_core::window::WindowAdapter;
 use i_slint_core::window::WindowInner;
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::rc::{Rc, Weak};
 
 use crate::{ElementHandle, ElementRoot, LayoutKind};
+
+/// Maximum number of element handles kept in the arena before evicting the oldest.
+const ELEMENT_HANDLE_CAP: usize = 10_000;
 
 thread_local! {
     static SHARED_STATE: RefCell<Option<Rc<IntrospectionState>>> = const { RefCell::new(None) };
@@ -89,6 +93,8 @@ pub(crate) struct TrackedWindow {
 pub(crate) struct IntrospectionState {
     pub windows: RefCell<generational_arena::Arena<TrackedWindow>>,
     pub element_handles: RefCell<generational_arena::Arena<ElementHandle>>,
+    /// Insertion-order queue for FIFO eviction. Front = oldest.
+    element_handle_order: RefCell<VecDeque<generational_arena::Index>>,
 }
 
 impl IntrospectionState {
@@ -96,6 +102,7 @@ impl IntrospectionState {
         Self {
             windows: Default::default(),
             element_handles: Default::default(),
+            element_handle_order: Default::default(),
         }
     }
 
@@ -142,7 +149,43 @@ impl IntrospectionState {
     }
 
     pub fn element_to_handle(&self, element: ElementHandle) -> generational_arena::Index {
-        self.element_handles.borrow_mut().insert(element)
+        let mut arena = self.element_handles.borrow_mut();
+        let index = arena.insert(element);
+        let mut order = self.element_handle_order.borrow_mut();
+        order.push_back(index);
+        // Evict oldest handles when over cap, skipping root element handles.
+        if arena.len() > ELEMENT_HANDLE_CAP {
+            // Collect root indices upfront to avoid borrowing self.windows per iteration.
+            let root_indices: std::collections::HashSet<generational_arena::Index> =
+                self.windows.borrow().iter().map(|(_, w)| w.root_element_handle).collect();
+            // Budget prevents infinite spinning when only root/stale entries remain.
+            // Note: arena may remain above cap by at most the number of tracked windows.
+            let mut budget = order.len();
+            while arena.len() > ELEMENT_HANDLE_CAP && budget > 0 {
+                budget -= 1;
+                let Some(oldest) = order.pop_front() else { break };
+                if !arena.contains(oldest) {
+                    continue; // stale entry — don't re-enqueue
+                }
+                if root_indices.contains(&oldest) {
+                    order.push_back(oldest);
+                    continue;
+                }
+                arena.remove(oldest);
+            }
+        }
+        index
+    }
+
+    /// Remove a set of element handles from the arena (used for scoped/ephemeral handles).
+    #[allow(dead_code)]
+    pub fn remove_handles(&self, handles: &[generational_arena::Index]) {
+        let mut arena = self.element_handles.borrow_mut();
+        for &h in handles {
+            arena.remove(h);
+        }
+        // No need to clean up element_handle_order — stale entries are
+        // harmless (remove on an already-removed index is a no-op).
     }
 
     pub fn element(
@@ -451,5 +494,78 @@ pub(crate) fn layout_kind_to_string(lk: &crate::LayoutKind) -> &'static str {
         crate::LayoutKind::VerticalLayout => "vertical",
         crate::LayoutKind::GridLayout => "grid",
         crate::LayoutKind::FlexBox => "flex-box",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_element() -> ElementHandle {
+        ElementHandle::new_test_dummy()
+    }
+
+    #[test]
+    fn test_element_to_handle_and_remove() {
+        let state = IntrospectionState::new();
+        let h1 = state.element_to_handle(dummy_element());
+        let h2 = state.element_to_handle(dummy_element());
+        assert_eq!(state.element_handles.borrow().len(), 2);
+
+        state.remove_handles(&[h1]);
+        assert_eq!(state.element_handles.borrow().len(), 1);
+        assert!(state.element_handles.borrow().get(h1).is_none());
+        assert!(state.element_handles.borrow().get(h2).is_some());
+    }
+
+    #[test]
+    fn test_remove_handles_idempotent() {
+        let state = IntrospectionState::new();
+        let h = state.element_to_handle(dummy_element());
+        state.remove_handles(&[h]);
+        assert_eq!(state.element_handles.borrow().len(), 0);
+        // Removing again is a no-op
+        state.remove_handles(&[h]);
+        assert_eq!(state.element_handles.borrow().len(), 0);
+    }
+
+    #[test]
+    fn test_eviction_caps_arena_size() {
+        let state = IntrospectionState::new();
+        let mut handles = Vec::new();
+        // Insert more than the cap
+        for _ in 0..ELEMENT_HANDLE_CAP + 100 {
+            handles.push(state.element_to_handle(dummy_element()));
+        }
+        // Arena should be capped
+        assert!(state.element_handles.borrow().len() <= ELEMENT_HANDLE_CAP);
+        // The most recent handles should still be valid
+        let last = *handles.last().unwrap();
+        assert!(state.element_handles.borrow().get(last).is_some());
+        // The earliest handles should have been evicted
+        let first = handles[0];
+        assert!(state.element_handles.borrow().get(first).is_none());
+    }
+
+    #[test]
+    fn test_eviction_preserves_root_element_handles() {
+        let state = IntrospectionState::new();
+        // Simulate a root element handle by inserting a window with a known handle
+        let root_handle = state.element_to_handle(dummy_element());
+        state.windows.borrow_mut().insert(TrackedWindow {
+            window_adapter: Weak::<crate::testing_backend::TestingWindow>::new(),
+            root_element_handle: root_handle,
+        });
+
+        // Fill past the cap
+        for _ in 0..ELEMENT_HANDLE_CAP + 100 {
+            state.element_to_handle(dummy_element());
+        }
+
+        // Root handle must survive eviction
+        assert!(
+            state.element_handles.borrow().get(root_handle).is_some(),
+            "root element handle should not be evicted"
+        );
     }
 }

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -15,8 +15,12 @@ mod testing_backend;
 pub use testing_backend::*;
 #[cfg(all(feature = "ffi", not(test)))]
 mod ffi;
+#[cfg(any(feature = "system-testing", feature = "mcp"))]
+pub(crate) mod introspection;
 #[cfg(feature = "system-testing")]
 pub mod systest;
+#[cfg(feature = "mcp")]
+pub mod mcp_server;
 
 /// Initialize the testing backend without support for event loop.
 /// This means that each test thread can use its own backend, but global functions that needs

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -20,7 +20,7 @@ pub(crate) mod introspection;
 #[cfg(feature = "system-testing")]
 pub mod systest;
 #[cfg(feature = "mcp")]
-pub mod mcp_server;
+pub(crate) mod mcp_server;
 
 /// Initialize the testing backend without support for event loop.
 /// This means that each test thread can use its own backend, but global functions that needs

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -17,10 +17,10 @@ pub use testing_backend::*;
 mod ffi;
 #[cfg(any(feature = "system-testing", feature = "mcp"))]
 pub(crate) mod introspection;
-#[cfg(feature = "system-testing")]
-pub mod systest;
 #[cfg(feature = "mcp")]
 pub(crate) mod mcp_server;
+#[cfg(feature = "system-testing")]
+pub mod systest;
 
 /// Initialize the testing backend without support for event loop.
 /// This means that each test thread can use its own backend, but global functions that needs

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -18,7 +18,7 @@ mod ffi;
 #[cfg(any(feature = "system-testing", feature = "mcp"))]
 pub(crate) mod introspection;
 #[cfg(feature = "mcp")]
-pub(crate) mod mcp_server;
+pub mod mcp_server;
 #[cfg(feature = "system-testing")]
 pub mod systest;
 

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -1,0 +1,1262 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Embedded MCP (Model Context Protocol) server for introspecting Slint applications.
+//!
+//! When enabled via the `SLINT_MCP_PORT` environment variable, the application starts
+//! an HTTP server implementing MCP's Streamable HTTP transport, allowing MCP clients
+//! (e.g. Claude) to inspect and interact with the running UI.
+//!
+//! # Usage
+//!
+//! Build with the `mcp` feature and set the environment variable:
+//! ```sh
+//! SLINT_MCP_PORT=8080 ./your-slint-app
+//! ```
+
+use base64::Engine;
+use futures_lite::{AsyncReadExt, AsyncWriteExt};
+use i_slint_core::api::EventLoopError;
+use i_slint_core::debug_log;
+use serde_json::Value;
+use std::rc::Rc;
+
+use crate::introspection::{
+    self, AccessibilityAction, IntrospectionState, QueryInstruction,
+};
+
+// ============================================================================
+// Handle serialization
+// ============================================================================
+
+fn handle_to_json(index: generational_arena::Index) -> Value {
+    let (idx, generation) = introspection::index_to_parts(index);
+    serde_json::json!({ "index": idx, "generation": generation })
+}
+
+fn handle_from_json(v: &Value) -> Result<generational_arena::Index, String> {
+    let index = v.get("index").and_then(|v| v.as_u64()).ok_or("missing index in handle")?;
+    let generation =
+        v.get("generation").and_then(|v| v.as_u64()).ok_or("missing generation in handle")?;
+    Ok(introspection::parts_to_index(index, generation))
+}
+
+// ============================================================================
+// MCP Tool Macro
+// ============================================================================
+
+/// Macro to declare MCP tools with automatic schema generation and dispatch.
+///
+/// Each tool declaration produces:
+/// - An entry in the `tools/list` response (name, description, input schema)
+/// - A match arm in the `tools/call` dispatch
+/// - Parameter deserialization from JSON arguments
+macro_rules! mcp_tools {
+    (
+        state: $state:ident, args: $args:ident;
+        $(
+            $(#[doc = $doc:literal])*
+            tool $name:ident (
+                $( $(#[doc = $param_doc:literal])* $param:ident : $param_ty:tt ),*
+                $(,)?
+            ) -> $ret:ty $body:block
+        )*
+    ) => {
+        fn tool_definitions() -> Value {
+            serde_json::json!({
+                "tools": [
+                    $(
+                        {
+                            "name": stringify!($name),
+                            "description": concat!($($doc, " "),*),
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    $(
+                                        stringify!($param): mcp_tools!(@schema $param_ty $(, $param_doc)*)
+                                    ),*
+                                },
+                                "required": mcp_tools!(@required $($param: $param_ty),*)
+                            }
+                        }
+                    ),*
+                ]
+            })
+        }
+
+        async fn handle_tool_call(
+            $state: &IntrospectionState,
+            name: &str,
+            $args: &Value,
+        ) -> Result<Value, String> {
+            match name {
+                $(
+                    stringify!($name) => {
+                        $(
+                            let $param = mcp_tools!(@extract $args, $param, $param_ty);
+                        )*
+                        let result: $ret = $body;
+                        result
+                    }
+                )*
+                _ => Err(format!("Unknown tool: {name}")),
+            }
+        }
+    };
+
+    // Schema generation for parameter types
+    (@schema Handle $(, $doc:literal)*) => {
+        serde_json::json!({
+            "type": "object",
+            "description": concat!($($doc, " "),*),
+            "properties": {
+                "index": { "type": "integer" },
+                "generation": { "type": "integer" }
+            },
+            "required": ["index", "generation"]
+        })
+    };
+    (@schema String $(, $doc:literal)*) => {
+        serde_json::json!({ "type": "string", "description": concat!($($doc, " "),*) })
+    };
+    (@schema OptionalString $(, $doc:literal)*) => {
+        serde_json::json!({ "type": "string", "description": concat!($($doc, " "),*) })
+    };
+    (@schema QueryArray $(, $doc:literal)*) => {
+        serde_json::json!({
+            "type": "array",
+            "description": concat!($($doc, " "),*),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "match_descendants": { "type": "boolean", "description": "If true, search recursively through all descendants" },
+                    "match_id": { "type": "string", "description": "Match elements by ID" },
+                    "match_type_name": { "type": "string", "description": "Match elements by type name" },
+                    "match_type_name_or_base": { "type": "string", "description": "Match elements by type name or inherited base type" },
+                    "match_accessible_role": { "type": "string", "description": "Match by accessible role (e.g., 'button', 'text', 'slider')" }
+                }
+            }
+        })
+    };
+    (@schema Bool $(, $doc:literal)*) => {
+        serde_json::json!({ "type": "boolean", "description": concat!($($doc, " "),*) })
+    };
+    (@schema OptionalBool $(, $doc:literal)*) => {
+        serde_json::json!({ "type": "boolean", "description": concat!($($doc, " "),*) })
+    };
+    (@schema OptionalInt $(, $doc:literal)*) => {
+        serde_json::json!({ "type": "integer", "description": concat!($($doc, " "),*) })
+    };
+
+    // Required fields: Handle and String are required, Optional* are not
+    (@required $($param:ident: $ty:tt),*) => {
+        {
+            #[allow(unused_mut)]
+            let mut required = Vec::<&str>::new();
+            $(
+                mcp_tools!(@required_check required, $param, $ty);
+            )*
+            required
+        }
+    };
+    (@required_check $vec:ident, $param:ident, Handle) => { $vec.push(stringify!($param)); };
+    (@required_check $vec:ident, $param:ident, String) => { $vec.push(stringify!($param)); };
+    (@required_check $vec:ident, $param:ident, QueryArray) => { $vec.push(stringify!($param)); };
+    (@required_check $vec:ident, $param:ident, Bool) => { $vec.push(stringify!($param)); };
+    (@required_check $vec:ident, $param:ident, $_ty:tt) => { };
+
+    // Parameter extraction from JSON args
+    (@extract $args:ident, $param:ident, Handle) => {
+        handle_from_json(
+            $args.get(stringify!($param))
+                .ok_or_else(|| format!("missing {}", stringify!($param)))?
+        )?
+    };
+    (@extract $args:ident, $param:ident, String) => {
+        $args.get(stringify!($param))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("missing {}", stringify!($param)))?
+            .to_string()
+    };
+    (@extract $args:ident, $param:ident, OptionalString) => {
+        $args.get(stringify!($param)).and_then(|v| v.as_str()).unwrap_or("").to_string()
+    };
+    (@extract $args:ident, $param:ident, QueryArray) => {
+        $args.get(stringify!($param))
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| format!("missing {}", stringify!($param)))?
+            .clone()
+    };
+    (@extract $args:ident, $param:ident, Bool) => {
+        $args.get(stringify!($param))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    };
+    (@extract $args:ident, $param:ident, OptionalBool) => {
+        $args.get(stringify!($param)).and_then(|v| v.as_bool())
+    };
+    (@extract $args:ident, $param:ident, OptionalInt) => {
+        $args.get(stringify!($param)).and_then(|v| v.as_u64())
+    };
+}
+
+// ============================================================================
+// Tool Definitions
+// ============================================================================
+
+mcp_tools! {
+    state: state, args: args;
+
+    /// List all windows in the application. Returns window handles for use with other tools.
+    /// This is typically the first tool to call.
+    tool list_windows() -> Result<Value, String> {
+        let handles: Vec<Value> = state.window_handles().into_iter().map(handle_to_json).collect();
+        Ok(serde_json::json!({ "windows": handles }))
+    }
+
+    /// Get properties of a window (size, position, fullscreen/maximized/minimized state,
+    /// root element handle). The root_element_handle is the entry point for element tree traversal.
+    tool get_window_properties(
+        /// Window handle from list_windows.
+        window_handle: Handle,
+    ) -> Result<Value, String> {
+        let wp = state.window_properties(window_handle)?;
+        Ok(serde_json::json!({
+            "is_fullscreen": wp.is_fullscreen,
+            "is_maximized": wp.is_maximized,
+            "is_minimized": wp.is_minimized,
+            "size": { "width": wp.size.width, "height": wp.size.height },
+            "position": { "x": wp.position.x, "y": wp.position.y },
+            "root_element_handle": handle_to_json(wp.root_element_handle)
+        }))
+    }
+
+    /// Find elements by their qualified ID (e.g. 'App::mybutton'). Returns element handles.
+    /// Use get_element_tree first to discover available element IDs.
+    tool find_elements_by_id(
+        /// Window handle.
+        window_handle: Handle,
+        /// Qualified element ID (e.g. 'App::mybutton').
+        element_id: String,
+    ) -> Result<Value, String> {
+        let elements = state.find_elements_by_id(window_handle, &element_id)?;
+        let handles: Vec<Value> = elements
+            .into_iter()
+            .map(|e| handle_to_json(state.element_to_handle(e)))
+            .collect();
+        Ok(serde_json::json!({ "elements": handles }))
+    }
+
+    /// Get all properties of an element: type info, accessible properties (label, value,
+    /// description, role, checked, enabled, etc.), geometry (position, size), and opacity.
+    tool get_element_properties(
+        /// Element handle.
+        element_handle: Handle,
+    ) -> Result<Value, String> {
+        let element = state.element("get_element_properties", element_handle)?;
+        Ok(element_properties_to_json(&state.element_properties(&element)))
+    }
+
+    /// Query descendants of an element using a chain of match instructions. Each instruction
+    /// narrows the search. Use match_descendants to search recursively, then filter by id,
+    /// type_name, or accessible_role. More efficient than get_element_tree for targeted searches.
+    tool query_element_descendants(
+        /// Element handle to start the query from.
+        element_handle: Handle,
+        /// Array of query instructions applied in order.
+        query: QueryArray,
+        /// If true, return all matches. If false, return only the first match.
+        find_all: OptionalBool,
+    ) -> Result<Value, String> {
+        let element = state.element("query_element_descendants", element_handle)?;
+        let instructions = parse_query_instructions(&query)?;
+        let find_all = find_all.unwrap_or(true);
+        let results = state.query_element_descendants(element, instructions, find_all)?;
+        let handles: Vec<Value> = results
+            .into_iter()
+            .map(|e| handle_to_json(state.element_to_handle(e)))
+            .collect();
+        Ok(serde_json::json!({ "elements": handles }))
+    }
+
+    /// Get all elements in the subtree starting from a root element. Returns a flat list of
+    /// elements with their properties and handles. Use this to get an overview of the UI, then
+    /// use get_element_properties or query_element_descendants for targeted exploration.
+    /// Limit the result count with max_elements (default: 200, max: 1000).
+    tool get_element_tree(
+        /// Root element handle (typically from get_window_properties root_element_handle).
+        element_handle: Handle,
+        /// Maximum number of elements to return (default: 200, max: 1000).
+        max_elements: OptionalInt,
+    ) -> Result<Value, String> {
+        let max_elements = max_elements.unwrap_or(200).min(1000) as usize;
+        collect_element_list(state, element_handle, max_elements)
+    }
+
+    /// Take a screenshot of a window. Returns an MCP image content block.
+    tool take_screenshot(
+        /// Window handle.
+        window_handle: Handle,
+    ) -> Result<Value, String> {
+        let png_data = state.take_snapshot(window_handle, "image/png")?;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&png_data);
+        Ok(serde_json::json!({
+            "_mcp_image": {
+                "data": b64,
+                "mimeType": "image/png"
+            },
+            "size_bytes": png_data.len()
+        }))
+    }
+
+    /// Simulate a mouse click on an element.
+    tool click_element(
+        /// Element handle.
+        element_handle: Handle,
+        /// Click action: "single_click" (default) or "double_click".
+        action: OptionalString,
+        /// Mouse button: "left" (default), "right", or "middle".
+        button: OptionalString,
+    ) -> Result<Value, String> {
+        let element = state.element("click_element", element_handle)?;
+        let button = match if button.is_empty() { "left" } else { &button } {
+            "left" => i_slint_core::platform::PointerEventButton::Left,
+            "right" => i_slint_core::platform::PointerEventButton::Right,
+            "middle" => i_slint_core::platform::PointerEventButton::Middle,
+            other => return Err(format!("Unknown button: {other}")),
+        };
+        match if action.is_empty() { "single_click" } else { &action } {
+            "single_click" => element.single_click(button).await,
+            "double_click" => element.double_click(button).await,
+            other => return Err(format!("Unknown click action: {other}")),
+        };
+        Ok(serde_json::json!({ "success": true }))
+    }
+
+    /// Invoke an accessibility action on an element (e.g. default action for buttons,
+    /// increment/decrement for sliders, expand for combo boxes).
+    tool invoke_accessibility_action(
+        /// Element handle.
+        element_handle: Handle,
+        /// The action: "default", "increment", "decrement", or "expand".
+        action: String,
+    ) -> Result<Value, String> {
+        let element = state.element("invoke_accessibility_action", element_handle)?;
+        let action = match action.as_str() {
+            "default" => AccessibilityAction::Default,
+            "increment" => AccessibilityAction::Increment,
+            "decrement" => AccessibilityAction::Decrement,
+            "expand" => AccessibilityAction::Expand,
+            other => return Err(format!("Unknown action: {other}")),
+        };
+        state.invoke_element_accessibility_action(&element, action)?;
+        Ok(serde_json::json!({ "success": true }))
+    }
+
+    /// Set the accessible value of an element (e.g. text input content, slider value).
+    tool set_element_value(
+        /// Element handle.
+        element_handle: Handle,
+        /// The value to set.
+        value: String,
+    ) -> Result<Value, String> {
+        let element = state.element("set_element_value", element_handle)?;
+        element.set_accessible_value(value);
+        Ok(serde_json::json!({ "success": true }))
+    }
+
+    /// Dispatch a keyboard event to a window.
+    tool dispatch_key_event(
+        /// Window handle.
+        window_handle: Handle,
+        /// The key text to send.
+        text: String,
+        /// Event type: "press", "release", or "press_and_release" (default).
+        event_type: OptionalString,
+    ) -> Result<Value, String> {
+        let event_type = if event_type.is_empty() { "press_and_release".to_string() } else { event_type };
+        let events: Vec<i_slint_core::platform::WindowEvent> = match event_type.as_str() {
+            "press" => vec![
+                i_slint_core::platform::WindowEvent::KeyPressed { text: text.clone().into() },
+            ],
+            "release" => vec![
+                i_slint_core::platform::WindowEvent::KeyReleased { text: text.clone().into() },
+            ],
+            "press_and_release" => vec![
+                i_slint_core::platform::WindowEvent::KeyPressed { text: text.clone().into() },
+                i_slint_core::platform::WindowEvent::KeyReleased { text: text.into() },
+            ],
+            other => return Err(format!("Unknown event_type: {other}")),
+        };
+        for event in events {
+            state.dispatch_window_event(window_handle, event)?;
+        }
+        Ok(serde_json::json!({ "success": true }))
+    }
+}
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+fn parse_query_instructions(arr: &[Value]) -> Result<Vec<QueryInstruction>, String> {
+    let mut instructions = Vec::new();
+    for item in arr {
+        let instr =
+            if item.get("match_descendants").and_then(|v| v.as_bool()).unwrap_or(false) {
+                QueryInstruction::MatchDescendants
+            } else if let Some(id) = item.get("match_id").and_then(|v| v.as_str()) {
+                QueryInstruction::MatchId(id.to_string())
+            } else if let Some(tn) = item.get("match_type_name").and_then(|v| v.as_str()) {
+                QueryInstruction::MatchTypeName(tn.to_string())
+            } else if let Some(tn) =
+                item.get("match_type_name_or_base").and_then(|v| v.as_str())
+            {
+                QueryInstruction::MatchTypeNameOrBase(tn.to_string())
+            } else if let Some(role_str) =
+                item.get("match_accessible_role").and_then(|v| v.as_str())
+            {
+                let role = introspection::string_to_accessible_role(role_str)
+                    .ok_or_else(|| format!("Unknown accessible role: {role_str}"))?;
+                QueryInstruction::MatchAccessibleRole(role)
+            } else {
+                return Err("Invalid query instruction".into());
+            };
+        instructions.push(instr);
+    }
+    Ok(instructions)
+}
+
+fn element_properties_to_json(ep: &introspection::ElementProperties) -> Value {
+    let type_info: Vec<Value> = ep
+        .type_names_and_ids
+        .iter()
+        .map(|(type_name, id)| serde_json::json!({ "type_name": type_name, "id": id }))
+        .collect();
+
+    let layout_kind = ep.layout_kind.as_ref().map(introspection::layout_kind_to_string);
+
+    serde_json::json!({
+        "type_info": type_info,
+        "accessible_role": ep.accessible_role,
+        "accessible_label": ep.accessible_label,
+        "accessible_value": ep.accessible_value,
+        "accessible_description": ep.accessible_description,
+        "accessible_placeholder_text": ep.accessible_placeholder_text,
+        "accessible_checked": ep.accessible_checked,
+        "accessible_checkable": ep.accessible_checkable,
+        "accessible_enabled": ep.accessible_enabled,
+        "accessible_read_only": ep.accessible_read_only,
+        "accessible_value_minimum": ep.accessible_value_minimum,
+        "accessible_value_maximum": ep.accessible_value_maximum,
+        "accessible_value_step": ep.accessible_value_step,
+        "size": { "width": ep.size.width, "height": ep.size.height },
+        "absolute_position": { "x": ep.absolute_position.x, "y": ep.absolute_position.y },
+        "computed_opacity": ep.computed_opacity,
+        "layout_kind": layout_kind
+    })
+}
+
+fn collect_element_list(
+    state: &IntrospectionState,
+    root_handle: generational_arena::Index,
+    max_elements: usize,
+) -> Result<Value, String> {
+    let root_element = state.element("get_element_tree", root_handle)?;
+
+    // Collect all descendants via visit_descendants (DFS order).
+    let mut elements: Vec<Value> = Vec::new();
+    let mut truncated = false;
+
+    // Add root element first
+    let root_props = state.element_properties(&root_element);
+    let mut root_node = element_properties_to_json(&root_props);
+    root_node
+        .as_object_mut()
+        .unwrap()
+        .insert("handle".to_string(), handle_to_json(root_handle));
+    elements.push(root_node);
+
+    root_element.visit_descendants(|child| {
+        if elements.len() >= max_elements {
+            truncated = true;
+            return std::ops::ControlFlow::Break(());
+        }
+        let child_handle = state.element_to_handle(child.clone());
+        let props = state.element_properties(&child);
+        let mut node = element_properties_to_json(&props);
+        node.as_object_mut()
+            .unwrap()
+            .insert("handle".to_string(), handle_to_json(child_handle));
+        elements.push(node);
+        std::ops::ControlFlow::<()>::Continue(())
+    });
+
+    Ok(serde_json::json!({
+        "elements": elements,
+        "total_count": elements.len(),
+        "truncated": truncated
+    }))
+}
+
+// ============================================================================
+// JSON-RPC 2.0
+// ============================================================================
+
+fn json_rpc_success(id: &Value, result: Value) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
+fn json_rpc_error(id: &Value, code: i32, message: String) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message }
+    })
+}
+
+async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Value> {
+    let request: Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => {
+            return Some(json_rpc_error(
+                &Value::Null,
+                -32700,
+                format!("Parse error: {e}"),
+            ))
+        }
+    };
+
+    let id = request.get("id").cloned().unwrap_or(Value::Null);
+    let method = request.get("method").and_then(|v| v.as_str()).unwrap_or("");
+    let is_notification = request.get("id").is_none();
+
+    let response = match method {
+        "initialize" => json_rpc_success(
+            &id,
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {
+                    "tools": {}
+                },
+                "serverInfo": {
+                    "name": "slint-mcp-embedded",
+                    "version": "0.1.0"
+                },
+                "instructions": concat!(
+                    "This is an embedded MCP server in a running Slint application. ",
+                    "It lets you inspect and interact with the application's UI.\n\n",
+                    "Recommended workflow:\n",
+                    "1. list_windows — get window handles\n",
+                    "2. get_window_properties — get the root_element_handle\n",
+                    "3. get_element_tree (max_depth=2-3) — explore the UI hierarchy\n",
+                    "4. Use find_elements_by_id or query_element_descendants for targeted lookups\n",
+                    "5. get_element_properties — inspect specific elements\n",
+                    "6. take_screenshot — see the current visual state\n\n",
+                    "Handles (window_handle, element_handle) are {index, generation} objects. ",
+                    "They remain valid as long as the UI element exists."
+                )
+            }),
+        ),
+        "notifications/initialized" => {
+            // Notification — no response needed
+            return None;
+        }
+        "tools/list" => json_rpc_success(&id, tool_definitions()),
+        "tools/call" => {
+            let params = request.get("params").cloned().unwrap_or(serde_json::json!({}));
+            let tool_name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let tool_args = params.get("arguments").cloned().unwrap_or(serde_json::json!({}));
+
+            match handle_tool_call(state, tool_name, &tool_args).await {
+                Ok(result) => {
+                    let content = if let Some(img) = result.get("_mcp_image") {
+                        let mut blocks = vec![serde_json::json!({
+                            "type": "image",
+                            "data": img.get("data").and_then(|v| v.as_str()).unwrap_or(""),
+                            "mimeType": img.get("mimeType").and_then(|v| v.as_str()).unwrap_or("image/png")
+                        })];
+                        let mut meta = result.clone();
+                        meta.as_object_mut().unwrap().remove("_mcp_image");
+                        if !meta.as_object().unwrap().is_empty() {
+                            blocks.push(serde_json::json!({
+                                "type": "text",
+                                "text": serde_json::to_string_pretty(&meta).unwrap()
+                            }));
+                        }
+                        blocks
+                    } else {
+                        vec![serde_json::json!({
+                            "type": "text",
+                            "text": serde_json::to_string_pretty(&result).unwrap()
+                        })]
+                    };
+                    json_rpc_success(&id, serde_json::json!({ "content": content }))
+                }
+                Err(e) => json_rpc_success(
+                    &id,
+                    serde_json::json!({
+                        "content": [{ "type": "text", "text": format!("Error: {e}") }],
+                        "isError": true
+                    }),
+                ),
+            }
+        }
+        _ => {
+            if is_notification {
+                return None;
+            }
+            json_rpc_error(&id, -32601, format!("Method not found: {method}"))
+        }
+    };
+
+    if is_notification {
+        None
+    } else {
+        Some(response)
+    }
+}
+
+// ============================================================================
+// HTTP Server (using httparse + async-net)
+// ============================================================================
+
+/// Read a complete HTTP request from a stream.
+/// Returns (method, path, headers, body).
+async fn read_http_request(
+    stream: &mut async_net::TcpStream,
+) -> Result<(String, String, Vec<(String, String)>, Vec<u8>), String> {
+    // Read headers into a buffer. We read in chunks until we find \r\n\r\n.
+    let mut buf = Vec::with_capacity(4096);
+    let header_end;
+    loop {
+        let mut chunk = [0u8; 1024];
+        let n = stream.read(&mut chunk).await.map_err(|e| format!("read error: {e}"))?;
+        if n == 0 {
+            return Err("connection closed".into());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+
+        if let Some(pos) = find_header_end(&buf) {
+            header_end = pos;
+            break;
+        }
+        if buf.len() > 64 * 1024 {
+            return Err("headers too large".into());
+        }
+    }
+
+    // Parse headers with httparse
+    let mut headers = [httparse::EMPTY_HEADER; 64];
+    let mut req = httparse::Request::new(&mut headers);
+    let status = req.parse(&buf[..header_end + 4]).map_err(|e| format!("parse error: {e}"))?;
+    if status.is_partial() {
+        return Err("incomplete HTTP request".into());
+    }
+
+    let method = req.method.unwrap_or("").to_string();
+    let path = req.path.unwrap_or("").to_string();
+    let parsed_headers: Vec<(String, String)> = req
+        .headers
+        .iter()
+        .map(|h| {
+            (
+                h.name.to_ascii_lowercase(),
+                String::from_utf8_lossy(h.value).to_string(),
+            )
+        })
+        .collect();
+
+    // Read body based on Content-Length (capped at 4 MB to prevent OOM)
+    const MAX_BODY_SIZE: usize = 4 * 1024 * 1024;
+    let content_length: usize = parsed_headers
+        .iter()
+        .find(|(k, _)| k == "content-length")
+        .and_then(|(_, v)| v.parse().ok())
+        .unwrap_or(0);
+    if content_length > MAX_BODY_SIZE {
+        return Err(format!("body too large: {content_length} bytes (max {MAX_BODY_SIZE})"));
+    }
+
+    // Body bytes we already have (after the header end)
+    let body_start = header_end + 4; // skip \r\n\r\n
+    let already_read = buf.len() - body_start;
+    let mut body = buf[body_start..].to_vec();
+
+    // Read remaining body bytes
+    if already_read < content_length {
+        let remaining = content_length - already_read;
+        let mut rest = vec![0u8; remaining];
+        stream.read_exact(&mut rest).await.map_err(|e| format!("body read error: {e}"))?;
+        body.extend_from_slice(&rest);
+    }
+
+    Ok((method, path, parsed_headers, body))
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+async fn write_http_response(
+    stream: &mut async_net::TcpStream,
+    status: u16,
+    status_text: &str,
+    headers: &[(&str, &str)],
+    body: &[u8],
+) -> Result<(), String> {
+    let mut response = format!("HTTP/1.1 {status} {status_text}\r\n");
+    for (k, v) in headers {
+        response.push_str(&format!("{k}: {v}\r\n"));
+    }
+    response.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    response.push_str("Connection: close\r\n");
+    response.push_str("\r\n");
+
+    stream.write_all(response.as_bytes()).await.map_err(|e| format!("write error: {e}"))?;
+    stream.write_all(body).await.map_err(|e| format!("write error: {e}"))?;
+    stream.flush().await.map_err(|e| format!("flush error: {e}"))?;
+    Ok(())
+}
+
+/// Validates the Origin header to protect against DNS rebinding attacks.
+/// Allows requests with no Origin (e.g. curl, MCP CLI clients), or with
+/// localhost-like origins.
+/// Checks whether an origin string refers to a localhost address.
+/// The origin after the scheme must be exactly "localhost", "127.0.0.1", or "[::1]",
+/// optionally followed by a port (":1234").
+fn is_localhost_origin(origin: &str) -> bool {
+    let host = origin
+        .strip_prefix("http://")
+        .or_else(|| origin.strip_prefix("https://"))
+        .unwrap_or("");
+    // Strip optional port
+    let host_no_port = if host.starts_with('[') {
+        // IPv6: [::1]:port
+        host.split_once(']').map(|(h, _)| &h[1..]).unwrap_or(host)
+    } else {
+        host.split(':').next().unwrap_or(host)
+    };
+    matches!(host_no_port, "localhost" | "127.0.0.1" | "::1" | "0.0.0.0")
+}
+
+fn validate_origin(headers: &[(String, String)]) -> bool {
+    let origin = headers.iter().find(|(k, _)| k == "origin").map(|(_, v)| v.as_str());
+    match origin {
+        None => true, // No Origin header — non-browser client (curl, MCP SDK, etc.)
+        Some(o) => is_localhost_origin(o.trim()),
+    }
+}
+
+async fn handle_connection(state: &IntrospectionState, mut stream: async_net::TcpStream) {
+    let (method, path, headers, body) = match read_http_request(&mut stream).await {
+        Ok(req) => req,
+        Err(e) => {
+            debug_log!("MCP HTTP: failed to read request: {e}");
+            return;
+        }
+    };
+
+    // Validate Origin header to prevent DNS rebinding attacks.
+    if !validate_origin(&headers) {
+        let _ = write_http_response(
+            &mut stream,
+            403,
+            "Forbidden",
+            &[],
+            b"Origin not allowed\n",
+        )
+        .await;
+        return;
+    }
+
+    // Handle CORS preflight for browser-based MCP clients.
+    if method == "OPTIONS" {
+        let origin = headers
+            .iter()
+            .find(|(k, _)| k == "origin")
+            .map(|(_, v)| v.as_str())
+            .unwrap_or("http://localhost");
+        let cors_headers = [
+            ("Access-Control-Allow-Origin", origin),
+            ("Access-Control-Allow-Methods", "POST, OPTIONS"),
+            ("Access-Control-Allow-Headers", "Content-Type, MCP-Protocol-Version, Mcp-Session-Id"),
+            ("Access-Control-Max-Age", "86400"),
+            ("Vary", "Origin"),
+        ];
+        let _ = write_http_response(&mut stream, 204, "No Content", &cors_headers, b"").await;
+        return;
+    }
+
+    // Only accept POST /mcp (or POST / for flexibility)
+    if method != "POST" || (path != "/mcp" && path != "/") {
+        let body = b"404 Not Found\n";
+        let _ = write_http_response(&mut stream, 404, "Not Found", &[], body).await;
+        return;
+    }
+
+    let body_str = String::from_utf8_lossy(&body);
+    let response = handle_mcp_request(state, &body_str).await;
+
+    // Mirror the request's Origin back (already validated above).
+    let origin = headers
+        .iter()
+        .find(|(k, _)| k == "origin")
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("http://localhost");
+    let resp_headers = [
+        ("Content-Type", "application/json"),
+        ("Access-Control-Allow-Origin", origin),
+        ("Vary", "Origin"),
+    ];
+
+    match response {
+        Some(resp) => {
+            let json = serde_json::to_string(&resp).unwrap();
+            let _ =
+                write_http_response(&mut stream, 200, "OK", &resp_headers, json.as_bytes()).await;
+        }
+        None => {
+            // Notification — 202 Accepted with no body
+            let _ = write_http_response(&mut stream, 202, "Accepted", &resp_headers, b"").await;
+        }
+    }
+}
+
+async fn run_server(state: Rc<IntrospectionState>, port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    let listener = match async_net::TcpListener::bind(&addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("MCP server: failed to bind to {addr}: {e}");
+            return;
+        }
+    };
+    eprintln!("Slint MCP server listening on http://{addr}/mcp");
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, _peer)) => {
+                stream.set_nodelay(true).ok();
+                // Spawn each connection handler so slow clients don't block others.
+                let state = state.clone();
+                let _ = i_slint_core::with_global_context(
+                    || panic!("uninitialized platform"),
+                    |context| {
+                        let _ = context.spawn_local(async move {
+                            handle_connection(&state, stream).await;
+                        });
+                    },
+                );
+            }
+            Err(e) => {
+                debug_log!("MCP server: accept error: {e}");
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+pub fn init() -> Result<(), EventLoopError> {
+    let Ok(port_str) = std::env::var("SLINT_MCP_PORT") else {
+        return Ok(());
+    };
+    let port: u16 = match port_str.parse() {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("SLINT_MCP_PORT: invalid port number '{port_str}'");
+            return Ok(());
+        }
+    };
+
+    // Use the shared introspection state (shared with systest when both features are enabled).
+    introspection::ensure_window_tracking()?;
+    let state = introspection::shared_state();
+
+    // Start the HTTP server. The future is queued and will execute once the event loop runs.
+    let server_started = Rc::new(std::cell::OnceCell::<i_slint_core::future::JoinHandle<()>>::new());
+    let server_started_clone = server_started.clone();
+    let state_clone = state.clone();
+
+    // Use the window-shown hook to trigger server start on first window,
+    // since spawn_local requires the event loop context.
+    let previous_hook = i_slint_core::context::set_window_shown_hook(None)
+        .map_err(|_| EventLoopError::NoEventLoopProvider)?;
+    let previous_hook = std::cell::RefCell::new(previous_hook);
+
+    i_slint_core::context::set_window_shown_hook(Some(Box::new(move |adapter| {
+        if let Some(prev) = previous_hook.borrow_mut().as_mut() {
+            prev(adapter);
+        }
+
+        let state = state_clone.clone();
+        server_started_clone.get_or_init(|| {
+            i_slint_core::with_global_context(
+                || panic!("uninitialized platform"),
+                |context| {
+                    context
+                        .spawn_local(async move {
+                            run_server(state, port).await;
+                        })
+                        .unwrap()
+                },
+            )
+            .unwrap()
+        });
+    })))
+    .map_err(|_| EventLoopError::NoEventLoopProvider)?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_handle_roundtrip() {
+        // Test basic roundtrip
+        let index = generational_arena::Index::from_raw_parts(0, 0);
+        let json = handle_to_json(index);
+        let back = handle_from_json(&json).unwrap();
+        assert_eq!(index, back);
+
+        // Test with larger values
+        let index = generational_arena::Index::from_raw_parts(42, 7);
+        let json = handle_to_json(index);
+        assert_eq!(json["index"], 42);
+        assert_eq!(json["generation"], 7);
+        let back = handle_from_json(&json).unwrap();
+        assert_eq!(index, back);
+    }
+
+    #[test]
+    fn test_handle_from_json_missing_fields() {
+        let v = serde_json::json!({});
+        assert!(handle_from_json(&v).is_err());
+
+        let v = serde_json::json!({"index": 0});
+        assert!(handle_from_json(&v).is_err());
+
+        let v = serde_json::json!({"generation": 0});
+        assert!(handle_from_json(&v).is_err());
+    }
+
+    #[test]
+    fn test_parse_query_instructions_all_types() {
+        let arr = vec![
+            serde_json::json!({"match_descendants": true}),
+            serde_json::json!({"match_id": "my_id"}),
+            serde_json::json!({"match_type_name": "Button"}),
+            serde_json::json!({"match_type_name_or_base": "TouchArea"}),
+            serde_json::json!({"match_accessible_role": "button"}),
+        ];
+        let instructions = parse_query_instructions(&arr).unwrap();
+        assert_eq!(instructions.len(), 5);
+        assert!(matches!(instructions[0], QueryInstruction::MatchDescendants));
+        assert!(matches!(&instructions[1], QueryInstruction::MatchId(id) if id == "my_id"));
+        assert!(matches!(&instructions[2], QueryInstruction::MatchTypeName(n) if n == "Button"));
+        assert!(matches!(&instructions[3], QueryInstruction::MatchTypeNameOrBase(n) if n == "TouchArea"));
+        assert!(matches!(instructions[4], QueryInstruction::MatchAccessibleRole(_)));
+    }
+
+    #[test]
+    fn test_parse_query_instructions_empty() {
+        let arr: Vec<Value> = vec![];
+        let instructions = parse_query_instructions(&arr).unwrap();
+        assert!(instructions.is_empty());
+    }
+
+    #[test]
+    fn test_parse_query_instructions_invalid() {
+        let arr = vec![serde_json::json!({"bogus": 123})];
+        assert!(parse_query_instructions(&arr).is_err());
+    }
+
+    #[test]
+    fn test_parse_query_instructions_unknown_role() {
+        let arr = vec![serde_json::json!({"match_accessible_role": "nonexistent"})];
+        assert!(parse_query_instructions(&arr).is_err());
+    }
+
+    #[test]
+    fn test_validate_origin() {
+        // No Origin header — allowed (non-browser client)
+        assert!(validate_origin(&[]));
+
+        // Localhost origins — allowed
+        assert!(validate_origin(&[("origin".into(), "http://localhost".into())]));
+        assert!(validate_origin(&[("origin".into(), "http://localhost:3000".into())]));
+        assert!(validate_origin(&[("origin".into(), "https://localhost:8443".into())]));
+        assert!(validate_origin(&[("origin".into(), "http://127.0.0.1:8080".into())]));
+        assert!(validate_origin(&[("origin".into(), "http://[::1]:3000".into())]));
+        assert!(validate_origin(&[("origin".into(), "http://0.0.0.0:8080".into())]));
+
+        // External origins — rejected
+        assert!(!validate_origin(&[("origin".into(), "http://evil.com".into())]));
+        assert!(!validate_origin(&[("origin".into(), "http://localhost.evil.com".into())]));
+        assert!(!validate_origin(&[("origin".into(), "https://attacker.com".into())]));
+
+        // Edge cases
+        assert!(!validate_origin(&[("origin".into(), "http://127.0.0.2".into())]));
+        assert!(!validate_origin(&[("origin".into(), "".into())]));
+        assert!(!validate_origin(&[("origin".into(), "localhost".into())])); // no scheme
+    }
+
+    #[test]
+    fn test_json_rpc_success() {
+        let result = json_rpc_success(&Value::from(1), serde_json::json!({"ok": true}));
+        assert_eq!(result["jsonrpc"], "2.0");
+        assert_eq!(result["id"], 1);
+        assert_eq!(result["result"]["ok"], true);
+    }
+
+    #[test]
+    fn test_json_rpc_error() {
+        let result = json_rpc_error(&Value::from(2), -32600, "Invalid Request".into());
+        assert_eq!(result["jsonrpc"], "2.0");
+        assert_eq!(result["id"], 2);
+        assert_eq!(result["error"]["code"], -32600);
+        assert_eq!(result["error"]["message"], "Invalid Request");
+    }
+
+    #[test]
+    fn test_find_header_end() {
+        assert_eq!(find_header_end(b"GET / HTTP/1.1\r\n\r\n"), Some(14));
+        assert_eq!(find_header_end(b"no double crlf here"), None);
+        assert_eq!(find_header_end(b"\r\n\r\n"), Some(0));
+        assert_eq!(find_header_end(b"a\r\n\r\nb"), Some(1));
+    }
+
+    #[test]
+    fn test_tool_definitions_structure() {
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().unwrap();
+        assert!(!tools.is_empty());
+
+        // Verify all tools have required fields
+        for tool in tools {
+            assert!(tool.get("name").and_then(|v| v.as_str()).is_some());
+            assert!(tool.get("description").and_then(|v| v.as_str()).is_some());
+            let schema = tool.get("inputSchema").unwrap();
+            assert_eq!(schema["type"], "object");
+        }
+
+        // Verify specific tools exist
+        let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(tool_names.contains(&"list_windows"));
+        assert!(tool_names.contains(&"get_window_properties"));
+        assert!(tool_names.contains(&"get_element_tree"));
+        assert!(tool_names.contains(&"take_screenshot"));
+        assert!(tool_names.contains(&"click_element"));
+        assert!(tool_names.contains(&"query_element_descendants"));
+    }
+
+    #[test]
+    fn test_element_properties_to_json() {
+        let ep = introspection::ElementProperties {
+            type_names_and_ids: vec![("Button".into(), "my_button".into())],
+            accessible_role: "button",
+            accessible_label: Some("Click me".into()),
+            accessible_value: None,
+            accessible_description: None,
+            accessible_placeholder_text: None,
+            accessible_checked: false,
+            accessible_checkable: false,
+            accessible_enabled: true,
+            accessible_read_only: false,
+            accessible_value_minimum: 0.0,
+            accessible_value_maximum: 0.0,
+            accessible_value_step: 0.0,
+            size: i_slint_core::api::LogicalSize { width: 100.0, height: 30.0 },
+            absolute_position: i_slint_core::api::LogicalPosition { x: 10.0, y: 20.0 },
+            computed_opacity: 1.0,
+            layout_kind: None,
+        };
+        let json = element_properties_to_json(&ep);
+        assert_eq!(json["accessible_role"], "button");
+        assert_eq!(json["accessible_label"], "Click me");
+        assert_eq!(json["size"]["width"], 100.0);
+        assert_eq!(json["absolute_position"]["x"], 10.0);
+        assert_eq!(json["accessible_enabled"], true);
+        assert!(json["layout_kind"].is_null());
+        assert_eq!(json["type_info"][0]["type_name"], "Button");
+        assert_eq!(json["type_info"][0]["id"], "my_button");
+    }
+
+    // ========================================================================
+    // handle_mcp_request integration tests
+    // ========================================================================
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        futures_lite::future::block_on(f)
+    }
+
+    fn make_state() -> IntrospectionState {
+        IntrospectionState::new()
+    }
+
+    #[test]
+    fn test_mcp_initialize() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+        ));
+        let resp = resp.expect("initialize should return a response");
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 1);
+        assert!(resp["result"]["protocolVersion"].as_str().is_some());
+        assert!(resp["result"]["serverInfo"]["name"].as_str().is_some());
+        assert!(resp["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn test_mcp_notification_returns_none() {
+        let state = make_state();
+        // notifications/initialized has no "id" field — it's a notification
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+        ));
+        assert!(resp.is_none(), "notification should not produce a response");
+    }
+
+    #[test]
+    fn test_mcp_unknown_notification_returns_none() {
+        let state = make_state();
+        // Unknown method with no "id" is also a notification
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","method":"some/unknown/notification"}"#,
+        ));
+        assert!(resp.is_none(), "unknown notification should not produce a response");
+    }
+
+    #[test]
+    fn test_mcp_tools_list() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+        ));
+        let resp = resp.unwrap();
+        assert_eq!(resp["id"], 2);
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        assert!(!tools.is_empty());
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"list_windows"));
+    }
+
+    #[test]
+    fn test_mcp_tools_call_list_windows() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_windows","arguments":{}}}"#,
+        ));
+        let resp = resp.unwrap();
+        assert_eq!(resp["id"], 3);
+        // No windows registered, so result should have empty windows array
+        let content = &resp["result"]["content"];
+        let text = content[0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["windows"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_mcp_tools_call_unknown_tool() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"nonexistent_tool","arguments":{}}}"#,
+        ));
+        let resp = resp.unwrap();
+        assert_eq!(resp["id"], 4);
+        assert!(resp["result"]["isError"].as_bool().unwrap_or(false));
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("Unknown tool"));
+    }
+
+    #[test]
+    fn test_mcp_unknown_method() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":5,"method":"bogus/method"}"#,
+        ));
+        let resp = resp.unwrap();
+        assert_eq!(resp["id"], 5);
+        assert_eq!(resp["error"]["code"], -32601);
+        assert!(resp["error"]["message"].as_str().unwrap().contains("Method not found"));
+    }
+
+    #[test]
+    fn test_mcp_malformed_json() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(&state, "this is not json"));
+        let resp = resp.unwrap();
+        assert_eq!(resp["error"]["code"], -32700);
+        assert!(resp["error"]["message"].as_str().unwrap().contains("Parse error"));
+    }
+
+    #[test]
+    fn test_mcp_missing_method() {
+        let state = make_state();
+        // Valid JSON-RPC but no method field — treated as unknown method ""
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":6}"#,
+        ));
+        let resp = resp.unwrap();
+        assert_eq!(resp["error"]["code"], -32601);
+    }
+
+    #[test]
+    fn test_mcp_tools_call_missing_required_param() {
+        let state = make_state();
+        // get_window_properties requires window_handle
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"get_window_properties","arguments":{}}}"#,
+        ));
+        let resp = resp.unwrap();
+        assert!(resp["result"]["isError"].as_bool().unwrap_or(false));
+    }
+
+    #[test]
+    fn test_element_properties_to_json_with_layout() {
+        let ep = introspection::ElementProperties {
+            type_names_and_ids: vec![],
+            accessible_role: "unknown",
+            accessible_label: None,
+            accessible_value: None,
+            accessible_description: None,
+            accessible_placeholder_text: None,
+            accessible_checked: false,
+            accessible_checkable: false,
+            accessible_enabled: false,
+            accessible_read_only: false,
+            accessible_value_minimum: 0.0,
+            accessible_value_maximum: 0.0,
+            accessible_value_step: 0.0,
+            size: i_slint_core::api::LogicalSize { width: 0.0, height: 0.0 },
+            absolute_position: i_slint_core::api::LogicalPosition { x: 0.0, y: 0.0 },
+            computed_opacity: 1.0,
+            layout_kind: Some(crate::LayoutKind::VerticalLayout),
+        };
+        let json = element_properties_to_json(&ep);
+        assert_eq!(json["layout_kind"], "vertical");
+    }
+}

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -21,9 +21,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::rc::Rc;
 
-use crate::introspection::{
-    self, AccessibilityAction, IntrospectionState, QueryInstruction,
-};
+use crate::introspection::{self, AccessibilityAction, IntrospectionState, QueryInstruction};
 
 // ============================================================================
 // Handle serialization
@@ -314,12 +312,9 @@ async fn handle_tool_call(
         }
         "find_elements_by_id" => {
             let p: FindElementsByIdParams = deserialize_params(args)?;
-            let elements =
-                state.find_elements_by_id(p.window_handle.to_index(), &p.element_id)?;
-            let handles: Vec<Value> = elements
-                .into_iter()
-                .map(|e| handle_to_json(state.element_to_handle(e)))
-                .collect();
+            let elements = state.find_elements_by_id(p.window_handle.to_index(), &p.element_id)?;
+            let handles: Vec<Value> =
+                elements.into_iter().map(|e| handle_to_json(state.element_to_handle(e))).collect();
             Ok(ToolResult::Json(serde_json::json!({ "elements": handles })))
         }
         "get_element_properties" => {
@@ -334,10 +329,8 @@ async fn handle_tool_call(
             let instructions = parse_query_instructions(&p.query)?;
             let find_all = p.find_all.unwrap_or(true);
             let results = state.query_element_descendants(element, instructions, find_all)?;
-            let handles: Vec<Value> = results
-                .into_iter()
-                .map(|e| handle_to_json(state.element_to_handle(e)))
-                .collect();
+            let handles: Vec<Value> =
+                results.into_iter().map(|e| handle_to_json(state.element_to_handle(e))).collect();
             Ok(ToolResult::Json(serde_json::json!({ "elements": handles })))
         }
         "get_element_tree" => {
@@ -402,12 +395,8 @@ async fn handle_tool_call(
                     text: p.text.clone().into(),
                 }],
                 "press_and_release" => vec![
-                    i_slint_core::platform::WindowEvent::KeyPressed {
-                        text: p.text.clone().into(),
-                    },
-                    i_slint_core::platform::WindowEvent::KeyReleased {
-                        text: p.text.into(),
-                    },
+                    i_slint_core::platform::WindowEvent::KeyPressed { text: p.text.clone().into() },
+                    i_slint_core::platform::WindowEvent::KeyReleased { text: p.text.into() },
                 ],
                 other => return Err(format!("Unknown event_type: {other}")),
             };
@@ -436,13 +425,9 @@ fn parse_query_instructions(arr: &[Value]) -> Result<Vec<QueryInstruction>, Stri
             instructions.push(QueryInstruction::MatchId(id.to_string()));
         } else if let Some(tn) = item.get("match_type_name").and_then(|v| v.as_str()) {
             instructions.push(QueryInstruction::MatchTypeName(tn.to_string()));
-        } else if let Some(tn) =
-            item.get("match_type_name_or_base").and_then(|v| v.as_str())
-        {
+        } else if let Some(tn) = item.get("match_type_name_or_base").and_then(|v| v.as_str()) {
             instructions.push(QueryInstruction::MatchTypeNameOrBase(tn.to_string()));
-        } else if let Some(role_str) =
-            item.get("match_accessible_role").and_then(|v| v.as_str())
-        {
+        } else if let Some(role_str) = item.get("match_accessible_role").and_then(|v| v.as_str()) {
             let role = introspection::string_to_accessible_role(role_str)
                 .ok_or_else(|| format!("Unknown accessible role: {role_str}"))?;
             instructions.push(QueryInstruction::MatchAccessibleRole(role));
@@ -497,10 +482,7 @@ fn collect_element_list(
     // Add root element first
     let root_props = state.element_properties(&root_element);
     let mut root_node = element_properties_to_json(&root_props);
-    root_node
-        .as_object_mut()
-        .unwrap()
-        .insert("handle".to_string(), handle_to_json(root_handle));
+    root_node.as_object_mut().unwrap().insert("handle".to_string(), handle_to_json(root_handle));
     elements.push(root_node);
 
     root_element.visit_descendants(|child| {
@@ -511,9 +493,7 @@ fn collect_element_list(
         let child_handle = state.element_to_handle(child.clone());
         let props = state.element_properties(&child);
         let mut node = element_properties_to_json(&props);
-        node.as_object_mut()
-            .unwrap()
-            .insert("handle".to_string(), handle_to_json(child_handle));
+        node.as_object_mut().unwrap().insert("handle".to_string(), handle_to_json(child_handle));
         elements.push(node);
         std::ops::ControlFlow::<()>::Continue(())
     });
@@ -548,13 +528,7 @@ fn json_rpc_error(id: &Value, code: i32, message: String) -> Value {
 async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Value> {
     let request: Value = match serde_json::from_str(body) {
         Ok(v) => v,
-        Err(e) => {
-            return Some(json_rpc_error(
-                &Value::Null,
-                -32700,
-                format!("Parse error: {e}"),
-            ))
-        }
+        Err(e) => return Some(json_rpc_error(&Value::Null, -32700, format!("Parse error: {e}"))),
     };
 
     // Batch requests (JSON arrays) are not supported.
@@ -651,11 +625,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
         }
     };
 
-    if is_notification {
-        None
-    } else {
-        Some(response)
-    }
+    if is_notification { None } else { Some(response) }
 }
 
 // ============================================================================
@@ -708,12 +678,7 @@ async fn read_http_request(
     let parsed_headers: Vec<(String, String)> = req
         .headers
         .iter()
-        .map(|h| {
-            (
-                h.name.to_ascii_lowercase(),
-                String::from_utf8_lossy(h.value).to_string(),
-            )
-        })
+        .map(|h| (h.name.to_ascii_lowercase(), String::from_utf8_lossy(h.value).to_string()))
         .collect();
 
     // Read body based on Content-Length (capped at 4 MB to prevent OOM).
@@ -785,10 +750,8 @@ async fn write_http_response(
 /// The origin after the scheme must be exactly "localhost", "127.0.0.1", or "[::1]",
 /// optionally followed by a port (":1234").
 fn is_localhost_origin(origin: &str) -> bool {
-    let host = origin
-        .strip_prefix("http://")
-        .or_else(|| origin.strip_prefix("https://"))
-        .unwrap_or("");
+    let host =
+        origin.strip_prefix("http://").or_else(|| origin.strip_prefix("https://")).unwrap_or("");
     // Strip optional port
     let host_no_port = if host.starts_with('[') {
         // IPv6: [::1]:port
@@ -812,9 +775,7 @@ fn validate_origin(headers: &[(String, String)]) -> Result<Option<&str>, ()> {
 
 /// Returns true if the client requested connection close.
 fn wants_close(headers: &[(String, String)]) -> bool {
-    headers
-        .iter()
-        .any(|(k, v)| k == "connection" && v.eq_ignore_ascii_case("close"))
+    headers.iter().any(|(k, v)| k == "connection" && v.eq_ignore_ascii_case("close"))
 }
 
 async fn handle_connection(state: &IntrospectionState, mut stream: async_net::TcpStream) {
@@ -861,8 +822,7 @@ async fn handle_connection(state: &IntrospectionState, mut stream: async_net::Tc
                 ("Access-Control-Max-Age", "86400"),
                 ("Vary", "Origin"),
             ];
-            let _ =
-                write_http_response(&mut stream, 204, "No Content", &cors_headers, b"").await;
+            let _ = write_http_response(&mut stream, 204, "No Content", &cors_headers, b"").await;
         } else if method != "POST" || (path != "/mcp" && path != "/") {
             let _ =
                 write_http_response(&mut stream, 404, "Not Found", &[], b"404 Not Found\n").await;
@@ -893,24 +853,13 @@ async fn handle_connection(state: &IntrospectionState, mut stream: async_net::Tc
             match response {
                 Some(resp) => {
                     let json = serde_json::to_string(&resp).unwrap();
-                    let _ = write_http_response(
-                        &mut stream,
-                        200,
-                        "OK",
-                        &resp_headers,
-                        json.as_bytes(),
-                    )
-                    .await;
+                    let _ =
+                        write_http_response(&mut stream, 200, "OK", &resp_headers, json.as_bytes())
+                            .await;
                 }
                 None => {
-                    let _ = write_http_response(
-                        &mut stream,
-                        202,
-                        "Accepted",
-                        &resp_headers,
-                        b"",
-                    )
-                    .await;
+                    let _ =
+                        write_http_response(&mut stream, 202, "Accepted", &resp_headers, b"").await;
                 }
             }
         }
@@ -975,7 +924,8 @@ pub fn init() -> Result<(), EventLoopError> {
     let state = introspection::shared_state();
 
     // Start the HTTP server. The future is queued and will execute once the event loop runs.
-    let server_started = Rc::new(std::cell::OnceCell::<i_slint_core::future::JoinHandle<()>>::new());
+    let server_started =
+        Rc::new(std::cell::OnceCell::<i_slint_core::future::JoinHandle<()>>::new());
     let server_started_clone = server_started.clone();
     let state_clone = state.clone();
 
@@ -1061,7 +1011,9 @@ mod tests {
         assert!(matches!(instructions[0], QueryInstruction::MatchDescendants));
         assert!(matches!(&instructions[1], QueryInstruction::MatchId(id) if id == "my_id"));
         assert!(matches!(&instructions[2], QueryInstruction::MatchTypeName(n) if n == "Button"));
-        assert!(matches!(&instructions[3], QueryInstruction::MatchTypeNameOrBase(n) if n == "TouchArea"));
+        assert!(
+            matches!(&instructions[3], QueryInstruction::MatchTypeNameOrBase(n) if n == "TouchArea")
+        );
         assert!(matches!(instructions[4], QueryInstruction::MatchAccessibleRole(_)));
     }
 
@@ -1340,10 +1292,7 @@ mod tests {
     fn test_mcp_missing_method() {
         let state = make_state();
         // Valid JSON-RPC but no method field — treated as unknown method ""
-        let resp = block_on(handle_mcp_request(
-            &state,
-            r#"{"jsonrpc":"2.0","id":6}"#,
-        ));
+        let resp = block_on(handle_mcp_request(&state, r#"{"jsonrpc":"2.0","id":6}"#));
         let resp = resp.unwrap();
         assert_eq!(resp["error"]["code"], -32601);
     }
@@ -1637,11 +1586,8 @@ mod tests {
     #[test]
     fn test_tool_click_element_missing_handle() {
         let state = make_state();
-        let result = call_tool(
-            &state,
-            "click_element",
-            serde_json::json!({"action": "triple_click"}),
-        );
+        let result =
+            call_tool(&state, "click_element", serde_json::json!({"action": "triple_click"}));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid parameters"));
     }

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -17,7 +17,7 @@
 use base64::Engine;
 use futures_lite::{AsyncReadExt, AsyncWriteExt};
 use i_slint_core::api::EventLoopError;
-use i_slint_core::debug_log;
+use serde::Deserialize;
 use serde_json::Value;
 use std::rc::Rc;
 
@@ -29,369 +29,394 @@ use crate::introspection::{
 // Handle serialization
 // ============================================================================
 
+/// An arena handle as sent over JSON: `{ "index": u64, "generation": u64 }`.
+#[derive(Deserialize)]
+struct Handle {
+    index: u64,
+    generation: u64,
+}
+
+impl Handle {
+    fn to_index(&self) -> generational_arena::Index {
+        introspection::parts_to_index(self.index, self.generation)
+    }
+}
+
 fn handle_to_json(index: generational_arena::Index) -> Value {
     let (idx, generation) = introspection::index_to_parts(index);
     serde_json::json!({ "index": idx, "generation": generation })
 }
 
-fn handle_from_json(v: &Value) -> Result<generational_arena::Index, String> {
-    let index = v.get("index").and_then(|v| v.as_u64()).ok_or("missing index in handle")?;
-    let generation =
-        v.get("generation").and_then(|v| v.as_u64()).ok_or("missing generation in handle")?;
-    Ok(introspection::parts_to_index(index, generation))
+// ============================================================================
+// Tool parameter structs
+// ============================================================================
+
+#[derive(Deserialize)]
+struct WindowHandleParam {
+    window_handle: Handle,
+}
+
+#[derive(Deserialize)]
+struct ElementHandleParam {
+    element_handle: Handle,
+}
+
+#[derive(Deserialize)]
+struct FindElementsByIdParams {
+    window_handle: Handle,
+    element_id: String,
+}
+
+#[derive(Deserialize)]
+struct QueryElementDescendantsParams {
+    element_handle: Handle,
+    query: Vec<Value>,
+    #[serde(default)]
+    find_all: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct GetElementTreeParams {
+    element_handle: Handle,
+    #[serde(default)]
+    max_elements: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct ClickElementParams {
+    element_handle: Handle,
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    button: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct InvokeAccessibilityActionParams {
+    element_handle: Handle,
+    action: String,
+}
+
+#[derive(Deserialize)]
+struct SetElementValueParams {
+    element_handle: Handle,
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct DispatchKeyEventParams {
+    window_handle: Handle,
+    text: String,
+    #[serde(default)]
+    event_type: Option<String>,
 }
 
 // ============================================================================
-// MCP Tool Macro
+// Tool definitions (schema for tools/list)
 // ============================================================================
 
-/// Macro to declare MCP tools with automatic schema generation and dispatch.
-///
-/// Each tool declaration produces:
-/// - An entry in the `tools/list` response (name, description, input schema)
-/// - A match arm in the `tools/call` dispatch
-/// - Parameter deserialization from JSON arguments
-macro_rules! mcp_tools {
-    (
-        state: $state:ident, args: $args:ident;
-        $(
-            $(#[doc = $doc:literal])*
-            tool $name:ident (
-                $( $(#[doc = $param_doc:literal])* $param:ident : $param_ty:tt ),*
-                $(,)?
-            ) -> $ret:ty $body:block
-        )*
-    ) => {
-        fn tool_definitions() -> Value {
-            serde_json::json!({
-                "tools": [
-                    $(
-                        {
-                            "name": stringify!($name),
-                            "description": concat!($($doc, " "),*),
-                            "inputSchema": {
+const HANDLE_SCHEMA: &str = r#"{
+    "type": "object",
+    "properties": {
+        "index": { "type": "integer" },
+        "generation": { "type": "integer" }
+    },
+    "required": ["index", "generation"]
+}"#;
+
+fn handle_schema(description: &str) -> Value {
+    let mut schema: Value = serde_json::from_str(HANDLE_SCHEMA).unwrap();
+    schema["description"] = Value::String(description.into());
+    schema
+}
+
+fn tool_definitions() -> Value {
+    serde_json::json!({
+        "tools": [
+            {
+                "name": "list_windows",
+                "description": "List all windows in the application. Returns window handles for use with other tools. This is typically the first tool to call.",
+                "inputSchema": { "type": "object", "properties": {} }
+            },
+            {
+                "name": "get_window_properties",
+                "description": "Get properties of a window (size, position, fullscreen/maximized/minimized state, root element handle). The root_element_handle is the entry point for element tree traversal.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "window_handle": handle_schema("Window handle from list_windows.")
+                    },
+                    "required": ["window_handle"]
+                }
+            },
+            {
+                "name": "find_elements_by_id",
+                "description": "Find elements by their qualified ID (e.g. 'App::mybutton'). Returns element handles. Use get_element_tree first to discover available element IDs.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "window_handle": handle_schema("Window handle."),
+                        "element_id": { "type": "string", "description": "Qualified element ID (e.g. 'App::mybutton')." }
+                    },
+                    "required": ["window_handle", "element_id"]
+                }
+            },
+            {
+                "name": "get_element_properties",
+                "description": "Get all properties of an element: type info, accessible properties (label, value, description, role, checked, enabled, etc.), geometry (position, size), and opacity.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "element_handle": handle_schema("Element handle.")
+                    },
+                    "required": ["element_handle"]
+                }
+            },
+            {
+                "name": "query_element_descendants",
+                "description": "Query descendants of an element using a chain of match instructions. Each instruction narrows the search. Use match_descendants to search recursively, then filter by id, type_name, or accessible_role. More efficient than get_element_tree for targeted searches.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "element_handle": handle_schema("Element handle to start the query from."),
+                        "query": {
+                            "type": "array",
+                            "description": "Array of query instructions applied in order.",
+                            "items": {
                                 "type": "object",
                                 "properties": {
-                                    $(
-                                        stringify!($param): mcp_tools!(@schema $param_ty $(, $param_doc)*)
-                                    ),*
-                                },
-                                "required": mcp_tools!(@required $($param: $param_ty),*)
+                                    "match_descendants": { "type": "boolean", "description": "If true, search recursively through all descendants" },
+                                    "match_id": { "type": "string", "description": "Match elements by ID" },
+                                    "match_type_name": { "type": "string", "description": "Match elements by type name" },
+                                    "match_type_name_or_base": { "type": "string", "description": "Match elements by type name or inherited base type" },
+                                    "match_accessible_role": { "type": "string", "description": "Match by accessible role (e.g., 'button', 'text', 'slider')" }
+                                }
                             }
-                        }
-                    ),*
-                ]
-            })
-        }
-
-        async fn handle_tool_call(
-            $state: &IntrospectionState,
-            name: &str,
-            $args: &Value,
-        ) -> Result<Value, String> {
-            match name {
-                $(
-                    stringify!($name) => {
-                        $(
-                            let $param = mcp_tools!(@extract $args, $param, $param_ty);
-                        )*
-                        let result: $ret = $body;
-                        result
-                    }
-                )*
-                _ => Err(format!("Unknown tool: {name}")),
-            }
-        }
-    };
-
-    // Schema generation for parameter types
-    (@schema Handle $(, $doc:literal)*) => {
-        serde_json::json!({
-            "type": "object",
-            "description": concat!($($doc, " "),*),
-            "properties": {
-                "index": { "type": "integer" },
-                "generation": { "type": "integer" }
+                        },
+                        "find_all": { "type": "boolean", "description": "If true (default), return all matches. If false, return only the first match." }
+                    },
+                    "required": ["element_handle", "query"]
+                }
             },
-            "required": ["index", "generation"]
-        })
-    };
-    (@schema String $(, $doc:literal)*) => {
-        serde_json::json!({ "type": "string", "description": concat!($($doc, " "),*) })
-    };
-    (@schema OptionalString $(, $doc:literal)*) => {
-        serde_json::json!({ "type": "string", "description": concat!($($doc, " "),*) })
-    };
-    (@schema QueryArray $(, $doc:literal)*) => {
-        serde_json::json!({
-            "type": "array",
-            "description": concat!($($doc, " "),*),
-            "items": {
-                "type": "object",
-                "properties": {
-                    "match_descendants": { "type": "boolean", "description": "If true, search recursively through all descendants" },
-                    "match_id": { "type": "string", "description": "Match elements by ID" },
-                    "match_type_name": { "type": "string", "description": "Match elements by type name" },
-                    "match_type_name_or_base": { "type": "string", "description": "Match elements by type name or inherited base type" },
-                    "match_accessible_role": { "type": "string", "description": "Match by accessible role (e.g., 'button', 'text', 'slider')" }
+            {
+                "name": "get_element_tree",
+                "description": "Get all elements in the subtree starting from a root element. Returns a flat list of elements with their properties and handles. Use this to get an overview of the UI, then use get_element_properties or query_element_descendants for targeted exploration. Limit the result count with max_elements (default: 200, max: 1000).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "element_handle": handle_schema("Root element handle (typically from get_window_properties root_element_handle)."),
+                        "max_elements": { "type": "integer", "description": "Maximum number of elements to return (default: 200, max: 1000)." }
+                    },
+                    "required": ["element_handle"]
+                }
+            },
+            {
+                "name": "take_screenshot",
+                "description": "Take a screenshot of a window. Returns an MCP image content block.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "window_handle": handle_schema("Window handle.")
+                    },
+                    "required": ["window_handle"]
+                }
+            },
+            {
+                "name": "click_element",
+                "description": "Simulate a mouse click on an element.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "element_handle": handle_schema("Element handle."),
+                        "action": { "type": "string", "description": "Click action: \"single_click\" (default) or \"double_click\"." },
+                        "button": { "type": "string", "description": "Mouse button: \"left\" (default), \"right\", or \"middle\"." }
+                    },
+                    "required": ["element_handle"]
+                }
+            },
+            {
+                "name": "invoke_accessibility_action",
+                "description": "Invoke an accessibility action on an element (e.g. default action for buttons, increment/decrement for sliders, expand for combo boxes).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "element_handle": handle_schema("Element handle."),
+                        "action": { "type": "string", "description": "The action: \"default\", \"increment\", \"decrement\", or \"expand\"." }
+                    },
+                    "required": ["element_handle", "action"]
+                }
+            },
+            {
+                "name": "set_element_value",
+                "description": "Set the accessible value of an element (e.g. text input content, slider value).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "element_handle": handle_schema("Element handle."),
+                        "value": { "type": "string", "description": "The value to set." }
+                    },
+                    "required": ["element_handle", "value"]
+                }
+            },
+            {
+                "name": "dispatch_key_event",
+                "description": "Dispatch a keyboard event to a window.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "window_handle": handle_schema("Window handle."),
+                        "text": { "type": "string", "description": "The key text to send." },
+                        "event_type": { "type": "string", "description": "Event type: \"press\", \"release\", or \"press_and_release\" (default)." }
+                    },
+                    "required": ["window_handle", "text"]
                 }
             }
-        })
-    };
-    (@schema Bool $(, $doc:literal)*) => {
-        serde_json::json!({ "type": "boolean", "description": concat!($($doc, " "),*) })
-    };
-    (@schema OptionalBool $(, $doc:literal)*) => {
-        serde_json::json!({ "type": "boolean", "description": concat!($($doc, " "),*) })
-    };
-    (@schema OptionalInt $(, $doc:literal)*) => {
-        serde_json::json!({ "type": "integer", "description": concat!($($doc, " "),*) })
-    };
-
-    // Required fields: Handle and String are required, Optional* are not
-    (@required $($param:ident: $ty:tt),*) => {
-        {
-            #[allow(unused_mut)]
-            let mut required = Vec::<&str>::new();
-            $(
-                mcp_tools!(@required_check required, $param, $ty);
-            )*
-            required
-        }
-    };
-    (@required_check $vec:ident, $param:ident, Handle) => { $vec.push(stringify!($param)); };
-    (@required_check $vec:ident, $param:ident, String) => { $vec.push(stringify!($param)); };
-    (@required_check $vec:ident, $param:ident, QueryArray) => { $vec.push(stringify!($param)); };
-    (@required_check $vec:ident, $param:ident, Bool) => { $vec.push(stringify!($param)); };
-    (@required_check $vec:ident, $param:ident, $_ty:tt) => { };
-
-    // Parameter extraction from JSON args
-    (@extract $args:ident, $param:ident, Handle) => {
-        handle_from_json(
-            $args.get(stringify!($param))
-                .ok_or_else(|| format!("missing {}", stringify!($param)))?
-        )?
-    };
-    (@extract $args:ident, $param:ident, String) => {
-        $args.get(stringify!($param))
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| format!("missing {}", stringify!($param)))?
-            .to_string()
-    };
-    (@extract $args:ident, $param:ident, OptionalString) => {
-        $args.get(stringify!($param)).and_then(|v| v.as_str()).unwrap_or("").to_string()
-    };
-    (@extract $args:ident, $param:ident, QueryArray) => {
-        $args.get(stringify!($param))
-            .and_then(|v| v.as_array())
-            .ok_or_else(|| format!("missing {}", stringify!($param)))?
-            .clone()
-    };
-    (@extract $args:ident, $param:ident, Bool) => {
-        $args.get(stringify!($param))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-    };
-    (@extract $args:ident, $param:ident, OptionalBool) => {
-        $args.get(stringify!($param)).and_then(|v| v.as_bool())
-    };
-    (@extract $args:ident, $param:ident, OptionalInt) => {
-        $args.get(stringify!($param)).and_then(|v| v.as_u64())
-    };
+        ]
+    })
 }
 
 // ============================================================================
-// Tool Definitions
+// Tool dispatch
 // ============================================================================
 
-mcp_tools! {
-    state: state, args: args;
+fn deserialize_params<T: serde::de::DeserializeOwned>(args: &Value) -> Result<T, String> {
+    serde_json::from_value(args.clone()).map_err(|e| format!("Invalid parameters: {e}"))
+}
 
-    /// List all windows in the application. Returns window handles for use with other tools.
-    /// This is typically the first tool to call.
-    tool list_windows() -> Result<Value, String> {
-        let handles: Vec<Value> = state.window_handles().into_iter().map(handle_to_json).collect();
-        Ok(serde_json::json!({ "windows": handles }))
-    }
+/// Tool call result: either a JSON value (rendered as text) or an image with optional metadata.
+enum ToolResult {
+    Json(Value),
+    Image { png_data: Vec<u8>, meta: Value },
+}
 
-    /// Get properties of a window (size, position, fullscreen/maximized/minimized state,
-    /// root element handle). The root_element_handle is the entry point for element tree traversal.
-    tool get_window_properties(
-        /// Window handle from list_windows.
-        window_handle: Handle,
-    ) -> Result<Value, String> {
-        let wp = state.window_properties(window_handle)?;
-        Ok(serde_json::json!({
-            "is_fullscreen": wp.is_fullscreen,
-            "is_maximized": wp.is_maximized,
-            "is_minimized": wp.is_minimized,
-            "size": { "width": wp.size.width, "height": wp.size.height },
-            "position": { "x": wp.position.x, "y": wp.position.y },
-            "root_element_handle": handle_to_json(wp.root_element_handle)
-        }))
-    }
-
-    /// Find elements by their qualified ID (e.g. 'App::mybutton'). Returns element handles.
-    /// Use get_element_tree first to discover available element IDs.
-    tool find_elements_by_id(
-        /// Window handle.
-        window_handle: Handle,
-        /// Qualified element ID (e.g. 'App::mybutton').
-        element_id: String,
-    ) -> Result<Value, String> {
-        let elements = state.find_elements_by_id(window_handle, &element_id)?;
-        let handles: Vec<Value> = elements
-            .into_iter()
-            .map(|e| handle_to_json(state.element_to_handle(e)))
-            .collect();
-        Ok(serde_json::json!({ "elements": handles }))
-    }
-
-    /// Get all properties of an element: type info, accessible properties (label, value,
-    /// description, role, checked, enabled, etc.), geometry (position, size), and opacity.
-    tool get_element_properties(
-        /// Element handle.
-        element_handle: Handle,
-    ) -> Result<Value, String> {
-        let element = state.element("get_element_properties", element_handle)?;
-        Ok(element_properties_to_json(&state.element_properties(&element)))
-    }
-
-    /// Query descendants of an element using a chain of match instructions. Each instruction
-    /// narrows the search. Use match_descendants to search recursively, then filter by id,
-    /// type_name, or accessible_role. More efficient than get_element_tree for targeted searches.
-    tool query_element_descendants(
-        /// Element handle to start the query from.
-        element_handle: Handle,
-        /// Array of query instructions applied in order.
-        query: QueryArray,
-        /// If true, return all matches. If false, return only the first match.
-        find_all: OptionalBool,
-    ) -> Result<Value, String> {
-        let element = state.element("query_element_descendants", element_handle)?;
-        let instructions = parse_query_instructions(&query)?;
-        let find_all = find_all.unwrap_or(true);
-        let results = state.query_element_descendants(element, instructions, find_all)?;
-        let handles: Vec<Value> = results
-            .into_iter()
-            .map(|e| handle_to_json(state.element_to_handle(e)))
-            .collect();
-        Ok(serde_json::json!({ "elements": handles }))
-    }
-
-    /// Get all elements in the subtree starting from a root element. Returns a flat list of
-    /// elements with their properties and handles. Use this to get an overview of the UI, then
-    /// use get_element_properties or query_element_descendants for targeted exploration.
-    /// Limit the result count with max_elements (default: 200, max: 1000).
-    tool get_element_tree(
-        /// Root element handle (typically from get_window_properties root_element_handle).
-        element_handle: Handle,
-        /// Maximum number of elements to return (default: 200, max: 1000).
-        max_elements: OptionalInt,
-    ) -> Result<Value, String> {
-        let max_elements = max_elements.unwrap_or(200).min(1000) as usize;
-        collect_element_list(state, element_handle, max_elements)
-    }
-
-    /// Take a screenshot of a window. Returns an MCP image content block.
-    tool take_screenshot(
-        /// Window handle.
-        window_handle: Handle,
-    ) -> Result<Value, String> {
-        let png_data = state.take_snapshot(window_handle, "image/png")?;
-        let b64 = base64::engine::general_purpose::STANDARD.encode(&png_data);
-        Ok(serde_json::json!({
-            "_mcp_image": {
-                "data": b64,
-                "mimeType": "image/png"
-            },
-            "size_bytes": png_data.len()
-        }))
-    }
-
-    /// Simulate a mouse click on an element.
-    tool click_element(
-        /// Element handle.
-        element_handle: Handle,
-        /// Click action: "single_click" (default) or "double_click".
-        action: OptionalString,
-        /// Mouse button: "left" (default), "right", or "middle".
-        button: OptionalString,
-    ) -> Result<Value, String> {
-        let element = state.element("click_element", element_handle)?;
-        let button = match if button.is_empty() { "left" } else { &button } {
-            "left" => i_slint_core::platform::PointerEventButton::Left,
-            "right" => i_slint_core::platform::PointerEventButton::Right,
-            "middle" => i_slint_core::platform::PointerEventButton::Middle,
-            other => return Err(format!("Unknown button: {other}")),
-        };
-        match if action.is_empty() { "single_click" } else { &action } {
-            "single_click" => element.single_click(button).await,
-            "double_click" => element.double_click(button).await,
-            other => return Err(format!("Unknown click action: {other}")),
-        };
-        Ok(serde_json::json!({ "success": true }))
-    }
-
-    /// Invoke an accessibility action on an element (e.g. default action for buttons,
-    /// increment/decrement for sliders, expand for combo boxes).
-    tool invoke_accessibility_action(
-        /// Element handle.
-        element_handle: Handle,
-        /// The action: "default", "increment", "decrement", or "expand".
-        action: String,
-    ) -> Result<Value, String> {
-        let element = state.element("invoke_accessibility_action", element_handle)?;
-        let action = match action.as_str() {
-            "default" => AccessibilityAction::Default,
-            "increment" => AccessibilityAction::Increment,
-            "decrement" => AccessibilityAction::Decrement,
-            "expand" => AccessibilityAction::Expand,
-            other => return Err(format!("Unknown action: {other}")),
-        };
-        state.invoke_element_accessibility_action(&element, action)?;
-        Ok(serde_json::json!({ "success": true }))
-    }
-
-    /// Set the accessible value of an element (e.g. text input content, slider value).
-    tool set_element_value(
-        /// Element handle.
-        element_handle: Handle,
-        /// The value to set.
-        value: String,
-    ) -> Result<Value, String> {
-        let element = state.element("set_element_value", element_handle)?;
-        element.set_accessible_value(value);
-        Ok(serde_json::json!({ "success": true }))
-    }
-
-    /// Dispatch a keyboard event to a window.
-    tool dispatch_key_event(
-        /// Window handle.
-        window_handle: Handle,
-        /// The key text to send.
-        text: String,
-        /// Event type: "press", "release", or "press_and_release" (default).
-        event_type: OptionalString,
-    ) -> Result<Value, String> {
-        let event_type = if event_type.is_empty() { "press_and_release".to_string() } else { event_type };
-        let events: Vec<i_slint_core::platform::WindowEvent> = match event_type.as_str() {
-            "press" => vec![
-                i_slint_core::platform::WindowEvent::KeyPressed { text: text.clone().into() },
-            ],
-            "release" => vec![
-                i_slint_core::platform::WindowEvent::KeyReleased { text: text.clone().into() },
-            ],
-            "press_and_release" => vec![
-                i_slint_core::platform::WindowEvent::KeyPressed { text: text.clone().into() },
-                i_slint_core::platform::WindowEvent::KeyReleased { text: text.into() },
-            ],
-            other => return Err(format!("Unknown event_type: {other}")),
-        };
-        for event in events {
-            state.dispatch_window_event(window_handle, event)?;
+async fn handle_tool_call(
+    state: &IntrospectionState,
+    name: &str,
+    args: &Value,
+) -> Result<ToolResult, String> {
+    match name {
+        "list_windows" => {
+            let handles: Vec<Value> =
+                state.window_handles().into_iter().map(handle_to_json).collect();
+            Ok(ToolResult::Json(serde_json::json!({ "windows": handles })))
         }
-        Ok(serde_json::json!({ "success": true }))
+        "get_window_properties" => {
+            let p: WindowHandleParam = deserialize_params(args)?;
+            let wp = state.window_properties(p.window_handle.to_index())?;
+            Ok(ToolResult::Json(serde_json::json!({
+                "is_fullscreen": wp.is_fullscreen,
+                "is_maximized": wp.is_maximized,
+                "is_minimized": wp.is_minimized,
+                "size": { "width": wp.size.width, "height": wp.size.height },
+                "position": { "x": wp.position.x, "y": wp.position.y },
+                "root_element_handle": handle_to_json(wp.root_element_handle)
+            })))
+        }
+        "find_elements_by_id" => {
+            let p: FindElementsByIdParams = deserialize_params(args)?;
+            let elements =
+                state.find_elements_by_id(p.window_handle.to_index(), &p.element_id)?;
+            let handles: Vec<Value> = elements
+                .into_iter()
+                .map(|e| handle_to_json(state.element_to_handle(e)))
+                .collect();
+            Ok(ToolResult::Json(serde_json::json!({ "elements": handles })))
+        }
+        "get_element_properties" => {
+            let p: ElementHandleParam = deserialize_params(args)?;
+            let element = state.element("get_element_properties", p.element_handle.to_index())?;
+            Ok(ToolResult::Json(element_properties_to_json(&state.element_properties(&element))))
+        }
+        "query_element_descendants" => {
+            let p: QueryElementDescendantsParams = deserialize_params(args)?;
+            let element =
+                state.element("query_element_descendants", p.element_handle.to_index())?;
+            let instructions = parse_query_instructions(&p.query)?;
+            let find_all = p.find_all.unwrap_or(true);
+            let results = state.query_element_descendants(element, instructions, find_all)?;
+            let handles: Vec<Value> = results
+                .into_iter()
+                .map(|e| handle_to_json(state.element_to_handle(e)))
+                .collect();
+            Ok(ToolResult::Json(serde_json::json!({ "elements": handles })))
+        }
+        "get_element_tree" => {
+            let p: GetElementTreeParams = deserialize_params(args)?;
+            let max_elements = p.max_elements.unwrap_or(200).clamp(1, 1000) as usize;
+            collect_element_list(state, p.element_handle.to_index(), max_elements)
+                .map(ToolResult::Json)
+        }
+        "take_screenshot" => {
+            let p: WindowHandleParam = deserialize_params(args)?;
+            let png_data = state.take_snapshot(p.window_handle.to_index(), "image/png")?;
+            Ok(ToolResult::Image {
+                meta: serde_json::json!({ "size_bytes": png_data.len() }),
+                png_data,
+            })
+        }
+        "click_element" => {
+            let p: ClickElementParams = deserialize_params(args)?;
+            let element = state.element("click_element", p.element_handle.to_index())?;
+            let button = match p.button.as_deref().unwrap_or("left") {
+                "left" => i_slint_core::platform::PointerEventButton::Left,
+                "right" => i_slint_core::platform::PointerEventButton::Right,
+                "middle" => i_slint_core::platform::PointerEventButton::Middle,
+                other => return Err(format!("Unknown button: {other}")),
+            };
+            match p.action.as_deref().unwrap_or("single_click") {
+                "single_click" => element.single_click(button).await,
+                "double_click" => element.double_click(button).await,
+                other => return Err(format!("Unknown click action: {other}")),
+            };
+            Ok(ToolResult::Json(serde_json::json!({ "success": true })))
+        }
+        "invoke_accessibility_action" => {
+            let p: InvokeAccessibilityActionParams = deserialize_params(args)?;
+            let element =
+                state.element("invoke_accessibility_action", p.element_handle.to_index())?;
+            let action = match p.action.as_str() {
+                "default" => AccessibilityAction::Default,
+                "increment" => AccessibilityAction::Increment,
+                "decrement" => AccessibilityAction::Decrement,
+                "expand" => AccessibilityAction::Expand,
+                other => return Err(format!("Unknown action: {other}")),
+            };
+            state.invoke_element_accessibility_action(&element, action)?;
+            Ok(ToolResult::Json(serde_json::json!({ "success": true })))
+        }
+        "set_element_value" => {
+            let p: SetElementValueParams = deserialize_params(args)?;
+            let element = state.element("set_element_value", p.element_handle.to_index())?;
+            element.set_accessible_value(p.value);
+            Ok(ToolResult::Json(serde_json::json!({ "success": true })))
+        }
+        "dispatch_key_event" => {
+            let p: DispatchKeyEventParams = deserialize_params(args)?;
+            let window_handle = p.window_handle.to_index();
+            let event_type = p.event_type.as_deref().unwrap_or("press_and_release");
+            let events: Vec<i_slint_core::platform::WindowEvent> = match event_type {
+                "press" => vec![i_slint_core::platform::WindowEvent::KeyPressed {
+                    text: p.text.clone().into(),
+                }],
+                "release" => vec![i_slint_core::platform::WindowEvent::KeyReleased {
+                    text: p.text.clone().into(),
+                }],
+                "press_and_release" => vec![
+                    i_slint_core::platform::WindowEvent::KeyPressed {
+                        text: p.text.clone().into(),
+                    },
+                    i_slint_core::platform::WindowEvent::KeyReleased {
+                        text: p.text.into(),
+                    },
+                ],
+                other => return Err(format!("Unknown event_type: {other}")),
+            };
+            for event in events {
+                state.dispatch_window_event(window_handle, event)?;
+            }
+            Ok(ToolResult::Json(serde_json::json!({ "success": true })))
+        }
+        _ => Err(format!("Unknown tool: {name}")),
     }
 }
 
@@ -402,27 +427,28 @@ mcp_tools! {
 fn parse_query_instructions(arr: &[Value]) -> Result<Vec<QueryInstruction>, String> {
     let mut instructions = Vec::new();
     for item in arr {
-        let instr =
+        if item.get("match_descendants").is_some() {
+            // Treat {match_descendants: false} as a no-op; only true adds the instruction.
             if item.get("match_descendants").and_then(|v| v.as_bool()).unwrap_or(false) {
-                QueryInstruction::MatchDescendants
-            } else if let Some(id) = item.get("match_id").and_then(|v| v.as_str()) {
-                QueryInstruction::MatchId(id.to_string())
-            } else if let Some(tn) = item.get("match_type_name").and_then(|v| v.as_str()) {
-                QueryInstruction::MatchTypeName(tn.to_string())
-            } else if let Some(tn) =
-                item.get("match_type_name_or_base").and_then(|v| v.as_str())
-            {
-                QueryInstruction::MatchTypeNameOrBase(tn.to_string())
-            } else if let Some(role_str) =
-                item.get("match_accessible_role").and_then(|v| v.as_str())
-            {
-                let role = introspection::string_to_accessible_role(role_str)
-                    .ok_or_else(|| format!("Unknown accessible role: {role_str}"))?;
-                QueryInstruction::MatchAccessibleRole(role)
-            } else {
-                return Err("Invalid query instruction".into());
-            };
-        instructions.push(instr);
+                instructions.push(QueryInstruction::MatchDescendants);
+            }
+        } else if let Some(id) = item.get("match_id").and_then(|v| v.as_str()) {
+            instructions.push(QueryInstruction::MatchId(id.to_string()));
+        } else if let Some(tn) = item.get("match_type_name").and_then(|v| v.as_str()) {
+            instructions.push(QueryInstruction::MatchTypeName(tn.to_string()));
+        } else if let Some(tn) =
+            item.get("match_type_name_or_base").and_then(|v| v.as_str())
+        {
+            instructions.push(QueryInstruction::MatchTypeNameOrBase(tn.to_string()));
+        } else if let Some(role_str) =
+            item.get("match_accessible_role").and_then(|v| v.as_str())
+        {
+            let role = introspection::string_to_accessible_role(role_str)
+                .ok_or_else(|| format!("Unknown accessible role: {role_str}"))?;
+            instructions.push(QueryInstruction::MatchAccessibleRole(role));
+        } else {
+            return Err("Invalid query instruction".into());
+        }
     }
     Ok(instructions)
 }
@@ -531,6 +557,15 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
         }
     };
 
+    // Batch requests (JSON arrays) are not supported.
+    if request.is_array() {
+        return Some(json_rpc_error(
+            &Value::Null,
+            -32600,
+            "Batch requests are not supported".into(),
+        ));
+    }
+
     let id = request.get("id").cloned().unwrap_or(Value::Null);
     let method = request.get("method").and_then(|v| v.as_str()).unwrap_or("");
     let is_notification = request.get("id").is_none();
@@ -553,7 +588,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "Recommended workflow:\n",
                     "1. list_windows — get window handles\n",
                     "2. get_window_properties — get the root_element_handle\n",
-                    "3. get_element_tree (max_depth=2-3) — explore the UI hierarchy\n",
+                    "3. get_element_tree (max_elements=200) — explore the UI hierarchy\n",
                     "4. Use find_elements_by_id or query_element_descendants for targeted lookups\n",
                     "5. get_element_properties — inspect specific elements\n",
                     "6. take_screenshot — see the current visual state\n\n",
@@ -574,26 +609,28 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
 
             match handle_tool_call(state, tool_name, &tool_args).await {
                 Ok(result) => {
-                    let content = if let Some(img) = result.get("_mcp_image") {
-                        let mut blocks = vec![serde_json::json!({
-                            "type": "image",
-                            "data": img.get("data").and_then(|v| v.as_str()).unwrap_or(""),
-                            "mimeType": img.get("mimeType").and_then(|v| v.as_str()).unwrap_or("image/png")
-                        })];
-                        let mut meta = result.clone();
-                        meta.as_object_mut().unwrap().remove("_mcp_image");
-                        if !meta.as_object().unwrap().is_empty() {
-                            blocks.push(serde_json::json!({
-                                "type": "text",
-                                "text": serde_json::to_string_pretty(&meta).unwrap()
-                            }));
+                    let content = match result {
+                        ToolResult::Image { png_data, meta } => {
+                            let b64 = base64::engine::general_purpose::STANDARD.encode(&png_data);
+                            let mut blocks = vec![serde_json::json!({
+                                "type": "image",
+                                "data": b64,
+                                "mimeType": "image/png"
+                            })];
+                            if !meta.as_object().map_or(true, |o| o.is_empty()) {
+                                blocks.push(serde_json::json!({
+                                    "type": "text",
+                                    "text": serde_json::to_string_pretty(&meta).unwrap()
+                                }));
+                            }
+                            blocks
                         }
-                        blocks
-                    } else {
-                        vec![serde_json::json!({
-                            "type": "text",
-                            "text": serde_json::to_string_pretty(&result).unwrap()
-                        })]
+                        ToolResult::Json(value) => {
+                            vec![serde_json::json!({
+                                "type": "text",
+                                "text": serde_json::to_string_pretty(&value).unwrap()
+                            })]
+                        }
                     };
                     json_rpc_success(&id, serde_json::json!({ "content": content }))
                 }
@@ -626,27 +663,35 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
 // ============================================================================
 
 /// Read a complete HTTP request from a stream.
-/// Returns (method, path, headers, body).
+/// `carry` contains leftover bytes from a previous read on this connection.
+/// Returns (method, path, headers, body, leftover) where leftover is any
+/// data past the current request's body (start of the next pipelined request).
 async fn read_http_request(
     stream: &mut async_net::TcpStream,
-) -> Result<(String, String, Vec<(String, String)>, Vec<u8>), String> {
+    carry: Vec<u8>,
+) -> Result<(String, String, Vec<(String, String)>, Vec<u8>, Vec<u8>), String> {
     // Read headers into a buffer. We read in chunks until we find \r\n\r\n.
-    let mut buf = Vec::with_capacity(4096);
+    let mut buf = carry;
     let header_end;
-    loop {
-        let mut chunk = [0u8; 1024];
-        let n = stream.read(&mut chunk).await.map_err(|e| format!("read error: {e}"))?;
-        if n == 0 {
-            return Err("connection closed".into());
-        }
-        buf.extend_from_slice(&chunk[..n]);
+    // Check if the carry buffer already contains a complete header.
+    if let Some(pos) = find_header_end(&buf) {
+        header_end = pos;
+    } else {
+        loop {
+            let mut chunk = [0u8; 1024];
+            let n = stream.read(&mut chunk).await.map_err(|e| format!("read error: {e}"))?;
+            if n == 0 {
+                return Err("connection closed".into());
+            }
+            buf.extend_from_slice(&chunk[..n]);
 
-        if let Some(pos) = find_header_end(&buf) {
-            header_end = pos;
-            break;
-        }
-        if buf.len() > 64 * 1024 {
-            return Err("headers too large".into());
+            if let Some(pos) = find_header_end(&buf) {
+                header_end = pos;
+                break;
+            }
+            if buf.len() > 64 * 1024 {
+                return Err("headers too large".into());
+            }
         }
     }
 
@@ -671,31 +716,42 @@ async fn read_http_request(
         })
         .collect();
 
-    // Read body based on Content-Length (capped at 4 MB to prevent OOM)
+    // Read body based on Content-Length (capped at 4 MB to prevent OOM).
+    // Reject conflicting Content-Length values per RFC 7230 §3.3.2.
     const MAX_BODY_SIZE: usize = 4 * 1024 * 1024;
-    let content_length: usize = parsed_headers
+    let cl_values: Vec<&str> = parsed_headers
         .iter()
-        .find(|(k, _)| k == "content-length")
-        .and_then(|(_, v)| v.parse().ok())
-        .unwrap_or(0);
+        .filter(|(k, _)| k == "content-length")
+        .map(|(_, v)| v.as_str())
+        .collect();
+    if cl_values.len() > 1 && !cl_values.iter().all(|v| *v == cl_values[0]) {
+        return Err("conflicting Content-Length headers".into());
+    }
+    let content_length: usize = cl_values.first().and_then(|v| v.parse().ok()).unwrap_or(0);
     if content_length > MAX_BODY_SIZE {
         return Err(format!("body too large: {content_length} bytes (max {MAX_BODY_SIZE})"));
     }
 
     // Body bytes we already have (after the header end)
     let body_start = header_end + 4; // skip \r\n\r\n
-    let already_read = buf.len() - body_start;
-    let mut body = buf[body_start..].to_vec();
+    let available = buf.len() - body_start;
 
-    // Read remaining body bytes
-    if already_read < content_length {
-        let remaining = content_length - already_read;
+    let (body, leftover) = if available >= content_length {
+        // We have the full body (and possibly the start of the next request)
+        let body = buf[body_start..body_start + content_length].to_vec();
+        let leftover = buf[body_start + content_length..].to_vec();
+        (body, leftover)
+    } else {
+        // Need to read more body bytes from the stream
+        let mut body = buf[body_start..].to_vec();
+        let remaining = content_length - available;
         let mut rest = vec![0u8; remaining];
         stream.read_exact(&mut rest).await.map_err(|e| format!("body read error: {e}"))?;
         body.extend_from_slice(&rest);
-    }
+        (body, Vec::new())
+    };
 
-    Ok((method, path, parsed_headers, body))
+    Ok((method, path, parsed_headers, body, leftover))
 }
 
 fn find_header_end(buf: &[u8]) -> Option<usize> {
@@ -714,7 +770,6 @@ async fn write_http_response(
         response.push_str(&format!("{k}: {v}\r\n"));
     }
     response.push_str(&format!("Content-Length: {}\r\n", body.len()));
-    response.push_str("Connection: close\r\n");
     response.push_str("\r\n");
 
     stream.write_all(response.as_bytes()).await.map_err(|e| format!("write error: {e}"))?;
@@ -741,88 +796,127 @@ fn is_localhost_origin(origin: &str) -> bool {
     } else {
         host.split(':').next().unwrap_or(host)
     };
-    matches!(host_no_port, "localhost" | "127.0.0.1" | "::1" | "0.0.0.0")
+    matches!(host_no_port, "localhost" | "127.0.0.1" | "::1")
 }
 
-fn validate_origin(headers: &[(String, String)]) -> bool {
+/// Returns the validated origin if present and allowed, or `None` if no origin was sent.
+/// Returns `Err` if the origin is present but not a localhost address.
+fn validate_origin(headers: &[(String, String)]) -> Result<Option<&str>, ()> {
     let origin = headers.iter().find(|(k, _)| k == "origin").map(|(_, v)| v.as_str());
     match origin {
-        None => true, // No Origin header — non-browser client (curl, MCP SDK, etc.)
-        Some(o) => is_localhost_origin(o.trim()),
+        None => Ok(None), // No Origin header — non-browser client (curl, MCP SDK, etc.)
+        Some(o) if is_localhost_origin(o.trim()) => Ok(Some(o.trim())),
+        Some(_) => Err(()),
     }
+}
+
+/// Returns true if the client requested connection close.
+fn wants_close(headers: &[(String, String)]) -> bool {
+    headers
+        .iter()
+        .any(|(k, v)| k == "connection" && v.eq_ignore_ascii_case("close"))
 }
 
 async fn handle_connection(state: &IntrospectionState, mut stream: async_net::TcpStream) {
-    let (method, path, headers, body) = match read_http_request(&mut stream).await {
-        Ok(req) => req,
-        Err(e) => {
-            debug_log!("MCP HTTP: failed to read request: {e}");
-            return;
-        }
-    };
+    let mut carry = Vec::new();
 
-    // Validate Origin header to prevent DNS rebinding attacks.
-    if !validate_origin(&headers) {
-        let _ = write_http_response(
-            &mut stream,
-            403,
-            "Forbidden",
-            &[],
-            b"Origin not allowed\n",
-        )
-        .await;
-        return;
-    }
+    loop {
+        let (method, path, headers, body, leftover) =
+            match read_http_request(&mut stream, carry).await {
+                Ok(req) => req,
+                Err(_) => return, // Connection closed or read error — done.
+            };
 
-    // Handle CORS preflight for browser-based MCP clients.
-    if method == "OPTIONS" {
-        let origin = headers
-            .iter()
-            .find(|(k, _)| k == "origin")
-            .map(|(_, v)| v.as_str())
-            .unwrap_or("http://localhost");
-        let cors_headers = [
-            ("Access-Control-Allow-Origin", origin),
-            ("Access-Control-Allow-Methods", "POST, OPTIONS"),
-            ("Access-Control-Allow-Headers", "Content-Type, MCP-Protocol-Version, Mcp-Session-Id"),
-            ("Access-Control-Max-Age", "86400"),
-            ("Vary", "Origin"),
-        ];
-        let _ = write_http_response(&mut stream, 204, "No Content", &cors_headers, b"").await;
-        return;
-    }
+        let close_after = wants_close(&headers);
+        carry = leftover;
 
-    // Only accept POST /mcp (or POST / for flexibility)
-    if method != "POST" || (path != "/mcp" && path != "/") {
-        let body = b"404 Not Found\n";
-        let _ = write_http_response(&mut stream, 404, "Not Found", &[], body).await;
-        return;
-    }
+        // Validate Origin header to prevent DNS rebinding attacks.
+        let allowed_origin = match validate_origin(&headers) {
+            Ok(origin) => origin,
+            Err(()) => {
+                let _ = write_http_response(
+                    &mut stream,
+                    403,
+                    "Forbidden",
+                    &[],
+                    b"Origin not allowed\n",
+                )
+                .await;
+                return;
+            }
+        };
 
-    let body_str = String::from_utf8_lossy(&body);
-    let response = handle_mcp_request(state, &body_str).await;
+        // The CORS origin to echo back: the validated origin, or "*" for non-browser clients.
+        let cors_origin = allowed_origin.unwrap_or("*");
 
-    // Mirror the request's Origin back (already validated above).
-    let origin = headers
-        .iter()
-        .find(|(k, _)| k == "origin")
-        .map(|(_, v)| v.as_str())
-        .unwrap_or("http://localhost");
-    let resp_headers = [
-        ("Content-Type", "application/json"),
-        ("Access-Control-Allow-Origin", origin),
-        ("Vary", "Origin"),
-    ];
-
-    match response {
-        Some(resp) => {
-            let json = serde_json::to_string(&resp).unwrap();
+        // Handle CORS preflight for browser-based MCP clients.
+        if method == "OPTIONS" {
+            let cors_headers = [
+                ("Access-Control-Allow-Origin", cors_origin),
+                ("Access-Control-Allow-Methods", "POST, OPTIONS"),
+                (
+                    "Access-Control-Allow-Headers",
+                    "Content-Type, MCP-Protocol-Version, Mcp-Session-Id",
+                ),
+                ("Access-Control-Max-Age", "86400"),
+                ("Vary", "Origin"),
+            ];
             let _ =
-                write_http_response(&mut stream, 200, "OK", &resp_headers, json.as_bytes()).await;
+                write_http_response(&mut stream, 204, "No Content", &cors_headers, b"").await;
+        } else if method != "POST" || (path != "/mcp" && path != "/") {
+            let _ =
+                write_http_response(&mut stream, 404, "Not Found", &[], b"404 Not Found\n").await;
+        } else if !headers
+            .iter()
+            .find(|(k, _)| k == "content-type")
+            .map(|(_, v)| v.as_str())
+            .is_some_and(|ct| ct.starts_with("application/json"))
+        {
+            let _ = write_http_response(
+                &mut stream,
+                415,
+                "Unsupported Media Type",
+                &[],
+                b"Content-Type must be application/json\n",
+            )
+            .await;
+        } else {
+            let body_str = String::from_utf8_lossy(&body);
+            let response = handle_mcp_request(state, &body_str).await;
+
+            let resp_headers = [
+                ("Content-Type", "application/json"),
+                ("Access-Control-Allow-Origin", cors_origin),
+                ("Vary", "Origin"),
+            ];
+
+            match response {
+                Some(resp) => {
+                    let json = serde_json::to_string(&resp).unwrap();
+                    let _ = write_http_response(
+                        &mut stream,
+                        200,
+                        "OK",
+                        &resp_headers,
+                        json.as_bytes(),
+                    )
+                    .await;
+                }
+                None => {
+                    let _ = write_http_response(
+                        &mut stream,
+                        202,
+                        "Accepted",
+                        &resp_headers,
+                        b"",
+                    )
+                    .await;
+                }
+            }
         }
-        None => {
-            // Notification — 202 Accepted with no body
-            let _ = write_http_response(&mut stream, 202, "Accepted", &resp_headers, b"").await;
+
+        if close_after {
+            return;
         }
     }
 }
@@ -854,7 +948,7 @@ async fn run_server(state: Rc<IntrospectionState>, port: u16) {
                 );
             }
             Err(e) => {
-                debug_log!("MCP server: accept error: {e}");
+                eprintln!("MCP server: accept error: {e}");
             }
         }
     }
@@ -929,28 +1023,28 @@ mod tests {
         // Test basic roundtrip
         let index = generational_arena::Index::from_raw_parts(0, 0);
         let json = handle_to_json(index);
-        let back = handle_from_json(&json).unwrap();
-        assert_eq!(index, back);
+        let handle: Handle = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(index, handle.to_index());
 
         // Test with larger values
         let index = generational_arena::Index::from_raw_parts(42, 7);
         let json = handle_to_json(index);
         assert_eq!(json["index"], 42);
         assert_eq!(json["generation"], 7);
-        let back = handle_from_json(&json).unwrap();
-        assert_eq!(index, back);
+        let handle: Handle = serde_json::from_value(json).unwrap();
+        assert_eq!(index, handle.to_index());
     }
 
     #[test]
-    fn test_handle_from_json_missing_fields() {
+    fn test_handle_deserialize_missing_fields() {
         let v = serde_json::json!({});
-        assert!(handle_from_json(&v).is_err());
+        assert!(serde_json::from_value::<Handle>(v).is_err());
 
         let v = serde_json::json!({"index": 0});
-        assert!(handle_from_json(&v).is_err());
+        assert!(serde_json::from_value::<Handle>(v).is_err());
 
         let v = serde_json::json!({"generation": 0});
-        assert!(handle_from_json(&v).is_err());
+        assert!(serde_json::from_value::<Handle>(v).is_err());
     }
 
     #[test]
@@ -985,6 +1079,13 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_query_instructions_match_descendants_false_is_noop() {
+        let arr = vec![serde_json::json!({"match_descendants": false})];
+        let instructions = parse_query_instructions(&arr).unwrap();
+        assert!(instructions.is_empty(), "match_descendants: false should be a no-op");
+    }
+
+    #[test]
     fn test_parse_query_instructions_unknown_role() {
         let arr = vec![serde_json::json!({"match_accessible_role": "nonexistent"})];
         assert!(parse_query_instructions(&arr).is_err());
@@ -992,26 +1093,38 @@ mod tests {
 
     #[test]
     fn test_validate_origin() {
-        // No Origin header — allowed (non-browser client)
-        assert!(validate_origin(&[]));
+        // No Origin header — allowed, returns Ok(None)
+        assert_eq!(validate_origin(&[]), Ok(None));
 
-        // Localhost origins — allowed
-        assert!(validate_origin(&[("origin".into(), "http://localhost".into())]));
-        assert!(validate_origin(&[("origin".into(), "http://localhost:3000".into())]));
-        assert!(validate_origin(&[("origin".into(), "https://localhost:8443".into())]));
-        assert!(validate_origin(&[("origin".into(), "http://127.0.0.1:8080".into())]));
-        assert!(validate_origin(&[("origin".into(), "http://[::1]:3000".into())]));
-        assert!(validate_origin(&[("origin".into(), "http://0.0.0.0:8080".into())]));
+        // Localhost origins — allowed, returns Ok(Some(origin))
+        assert!(validate_origin(&[("origin".into(), "http://localhost".into())]).is_ok());
+        assert_eq!(
+            validate_origin(&[("origin".into(), "http://localhost:3000".into())]),
+            Ok(Some("http://localhost:3000"))
+        );
+        assert!(validate_origin(&[("origin".into(), "https://localhost:8443".into())]).is_ok());
+        assert!(validate_origin(&[("origin".into(), "http://127.0.0.1:8080".into())]).is_ok());
+        assert!(validate_origin(&[("origin".into(), "http://[::1]:3000".into())]).is_ok());
 
         // External origins — rejected
-        assert!(!validate_origin(&[("origin".into(), "http://evil.com".into())]));
-        assert!(!validate_origin(&[("origin".into(), "http://localhost.evil.com".into())]));
-        assert!(!validate_origin(&[("origin".into(), "https://attacker.com".into())]));
+        assert!(validate_origin(&[("origin".into(), "http://evil.com".into())]).is_err());
+        assert!(validate_origin(&[("origin".into(), "http://localhost.evil.com".into())]).is_err());
+        assert!(validate_origin(&[("origin".into(), "https://attacker.com".into())]).is_err());
 
         // Edge cases
-        assert!(!validate_origin(&[("origin".into(), "http://127.0.0.2".into())]));
-        assert!(!validate_origin(&[("origin".into(), "".into())]));
-        assert!(!validate_origin(&[("origin".into(), "localhost".into())])); // no scheme
+        assert!(validate_origin(&[("origin".into(), "http://0.0.0.0:8080".into())]).is_err());
+        assert!(validate_origin(&[("origin".into(), "http://127.0.0.2".into())]).is_err());
+        assert!(validate_origin(&[("origin".into(), "".into())]).is_err());
+        assert!(validate_origin(&[("origin".into(), "localhost".into())]).is_err()); // no scheme
+    }
+
+    #[test]
+    fn test_wants_close() {
+        assert!(!wants_close(&[]));
+        assert!(!wants_close(&[("connection".into(), "keep-alive".into())]));
+        assert!(wants_close(&[("connection".into(), "close".into())]));
+        assert!(wants_close(&[("connection".into(), "Close".into())]));
+        assert!(!wants_close(&[("content-type".into(), "close".into())]));
     }
 
     #[test]
@@ -1212,6 +1325,18 @@ mod tests {
     }
 
     #[test]
+    fn test_mcp_batch_request_rejected() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"[{"jsonrpc":"2.0","id":1,"method":"initialize"},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]"#,
+        ));
+        let resp = resp.unwrap();
+        assert_eq!(resp["error"]["code"], -32600);
+        assert!(resp["error"]["message"].as_str().unwrap().contains("Batch"));
+    }
+
+    #[test]
     fn test_mcp_missing_method() {
         let state = make_state();
         // Valid JSON-RPC but no method field — treated as unknown method ""
@@ -1258,5 +1383,455 @@ mod tests {
         };
         let json = element_properties_to_json(&ep);
         assert_eq!(json["layout_kind"], "vertical");
+    }
+
+    // ========================================================================
+    // Parameter deserialization tests
+    // ========================================================================
+
+    #[test]
+    fn test_deserialize_window_handle_param() {
+        let v = serde_json::json!({"window_handle": {"index": 1, "generation": 2}});
+        let p: WindowHandleParam = serde_json::from_value(v).unwrap();
+        assert_eq!(p.window_handle.index, 1);
+        assert_eq!(p.window_handle.generation, 2);
+    }
+
+    #[test]
+    fn test_deserialize_window_handle_param_wrong_type() {
+        let v = serde_json::json!({"window_handle": "not_an_object"});
+        assert!(serde_json::from_value::<WindowHandleParam>(v).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_find_elements_by_id_params() {
+        let v = serde_json::json!({
+            "window_handle": {"index": 0, "generation": 0},
+            "element_id": "App::button1"
+        });
+        let p: FindElementsByIdParams = serde_json::from_value(v).unwrap();
+        assert_eq!(p.element_id, "App::button1");
+    }
+
+    #[test]
+    fn test_deserialize_find_elements_by_id_missing_id() {
+        let v = serde_json::json!({"window_handle": {"index": 0, "generation": 0}});
+        assert!(serde_json::from_value::<FindElementsByIdParams>(v).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_click_element_defaults() {
+        let v = serde_json::json!({"element_handle": {"index": 0, "generation": 0}});
+        let p: ClickElementParams = serde_json::from_value(v).unwrap();
+        assert!(p.action.is_none());
+        assert!(p.button.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_click_element_with_optionals() {
+        let v = serde_json::json!({
+            "element_handle": {"index": 0, "generation": 0},
+            "action": "double_click",
+            "button": "right"
+        });
+        let p: ClickElementParams = serde_json::from_value(v).unwrap();
+        assert_eq!(p.action.as_deref(), Some("double_click"));
+        assert_eq!(p.button.as_deref(), Some("right"));
+    }
+
+    #[test]
+    fn test_deserialize_dispatch_key_event_defaults() {
+        let v = serde_json::json!({
+            "window_handle": {"index": 0, "generation": 0},
+            "text": "a"
+        });
+        let p: DispatchKeyEventParams = serde_json::from_value(v).unwrap();
+        assert_eq!(p.text, "a");
+        assert!(p.event_type.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_get_element_tree_defaults() {
+        let v = serde_json::json!({"element_handle": {"index": 0, "generation": 0}});
+        let p: GetElementTreeParams = serde_json::from_value(v).unwrap();
+        assert!(p.max_elements.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_query_element_descendants_defaults() {
+        let v = serde_json::json!({
+            "element_handle": {"index": 0, "generation": 0},
+            "query": [{"match_descendants": true}]
+        });
+        let p: QueryElementDescendantsParams = serde_json::from_value(v).unwrap();
+        assert!(p.find_all.is_none());
+        assert_eq!(p.query.len(), 1);
+    }
+
+    #[test]
+    fn test_deserialize_params_wrong_type() {
+        // Passing a string where an object is expected
+        let result = deserialize_params::<WindowHandleParam>(&serde_json::json!("string"));
+        let err = result.err().expect("should fail");
+        assert!(err.contains("Invalid parameters"));
+    }
+
+    #[test]
+    fn test_deserialize_invoke_accessibility_action_params() {
+        let v = serde_json::json!({
+            "element_handle": {"index": 5, "generation": 3},
+            "action": "increment"
+        });
+        let p: InvokeAccessibilityActionParams = serde_json::from_value(v).unwrap();
+        assert_eq!(p.action, "increment");
+        assert_eq!(p.element_handle.index, 5);
+    }
+
+    #[test]
+    fn test_deserialize_invoke_accessibility_action_missing_action() {
+        let v = serde_json::json!({"element_handle": {"index": 0, "generation": 0}});
+        assert!(serde_json::from_value::<InvokeAccessibilityActionParams>(v).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_set_element_value_params() {
+        let v = serde_json::json!({
+            "element_handle": {"index": 0, "generation": 0},
+            "value": "hello"
+        });
+        let p: SetElementValueParams = serde_json::from_value(v).unwrap();
+        assert_eq!(p.value, "hello");
+    }
+
+    #[test]
+    fn test_deserialize_set_element_value_missing_value() {
+        let v = serde_json::json!({"element_handle": {"index": 0, "generation": 0}});
+        assert!(serde_json::from_value::<SetElementValueParams>(v).is_err());
+    }
+
+    // ========================================================================
+    // Tool error path tests (via handle_tool_call)
+    // ========================================================================
+
+    /// Helper: call a tool and return the result directly.
+    fn call_tool(state: &IntrospectionState, name: &str, args: Value) -> Result<Value, String> {
+        block_on(handle_tool_call(state, name, &args)).map(|r| match r {
+            ToolResult::Json(v) => v,
+            ToolResult::Image { png_data, meta } => {
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&png_data);
+                serde_json::json!({ "image_data": b64, "meta": meta })
+            }
+        })
+    }
+
+    /// Helper: make a handle JSON for an index that doesn't exist in the arena.
+    fn bogus_handle() -> Value {
+        serde_json::json!({"index": 999, "generation": 999})
+    }
+
+    #[test]
+    fn test_tool_get_window_properties_invalid_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "get_window_properties",
+            serde_json::json!({"window_handle": bogus_handle()}),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid window handle"));
+    }
+
+    #[test]
+    fn test_tool_find_elements_by_id_invalid_window() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "find_elements_by_id",
+            serde_json::json!({
+                "window_handle": bogus_handle(),
+                "element_id": "App::foo"
+            }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_get_element_properties_invalid_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "get_element_properties",
+            serde_json::json!({"element_handle": bogus_handle()}),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid element handle"));
+    }
+
+    #[test]
+    fn test_tool_query_element_descendants_invalid_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "query_element_descendants",
+            serde_json::json!({
+                "element_handle": bogus_handle(),
+                "query": [{"match_descendants": true}]
+            }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_get_element_tree_invalid_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "get_element_tree",
+            serde_json::json!({"element_handle": bogus_handle()}),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_take_screenshot_invalid_window() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "take_screenshot",
+            serde_json::json!({"window_handle": bogus_handle()}),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_click_element_invalid_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "click_element",
+            serde_json::json!({"element_handle": bogus_handle()}),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_click_element_invalid_button() {
+        let state = make_state();
+        // Dummy elements fail is_valid(), so we get an element error before
+        // reaching button validation. Verify the error path works.
+        let handle_idx = state.element_to_handle(crate::ElementHandle::new_test_dummy());
+        let handle = handle_to_json(handle_idx);
+        let result = call_tool(
+            &state,
+            "click_element",
+            serde_json::json!({
+                "element_handle": handle,
+                "button": "imaginary"
+            }),
+        );
+        assert!(result.is_err());
+        // Element is invalid (test dummy), so we get an element error
+        assert!(result.unwrap_err().contains("element"));
+    }
+
+    #[test]
+    fn test_tool_click_element_missing_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "click_element",
+            serde_json::json!({"action": "triple_click"}),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid parameters"));
+    }
+
+    #[test]
+    fn test_tool_invoke_accessibility_action_invalid_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "invoke_accessibility_action",
+            serde_json::json!({
+                "element_handle": bogus_handle(),
+                "action": "default"
+            }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_invoke_accessibility_action_unknown_action() {
+        let state = make_state();
+        // Dummy elements fail is_valid(), so we get an element error
+        let handle_idx = state.element_to_handle(crate::ElementHandle::new_test_dummy());
+        let handle = handle_to_json(handle_idx);
+        let result = call_tool(
+            &state,
+            "invoke_accessibility_action",
+            serde_json::json!({
+                "element_handle": handle,
+                "action": "fly"
+            }),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("element"));
+    }
+
+    #[test]
+    fn test_tool_invoke_accessibility_action_missing_action() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "invoke_accessibility_action",
+            serde_json::json!({"element_handle": {"index": 0, "generation": 0}}),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid parameters"));
+    }
+
+    #[test]
+    fn test_tool_set_element_value_invalid_handle() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "set_element_value",
+            serde_json::json!({
+                "element_handle": bogus_handle(),
+                "value": "test"
+            }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_dispatch_key_event_invalid_window() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "dispatch_key_event",
+            serde_json::json!({
+                "window_handle": bogus_handle(),
+                "text": "a"
+            }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_dispatch_key_event_unknown_event_type() {
+        let state = make_state();
+        let result = call_tool(
+            &state,
+            "dispatch_key_event",
+            serde_json::json!({
+                "window_handle": bogus_handle(),
+                "text": "a",
+                "event_type": "smash"
+            }),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown event_type"));
+    }
+
+    // ========================================================================
+    // Tool error wrapping via MCP request (isError flag)
+    // ========================================================================
+
+    #[test]
+    fn test_mcp_tool_error_is_wrapped_correctly() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"get_element_properties","arguments":{"element_handle":{"index":999,"generation":999}}}}"#,
+        ));
+        let resp = resp.unwrap();
+        assert_eq!(resp["id"], 10);
+        assert!(resp["result"]["isError"].as_bool().unwrap());
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("Error:"));
+    }
+
+    #[test]
+    fn test_mcp_tool_deserialization_error_is_wrapped() {
+        let state = make_state();
+        // Pass wrong type for window_handle (string instead of object)
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"get_window_properties","arguments":{"window_handle":"bad"}}}"#,
+        ));
+        let resp = resp.unwrap();
+        assert!(resp["result"]["isError"].as_bool().unwrap());
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("Invalid parameters"));
+    }
+
+    // ========================================================================
+    // Tool definitions schema validation
+    // ========================================================================
+
+    #[test]
+    fn test_tool_definitions_required_fields_match_params() {
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().unwrap();
+
+        for tool in tools {
+            let name = tool["name"].as_str().unwrap();
+            let schema = &tool["inputSchema"];
+            let required = schema.get("required").and_then(|r| r.as_array());
+            let properties = schema["properties"].as_object().unwrap();
+
+            // Every required field must exist in properties
+            if let Some(req) = required {
+                for field in req {
+                    let field_name = field.as_str().unwrap();
+                    assert!(
+                        properties.contains_key(field_name),
+                        "Tool '{name}': required field '{field_name}' not in properties"
+                    );
+                }
+            }
+
+            // Every property with a handle schema should be required
+            for (prop_name, prop_schema) in properties {
+                if prop_schema.get("properties").is_some()
+                    && prop_schema["properties"].get("index").is_some()
+                    && prop_schema["properties"].get("generation").is_some()
+                {
+                    let is_required = required
+                        .map(|r| r.iter().any(|f| f.as_str() == Some(prop_name)))
+                        .unwrap_or(false);
+                    assert!(
+                        is_required,
+                        "Tool '{name}': handle property '{prop_name}' should be required"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_tool_definitions_all_tools_present() {
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+
+        let expected = [
+            "list_windows",
+            "get_window_properties",
+            "find_elements_by_id",
+            "get_element_properties",
+            "query_element_descendants",
+            "get_element_tree",
+            "take_screenshot",
+            "click_element",
+            "invoke_accessibility_action",
+            "set_element_value",
+            "dispatch_key_event",
+        ];
+        for name in &expected {
+            assert!(names.contains(name), "Missing tool definition: {name}");
+        }
+        assert_eq!(names.len(), expected.len(), "Unexpected extra tool definitions");
     }
 }

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -280,6 +280,13 @@ pub struct ElementHandle {
 }
 
 impl ElementHandle {
+    /// Create an invalid ElementHandle for unit testing arena bookkeeping.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn new_test_dummy() -> Self {
+        Self { item: ItemWeak::default(), element_index: 0 }
+    }
+
     fn collect_elements(item: ItemRc) -> impl Iterator<Item = ElementHandle> {
         (0..item.element_count().unwrap_or_else(|| {
             warn_missing_debug_info();

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -11,9 +11,7 @@ use std::io::Cursor;
 use std::rc::Rc;
 
 use crate::LayoutKind;
-use crate::introspection::{
-    AccessibilityAction, IntrospectionState, QueryInstruction,
-};
+use crate::introspection::{AccessibilityAction, IntrospectionState, QueryInstruction};
 
 #[allow(non_snake_case, unused_imports, non_camel_case_types, clippy::all)]
 mod proto {
@@ -112,11 +110,9 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_element_properties(
                 proto::RequestElementProperties { element_handle },
             ) => {
-                let index = handle_to_index(
-                    element_handle.ok_or_else(|| {
-                        "element properties request missing element handle".to_string()
-                    })?,
-                );
+                let index = handle_to_index(element_handle.ok_or_else(|| {
+                    "element properties request missing element handle".to_string()
+                })?);
                 let element = self.state.element("element properties request", index)?;
                 let ep = self.state.element_properties(&element);
                 proto::mod_AUTResponse::OneOfmsg::element_properties(
@@ -164,9 +160,8 @@ impl TestingClient {
                 let index = handle_to_index(element_handle.ok_or_else(|| {
                     "invoke element accessibility action request missing element handle".to_string()
                 })?);
-                let element = self
-                    .state
-                    .element("invoke element accessibility action request", index)?;
+                let element =
+                    self.state.element("invoke element accessibility action request", index)?;
                 let action = match action {
                     proto::ElementAccessibilityAction::Default_ => AccessibilityAction::Default,
                     proto::ElementAccessibilityAction::Increment => AccessibilityAction::Increment,
@@ -184,8 +179,7 @@ impl TestingClient {
                 let index = handle_to_index(element_handle.ok_or_else(|| {
                     "set element accessible value request missing element handle".to_string()
                 })?);
-                let element =
-                    self.state.element("set element accessible value request", index)?;
+                let element = self.state.element("set element accessible value request", index)?;
                 element.set_accessible_value(value);
                 proto::mod_AUTResponse::OneOfmsg::set_element_accessible_value_response(
                     proto::SetElementAccessibleValueResponse {},
@@ -194,9 +188,10 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_take_snapshot(
                 proto::RequestTakeSnapshot { window_handle, image_mime_type },
             ) => {
-                let window_index = handle_to_index(window_handle.ok_or_else(|| {
-                    "grab window request missing window handle".to_string()
-                })?);
+                let window_index = handle_to_index(
+                    window_handle
+                        .ok_or_else(|| "grab window request missing window handle".to_string())?,
+                );
                 let window_contents_as_encoded_image =
                     self.state.take_snapshot(window_index, &image_mime_type)?;
                 proto::mod_AUTResponse::OneOfmsg::take_snapshot_response(
@@ -206,9 +201,10 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_element_click(
                 proto::RequestElementClick { element_handle, action, button },
             ) => {
-                let index = handle_to_index(element_handle.ok_or_else(|| {
-                    "element click request missing element handle".to_string()
-                })?);
+                let index =
+                    handle_to_index(element_handle.ok_or_else(|| {
+                        "element click request missing element handle".to_string()
+                    })?);
                 let element = self.state.element("element click request", index)?;
                 let button = convert_pointer_event_button(button);
                 match action {
@@ -225,9 +221,10 @@ impl TestingClient {
                 let window_index = handle_to_index(window_handle.ok_or_else(|| {
                     "window event dispatch request missing window handle".to_string()
                 })?);
-                let event = convert_window_event(event.ok_or_else(|| {
-                    "window event dispatch request missing event".to_string()
-                })?)?;
+                let event =
+                    convert_window_event(event.ok_or_else(|| {
+                        "window event dispatch request missing event".to_string()
+                    })?)?;
                 self.state.dispatch_window_event(window_index, event)?;
                 proto::mod_AUTResponse::OneOfmsg::dispatch_window_event_response(
                     proto::DispatchWindowEventResponse {},

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -351,12 +351,12 @@ async fn message_loop(
 // ============================================================================
 
 fn index_to_handle(index: generational_arena::Index) -> proto::Handle {
-    let (index, generation) = index.into_raw_parts();
-    proto::Handle { index: index as u64, generation }
+    let (index, generation) = crate::introspection::index_to_parts(index);
+    proto::Handle { index, generation }
 }
 
 fn handle_to_index(handle: proto::Handle) -> generational_arena::Index {
-    generational_arena::Index::from_raw_parts(handle.index as usize, handle.generation)
+    crate::introspection::parts_to_index(handle.index, handle.generation)
 }
 
 fn send_physical_size(sz: i_slint_core::api::PhysicalSize) -> proto::PhysicalSize {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -6,39 +6,22 @@ use futures_lite::AsyncReadExt;
 use futures_lite::AsyncWriteExt;
 use i_slint_core::api::EventLoopError;
 use i_slint_core::debug_log;
-use i_slint_core::item_tree::ItemTreeRc;
-use i_slint_core::window::WindowAdapter;
-use i_slint_core::window::WindowInner;
 use quick_protobuf::{MessageRead, MessageWrite};
-use std::cell::RefCell;
 use std::io::Cursor;
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 
-use crate::{ElementHandle, ElementRoot, LayoutKind};
-
-struct RootWrapper<'a>(&'a ItemTreeRc);
-
-impl ElementRoot for RootWrapper<'_> {
-    fn item_tree(&self) -> ItemTreeRc {
-        self.0.clone()
-    }
-}
-
-impl super::Sealed for RootWrapper<'_> {}
+use crate::LayoutKind;
+use crate::introspection::{
+    AccessibilityAction, IntrospectionState, QueryInstruction,
+};
 
 #[allow(non_snake_case, unused_imports, non_camel_case_types, clippy::all)]
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/proto.rs"));
 }
 
-struct TestedWindow {
-    window_adapter: Weak<dyn WindowAdapter>,
-    root_element_handle: proto::Handle,
-}
-
 struct TestingClient {
-    windows: RefCell<generational_arena::Arena<TestedWindow>>,
-    element_handles: RefCell<generational_arena::Arena<ElementHandle>>,
+    state: Rc<IntrospectionState>,
     message_loop_future: std::cell::OnceCell<i_slint_core::future::JoinHandle<()>>,
     server_addr: String,
 }
@@ -50,24 +33,13 @@ impl TestingClient {
         };
 
         Some(Rc::new(Self {
-            windows: Default::default(),
-            element_handles: Default::default(),
+            state: crate::introspection::shared_state(),
             message_loop_future: Default::default(),
             server_addr,
         }))
     }
 
-    fn add_window(self: Rc<Self>, adapter: &Rc<dyn WindowAdapter>) {
-        self.windows.borrow_mut().insert(TestedWindow {
-            window_adapter: Rc::downgrade(adapter),
-            root_element_handle: {
-                let window = adapter.window();
-                let item_tree = WindowInner::from_pub(window).component();
-                let root_wrapper = RootWrapper(&item_tree);
-                self.element_to_handle(root_wrapper.root_element())
-            },
-        });
-
+    fn start_message_loop(self: Rc<Self>) {
         let this = self.clone();
         self.message_loop_future.get_or_init(|| {
             i_slint_core::with_global_context(
@@ -97,42 +69,111 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_window_list(..) => {
                 proto::mod_AUTResponse::OneOfmsg::window_list(proto::WindowListResponse {
                     window_handles: self
-                        .windows
-                        .borrow()
-                        .iter()
-                        .map(|(index, _)| index_to_handle(index))
+                        .state
+                        .window_handles()
+                        .into_iter()
+                        .map(index_to_handle)
                         .collect(),
                 })
             }
             proto::mod_RequestToAUT::OneOfmsg::request_window_properties(
                 proto::RequestWindowProperties { window_handle },
-            ) => proto::mod_AUTResponse::OneOfmsg::window_properties(self.window_properties(
-                handle_to_index(window_handle.ok_or_else(|| {
+            ) => {
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
                     "window properties request missing window handle".to_string()
-                })?),
-            )?),
+                })?);
+                let wp = self.state.window_properties(window_index)?;
+                proto::mod_AUTResponse::OneOfmsg::window_properties(
+                    proto::WindowPropertiesResponse {
+                        is_fullscreen: wp.is_fullscreen,
+                        is_maximized: wp.is_maximized,
+                        is_minimized: wp.is_minimized,
+                        size: send_physical_size(wp.size).into(),
+                        position: send_physical_position(wp.position).into(),
+                        root_element_handle: index_to_handle(wp.root_element_handle).into(),
+                    },
+                )
+            }
             proto::mod_RequestToAUT::OneOfmsg::request_find_elements_by_id(
                 proto::RequestFindElementsById { window_handle, elements_id },
             ) => {
-                let elements = self.find_elements_by_id(
-                    handle_to_index(window_handle.ok_or_else(|| {
-                        "find elements by id request missing window handle".to_string()
-                    })?),
-                    &elements_id,
-                )?;
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
+                    "find elements by id request missing window handle".to_string()
+                })?);
+                let elements = self.state.find_elements_by_id(window_index, &elements_id)?;
                 proto::mod_AUTResponse::OneOfmsg::elements(proto::ElementsResponse {
-                    element_handles: elements.map(|elem| self.element_to_handle(elem)).collect(),
+                    element_handles: elements
+                        .into_iter()
+                        .map(|elem| self.state.element_to_handle(elem))
+                        .map(index_to_handle)
+                        .collect(),
                 })
             }
             proto::mod_RequestToAUT::OneOfmsg::request_element_properties(
                 proto::RequestElementProperties { element_handle },
-            ) => proto::mod_AUTResponse::OneOfmsg::element_properties(
-                self.element_properties(element_handle)?,
-            ),
+            ) => {
+                let index = handle_to_index(
+                    element_handle.ok_or_else(|| {
+                        "element properties request missing element handle".to_string()
+                    })?,
+                );
+                let element = self.state.element("element properties request", index)?;
+                let ep = self.state.element_properties(&element);
+                proto::mod_AUTResponse::OneOfmsg::element_properties(
+                    proto::ElementPropertiesResponse {
+                        type_names_and_ids: ep
+                            .type_names_and_ids
+                            .into_iter()
+                            .map(|(type_name, id)| proto::ElementTypeNameAndId { type_name, id })
+                            .collect(),
+                        accessible_label: ep.accessible_label.unwrap_or_default(),
+                        accessible_value: ep.accessible_value.unwrap_or_default(),
+                        accessible_value_maximum: ep.accessible_value_maximum,
+                        accessible_value_minimum: ep.accessible_value_minimum,
+                        accessible_value_step: ep.accessible_value_step,
+                        accessible_description: ep.accessible_description.unwrap_or_default(),
+                        accessible_checked: ep.accessible_checked,
+                        accessible_checkable: ep.accessible_checkable,
+                        size: send_logical_size(ep.size).into(),
+                        absolute_position: send_logical_position(ep.absolute_position).into(),
+                        accessible_role: convert_accessible_role_str_to_proto(ep.accessible_role)
+                            .unwrap_or_default(),
+                        computed_opacity: ep.computed_opacity,
+                        accessible_placeholder_text: ep
+                            .accessible_placeholder_text
+                            .unwrap_or_default(),
+                        accessible_enabled: ep.accessible_enabled,
+                        accessible_read_only: ep.accessible_read_only,
+                        layout_kind: match ep.layout_kind {
+                            Some(LayoutKind::HorizontalLayout) => {
+                                proto::LayoutKind::HorizontalLayout.into()
+                            }
+                            Some(LayoutKind::VerticalLayout) => {
+                                proto::LayoutKind::VerticalLayout.into()
+                            }
+                            Some(LayoutKind::GridLayout) => proto::LayoutKind::GridLayout.into(),
+                            Some(LayoutKind::FlexBox) => proto::LayoutKind::FlexBox.into(),
+                            None => proto::LayoutKind::NotALayout.into(),
+                        },
+                    },
+                )
+            }
             proto::mod_RequestToAUT::OneOfmsg::request_invoke_element_accessibility_action(
                 proto::RequestInvokeElementAccessibilityAction { element_handle, action },
             ) => {
-                self.invoke_element_accessibility_action(element_handle, action)?;
+                let index = handle_to_index(element_handle.ok_or_else(|| {
+                    "invoke element accessibility action request missing element handle".to_string()
+                })?);
+                let element = self
+                    .state
+                    .element("invoke element accessibility action request", index)?;
+                let action = match action {
+                    proto::ElementAccessibilityAction::Default_ => AccessibilityAction::Default,
+                    proto::ElementAccessibilityAction::Increment => AccessibilityAction::Increment,
+                    proto::ElementAccessibilityAction::Decrement => AccessibilityAction::Decrement,
+                    proto::ElementAccessibilityAction::Expand => AccessibilityAction::Expand,
+                };
+                self.state.invoke_element_accessibility_action(&element, action)?;
                 proto::mod_AUTResponse::OneOfmsg::invoke_element_accessibility_action_response(
                     proto::InvokeElementAccessibilityActionResponse {},
                 )
@@ -140,8 +181,11 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_set_element_accessible_value(
                 proto::RequestSetElementAccessibleValue { element_handle, value },
             ) => {
+                let index = handle_to_index(element_handle.ok_or_else(|| {
+                    "set element accessible value request missing element handle".to_string()
+                })?);
                 let element =
-                    self.element("set element accessible value request", element_handle)?;
+                    self.state.element("set element accessible value request", index)?;
                 element.set_accessible_value(value);
                 proto::mod_AUTResponse::OneOfmsg::set_element_accessible_value_response(
                     proto::SetElementAccessibleValueResponse {},
@@ -150,19 +194,22 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_take_snapshot(
                 proto::RequestTakeSnapshot { window_handle, image_mime_type },
             ) => {
-                proto::mod_AUTResponse::OneOfmsg::take_snapshot_response(self.take_snapshot(
-                    handle_to_index(
-                        window_handle.ok_or_else(|| {
-                            "grab window request missing window handle".to_string()
-                        })?,
-                    ),
-                    image_mime_type,
-                )?)
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
+                    "grab window request missing window handle".to_string()
+                })?);
+                let window_contents_as_encoded_image =
+                    self.state.take_snapshot(window_index, &image_mime_type)?;
+                proto::mod_AUTResponse::OneOfmsg::take_snapshot_response(
+                    proto::TakeSnapshotResponse { window_contents_as_encoded_image },
+                )
             }
             proto::mod_RequestToAUT::OneOfmsg::request_element_click(
                 proto::RequestElementClick { element_handle, action, button },
             ) => {
-                let element = self.element("element click request", element_handle)?;
+                let index = handle_to_index(element_handle.ok_or_else(|| {
+                    "element click request missing element handle".to_string()
+                })?);
+                let element = self.state.element("element click request", index)?;
                 let button = convert_pointer_event_button(button);
                 match action {
                     proto::ClickAction::SingleClick => element.single_click(button).await,
@@ -175,14 +222,13 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_dispatch_window_event(
                 proto::RequestDispatchWindowEvent { window_handle, event },
             ) => {
-                self.dispatch_window_event(
-                    handle_to_index(window_handle.ok_or_else(|| {
-                        "window event dispatch request missing window handle".to_string()
-                    })?),
-                    convert_window_event(event.ok_or_else(|| {
-                        "window event dispatch request missing event".to_string()
-                    })?)?,
-                )?;
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
+                    "window event dispatch request missing window handle".to_string()
+                })?);
+                let event = convert_window_event(event.ok_or_else(|| {
+                    "window event dispatch request missing event".to_string()
+                })?)?;
+                self.state.dispatch_window_event(window_index, event)?;
                 proto::mod_AUTResponse::OneOfmsg::dispatch_window_event_response(
                     proto::DispatchWindowEventResponse {},
                 )
@@ -190,251 +236,25 @@ impl TestingClient {
             proto::mod_RequestToAUT::OneOfmsg::request_query_element_descendants(
                 proto::RequestQueryElementDescendants { element_handle, query_stack, find_all },
             ) => {
-                let element = self.element("run element query request", element_handle)?;
-                let elements = self.query_element_descendants(element, query_stack, find_all)?;
+                let index = handle_to_index(element_handle.ok_or_else(|| {
+                    "run element query request missing element handle".to_string()
+                })?);
+                let element = self.state.element("run element query request", index)?;
+                let instructions = convert_query_instructions(query_stack)?;
+                let elements =
+                    self.state.query_element_descendants(element, instructions, find_all)?;
                 proto::mod_AUTResponse::OneOfmsg::element_query_response(
                     proto::ElementQueryResponse {
                         element_handles: elements
                             .into_iter()
-                            .map(|elem| self.element_to_handle(elem))
+                            .map(|elem| self.state.element_to_handle(elem))
+                            .map(index_to_handle)
                             .collect(),
                     },
                 )
             }
             proto::mod_RequestToAUT::OneOfmsg::None => return Err("Unknown request".into()),
         })
-    }
-
-    fn window_properties(
-        &self,
-        window_index: generational_arena::Index,
-    ) -> Result<proto::WindowPropertiesResponse, String> {
-        let adapter = self.window_adapter(window_index)?;
-        let window = adapter.window();
-        Ok(proto::WindowPropertiesResponse {
-            is_fullscreen: window.is_fullscreen(),
-            is_maximized: window.is_maximized(),
-            is_minimized: window.is_minimized(),
-            size: send_physical_size(window.size()).into(),
-            position: send_physical_position(window.position()).into(),
-            root_element_handle: self.root_element_handle(window_index)?.into(),
-        })
-    }
-
-    fn take_snapshot(
-        &self,
-        window_index: generational_arena::Index,
-        image_mime_type: String,
-    ) -> Result<proto::TakeSnapshotResponse, String> {
-        let adapter = self.window_adapter(window_index)?;
-        let window = adapter.window();
-        let buffer =
-            window.take_snapshot().map_err(|e| format!("Error grabbing window screenshot: {e}"))?;
-        let mut window_contents_as_encoded_image: Vec<u8> = Vec::new();
-        let mut cursor = std::io::Cursor::new(&mut window_contents_as_encoded_image);
-        let format = if image_mime_type.is_empty() {
-            image::ImageFormat::Png
-        } else {
-            image::ImageFormat::from_mime_type(&image_mime_type).ok_or_else(|| {
-                format!(
-                    "Unsupported image format {image_mime_type} requested for window snapshotting"
-                )
-            })?
-        };
-
-        image::write_buffer_with_format(
-            &mut cursor,
-            buffer.as_bytes(),
-            buffer.width(),
-            buffer.height(),
-            image::ExtendedColorType::Rgba8,
-            format,
-        )
-        .map_err(|encode_err| {
-            format!("error encoding {image_mime_type} image after screenshot: {encode_err}")
-        })?;
-        Ok(proto::TakeSnapshotResponse { window_contents_as_encoded_image })
-    }
-
-    fn dispatch_window_event(
-        &self,
-        window_index: generational_arena::Index,
-        event: i_slint_core::platform::WindowEvent,
-    ) -> Result<(), String> {
-        let adapter = self.window_adapter(window_index)?;
-        let window = adapter.window();
-        window.dispatch_event(event);
-        Ok(())
-    }
-
-    fn find_elements_by_id(
-        &self,
-        window_index: generational_arena::Index,
-        elements_id: &str,
-    ) -> Result<impl Iterator<Item = crate::ElementHandle>, String> {
-        let adapter = self.window_adapter(window_index)?;
-        let window = adapter.window();
-        let item_tree = WindowInner::from_pub(window).component();
-        Ok(ElementHandle::find_by_element_id(&RootWrapper(&item_tree), elements_id)
-            .collect::<Vec<_>>()
-            .into_iter())
-    }
-
-    fn query_element_descendants(
-        &self,
-        element: ElementHandle,
-        query_stack: Vec<proto::ElementQueryInstruction>,
-        find_all: bool,
-    ) -> Result<Vec<crate::ElementHandle>, String> {
-        let mut query = element.query_descendants();
-        for instruction in query_stack {
-            match instruction.instruction {
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_descendants(_) => {
-                    query = query.match_descendants();
-                }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_id(id) => {
-                    query = query.match_id(id)
-                }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_type_name(type_name) => {
-                    query = query.match_type_name(type_name)
-                }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_type_name_or_base(type_name_or_base) => {
-                    query = query.match_inherits(type_name_or_base)
-                }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_accessible_role(role) => {
-                    query = query.match_accessible_role(convert_from_proto_accessible_role(role).ok_or_else(|| "Unknown accessibility role used in element query".to_string())?)
-                }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::None => {
-                    return Err("unknown element query instruction".into());
-                }
-            }
-        }
-        Ok(if find_all { query.find_all() } else { query.find_first().into_iter().collect() })
-    }
-
-    fn element(
-        &self,
-        request: &'static str,
-        element_handle: Option<proto::Handle>,
-    ) -> Result<ElementHandle, String> {
-        let index = handle_to_index(
-            element_handle.ok_or_else(|| format!("{request} missing element handle"))?,
-        );
-        let element = self
-            .element_handles
-            .borrow()
-            .get(index)
-            .ok_or_else(|| format!("Invalid element handle for {request}"))?
-            .clone();
-        if !element.is_valid() {
-            self.element_handles.borrow_mut().remove(index);
-            return Err(format!(
-                "Element handle for {request} refers to element that was destroyed"
-            ));
-        }
-        Ok(element)
-    }
-
-    fn element_to_handle(&self, element: ElementHandle) -> proto::Handle {
-        index_to_handle(self.element_handles.borrow_mut().insert(element))
-    }
-
-    fn element_properties(
-        &self,
-        element_handle: Option<proto::Handle>,
-    ) -> Result<proto::ElementPropertiesResponse, String> {
-        let element = self.element("element properties request", element_handle)?;
-        let type_names_and_ids = core::iter::once(proto::ElementTypeNameAndId {
-            type_name: element.type_name().unwrap().into(),
-            id: element.id().unwrap().into(),
-        })
-        .chain(element.bases().unwrap().map(|base_type_name| proto::ElementTypeNameAndId {
-            type_name: base_type_name.into(),
-            id: "root".into(),
-        }))
-        .collect();
-        Ok(proto::ElementPropertiesResponse {
-            type_names_and_ids,
-            accessible_label: element
-                .accessible_label()
-                .map_or(Default::default(), |s| s.to_string()),
-            accessible_value: element.accessible_value().unwrap_or_default().to_string(),
-            accessible_value_maximum: element.accessible_value_maximum().unwrap_or_default(),
-            accessible_value_minimum: element.accessible_value_minimum().unwrap_or_default(),
-            accessible_value_step: element.accessible_value_step().unwrap_or_default(),
-            accessible_description: element
-                .accessible_description()
-                .unwrap_or_default()
-                .to_string(),
-            accessible_checked: element.accessible_checked().unwrap_or_default(),
-            accessible_checkable: element.accessible_checkable().unwrap_or_default(),
-            size: send_logical_size(element.size()).into(),
-            absolute_position: send_logical_position(element.absolute_position()).into(),
-            accessible_role: convert_to_proto_accessible_role(element.accessible_role().unwrap())
-                .unwrap_or_default(),
-            computed_opacity: element.computed_opacity(),
-            accessible_placeholder_text: element
-                .accessible_placeholder_text()
-                .unwrap_or_default()
-                .to_string(),
-            accessible_enabled: element.accessible_enabled().unwrap_or_default(),
-            accessible_read_only: element.accessible_read_only().unwrap_or_default(),
-            layout_kind: match element.layout_kind() {
-                Some(LayoutKind::HorizontalLayout) => proto::LayoutKind::HorizontalLayout.into(),
-                Some(LayoutKind::VerticalLayout) => proto::LayoutKind::VerticalLayout.into(),
-                Some(LayoutKind::GridLayout) => proto::LayoutKind::GridLayout.into(),
-                Some(LayoutKind::FlexBox) => proto::LayoutKind::FlexBox.into(),
-                None => proto::LayoutKind::NotALayout.into(),
-            },
-        })
-    }
-
-    fn invoke_element_accessibility_action(
-        &self,
-        element_handle: Option<proto::Handle>,
-        action: proto::ElementAccessibilityAction,
-    ) -> Result<(), String> {
-        let element =
-            self.element("invoke element accessibility action request", element_handle)?;
-        match action {
-            proto::ElementAccessibilityAction::Default_ => {
-                element.invoke_accessible_default_action()
-            }
-            proto::ElementAccessibilityAction::Increment => {
-                element.invoke_accessible_increment_action()
-            }
-            proto::ElementAccessibilityAction::Decrement => {
-                element.invoke_accessible_decrement_action()
-            }
-            proto::ElementAccessibilityAction::Expand => element.invoke_accessible_expand_action(),
-        }
-        Ok(())
-    }
-
-    fn root_element_handle(
-        &self,
-        window_index: generational_arena::Index,
-    ) -> Result<proto::Handle, String> {
-        Ok(self
-            .windows
-            .borrow()
-            .get(window_index)
-            .ok_or_else(|| "Invalid window handle".to_string())?
-            .root_element_handle
-            .clone())
-    }
-
-    fn window_adapter(
-        &self,
-        window_index: generational_arena::Index,
-    ) -> Result<Rc<dyn WindowAdapter>, String> {
-        self.windows
-            .borrow()
-            .get(window_index)
-            .ok_or_else(|| "Invalid window handle".to_string())?
-            .window_adapter
-            .upgrade()
-            .ok_or_else(|| "Attempting to access deleted window".to_string())
     }
 }
 
@@ -443,10 +263,22 @@ pub fn init() -> Result<(), EventLoopError> {
         return Ok(());
     };
 
+    // Use the shared introspection state (shared with mcp_server when both features are enabled).
+    crate::introspection::ensure_window_tracking()?;
+
+    // Chain with the existing hook (from ensure_window_tracking) to start the
+    // message loop on first window show.
+    let previous_hook = i_slint_core::context::set_window_shown_hook(None)
+        .map_err(|_| EventLoopError::NoEventLoopProvider)?;
+    let previous_hook = std::cell::RefCell::new(previous_hook);
+
     i_slint_core::context::set_window_shown_hook(Some(Box::new(move |adapter| {
-        client.clone().add_window(adapter)
+        if let Some(prev) = previous_hook.borrow_mut().as_mut() {
+            prev(adapter);
+        }
+        client.clone().start_message_loop()
     })))
-    .unwrap();
+    .map_err(|_| EventLoopError::NoEventLoopProvider)?;
 
     Ok(())
 }
@@ -514,6 +346,10 @@ async fn message_loop(
     stream.shutdown(std::net::Shutdown::Both).ok();
 }
 
+// ============================================================================
+// Proto conversion helpers
+// ============================================================================
+
 fn index_to_handle(index: generational_arena::Index) -> proto::Handle {
     let (index, generation) = index.into_raw_parts();
     proto::Handle { index: index as u64, generation }
@@ -543,32 +379,64 @@ fn convert_logical_position(pos: proto::LogicalPosition) -> i_slint_core::api::L
     i_slint_core::api::LogicalPosition { x: pos.x, y: pos.y }
 }
 
-fn convert_to_proto_accessible_role(
-    role: i_slint_core::items::AccessibleRole,
-) -> Option<proto::AccessibleRole> {
+fn convert_query_instructions(
+    query_stack: Vec<proto::ElementQueryInstruction>,
+) -> Result<Vec<QueryInstruction>, String> {
+    let mut instructions = Vec::new();
+    for instruction in query_stack {
+        let qi = match instruction.instruction {
+            proto::mod_ElementQueryInstruction::OneOfinstruction::match_descendants(_) => {
+                QueryInstruction::MatchDescendants
+            }
+            proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_id(id) => {
+                QueryInstruction::MatchId(id)
+            }
+            proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_type_name(
+                type_name,
+            ) => QueryInstruction::MatchTypeName(type_name),
+            proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_type_name_or_base(
+                type_name_or_base,
+            ) => QueryInstruction::MatchTypeNameOrBase(type_name_or_base),
+            proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_accessible_role(
+                role,
+            ) => {
+                let role = convert_from_proto_accessible_role(role).ok_or_else(|| {
+                    "Unknown accessibility role used in element query".to_string()
+                })?;
+                QueryInstruction::MatchAccessibleRole(role)
+            }
+            proto::mod_ElementQueryInstruction::OneOfinstruction::None => {
+                return Err("unknown element query instruction".into());
+            }
+        };
+        instructions.push(qi);
+    }
+    Ok(instructions)
+}
+
+/// Convert an accessible role string (from introspection) to a proto enum.
+fn convert_accessible_role_str_to_proto(role: &str) -> Option<proto::AccessibleRole> {
     Some(match role {
-        i_slint_core::items::AccessibleRole::None => proto::AccessibleRole::Unknown,
-        i_slint_core::items::AccessibleRole::Button => proto::AccessibleRole::Button,
-        i_slint_core::items::AccessibleRole::Checkbox => proto::AccessibleRole::Checkbox,
-        i_slint_core::items::AccessibleRole::Combobox => proto::AccessibleRole::Combobox,
-        i_slint_core::items::AccessibleRole::Groupbox => proto::AccessibleRole::Groupbox,
-        i_slint_core::items::AccessibleRole::List => proto::AccessibleRole::List,
-        i_slint_core::items::AccessibleRole::Slider => proto::AccessibleRole::Slider,
-        i_slint_core::items::AccessibleRole::Spinbox => proto::AccessibleRole::Spinbox,
-        i_slint_core::items::AccessibleRole::Tab => proto::AccessibleRole::Tab,
-        i_slint_core::items::AccessibleRole::TabList => proto::AccessibleRole::TabList,
-        i_slint_core::items::AccessibleRole::Text => proto::AccessibleRole::Text,
-        i_slint_core::items::AccessibleRole::Table => proto::AccessibleRole::Table,
-        i_slint_core::items::AccessibleRole::Tree => proto::AccessibleRole::Tree,
-        i_slint_core::items::AccessibleRole::ProgressIndicator => {
-            proto::AccessibleRole::ProgressIndicator
-        }
-        i_slint_core::items::AccessibleRole::TextInput => proto::AccessibleRole::TextInput,
-        i_slint_core::items::AccessibleRole::Switch => proto::AccessibleRole::Switch,
-        i_slint_core::items::AccessibleRole::ListItem => proto::AccessibleRole::ListItem,
-        i_slint_core::items::AccessibleRole::TabPanel => proto::AccessibleRole::TabPanel,
-        i_slint_core::items::AccessibleRole::Image => proto::AccessibleRole::Image,
-        i_slint_core::items::AccessibleRole::RadioButton => proto::AccessibleRole::RadioButton,
+        "unknown" => proto::AccessibleRole::Unknown,
+        "button" => proto::AccessibleRole::Button,
+        "checkbox" => proto::AccessibleRole::Checkbox,
+        "combobox" => proto::AccessibleRole::Combobox,
+        "groupbox" => proto::AccessibleRole::Groupbox,
+        "list" => proto::AccessibleRole::List,
+        "slider" => proto::AccessibleRole::Slider,
+        "spinbox" => proto::AccessibleRole::Spinbox,
+        "tab" => proto::AccessibleRole::Tab,
+        "tab-list" => proto::AccessibleRole::TabList,
+        "text" => proto::AccessibleRole::Text,
+        "table" => proto::AccessibleRole::Table,
+        "tree" => proto::AccessibleRole::Tree,
+        "progress-indicator" => proto::AccessibleRole::ProgressIndicator,
+        "text-input" => proto::AccessibleRole::TextInput,
+        "switch" => proto::AccessibleRole::Switch,
+        "list-item" => proto::AccessibleRole::ListItem,
+        "tab-panel" => proto::AccessibleRole::TabPanel,
+        "image" => proto::AccessibleRole::Image,
+        "radio-button" => proto::AccessibleRole::RadioButton,
         _ => return None,
     })
 }
@@ -680,7 +548,7 @@ fn convert_window_event(
 fn test_accessibility_role_mapping_complete() {
     macro_rules! test_accessibility_enum_mapping_inner {
         (AccessibleRole, $($Value:ident,)*) => {
-            $(assert!(convert_to_proto_accessible_role(i_slint_core::items::AccessibleRole::$Value).is_some());)*
+            $(assert!(crate::introspection::accessible_role_to_string(i_slint_core::items::AccessibleRole::$Value) == "unknown" || convert_accessible_role_str_to_proto(crate::introspection::accessible_role_to_string(i_slint_core::items::AccessibleRole::$Value)).is_some());)*
         };
         ($_:ident, $($Value:ident,)*) => {};
     }


### PR DESCRIPTION
## Summary

- Add an in-process MCP (Model Context Protocol) server to the Slint testing backend, allowing MCP clients (e.g. coding assistants like Claude) to inspect and interact with a running Slint application's UI directly — no separate bridge process needed
- When the `mcp` feature is enabled and `SLINT_MCP_PORT=<port>` is set at runtime, an HTTP server starts on `127.0.0.1:<port>` implementing the MCP Streamable HTTP transport with 11 tools: `list_windows`, `get_window_properties`, `find_elements_by_id`, `get_element_properties`, `query_element_descendants`, `get_element_tree`, `take_screenshot`, `click_element`, `invoke_accessibility_action`, `set_element_value`, `dispatch_key_event`
- Refactors the existing `systest` module to share an `IntrospectionState` with the new MCP transport, avoiding code duplication for window tracking, element handle management, property extraction, and query execution

### Architecture

```
slint/mcp → selector/mcp → testing/mcp
                                ├── introspection.rs  (shared state: window/element arenas, properties, queries)
                                ├── mcp_server.rs     (HTTP server, JSON-RPC 2.0, 11 MCP tools)
                                └── systest.rs        (refactored to use shared IntrospectionState)
```

### Key design decisions

- **Feature-gated**: `mcp` feature is fully opt-in, zero cost when disabled
- **Localhost-only**: Binds to `127.0.0.1`, validates Origin header against localhost addresses for DNS rebinding protection
- **Arena eviction**: FIFO eviction with 10k handle cap prevents unbounded memory growth; root element handles are never evicted; circuit breaker prevents infinite loops
- **HTTP/1.1 keep-alive**: Carry-over buffer handles pipelined requests; `Connection: close` respected
- **Serde for parameters**: Typed `Deserialize` structs for all tool parameters with proper error messages
- **63 unit tests** covering JSON-RPC protocol, parameter deserialization, tool error paths, origin validation, eviction logic, and schema validation

## Test plan

- [x] `cargo test -p i-slint-backend-testing --features mcp --lib` — 63 tests pass
- [x] `cargo check -p i-slint-backend-testing --features system-testing` — systest refactor compiles
- [x] Manual integration test against gallery example with live MCP client (14 interaction scenarios verified)
- [ ] CI with `--features mcp` enabled