### PR TITLE
fix: uv build issue not incuding `langauge.pyi`

### DIFF
--- a/api/python/slint/build.rs
+++ b/api/python/slint/build.rs
@@ -98,7 +98,10 @@ macro_rules! generate_builtin_structs_pyi {
 i_slint_common::for_each_builtin_structs!(generate_builtin_structs_pyi);
 
 fn main() {
-    let pyi_path = "slint/language.pyi";
+    let pyi_path = std::path::Path::new("slint/language.pyi");
+    if let Some(parent) = pyi_path.parent() {
+        std::fs::create_dir_all(parent).expect("Failed to create slint/ directory");
+    }
     let file = File::create(pyi_path).expect("Failed to create language.pyi");
     let mut writer = BufWriter::new(file);
     generate_pyi(&mut writer);

--- a/api/python/slint/pyproject.toml
+++ b/api/python/slint/pyproject.toml
@@ -52,3 +52,5 @@ cache-keys = [{ file = "pyproject.toml" }, { file = "Cargo.toml" }, { file = "**
 
 [tool.maturin]
 editable-profile = "dev"
+# added so it includes in wheel build to overrite the default behavior of not including untracked files
+include = ["slint/language.pyi"]


### PR DESCRIPTION
fix: ensure the output directory `slint` exists before creating `language.pyi`.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
