### PR TITLE
Material Style: no need to limit the button height

### DIFF
--- a/internal/compiler/widgets/material/button.slint
+++ b/internal/compiler/widgets/material/button.slint
@@ -83,8 +83,8 @@ export component Button {
 
     callback clicked;
 
-    min-height: max(40px, layout.min-height);
-    min-width: max(40px, layout.min-width);
+    min-height: layout.min-height;
+    min-width: layout.min-width;
     forward-focus: base;
 
     accessible-role: button;


### PR DESCRIPTION
Because it is related to the text size
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
