### PR TITLE
fix: correct placeholder text color in fluent input components

### DIFF
--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -60,16 +60,13 @@ export component LineEdit {
     states [
         disabled when !root.enabled : {
             background.background: FluentPalette.control-disabled;
-            background.border-color: FluentPalette.border;
             base.text-color: FluentPalette.text-disabled;
             base.selection-foreground-color: FluentPalette.text-accent-foreground-disabled;
             base.placeholder-color: FluentPalette.text-disabled;
         }
         focused when root.has-focus : {
             background.background: FluentPalette.control-input-active;
-            background.border-color: FluentPalette.border;
             focus-border.background: FluentPalette.accent-background;
-            base.placeholder-color: FluentPalette.text-tertiary;
         }
     ]
 
@@ -125,6 +122,7 @@ export component LineEdit {
             y: parent.height - self.height;
             width: parent.width - 2 * parent.border-radius;
             height: 2px;
+            border-radius: 1px;
         }
     }
 }

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -64,13 +64,12 @@ export component TextEdit {
     states [
         disabled when !root.enabled: {
             base.background: FluentPalette.control-disabled;
-            base.border-color: FluentPalette.border;
             base.foreground: FluentPalette.text-disabled;
             base.selection-foreground-color: FluentPalette.text-accent-foreground-disabled;
+            base.placeholder-color: FluentPalette.text-disabled;
         }
         focused when root.has-focus: {
             base.background: FluentPalette.control-input-active;
-            base.border-color: FluentPalette.border;
             i-focus-border.background: FluentPalette.accent-background;
         }
     ]
@@ -95,6 +94,7 @@ export component TextEdit {
             y: parent.height - self.height;
             width: parent.width - 2 * parent.border-radius;
             height: 2px;
+            border-radius: 1px;
         }
     }
 }


### PR DESCRIPTION
- Remove incorrect border-color overwrites in disabled and focused states
- Fix placeholder-color in TextEdit disabled state to use text-disabled
- Remove placeholder-color change from focused state that was overriding styling
- Add border-radius to focus border for improved visual consistency
- Applies to both LineEdit and TextEdit components in fluent style

Fixes #9121

