### PR TITLE
wasm: don't require web_sys_unstable_apis for clipboard handling

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -52,12 +52,9 @@ jobs:
     wasm_demo:
         uses: ./.github/workflows/wasm_demos.yaml
         with:
-            rustflags: "--cfg=web_sys_unstable_apis"
             build_artifacts: true
     wasm:
         uses: ./.github/workflows/wasm_editor_and_interpreter.yaml
-        with:
-            rustflags: "--cfg=web_sys_unstable_apis"
     cpp_package:
         uses: ./.github/workflows/cpp_package.yaml
         with:

--- a/.github/workflows/wasm_demos.yaml
+++ b/.github/workflows/wasm_demos.yaml
@@ -7,9 +7,6 @@ on:
     workflow_dispatch:
     workflow_call:
         inputs:
-            rustflags:
-                type: string
-                description: extra rustflags
             build_artifacts:
                 type: boolean
                 required: true
@@ -20,7 +17,6 @@ jobs:
         env:
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             CARGO_INCREMENTAL: false
-            RUSTFLAGS: ${{ github.event.inputs.rustflags || inputs.rustflags }}
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -7,17 +7,12 @@ name: Build and test the slintpad and required WASM binaries
 on:
     workflow_dispatch:
     workflow_call:
-        inputs:
-            rustflags:
-                type: string
-                description: extra rustflags
 
 jobs:
     wasm:
         env:
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             CARGO_INCREMENTAL: false
-            RUSTFLAGS: ${{ github.event.inputs.rustflags || inputs.rustflags }}
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v6

--- a/docs/astro/src/content/docs/guide/platforms/web.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/web.mdx
@@ -89,15 +89,3 @@ Replace `YOUR_APPLICATION` with the name of your crate.
 :::note[Note]
 Many web browser load `.wasm` files only in trusted contexts. If during development you observe the browser producing permission errors, then you may need to serve files through a web server, instead of the file system directly.
 :::
-
-## Clipboard Support
-
-Slint's text input widgets supports copy and paste when running in the browser.
-This is implemented using the browser's clipboard API via the `web-sys` crate.
-Because the clipboard API in `web-sys` is still unstable, you need to opt in by setting the following environment variable when building:
-
-```bash
-RUSTFLAGS=--cfg=web_sys_unstable_apis
-```
-
-You can read more in the [`web-sys` unstable APIs documentation](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html).

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -14,7 +14,5 @@ fn main() {
        use_winit_theme: { any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32", target_os = "android") },
        muda: { all(feature = "muda", any(target_os = "windows", target_os = "macos")) },
     }
-    // This uses `web_sys_unstable_api`, which is typically set via `RUST_FLAGS`
-    println!("cargo:rustc-check-cfg=cfg(web_sys_unstable_apis)");
     println!("cargo:rustc-check-cfg=cfg(slint_nightly_test)");
 }

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -69,62 +69,16 @@ impl WasmInputHelper {
         let is_apple = i_slint_core::is_apple_platform();
 
         let shared_state = Rc::new(RefCell::new(WasmInputState::default()));
-        #[cfg(web_sys_unstable_apis)]
-        {
-            let win = window_adapter.clone();
-            h.add_event_listener("paste", move |e: web_sys::ClipboardEvent| {
-                if let Some(window_adapter) = win.upgrade() {
-                    let Some(text) = e.clipboard_data().and_then(|data| data.get_data("text").ok())
-                    else {
-                        return;
-                    };
-                    e.prevent_default();
-                    let synthetic_clipboard_data = RefCell::new(text);
-                    CURRENT_WASM_CLIPBOARD_DATA.set(&synthetic_clipboard_data, || {
-                        if let Some(focus_item) = WindowInner::from_pub(&window_adapter.window())
-                            .focus_item
-                            .borrow()
-                            .upgrade()
-                        {
-                            if let Some(text_input) =
-                                focus_item.downcast::<i_slint_core::items::TextInput>()
-                            {
-                                text_input.as_pin_ref().paste(&window_adapter, &focus_item);
-                            }
-                        }
-                    })
-                }
-            });
-            let win = window_adapter.clone();
-            h.add_event_listener("copy", move |e: web_sys::ClipboardEvent| {
-                if let Some(window_adapter) = win.upgrade() {
-                    e.prevent_default();
-
-                    let synthetic_clipboard_data = RefCell::new(String::default());
-                    CURRENT_WASM_CLIPBOARD_DATA.set(&synthetic_clipboard_data, || {
-                        if let Some(focus_item) = WindowInner::from_pub(&window_adapter.window())
-                            .focus_item
-                            .borrow()
-                            .upgrade()
-                        {
-                            if let Some(text_input) =
-                                focus_item.downcast::<i_slint_core::items::TextInput>()
-                            {
-                                let text =
-                                    text_input.as_pin_ref().copy(&window_adapter, &focus_item);
-                            }
-                        }
-                    });
-                    if let Some(data) = e.clipboard_data() {
-                        data.set_data("text", &synthetic_clipboard_data.into_inner()).ok();
-                    }
-                }
-            });
-
-            let win = window_adapter.clone();
-            h.add_event_listener("cut", move |e: web_sys::ClipboardEvent| {
-                if let Some(window_adapter) = win.upgrade() {
-                    e.prevent_default();
+        let win = window_adapter.clone();
+        h.add_event_listener("paste", move |e: web_sys::ClipboardEvent| {
+            if let Some(window_adapter) = win.upgrade() {
+                let Some(text) = e.clipboard_data().and_then(|data| data.get_data("text").ok())
+                else {
+                    return;
+                };
+                e.prevent_default();
+                let synthetic_clipboard_data = RefCell::new(text);
+                CURRENT_WASM_CLIPBOARD_DATA.set(&synthetic_clipboard_data, || {
                     if let Some(focus_item) = WindowInner::from_pub(&window_adapter.window())
                         .focus_item
                         .borrow()
@@ -133,25 +87,65 @@ impl WasmInputHelper {
                         if let Some(text_input) =
                             focus_item.downcast::<i_slint_core::items::TextInput>()
                         {
-                            let (anchor, cursor) =
-                                text_input.as_pin_ref().selection_anchor_and_cursor();
-                            if anchor == cursor {
-                                return;
-                            }
-                            let text = text_input.as_pin_ref().text();
-                            if let Some(data) = e.clipboard_data() {
-                                data.set_data("text", &text[anchor..cursor]).ok();
-                            }
-                            text_input.as_pin_ref().delete_selection(
-                                &window_adapter,
-                                &focus_item,
-                                i_slint_core::items::TextChangeNotify::TriggerCallbacks,
-                            );
+                            text_input.as_pin_ref().paste(&window_adapter, &focus_item);
                         }
                     }
+                })
+            }
+        });
+        let win = window_adapter.clone();
+        h.add_event_listener("copy", move |e: web_sys::ClipboardEvent| {
+            if let Some(window_adapter) = win.upgrade() {
+                e.prevent_default();
+
+                let synthetic_clipboard_data = RefCell::new(String::default());
+                CURRENT_WASM_CLIPBOARD_DATA.set(&synthetic_clipboard_data, || {
+                    if let Some(focus_item) = WindowInner::from_pub(&window_adapter.window())
+                        .focus_item
+                        .borrow()
+                        .upgrade()
+                    {
+                        if let Some(text_input) =
+                            focus_item.downcast::<i_slint_core::items::TextInput>()
+                        {
+                            let text = text_input.as_pin_ref().copy(&window_adapter, &focus_item);
+                        }
+                    }
+                });
+                if let Some(data) = e.clipboard_data() {
+                    data.set_data("text", &synthetic_clipboard_data.into_inner()).ok();
                 }
-            });
-        }
+            }
+        });
+
+        let win = window_adapter.clone();
+        h.add_event_listener("cut", move |e: web_sys::ClipboardEvent| {
+            if let Some(window_adapter) = win.upgrade() {
+                e.prevent_default();
+                if let Some(focus_item) =
+                    WindowInner::from_pub(&window_adapter.window()).focus_item.borrow().upgrade()
+                {
+                    if let Some(text_input) =
+                        focus_item.downcast::<i_slint_core::items::TextInput>()
+                    {
+                        let (anchor, cursor) =
+                            text_input.as_pin_ref().selection_anchor_and_cursor();
+                        if anchor == cursor {
+                            return;
+                        }
+                        let text = text_input.as_pin_ref().text();
+                        if let Some(data) = e.clipboard_data() {
+                            data.set_data("text", &text[anchor..cursor]).ok();
+                        }
+                        text_input.as_pin_ref().delete_selection(
+                            &window_adapter,
+                            &focus_item,
+                            i_slint_core::items::TextChangeNotify::TriggerCallbacks,
+                        );
+                    }
+                }
+            }
+        });
 
         let win = window_adapter.clone();
         h.add_event_listener("blur", move |_: web_sys::Event| {


### PR DESCRIPTION
We used to require cfg(web_sys_unstable_apis) to access the clipboard API. Since https://github.com/wasm-bindgen/wasm-bindgen/pull/3791 that's not needed anymore. The cfg became an issue with https://github.com/wasm-bindgen/wasm-bindgen/commit/464f845eac585f730ea9e66d6c72eefcda296e09 , which changes API in a way that breaks the softbuffer build.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
