### PR TITLE
CI: Fix builds of Skia in the CI

### DIFF
--- a/.github/actions/install-skia-dependencies/action.yaml
+++ b/.github/actions/install-skia-dependencies/action.yaml
@@ -17,3 +17,11 @@ runs:
           if: runner.os == 'Windows'
           run: rm /usr/bin/link
           shell: bash
+        - name: Unselect homebrew clang to work around https://github.com/actions/runner-images/issues/13827
+          if: runner.os == 'macOS'
+          shell: bash
+          run: |
+              echo "CLANGCC=/usr/bin/clang" >> $GITHUB_ENV
+              echo "CLANGCXX=/usr/bin/clang++" >> $GITHUB_ENV
+              libclang_path=$(xcode-select --print-path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/
+              echo "LIBCLANG_PATH=$libclang_path" >> $GITHUB_ENV


### PR DESCRIPTION
Work around issue in the GH runner images that put homebrew clang first into the path, which has difficulties compiling CoreText header files.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
