### PR TITLE
C++: delete `ChangeTracker` copy constructor

### DIFF
--- a/api/cpp/include/private/slint_properties.h
+++ b/api/cpp/include/private/slint_properties.h
@@ -381,6 +381,8 @@ struct ChangeTracker
 {
     ChangeTracker() { cbindgen_private::slint_change_tracker_construct(&inner); }
     ~ChangeTracker() { cbindgen_private::slint_change_tracker_drop(&inner); }
+    ChangeTracker(const ChangeTracker &) = delete;
+    ChangeTracker &operator=(const ChangeTracker &) = delete;
 
     template<typename Data, typename FnEval, typename FnNotify>
     void init(Data data, FnEval fn_eval, FnNotify fn_notify)


### PR DESCRIPTION
That would be a bug as the underlying thing don't implement clone
