### PR TITLE
GridLayout: handle nested repeaters with different child counts

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2690,6 +2690,16 @@ fn generate_grid_layout_input_decl(
                 }
             }
         }
+        // Padding loop: fill remaining slots with sentinel values. C++ zero-initializes
+        // result (col=0, row=0), so we need to specify auto explicitly.
+        write!(
+            fill_code,
+            "while (write_idx < result.size()) {{\n\
+                 result[write_idx] = slint::cbindgen_private::GridLayoutInputData {{ false, {auto_val:.1}f, {auto_val:.1}f, 1.0f, 1.0f }};\n\
+                 ++write_idx;\n\
+             }}\n"
+        )
+        .unwrap();
         vec!["[[maybe_unused]] auto self = this;".into(), fill_code]
     } else {
         vec!["[[maybe_unused]] auto self = this;".into(), statement]

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1952,7 +1952,6 @@ fn generate_repeated_component(
         if has_inner_repeaters {
             let templates = root_sc.row_child_templates.as_ref().unwrap();
             let static_count = llr::static_child_count(templates);
-            let auto_val = i_slint_common::ROW_COL_AUTO;
 
             // Generate fill code: one snippet per template entry.
             // new_row is re-evaluated per slot (write_idx == 0 && new_row) so that only the
@@ -1986,10 +1985,7 @@ fn generate_repeated_component(
                                 if write_idx < result.len() {
                                     result[write_idx] = sp::GridLayoutInputData {
                                         new_row: write_idx == 0 && new_row,
-                                        col: #auto_val,
-                                        row: #auto_val,
-                                        colspan: 1.0f32,
-                                        rowspan: 1.0f32,
+                                        ..Default::default()
                                     };
                                 }
                                 write_idx += 1;

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -464,7 +464,7 @@ pub struct GridLayoutData {
 /// The input data for a cell of a GridLayout, before row/col determination and before H/V split
 /// Used as input to organize_grid_layout()
 #[repr(C)]
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct GridLayoutInputData {
     /// whether this cell is the first one in a Row element
     pub new_row: bool,
@@ -477,6 +477,18 @@ pub struct GridLayoutInputData {
     /// Only the u16 range is valid, values outside of that will be clamped with a warning at runtime
     pub colspan: f32,
     pub rowspan: f32,
+}
+
+impl Default for GridLayoutInputData {
+    fn default() -> Self {
+        Self {
+            new_row: false,
+            col: i_slint_common::ROW_COL_AUTO,
+            row: i_slint_common::ROW_COL_AUTO,
+            colspan: 1.0,
+            rowspan: 1.0,
+        }
+    }
 }
 
 /// The organized layout data for a GridLayout, after row/col determination:

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -433,12 +433,13 @@ fn repeater_instances(
 fn grid_layout_input_data(
     grid_layout: &i_slint_compiler::layout::GridLayout,
     ctx: &EvalLocalContext,
-    _repeater_steps: &[u32],
+    repeater_steps: &[u32],
 ) -> Vec<GridLayoutInputData> {
     let component = ctx.component_instance;
     let mut result = Vec::with_capacity(grid_layout.elems.len());
     let mut after_repeater_in_same_row = false;
     let mut new_row = true;
+    let mut repeater_idx = 0usize;
     for elem in grid_layout.elems.iter() {
         let eval_or_default = |expr: &RowColExpr, component: InstanceRef| match expr {
             RowColExpr::Literal(value) => *value as f32,
@@ -469,6 +470,7 @@ fn grid_layout_input_data(
                 if let Some(children) = elem.cell.borrow().child_items.as_ref() {
                     // Repeated row
                     new_row = true;
+                    let start_count = result.len();
 
                     // Single pass in declaration order: push statics and inner-repeater
                     // auto-cells interleaved so that column assignments match template order.
@@ -507,10 +509,7 @@ fn grid_layout_input_data(
                                 for i in 0..inner_instances.len() {
                                     result.push(GridLayoutInputData {
                                         new_row: i == 0 && new_row,
-                                        col: i_slint_common::ROW_COL_AUTO,
-                                        row: i_slint_common::ROW_COL_AUTO,
-                                        colspan: 1.0,
-                                        rowspan: 1.0,
+                                        ..Default::default()
                                     });
                                 }
                                 if !inner_instances.is_empty() {
@@ -518,6 +517,13 @@ fn grid_layout_input_data(
                                 }
                             }
                         }
+                    }
+                    // Pad to match max step count for this repeater (handles jagged arrays)
+                    let cells_pushed = result.len() - start_count;
+                    let expected_step =
+                        repeater_steps.get(repeater_idx).copied().unwrap_or(0) as usize;
+                    for _ in cells_pushed..expected_step {
+                        result.push(GridLayoutInputData::default());
                     }
                 } else {
                     // Single repeated item
@@ -530,6 +536,7 @@ fn grid_layout_input_data(
                     new_row = false;
                 }
             }
+            repeater_idx += 1;
             after_repeater_in_same_row = true;
         } else {
             let new_row =
@@ -598,7 +605,7 @@ fn grid_repeater_steps(
                 Some(ci)
                     if ci.iter().any(i_slint_compiler::layout::RowChildTemplate::is_repeated) =>
                 {
-                    // Compute max runtime count across all instances (padding didn't happen yet)
+                    // Compute max runtime count across all instances (padding with empty cells didn't happen yet)
                     let component_vec = repeater_instances(component, &elem.item.element);
                     component_vec
                         .iter()
@@ -625,7 +632,7 @@ fn grid_layout_constraints(
     grid_layout: &i_slint_compiler::layout::GridLayout,
     orientation: Orientation,
     ctx: &mut EvalLocalContext,
-    _repeater_steps: &[u32],
+    repeater_steps: &[u32],
 ) -> Vec<core_layout::LayoutItemInfo> {
     let component = ctx.component_instance;
     let expr_eval = |nr: &NamedReference| -> f32 {
@@ -633,6 +640,7 @@ fn grid_layout_constraints(
     };
     let mut constraints = Vec::with_capacity(grid_layout.elems.len());
 
+    let mut repeater_idx = 0usize;
     for layout_elem in grid_layout.elems.iter() {
         if layout_elem.item.element.borrow().repeated.is_some() {
             let component_vec = repeater_instances(component, &layout_elem.item.element);
@@ -641,7 +649,9 @@ fn grid_layout_constraints(
             if has_children {
                 // Repeated row
                 let ci = child_items.as_ref().unwrap();
+                let step = repeater_steps.get(repeater_idx).copied().unwrap_or(0) as usize;
                 for sub_comp in &component_vec {
+                    let per_instance_start = constraints.len();
                     // Evaluate constraints in the context of the repeated sub-component
                     generativity::make_guard!(guard);
                     let sub_pin = sub_comp.as_pin_ref();
@@ -714,6 +724,14 @@ fn grid_layout_constraints(
                             }
                         }
                     }
+                    // Pad this instance to the step size (handles jagged arrays where
+                    // inner repeaters have different lengths across outer Row instances).
+                    let pushed = constraints.len() - per_instance_start;
+                    for _ in pushed..step {
+                        constraints.push(core_layout::LayoutItemInfo {
+                            constraint: core_layout::LayoutInfo::default(),
+                        });
+                    }
                 }
             } else {
                 // Single repeated item
@@ -723,6 +741,7 @@ fn grid_layout_constraints(
                         .map(|x| x.as_pin_ref().layout_item_info(to_runtime(orientation), None)),
                 );
             }
+            repeater_idx += 1;
         } else {
             let mut layout_info = get_layout_info(
                 &layout_elem.item.element,

--- a/tests/cases/layout/grid_nested_for_irregular.slint
+++ b/tests/cases/layout/grid_nested_for_irregular.slint
@@ -1,0 +1,155 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test two sets of repeated Rows with nested `for`, each with different column counts and row counts.
+
+export component TestCase inherits Window {
+    default-font-size: 20px;
+    width: 800phx;
+    height: 600phx;
+
+    property <[{ label: string, values: [string]}]> first_row_set: [
+        { label: "N1", values: ["a", "b"] },
+        { label: "N2", values: ["c"] },
+        { label: "N3", values: ["d", "e", "f"] },
+    ];
+
+    property <[[string]]> second_row_set: [
+        ["p", "q", "r", "s"],
+        ["t"],
+    ];
+
+    out property <string> clicked_text;
+    out property <int> clicked_row: -1;
+    out property <int> clicked_col: -1;
+
+    GridLayout {
+        // First set: 3 rows, each with 1 static + a variable number of columns
+        for row_data in first_row_set: Row {
+            Text {
+                text: row_data.label;
+                min-height: 80phx;
+            }
+
+            for val in row_data.values: Text {
+                text: val;
+            }
+        }
+
+        // Second set: 2 rows, each with a variable number of columns
+        for row_data[row_idx] in second_row_set: Row {
+            for val[col_idx] in row_data: cell := Rectangle {
+                background: ta.pressed ? #888 : transparent;
+                min-width: 100phx;
+                min-height: 60phx;
+                Text {
+                    text: val;
+                }
+
+                ta := TouchArea {
+                    clicked => {
+                        clicked_text = val + "@" + row_idx + "," + col_idx;
+                        clicked_row = cell.row;
+                        clicked_col = cell.col;
+                    }
+                }
+            }
+
+            eor := Rectangle {
+                background: eor_ta.pressed ? #888 : transparent;
+                min-width: 150phx;
+                min-height: 60phx;
+                Text {
+                    text: "end of row";
+                }
+
+                eor_ta := TouchArea {
+                    clicked => {
+                        clicked_text = "eor@" + row_idx;
+                        clicked_row = eor.row;
+                        clicked_col = eor.col;
+                    }
+                }
+            }
+        }
+
+        // End marker
+        end := Text {
+            text: clicked_text != "" ? clicked_text : "end";
+        }
+    }
+
+    // First set: 3 rows (rows 0-2), second set: 2 rows (rows 3-4), end marker is row 5
+    out property <int> end_row: end.row;
+    out property <int> end_col: end.col;
+    out property <bool> test: end.row == 5 && end.col == 0;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_end_row(), 5);
+assert_eq!(instance.get_end_col(), 0);
+assert!(instance.get_test());
+
+// Click on second_row_set[0][0] = "p" (should be row 3, col 0)
+// Row 3: y=355, size≈98 → center≈404. Col 0: x=0, size=140 → center=70.
+slint_testing::send_mouse_click(&instance, 70., 404.);
+assert_eq!(instance.get_clicked_text(), "p@0,0");
+assert_eq!(instance.get_clicked_row(), 3);
+assert_eq!(instance.get_clicked_col(), 0);
+
+// Click on second_row_set[0]'s "end of row" (should be row 3, col 4 - after p,q,r,s)
+// Col 4: x=610, size=190 → center=705.
+slint_testing::send_mouse_click(&instance, 705., 404.);
+assert_eq!(instance.get_clicked_text(), "eor@0");
+assert_eq!(instance.get_clicked_row(), 3);
+assert_eq!(instance.get_clicked_col(), 4);
+
+// Click on second_row_set[1][0] = "t" (should be row 4, col 0)
+// Row 4: y=453, size≈98 → center≈502.
+slint_testing::send_mouse_click(&instance, 70., 502.);
+assert_eq!(instance.get_clicked_text(), "t@1,0");
+assert_eq!(instance.get_clicked_row(), 4);
+assert_eq!(instance.get_clicked_col(), 0);
+
+// Click on second_row_set[1]'s "end of row" (should be row 4, col 1 - after t)
+// Col 1: x=140, size=190 → center=235.
+slint_testing::send_mouse_click(&instance, 235., 502.);
+assert_eq!(instance.get_clicked_text(), "eor@1");
+assert_eq!(instance.get_clicked_row(), 4);
+assert_eq!(instance.get_clicked_col(), 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_end_row(), 5);
+assert_eq(instance.get_end_col(), 0);
+assert(instance.get_test());
+
+// Click on second_row_set[0][0] = "p" (should be row 3, col 0)
+slint_testing::send_mouse_click(&instance, 70., 404.);
+assert_eq(instance.get_clicked_text(), "p@0,0");
+assert_eq(instance.get_clicked_row(), 3);
+assert_eq(instance.get_clicked_col(), 0);
+
+// Click on second_row_set[0]'s "end of row" (should be row 3, col 4 - after p,q,r,s)
+slint_testing::send_mouse_click(&instance, 705., 404.);
+assert_eq(instance.get_clicked_text(), "eor@0");
+assert_eq(instance.get_clicked_row(), 3);
+assert_eq(instance.get_clicked_col(), 4);
+
+// Click on second_row_set[1][0] = "t" (should be row 4, col 0)
+slint_testing::send_mouse_click(&instance, 70., 502.);
+assert_eq(instance.get_clicked_text(), "t@1,0");
+assert_eq(instance.get_clicked_row(), 4);
+assert_eq(instance.get_clicked_col(), 0);
+
+// Click on second_row_set[1]'s "end of row" (should be row 4, col 1 - after t)
+slint_testing::send_mouse_click(&instance, 235., 502.);
+assert_eq(instance.get_clicked_text(), "eor@1");
+assert_eq(instance.get_clicked_row(), 4);
+assert_eq(instance.get_clicked_col(), 1);
+```
+*/


### PR DESCRIPTION
aka "jagged arrays"

Since the common case is that all rows have the same amount
of columns, the cache is based on that assumption, and the generated
code ensures that this is always the case, taking the max() of all rows
and adding "padding cells" where needed. This allows a cache format
that lets us do direct jumps in the 2D parts of the cache (nested
repeaters), without needing a per-row jump table.