### PR TITLE
Fix GridLayoutCell shared between inlined copies of a component

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -548,6 +548,14 @@ pub struct GridLayout {
 }
 
 impl GridLayout {
+    /// Clone each element's cell into a new Rc, breaking any Rc sharing with the original.
+    pub fn clone_cells(&mut self) {
+        for e in &mut self.elems {
+            let cloned = Rc::new(RefCell::new(e.cell.borrow().clone()));
+            e.cell = cloned;
+        }
+    }
+
     pub fn visit_rowcol_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
         for elem in &mut self.elems {
             let mut cell = elem.cell.borrow_mut();

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -319,10 +319,19 @@ fn inline_element(
         .inlined_init_code
         .insert(elem.borrow().span().offset, Expression::CodeBlock(inlined_init_code));
 
-    // Now fixup all binding and reference
+    // Now fixup all bindings and references
     for e in mapping.values() {
-        visit_all_named_references_in_element(e, |nr| fixup_reference(nr, &mapping));
+        // Must run before visit_all_named_references_in_element to break shared
+        // GridLayoutCell Rcs (otherwise NR fixup would modify the original's cells).
         visit_element_expressions(e, |expr, _, _| fixup_element_references(expr, &mapping));
+        // Also clone grid cells in the debug layout, which
+        // visit_all_named_references_in_element also visits.
+        for d in &mut e.borrow_mut().debug {
+            if let Some(crate::layout::Layout::GridLayout(grid)) = d.layout.as_mut() {
+                grid.clone_cells();
+            }
+        }
+        visit_all_named_references_in_element(e, |nr| fixup_reference(nr, &mapping));
     }
     for p in root_component.popup_windows.borrow_mut().iter_mut() {
         fixup_reference(&mut p.x, &mapping);
@@ -601,6 +610,7 @@ fn fixup_element_references(expr: &mut Expression, mapping: &Mapping) {
             for e in &mut layout.elems {
                 fxe(&mut e.item.element);
             }
+            layout.clone_cells();
         }
         Expression::SolveFlexboxLayout(layout)
         | Expression::ComputeFlexboxLayoutInfo(layout, _) => {

--- a/tests/cases/layout/gridlayout_inline_shared_cell.slint
+++ b/tests/cases/layout/gridlayout_inline_shared_cell.slint
@@ -1,0 +1,43 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test that a component with a GridLayout can be inlined multiple times
+// without sharing GridLayoutCell data between the copies.
+// Regression test: previously the Rc<RefCell<GridLayoutCell>> was shared
+// after inlining, causing a panic at runtime.
+
+component MyComponent inherits GridLayout {
+    Row {
+        r := Rectangle {
+            colspan: 2;
+            background: red;
+        }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+
+    if true: first := MyComponent { }
+    if true: second := MyComponent { }
+
+    out property <bool> test: true;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,7 +6,7 @@ set -eu
 unset CDPATH
 
 usage() {
-  echo "Usage: $0 <rust|cpp|interpreter|nodejs> [<filter>] [<cargo test args>...]" >&2
+  echo "Usage: $0 <rust|cpp|interpreter|python|nodejs> [<filter>] [<cargo test args>...]" >&2
 }
 
 fatal() {
@@ -23,7 +23,7 @@ fi
 driver="$1"
 
 case "$driver" in
-  rust|cpp|interpreter|nodejs) ;;
+  rust|cpp|interpreter|python|nodejs) ;;
   *)
     fatal "Invalid driver: $driver"
     ;;


### PR DESCRIPTION
When a component containing a GridLayout was inlined multiple times,
the GridLayoutCell Rc<RefCell<>> in layout expressions (OrganizeGridLayout,
SolveGridLayout, etc.) was shallow-cloned, causing all copies to share
the same cell data. This led to panics at runtime as properties from
the wrong component were accessed.

The fix updates fixup_element_references to replace the cell Rc with
the deep-cloned one from the mapped element after inlining.

Fixes: #11024