### PR TITLE
Python: Fix type check failures with latest ty

### DIFF
--- a/.github/workflows/python_test_reusable.yaml
+++ b/.github/workflows/python_test_reusable.yaml
@@ -45,8 +45,7 @@ jobs:
               run: uv sync
             - name: Run ty
               working-directory: api/python/slint
-              # Pin ty to avoid running into https://github.com/astral-sh/ty/issues/3129
-              run: uvx ty@0.0.24 check
+              run: uvx ty check
             - name: Run ruff linter
               working-directory: api/python/slint
               run: uv tool run ruff check

--- a/api/python/slint/slint/language.py
+++ b/api/python/slint/slint/language.py
@@ -3,7 +3,6 @@
 
 from . import slint as native
 
-StandardListViewItem = native.language.StandardListViewItem  # type: ignore[unresolved-attribute]
 
-KeyEvent = native.language.KeyEvent  # type: ignore[unresolved-attribute]
-KeyboardModifiers = native.language.KeyboardModifiers  # type: ignore[unresolved-attribute]
+def __getattr__(name: str):
+    return getattr(native.language, name)

--- a/api/python/slint/slint/slint.pyi
+++ b/api/python/slint/slint/slint.pyi
@@ -13,6 +13,7 @@ from typing import Any, List
 from collections.abc import Callable, Buffer, Coroutine
 from enum import Enum, auto
 import gettext
+from . import language as language
 
 class RgbColor:
     red: int


### PR DESCRIPTION
Make sure language.pyi is accessible when importing slint.pyi, i.e. re-export it.

Also, don't hard code types in language.py when we can dynamically dispatch to the native package.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
