### PR TITLE
fix: scroll combobox to selected item when dropdown opens

### DIFF
--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -16,7 +16,7 @@ export component ComboBox {
     callback selected <=> base.selected;
 
     property <length> popup-padding: 4px;
-
+    property <length> popup-scroll-y: -max(0, root.current-index - root.visible-items + 1) * CosmicSizeSettings.item-height;
     property <int> visible-items: min(6, model.length);
 
     min-width: max(160px, layout.min-height);
@@ -110,6 +110,7 @@ export component ComboBox {
 
             MenuBorder {
                 ScrollView {
+                    viewport-y: root.popup-scroll-y;
                     VerticalLayout {
                         alignment: start;
                         padding: root.popup-padding;

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -17,6 +17,7 @@ export component ComboBox {
 
     property <brush> background: CupertinoPalette.control-background;
     property <length> popup-padding: 4px;
+    property <length> popup-scroll-y: -max(0, root.current-index - root.visible-items + 1) * CupertinoSizeSettings.item-height;
     property <int> visible-items: min(6, model.length);
 
     min-width: max(160px, layout.min-width);
@@ -187,6 +188,7 @@ export component ComboBox {
 
             MenuBorder {
                 ScrollView {
+                    viewport-y: root.popup-scroll-y;
                     VerticalLayout {
                         alignment: start;
                         padding: root.popup-padding;

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -16,6 +16,7 @@ export component ComboBox {
     callback selected <=> base.selected;
 
     property <length> popup-padding: 4px;
+    property <length> popup-scroll-y: -max(0, root.current-index - root.visible-items + 1) * FluentSizeSettings.item-height;
     property <int> visible-items: min(6, model.length);
 
     min-width: max(160px, layout.min-height);
@@ -107,18 +108,23 @@ export component ComboBox {
         // Ideally it should be so that the current element is over the popup.
         y: -4px;
         width: root.width;
-        height: root.visible-items * FluentSizeSettings.item-height +  2 * root.popup-padding;
+        height: root.visible-items * FluentSizeSettings.item-height + 2 * root.popup-padding;
+
         forward-focus: inner-fs;
 
         inner-fs := FocusScope {
             focus-changed-event => {
                 base.popup-has-focus = self.has-focus;
             }
+
             key-pressed(event) => {
                 return base.popup-key-handler(event);
             }
+
             MenuBorder {
                 ScrollView {
+                    viewport-y: root.popup-scroll-y;
+
                     VerticalLayout {
                         alignment: start;
                         padding: root.popup-padding;

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -17,6 +17,7 @@ export component ComboBox {
     callback selected <=> base.selected;
 
     property <int> visible-items: min(6, model.length);
+    property <length> popup-scroll-y: -max(0, root.current-index - root.visible-items + 1) * MaterialSizeSettings.item-height;
 
     min-width: max(160px, layout.min-width);
     min-height: max(22px, layout.min-height);
@@ -115,6 +116,7 @@ export component ComboBox {
             }
 
             ScrollView {
+                viewport-y: root.popup-scroll-y;
                 VerticalLayout {
                     alignment: start;
 

--- a/internal/compiler/widgets/qt/combobox.slint
+++ b/internal/compiler/widgets/qt/combobox.slint
@@ -13,6 +13,9 @@ export component ComboBox {
 
     callback selected <=> base.selected;
 
+    property <int> visible-items: min(6, model.length);
+    property <length> popup-scroll-y: -max(0, root.current-index - root.visible-items + 1) * 2rem;
+
     accessible-role: combobox;
     accessible-enabled: root.enabled;
     accessible-expandable: true;
@@ -35,7 +38,7 @@ export component ComboBox {
         width: 100%;
         height: 100%;
         show-popup => {
-            if model.length <= 6 {
+            if model.length <= root.visible-items {
                 small-popup.show();
             } else {
                 big-popup.show();
@@ -51,8 +54,7 @@ export component ComboBox {
         x: 0;
         y: root.height;
         width: root.width;
-        // Try to hardcode about the size of 6 items
-        height: 6 * 2rem;
+        height: root.visible-items * 2rem;
         forward-focus: inner-fs;
 
         NativeComboBoxPopup {
@@ -69,6 +71,7 @@ export component ComboBox {
             }
 
             ScrollView {
+                viewport-y: root.popup-scroll-y;
                 VerticalLayout {
                     alignment: start;
 


### PR DESCRIPTION
When opening a combobox dropdown with a large model, ensure that the selected item is visible and scrolled into view. Previously, if the selected index was outside the visible viewport (e.g., last item in a
long list), the dropdown would show the wrong item.

Fixes #6619