### PR TITLE
fix: expose public StyledText markdown parsing API

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -213,8 +213,6 @@ compile_error!(
 pub use slint_macros::slint;
 
 pub use i_slint_backend_selector::api::*;
-#[cfg(feature = "std")]
-pub use i_slint_common::styled_text::StyledTextError;
 pub use i_slint_core::api::*;
 #[doc(hidden)]
 #[deprecated(note = "Experimental type was made public by mistake")]
@@ -227,6 +225,8 @@ pub use i_slint_core::model::{
     ReverseModel, SortModel, VecModel,
 };
 pub use i_slint_core::styled_text::StyledText;
+#[cfg(feature = "std")]
+pub use i_slint_core::styled_text::StyledTextFromMarkdownError;
 pub use i_slint_core::timers::{Timer, TimerMode};
 pub use i_slint_core::translations::{SelectBundledTranslationError, select_bundled_translation};
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -241,14 +241,35 @@ pub fn parse_markdown(markdown: &str) -> Result<StyledText, StyledTextError<'sta
     StyledText::parse(markdown)
 }
 
-/// Parses markdown into [`StyledText`] and substitutes `{}` or `{n}` placeholders with existing
-/// styled text arguments.
+/// Parses markdown into [`StyledText`] and substitutes `{}` placeholders with existing styled
+/// text arguments.
 #[cfg(feature = "std")]
 pub fn parse_markdown_with_arguments(
     format_string: &str,
     arguments: &[StyledText],
 ) -> Result<StyledText, StyledTextError<'static>> {
-    StyledText::parse_interpolated(format_string, arguments)
+    let mut rewritten = String::with_capacity(format_string.len());
+    let mut chars = format_string.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '{' if chars.peek() == Some(&'{') => {
+                chars.next();
+                rewritten.push('{');
+            }
+            '}' if chars.peek() == Some(&'}') => {
+                chars.next();
+                rewritten.push('}');
+            }
+            '{' if chars.peek() == Some(&'}') => {
+                chars.next();
+                rewritten.push(i_slint_common::styled_text::MARKDOWN_INTERPOLATION_PLACEHOLDER);
+            }
+            ch => rewritten.push(ch),
+        }
+    }
+
+    StyledText::parse_interpolated(&rewritten, arguments)
 }
 
 /// Converts plain text into [`StyledText`] without applying markdown parsing.

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -213,6 +213,8 @@ compile_error!(
 pub use slint_macros::slint;
 
 pub use i_slint_backend_selector::api::*;
+#[cfg(feature = "std")]
+pub use i_slint_common::styled_text::StyledTextError;
 pub use i_slint_core::api::*;
 #[doc(hidden)]
 #[deprecated(note = "Experimental type was made public by mistake")]
@@ -224,10 +226,36 @@ pub use i_slint_core::model::{
     FilterModel, MapModel, Model, ModelExt, ModelNotify, ModelPeer, ModelRc, ModelTracker,
     ReverseModel, SortModel, VecModel,
 };
+pub use i_slint_core::styled_text::StyledText;
 pub use i_slint_core::timers::{Timer, TimerMode};
 pub use i_slint_core::translations::{SelectBundledTranslationError, select_bundled_translation};
 
 pub mod private_unstable_api;
+
+/// Parses markdown into [`StyledText`], which can then be assigned to a `styled-text` property.
+///
+/// Use [`parse_markdown_with_arguments()`] if you need placeholder interpolation with existing
+/// styled text values.
+#[cfg(feature = "std")]
+pub fn parse_markdown(markdown: &str) -> Result<StyledText, StyledTextError<'static>> {
+    StyledText::parse(markdown)
+}
+
+/// Parses markdown into [`StyledText`] and substitutes `{}` or `{n}` placeholders with existing
+/// styled text arguments.
+#[cfg(feature = "std")]
+pub fn parse_markdown_with_arguments(
+    format_string: &str,
+    arguments: &[StyledText],
+) -> Result<StyledText, StyledTextError<'static>> {
+    StyledText::parse_interpolated(format_string, arguments)
+}
+
+/// Converts plain text into [`StyledText`] without applying markdown parsing.
+#[cfg(feature = "std")]
+pub fn string_to_styled_text(text: impl Into<String>) -> StyledText {
+    StyledText::from_plain_text(text.into())
+}
 
 /// Enters the main event loop. This is necessary in order to receive
 /// events from the windowing system for rendering to the screen

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -232,52 +232,6 @@ pub use i_slint_core::translations::{SelectBundledTranslationError, select_bundl
 
 pub mod private_unstable_api;
 
-/// Parses markdown into [`StyledText`], which can then be assigned to a `styled-text` property.
-///
-/// Use [`parse_markdown_with_arguments()`] if you need placeholder interpolation with existing
-/// styled text values.
-#[cfg(feature = "std")]
-pub fn parse_markdown(markdown: &str) -> Result<StyledText, StyledTextError<'static>> {
-    StyledText::parse(markdown)
-}
-
-/// Parses markdown into [`StyledText`] and substitutes `{}` placeholders with existing styled
-/// text arguments.
-#[cfg(feature = "std")]
-pub fn parse_markdown_with_arguments(
-    format_string: &str,
-    arguments: &[StyledText],
-) -> Result<StyledText, StyledTextError<'static>> {
-    let mut rewritten = String::with_capacity(format_string.len());
-    let mut chars = format_string.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        match ch {
-            '{' if chars.peek() == Some(&'{') => {
-                chars.next();
-                rewritten.push('{');
-            }
-            '}' if chars.peek() == Some(&'}') => {
-                chars.next();
-                rewritten.push('}');
-            }
-            '{' if chars.peek() == Some(&'}') => {
-                chars.next();
-                rewritten.push(i_slint_common::styled_text::MARKDOWN_INTERPOLATION_PLACEHOLDER);
-            }
-            ch => rewritten.push(ch),
-        }
-    }
-
-    StyledText::parse_interpolated(&rewritten, arguments)
-}
-
-/// Converts plain text into [`StyledText`] without applying markdown parsing.
-#[cfg(feature = "std")]
-pub fn string_to_styled_text(text: impl Into<String>) -> StyledText {
-    StyledText::from_plain_text(text.into())
-}
-
 /// Enters the main event loop. This is necessary in order to receive
 /// events from the windowing system for rendering to the screen
 /// and reacting to user input.

--- a/api/rs/slint/tests/styled_text.rs
+++ b/api/rs/slint/tests/styled_text.rs
@@ -21,4 +21,7 @@ fn styled_text_can_be_created_from_rust_markdown() {
     let plain = slint::StyledText::from_plain_text("plain text");
     component.set_text(plain.clone());
     assert_eq!(component.get_text(), plain);
+
+    let error = slint::StyledText::from_markdown("# heading").unwrap_err();
+    assert!(error.to_string().starts_with("Unimplemented tag: Heading"));
 }

--- a/api/rs/slint/tests/styled_text.rs
+++ b/api/rs/slint/tests/styled_text.rs
@@ -14,16 +14,11 @@ fn styled_text_can_be_created_from_rust_markdown() {
     }
 
     let component = Test::new().unwrap();
-    let greeting = slint::parse_markdown("Hello *world*!").unwrap();
+    let greeting = slint::StyledText::from_markdown("Hello *world*!").unwrap();
     component.set_text(greeting.clone());
     assert_eq!(component.get_text(), greeting);
 
-    let emphasis = slint::parse_markdown("*world*").unwrap();
-    let interpolated = slint::parse_markdown_with_arguments("Hello {}!", &[emphasis]).unwrap();
-    component.set_text(interpolated.clone());
-    assert_eq!(component.get_text(), interpolated);
-
-    let plain = slint::string_to_styled_text("plain text");
+    let plain = slint::StyledText::from_plain_text("plain text");
     component.set_text(plain.clone());
     assert_eq!(component.get_text(), plain);
 }

--- a/api/rs/slint/tests/styled_text.rs
+++ b/api/rs/slint/tests/styled_text.rs
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use ::slint::slint;
+
+#[test]
+fn styled_text_can_be_created_from_rust_markdown() {
+    i_slint_backend_testing::init_no_event_loop();
+
+    slint! {
+        export component Test inherits Window {
+            in-out property <styled-text> text;
+        }
+    }
+
+    let component = Test::new().unwrap();
+    let greeting = slint::parse_markdown("Hello *world*!").unwrap();
+    component.set_text(greeting.clone());
+    assert_eq!(component.get_text(), greeting);
+
+    let emphasis = slint::parse_markdown("*world*").unwrap();
+    let interpolated = slint::parse_markdown_with_arguments("Hello {}!", &[emphasis]).unwrap();
+    component.set_text(interpolated.clone());
+    assert_eq!(component.get_text(), interpolated);
+
+    let plain = slint::string_to_styled_text("plain text");
+    component.set_text(plain.clone());
+    assert_eq!(component.get_text(), plain);
+}

--- a/api/rs/slint/tests/styled_text.rs
+++ b/api/rs/slint/tests/styled_text.rs
@@ -23,5 +23,9 @@ fn styled_text_can_be_created_from_rust_markdown() {
     assert_eq!(component.get_text(), plain);
 
     let error = slint::StyledText::from_markdown("# heading").unwrap_err();
-    assert!(error.to_string().starts_with("Unimplemented tag: Heading"));
+    let error = error.to_string();
+    assert!(
+        error.starts_with("Markdown headings are not supported"),
+        "unexpected markdown error: {error}"
+    );
 }

--- a/api/rs/slint/type-mappings.md
+++ b/api/rs/slint/type-mappings.md
@@ -19,7 +19,7 @@ The follow table summarizes the entire mapping:
 | `Point` | [`LogicalPosition`] | A struct with `x` and `y` fields, representing logical coordinates. |
 | `relative-font-size` | `f32` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | `string` | [`SharedString`] | A reference-counted string type that can be easily converted to a str reference. |
-| `styled-text` | [`StyledText`] | Use [`parse_markdown`](crate::parse_markdown) or [`string_to_styled_text`](crate::string_to_styled_text) to create values in Rust. |
+| `styled-text` | [`StyledText`] | Use [`StyledText::from_markdown`](crate::StyledText::from_markdown) or [`StyledText::from_plain_text`](crate::StyledText::from_plain_text) to create values in Rust. |
 | anonymous object | anonymous tuple | The fields are in alphabetical order. |
 | enumeration | `enum` of the same name | The values are converted to CamelCase |
 | structure | `struct` of the same name | |

--- a/api/rs/slint/type-mappings.md
+++ b/api/rs/slint/type-mappings.md
@@ -19,6 +19,7 @@ The follow table summarizes the entire mapping:
 | `Point` | [`LogicalPosition`] | A struct with `x` and `y` fields, representing logical coordinates. |
 | `relative-font-size` | `f32` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | `string` | [`SharedString`] | A reference-counted string type that can be easily converted to a str reference. |
+| `styled-text` | [`StyledText`] | Use [`parse_markdown`](crate::parse_markdown) or [`string_to_styled_text`](crate::string_to_styled_text) to create values in Rust. |
 | anonymous object | anonymous tuple | The fields are in alphabetical order. |
 | enumeration | `enum` of the same name | The values are converted to CamelCase |
 | structure | `struct` of the same name | |

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -4145,7 +4145,7 @@ fn compile_builtin_function_call(
         BuiltinFunction::ParseMarkdown => {
             let format_string = a.next().unwrap();
             let args = a.next().unwrap();
-            quote!(sp::parse_markdown::<sp::StyledText>(&#format_string, &#args))
+            quote!(sp::parse_markdown(&#format_string, &#args))
         }
         BuiltinFunction::StringToStyledText => {
             let string = a.next().unwrap();

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -20,12 +20,10 @@ impl StyledText {
     pub fn parse(
         markdown: &str,
     ) -> Result<Self, i_slint_common::styled_text::StyledTextError<'static>> {
-        Ok(
-            i_slint_common::styled_text::StyledText::parse_interpolated::<
-                i_slint_common::styled_text::StyledText,
-            >(markdown, &[])?
-            .into(),
-        )
+        Ok(i_slint_common::styled_text::StyledText::parse_interpolated::<
+            i_slint_common::styled_text::StyledText,
+        >(markdown, &[])?
+        .into())
     }
 
     /// Parses markdown and substitutes `{}` or `{n}` placeholders with styled text arguments.

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -11,6 +11,19 @@ pub struct StyledText {
 
 #[cfg(feature = "std")]
 impl StyledText {
+    /// Creates styled text from plain text without applying markdown parsing.
+    pub fn from_plain_text(text: alloc::string::String) -> Self {
+        i_slint_common::styled_text::StyledText::from_plain_text(text).into()
+    }
+
+    /// Parses markdown into styled text.
+    pub fn parse(
+        markdown: &str,
+    ) -> Result<Self, i_slint_common::styled_text::StyledTextError<'static>> {
+        Self::parse_interpolated(markdown, &[])
+    }
+
+    /// Parses markdown and substitutes `{}` or `{n}` placeholders with styled text arguments.
     pub fn parse_interpolated<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph]>>(
         format_string: &str,
         args: &[S],

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -13,9 +13,7 @@ pub struct StyledText {
 impl StyledText {
     /// Creates styled text from plain text without applying markdown parsing.
     pub fn from_plain_text(text: alloc::string::String) -> Self {
-        Self {
-            paragraphs: [i_slint_common::styled_text::paragraph_from_plain_text(text)].into(),
-        }
+        Self { paragraphs: [i_slint_common::styled_text::paragraph_from_plain_text(text)].into() }
     }
 
     /// Parses markdown into styled text.
@@ -25,7 +23,8 @@ impl StyledText {
         Self::parse_interpolated::<Self>(markdown, &[])
     }
 
-    /// Parses markdown and substitutes `{}` or `{n}` placeholders with styled text arguments.
+    /// Parses markdown and substitutes private interpolation placeholders with styled text
+    /// arguments.
     pub fn parse_interpolated<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph]>>(
         format_string: &str,
         args: &[S],

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -20,7 +20,12 @@ impl StyledText {
     pub fn parse(
         markdown: &str,
     ) -> Result<Self, i_slint_common::styled_text::StyledTextError<'static>> {
-        Self::parse_interpolated(markdown, &[])
+        Ok(
+            i_slint_common::styled_text::StyledText::parse_interpolated::<
+                i_slint_common::styled_text::StyledText,
+            >(markdown, &[])?
+            .into(),
+        )
     }
 
     /// Parses markdown and substitutes `{}` or `{n}` placeholders with styled text arguments.

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -116,10 +116,7 @@ pub mod ffi {
     }
 }
 
-pub fn parse_markdown<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph]>>(
-    _format_string: &str,
-    _args: &[S],
-) -> StyledText {
+pub fn parse_markdown(_format_string: &str, _args: &[StyledText]) -> StyledText {
     #[cfg(feature = "std")]
     {
         let (paragraphs, errors) =

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -13,17 +13,16 @@ pub struct StyledText {
 impl StyledText {
     /// Creates styled text from plain text without applying markdown parsing.
     pub fn from_plain_text(text: alloc::string::String) -> Self {
-        i_slint_common::styled_text::StyledText::from_plain_text(text).into()
+        Self {
+            paragraphs: [i_slint_common::styled_text::paragraph_from_plain_text(text)].into(),
+        }
     }
 
     /// Parses markdown into styled text.
     pub fn parse(
         markdown: &str,
     ) -> Result<Self, i_slint_common::styled_text::StyledTextError<'static>> {
-        Ok(i_slint_common::styled_text::StyledText::parse_interpolated::<
-            i_slint_common::styled_text::StyledText,
-        >(markdown, &[])?
-        .into())
+        Self::parse_interpolated::<Self>(markdown, &[])
     }
 
     /// Parses markdown and substitutes `{}` or `{n}` placeholders with styled text arguments.
@@ -118,9 +117,7 @@ pub fn string_to_styled_text(_string: alloc::string::String) -> StyledText {
         if _string.is_empty() {
             return Default::default();
         }
-        StyledText {
-            paragraphs: [i_slint_common::styled_text::paragraph_from_plain_text(_string)].into(),
-        }
+        StyledText::from_plain_text(_string)
     }
     #[cfg(not(feature = "std"))]
     Default::default()

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -22,7 +22,7 @@ impl StyledTextFromMarkdownError {
         Self {
             message: errors
                 .iter()
-                .map(core::string::ToString::to_string)
+                .map(alloc::string::ToString::to_string)
                 .collect::<alloc::vec::Vec<_>>()
                 .join("\n"),
         }
@@ -119,8 +119,13 @@ pub mod ffi {
 pub fn parse_markdown(_format_string: &str, _args: &[StyledText]) -> StyledText {
     #[cfg(feature = "std")]
     {
+        let paragraph_slices = _args
+            .iter()
+            .map(|styled_text| styled_text.paragraphs.as_slice())
+            .collect::<alloc::vec::Vec<_>>();
+
         let (paragraphs, errors) =
-            i_slint_common::styled_text::parse_interpolated(_format_string, _args);
+            i_slint_common::styled_text::parse_interpolated(_format_string, &paragraph_slices);
 
         for e in &errors {
             crate::debug_log!("@markdown: {e}");

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -9,35 +9,57 @@ pub struct StyledText {
     pub(crate) paragraphs: crate::SharedVector<i_slint_common::styled_text::StyledTextParagraph>,
 }
 
+/// Error returned when [`StyledText::from_markdown`] cannot parse the provided markdown input.
 #[cfg(feature = "std")]
-impl StyledText {
-    /// Creates styled text from plain text without applying markdown parsing.
-    pub fn from_plain_text(text: alloc::string::String) -> Self {
-        Self { paragraphs: [i_slint_common::styled_text::paragraph_from_plain_text(text)].into() }
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyledTextFromMarkdownError {
+    message: alloc::string::String,
+}
 
-    /// Parses markdown into styled text.
-    pub fn parse(
-        markdown: &str,
-    ) -> Result<Self, i_slint_common::styled_text::StyledTextError<'static>> {
-        Self::parse_interpolated::<Self>(markdown, &[])
-    }
-
-    /// Parses markdown and substitutes private interpolation placeholders with styled text
-    /// arguments.
-    pub fn parse_interpolated<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph]>>(
-        format_string: &str,
-        args: &[S],
-    ) -> (Self, alloc::vec::Vec<i_slint_common::styled_text::StyledTextParseError>) {
-        let (paragraphs, errors) =
-            i_slint_common::styled_text::parse_interpolated(format_string, args);
-        (Self { paragraphs: paragraphs.as_slice().into() }, errors)
+#[cfg(feature = "std")]
+impl StyledTextFromMarkdownError {
+    fn new(errors: alloc::vec::Vec<i_slint_common::styled_text::StyledTextParseError>) -> Self {
+        Self {
+            message: errors
+                .iter()
+                .map(core::string::ToString::to_string)
+                .collect::<alloc::vec::Vec<_>>()
+                .join("\n"),
+        }
     }
 }
 
-impl AsRef<[i_slint_common::styled_text::StyledTextParagraph]> for StyledText {
-    fn as_ref(&self) -> &[i_slint_common::styled_text::StyledTextParagraph] {
-        &self.paragraphs
+#[cfg(feature = "std")]
+impl core::fmt::Display for StyledTextFromMarkdownError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for StyledTextFromMarkdownError {}
+
+#[cfg(feature = "std")]
+impl StyledText {
+    /// Creates styled text from plain text without applying markdown parsing.
+    pub fn from_plain_text(text: &str) -> Self {
+        Self {
+            paragraphs: [i_slint_common::styled_text::paragraph_from_plain_text(text.into())]
+                .into(),
+        }
+    }
+
+    /// Parses markdown into styled text.
+    pub fn from_markdown(markdown: &str) -> Result<Self, StyledTextFromMarkdownError> {
+        let (paragraphs, errors) = i_slint_common::styled_text::parse_interpolated::<
+            &[i_slint_common::styled_text::StyledTextParagraph],
+        >(markdown, &[]);
+
+        if errors.is_empty() {
+            Ok(Self { paragraphs: paragraphs.as_slice().into() })
+        } else {
+            Err(StyledTextFromMarkdownError::new(errors))
+        }
     }
 }
 
@@ -100,11 +122,14 @@ pub fn parse_markdown<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph
 ) -> StyledText {
     #[cfg(feature = "std")]
     {
-        let (styled_text, errors) = StyledText::parse_interpolated(_format_string, _args);
+        let (paragraphs, errors) =
+            i_slint_common::styled_text::parse_interpolated(_format_string, _args);
+
         for e in &errors {
             crate::debug_log!("@markdown: {e}");
         }
-        styled_text
+
+        StyledText { paragraphs: paragraphs.as_slice().into() }
     }
     #[cfg(not(feature = "std"))]
     Default::default()
@@ -116,18 +141,18 @@ pub fn string_to_styled_text(_string: alloc::string::String) -> StyledText {
         if _string.is_empty() {
             return Default::default();
         }
-        StyledText::from_plain_text(_string)
+        StyledText::from_plain_text(&_string)
     }
     #[cfg(not(feature = "std"))]
     Default::default()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
 
     #[test]
-    fn string_to_styled_text() {
+    fn string_to_styled_text_returns_default_for_empty_string() {
         assert_eq!(super::string_to_styled_text(Default::default()), StyledText::default());
     }
 }

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -88,9 +88,9 @@ export component TestCase inherits Window {
 ```rust
 use slint::private_unstable_api::re_exports::StyledText;
 let instance = TestCase::new().unwrap();
-assert_eq!(instance.get_t1(), StyledText::parse_interpolated::<StyledText>("Hello World", &[]).0);
-assert_eq!(instance.get_t2(), StyledText::parse_interpolated::<StyledText>("Hello \\*World\\*", &[]).0);
-assert_eq!(instance.get_t3(), StyledText::parse_interpolated::<StyledText>("Hello *World*", &[]).0);
+assert_eq!(instance.get_t1(), StyledText::from_markdown("Hello World").unwrap());
+assert_eq!(instance.get_t2(), StyledText::from_markdown("Hello \\*World\\*").unwrap());
+assert_eq!(instance.get_t3(), StyledText::from_markdown("Hello *World*").unwrap());
 assert_eq!(instance.get_w1(), 66.0);
 assert_eq!(instance.get_w2(), 80.0);
 assert_eq!(instance.get_w3(), 64.0);


### PR DESCRIPTION
 This adds the missing public Rust API for creating `StyledText` values in
 application code and passing them to `styled-text` properties.

Fixes #11158

  Tests:
  - `cargo fmt --all`
  - `cargo test -p slint --test styled_text`