### PR TITLE
fix: prevent ComboBox popup from closing on scrollbar interaction

### DIFF
--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -98,6 +98,7 @@ export component ComboBox {
         y: root.height + 4px;
         width: root.width;
         height: root.visible-items * CosmicSizeSettings.item-height  + 2 * root.popup-padding;
+        close-policy: close-on-click-outside;
         forward-focus: inner-fs;
 
         inner-fs := FocusScope {
@@ -124,6 +125,7 @@ export component ComboBox {
                             touch-area := TouchArea {
                                 clicked => {
                                     base.select(index);
+                                    popup.close();
                                 }
                             }
                         }

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -176,6 +176,7 @@ export component ComboBox {
         y: parent.height + 6px;
         width: root.width;
         height: root.visible-items * CupertinoSizeSettings.item-height  + 2 * root.popup-padding;
+        close-policy: close-on-click-outside;
         forward-focus: inner-fs;
 
         inner-fs := FocusScope {
@@ -205,6 +206,7 @@ export component ComboBox {
                             touch-area := TouchArea {
                                 clicked => {
                                     base.select(index);
+                                    popup.close();
                                 }
                             }
                         }

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -109,7 +109,7 @@ export component ComboBox {
         y: -4px;
         width: root.width;
         height: root.visible-items * FluentSizeSettings.item-height + 2 * root.popup-padding;
-
+        close-policy: close-on-click-outside;
         forward-focus: inner-fs;
 
         inner-fs := FocusScope {
@@ -138,6 +138,7 @@ export component ComboBox {
                             touch-area := TouchArea {
                                 clicked => {
                                     base.select(index);
+                                    popup.close();
                                 }
                             }
                         }

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -97,6 +97,7 @@ export component ComboBox {
         y: root.height;
         width: root.width;
         height: root.visible-items * MaterialSizeSettings.item-height;
+        close-policy: close-on-click-outside;
         forward-focus: inner-fs;
 
         popup-container := Rectangle {
@@ -129,6 +130,7 @@ export component ComboBox {
                         touch-area := StateLayer {
                             clicked => {
                                 base.select(index);
+                                popup.close();
                             }
                         }
                     }

--- a/internal/compiler/widgets/qt/combobox.slint
+++ b/internal/compiler/widgets/qt/combobox.slint
@@ -55,6 +55,7 @@ export component ComboBox {
         y: root.height;
         width: root.width;
         height: root.visible-items * 2rem;
+        close-policy: close-on-click-outside;
         forward-focus: inner-fs;
 
         NativeComboBoxPopup {
@@ -84,6 +85,7 @@ export component ComboBox {
                         ta2 := TouchArea {
                             clicked => {
                                 base.select(index);
+                                big-popup.close();
                             }
                         }
                     }
@@ -96,6 +98,7 @@ export component ComboBox {
         x: 0;
         y: root.height;
         width: root.width;
+        close-policy: close-on-click-outside;
         NativeComboBoxPopup {
             width: 100%;
             height: 100%;
@@ -124,6 +127,7 @@ export component ComboBox {
                     ta := TouchArea {
                         clicked => {
                             base.select(index);
+                            small-popup.close();
                         }
                     }
                 }


### PR DESCRIPTION
The ComboBox popup was closing on any click, including scrollbar drags. Change close-policy from 'close-on-click' to 'close-on-click-outside' and handle popup closure programmatically:
- Close only when clicking outside the popup
- Close explicitly when an item is selected
- Close on Escape key or focus loss

Fixes #9106