### PR TITLE
CI: trigger www-releases deploy workflows after pushing updates

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -563,6 +563,18 @@ jobs:
                 git commit --message "Update $NAME from $GITHUB_REPOSITORY" --message "Pull web demos and C++/Rust reference docs from commit $GITHUB_SHA ($GITHUB_REF)"
                 git push
 
+            - name: Trigger www-releases deploy
+              if: ${{ steps.www-releases.outputs.has-diff == 'yes' }}
+              env:
+                GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                RELEASE_INPUT: ${{ github.event.inputs.release }}
+              run: |
+                if [ "$RELEASE_INPUT" = "true" ]; then
+                  gh workflow run deploy-releases.yaml --repo slint-ui/www-releases
+                else
+                  gh workflow run deploy-snapshots.yaml --repo slint-ui/www-releases
+                fi
+
     prepare_release:
         if: github.event.inputs.private != 'true'
         needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin]

--- a/.github/workflows/upgrade_version.yaml
+++ b/.github/workflows/upgrade_version.yaml
@@ -109,3 +109,8 @@ jobs:
                   git add -u .
                   git commit --message "Update $NAME from $GITHUB_REPOSITORY" --message "Update versions.json"
                   git push
+            - name: Trigger www-releases deploy
+              run: |
+                  gh workflow run deploy-releases.yaml --repo slint-ui/www-releases
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This is an attempt to work around the paths filter in the www-releases repo not working reliably.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
