### PR TITLE
cpp: Add [[maybe_unused]] to function parameters

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3037,7 +3037,7 @@ fn generate_functions<'a>(
                 f.args
                     .iter()
                     .enumerate()
-                    .map(|(i, ty)| format!("{} arg_{}", ty.cpp_type().unwrap(), i))
+                    .map(|(i, ty)| format!("[[maybe_unused]] {} arg_{}", ty.cpp_type().unwrap(), i))
                     .join(", "),
                 f.ret_ty.cpp_type().unwrap()
             ),


### PR DESCRIPTION
Avoiding C++ compiler warnings about unused function parameters in Slint functions. Callback parameters already have `[[maybe_unused]]`, but function parameters don't.

Concrete use case:

```slint
pure function render-image(path: string, width: length, theme: Theme) -> image {
    Backend.render-image(path, width)
}

Image {
    source: render-image(Data.project-preview-path, parent.width, Data.theme);
}
```

This `render-image()` function only wraps a backend callback to add the dependency to an additional property (a `Theme` object in this case). So the `theme` parameter looks unused, but it acts as a dependency to ensure re-evaluation when it changes. Therefore I think it should be possible to have unused function parameters without leading to C++ compiler warnings.

EDIT: I'm not sure if that is really a good example - maybe I should better pass `theme` all the way down to the backend and ignore it there :thinking:  But I think the `[[maybe_unused]]` makes sense anyway, regardless of a concrete use-case - if an unused parameter is considered as illegal, IMO it should be a warning from `slint-compiler`, not from the C++ compiler.