### PR TITLE
Reduce some text dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,8 +5067,8 @@ dependencies = [
  "fontique",
  "htmlparser",
  "pulldown-cmark",
+ "skrifa",
  "thiserror 2.0.18",
- "ttf-parser 0.25.1",
 ]
 
 [[package]]

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -5413,8 +5413,8 @@ dependencies = [
  "fontique 0.8.0",
  "htmlparser",
  "pulldown-cmark",
+ "skrifa 0.40.0",
  "thiserror 2.0.18",
- "ttf-parser",
 ]
 
 [[package]]

--- a/internal/common/Cargo.toml
+++ b/internal/common/Cargo.toml
@@ -18,14 +18,14 @@ path = "lib.rs"
 
 [features]
 default = []
-shared-fontique = ["dep:fontique", "dep:ttf-parser"]
+shared-fontique = ["dep:fontique", "dep:skrifa"]
 color-parsing = []
 fontconfig-dlopen = ["fontique?/fontconfig-dlopen"]
 markdown = ["dep:pulldown-cmark", "dep:htmlparser", "dep:thiserror", "color-parsing"]
 
 [dependencies]
-ttf-parser = { workspace = true, optional = true }
 fontique = { workspace = true, optional = true }
+skrifa = { workspace = true, optional = true }
 pulldown-cmark = { version = "0.13.0", optional = true }
 htmlparser = { version = "0.2.1", optional = true }
 thiserror = { version = "2.0.17", optional = true }

--- a/internal/common/sharedfontique.rs
+++ b/internal/common/sharedfontique.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 pub use fontique;
-pub use ttf_parser;
+pub use skrifa;
 
 #[cfg(any(target_family = "wasm", target_os = "nto"))]
 use fontique::ScriptExt;
@@ -150,17 +150,22 @@ pub struct DesignFontMetrics {
 
 impl DesignFontMetrics {
     pub fn new(font: &fontique::QueryFont) -> Self {
-        let face = ttf_parser::Face::parse(font.blob.data(), font.index).unwrap();
-        Self::new_from_face(&face)
+        let font_ref = skrifa::FontRef::from_index(font.blob.data(), font.index).unwrap();
+        Self::new_from_font_ref(&font_ref)
     }
 
-    pub fn new_from_face(face: &ttf_parser::Face) -> Self {
+    pub fn new_from_font_ref(font_ref: &skrifa::FontRef) -> Self {
+        let metrics = skrifa::metrics::Metrics::new(
+            font_ref,
+            skrifa::instance::Size::unscaled(),
+            skrifa::instance::LocationRef::default(),
+        );
         Self {
-            ascent: face.ascender() as f32,
-            descent: face.descender() as f32,
-            x_height: face.x_height().unwrap_or_default() as f32,
-            cap_height: face.capital_height().unwrap_or_default() as f32,
-            units_per_em: face.units_per_em() as f32,
+            ascent: metrics.ascent,
+            descent: metrics.descent,
+            x_height: metrics.x_height.unwrap_or_default(),
+            cap_height: metrics.cap_height.unwrap_or_default(),
+            units_per_em: metrics.units_per_em as f32,
         }
     }
 }

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::rc::Rc;
 
-use i_slint_common::sharedfontique::{self, fontique, ttf_parser};
+use i_slint_common::sharedfontique::{self, fontique, skrifa};
 
 #[derive(Clone)]
 struct Font {
@@ -311,9 +311,9 @@ fn embed_font(
 
     character_map.sort_by_key(|entry| entry.code_point);
 
-    let face_info = ttf_parser::Face::parse(font.font.blob.data(), font.font.index).unwrap();
-
-    let metrics = sharedfontique::DesignFontMetrics::new_from_face(&face_info);
+    let font_ref = skrifa::FontRef::from_index(font.font.blob.data(), font.font.index).unwrap();
+    let metrics = sharedfontique::DesignFontMetrics::new_from_font_ref(&font_ref);
+    let attrs = skrifa::attribute::Attributes::new(&font_ref);
 
     BitmapFont {
         family_name,
@@ -324,8 +324,8 @@ fn embed_font(
         x_height: metrics.x_height,
         cap_height: metrics.cap_height,
         glyphs,
-        weight: face_info.weight().to_number(),
-        italic: face_info.style() != ttf_parser::Style::Normal,
+        weight: attrs.weight.value() as u16,
+        italic: attrs.style != skrifa::attribute::Style::Normal,
         #[cfg(feature = "sdf-fonts")]
         sdf: _compiler_config.use_sdf_fonts,
         #[cfg(not(feature = "sdf-fonts"))]


### PR DESCRIPTION
- Replace ttf-parser with skrifa

This doesn't provide immediate "relief" but moves us into the right direction and once usvg for example switches over to parley/etc. we're ready.