### PR TITLE
docs: improved `debug()` description and added an example

### DIFF
--- a/docs/astro/src/content/docs/guide/development/debugging_techniques.mdx
+++ b/docs/astro/src/content/docs/guide/development/debugging_techniques.mdx
@@ -10,6 +10,28 @@ On this page we share different techniques and tools we've built into Slint that
 ## Debugging Property Values
 
 Use the <Link type="DebugFn" label="debug()" /> function to print the values of properties to stderr.
+It supports multiple arguments and different types. Non-scalar types (e.g. `struct` types) are usually
+represented as a single line `json` string.
+
+**Example**
+
+```slint
+TouchArea {
+    moved => {
+        // a single constant string argument
+        debug("moved");
+
+        // output: moved
+    }
+
+    pointer-event(event) => {
+        // multiple variable arguments with different types
+        debug(self.mouse-x, self.mouse-y, event);
+
+        // output: 135(px) 402(px) { button: other, kind: move, modifiers: { alt: false, control: false, meta: false, shift: false } }
+    }
+}
+```
 
 ## Slow Motion Animations
 


### PR DESCRIPTION
I started working more seriously with `slint` and noticed some room for improvement in the docs. I would like to contribute and would be happy to write more documentation of existing features by providing clearer descriptions and examples where useful.

Please let me know if this is something that is welcome or if this is something the main staff is required to do and if the form of this PR is correct.

Thank you,

sandreas

