### PR TITLE
Propagate layout constraints from non-inlined component children

### DIFF
--- a/demos/weather-demo/ui/forecast_with_graph.slint
+++ b/demos/weather-demo/ui/forecast_with_graph.slint
@@ -104,12 +104,13 @@ export component DayForecastGraph inherits Rectangle {
         }
     }
 
-    layout := HorizontalLayout {
+    layout := Rectangle {
         for index in root.days-count:
             DayForecastGraphEntry {
                 property <WeatherForecastInfo> day-forecast-weather: root.forecast-weather[index];
                 property <duration> animation-duration: 0ms;
 
+                x: index * root.day-width;
                 width: root.day-width;
                 day-name: day-forecast-weather.day-name;
                 day-weather: day-forecast-weather.weather-info;

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -685,8 +685,22 @@ impl FlexboxLayout {
     }
 }
 
-/// Get the implicit layout info of a particular element
-pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> Expression {
+/// Controls whether `implicit_layout_info_call` returns layout info for builtins
+/// that don't have an intrinsic size (Rectangle, Empty, TouchArea, etc.).
+#[derive(Clone, Copy, PartialEq)]
+pub enum BuiltinFilter {
+    /// Return layout info for all builtins (existing behavior).
+    All,
+    /// Skip builtins whose `default_size_binding` is not `ImplicitSize`.
+    SkipNonImplicit,
+}
+
+/// Get the implicit layout info of a particular element.
+pub fn implicit_layout_info_call(
+    elem: &ElementRc,
+    orientation: Orientation,
+    filter: BuiltinFilter,
+) -> Option<Expression> {
     let mut elem_it = elem.clone();
     loop {
         return match &elem_it.clone().borrow().base_type {
@@ -696,7 +710,10 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                         // We cannot take nr as is because it is relative to the elem's component. We therefore need to
                         // use `elem` as an element for the PropertyReference, not `root` within the base of elem
                         debug_assert!(Rc::ptr_eq(&nr.element(), &base_comp.root_element));
-                        Expression::PropertyReference(NamedReference::new(elem, nr.name().clone()))
+                        Some(Expression::PropertyReference(NamedReference::new(
+                            elem,
+                            nr.name().clone(),
+                        )))
                     }
                     None => {
                         elem_it = base_comp.root_element.clone();
@@ -717,9 +734,12 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                         | "Clip"
                 ) =>
             {
+                if filter == BuiltinFilter::SkipNonImplicit {
+                    return None;
+                }
                 // hard-code the value for rectangle because many rectangle end up optimized away and we
                 // don't want to depend on the element.
-                Expression::Struct {
+                Some(Expression::Struct {
                     ty: crate::typeregister::layout_info_type(),
                     values: [("min", 0.), ("max", f32::MAX), ("preferred", 0.)]
                         .iter()
@@ -737,13 +757,20 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                                 }),
                         )
                         .collect(),
-                }
+                })
             }
-            _ => Expression::FunctionCall {
+            ElementType::Builtin(base_type)
+                if filter == BuiltinFilter::SkipNonImplicit
+                    && base_type.default_size_binding
+                        != crate::langtype::DefaultSizeBinding::ImplicitSize =>
+            {
+                None
+            }
+            _ => Some(Expression::FunctionCall {
                 function: BuiltinFunction::ImplicitLayoutInfo(orientation).into(),
                 arguments: vec![Expression::ElementReference(Rc::downgrade(elem))],
                 source_location: None,
-            },
+            }),
         };
     }
 }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1114,7 +1114,12 @@ pub fn get_layout_info(
         llr_Expression::PropertyReference(ctx.map_property_reference(layout_info_prop))
     } else {
         super::lower_expression::lower_expression(
-            &crate::layout::implicit_layout_info_call(elem, orientation),
+            &crate::layout::implicit_layout_info_call(
+                elem,
+                orientation,
+                crate::layout::BuiltinFilter::All,
+            )
+            .unwrap(),
             ctx,
         )
     };

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3028,8 +3028,18 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
             SmolStr::new_static("layoutinfo-h"),
             crate::typeregister::layout_info_type().into(),
         );
-        let expr_h = crate::layout::implicit_layout_info_call(old_root, Orientation::Horizontal);
-        let expr_v = crate::layout::implicit_layout_info_call(old_root, Orientation::Vertical);
+        let expr_h = crate::layout::implicit_layout_info_call(
+            old_root,
+            Orientation::Horizontal,
+            crate::layout::BuiltinFilter::All,
+        )
+        .unwrap();
+        let expr_v = crate::layout::implicit_layout_info_call(
+            old_root,
+            Orientation::Vertical,
+            crate::layout::BuiltinFilter::All,
+        )
+        .unwrap();
         let expr_v =
             BindingExpression::new_with_span(expr_v, old_root.borrow().to_source_location());
         li_v.element().borrow_mut().bindings.insert(li_v.name().clone(), expr_v.into());

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -17,7 +17,7 @@ use crate::expression_tree::{
     BindingExpression, BuiltinFunction, Expression, MinMaxOp, NamedReference, Unit,
 };
 use crate::langtype::{BuiltinElement, DefaultSizeBinding, Type};
-use crate::layout::{LayoutConstraints, Orientation, implicit_layout_info_call};
+use crate::layout::{BuiltinFilter, LayoutConstraints, Orientation, implicit_layout_info_call};
 use crate::object_tree::{Component, ElementRc};
 use smol_str::{SmolStr, format_smolstr};
 use std::collections::HashMap;
@@ -190,15 +190,16 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
                     }
                     let explicit_constraints =
                         LayoutConstraints::new(c, diag, DiagnosticLevel::Error);
-                    let use_implicit_size = c.borrow().builtin_type().is_some_and(|b| {
-                        b.default_size_binding == DefaultSizeBinding::ImplicitSize
-                    });
 
                     let compute = |orientation| {
-                        if !explicit_constraints.has_explicit_restrictions(orientation) {
-                            use_implicit_size.then(|| implicit_layout_info_call(c, orientation))
-                        } else {
+                        if explicit_constraints.has_explicit_restrictions(orientation) {
                             Some(explicit_layout_info(c, orientation))
+                        } else {
+                            implicit_layout_info_call(
+                                c,
+                                orientation,
+                                BuiltinFilter::SkipNonImplicit,
+                            )
                         }
                     };
                     Some((compute(Orientation::Horizontal), compute(Orientation::Vertical)))
@@ -222,8 +223,10 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         crate::typeregister::layout_info_type().into(),
     );
     elem.borrow_mut().layout_info_prop = Some((li_h.clone(), li_v.clone()));
-    let mut expr_h = implicit_layout_info_call(elem, Orientation::Horizontal);
-    let mut expr_v = implicit_layout_info_call(elem, Orientation::Vertical);
+    let mut expr_h =
+        implicit_layout_info_call(elem, Orientation::Horizontal, BuiltinFilter::All).unwrap();
+    let mut expr_v =
+        implicit_layout_info_call(elem, Orientation::Vertical, BuiltinFilter::All).unwrap();
 
     let explicit_constraints = LayoutConstraints::new(elem, diag, DiagnosticLevel::Warning);
     if !explicit_constraints.fixed_width {

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -204,7 +204,12 @@ pub fn initialize(elem: &ElementRc, name: &str) -> Option<Expression> {
 fn layout_constraint_prop(elem: &ElementRc, field: &str, orient: Orientation) -> Expression {
     let expr = match elem.borrow().layout_info_prop(orient) {
         Some(e) => Expression::PropertyReference(e.clone()),
-        None => crate::layout::implicit_layout_info_call(elem, orient),
+        None => crate::layout::implicit_layout_info_call(
+            elem,
+            orient,
+            crate::layout::BuiltinFilter::All,
+        )
+        .unwrap(),
     };
     Expression::StructFieldAccess { base: expr.into(), name: field.into() }
 }

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout4.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout4.slint
@@ -2,45 +2,46 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 component Foo {
-//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//            >^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//            >^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
     HorizontalLayout {
-//  >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^error{The binding for the property 'layout-cache' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
-//  >               <^^^^^error{The binding for the property 'layout-cache' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
-//  >               <^^^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
-//  >               <^^^^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//  >               <error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^error{The binding for the property 'layout-cache' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
+//  >               <^^^^^error{The binding for the property 'layout-cache' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
+//  >               <^^^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
+//  >               <^^^^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
 
         Text {
             text: "hello";
             font_size: self.width / 2.5;
-//                     >               <error{The binding for the property 'font-size' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//                     >               <^error{The binding for the property 'font-size' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//                     >               <error{The binding for the property 'font-size' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//                     >               <^error{The binding for the property 'font-size' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
         }
     }
 }
-//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//<^<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//<^<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
 
 component Bar {
-//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//            >error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
     HorizontalLayout {
-//  >               <error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^error{The binding for the property 'layout-cache' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache)}
+//  >               <error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^error{The binding for the property 'layout-cache' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >               <^^^^error{The binding for the property 'width' is part of a binding loop (layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layout-cache)}
         Foo {}
         Foo {}
     }
 }
-//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//<<<error{The binding for the property 'layoutinfo-h' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
 
 export component Apps inherits Window {
     Bar {}
-//  >  <error{The binding for the property 'preferred-width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
-//  >  <^error{The binding for the property 'width' is part of a binding loop (font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size)}
+//  >  <error{The binding for the property 'preferred-width' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >  <^error{The binding for the property 'width' is part of a binding loop (layoutinfo-h -> preferred-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
+//  >  <^^error{The binding for the property 'min-width' is part of a binding loop (layoutinfo-h -> min-width -> width -> width -> layout-cache -> width -> width -> layout-cache -> width -> font-size -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h -> layoutinfo-h)}
 }

--- a/tests/cases/layout/layout_constraints_not_depending_on_inlining.slint
+++ b/tests/cases/layout/layout_constraints_not_depending_on_inlining.slint
@@ -1,0 +1,75 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Abc inherits Rectangle {
+    VerticalLayout {
+        Rectangle {
+            min-width: 100px;
+        }
+    }
+    @children
+}
+
+component T1 {
+    HorizontalLayout {
+        Rectangle {
+            Abc { }
+        }
+    }
+}
+// Manually inline Abc
+component T2 {
+    HorizontalLayout {
+        Rectangle {
+            Rectangle {
+                VerticalLayout {
+                    Rectangle {
+                        min-width: 100px;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Force inlining because of a children
+component T3 {
+    HorizontalLayout {
+        Rectangle {
+            Abc { Rectangle{} }
+        }
+    }
+}
+
+export component TestCase {
+
+    l := HorizontalLayout {
+        t1 := T1 {}
+        t2 := T2 {}
+        t3 := T3 {}
+        abc := Abc { }
+    }
+
+    out property <bool> test: l.min-width == 100px * 4 && t1.min-width == 100px && t2.min-width == 100px && t3.min-width == 100px && abc.min-width == 100px;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
When a component with internal layout constraints (e.g., a VerticalLayout
with min-width) was used without being inlined, its constraints were not
propagated to the parent layout. This caused layout behavior to differ
depending on whether a component was inlined or not.

The fix adds a fallback in gen_layout_info_prop: when a child is a
non-inlined component reference whose base component's root element has
layout_info_prop, use implicit_layout_info_call to propagate the
constraints across the component boundary.

Fixes: #7700

------------------

Claude came up with this, I don't know this code enough to validate whether this is the right approach.
I asked
"non-inlined non-repeated", does this mean the bug still exists for inlined and/or repeated?

and the answer was:
    No — the three cases are:
      1. Inlined: The component's internal elements become direct children of the parent, so gen_layout_info_prop sees the VerticalLayout (with its layout_info_prop) as a direct child. Works already.
      2. Repeated: Excluded at line 187-189 (the existing if c.borrow().repeated.is_some() { return None; } with the FIXME comment about #407). This is a pre-existing limitation for all layout types, not specific to this bug.                                                                                                                                                                                  
      3. Non-inlined, non-repeated: This was the broken case, now fixed.

So "non-inlined non-repeated" is the only case that needed fixing. The repeated.is_none() check in my code isn't hiding a bug — it avoids the implicit_layout_info_call on repeated elements which would panic (as I discovered), and repeated elements are already handled (or rather, explicitly not handled) by the existing code above. 