### PR TITLE
Fix path rendering with the software renderer from C++ when libm is r…

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -74,7 +74,6 @@ endfunction()
 # defaults need to be kept in sync with the Rust bit (cpp/Cargo.toml and cbindgen.rs)
 
 define_cargo_feature(freestanding "Enable use of freestanding environment. This is only for bare-metal systems. Most other features are incompatible with this one" OFF)
-define_cargo_feature(libm "This feature enables floating point arithmetic emulation using the libm crate. Use this in MCU environments where the processor does not support floating point arithmetic." OFF)
 
 # Compat options (must be declared after the STD feature, but before the other renderer features)
 function(define_renderer_winit_compat_option renderer)

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -46,7 +46,6 @@ software-renderer-path = ["i-slint-renderer-software/path"]
 gettext = ["i-slint-core/gettext-rs"]
 accessibility = ["i-slint-backend-selector/accessibility"]
 system-testing = ["i-slint-backend-selector/system-testing"]
-libm = ["i-slint-core/libm", "i-slint-renderer-software?/libm"]
 
 std = [
   "i-slint-core/default",
@@ -57,7 +56,7 @@ std = [
   "i-slint-backend-selector/raw-window-handle-06",
   "i-slint-core/tr",
 ]
-freestanding = ["i-slint-core/libm", "i-slint-core/unsafe-single-threaded"]
+freestanding = ["i-slint-core/libm", "i-slint-core/unsafe-single-threaded", "i-slint-renderer-software?/libm"]
 experimental = ["i-slint-renderer-software?/experimental"]
 
 default = ["std", "backend-winit", "renderer-femtovg", "backend-qt"]


### PR DESCRIPTION
…equired

Revert commit e8346700ae2c000871668ff333aa6f99a4293cf8 and instead add the missing libm feature enablement to the existing SLINT_FEATURE_FREESTANDING.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
