### PR TITLE
Testing backend: fix doctest and clippy warning

### DIFF
--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -112,9 +112,10 @@ export component App {
 #         // ...
 #     }
 # }
-# }
+# } /*
 #[test]
 fn test_basic_user_interface()
+# */
 {
     i_slint_backend_testing::init_no_event_loop();
     let app = App::new().unwrap();
@@ -157,9 +158,13 @@ example wraps the core functions for testing in an async closure:
 ```rust
 
 use slint::platform::PointerEventButton;
+use i_slint_backend_testing::ElementHandle;
 
+# /*
 #[test]
-fn test_click() {
+fn test_click()
+# */
+{
     i_slint_backend_testing::init_integration_test_with_system_time();
 
     slint::spawn_local(async move {


### PR DESCRIPTION
Trying to leave the `#[test]` in the docs while still being hidden for the test.
It should render well in the docs at the expense of being a bit akward in the README

```
warning: unit tests in doctest are not executed
   --> internal/backends/testing/README.md:161:1
    |
161 | / #[test]
162 | | fn test_click() {
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#test_attr_in_doctest
    = note: `#[warn(clippy::test_attr_in_doctest)]` on by default
```
