### PR TITLE
StyledText: fixes for link behavior

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -888,7 +888,6 @@ impl i_slint_core::platform::Platform for Backend {
         clipboard::select_clipboard(&mut pair, clipboard).and_then(|c| c.get_contents().ok())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     fn open_url(&self, url: &str) {
         if let Err(e) = webbrowser::open(url) {
             eprintln!("Failed to open URL: {}", e);

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -304,21 +304,24 @@ impl Item for StyledTextItem {
         };
         match event {
             #[cfg(feature = "shared-parley")]
-            MouseEvent::Moved { position, .. } => {
-                if find_link(position).is_some() {
-                    *cursor = super::MouseCursor::Pointer;
-                }
-                InputEventResult::EventIgnored
-            }
-            #[cfg(feature = "shared-parley")]
-            MouseEvent::Pressed {
+            MouseEvent::Released {
                 position,
                 button: PointerEventButton::Left,
                 click_count: _,
                 is_touch: _,
             } => {
                 if let Some(link) = find_link(position) {
+                    *cursor = super::MouseCursor::Pointer;
                     Self::FIELD_OFFSETS.link_clicked.apply_pin(self).call(&(link.into(),));
+                }
+                InputEventResult::EventAccepted
+            }
+            #[cfg(feature = "shared-parley")]
+            MouseEvent::Moved { position, .. }
+            | MouseEvent::Pressed { position, .. }
+            | MouseEvent::Released { position, .. } => {
+                if find_link(position).is_some() {
+                    *cursor = super::MouseCursor::Pointer;
                 }
                 InputEventResult::EventAccepted
             }

--- a/tests/cases/elements/styledtext.slint
+++ b/tests/cases/elements/styledtext.slint
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component TestCase inherits Window {
+    TouchArea { mouse-cursor: not-allowed; }
     VerticalLayout {
         st := StyledText {
             text: @markdown("Hello **World**: {} *{}*", "_abc_", @markdown("<u>xyz</u>"));


### PR DESCRIPTION
open_url should work on the browser/wasm.

Link should open on mouse release, not press.

Also make sure that we accept the move/press event, otherwise toucharea under the StyledText take over the cursor (This was making the cursor not change on live preview / slintpad as the preview has a TouchArea underneath)

