### PR TITLE
lsp/fmt: fix struct formatting regressions around comments and top-level

### DIFF
--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -51,18 +51,6 @@ impl FormatState {
         self.whitespace_to_add = Some(new_line);
     }
 
-    fn blank_line(&mut self) {
-        self.new_line();
-        let pending_newlines = self
-            .whitespace_to_add
-            .as_deref()
-            .map(|ws| ws.chars().take_while(|c| *c == '\n').count())
-            .unwrap_or(0);
-        if pending_newlines < 2 {
-            self.new_line();
-        }
-    }
-
     fn insert_whitespace(&mut self, arg: &str) {
         if self.after_comment {
             return;
@@ -84,11 +72,11 @@ fn format_node(
     state: &mut FormatState,
 ) -> Result<(), std::io::Error> {
     match node.kind() {
-        SyntaxKind::Document => {
-            return format_document_node(node, writer, state);
-        }
         SyntaxKind::Component => {
             return format_component(node, writer, state);
+        }
+        SyntaxKind::Document => {
+            return format_document_node(node, writer, state);
         }
         SyntaxKind::Element => {
             return format_element(node, writer, state);
@@ -210,21 +198,27 @@ fn format_document_node(
     state: &mut FormatState,
 ) -> Result<(), std::io::Error> {
     for n in node.children_with_tokens() {
-        if n.kind() != SyntaxKind::Comment
-            && let Some(last_removed_whitespace) = state.last_removed_whitespace.take()
-            && has_empty_line(&last_removed_whitespace)
+        if let Some(t) = n.as_token()
+            && t.kind() == SyntaxKind::Whitespace
+            && whitespace_has_empty_line(t.text())
+            && next_non_trivia_token_kind(&n).is_some_and(|kind| kind != SyntaxKind::Eof)
         {
-            state.blank_line();
+            // Preserve document-level blank lines as written and override any
+            // pending newline inserted by the preceding formatter branch.
+            state.skip_all_whitespace = false;
+            state.whitespace_to_add = None;
+            state.last_removed_whitespace = None;
+            state.after_comment = false;
+            state.insertion_count += 1;
+            writer.no_change(t.clone())?;
+            continue;
         }
 
-        if n.kind() == SyntaxKind::Whitespace && !state.after_comment {
-            let is_empty_line = n.as_token().map(|n| has_empty_line(n.text())).unwrap_or(false);
-            if is_empty_line {
-                state.blank_line();
-                continue;
-            }
+        // Comments are tokens, but top-level items are nodes. Make sure a preceding
+        // comment does not suppress indentation inside the next formatted node.
+        if n.as_node().is_some() {
+            state.after_comment = false;
         }
-
         fold(n, writer, state)?;
     }
     Ok(())
@@ -285,7 +279,7 @@ impl SyntaxMatch {
     }
 }
 
-fn has_empty_line(text: &str) -> bool {
+fn whitespace_has_empty_line(text: &str) -> bool {
     let mut newlines = 0;
     for b in text.bytes() {
         if b == b'\n' {
@@ -296,6 +290,35 @@ fn has_empty_line(text: &str) -> bool {
         }
     }
     false
+}
+
+fn next_non_trivia_token_kind(item: &NodeOrToken) -> Option<SyntaxKind> {
+    match item {
+        NodeOrToken::Node(node) => Some(node.kind()),
+        NodeOrToken::Token(token) => {
+            let mut current = token.clone();
+            loop {
+                match current.kind() {
+                    SyntaxKind::Whitespace | SyntaxKind::Comment => {
+                        current = current.next_token()?;
+                    }
+                    kind => return Some(kind),
+                }
+            }
+        }
+    }
+}
+
+fn prev_non_trivia_token_kind(token: i_slint_compiler::parser::SyntaxToken) -> Option<SyntaxKind> {
+    let mut current = token;
+    loop {
+        match current.kind() {
+            SyntaxKind::Whitespace | SyntaxKind::Comment => {
+                current = current.prev_token()?;
+            }
+            kind => return Some(kind),
+        }
+    }
 }
 
 fn whitespace_to(
@@ -346,22 +369,6 @@ fn finish_node(
         fold(n, writer, state)?;
     }
     Ok(true)
-}
-
-fn next_non_whitespace_kind(next: Option<&NodeOrToken>) -> Option<SyntaxKind> {
-    let mut token = next.and_then(|next| match next {
-        NodeOrToken::Node(node) => node.first_token(),
-        NodeOrToken::Token(token) => Some(token.clone()),
-    });
-
-    while let Some(current) = token {
-        if !matches!(current.kind(), SyntaxKind::Whitespace | SyntaxKind::Comment) {
-            return Some(current.kind());
-        }
-        token = current.next_token();
-    }
-
-    None
 }
 
 fn format_component(
@@ -428,13 +435,14 @@ fn format_element(
         if n.kind() != SyntaxKind::Comment
             && let Some(last_removed_whitespace) = state.last_removed_whitespace.take()
         {
-            let is_empty_line = has_empty_line(&last_removed_whitespace);
+            let is_empty_line = whitespace_has_empty_line(&last_removed_whitespace);
             if is_empty_line && !inserted_newline {
                 state.new_line();
             }
         }
         if n.kind() == SyntaxKind::Whitespace && !state.after_comment {
-            let is_empty_line = n.as_token().map(|n| has_empty_line(n.text())).unwrap_or(false);
+            let is_empty_line =
+                n.as_token().map(|n| whitespace_has_empty_line(n.text())).unwrap_or(false);
             if is_empty_line {
                 if !inserted_newline {
                     state.new_line();
@@ -865,7 +873,8 @@ fn format_codeblock(
     for n in sub {
         state.skip_all_whitespace = true;
         if n.kind() == SyntaxKind::Whitespace {
-            let is_empty_line = n.as_token().map(|n| has_empty_line(n.text())).unwrap_or(false);
+            let is_empty_line =
+                n.as_token().map(|n| whitespace_has_empty_line(n.text())).unwrap_or(false);
             if is_empty_line {
                 state.new_line();
             }
@@ -1010,13 +1019,8 @@ fn format_array(
     let has_trailing_comma = node
         .last_token()
         .and_then(|last| last.prev_token())
-        .map(|second_last| {
-            if second_last.kind() == SyntaxKind::Whitespace {
-                second_last.prev_token().map(|n| n.kind() == SyntaxKind::Comma).unwrap_or(false)
-            } else {
-                second_last.kind() == SyntaxKind::Comma
-            }
-        })
+        .and_then(prev_non_trivia_token_kind)
+        .map(|kind| kind == SyntaxKind::Comma)
         .unwrap_or(false);
     // len of all children
     let len = node.children().fold(0, |acc, e| {
@@ -1305,13 +1309,8 @@ fn format_object_literal(
     let has_trailing_comma = node
         .last_token()
         .and_then(|last| last.prev_token())
-        .map(|second_last| {
-            if second_last.kind() == SyntaxKind::Whitespace {
-                second_last.prev_token().map(|n| n.kind() == SyntaxKind::Comma).unwrap_or(false)
-            } else {
-                second_last.kind() == SyntaxKind::Comma
-            }
-        })
+        .and_then(prev_non_trivia_token_kind)
+        .map(|kind| kind == SyntaxKind::Comma)
         .unwrap_or(false);
     // len of all children
     let len = node.children().fold(0, |acc, e| {
@@ -1343,13 +1342,18 @@ fn format_object_literal(
 
         if let SyntaxMatch::Found(SyntaxKind::ObjectMember) = el {
             if indent_with_new_line {
+                state.after_comment = false;
                 state.new_line();
             } else {
                 state.insert_whitespace(" ");
             }
 
             // are we at the end of literal?
-            let at_end = next_non_whitespace_kind(sub.peek()) == Some(SyntaxKind::RBrace);
+            let at_end = sub
+                .peek()
+                .and_then(next_non_trivia_token_kind)
+                .map(|kind| kind == SyntaxKind::RBrace)
+                .unwrap_or(false);
 
             if at_end && indent_with_new_line {
                 state.indentation_level -= 1;
@@ -1391,13 +1395,8 @@ fn format_object_type(
     let has_trailing_comma = node
         .last_token()
         .and_then(|last| last.prev_token())
-        .map(|second_last| {
-            if second_last.kind() == SyntaxKind::Whitespace {
-                second_last.prev_token().map(|n| n.kind() == SyntaxKind::Comma).unwrap_or(false)
-            } else {
-                second_last.kind() == SyntaxKind::Comma
-            }
-        })
+        .and_then(prev_non_trivia_token_kind)
+        .map(|kind| kind == SyntaxKind::Comma)
         .unwrap_or(false);
     let len = node.children().fold(0, |acc, e| {
         let mut len = 0;
@@ -1431,7 +1430,11 @@ fn format_object_type(
         )?;
 
         if let SyntaxMatch::Found(SyntaxKind::ObjectTypeMember) = el {
-            let at_end = next_non_whitespace_kind(sub.peek()) == Some(SyntaxKind::RBrace);
+            let at_end = sub
+                .peek()
+                .and_then(next_non_trivia_token_kind)
+                .map(|kind| kind == SyntaxKind::RBrace)
+                .unwrap_or(false);
 
             if indent_with_new_line {
                 state.new_line();
@@ -1751,7 +1754,18 @@ mod tests {
         let doc = syntax_nodes::Document::new(syntax_node).unwrap();
         let mut file = Vec::new();
         format_document(doc, &mut FileWriter { file: &mut file }).unwrap();
-        assert_eq!(String::from_utf8(file).unwrap(), formatted);
+        let first_pass = String::from_utf8(file).unwrap();
+        assert_eq!(first_pass, formatted);
+
+        let syntax_node = i_slint_compiler::parser::parse(
+            first_pass.clone(),
+            None,
+            &mut BuildDiagnostics::default(),
+        );
+        let doc = syntax_nodes::Document::new(syntax_node).unwrap();
+        let mut file = Vec::new();
+        format_document(doc, &mut FileWriter { file: &mut file }).unwrap();
+        assert_eq!(String::from_utf8(file).unwrap(), first_pass);
     }
 
     #[test]
@@ -2629,6 +2643,109 @@ export component MainWindow inherits Rectangle {
         y: 8px;
     }
 }
+"#,
+        );
+    }
+
+    #[test]
+    fn preserve_empty_lines_between_top_level_declarations() {
+        assert_formatting(
+            r#"
+struct Foo {}
+
+struct Bar {
+    dummy: int,
+}
+
+component HelloWorld {
+    // ...
+}
+"#,
+            r#"
+struct Foo {}
+
+struct Bar {
+    dummy: int,
+}
+
+component HelloWorld {
+    // ...
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn preserve_top_level_comment_spacing() {
+        assert_formatting(
+            r#"
+component RoundButton inherits Image {
+    property <int> x;
+}
+// From UpAndDownButton.cpp
+component UpAndDownButton inherits Rectangle {
+    callback changed(int);
+}
+"#,
+            r#"
+component RoundButton inherits Image {
+    property <int> x;
+}
+// From UpAndDownButton.cpp
+component UpAndDownButton inherits Rectangle {
+    callback changed(int);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn preserve_blank_line_before_top_level_comment() {
+        assert_formatting(
+            r#"
+component RoundButton inherits Image {
+    callback clicked;
+}
+
+// From UpAndDownButton.cpp
+component UpAndDownButton inherits Rectangle {
+    callback changed(int);
+}
+"#,
+            r#"
+component RoundButton inherits Image {
+    callback clicked;
+}
+
+// From UpAndDownButton.cpp
+component UpAndDownButton inherits Rectangle {
+    callback changed(int);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn preserve_blank_lines_between_top_level_items() {
+        assert_formatting(
+            r#"
+struct Palette {}
+
+global Skin {
+    // ...
+}
+
+export component Clock {
+}
+"#,
+            r#"
+struct Palette {}
+
+global Skin {
+    // ...
+}
+
+export component Clock { }
 "#,
         );
     }


### PR DESCRIPTION
### Summary
The fix makes object-type formatting treat comments as a multiline case, improves the lookahead for closing braces so comments do not confuse it, and preserves intended blank lines between top-level declarations.

Fixes #11104 