### PR TITLE
cpp: Make update_all_translations() unconditionally available

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -469,8 +469,8 @@ inline bool set_translator(std::unique_ptr<Translator> obj)
 #endif
 
 /// Forces all the strings that are translated with `@tr(...)` to be re-evaluated.
-/// This is useful if the language is changed at runtime, if either gettext
-/// or a custom translator is used. For bundled translations, there is no need
+/// Call this function after changing the language at run-time and when translating
+/// with either gettext or a custom translator. For bundled translations, there is no need
 /// to call this function.
 ///
 /// Example (assuming usage of gettext):


### PR DESCRIPTION
This function was only available if the gettext feature was enabled. But the function is also useful in conjunction with an external translator (see #10979), and the corresponding Rust implementation is unconditionally enabled anyway (not dependent on gettext). So the C++ API can/should be available too.

This is technically independent of #10979 (except from mentioning the custom translator in the comment), thus a separate PR. But in practice it is useful only if #10979 is merged too.
