### PR TITLE
Rename `PinchGestureHandler` -> `ScaleRotateGestureHandler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project are documented in this file.
  - Added printable keys in the `Key` namespace.
  - Added `FlexBoxLayout`.
  - Added support for styled text with `StyledText` element, `styled-text` type, and `@markdown(...)` macro.
- - Added `PinchGestureHandler` element for handling multi-touch pinch gestures.
+ - Added `ScaleRotateGestureHandler` element for handling multi-touch pinch gestures.
  - Fixed compiler panic when accessing model data from repeated menu. (#10927)
  - Added `Path::fit-style` property.
  - `TextHorizontalAlignment`: Added `start` and `end` variants.

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -304,7 +304,7 @@ fn gen_corelib(
         "FocusScope",
         "KeyBinding",
         "SwipeGestureHandler",
-        "PinchGestureHandler",
+        "ScaleRotateGestureHandler",
         "Flickable",
         "SimpleText",
         "StyledTextItem",

--- a/docs/astro/src/content/docs/guide/language/coding/positioning-and-layouts.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/positioning-and-layouts.mdx
@@ -86,7 +86,7 @@ don't have content and default to fill their parent element when they do not hav
 -   `FocusScope`
 -   `Flickable`
 -   `SwipeGestureHandler`
--   `PinchGestureHandler`
+-   `ScaleRotateGestureHandler`
 
 Layouts are also defaulting to fill the parent, regardless of their own preferred size.
 Other elements, including custom ones that don't inherit from a base, default to using their preferred size.

--- a/docs/astro/src/content/docs/reference/gestures/scalerotategesturehandler.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/scalerotategesturehandler.mdx
@@ -1,11 +1,11 @@
 ---
-title: PinchGestureHandler
-description: PinchGestureHandler element api.
+title: ScaleRotateGestureHandler
+description: ScaleRotateGestureHandler element api.
 ---
 import SlintProperty  from '@slint/common-files/src/components/SlintProperty.astro';
 
 
-Use the `PinchGestureHandler` to handle pinch, rotation, and smart-magnify gestures from trackpads or touchscreens.
+Use the `ScaleRotateGestureHandler` to handle pinch, rotation, and smart-magnify gestures from trackpads or touchscreens.
 Recognition is limited to the element's geometry.
 
 ```slint playground
@@ -16,7 +16,7 @@ export component Example inherits Window {
     property <float> start-scale;
     property <angle> start-rotation;
 
-    pinch := PinchGestureHandler {
+    gesture := ScaleRotateGestureHandler {
         started => {
             start-scale = rect.current-scale;
             start-rotation = rect.current-rotation;
@@ -57,7 +57,7 @@ On other platforms, it processes raw two-finger touch input for pinch and rotati
 
 ### enabled
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
-When disabled, the `PinchGestureHandler` doesn't recognize any gestures and any on-going gesture is cancelled.
+When disabled, the `ScaleRotateGestureHandler` doesn't recognize any gestures and any on-going gesture is cancelled.
 </SlintProperty>
 
 ### active
@@ -81,7 +81,7 @@ When the gesture is not active, the value is `0deg`.
 
 ### center
 <SlintProperty propName="center" typeName="struct" structName="Point" propertyVisibility="out">
-The center point of the gesture, in the coordinate system of the `PinchGestureHandler`.
+The center point of the gesture, in the coordinate system of the `ScaleRotateGestureHandler`.
 For two-finger touch input, this is the midpoint between the two fingers.
 For trackpad gestures, this is the mouse cursor position.
 </SlintProperty>

--- a/examples/native-gestures/native-gestures.slint
+++ b/examples/native-gestures/native-gestures.slint
@@ -89,7 +89,7 @@ component GestureArea inherits Rectangle {
         }
     }
 
-    gesture := PinchGestureHandler {
+    gesture := ScaleRotateGestureHandler {
         started => {
             set-status("active");
         }
@@ -203,7 +203,7 @@ export component MainWindow inherits Window {
             alignment: center;
 
             Text {
-                text: "PinchGestureHandler Demo";
+                text: "ScaleRotateGestureHandler Demo";
                 color: #e0e0f0;
                 font-size: 14px;
                 font-weight: 700;
@@ -230,7 +230,7 @@ export component MainWindow inherits Window {
         }
 
         if root.orientation == Orientation.portrait: Text {
-            text: "PinchGestureHandler Demo";
+            text: "ScaleRotateGestureHandler Demo";
             color: #e0e0f0;
             font-size: 18px;
             font-weight: 700;

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -120,7 +120,7 @@ pub fn set_window_scale_factor<
 /// Send a platform pinch gesture event to the component's window.
 ///
 /// `delta` is the incremental scale change (e.g. 0.0 for start, 0.5 for 50% increase).
-/// The PinchGestureHandler accumulates deltas: `scale *= (1.0 + delta)`.
+/// The ScaleRotateGestureHandler accumulates deltas: `scale *= (1.0 + delta)`.
 pub fn send_pinch_gesture<
     X: vtable::HasStaticVTable<ItemTreeVTable>,
     Component: Into<vtable::VRc<ItemTreeVTable, X>> + ComponentHandle,

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -229,7 +229,7 @@ export component SwipeGestureHandler {
     //-default_size_binding:expands_to_parent_geometry
 }
 
-export component PinchGestureHandler {
+export component ScaleRotateGestureHandler {
     in property <bool> enabled: true;
 
     out property <bool> active;

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -53,7 +53,7 @@ pub enum MouseEvent {
     /// The mouse is released while dragging over this item.
     Drop(DropEvent),
     /// A platform-recognized pinch gesture (macOS/iOS trackpad, Qt).
-    /// `delta` is the incremental scale change; PinchGestureHandler accumulates it.
+    /// `delta` is the incremental scale change; ScaleRotateGestureHandler accumulates it.
     PinchGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
     /// A platform-recognized rotation gesture (macOS/iOS trackpad, Qt).
     /// `delta` is the incremental rotation in degrees using the Slint convention:

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -691,7 +691,7 @@ declare_item_vtable! {
 }
 
 declare_item_vtable! {
-    fn slint_get_PinchGestureHandlerVTable() -> PinchGestureHandlerVTable for PinchGestureHandler
+    fn slint_get_ScaleRotateGestureHandlerVTable() -> ScaleRotateGestureHandlerVTable for ScaleRotateGestureHandler
 }
 
 #[repr(C)]

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -961,7 +961,7 @@ mod ffi {
     }
 }
 
-/// The implementation of the `PinchGestureHandler` element.
+/// The implementation of the `ScaleRotateGestureHandler` element.
 ///
 /// Provides an API surface for platform-recognized pinch gesture events.
 /// Receives `MouseEvent::PinchGesture` events via the normal mouse event
@@ -969,7 +969,7 @@ mod ffi {
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
-pub struct PinchGestureHandler {
+pub struct ScaleRotateGestureHandler {
     pub enabled: Property<bool>,
 
     // Output properties
@@ -994,7 +994,7 @@ pub struct PinchGestureHandler {
     pub cached_rendering_data: CachedRenderingData,
 }
 
-impl Item for PinchGestureHandler {
+impl Item for ScaleRotateGestureHandler {
     fn init(self: Pin<&Self>, _self_rc: &ItemRc) {
         self.scale.set(1.0);
     }
@@ -1167,12 +1167,12 @@ impl Item for PinchGestureHandler {
     }
 }
 
-impl ItemConsts for PinchGestureHandler {
+impl ItemConsts for ScaleRotateGestureHandler {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
         Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
-impl PinchGestureHandler {
+impl ScaleRotateGestureHandler {
     fn cancel_impl(self: Pin<&Self>) {
         if !self.active() {
             return;

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1036,7 +1036,7 @@ fn generate_rtti() -> HashMap<&'static str, Rc<ItemRTTI>> {
             rtti_for::<FocusScope>(),
             rtti_for::<KeyBinding>(),
             rtti_for::<SwipeGestureHandler>(),
-            rtti_for::<PinchGestureHandler>(),
+            rtti_for::<ScaleRotateGestureHandler>(),
             rtti_for::<Path>(),
             rtti_for::<Flickable>(),
             rtti_for::<WindowItem>(),

--- a/tests/cases/elements/scalerotategesturehandler.slint
+++ b/tests/cases/elements/scalerotategesturehandler.slint
@@ -13,7 +13,7 @@ export component TestCase inherits Window {
     out property <Point> center <=> pinch.center;
     out property <bool> smart-magnified: false;
 
-    pinch := PinchGestureHandler {
+    pinch := ScaleRotateGestureHandler {
         started => {
             r += "started;";
         }

--- a/tests/cases/elements/scalerotategesturehandler_nested.slint
+++ b/tests/cases/elements/scalerotategesturehandler_nested.slint
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
     out property <bool> outer-active <=> outer.active;
     out property <bool> inner-active <=> inner.active;
 
-    outer := PinchGestureHandler {
+    outer := ScaleRotateGestureHandler {
         started => { r += "outer-started;"; }
         updated => { r += "outer-updated;"; }
         ended => { r += "outer-ended;"; }
@@ -21,7 +21,7 @@ export component TestCase inherits Window {
             width: 200px;
             height: 200px;
 
-            inner := PinchGestureHandler {
+            inner := ScaleRotateGestureHandler {
                 started => { r += "inner-started;"; }
                 updated => { r += "inner-updated;"; }
                 ended => { r += "inner-ended;"; }


### PR DESCRIPTION
As discussed in the 1.16 API Review