### PR TITLE
Use TypeScript better in node tests

### DIFF
--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -304,9 +304,9 @@ test("get/set image properties", async () => {
             (slintImage as ImageData).data,
         );
 
-        expect((instance.getProperty("external-image") as ImageData).path).toStrictEqual(
-            undefined,
-        );
+        expect(
+            (instance.getProperty("external-image") as ImageData).path,
+        ).toStrictEqual(undefined);
     }
 });
 
@@ -903,13 +903,7 @@ test("invoke callback", () => {
         },
     );
 
-    instance.invoke("great", [
-        "simon",
-        "olivier",
-        "auri",
-        "tobias",
-        "florian",
-    ]);
+    instance.invoke("great", ["simon", "olivier", "auri", "tobias", "florian"]);
     expect(speakTest).toStrictEqual(
         "hello simon, olivier, auri, tobias and florian",
     );


### PR DESCRIPTION
This small change just makes more use of TypeScript in the tests.
A helper function ensures the app instance isn't null and is
now correctly typed.
1. The instance is now typed and not 'any'.
2. No need for a bunch of redundant checks to see if the instance is
   null.
3. No need for a lot of '!' usage all over the file as typescript knows
   it's a valid instance and what methods the object has.
4. You now get nice autocomplete of methods on the `instance` object.