### PR TITLE
Fix: default-features=false vs no-default-features=true

### DIFF
--- a/tests/backends/Cargo.toml
+++ b/tests/backends/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 [dependencies]
 # This disables the default feature selection so that each test binary is forced to set up
 # the right backend and doesn't accidentally just use the default backend!
-slint = { workspace = true, no-default-features = true, features = ["std", "compat-1-2", "renderer-software"] }
+slint = { workspace = true, default-features = false, features = ["std", "compat-1-2", "renderer-software"] }
 i-slint-backend-winit = { workspace = true, features = ["x11", "wayland", "renderer-software"] }
 i-slint-backend-qt = { workspace = true, features = ["default"] }
 


### PR DESCRIPTION
--no-default-features is the command-line-flag, and not the key for the
Cargo.toml...

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
