### PR TITLE
Show binding loops as actual cycles in error messages

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -318,21 +318,29 @@ fn analyze_binding(
     if context.currently_analyzing.contains(current) {
         let mut loop_description = String::new();
         let mut has_window_layout = false;
+
+        fn push_prop(prop: &PropertyPath, out: &mut String) {
+            if !out.is_empty() {
+                out.push_str(" -> ");
+            }
+            match prop.prop.element().borrow().id.as_str() {
+                "" => out.push_str(prop.prop.name()),
+                id => {
+                    out.push_str(id);
+                    out.push('.');
+                    out.push_str(prop.prop.name());
+                }
+            }
+        }
+
+        // Build description by iterating in reverse (trigger direction: "A triggers B")
+        // and close the loop by prepending `current` at the start.
+        push_prop(current, &mut loop_description);
         for it in context.currently_analyzing.iter().rev() {
             if context.window_layout_property.as_ref().is_some_and(|p| p == it) {
                 has_window_layout = true;
             }
-            if !loop_description.is_empty() {
-                loop_description.push_str(" -> ");
-            }
-            match it.prop.element().borrow().id.as_str() {
-                "" => loop_description.push_str(it.prop.name()),
-                id => {
-                    loop_description.push_str(id);
-                    loop_description.push('.');
-                    loop_description.push_str(it.prop.name());
-                }
-            }
+            push_prop(it, &mut loop_description);
             if it == current {
                 break;
             }

--- a/internal/compiler/tests/syntax/analysis/binding_loop1.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop1.slint
@@ -7,7 +7,7 @@ WithStates := Rectangle {
     property <brush> extra_background;
     property <bool> condition;
     background: yellow; //FIXME: ideally we'd keep the span within the state
-//              >     <error{The binding for the property 'background' is part of a binding loop (extra-background -> background)}
+//              >     <error{The binding for the property 'background' is part of a binding loop (background -> extra-background -> background)}
     states [
         xxx when condition : {
             background: extra_background;
@@ -19,29 +19,29 @@ export Test := Rectangle {
 //          ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
 
     property <int> a: 45 + root.b;
-//                    >          <error{The binding for the property 'a' is part of a binding loop (root_window.d -> root_window.c -> root_window.b -> root_window.a)}
+//                    >          <error{The binding for the property 'a' is part of a binding loop (root_window.a -> root_window.d -> root_window.c -> root_window.b -> root_window.a)}
     property <float> b: root.c;
-//                      >     <error{The binding for the property 'b' is part of a binding loop (root_window.d -> root_window.c -> root_window.b -> root_window.a)}
+//                      >     <error{The binding for the property 'b' is part of a binding loop (root_window.a -> root_window.d -> root_window.c -> root_window.b -> root_window.a)}
     property <int> c <=> d;
-//                   >    <error{The binding for the property 'c' is part of a binding loop (root_window.d -> root_window.c -> root_window.b -> root_window.a)}
+//                   >    <error{The binding for the property 'c' is part of a binding loop (root_window.a -> root_window.d -> root_window.c -> root_window.b -> root_window.a)}
     property <int> d: root.a + root.e;
-//                    >              <error{The binding for the property 'd' is part of a binding loop (root_window.d -> root_window.c -> root_window.b -> root_window.a)}
+//                    >              <error{The binding for the property 'd' is part of a binding loop (root_window.a -> root_window.d -> root_window.c -> root_window.b -> root_window.a)}
     property <int> e: root.b;
-//                    >     <error{The binding for the property 'e' is part of a binding loop (root_window.e -> root_window.d -> root_window.c -> root_window.b)}
+//                    >     <error{The binding for the property 'e' is part of a binding loop (root_window.b -> root_window.e -> root_window.d -> root_window.c -> root_window.b)}
     property <int> w: root.a + root.b; // This id not part of a loop
 
     property<bool> cond: xx.x == 0;
-//                       >        <error{The binding for the property 'cond' is part of a binding loop (xx.y -> xx.x -> root_window.cond)}
+//                       >        <error{The binding for the property 'cond' is part of a binding loop (root_window.cond -> xx.y -> xx.x -> root_window.cond)}
 
     xx := Rectangle {
         x: y;
-//         ><error{The binding for the property 'x' is part of a binding loop (xx.y -> xx.x -> root_window.cond)}
+//         ><error{The binding for the property 'x' is part of a binding loop (root_window.cond -> xx.y -> xx.x -> root_window.cond)}
         y: root.cond ? 42px : 55px;
-//         >                      <error{The binding for the property 'y' is part of a binding loop (xx.y -> xx.x -> root_window.cond)}
+//         >                      <error{The binding for the property 'y' is part of a binding loop (root_window.cond -> xx.y -> xx.x -> root_window.cond)}
     }
 
     WithStates {
         extra_background: background;
-//                        >         <error{The binding for the property 'extra-background' is part of a binding loop (extra-background -> background)}
+//                        >         <error{The binding for the property 'extra-background' is part of a binding loop (background -> extra-background -> background)}
     }
 }

--- a/internal/compiler/tests/syntax/analysis/binding_loop2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop2.slint
@@ -6,7 +6,7 @@ T1 := Rectangle {
 // ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     property <int> foo;
     property <int> bar: foo;
-//                      >  <error{The binding for the property 'bar' is part of a binding loop (foo -> bar)}
+//                      >  <error{The binding for the property 'bar' is part of a binding loop (bar -> foo -> bar)}
     Text { text: bar; }
 }
 
@@ -14,23 +14,23 @@ T2 := Rectangle {
 // ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     property <string> t2_text;
     t:= Text { text: t2_text; }
-//                   >      <error{The binding for the property 'text' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
-//                   >      <^error{The binding for the property 'text' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                   >      <error{The binding for the property 'text' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                   >      <^error{The binding for the property 'text' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
     property t_alias <=> t.text;
-//                   >         <error{The binding for the property 't-alias' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
-//                   >         <^error{The binding for the property 't-alias' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                   >         <error{The binding for the property 't-alias' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                   >         <^error{The binding for the property 't-alias' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
 }
 
 T3 := Rectangle {
 // ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     property <string> hello;
     property <string> al <=> a.t_alias;
-//                       >            <error{The binding for the property 'al' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                       >            <error{The binding for the property 'al' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
     HorizontalLayout {
         a := T2 { t2_text: b.t_alias; }
-//                         >        <error{The binding for the property 't2-text' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                         >        <error{The binding for the property 't2-text' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
         b := T2 { t2_text: root.hello;  }
-//                         >         <error{The binding for the property 't2-text' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                         >         <error{The binding for the property 't2-text' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
     }
 }
 
@@ -46,9 +46,9 @@ export App := Rectangle {
     VerticalLayout {
         T1 { foo: 44; }
         T1 { foo: bar; }
-//                >  <error{The binding for the property 'foo' is part of a binding loop (foo -> bar)}
+//                >  <error{The binding for the property 'foo' is part of a binding loop (bar -> foo -> bar)}
         T3 { hello: al; }
-//                  > <error{The binding for the property 'hello' is part of a binding loop (hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
+//                  > <error{The binding for the property 'hello' is part of a binding loop (al -> hello -> b.t2-text -> t.text -> b.t-alias -> a.t2-text -> t.text -> a.t-alias -> al)}
 
         T4 { my_property: my_property; }
 //                        >          <error{Property 'my-property' cannot refer to itself}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_function.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_function.slint
@@ -5,30 +5,30 @@ Compo1 := Rectangle {
 //     ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
 
     property <int> a : aa();
-//                     >   <error{The binding for the property 'a' is part of a binding loop (cc.aa -> cc.a)}
+//                     >   <error{The binding for the property 'a' is part of a binding loop (cc.a -> cc.aa -> cc.a)}
     pure callback aa() -> int;
 
     function factorial(n: int) -> int {
-//  >error{The binding for the property 'factorial' is part of a binding loop (cc.factorial)}
+//  >error{The binding for the property 'factorial' is part of a binding loop (cc.factorial -> cc.factorial)}
         return n == 0 ? 1 : factorial(n - 1) * n;
     }
-//  <error{The binding for the property 'factorial' is part of a binding loop (cc.factorial)}
+//  <error{The binding for the property 'factorial' is part of a binding loop (cc.factorial -> cc.factorial)}
 
 
     property <int> b;
     public pure function bb() -> int { return b; }
-//  >                                            <error{The binding for the property 'bb' is part of a binding loop (cc.bb -> cc.b)}
+//  >                                            <error{The binding for the property 'bb' is part of a binding loop (cc.b -> cc.bb -> cc.b)}
 }
 
 export App := Rectangle {
 //         ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     cc := Compo1 {
         aa() => { return self.a; }
-//      >error{The binding for the property 'aa' is part of a binding loop (cc.aa -> cc.a)}
+//      >error{The binding for the property 'aa' is part of a binding loop (cc.a -> cc.aa -> cc.a)}
 
         b: self.bb();
-//     <error{The binding for the property 'aa' is part of a binding loop (cc.aa -> cc.a)}
-//         >        <^error{The binding for the property 'b' is part of a binding loop (cc.bb -> cc.b)}
+//     <error{The binding for the property 'aa' is part of a binding loop (cc.a -> cc.aa -> cc.a)}
+//         >        <^error{The binding for the property 'b' is part of a binding loop (cc.b -> cc.bb -> cc.b)}
     }
 
 

--- a/internal/compiler/tests/syntax/analysis/binding_loop_image.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_image.slint
@@ -4,21 +4,21 @@
 // Issue 10342
 
 export component MyPanel {
-//                       >error{The binding for the property 'layoutinfo-v' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+//                       >error{The binding for the property 'layoutinfo-v' is part of a binding loop (height -> fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
     fb := Image {
         width: 100%;
         source-clip-width: root.width / 0.531px;
         source-clip-height: root.height / 0.531px;
-//                          >                    <error{The binding for the property 'source-clip-height' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+//                          >                    <error{The binding for the property 'source-clip-height' is part of a binding loop (height -> fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
     }
 
 }
-//<<<error{The binding for the property 'layoutinfo-v' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+//<<<error{The binding for the property 'layoutinfo-v' is part of a binding loop (height -> fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
 
 export component MainWindow inherits Window {
     MyPanel {
-//  >      <error{The binding for the property 'preferred-height' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
-//  >      <^error{The binding for the property 'height' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+//  >      <error{The binding for the property 'preferred-height' is part of a binding loop (height -> fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+//  >      <^error{The binding for the property 'height' is part of a binding loop (height -> fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
         x: 30px;
         y: 30px;
         width: 200px;

--- a/internal/compiler/tests/syntax/analysis/binding_loop_issue_772.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_issue_772.slint
@@ -10,10 +10,10 @@ Alias := Rectangle {
 export Foo := Rectangle {
 //         ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     property <int> base-prop: alias.viewport_width;
-//                            >                   <error{The binding for the property 'base-prop' is part of a binding loop (alias.ps-width -> root_window.base-prop)}
+//                            >                   <error{The binding for the property 'base-prop' is part of a binding loop (root_window.base-prop -> alias.ps-width -> root_window.base-prop)}
 
     alias := Alias { ps_width: base-prop; }
-//                             >        <error{The binding for the property 'ps-width' is part of a binding loop (alias.ps-width -> root_window.base-prop)}
+//                             >        <error{The binding for the property 'ps-width' is part of a binding loop (root_window.base-prop -> alias.ps-width -> root_window.base-prop)}
 
     Text {
         text: base-prop;

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout.slint
@@ -3,16 +3,16 @@
 
 TC := Rectangle {
 // ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
-//    >        <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//    >        <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
     outer := VerticalLayout {
-//           >             <error{The binding for the property 'width' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
-//           >             <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//           >             <error{The binding for the property 'width' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//           >             <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
         inner := HorizontalLayout {
-//               >               <error{The binding for the property 'width' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
-//               >               <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//               >               <error{The binding for the property 'width' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//               >               <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
             inner_inner := VerticalLayout {
                 width: parent.width;
-//                     >           <error{The binding for the property 'width' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//                     >           <error{The binding for the property 'width' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
                 Rectangle {}
             }
         }
@@ -22,35 +22,35 @@ TC := Rectangle {
 
 export Test := Rectangle {
 //          ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
-//             >        <^warning{The binding for the property 'width' is part of a binding loop (root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//             >        <^warning{The binding for the property 'width' is part of a binding loop (root_window.layoutinfo-h -> root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
     VerticalLayout {  // FIXME: That's an internal property, but people might understand
-//  >             <error{The binding for the property 'min-width' is part of a binding loop (min-width -> width -> layoutinfo-h)}
-//  >             <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (min-width -> width -> layoutinfo-h)}
+//  >             <error{The binding for the property 'min-width' is part of a binding loop (layoutinfo-h -> min-width -> width -> layoutinfo-h)}
+//  >             <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> min-width -> width -> layoutinfo-h)}
         Rectangle {
             width: parent.min_width;
-//                 >               <error{The binding for the property 'width' is part of a binding loop (min-width -> width -> layoutinfo-h)}
+//                 >               <error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> min-width -> width -> layoutinfo-h)}
         }
     }
 
 
     l := HorizontalLayout {  // FIXME: That's an internal property, but people might understand
-//       >               <error{The binding for the property 'preferred-width' is part of a binding loop (l.preferred-width -> text -> l.layoutinfo-h)}
-//       >               <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (l.preferred-width -> text -> l.layoutinfo-h)}
-//       >               <^^error{The binding for the property 'layoutinfo-v' is part of a binding loop (l.layoutinfo-v -> l.preferred-height -> text)}
-//       >               <^^^error{The binding for the property 'preferred-height' is part of a binding loop (l.layoutinfo-v -> l.preferred-height -> text)}
-//       >               <^^^^warning{The binding for the property 'width' is part of a binding loop (root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//       >               <^^^^^warning{The binding for the property 'layout-cache' is part of a binding loop (root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//       >               <^^^^^^warning{The binding for the property 'width' is part of a binding loop (root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//       >               <error{The binding for the property 'preferred-width' is part of a binding loop (l.layoutinfo-h -> l.preferred-width -> text -> l.layoutinfo-h)}
+//       >               <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (l.layoutinfo-h -> l.preferred-width -> text -> l.layoutinfo-h)}
+//       >               <^^error{The binding for the property 'layoutinfo-v' is part of a binding loop (text -> l.layoutinfo-v -> l.preferred-height -> text)}
+//       >               <^^^error{The binding for the property 'preferred-height' is part of a binding loop (text -> l.layoutinfo-v -> l.preferred-height -> text)}
+//       >               <^^^^warning{The binding for the property 'width' is part of a binding loop (root_window.layoutinfo-h -> root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//       >               <^^^^^warning{The binding for the property 'layout-cache' is part of a binding loop (root_window.layoutinfo-h -> root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//       >               <^^^^^^warning{The binding for the property 'width' is part of a binding loop (root_window.layoutinfo-h -> root.width -> l.width -> l.layout-cache -> width -> l.layoutinfo-v -> l.preferred-height -> text -> l.layoutinfo-h -> root.layoutinfo-h -> root_window.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
         Text {
             text: "hello \{l.preferred-width/1px}x\{l.preferred-height/1px}";
-//                >                                                         <error{The binding for the property 'text' is part of a binding loop (l.preferred-width -> text -> l.layoutinfo-h)}
+//                >                                                         <error{The binding for the property 'text' is part of a binding loop (l.layoutinfo-h -> l.preferred-width -> text -> l.layoutinfo-h)}
             wrap: word-wrap;
         }
     }
 
     tc := TC {
-//        > <error{The binding for the property 'preferred-width' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//        > <error{The binding for the property 'preferred-width' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
         width: preferred-width;
-//             >              <error{The binding for the property 'width' is part of a binding loop (tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
+//             >              <error{The binding for the property 'width' is part of a binding loop (tc.layoutinfo-h -> tc.preferred-width -> tc.width -> outer.width -> inner.width -> inner-inner.width -> inner.layoutinfo-h -> outer.layoutinfo-h -> tc.layoutinfo-h)}
     }
 }

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout2.slint
@@ -6,19 +6,19 @@ Wrap := Rectangle {
     property woo <=> text.wrap;
 
     VerticalLayout {
-//  >             <error{The binding for the property 'layout-cache' is part of a binding loop (layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
-//  >             <^error{The binding for the property 'height' is part of a binding loop (layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
+//  >             <error{The binding for the property 'layout-cache' is part of a binding loop (square.width -> layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
+//  >             <^error{The binding for the property 'height' is part of a binding loop (square.width -> layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
         HorizontalLayout {
-//      >               <error{The binding for the property 'layout-cache' is part of a binding loop (layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
-//      >               <^error{The binding for the property 'width' is part of a binding loop (layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
-//      >               <^^error{The binding for the property 'layoutinfo-v' is part of a binding loop (layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
+//      >               <error{The binding for the property 'layout-cache' is part of a binding loop (square.width -> layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
+//      >               <^error{The binding for the property 'width' is part of a binding loop (square.width -> layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
+//      >               <^^error{The binding for the property 'layoutinfo-v' is part of a binding loop (square.width -> layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
             text := Text {
                 text: "Hello World";
             }
             square := Rectangle {
-//                    >        <error{The binding for the property 'height' is part of a binding loop (layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
+//                    >        <error{The binding for the property 'height' is part of a binding loop (square.width -> layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
                 width: height;
-//                     >     <error{The binding for the property 'width' is part of a binding loop (layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
+//                     >     <error{The binding for the property 'width' is part of a binding loop (square.width -> layout-cache -> text.width -> layoutinfo-v -> layout-cache -> height -> square.height -> square.width)}
                 background: violet;
             }
         }
@@ -29,19 +29,19 @@ Wrap := Rectangle {
 
 export Test := Window {
 //          ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
-//             >     <^warning{The binding for the property 'layoutinfo-v' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//             >     <^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//             >     <^warning{The binding for the property 'layoutinfo-v' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//             >     <^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
     property <image> source;
     GridLayout {
-//  >         <warning{The binding for the property 'width' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >         <^warning{The binding for the property 'layout-cache-h' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >         <^^warning{The binding for the property 'width' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >         <^^^warning{The binding for the property 'layoutinfo-v' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >         <^^^^warning{The binding for the property 'height' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >         <^^^^^warning{The binding for the property 'layout-cache-v' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >         <^^^^^^warning{The binding for the property 'height' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >         <^^^^^^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <^warning{The binding for the property 'layout-cache-h' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <^^warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <^^^warning{The binding for the property 'layoutinfo-v' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <^^^^warning{The binding for the property 'height' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <^^^^^warning{The binding for the property 'layout-cache-v' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <^^^^^^warning{The binding for the property 'height' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >         <^^^^^^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
 
         Image {
@@ -49,7 +49,7 @@ export Test := Window {
         }
         Rectangle {
             width: height;
-//                 >     <warning{The binding for the property 'width' is part of a binding loop (width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                 >     <warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> layout-cache-h -> width -> layoutinfo-v -> root.layoutinfo-v -> height -> layout-cache-v -> height -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
         }
     }
 

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout3.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout3.slint
@@ -3,19 +3,19 @@
 
 Compo := Rectangle {
 //    ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
-//       >        <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
+//       >        <^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
 
     property <string> the_text;
 
     lay := HorizontalLayout {
-//         >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
+//         >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
         if true : Rectangle {
-//                >        <error{The binding for the property 'layoutinfo-h' is part of a binding loop (preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
+//                >        <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
             VerticalLayout {
-//          >             <error{The binding for the property 'layoutinfo-h' is part of a binding loop (preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
+//          >             <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
                 Text {
                     text: root.the_text;
-//                        >            <error{The binding for the property 'text' is part of a binding loop (preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
+//                        >            <error{The binding for the property 'text' is part of a binding loop (layoutinfo-h -> preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
                 }
             }
         }
@@ -26,8 +26,8 @@ Compo := Rectangle {
 export Foo := Rectangle {
 //         ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     Compo {
-//  >    <error{The binding for the property 'preferred-width' is part of a binding loop (preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
+//  >    <error{The binding for the property 'preferred-width' is part of a binding loop (layoutinfo-h -> preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
         the_text: self.preferred-width / 1px;
-//                >                         <error{The binding for the property 'the-text' is part of a binding loop (preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
+//                >                         <error{The binding for the property 'the-text' is part of a binding loop (layoutinfo-h -> preferred-width -> the-text -> text -> layoutinfo-h -> layoutinfo-h -> lay.layoutinfo-h -> layoutinfo-h)}
     }
 }

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout4.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout4.slint
@@ -2,45 +2,45 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 component Foo {
-//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//            >^error{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//            >^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
     HorizontalLayout {
-//  >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^error{The binding for the property 'layout-cache' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
-//  >               <^^^^^error{The binding for the property 'layout-cache' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
-//  >               <^^^^^^error{The binding for the property 'width' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
-//  >               <^^^^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//  >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^^error{The binding for the property 'layout-cache' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^^^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//  >               <^^^^^error{The binding for the property 'layout-cache' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//  >               <^^^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//  >               <^^^^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
 
         Text {
             text: "hello";
             font_size: self.width / 2.5;
-//                     >               <error{The binding for the property 'font-size' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//                     >               <^error{The binding for the property 'font-size' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//                     >               <error{The binding for the property 'font-size' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//                     >               <^error{The binding for the property 'font-size' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
         }
     }
 }
-//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//<^<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//<^<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
 
 component Bar {
-//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
     HorizontalLayout {
-//  >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^error{The binding for the property 'layout-cache' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//  >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^^error{The binding for the property 'layout-cache' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^^^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
         Foo {}
         Foo {}
     }
 }
-//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
 
 export component Apps inherits Window {
     Bar {}
-//  >  <error{The binding for the property 'preferred-width' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >  <^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >  <error{The binding for the property 'preferred-width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >  <^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
 }

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout_if.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout_if.slint
@@ -6,37 +6,37 @@ component Wrapper {
     height: 100%;
 
     Rectangle {
-//  >        <error{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
+//  >        <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
         VerticalLayout {
-//      >             <error{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
+//      >             <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
             if root.width > 200px: Rectangle { }
         }
     }
 }
 
 component WrapperInherited inherits Rectangle {
-//                                  >        <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                                  >        <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
     VerticalLayout {
-//  >             <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >             <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
         if root.width > 200px: Rectangle { }
     }
 }
 
 export component Test inherits Window {
-//                             >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                             >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
     VerticalLayout {
-//  >             <warning{The binding for the property 'width' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >             <^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >             <warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >             <^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
         HorizontalLayout {
-//      >               <warning{The binding for the property 'width' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//      >               <^warning{The binding for the property 'layout-cache' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//      >               <^^warning{The binding for the property 'width' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//      >               <^^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//      >               <^^^^error{The binding for the property 'width' is part of a binding loop (width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
+//      >               <warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//      >               <^warning{The binding for the property 'layout-cache' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//      >               <^^warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//      >               <^^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> width -> layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//      >               <^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
             WrapperInherited { }
             Wrapper { }
-//          >      <error{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
+//          >      <error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
         }
     }
 }

--- a/internal/compiler/tests/syntax/analysis/binding_loop_mappointtowindow.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_mappointtowindow.slint
@@ -6,9 +6,9 @@ export App := Rectangle {
 
     Rectangle {
         x: inner.absolute-position.x > 10px ? 10px : 0px;
-//         >                                            <error{The binding for the property 'x' is part of a binding loop (inner.absolute-position -> x)}
+//         >                                            <error{The binding for the property 'x' is part of a binding loop (x -> inner.absolute-position -> x)}
         inner := Rectangle {
-//               >        <error{The binding for the property 'absolute-position' is part of a binding loop (inner.absolute-position -> x)}
+//               >        <error{The binding for the property 'absolute-position' is part of a binding loop (x -> inner.absolute-position -> x)}
         }
     }
 

--- a/internal/compiler/tests/syntax/analysis/binding_loop_self.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_self.slint
@@ -12,11 +12,11 @@ export Test := Rectangle {
         property <int> num_elements;
         num-elements: 4;
         Key { pos: 1; num_elements: num_elements; }
-//                                  >           <error{The binding for the property 'num-elements' is part of a binding loop (num-elements)}
+//                                  >           <error{The binding for the property 'num-elements' is part of a binding loop (num-elements -> num-elements)}
         Key { pos: 2; num_elements: self.num_elements; }
-//                                  >                <error{The binding for the property 'num-elements' is part of a binding loop (num-elements)}
+//                                  >                <error{The binding for the property 'num-elements' is part of a binding loop (num-elements -> num-elements)}
         Key { pos: 3; num_elements: parent.num_elements; }
         Key { pos: 4; num_elements: num_elements; }
-//                                  >           <error{The binding for the property 'num-elements' is part of a binding loop (num-elements)}
+//                                  >           <error{The binding for the property 'num-elements' is part of a binding loop (num-elements -> num-elements)}
     }
 }

--- a/internal/compiler/tests/syntax/analysis/binding_loop_text.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_text.slint
@@ -12,26 +12,26 @@ component OkButton inherits Text {
 
 component KoButton inherits Text {
     font-size: G.size;  // use rem without access to Window
-//             >     <error{The binding for the property 'font-size' is part of a binding loop (b.font-size -> root.default-font-size)}
+//             >     <error{The binding for the property 'font-size' is part of a binding loop (root.default-font-size -> b.font-size -> root.default-font-size)}
 }
 
 export component Test inherits Window {
     Text { font-size: self.font-metrics.ascent; }
-//  >   <error{The binding for the property 'font-metrics' is part of a binding loop (font-metrics -> font-size)}
-//                    >                       <^error{The binding for the property 'font-size' is part of a binding loop (font-metrics -> font-size)}
+//  >   <error{The binding for the property 'font-metrics' is part of a binding loop (font-size -> font-metrics -> font-size)}
+//                    >                       <^error{The binding for the property 'font-size' is part of a binding loop (font-size -> font-metrics -> font-size)}
 
     t1 := Text { font-italic: t2.font-metrics.cap-height > 10px; }
-//                            >                                <error{The binding for the property 'font-italic' is part of a binding loop (t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
-//        >   <^error{The binding for the property 'font-metrics' is part of a binding loop (t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
+//                            >                                <error{The binding for the property 'font-italic' is part of a binding loop (t2.font-weight -> t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
+//        >   <^error{The binding for the property 'font-metrics' is part of a binding loop (t2.font-weight -> t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
     t2 := Text { font-weight: t1.font-metrics.descent / 0.5px; }
-//        >   <error{The binding for the property 'font-metrics' is part of a binding loop (t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
-//                            >                              <^error{The binding for the property 'font-weight' is part of a binding loop (t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
+//        >   <error{The binding for the property 'font-metrics' is part of a binding loop (t2.font-weight -> t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
+//                            >                              <^error{The binding for the property 'font-weight' is part of a binding loop (t2.font-weight -> t2.font-metrics -> t1.font-italic -> t1.font-metrics -> t2.font-weight)}
 
     OkButton {}
 
     b := KoButton {}
     default-font-size: b.font-size;
-//                     >          <error{The binding for the property 'default-font-size' is part of a binding loop (b.font-size -> root.default-font-size)}
+//                     >          <error{The binding for the property 'default-font-size' is part of a binding loop (root.default-font-size -> b.font-size -> root.default-font-size)}
 
     dialog1 := Window {
 //             >     <warning{Window elements as children do not create separate windows (this may change in the future)↵Consider using a PopupWindow instead}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_window.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_window.slint
@@ -6,16 +6,16 @@
 import { HorizontalBox, VerticalBox } from "std-widgets.slint";
 
 export component MainWindow inherits Window {
-//                                   >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                                   >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
     HorizontalBox {
-//  >            <warning{The binding for the property 'width' is part of a binding loop (width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//  >            <^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >            <warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >            <^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
         VerticalBox {
 
             width: parent.width;
-//                 >           <warning{The binding for the property 'width' is part of a binding loop (width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                 >           <warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> width -> width -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
             //height: parent.height;
             Text {
                 text: "Test";

--- a/internal/compiler/tests/syntax/analysis/binding_loop_window2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_window2.slint
@@ -3,12 +3,12 @@
 
 // Issue #3898
 export component LspCrash inherits Window {
-//                                 >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (padding-left -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                                 >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> padding-left -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
     HorizontalLayout {
-//  >               <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (padding-left -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//  >               <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> padding-left -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
         padding-left: parent.width * 0.015;
-//                    >                   <warning{The binding for the property 'padding-left' is part of a binding loop (padding-left -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                    >                   <warning{The binding for the property 'padding-left' is part of a binding loop (root.layoutinfo-h -> padding-left -> layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
         Rectangle {}
     }
 }

--- a/internal/compiler/tests/syntax/basic/gridlayout_binding_loop.slint
+++ b/internal/compiler/tests/syntax/basic/gridlayout_binding_loop.slint
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component TestCase inherits Window {
-//                                 >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//                                 >     <warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
 
     lay1 := GridLayout {
-//          >         <warning{The binding for the property 'width' is part of a binding loop (lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//          >         <^warning{The binding for the property 'layout-cache-h' is part of a binding loop (lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//          >         <^^warning{The binding for the property 'x' is part of a binding loop (lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//          >         <^^^warning{The binding for the property 'layout-organized-data' is part of a binding loop (lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
-//          >         <^^^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//          >         <warning{The binding for the property 'width' is part of a binding loop (root.layoutinfo-h -> lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//          >         <^warning{The binding for the property 'layout-cache-h' is part of a binding loop (root.layoutinfo-h -> lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//          >         <^^warning{The binding for the property 'x' is part of a binding loop (root.layoutinfo-h -> lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//          >         <^^^warning{The binding for the property 'layout-organized-data' is part of a binding loop (root.layoutinfo-h -> lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//          >         <^^^^warning{The binding for the property 'layoutinfo-h' is part of a binding loop (root.layoutinfo-h -> lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
 
         Text {
             row: 1;
             col: self.x > 10px ? 3 : 4;
-//               >                    <warning{The binding for the property 'col' is part of a binding loop (lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
+//               >                    <warning{The binding for the property 'col' is part of a binding loop (root.layoutinfo-h -> lay1.width -> lay1.layout-cache-h -> x -> col -> lay1.layout-organized-data -> lay1.layoutinfo-h -> root.layoutinfo-h).↵This was allowed in previous version of Slint, but is deprecated and may cause panic at runtime}
         }
     }
 }

--- a/internal/compiler/tests/syntax/functions/functions_purity_recursive_5220.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity_recursive_5220.slint
@@ -14,9 +14,8 @@ export component App inherits Window{
 
     in property <int> abc: get_abc1();
     function get_abc1() -> int { return get_abc2(); }
-//  >                                               <error{The binding for the property 'get-abc1' is part of a binding loop (root.get-abc2 -> root.get-abc1)}
+//  >                                               <error{The binding for the property 'get-abc1' is part of a binding loop (root.get-abc1 -> root.get-abc2 -> root.get-abc1)}
     function get_abc2() -> int { return get_abc1(); }
-//  >                                               <error{The binding for the property 'get-abc2' is part of a binding loop (root.get-abc2 -> root.get-abc1)}
+//  >                                               <error{The binding for the property 'get-abc2' is part of a binding loop (root.get-abc1 -> root.get-abc2 -> root.get-abc1)}
 
 }
-

--- a/internal/compiler/tests/syntax/lookup/two_way_binding.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding.slint
@@ -37,9 +37,9 @@ export X := Rectangle {
 
     Rectangle {
         x <=> self.loop_on_x;
-//      >                   <error{The binding for the property 'x' is part of a binding loop (x -> loop-on-x)}
+//      >                   <error{The binding for the property 'x' is part of a binding loop (loop-on-x -> x -> loop-on-x)}
         property <length> loop_on_x <=> x;
-//                                  >    <error{The binding for the property 'loop-on-x' is part of a binding loop (x -> loop-on-x)}
+//                                  >    <error{The binding for the property 'loop-on-x' is part of a binding loop (loop-on-x -> x -> loop-on-x)}
     }
 
     property gyoyo <=> G.yoyo;

--- a/internal/compiler/tests/typeloader/incpath/should_fail4.slint
+++ b/internal/compiler/tests/typeloader/incpath/should_fail4.slint
@@ -11,7 +11,7 @@ export Unused := Rectangle {
 export Z := Rectangle {
 //       ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     property <int> b1: b2;
-//                     > <error{The binding for the property 'b1' is part of a binding loop (b2 -> b1)}
+//                     > <error{The binding for the property 'b1' is part of a binding loop (b1 -> b2 -> b1)}
     property <int> b2: b1;
-//                     > <error{The binding for the property 'b2' is part of a binding loop (b2 -> b1)}
+//                     > <error{The binding for the property 'b2' is part of a binding loop (b1 -> b2 -> b1)}
 }


### PR DESCRIPTION
The binding loop description now starts and ends with the same property,
making the cycle visually obvious. For example:

  Before: root.d -> root.c -> root.b -> root.a
  After:  root.a -> root.d -> root.c -> root.b -> root.a

The arrow direction is unchanged ("A -> B" means a change in A triggers B).