### PR TITLE
feat(core): make portable-atomic's feature critical-section optional

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -46,7 +46,7 @@ std = [
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
-unsafe-single-threaded = []
+unsafe-single-threaded = ["portable-atomic/unsafe-assume-single-core"]
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
@@ -70,7 +70,7 @@ unstable-wgpu-28 = ["dep:wgpu-28"]
 tr = ["dep:tr"]
 
 32-bit-color = []
-default = ["std", "unicode", "shared-parley"]
+default = ["std", "unicode", "shared-parley", "portable-atomic/critical-section"]
 
 shared-parley = ["shared-fontique", "dep:parley", "dep:skrifa"]
 
@@ -85,7 +85,7 @@ i-slint-core-macros = { workspace = true, features = ["default"] }
 const-field-offset = { version = "0.1.5", path = "../../helper_crates/const-field-offset" }
 vtable = { workspace = true }
 
-portable-atomic = { version = "1", features = ["critical-section"] }
+portable-atomic = "1"
 auto_enums = { version = "0.8.0", optional = true }
 cfg-if = "1"
 derive_more = { workspace = true, features = ["error"] }


### PR DESCRIPTION
Previously, the **critical-section** feature for the **portable-atomic** dependency was always enabled, even when the **unsafe-assume-single-core** feature was activated. Since these two features are incompatible with each other in **portable-atomic**, this led to compilation errors when crates like **esp-hal** (with single core options) were used alongside.