### PR TITLE
skia: make GL context not-current after OpenGLSurface drop

### DIFF
--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -18,12 +18,41 @@ use i_slint_core::platform::PlatformError;
 
 use crate::SkiaSharedContext;
 
+/// Wraps a [`glutin::context::PossiblyCurrentContext`] and makes it not-current on drop,
+/// so that no stale thread-local state remains after the context is destroyed.
+struct GlutinContext(Option<glutin::context::PossiblyCurrentContext>);
+
+impl GlutinContext {
+    fn new(context: glutin::context::PossiblyCurrentContext) -> Self {
+        Self(Some(context))
+    }
+}
+
+impl std::ops::Deref for GlutinContext {
+    type Target = glutin::context::PossiblyCurrentContext;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl Drop for GlutinContext {
+    fn drop(&mut self) {
+        if let Some(context) = self.0.take()
+            && let Err(e) = context.make_not_current()
+        {
+            i_slint_core::debug_log!(
+                "Skia OpenGL Renderer: Failed to make context not current: {e}"
+            );
+        }
+    }
+}
+
 /// This surface type renders into the given window with OpenGL, using glutin and glow libraries.
 pub struct OpenGLSurface {
     fb_info: skia_safe::gpu::gl::FramebufferInfo,
     surface: RefCell<skia_safe::Surface>,
     gr_context: RefCell<skia_safe::gpu::DirectContext>,
-    glutin_context: glutin::context::PossiblyCurrentContext,
+    glutin_context: GlutinContext,
     glutin_surface: glutin::surface::Surface<glutin::surface::WindowSurface>,
 }
 
@@ -271,7 +300,7 @@ impl OpenGLSurface {
             fb_info,
             surface,
             gr_context: RefCell::new(gr_context),
-            glutin_context: current_glutin_context,
+            glutin_context: GlutinContext::new(current_glutin_context),
             glutin_surface,
         })
     }


### PR DESCRIPTION
OpenGLSurface::drop() makes the glutin context current, so that Skia's glDelete calls succeed. However it was left current. This leaves stale data in TLS that can cause problems. In the case of the report, the app (well, DAW plugin) would tear down also the x11 connection after the drop. However mesa still kept a reference to the underlying x11 pixmap the context was originally bound to, so later, when creating a new window and making a new context current, it would try to touch the previous context, it's x11 pixmap and x11 connection, which was a dangling pointer.

Wrap the glutin context in a GlutinContext newtype whose Drop impl calls
make_not_current() to clean up TLS state. Field drop order ensures Skia
types are destroyed while the context is still current.

Fixes #11039

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
