### PR TITLE
PichGestureHandler: Rename smart-magnify to double-tapped, and pass the position parameter

### DIFF
--- a/docs/astro/src/content/docs/reference/gestures/pinchgesturehandler.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/pinchgesturehandler.mdx
@@ -91,4 +91,4 @@ For trackpad gestures, this is the mouse cursor position.
 -   **`updated()`**: Invoked whenever the `scale`, `rotation`, or `center` changes during the gesture.
 -   **`ended()`**: Invoked when the gesture completes normally (fingers lifted).
 -   **`cancelled()`**: Invoked when the gesture is cancelled, for example when the handler is disabled during an active gesture or the window loses focus.
--   **`smart-magnify()`**: Invoked on a platform "smart magnify" gesture (two-finger double-tap on macOS/iOS trackpads). This does not activate the gesture or change `scale`/`rotation`.
+-   **`double-tapped(position: Point)`**: Invoked on a platform "smart magnify" gesture (two-finger double-tap on macOS/iOS trackpads). This does not activate the gesture or change `scale`/`rotation`.

--- a/examples/native-gestures/native-gestures.slint
+++ b/examples/native-gestures/native-gestures.slint
@@ -214,7 +214,7 @@ export component MainWindow inherits Window {
             root.status-text = "cancelled";
         }
 
-        smart-magnify => {
+        double-tapped => {
             if gestureData.current-scale > 1.5 {
                 gestureData.current-scale = 1.0;
                 gestureData.current-rotation = 0deg;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -241,7 +241,7 @@ export component PinchGestureHandler {
     callback updated();
     callback ended();
     callback cancelled();
-    callback smart-magnify();
+    callback double-tapped(position: Point);
 
     //-default_size_binding:expands_to_parent_geometry
 }

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use super::{
-    EventResult, FocusReasonArg, Item, ItemConsts, ItemRc, ItemRendererRef, KeyEventArg,
-    MouseCursor, PointerEvent, PointerEventArg, PointerEventButton, PointerEventKind,
-    PointerScrollEvent, PointerScrollEventArg, RenderingResult, VoidArg,
+    EventResult, FocusReasonArg, Item, ItemConsts, ItemRc, ItemRendererRef, ItemTreeVTable,
+    KeyEventArg, MouseCursor, PointArg, PointerEvent, PointerEventArg, PointerEventButton,
+    PointerEventKind, PointerScrollEvent, PointerScrollEventArg, RenderingResult, VoidArg,
 };
 use crate::api::LogicalPosition;
 use crate::input::{
@@ -12,7 +12,6 @@ use crate::input::{
     InternalKeyEvent, KeyEventResult, KeyEventType, Keys, MouseEvent,
 };
 use crate::item_rendering::CachedRenderingData;
-use crate::items::ItemTreeVTable;
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PointLengths};
 use crate::properties::PropertyTracker;
@@ -988,7 +987,7 @@ pub struct PinchGestureHandler {
     pub updated: Callback<VoidArg>,
     pub ended: Callback<VoidArg>,
     pub cancelled: Callback<VoidArg>,
-    pub smart_magnify: Callback<VoidArg>,
+    pub double_tapped: Callback<PointArg>,
 
     /// FIXME: remove this
     pub cached_rendering_data: CachedRenderingData,
@@ -1129,11 +1128,14 @@ impl Item for PinchGestureHandler {
                     }
                 }
             }
-            MouseEvent::DoubleTapGesture { .. } => {
+            MouseEvent::DoubleTapGesture { position } => {
                 if !self.enabled() {
                     return InputEventResult::EventIgnored;
                 }
-                Self::FIELD_OFFSETS.smart_magnify.apply_pin(self).call(&());
+                Self::FIELD_OFFSETS
+                    .double_tapped
+                    .apply_pin(self)
+                    .call(&(LogicalPosition::from_euclid(*position),));
                 InputEventResult::EventAccepted
             }
             // Grab mouse during active gesture to maintain exclusivity.

--- a/tests/cases/elements/pinchgesturehandler.slint
+++ b/tests/cases/elements/pinchgesturehandler.slint
@@ -11,7 +11,7 @@ export component TestCase inherits Window {
     out property <float> scale <=> pinch.scale;
     out property <angle> rotation <=> pinch.rotation;
     out property <Point> center <=> pinch.center;
-    out property <bool> smart-magnified: false;
+    out property <Point> smart-magnified;
 
     pinch := PinchGestureHandler {
         started => {
@@ -26,8 +26,8 @@ export component TestCase inherits Window {
         cancelled => {
             r += "cancelled;";
         }
-        smart-magnify => {
-            root.smart-magnified = true;
+        double-tapped(position) => {
+            root.smart-magnified = position;
         }
     }
 }
@@ -239,9 +239,9 @@ slint_testing::send_pinch_gesture(&instance, 0.0, 300.0, 300.0, TouchPhase::Ende
 let instance = TestCase::new().unwrap();
 
 // === Test 12: DoubleTapGesture fires smart-magnify callback ===
-assert_eq!(instance.get_smart_magnified(), false);
-slint_testing::send_double_tap_gesture(&instance, 300.0, 300.0);
-assert_eq!(instance.get_smart_magnified(), true);
+assert_eq!(instance.get_smart_magnified(), Default::default());
+slint_testing::send_double_tap_gesture(&instance, 350.0, 300.0);
+assert_eq!(instance.get_smart_magnified(), slint::LogicalPosition::new(350.0, 300.0));
 // DoubleTapGesture should not activate the gesture
 assert_eq!(instance.get_active(), false);
 ```
@@ -252,7 +252,7 @@ let instance = TestCase::new().unwrap();
 // === Test 13: DoubleTapGesture ignored when disabled ===
 instance.set_enabled(false);
 slint_testing::send_double_tap_gesture(&instance, 300.0, 300.0);
-assert_eq!(instance.get_smart_magnified(), false);
+assert_eq!(instance.get_smart_magnified(), Default::default());
 ```
 
 ```rust


### PR DESCRIPTION
Double tapped is the name of the event and is more accurate. Also do not ignore the position from the event and forward it to the callback.

