### PR TITLE
CI: Prospective fix for failing ruff invocations in the autofix workflow

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -23,8 +23,9 @@ depends = ["fix:rust:lockfile"]
 
 ["fix:python:format"]
 description = "Run ruff format"
-run = "ruff format"
-tools = { "ruff" = "0.11.8" }
+# Run via uv as the ruff installation via mise is unreliable in the CI.
+# It keeps failing to find ruff, despite saying that it was installed.
+run = "uv tool run ruff@0.11.8 format"
 
 ["fix:rust:format"]
 description = "Run cargo fmt --all"


### PR DESCRIPTION
Occasionally running ruff fails in the sense of not finding the binary, despite mise claiming that it was successfully installed.

Work around this by invoking ruff the way everyone else does, via uv.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
