### PR TITLE
FlexBoxLayout: fix min-width/min-height axis confusion for column direction

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1657,13 +1657,10 @@ pub fn flexbox_layout_info(
         return LayoutInfo { min: pad, preferred: pad, max: pad, ..Default::default() };
     }
 
-    // Min size is the maximum of any single item (since they can wrap) plus padding
-    let (cells, padding, spacing) = match (direction, orientation) {
-        (FlexDirection::Row | FlexDirection::RowReverse, Orientation::Horizontal)
-        | (FlexDirection::Column | FlexDirection::ColumnReverse, Orientation::Vertical) => {
-            (&cells_h, padding_h, spacing_h)
-        }
-        _ => (&cells_v, padding_v, spacing_v),
+    // Min size is the maximum of any single item (since they can wrap) plus padding.
+    let (cells, padding, spacing) = match orientation {
+        Orientation::Horizontal => (&cells_h, padding_h, spacing_h),
+        Orientation::Vertical => (&cells_v, padding_v, spacing_v),
     };
     let extra_pad = padding.begin + padding.end;
     let min =

--- a/tests/cases/layout/flexbox_column_varying_widths.slint
+++ b/tests/cases/layout/flexbox_column_varying_widths.slint
@@ -8,7 +8,7 @@ export component TestCase inherits Window {
     height: 250px;
 
     // Items with varying widths and multiple columns
-    FlexBoxLayout {
+    flex := FlexBoxLayout {
         flex-direction: column;
         spacing: 5px;
         padding: 0px;
@@ -41,7 +41,14 @@ export component TestCase inherits Window {
     // r1 and r2 fit in first column (40+5+40=85 < 250)
     // r3 and r4 fit in first column too (85+5+40+5+40=175 < 250)
     // All items stay in one column
-    out property <bool> test: r1.x == 0px && r1.y == 0px && r2.x == 0px && r2.y == 45px && r3.x == 0px && r3.y == 90px && r4.x == 0px && r4.y == 135px;
+    out property <bool> test_positions: r1.x == 0px && r1.y == 0px && r2.x == 0px && r2.y == 45px && r3.x == 0px && r3.y == 90px && r4.x == 0px && r4.y == 135px;
+
+    // min-height = max single item height (items can wrap to new columns) = 40px
+    // min-width  = max single item width (cross-axis, widest item) = 60px
+    out property <bool> test_min_height: flex.min-height == 40px;
+    out property <bool> test_min_width: flex.min-width == 60px;
+
+    out property <bool> test: test_positions && test_min_height && test_min_width;
 }
 
 /*


### PR DESCRIPTION
flexbox_layout_info() selected cells/padding/spacing using a
(direction, orientation) match. The intention was to pick the
main-axis cells for a main-axis query and cross-axis cells for a
cross-axis query. But the match was wrong:

  (Column, Vertical)   → main axis → should use cells_v (heights)
                          but selected cells_h (widths)
  (Column, Horizontal) → cross axis → should use cells_h (widths)
                          but selected cells_v (heights)

For a column layout with items wider than tall (e.g. width=80px,
height=40px), this caused:
  - min-height reported as 80px (max item width) instead of 40px
  - min-width  reported as 40px (max item height) instead of 80px

Fix: select cells/padding/spacing by orientation alone — height
queries always use cells_v, width queries always use cells_h,
regardless of flex direction.

The bug was visible in flexbox-interactive.slint when selecting
Flex Direction: Column, and trying to shrink the window height
as much as possible - it didn't shrink all the way to the height
of the one row of items.