### PR TITLE
FlexBoxLayout: solve only depends on main-axis container dimension

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -610,6 +610,36 @@ pub struct FlexBoxLayout {
 }
 
 impl FlexBoxLayout {
+    /// Returns true if the given orientation is the main axis, based on compile-time
+    /// direction analysis. Returns false if direction is unknown at compile time
+    /// (conservatively treating it as cross-axis).
+    pub fn is_main_axis(&self, orientation: Orientation) -> bool {
+        use crate::expression_tree::Expression;
+        let direction = match self.direction.as_ref() {
+            None => Some(FlexDirection::Row), // default
+            Some(nr) => nr.element().borrow().bindings.get(nr.name()).and_then(|binding| {
+                match &binding.borrow().expression {
+                    Expression::EnumerationValue(ev) => match ev.value {
+                        0 => Some(FlexDirection::Row),
+                        1 => Some(FlexDirection::RowReverse),
+                        2 => Some(FlexDirection::Column),
+                        3 => Some(FlexDirection::ColumnReverse),
+                        _ => None,
+                    },
+                    _ => None,
+                }
+            }),
+        };
+        matches!(
+            (direction, orientation),
+            (Some(FlexDirection::Row | FlexDirection::RowReverse), Orientation::Horizontal)
+                | (
+                    Some(FlexDirection::Column | FlexDirection::ColumnReverse),
+                    Orientation::Vertical
+                )
+        )
+    }
+
     pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
         for cell in &mut self.elems {
             cell.item.constraints.visit_named_references(visitor);

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -553,43 +553,63 @@ fn recurse_expression(
             if let Some(nr) = layout.direction.as_ref() {
                 vis(&nr.clone().into(), P);
             }
-            // Visit all layout geometry dependencies
+            // Visit layout geometry dependencies
             if matches!(expr, Expression::SolveFlexBoxLayout(..)) {
-                // FlexBoxLayout needs both width and height
-                if let Some(nr) = layout.geometry.rect.width_reference.as_ref() {
-                    vis(&nr.clone().into(), P);
+                // The solve only needs the main-axis dimension (width for row, height for column).
+                // The cross-axis dimension is determined by the content, not constrained by
+                // the container (items overflow or wrap as needed).
+                if layout.is_main_axis(Orientation::Horizontal) {
+                    if let Some(nr) = layout.geometry.rect.width_reference.as_ref() {
+                        vis(&nr.clone().into(), P);
+                    }
+                } else if layout.is_main_axis(Orientation::Vertical) {
+                    if let Some(nr) = layout.geometry.rect.height_reference.as_ref() {
+                        vis(&nr.clone().into(), P);
+                    }
+                } else {
+                    // Runtime direction: conservatively depend on both
+                    if let Some(nr) = layout.geometry.rect.width_reference.as_ref() {
+                        vis(&nr.clone().into(), P);
+                    }
+                    if let Some(nr) = layout.geometry.rect.height_reference.as_ref() {
+                        vis(&nr.clone().into(), P);
+                    }
                 }
-                if let Some(nr) = layout.geometry.rect.height_reference.as_ref() {
-                    vis(&nr.clone().into(), P);
+            } else if let Expression::ComputeFlexBoxLayoutInfo(_, orientation) = expr {
+                // Main-axis layout info only depends on same-axis item constraints,
+                // to avoid cross-axis binding loops. Cross-axis info needs both axes
+                // plus the perpendicular dimension (for wrapping).
+                let is_main_axis = layout.is_main_axis(*orientation);
+                if is_main_axis {
+                    // Main axis: only visit same-axis item dependencies
+                    visit_layout_items_dependencies(
+                        layout.elems.iter().map(|fi| &fi.item),
+                        *orientation,
+                        vis,
+                    );
+                } else {
+                    // Cross axis: visit both orientations + perpendicular dimension
+                    if *orientation == Orientation::Vertical
+                        && let Some(nr) = layout.geometry.rect.width_reference.as_ref()
+                    {
+                        vis(&nr.clone().into(), P);
+                    }
+                    if *orientation == Orientation::Horizontal
+                        && let Some(nr) = layout.geometry.rect.height_reference.as_ref()
+                    {
+                        vis(&nr.clone().into(), P);
+                    }
+                    visit_layout_items_dependencies(
+                        layout.elems.iter().map(|fi| &fi.item),
+                        Orientation::Horizontal,
+                        vis,
+                    );
+                    visit_layout_items_dependencies(
+                        layout.elems.iter().map(|fi| &fi.item),
+                        Orientation::Vertical,
+                        vis,
+                    );
                 }
-            } else if let Expression::ComputeFlexBoxLayoutInfo(_, _orientation) = expr {
-                // Technically, due to wrapping, there's a dependency on width for the vertical orientation (for Rows/RowsReverse)
-                // or a dependency on height for the horizontal orientation (for Columns/ColumnsReverse).
-                // But since the flex direction, which can be changed at runtime, we don't know which one will apply.
-                // And doing both leads to binding loops...
-                // We could detect the case of a constant flex direction (like in lower_layout_expression.rs) but
-                // that still wouldn't fix the case of runtime direction changes...
-                /*if *orientation == Orientation::Vertical
-                    && let Some(nr) = layout.geometry.rect.width_reference.as_ref()
-                {
-                    vis(&nr.clone().into(), P);
-                }
-                if *orientation == Orientation::Horizontal
-                    && let Some(nr) = layout.geometry.rect.height_reference.as_ref()
-                {
-                    vis(&nr.clone().into(), P);
-                }*/
-                // Visit item dependencies for relevant orientations
-                visit_layout_items_dependencies(
-                    layout.elems.iter().map(|fi| &fi.item),
-                    Orientation::Horizontal,
-                    vis,
-                );
-                visit_layout_items_dependencies(
-                    layout.elems.iter().map(|fi| &fi.item),
-                    Orientation::Vertical,
-                    vis,
-                );
             }
             let mut g = layout.geometry.clone();
             g.rect = Default::default(); // already visited;

--- a/tests/cases/layout/flexbox_image.slint
+++ b/tests/cases/layout/flexbox_image.slint
@@ -1,0 +1,43 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test FlexBoxLayout with an Image child (height-for-width behavior).
+// This used to trigger a binding loop because the Image's vertical layout info
+// depends on its width (aspect ratio), creating a cross-axis dependency cycle.
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 300px;
+
+    FlexBoxLayout {
+        r := Rectangle {
+            width: 100px;
+            height: 50px;
+            background: red;
+        }
+        img := Image {
+            preferred-width: 200px;
+            min-height: 48px;
+        }
+    }
+
+    // Verify items are laid out (not broken by binding loop)
+    out property <bool> test: r.x == 0px && r.width == 100px && img.x >= 100px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
For a row flex, the solve needs the container's width (to determine wrapping) but not its height — the cross-axis size is determined by the content. Previously, the binding analysis marked the solve as depending on both width and height, creating a binding loop when children have height-for-width behavior (e.g., Image with aspect ratio).

Now the solve only depends on the main-axis dimension (width for row, height for column), breaking the cross-axis binding loop.

Adds FlexBoxLayout::is_main_axis() to determine at compile time whether a given orientation is the main axis based on a constant flex-direction.

Fixes #11168

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
