### PR TITLE
Tweak dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,10 @@ updates:
       - dependency-name: "@codingame/monaco-vscode-storage-service-override"
       - dependency-name: "@codingame/monaco-vscode-api"
       - dependency-name: "@codingame/monaco-vscode-editor-api"
-      - dependency-name: "@napi-rs/cli"
+      - dependency-name: "@codingame/monaco-vscode-theme-service-override"
       - dependency-name: "monaco-editor-wrapper"
       - dependency-name: "monaco-languageclient"
+      - dependency-name: "tailwindcss"
 
     groups:
       npm-major-updates:


### PR DESCRIPTION
Ignore another vscode dependency and tailwindcss.

Now nap-rs has been updated there is no need to ignore updates.