### PR TITLE
Qt: Fix including GL/gl.h through Qt headers

### DIFF
--- a/internal/backends/qt/build.rs
+++ b/internal/backends/qt/build.rs
@@ -42,6 +42,11 @@ fn main() {
     config.flag_if_supported("/std:c++17");
     // Workaround QTBUG-123153
     config.flag_if_supported("-Wno-template-id-cdtor");
+    // On some systems, the header GL/gl.h (included by some Qt headers) is not
+    // in the compilers default include path, which makes the build fail due to
+    // this header not beeing found. As we don't need OpenGL, we explicitly
+    // disable it with this define. See issue #10989.
+    config.define("QT_NO_OPENGL", None);
     config.include(std::env::var("DEP_QT_INCLUDE_PATH").unwrap()).build("lib.rs");
 
     println!("cargo:rerun-if-changed=lib.rs");

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -263,6 +263,7 @@ impl SlintAccessibleItemData {
 }
 
 cpp! {{
+    // Note: Do not include <QtWidgets> to avoid inclusion of gl.h (see #10989).
     #include <QtGui/QAccessible>
     #include <QtWidgets/QWidget>
 

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -147,6 +147,7 @@ impl QImageWrapArray {
 }
 
 cpp! {{
+    // Note: Do not include <QtWidgets> to avoid inclusion of gl.h (see #10989).
     #include <QtWidgets/QApplication>
     #include <QtWidgets/QStyle>
     #include <QtWidgets/QStyleOption>

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -45,26 +45,38 @@ use i_slint_core::renderer::Renderer;
 use std::cell::OnceCell;
 
 cpp! {{
-    #include <QtWidgets/QtWidgets>
-    #include <QtWidgets/QGraphicsScene>
-    #include <QtWidgets/QGraphicsBlurEffect>
-    #include <QtWidgets/QGraphicsPixmapItem>
-    #include <QtGui/QAccessible>
-    #include <QtGui/QPainter>
-    #include <QtGui/QPaintEngine>
-    #include <QtGui/QPainterPath>
-    #include <QtGui/QWindow>
-    #include <QtGui/QResizeEvent>
-    #include <QtGui/QTextLayout>
-    #include <QtGui/QImageReader>
-    #include <QtGui/QCursor>
+    // Note: Do not include <QtWidgets> to avoid inclusion of gl.h (see #10989).
     #include <QtCore/QBasicTimer>
-    #include <QtCore/QTimer>
-    #include <QtCore/QPointer>
     #include <QtCore/QBuffer>
     #include <QtCore/QEvent>
     #include <QtCore/QFileInfo>
+    #include <QtCore/QMutex>
+    #include <QtCore/QPointer>
+    #include <QtCore/QThread>
+    #include <QtCore/QTimer>
+    #include <QtGui/QAccessible>
+    #include <QtGui/QCursor>
+    #include <QtGui/QIconEngine>
+    #include <QtGui/QImageReader>
+    #include <QtGui/QPaintEngine>
+    #include <QtGui/QPainter>
+    #include <QtGui/QPainterPath>
+    #include <QtGui/QResizeEvent>
+    #include <QtGui/QTextLayout>
+    #include <QtGui/QWindow>
+    #include <QtWidgets/QCheckBox>
+    #include <QtWidgets/QComboBox>
+    #include <QtWidgets/QGraphicsBlurEffect>
+    #include <QtWidgets/QGraphicsPixmapItem>
+    #include <QtWidgets/QGraphicsScene>
+    #include <QtWidgets/QGroupBox>
+    #include <QtWidgets/QLineEdit>
+    #include <QtWidgets/QProgressBar>
+    #include <QtWidgets/QPushButton>
+    #include <QtWidgets/QSpinBox>
 
+
+    #include <cmath>
     #include <memory>
 
     void ensure_initialized(bool from_qt_backend);


### PR DESCRIPTION
Make sure that `GL/gl.h` is never included, as this would lead to compile errors on systems where this file is not found.

I did not only remove the `#include <QtWidgets/QtWidgets>` which caused the problem, but also now passing `-DQT_NO_OPENGL` to be really sure the same problem doesn't (accidentally) occur again. I verified that `-DQT_NO_OPENGL` alone would already fix the compile error on OpenBSD.

Fixes #10989

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
