### PR TITLE
Don't expose StateInfo as a 'public' slint struct

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -165,7 +165,6 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
                     let pri_type = stringify!($pri_type).replace(' ', "");
                     let pri_type = match pri_type.as_str() {
                         "usize" => "uintptr_t",
-                        "crate::animations::Instant" => "uint64_t",
                         // This shouldn't be accessed by the C++ anyway, just need to have the same ABI in a struct
                         "Option<i32>" => "std::pair<int32_t, int32_t>",
                         "Option<core::ops::Range<i32>>" => "std::tuple<int32_t, int32_t, int32_t>",
@@ -236,6 +235,7 @@ fn default_config() -> cbindgen::Config {
             ("MenuEntryModel".into(), "std::shared_ptr<slint::Model<MenuEntry>>".into()),
             ("Coord".into(), "float".into()),
             ("Channel".into(), "uint8_t".into()),
+            ("Instant".into(), "uint64_t".into()),
         ]
         .iter()
         .cloned()
@@ -446,6 +446,7 @@ fn gen_corelib(
     properties_config.export.exclude.clear();
     properties_config.structure.derive_eq = true;
     properties_config.structure.derive_neq = true;
+    properties_config.export.include.push("StateInfo".into());
     private_exported_types.extend(properties_config.export.include.iter().cloned());
     cbindgen::Builder::new()
         .with_config(properties_config)

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -26,7 +26,6 @@
 /// i_slint_common::for_each_builtin_structs!(print_builtin_structs);
 /// ```
 #[macro_export]
-#[allow(clippy::crate_in_macro_def)] // Intentional: this macro is consumed in crates where `crate::animations::Instant` must resolve in the caller.
 macro_rules! for_each_builtin_structs {
     ($macro:ident) => {
         $macro![
@@ -149,22 +148,6 @@ macro_rules! for_each_builtin_structs {
                     width: Coord,
                 }
                 private {
-                }
-            }
-
-            /// Value of the state property
-            /// A state is just the current state, but also has information about the previous state and the moment it changed
-            struct StateInfo {
-                @name = BuiltinPrivateStruct::StateInfo,
-                export {
-                    /// The current state value
-                    current_state: i32,
-                    /// The previous state
-                    previous_state: i32,
-                }
-                private {
-                    /// The instant in which the state changed last
-                    change_time: crate::animations::Instant,
                 }
             }
 

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -122,7 +122,7 @@ pub async fn run_passes(
             &palette,
             diag,
         );
-        lower_states::lower_states(component, &doc.local_registry, diag);
+        lower_states::lower_states(component, diag);
         lower_text_input_interface::lower_text_input_interface(component);
         compile_paths::compile_paths(
             component,

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -15,13 +15,8 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
 
-pub fn lower_states(
-    component: &Rc<Component>,
-    tr: &crate::typeregister::TypeRegister,
-    diag: &mut BuildDiagnostics,
-) {
-    let state_info_type = tr.lookup("StateInfo");
-    assert!(matches!(state_info_type, Type::Struct(ref s) if s.name.is_some()));
+pub fn lower_states(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
+    let state_info_type = crate::typeregister::BUILTIN.with(|b| b.state_info_type.clone().into());
     recurse_elem(&component.root_element, &(), &mut |elem, _| {
         lower_state_in_element(elem, &state_info_type, diag)
     });

--- a/internal/compiler/tests/syntax/basic/property_declaration.slint
+++ b/internal/compiler/tests/syntax/basic/property_declaration.slint
@@ -30,4 +30,7 @@ export Test := Comp {
 
     property<color> color;
 //                  >   <error{Cannot override property 'color'}
+
+    property<StateInfo> state-info : { current-state: 0, previous-state: 4 };
+//           >       <error{Unknown type 'StateInfo'}
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -86,6 +86,7 @@ pub struct BuiltinTypes {
     pub logical_size_type: Rc<Struct>,
     pub font_metrics_type: Type,
     pub layout_info_type: Rc<Struct>,
+    pub state_info_type: Rc<Struct>,
     pub gridlayout_input_data_type: Type,
     pub path_element_type: Type,
     pub layout_item_info_type: Type,
@@ -144,6 +145,15 @@ impl BuiltinTypes {
                 arg_names: Vec::new(),
             })),
             layout_info_type: layout_info_type.clone(),
+            state_info_type: Rc::new(Struct {
+                fields: IntoIterator::into_iter([
+                    (SmolStr::new_static("current-state"), Type::Int32),
+                    (SmolStr::new_static("previous-state"), Type::Int32),
+                    (SmolStr::new_static("change-time"), Type::Duration),
+                ])
+                .collect(),
+                name: BuiltinPrivateStruct::StateInfo.into(),
+            }),
             path_element_type: Type::Struct(Rc::new(Struct {
                 fields: Default::default(),
                 name: BuiltinPrivateStruct::PathElement.into(),

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1625,8 +1625,20 @@ fn test_two_way_with_map() {
 mod change_tracker;
 pub use change_tracker::*;
 mod properties_animations;
-pub use crate::items::StateInfo;
 pub use properties_animations::*;
+
+/// Value of the state property
+/// A state is just the current state, but also has information about the previous state and the moment it changed
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[repr(C)]
+pub struct StateInfo {
+    /// The current state value
+    pub current_state: i32,
+    /// The previous state
+    pub previous_state: i32,
+    /// The instant in which the state changed last
+    pub change_time: crate::animations::Instant,
+}
 
 struct StateInfoBinding<F> {
     dirty_time: Cell<Option<crate::animations::Instant>>,

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -302,9 +302,7 @@ macro_rules! declare_value_struct_conversion {
             export {
                 $( $(#[$pub_attr:meta])* $pub_field:ident : $pub_type:ty, )*
             }
-            private {
-                $( $(#[$pri_attr:meta])* $pri_field:ident : $pri_type:ty, )*
-            }
+            private { $($pri:tt)* }
         }
     )*) => {
         $(
@@ -312,7 +310,6 @@ macro_rules! declare_value_struct_conversion {
                 fn from(item: $Name) -> Self {
                     let mut struct_ = Struct::default();
                     $(struct_.set_field(stringify!($pub_field).into(), item.$pub_field.into());)*
-                    $(handle_private!(SET $Name $pri_field, struct_, item);)*
                     Value::Struct(struct_)
                 }
             }
@@ -326,7 +323,6 @@ macro_rules! declare_value_struct_conversion {
                             #[allow(unused)]
                             let mut res: Ty = Ty::default();
                             $(res.$pub_field = x.get_field(stringify!($pub_field)).ok_or(())?.clone().try_into().map_err(|_|())?;)*
-                            $(handle_private!(GET $Name $pri_field, x, res);)*
                             Ok(res)
                         }
                         _ => Err(()),
@@ -337,21 +333,10 @@ macro_rules! declare_value_struct_conversion {
     };
 }
 
-macro_rules! handle_private {
-    (SET StateInfo $field:ident, $struct_:ident, $item:ident) => {
-        $struct_.set_field(stringify!($field).into(), $item.$field.into())
-    };
-    (SET $_:ident $field:ident, $struct_:ident, $item:ident) => {{}};
-    (GET StateInfo $field:ident, $struct_:ident, $item:ident) => {
-        $item.$field =
-            $struct_.get_field(stringify!($field)).ok_or(())?.clone().try_into().map_err(|_| ())?
-    };
-    (GET $_:ident $field:ident, $struct_:ident, $item:ident) => {{}};
-}
-
 declare_value_struct_conversion!(struct i_slint_core::layout::LayoutInfo { min, max, min_percent, max_percent, preferred, stretch });
 declare_value_struct_conversion!(struct i_slint_core::graphics::Point { x, y, ..Default::default()});
 declare_value_struct_conversion!(struct i_slint_core::api::LogicalPosition { x, y });
+declare_value_struct_conversion!(struct i_slint_core::properties::StateInfo { current_state, previous_state, change_time });
 
 i_slint_common::for_each_builtin_structs!(declare_value_struct_conversion);
 

--- a/xtask/src/slintdocs.rs
+++ b/xtask/src/slintdocs.rs
@@ -297,8 +297,6 @@ pub fn extract_builtin_structs() -> std::collections::BTreeMap<String, StructDoc
 
     i_slint_common::for_each_builtin_structs!(gen_structs);
 
-    // `StateInfo` should not be in the documentation, so remove it again
-    structs.remove("StateInfo");
     // Internal type
     structs.remove("MenuEntry");
     // Experimental type


### PR DESCRIPTION
Using `StateInfo` from slint would lead to various panic in the compiler as it is handled differently