### PR TITLE
C++: fix call to open-url with a string literal

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -317,11 +317,16 @@ inline StyledText parse_markdown(const SharedString &format_string,
     return result;
 }
 
-inline StyledText string_to_styled_text(SharedString text)
+inline StyledText string_to_styled_text(const SharedString &text)
 {
     StyledText result;
-    cbindgen_private::slint_string_to_styled_text(text, &result);
+    cbindgen_private::slint_string_to_styled_text(&text, &result);
     return result;
+}
+
+inline void open_url(const SharedString &url, const WindowAdapterRc &window_adapter)
+{
+    cbindgen_private::slint_open_url(&url, &window_adapter.handle());
 }
 
 inline SharedString translate_from_bundle(std::span<const char8_t *const> strs,

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn slint_open_url(url: &SharedString, win: *const WindowAd
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn slint_string_to_styled_text(text: SharedString, out: &mut StyledText) {
+pub extern "C" fn slint_string_to_styled_text(text: &SharedString, out: &mut StyledText) {
     *out = i_slint_core::styled_text::string_to_styled_text(text.to_string());
 }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4604,7 +4604,7 @@ fn compile_builtin_function_call(
         BuiltinFunction::OpenUrl => {
             let url = a.next().unwrap();
             let window = access_window_field(ctx);
-            format!("slint::cbindgen_private::slint_open_url(&{}, &{}.handle())", url, window)
+            format!("slint::private_api::open_url({url}, {window})")
         }
         BuiltinFunction::ParseMarkdown => {
             let format_string = a.next().unwrap();

--- a/tests/cases/expr/open_url.slint
+++ b/tests/cases/expr/open_url.slint
@@ -1,11 +1,20 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase  {
     callback open-url-callback(url: string);
     open-url-callback(url) => {
         Platform.open-url(url);
     }
+
+    TouchArea {
+        clicked => {
+            // Just a compile test
+            Platform.open-url("xyz");
+        }
+    }
+
+
 }
 
 /*


### PR DESCRIPTION
Otherwise we get this error:
```
    error: taking the address of a temporary object of type 'slint::SharedString' [-Waddress-of-temporary]
           slint::cbindgen_private::slint_open_url(&slint::SharedString(u8"xyz"), &self->globals->window().window_handle().handle());
                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Also fix `slint_string_to_styled_text` to take the SharedString by reference, as we might have a ABI mismatch as SharedString has a destructor

