### PR TITLE
Replace quick-protobuf with prost + protox in system-testing backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5008,8 +5014,9 @@ dependencies = [
  "i-slint-core-macros",
  "image",
  "include_dir",
- "pb-rs",
- "quick-protobuf",
+ "prost",
+ "prost-build",
+ "protox",
  "slint",
  "vtable",
 ]
@@ -5928,7 +5935,7 @@ dependencies = [
  "ena",
  "itertools 0.14.0",
  "lalrpop-util 0.22.2",
- "petgraph",
+ "petgraph 0.7.1",
  "pico-args",
  "regex",
  "regex-syntax",
@@ -6184,6 +6191,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version 0.4.1",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -6511,6 +6552,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6596,6 +6659,12 @@ name = "muldiv"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "naga"
@@ -7820,16 +7889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pb-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354a34df9c65b596152598001c0fe3393379ec2db03ae30b9985659422e2607e"
-dependencies = [
- "log",
- "nom 7.1.3",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7842,6 +7901,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -8232,6 +8302,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "logos",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8395,15 +8555,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "quick-xml"

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -21,7 +21,16 @@ path = "lib.rs"
 internal = ["include_dir"]
 # ffi for C++ bindings
 ffi = []
-system-testing = ["prost", "prost-build", "protox", "generational-arena", "async-net", "futures-lite", "byteorder", "image"]
+system-testing = [
+  "prost",
+  "prost-build",
+  "protox",
+  "generational-arena",
+  "async-net",
+  "futures-lite",
+  "byteorder",
+  "image",
+]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["std", "shared-parley"] }

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -21,13 +21,13 @@ path = "lib.rs"
 internal = ["include_dir"]
 # ffi for C++ bindings
 ffi = []
-system-testing = ["quick-protobuf", "pb-rs", "generational-arena", "async-net", "futures-lite", "byteorder", "image"]
+system-testing = ["prost", "prost-build", "protox", "generational-arena", "async-net", "futures-lite", "byteorder", "image"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["std", "shared-parley"] }
 i-slint-common = { workspace = true, features = ["shared-fontique"] }
 vtable = { workspace = true }
-quick-protobuf = { version = "0.8.1", optional = true }
+prost = { version = "0.14", optional = true }
 generational-arena = { version = "0.2.9", optional = true }
 async-net = { version = "2.0.0", optional = true }
 futures-lite = { version = "2.3.0", optional = true }
@@ -36,7 +36,8 @@ image = { workspace = true, optional = true, features = ["png"] }
 include_dir = { version = "0.7", optional = true }
 
 [build-dependencies]
-pb-rs = { version = "0.10.0", optional = true, default-features = false }
+prost-build = { version = "0.14", optional = true }
+protox = { version = "0.9", optional = true }
 
 [dev-dependencies]
 slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -4,13 +4,13 @@
 fn main() {
     #[cfg(feature = "system-testing")]
     {
-        let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
-        let proto_file = std::path::PathBuf::from(::std::env::var("CARGO_MANIFEST_DIR").unwrap())
-            .join("slint_systest.proto");
-        let config_builder = pb_rs::ConfigBuilder::new(&[proto_file], None, Some(&out_dir), &[])
-            .unwrap()
-            .headers(false)
-            .dont_use_cow(true);
-        pb_rs::types::FileDescriptor::run(&config_builder.build()).unwrap();
+        let manifest_dir =
+            std::path::PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+        let proto_file = manifest_dir.join("slint_systest.proto");
+        let fds = protox::compile([&proto_file], [&manifest_dir])
+            .expect("failed to compile slint_systest.proto");
+        prost_build::Config::new()
+            .compile_fds(fds)
+            .expect("failed to generate Rust code from proto descriptors");
     }
 }

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -9,7 +9,7 @@ use i_slint_core::debug_log;
 use i_slint_core::item_tree::ItemTreeRc;
 use i_slint_core::window::WindowAdapter;
 use i_slint_core::window::WindowInner;
-use quick_protobuf::{MessageRead, MessageWrite};
+use prost::Message;
 use std::cell::RefCell;
 use std::io::Cursor;
 use std::rc::{Rc, Weak};
@@ -91,66 +91,72 @@ impl TestingClient {
 
     async fn handle_request(
         &self,
-        request: proto::mod_RequestToAUT::OneOfmsg,
-    ) -> Result<proto::mod_AUTResponse::OneOfmsg, String> {
+        request: Option<proto::request_to_aut::Msg>,
+    ) -> Result<proto::aut_response::Msg, String> {
+        use proto::aut_response::Msg as Resp;
+        use proto::request_to_aut::Msg as Req;
+
+        let request = request.ok_or_else(|| "Empty request".to_string())?;
+
         Ok(match request {
-            proto::mod_RequestToAUT::OneOfmsg::request_window_list(..) => {
-                proto::mod_AUTResponse::OneOfmsg::window_list(proto::WindowListResponse {
-                    window_handles: self
-                        .windows
-                        .borrow()
-                        .iter()
-                        .map(|(index, _)| index_to_handle(index))
-                        .collect(),
-                })
+            Req::RequestWindowList(..) => Resp::WindowList(proto::WindowListResponse {
+                window_handles: self
+                    .windows
+                    .borrow()
+                    .iter()
+                    .map(|(index, _)| index_to_handle(index))
+                    .collect(),
+            }),
+            Req::RequestWindowProperties(proto::RequestWindowProperties { window_handle }) => {
+                Resp::WindowProperties(self.window_properties(handle_to_index(
+                    window_handle.ok_or_else(|| {
+                        "window properties request missing window handle".to_string()
+                    })?,
+                ))?)
             }
-            proto::mod_RequestToAUT::OneOfmsg::request_window_properties(
-                proto::RequestWindowProperties { window_handle },
-            ) => proto::mod_AUTResponse::OneOfmsg::window_properties(self.window_properties(
-                handle_to_index(window_handle.ok_or_else(|| {
-                    "window properties request missing window handle".to_string()
-                })?),
-            )?),
-            proto::mod_RequestToAUT::OneOfmsg::request_find_elements_by_id(
-                proto::RequestFindElementsById { window_handle, elements_id },
-            ) => {
+            Req::RequestFindElementsById(proto::RequestFindElementsById {
+                window_handle,
+                elements_id,
+            }) => {
                 let elements = self.find_elements_by_id(
                     handle_to_index(window_handle.ok_or_else(|| {
                         "find elements by id request missing window handle".to_string()
                     })?),
                     &elements_id,
                 )?;
-                proto::mod_AUTResponse::OneOfmsg::elements(proto::ElementsResponse {
+                Resp::Elements(proto::ElementsResponse {
                     element_handles: elements.map(|elem| self.element_to_handle(elem)).collect(),
                 })
             }
-            proto::mod_RequestToAUT::OneOfmsg::request_element_properties(
-                proto::RequestElementProperties { element_handle },
-            ) => proto::mod_AUTResponse::OneOfmsg::element_properties(
-                self.element_properties(element_handle)?,
-            ),
-            proto::mod_RequestToAUT::OneOfmsg::request_invoke_element_accessibility_action(
-                proto::RequestInvokeElementAccessibilityAction { element_handle, action },
+            Req::RequestElementProperties(proto::RequestElementProperties { element_handle }) => {
+                Resp::ElementProperties(self.element_properties(element_handle)?)
+            }
+            Req::RequestInvokeElementAccessibilityAction(
+                msg @ proto::RequestInvokeElementAccessibilityAction { element_handle, .. },
             ) => {
+                let action =
+                    proto::ElementAccessibilityAction::try_from(msg.action).map_err(|_| {
+                        format!("invalid ElementAccessibilityAction value: {}", msg.action)
+                    })?;
                 self.invoke_element_accessibility_action(element_handle, action)?;
-                proto::mod_AUTResponse::OneOfmsg::invoke_element_accessibility_action_response(
+                Resp::InvokeElementAccessibilityActionResponse(
                     proto::InvokeElementAccessibilityActionResponse {},
                 )
             }
-            proto::mod_RequestToAUT::OneOfmsg::request_set_element_accessible_value(
-                proto::RequestSetElementAccessibleValue { element_handle, value },
-            ) => {
+            Req::RequestSetElementAccessibleValue(proto::RequestSetElementAccessibleValue {
+                element_handle,
+                value,
+            }) => {
                 let element =
                     self.element("set element accessible value request", element_handle)?;
                 element.set_accessible_value(value);
-                proto::mod_AUTResponse::OneOfmsg::set_element_accessible_value_response(
-                    proto::SetElementAccessibleValueResponse {},
-                )
+                Resp::SetElementAccessibleValueResponse(proto::SetElementAccessibleValueResponse {})
             }
-            proto::mod_RequestToAUT::OneOfmsg::request_take_snapshot(
-                proto::RequestTakeSnapshot { window_handle, image_mime_type },
-            ) => {
-                proto::mod_AUTResponse::OneOfmsg::take_snapshot_response(self.take_snapshot(
+            Req::RequestTakeSnapshot(proto::RequestTakeSnapshot {
+                window_handle,
+                image_mime_type,
+            }) => {
+                Resp::TakeSnapshotResponse(self.take_snapshot(
                     handle_to_index(
                         window_handle.ok_or_else(|| {
                             "grab window request missing window handle".to_string()
@@ -159,22 +165,28 @@ impl TestingClient {
                     image_mime_type,
                 )?)
             }
-            proto::mod_RequestToAUT::OneOfmsg::request_element_click(
-                proto::RequestElementClick { element_handle, action, button },
-            ) => {
+            Req::RequestElementClick(proto::RequestElementClick {
+                element_handle,
+                action,
+                button,
+            }) => {
                 let element = self.element("element click request", element_handle)?;
-                let button = convert_pointer_event_button(button);
-                match action {
+                let button = convert_pointer_event_button(
+                    proto::PointerEventButton::try_from(button)
+                        .map_err(|_| format!("invalid PointerEventButton value: {button}"))?,
+                );
+                match proto::ClickAction::try_from(action)
+                    .map_err(|_| format!("invalid ClickAction value: {action}"))?
+                {
                     proto::ClickAction::SingleClick => element.single_click(button).await,
                     proto::ClickAction::DoubleClick => element.double_click(button).await,
                 }
-                proto::mod_AUTResponse::OneOfmsg::element_click_response(
-                    proto::ElementClickResponse {},
-                )
+                Resp::ElementClickResponse(proto::ElementClickResponse {})
             }
-            proto::mod_RequestToAUT::OneOfmsg::request_dispatch_window_event(
-                proto::RequestDispatchWindowEvent { window_handle, event },
-            ) => {
+            Req::RequestDispatchWindowEvent(proto::RequestDispatchWindowEvent {
+                window_handle,
+                event,
+            }) => {
                 self.dispatch_window_event(
                     handle_to_index(window_handle.ok_or_else(|| {
                         "window event dispatch request missing window handle".to_string()
@@ -183,25 +195,22 @@ impl TestingClient {
                         "window event dispatch request missing event".to_string()
                     })?)?,
                 )?;
-                proto::mod_AUTResponse::OneOfmsg::dispatch_window_event_response(
-                    proto::DispatchWindowEventResponse {},
-                )
+                Resp::DispatchWindowEventResponse(proto::DispatchWindowEventResponse {})
             }
-            proto::mod_RequestToAUT::OneOfmsg::request_query_element_descendants(
-                proto::RequestQueryElementDescendants { element_handle, query_stack, find_all },
-            ) => {
+            Req::RequestQueryElementDescendants(proto::RequestQueryElementDescendants {
+                element_handle,
+                query_stack,
+                find_all,
+            }) => {
                 let element = self.element("run element query request", element_handle)?;
                 let elements = self.query_element_descendants(element, query_stack, find_all)?;
-                proto::mod_AUTResponse::OneOfmsg::element_query_response(
-                    proto::ElementQueryResponse {
-                        element_handles: elements
-                            .into_iter()
-                            .map(|elem| self.element_to_handle(elem))
-                            .collect(),
-                    },
-                )
+                Resp::ElementQueryResponse(proto::ElementQueryResponse {
+                    element_handles: elements
+                        .into_iter()
+                        .map(|elem| self.element_to_handle(elem))
+                        .collect(),
+                })
             }
-            proto::mod_RequestToAUT::OneOfmsg::None => return Err("Unknown request".into()),
         })
     }
 
@@ -215,9 +224,9 @@ impl TestingClient {
             is_fullscreen: window.is_fullscreen(),
             is_maximized: window.is_maximized(),
             is_minimized: window.is_minimized(),
-            size: send_physical_size(window.size()).into(),
-            position: send_physical_position(window.position()).into(),
-            root_element_handle: self.root_element_handle(window_index)?.into(),
+            size: Some(send_physical_size(window.size())),
+            position: Some(send_physical_position(window.position())),
+            root_element_handle: Some(self.root_element_handle(window_index)?),
         })
     }
 
@@ -286,26 +295,31 @@ impl TestingClient {
         query_stack: Vec<proto::ElementQueryInstruction>,
         find_all: bool,
     ) -> Result<Vec<crate::ElementHandle>, String> {
+        use proto::element_query_instruction::Instruction;
         let mut query = element.query_descendants();
         for instruction in query_stack {
-            match instruction.instruction {
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_descendants(_) => {
+            match instruction
+                .instruction
+                .ok_or_else(|| "empty element query instruction".to_string())?
+            {
+                Instruction::MatchDescendants(_) => {
                     query = query.match_descendants();
                 }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_id(id) => {
-                    query = query.match_id(id)
-                }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_type_name(type_name) => {
+                Instruction::MatchElementId(id) => query = query.match_id(id),
+                Instruction::MatchElementTypeName(type_name) => {
                     query = query.match_type_name(type_name)
                 }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_type_name_or_base(type_name_or_base) => {
+                Instruction::MatchElementTypeNameOrBase(type_name_or_base) => {
                     query = query.match_inherits(type_name_or_base)
                 }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::match_element_accessible_role(role) => {
-                    query = query.match_accessible_role(convert_from_proto_accessible_role(role).ok_or_else(|| "Unknown accessibility role used in element query".to_string())?)
-                }
-                proto::mod_ElementQueryInstruction::OneOfinstruction::None => {
-                    return Err("unknown element query instruction".into());
+                Instruction::MatchElementAccessibleRole(role_i32) => {
+                    let role = proto::AccessibleRole::try_from(role_i32)
+                        .map_err(|_| format!("invalid AccessibleRole value: {role_i32}"))?;
+                    query = query.match_accessible_role(
+                        convert_from_proto_accessible_role(role).ok_or_else(|| {
+                            "Unknown accessibility role used in element query".to_string()
+                        })?,
+                    )
                 }
             }
         }
@@ -368,10 +382,11 @@ impl TestingClient {
                 .to_string(),
             accessible_checked: element.accessible_checked().unwrap_or_default(),
             accessible_checkable: element.accessible_checkable().unwrap_or_default(),
-            size: send_logical_size(element.size()).into(),
-            absolute_position: send_logical_position(element.absolute_position()).into(),
+            size: Some(send_logical_size(element.size())),
+            absolute_position: Some(send_logical_position(element.absolute_position())),
             accessible_role: convert_to_proto_accessible_role(element.accessible_role().unwrap())
-                .unwrap_or_default(),
+                .unwrap_or_default()
+                .into(),
             computed_opacity: element.computed_opacity(),
             accessible_placeholder_text: element
                 .accessible_placeholder_text()
@@ -380,11 +395,11 @@ impl TestingClient {
             accessible_enabled: element.accessible_enabled().unwrap_or_default(),
             accessible_read_only: element.accessible_read_only().unwrap_or_default(),
             layout_kind: match element.layout_kind() {
-                Some(LayoutKind::HorizontalLayout) => proto::LayoutKind::HorizontalLayout,
-                Some(LayoutKind::VerticalLayout) => proto::LayoutKind::VerticalLayout,
-                Some(LayoutKind::GridLayout) => proto::LayoutKind::GridLayout,
-                Some(LayoutKind::FlexboxLayout) => proto::LayoutKind::FlexboxLayout,
-                None => proto::LayoutKind::NotALayout,
+                Some(LayoutKind::HorizontalLayout) => proto::LayoutKind::HorizontalLayout.into(),
+                Some(LayoutKind::VerticalLayout) => proto::LayoutKind::VerticalLayout.into(),
+                Some(LayoutKind::GridLayout) => proto::LayoutKind::GridLayout.into(),
+                Some(LayoutKind::FlexboxLayout) => proto::LayoutKind::FlexboxLayout.into(),
+                None => proto::LayoutKind::NotALayout.into(),
             },
         })
     }
@@ -397,7 +412,7 @@ impl TestingClient {
         let element =
             self.element("invoke element accessibility action request", element_handle)?;
         match action {
-            proto::ElementAccessibilityAction::Default_ => {
+            proto::ElementAccessibilityAction::Default => {
                 element.invoke_accessible_default_action()
             }
             proto::ElementAccessibilityAction::Increment => {
@@ -420,8 +435,7 @@ impl TestingClient {
             .borrow()
             .get(window_index)
             .ok_or_else(|| "Invalid window handle".to_string())?
-            .root_element_handle
-            .clone())
+            .root_element_handle)
     }
 
     fn window_adapter(
@@ -454,9 +468,9 @@ pub fn init() -> Result<(), EventLoopError> {
 async fn message_loop(
     server_addr: &str,
     mut message_callback: impl FnMut(
-        proto::mod_RequestToAUT::OneOfmsg,
+        Option<proto::request_to_aut::Msg>,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<proto::mod_AUTResponse::OneOfmsg, String>>>,
+        Box<dyn std::future::Future<Output = Result<proto::aut_response::Msg, String>>>,
     >,
 ) {
     debug_log!("Attempting to connect to testing server at {server_addr}");
@@ -488,22 +502,19 @@ async fn message_loop(
             break "Unable to read request data from AUT connection";
         }
 
-        let message = match proto::RequestToAUT::from_reader(
-            &mut quick_protobuf::reader::BytesReader::from_bytes(&message_buf),
-            &message_buf,
-        ) {
+        let message = match proto::RequestToAut::decode(&message_buf[..]) {
             Ok(msg) => msg,
             Err(_) => {
                 break "Error de-serializing AUT request message";
             }
         };
         let response = message_callback(message.msg).await.unwrap_or_else(|message| {
-            proto::mod_AUTResponse::OneOfmsg::error(proto::ErrorResponse { message })
+            proto::aut_response::Msg::Error(proto::ErrorResponse { message })
         });
-        let response = proto::AUTResponse { msg: response };
+        let response = proto::AutResponse { msg: Some(response) };
         let mut binary_message = Vec::new();
-        binary_message.write_u32::<BigEndian>(response.get_size() as u32).unwrap();
-        response.write_message(&mut quick_protobuf::Writer::new(&mut binary_message)).unwrap();
+        binary_message.write_u32::<BigEndian>(response.encoded_len() as u32).unwrap();
+        response.encode(&mut binary_message).unwrap();
         if stream.write_all(&binary_message).await.is_err() {
             break "Unable to write AUT response body";
         }
@@ -615,28 +626,32 @@ fn convert_pointer_event_button(
 fn convert_window_event(
     event: proto::WindowEvent,
 ) -> Result<i_slint_core::platform::WindowEvent, String> {
-    Ok(match event.event {
-        proto::mod_WindowEvent::OneOfevent::pointer_pressed(proto::PointerPressEvent {
-            position,
-            button,
-        }) => i_slint_core::platform::WindowEvent::PointerPressed {
-            position: convert_logical_position(
-                position
-                    .ok_or_else(|| "Missing logical position in pointer press event".to_string())?,
-            ),
-            button: convert_pointer_event_button(button),
-        },
-        proto::mod_WindowEvent::OneOfevent::pointer_released(proto::PointerReleaseEvent {
-            position,
-            button,
-        }) => i_slint_core::platform::WindowEvent::PointerReleased {
-            position: convert_logical_position(
-                position
-                    .ok_or_else(|| "Missing logical position in pointer press event".to_string())?,
-            ),
-            button: convert_pointer_event_button(button),
-        },
-        proto::mod_WindowEvent::OneOfevent::pointer_moved(proto::PointerMoveEvent { position }) => {
+    use proto::window_event::Event;
+    let event = event.event.ok_or_else(|| "empty window event".to_string())?;
+    Ok(match event {
+        Event::PointerPressed(proto::PointerPressEvent { position, button }) => {
+            i_slint_core::platform::WindowEvent::PointerPressed {
+                position: convert_logical_position(position.ok_or_else(|| {
+                    "Missing logical position in pointer press event".to_string()
+                })?),
+                button: convert_pointer_event_button(
+                    proto::PointerEventButton::try_from(button)
+                        .map_err(|_| format!("invalid PointerEventButton value: {button}"))?,
+                ),
+            }
+        }
+        Event::PointerReleased(proto::PointerReleaseEvent { position, button }) => {
+            i_slint_core::platform::WindowEvent::PointerReleased {
+                position: convert_logical_position(position.ok_or_else(|| {
+                    "Missing logical position in pointer release event".to_string()
+                })?),
+                button: convert_pointer_event_button(
+                    proto::PointerEventButton::try_from(button)
+                        .map_err(|_| format!("invalid PointerEventButton value: {button}"))?,
+                ),
+            }
+        }
+        Event::PointerMoved(proto::PointerMoveEvent { position }) => {
             i_slint_core::platform::WindowEvent::PointerMoved {
                 position: convert_logical_position(
                     position.ok_or_else(|| {
@@ -645,11 +660,7 @@ fn convert_window_event(
                 ),
             }
         }
-        proto::mod_WindowEvent::OneOfevent::pointer_scrolled(proto::PointerScrolledEvent {
-            position,
-            delta_x,
-            delta_y,
-        }) => {
+        Event::PointerScrolled(proto::PointerScrolledEvent { position, delta_x, delta_y }) => {
             i_slint_core::platform::WindowEvent::PointerScrolled {
                 position: convert_logical_position(position.ok_or_else(|| {
                     "Missing logical position in pointer scroll event".to_string()
@@ -658,20 +669,17 @@ fn convert_window_event(
                 delta_y,
             }
         }
-        proto::mod_WindowEvent::OneOfevent::pointer_exited(proto::PointerExitedEvent {}) => {
+        Event::PointerExited(proto::PointerExitedEvent {}) => {
             i_slint_core::platform::WindowEvent::PointerExited {}
         }
-        proto::mod_WindowEvent::OneOfevent::key_pressed(proto::KeyPressedEvent { text }) => {
+        Event::KeyPressed(proto::KeyPressedEvent { text }) => {
             i_slint_core::platform::WindowEvent::KeyPressed { text: text.into() }
         }
-        proto::mod_WindowEvent::OneOfevent::key_press_repeated(proto::KeyPressRepeatedEvent {
-            text,
-        }) => i_slint_core::platform::WindowEvent::KeyPressRepeated { text: text.into() },
-        proto::mod_WindowEvent::OneOfevent::key_released(proto::KeyReleasedEvent { text }) => {
-            i_slint_core::platform::WindowEvent::KeyReleased { text: text.into() }
+        Event::KeyPressRepeated(proto::KeyPressRepeatedEvent { text }) => {
+            i_slint_core::platform::WindowEvent::KeyPressRepeated { text: text.into() }
         }
-        proto::mod_WindowEvent::OneOfevent::None => {
-            return Err("Unknown window event received in system testing protobuf".to_string());
+        Event::KeyReleased(proto::KeyReleasedEvent { text }) => {
+            i_slint_core::platform::WindowEvent::KeyReleased { text: text.into() }
         }
     })
 }


### PR DESCRIPTION
## Summary

- Replace `pb-rs` + `quick-protobuf` with `protox` + `prost` for protobuf code generation and serialization in the `system-testing` feature
- `protox` is a pure-Rust protoc replacement (~300 KB, no external binary), `prost` is the de facto standard Rust protobuf runtime
- All enum fields now go through `try_from(i32)` with descriptive error messages instead of being used directly
- Fixes a pre-existing copy-paste bug where `PointerReleased` error message said "pointer press event"

This is step 1 of 3 toward simplifying the MCP server (#10985). The follow-up PRs will:
1. Add `pbjson-build` to generate `serde::Serialize`/`Deserialize` impls from the proto descriptors
2. Rewrite the MCP server as a thin JSON-RPC wrapper using the serde-enabled prost types, eliminating ~370 LOC of hand-written JSON serialization

See discussion: https://github.com/slint-ui/slint/pull/10985#issuecomment-4150143803

## Test plan

- [x] `cargo build -p i-slint-backend-testing --features system-testing` compiles
- [x] `test_accessibility_role_mapping_complete` passes
- [x] `test_wire_compatibility` — new test verifying encode/decode round-trip and frame prefix convention
- [ ] CI passes