### PR TITLE
AboutSlint: open slint.dev when clicked

### DIFF
--- a/internal/compiler/widgets/common/about-slint.slint
+++ b/internal/compiler/widgets/common/about-slint.slint
@@ -27,4 +27,7 @@ export component AboutSlint {
             horizontal-alignment: center;
         }
     }
+    TouchArea {
+        clicked => { Platform.open-url("https://slint.dev"); }
+    }
 }

--- a/tests/cases/widgets/about.slint
+++ b/tests/cases/widgets/about.slint
@@ -23,6 +23,12 @@ let image = image_search.next().unwrap();
 assert_eq!(image.accessible_role(), Some(AccessibleRole::Image));
 
 let _ = instance.global::<Palette<'_>>().get_color_scheme();
+
+// clicking on about slint should open slint.dev
+let pos = image.absolute_position();
+slint_testing::send_mouse_click(&instance, pos.x, pos.y);
+let url = slint_testing::access_testing_window(instance.window(), |window| window.open_url());
+assert_eq!(url, Some("https://slint.dev".into()));
 ```
 
 ```cpp


### PR DESCRIPTION
Since we have open-url now, we can as well use it.