### PR TITLE
CI: Fix clippy getting confused on macOS

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1166,8 +1166,8 @@ impl Item for TextInput {
                         ));
                     }
 
-                    #[cfg(not(target_vendor = "apple"))]
-                    if *_reason == FocusReason::TabNavigation {
+                    if cfg!(not(target_vendor = "apple")) && *_reason == FocusReason::TabNavigation
+                    {
                         self.select_all(window_adapter, self_rc);
                     }
                 }


### PR DESCRIPTION
The macos block would make clippy suggest to use an if let, but that doesn't make sense here. So disambiguate that with a cfg! instead.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
