### PR TITLE
ListView: another fix for badly detected const property for listview properties

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1776,8 +1776,16 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> ElementRc {
+        let e = Element::from_sub_element_node(
+            node.SubElement(),
+            parent.borrow().base_type.clone(),
+            component_child_insertion_point,
+            is_in_legacy_component,
+            diag,
+            tr,
+        );
         let is_listview = if parent.borrow().base_type.to_string() == "ListView" {
-            Some(ListViewInfo {
+            let lvi = ListViewInfo {
                 viewport_y: NamedReference::new(parent, SmolStr::new_static("viewport-y")),
                 viewport_height: NamedReference::new(
                     parent,
@@ -1786,7 +1794,12 @@ impl Element {
                 viewport_width: NamedReference::new(parent, SmolStr::new_static("viewport-width")),
                 listview_height: NamedReference::new(parent, SmolStr::new_static("visible-height")),
                 listview_width: NamedReference::new(parent, SmolStr::new_static("visible-width")),
-            })
+            };
+            // these properties are set by the ListView layouting code
+            lvi.viewport_height.mark_as_set();
+            lvi.viewport_width.mark_as_set();
+            e.borrow().geometry_props.as_ref().unwrap().y.mark_as_set();
+            Some(lvi)
         } else {
             None
         };
@@ -1803,14 +1816,6 @@ impl Element {
             is_conditional_element: false,
             is_listview,
         };
-        let e = Element::from_sub_element_node(
-            node.SubElement(),
-            parent.borrow().base_type.clone(),
-            component_child_insertion_point,
-            is_in_legacy_component,
-            diag,
-            tr,
-        );
         e.borrow_mut().repeated = Some(rei);
         e
     }

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -79,8 +79,6 @@ fn create_viewport_element(flickable: &ElementRc, native_empty: &Rc<NativeClass>
             );
             inner_elem.borrow_mut().geometry_props.as_mut().unwrap().y = new_y;
         }
-        listview.viewport_height.mark_as_set();
-        listview.viewport_width.mark_as_set();
     }
 
     let viewport = Element::make_rc(Element {

--- a/tests/cases/issues/issue_11127_listview-no-flickable.slint
+++ b/tests/cases/issues/issue_11127_listview-no-flickable.slint
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component ScrollView {
+    out property <length> visible_width;
+    out property <length> visible_height;
+    in_out property <length> viewport_width;
+    in_out property <length> viewport_height;
+    in_out property <length> viewport_x;
+    in_out property <length> viewport_y;
+
+    Rectangle {
+        @children
+    }
+}
+
+component ListView inherits ScrollView { }
+
+export component TestCase inherits Window {
+    width: 164px;
+    height: 164px;
+    ListView {
+        width: 100%; height: 100%;
+        for entry in 666: VerticalLayout {
+            HorizontalLayout {
+                height: 40px;
+                Text { text: entry; }
+            }
+        }
+    }
+}
+
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 5., 5.);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 50., 50.);
+```
+
+*/


### PR DESCRIPTION
The previous fix for #11127 only worked if there was a Flickable.
But code in the wild also make a ListView were children are not direct child of a Flickable

