### PR TITLE
femtovg: Fix render_to_texture API to take a texture view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3368,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "femtovg"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798c7ede43463c7e67dd1cf12ea5637610bef392708ae21b2eb10a3ad49204fa"
+checksum = "e51acc7027a6fa8e3b5daf3b914fb52cf147a6c5f0648bd2682f03c0d221352f"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -10194,7 +10194,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -696,7 +696,6 @@ version = "1.16.0"
 dependencies = [
  "bevy 0.19.0-dev",
  "bevy_image 0.19.0-dev",
- "femtovg",
  "slint",
  "spin_on",
  "wgpu 28.0.0",
@@ -4316,26 +4315,20 @@ dependencies = [
 
 [[package]]
 name = "femtovg"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798c7ede43463c7e67dd1cf12ea5637610bef392708ae21b2eb10a3ad49204fa"
+checksum = "e51acc7027a6fa8e3b5daf3b914fb52cf147a6c5f0648bd2682f03c0d221352f"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "fnv",
  "glow 0.17.0",
- "image",
  "imgref",
  "itertools 0.14.0",
  "log",
- "lru",
  "rgb",
- "rustybuzz",
  "slotmap",
  "swash",
- "ttf-parser",
- "unicode-bidi",
- "unicode-segmentation",
  "wasm-bindgen",
  "web-sys",
  "wgpu 28.0.0",
@@ -6132,12 +6125,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 
 [[package]]
 name = "lyon_algorithms"

--- a/examples/bevy/bevy-hosts-slint-gpu/Cargo.toml
+++ b/examples/bevy/bevy-hosts-slint-gpu/Cargo.toml
@@ -21,5 +21,4 @@ slint = { path = "../../../api/rs/slint", default-features = false, features = [
 bevy = { git = "https://github.com/bevyengine/bevy", rev = "cc172dfc" }
 bevy_image = { git = "https://github.com/bevyengine/bevy", rev = "cc172dfc", features = ["zstd_rust"] }
 wgpu-28 = { package = "wgpu", version = "28", default-features = false, features = ["wgsl"] }
-femtovg = { version = "0.21.0", features = ["image-loading"] }
 spin_on = "0.1.1"

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1"
 derive_more = { workspace = true }
 lyon_path = { workspace = true }
 pin-weak = "1"
-femtovg = { version = "0.21.0", default-features = false, features = ["swash"] }
+femtovg = { version = "0.22.0", default-features = false, features = ["swash"] }
 imgref = { version = "1.6.1" }
 rgb = { version = "0.8.27" }
 

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -45,7 +45,7 @@ pub mod wgpu;
 pub use wgpu::FemtoVGWGPURenderer;
 
 pub trait WindowSurface<R: femtovg::Renderer> {
-    fn render_surface(&self) -> &R::Surface;
+    fn render_output(&self) -> impl Into<R::RenderOutput>;
 }
 
 pub trait GraphicsBackend {
@@ -198,7 +198,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     // the back buffer, in order to allow the callback to provide its own rendering of the background.
                     // femtovg's clear_rect() will merely schedule a clear call, so flush right away to make it immediate.
 
-                    let commands = femtovg_canvas.flush_to_surface(surface.render_surface());
+                    let commands = femtovg_canvas.flush_to_output(surface.render_output());
                     self.graphics_backend.submit_commands(commands);
 
                     femtovg_canvas.set_size(width.get(), height.get(), scale);
@@ -260,7 +260,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     collector.measure_frame_rendered(&mut item_renderer, metrics);
                 }
 
-                let commands = canvas.borrow_mut().flush_to_surface(surface.render_surface());
+                let commands = canvas.borrow_mut().flush_to_output(surface.render_output());
                 self.graphics_backend.submit_commands(commands);
 
                 // Delete any images and layer images (and their FBOs) before making the context not current anymore, to

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -156,8 +156,9 @@ impl OpenGLBackend {
 pub struct GLWindowSurface {}
 
 impl WindowSurface<femtovg::renderer::OpenGl> for GLWindowSurface {
-    fn render_surface(&self) -> &<femtovg::renderer::OpenGl as femtovg::Renderer>::Surface {
-        &()
+    fn render_output(
+        &self,
+    ) -> impl Into<<femtovg::renderer::OpenGl as femtovg::Renderer>::RenderOutput> {
     }
 }
 

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -7,7 +7,7 @@ use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::RendererSealed;
 use i_slint_core::{api::PhysicalSize as PhysicalWindowSize, graphics::RequestedGraphicsAPI};
 
-use crate::{FemtoVGRenderer, GraphicsBackend, WindowSurface, wgpu::wgpu::Texture};
+use crate::{FemtoVGRenderer, GraphicsBackend, WindowSurface};
 
 use wgpu_28 as wgpu;
 
@@ -24,7 +24,7 @@ pub struct WGPUWindowSurface {
 }
 
 impl WindowSurface<femtovg::renderer::WGPURenderer> for WGPUWindowSurface {
-    fn render_surface(&self) -> &Texture {
+    fn render_output(&self) -> impl Into<femtovg::renderer::WGPURenderOutput> {
         &self.surface_texture.texture
     }
 }
@@ -72,7 +72,7 @@ impl GraphicsBackend for WGPUBackend {
     }
 
     fn submit_commands(&self, commands: <Self::Renderer as femtovg::Renderer>::CommandBuffer) {
-        self.queue.borrow().as_ref().unwrap().submit(Some(commands));
+        self.queue.borrow().as_ref().unwrap().submit(commands);
     }
 
     fn present_surface(
@@ -181,12 +181,12 @@ impl FemtoVGRenderer<WGPUBackend> {
 }
 
 struct TextureWindowSurface {
-    texture: wgpu::Texture,
+    render_output: femtovg::renderer::WGPURenderOutput,
 }
 
 impl WindowSurface<femtovg::renderer::WGPURenderer> for TextureWindowSurface {
-    fn render_surface(&self) -> &wgpu::Texture {
-        &self.texture
+    fn render_output(&self) -> impl Into<femtovg::renderer::WGPURenderOutput> {
+        self.render_output.clone()
     }
 }
 
@@ -194,7 +194,7 @@ struct WgpuTextureBackend {
     instance: wgpu::Instance,
     device: wgpu::Device,
     queue: wgpu::Queue,
-    current_texture: RefCell<Option<wgpu::Texture>>,
+    render_output: RefCell<Option<femtovg::renderer::WGPURenderOutput>>,
 }
 
 impl GraphicsBackend for WgpuTextureBackend {
@@ -213,13 +213,13 @@ impl GraphicsBackend for WgpuTextureBackend {
     fn begin_surface_rendering(
         &self,
     ) -> Result<Self::WindowSurface, Box<dyn std::error::Error + Send + Sync>> {
-        let texture =
-            self.current_texture.borrow().clone().ok_or("No texture set for rendering")?;
-        Ok(TextureWindowSurface { texture })
+        let render_output =
+            self.render_output.borrow().clone().ok_or("No texture set for rendering")?;
+        Ok(TextureWindowSurface { render_output })
     }
 
     fn submit_commands(&self, commands: <Self::Renderer as femtovg::Renderer>::CommandBuffer) {
-        self.queue.submit(Some(commands));
+        self.queue.submit(commands);
     }
 
     fn present_surface(
@@ -278,7 +278,7 @@ impl FemtoVGWGPURenderer {
             instance,
             device: device.clone(),
             queue: queue.clone(),
-            current_texture: RefCell::new(None),
+            render_output: RefCell::new(None),
         };
         let renderer = FemtoVGRenderer::new_internal(backend);
 
@@ -294,14 +294,36 @@ impl FemtoVGWGPURenderer {
         Ok(Self(renderer))
     }
 
-    /// Render the scene to the given texture.
-    ///
-    /// The texture must be a valid WGPU texture.
-    pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
-        *self.0.graphics_backend.current_texture.borrow_mut() = Some(texture.clone());
+    /// Render the scene to the given texture view, with the specified size and format.
+    pub fn render_to_texture_view(
+        &self,
+        texture_view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+        format: wgpu::TextureFormat,
+    ) -> Result<(), PlatformError> {
+        *self.0.graphics_backend.render_output.borrow_mut() =
+            Some(femtovg::renderer::WGPURenderOutput {
+                view: texture_view.clone(),
+                width,
+                height,
+                format,
+            });
         let result = self.0.render();
-        *self.0.graphics_backend.current_texture.borrow_mut() = None;
+        *self.0.graphics_backend.render_output.borrow_mut() = None;
         result
+    }
+
+    /// Render the scene to the given texture.
+    /// This is a convenience method that creates a texture view for the entire texture and calls `render_to_texture_view`.
+    pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
+        let size = texture.size();
+        self.render_to_texture_view(
+            &texture.create_view(&wgpu::TextureViewDescriptor::default()),
+            size.width,
+            size.height,
+            texture.format(),
+        )
     }
 }
 


### PR DESCRIPTION
In API review, we decided that this is the cleaner API that permits also specifying all the aspects of the view as well as choosing a format.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
