### PR TITLE
FlexBoxLayout: implement flex-wrap property

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -209,11 +209,12 @@ flexbox_layout_info(cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> ce
                     float spacing_h, float spacing_v, const cbindgen_private::Padding &padding_h,
                     const cbindgen_private::Padding &padding_v,
                     cbindgen_private::Orientation orientation,
-                    cbindgen_private::FlexDirection direction, float constraint_size)
+                    cbindgen_private::FlexDirection direction, float constraint_size,
+                    cbindgen_private::FlexWrap flex_wrap)
 {
     return cbindgen_private::slint_flexbox_layout_info(cells_h, cells_v, spacing_h, spacing_v,
                                                        &padding_h, &padding_v, orientation,
-                                                       direction, constraint_size);
+                                                       direction, constraint_size, flex_wrap);
 }
 
 /// Access the layout cache of an item within a repeater (standard cache)

--- a/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
@@ -110,6 +110,15 @@ The primary direction in which items are placed. Set to `row` to place items hor
 It also supports `row-reverse` and `column-reverse` which invert the flow: `row-reverse` places items right-to-left (starting at the right edge), and `column-reverse` places items bottom-to-top (starting at the bottom edge).
 </SlintProperty>
 
+### flex-wrap
+<SlintProperty propName="flex-wrap" typeName="enum" enumName="FlexWrap">
+Controls whether flex items wrap onto multiple lines when they don't fit in the container.
+- `wrap`: Items wrap onto the next line in the normal direction (default). New lines are added in the cross-axis direction.
+- `no-wrap`: All items are placed on a single line. Items may overflow the container.
+- `wrap-reverse`: Items wrap onto the next line, but lines are stacked in the reverse cross-axis direction.
+The default value is `wrap`.
+</SlintProperty>
+
 ### align-content
 <SlintProperty propName="align-content" typeName="enum" enumName="FlexAlignContent">
 Set the distribution of flex lines along the cross axis.

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -24,7 +24,7 @@ export component MainWindow inherits Window {
     title: "FlexBox Layout - Direction Test";
     default-font-size: 20px;
 
-    property <[string]> names: ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"];
+    property <[string]> names: ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"];
     property <[string]> direction_options: ["Row", "RowReverse", "Column", "ColumnReverse"];
     property <[FlexDirection]> direction_values: [
         FlexDirection.row,
@@ -55,6 +55,8 @@ export component MainWindow inherits Window {
         FlexAlignItems.end,
         FlexAlignItems.center
     ];
+    property <[string]> flex_wrap_options: ["Wrap", "NoWrap", "WrapReverse"];
+    property <[FlexWrap]> flex_wrap_values: [FlexWrap.wrap, FlexWrap.no-wrap, FlexWrap.wrap-reverse];
 
     VerticalLayout {
         padding: 20phx;
@@ -62,6 +64,16 @@ export component MainWindow inherits Window {
 
         HorizontalLayout {
             spacing: 10phx;
+            Text {
+                text: "Flex Wrap:";
+                vertical-alignment: center;
+            }
+
+            flex_wrap_combo := ComboBox {
+                model: flex_wrap_options;
+                current-index: 0;
+            }
+
             Text {
                 text: "Flex Direction:";
                 vertical-alignment: center;
@@ -117,12 +129,13 @@ export component MainWindow inherits Window {
                 alignment: alignment_values[alignment_combo.current-index];
                 align-content: align_content_values[align_content_combo.current-index];
                 align-items: align_items_values[align_items_combo.current-index];
+                flex-wrap: flex_wrap_values[flex_wrap_combo.current-index];
                 padding: 10phx;
                 spacing: 10phx;
 
                 for text in names: Cell {
                     cell_text: text;
-                    width: 80phx;
+                    width: 120phx;
                     height: 60phx;
                 }
             }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -395,6 +395,17 @@ macro_rules! for_each_enums {
                 Center,
             }
 
+            /// Controls whether flex items wrap onto multiple lines.
+            #[non_exhaustive]
+            enum FlexWrap {
+                /// Flex items wrap onto multiple lines, from top to bottom (for row direction) or left to right (for column direction).
+                Wrap,
+                /// All flex items are laid out on a single line (default for CSS, but Slint defaults to `wrap`).
+                NoWrap,
+                /// Flex items wrap onto multiple lines in the reverse direction.
+                WrapReverse,
+            }
+
             /// PathEvent is a low-level data structure describing the composition of a path. Typically it is
             /// generated at compile time from a higher-level description, such as SVG commands.
             #[non_exhaustive]

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -471,6 +471,7 @@ export component FlexBoxLayout {
     in property <FlexDirection> flex-direction;
     in property <FlexAlignContent> align-content;
     in property <FlexAlignItems> align-items;
+    in property <FlexWrap> flex-wrap;
 }
 
 component MoveTo {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -595,6 +595,7 @@ pub struct FlexBoxLayout {
     pub direction: Option<NamedReference>,
     pub align_content: Option<NamedReference>,
     pub align_items: Option<NamedReference>,
+    pub flex_wrap: Option<NamedReference>,
 }
 
 impl FlexBoxLayout {
@@ -610,6 +611,9 @@ impl FlexBoxLayout {
             visitor(&mut *e)
         }
         if let Some(e) = self.align_items.as_mut() {
+            visitor(&mut *e)
+        }
+        if let Some(e) = self.flex_wrap.as_mut() {
             visitor(&mut *e)
         }
     }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -338,6 +338,11 @@ pub(super) fn solve_flexbox_layout(
                     .with(|e| Type::Enumeration(e.enums.FlexAlignItems.clone())),
                 fld.align_items,
             ),
+            (
+                "flex_wrap",
+                crate::typeregister::BUILTIN.with(|e| Type::Enumeration(e.enums.FlexWrap.clone())),
+                fld.flex_wrap,
+            ),
             ("cells_h", fld.cells_h.ty(ctx), fld.cells_h),
             ("cells_v", fld.cells_v.ty(ctx), fld.cells_v),
         ],
@@ -496,6 +501,7 @@ fn compute_flexbox_layout_info_for_direction(
             orientation_expr,
             fld.direction,
             constraint_size,
+            fld.flex_wrap,
         ];
 
         match fld.compute_cells {
@@ -533,6 +539,7 @@ fn compute_flexbox_layout_info_for_direction(
             }),
             fld.direction,
             llr_Expression::NumberLiteral(f32::MAX.into()),
+            fld.flex_wrap,
         ];
 
         match fld.compute_cells {
@@ -564,6 +571,7 @@ struct FlexBoxLayoutDataResult {
     direction: llr_Expression,
     align_content: llr_Expression,
     align_items: llr_Expression,
+    flex_wrap: llr_Expression,
     cells_h: llr_Expression,
     cells_v: llr_Expression,
     /// When there are repeaters involved, we need to do a WithFlexBoxLayoutItemInfo with the
@@ -619,6 +627,16 @@ fn flexbox_layout_data(
         })
     };
 
+    let flex_wrap = if let Some(expr) = &layout.flex_wrap {
+        llr_Expression::PropertyReference(ctx.map_property_reference(expr))
+    } else {
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexWrap.clone());
+        llr_Expression::EnumerationValue(EnumerationValue {
+            value: e.default_value,
+            enumeration: e,
+        })
+    };
+
     let repeater_count =
         layout.elems.iter().filter(|i| i.element.borrow().repeated.is_some()).count();
 
@@ -656,6 +674,7 @@ fn flexbox_layout_data(
             direction,
             align_content,
             align_items,
+            flex_wrap,
             cells_h,
             cells_v,
             compute_cells: None,
@@ -698,6 +717,7 @@ fn flexbox_layout_data(
             direction,
             align_content,
             align_items,
+            flex_wrap,
             cells_h,
             cells_v,
             compute_cells: Some(("cells_h".into(), "cells_v".into(), elements)),

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -886,6 +886,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
     let direction = crate::layout::binding_reference(layout_element, "flex-direction");
     let align_content = crate::layout::binding_reference(layout_element, "align-content");
     let align_items = crate::layout::binding_reference(layout_element, "align-items");
+    let flex_wrap = crate::layout::binding_reference(layout_element, "flex-wrap");
 
     let mut layout = crate::layout::FlexBoxLayout {
         elems: Default::default(),
@@ -893,6 +894,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
         direction,
         align_content,
         align_items,
+        flex_wrap,
     };
 
     // FlexBoxLayout needs 4 values per item: x, y, width, height

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -7,6 +7,7 @@ export component X inherits Rectangle {
         alignment: center;
         align-content: stretch;
         align-items: stretch;
+        flex-wrap: wrap;
         gap: 10px;
 //      > <error{Use spacing instead of gap}
         row-gap: 5px;

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,7 +6,7 @@
 // cspell:ignore coord
 
 use crate::items::{
-    DialogButtonRole, FlexAlignContent, FlexAlignItems, FlexDirection, LayoutAlignment,
+    DialogButtonRole, FlexAlignContent, FlexAlignItems, FlexDirection, FlexWrap, LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
 use alloc::format;
@@ -1126,7 +1126,7 @@ pub struct BoxLayoutData<'a> {
 
 #[repr(C)]
 #[derive(Debug)]
-/// The FlexBoxLayoutData is used for a flex layout with wrapping.
+/// The FlexBoxLayoutData is used for a flex layout.
 pub struct FlexBoxLayoutData<'a> {
     pub width: Coord,
     pub height: Coord,
@@ -1138,6 +1138,7 @@ pub struct FlexBoxLayoutData<'a> {
     pub direction: FlexDirection,
     pub align_content: FlexAlignContent,
     pub align_items: FlexAlignItems,
+    pub flex_wrap: FlexWrap,
     /// Horizontal constraints (width) for each cell
     pub cells_h: Slice<'a, LayoutItemInfo>,
     /// Vertical constraints (height) for each cell
@@ -1285,7 +1286,8 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, FlexAlignContent, FlexAlignItems, LayoutAlignment, LayoutItemInfo, Padding, Slice,
+        Coord, FlexAlignContent, FlexAlignItems, FlexWrap as SlintFlexWrap, LayoutAlignment,
+        LayoutItemInfo, Padding, Slice,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
@@ -1305,6 +1307,7 @@ mod flexbox_taffy {
         pub alignment: LayoutAlignment,
         pub align_content: FlexAlignContent,
         pub align_items: FlexAlignItems,
+        pub flex_wrap: SlintFlexWrap,
         pub flex_direction: TaffyFlexDirection,
         pub container_width: Option<Coord>,
         pub container_height: Option<Coord>,
@@ -1409,7 +1412,11 @@ mod flexbox_taffy {
                     Style {
                         display: Display::Flex,
                         flex_direction: params.flex_direction,
-                        flex_wrap: FlexWrap::Wrap,
+                        flex_wrap: match params.flex_wrap {
+                            SlintFlexWrap::Wrap => FlexWrap::Wrap,
+                            SlintFlexWrap::NoWrap => FlexWrap::NoWrap,
+                            SlintFlexWrap::WrapReverse => FlexWrap::WrapReverse,
+                        },
                         justify_content: Some(match params.alignment {
                             // Start/End map to FlexStart/FlexEnd to respect flex direction (including reverse)
                             // AlignContent::Start/End would ignore direction and always use writing mode
@@ -1607,6 +1614,7 @@ pub fn solve_flexbox_layout(
         alignment: data.alignment,
         align_content: data.align_content,
         align_items: data.align_items,
+        flex_wrap: data.flex_wrap,
         flex_direction: taffy_direction,
         container_width,
         container_height,
@@ -1646,6 +1654,7 @@ pub fn flexbox_layout_info(
     orientation: Orientation,
     direction: FlexDirection,
     constraint_size: Coord,
+    flex_wrap: FlexWrap,
 ) -> LayoutInfo {
     if cells_h.is_empty() {
         assert!(cells_v.is_empty());
@@ -1657,14 +1666,11 @@ pub fn flexbox_layout_info(
         return LayoutInfo { min: pad, preferred: pad, max: pad, ..Default::default() };
     }
 
-    // Min size is the maximum of any single item (since they can wrap) plus padding.
     let (cells, padding, spacing) = match orientation {
         Orientation::Horizontal => (&cells_h, padding_h, spacing_h),
         Orientation::Vertical => (&cells_v, padding_v, spacing_v),
     };
     let extra_pad = padding.begin + padding.end;
-    let min =
-        cells.iter().map(|c| c.constraint.min).fold(0.0 as Coord, |a, b| a.max(b)) + extra_pad;
 
     // Determine if we're asking for main-axis or cross-axis
     let is_main_axis = matches!(
@@ -1673,20 +1679,35 @@ pub fn flexbox_layout_info(
             | (FlexDirection::Column | FlexDirection::ColumnReverse, Orientation::Vertical)
     );
 
-    // The main-axis constraint determines how items wrap.
-    // For main-axis queries, use sqrt of total item area as an approximation.
-    // For cross-axis queries, use the provided constraint_size.
-    let main_axis_constraint = if is_main_axis {
-        // constraint_size is not used for the main axis
-        let total_area = cells_h
-            .iter()
-            .map(|c| c.constraint.preferred_bounded())
-            .zip(cells_v.iter().map(|c| c.constraint.preferred_bounded()))
-            .map(|(h, v)| h * v)
-            .sum::<Coord>();
-        let count = cells.len();
-        Float::sqrt(total_area as f32) as Coord + spacing * (count - 1) as Coord + extra_pad
+    let min = if matches!(flex_wrap, FlexWrap::NoWrap) && is_main_axis {
+        // No wrapping: items must all fit in one line, min = sum of minimums + spacing
+        cells.iter().map(|c| c.constraint.min).sum::<Coord>()
+            + spacing * (cells.len().saturating_sub(1)) as Coord
+            + extra_pad
     } else {
+        // Wrapping (or cross-axis): the widest/tallest single item must fit
+        cells.iter().map(|c| c.constraint.min).fold(0.0 as Coord, |a, b| a.max(b)) + extra_pad
+    };
+
+    // The main-axis constraint determines how items wrap.
+    let main_axis_constraint = if is_main_axis {
+        // Note that constraint_size is not used for the main axis
+        if matches!(flex_wrap, FlexWrap::NoWrap) {
+            // No wrapping: items won't wrap regardless of size, use max content
+            Coord::MAX
+        } else {
+            // Use sqrt of total item area as an approximation.
+            let total_area = cells_h
+                .iter()
+                .map(|c| c.constraint.preferred_bounded())
+                .zip(cells_v.iter().map(|c| c.constraint.preferred_bounded()))
+                .map(|(h, v)| h * v)
+                .sum::<Coord>();
+            let count = cells.len();
+            Float::sqrt(total_area as f32) as Coord + spacing * (count - 1) as Coord + extra_pad
+        }
+    } else {
+        // For cross-axis queries, use the provided constraint_size.
         constraint_size
     };
 
@@ -1712,6 +1733,7 @@ pub fn flexbox_layout_info(
         alignment: LayoutAlignment::Start,
         align_content: FlexAlignContent::Stretch,
         align_items: FlexAlignItems::Stretch,
+        flex_wrap,
         flex_direction: taffy_direction,
         container_width,
         container_height,
@@ -1877,6 +1899,7 @@ pub(crate) mod ffi {
         orientation: Orientation,
         direction: FlexDirection,
         constraint_size: Coord,
+        flex_wrap: FlexWrap,
     ) -> LayoutInfo {
         super::flexbox_layout_info(
             cells_h,
@@ -1888,6 +1911,7 @@ pub(crate) mod ffi {
             orientation,
             direction,
             constraint_size,
+            flex_wrap,
         )
     }
 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -213,6 +213,10 @@ pub(crate) fn solve_flexbox_layout(
         .map_or(i_slint_core::items::FlexAlignItems::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
+    let flex_wrap =
+        flexbox_layout.flex_wrap.as_ref().map_or(i_slint_core::items::FlexWrap::default(), |nr| {
+            eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
+        });
 
     let (padding_h, spacing_h) =
         padding_and_spacing(&flexbox_layout.geometry, Orientation::Horizontal, &expr_eval);
@@ -231,6 +235,7 @@ pub(crate) fn solve_flexbox_layout(
             direction,
             align_content,
             align_items,
+            flex_wrap,
             cells_h: Slice::from(cells_h.as_slice()),
             cells_v: Slice::from(cells_v.as_slice()),
         },
@@ -293,6 +298,11 @@ pub(crate) fn compute_flexbox_layout_info(
     let (padding_v, spacing_v) =
         padding_and_spacing(&flexbox_layout.geometry, Orientation::Vertical, &expr_eval);
 
+    let flex_wrap =
+        flexbox_layout.flex_wrap.as_ref().map_or(i_slint_core::items::FlexWrap::default(), |nr| {
+            eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
+        });
+
     if is_main_axis {
         // Main axis: use simple layout info (no constraint needed)
         // This avoids reading the perpendicular dimension and prevents circular dependencies
@@ -306,6 +316,7 @@ pub(crate) fn compute_flexbox_layout_info(
             to_runtime(orientation),
             direction,
             Coord::MAX,
+            flex_wrap,
         )
         .into()
     } else {
@@ -334,6 +345,7 @@ pub(crate) fn compute_flexbox_layout_info(
             to_runtime(orientation),
             direction,
             constraint_size,
+            flex_wrap,
         )
         .into()
     }


### PR DESCRIPTION
Possible values: wrap, no-wrap, and wrap-reverse.

Unlike CSS, the default is wrap:
- it preserves the behavior before this commit
- in a slint layout people expect their items to wrap so that
  they are visible in the window, rather than being truncated due
  to insufficient width (or the window becoming huge horizontally
  to accomodate for all items)