### PR TITLE
Rename FlexBoxLayout to FlexboxLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project are documented in this file.
  - Fixed empty `GridLayout` not taking padding into account.
  - Added support for Keyboard shortcuts with `KeyBinding` element, `keys` type, and `@keys(...)` macro.
  - Added printable keys in the `Key` namespace.
- - Added `FlexBoxLayout`.
+ - Added `FlexboxLayout`.
  - Added support for styled text with `StyledText` element, `styled-text` type, and `@markdown(...)` macro.
  - Added `ScaleRotateGestureHandler` element for handling multi-touch pinch gestures.
  - Fixed compiler panic when accessing model data from repeated menu. (#10927)

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -195,7 +195,7 @@ box_layout_info_ortho(cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> 
     return cbindgen_private::slint_box_layout_info_ortho(cells, &padding);
 }
 
-inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexBoxLayoutData &data,
+inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexboxLayoutData &data,
                                                 cbindgen_private::Slice<int> repeater_indices)
 {
     SharedVector<float> result;
@@ -206,8 +206,8 @@ inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexBoxL
 }
 
 inline cbindgen_private::LayoutInfo
-flexbox_layout_info(cbindgen_private::Slice<cbindgen_private::FlexBoxLayoutItemInfo> cells_h,
-                    cbindgen_private::Slice<cbindgen_private::FlexBoxLayoutItemInfo> cells_v,
+flexbox_layout_info(cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_h,
+                    cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_v,
                     float spacing_h, float spacing_v, const cbindgen_private::Padding &padding_h,
                     const cbindgen_private::Padding &padding_v,
                     cbindgen_private::Orientation orientation,

--- a/demos/printerdemo/ui/pages/home_page.slint
+++ b/demos/printerdemo/ui/pages/home_page.slint
@@ -82,7 +82,7 @@ export component HomePage inherits Page {
     }
 
 
-    flex := FlexBoxLayout {
+    flex := FlexboxLayout {
         x: DemoPalette.default-margin;
         y: parent.height - DemoPalette.default-margin - self.preferred-height;
         width: self.preferred-width;

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -290,7 +290,7 @@ export default defineConfig({
                                                 slug: "reference/layouts/verticallayout",
                                             },
                                             {
-                                                label: "FlexBoxLayout",
+                                                label: "FlexboxLayout",
                                                 slug: "reference/layouts/flexboxlayout",
                                             },
                                         ],

--- a/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
@@ -1,21 +1,21 @@
 ---
-title: FlexBoxLayout
-description: FlexBoxLayout element api.
+title: FlexboxLayout
+description: FlexboxLayout element api.
 ---
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 
-`FlexBoxLayout` is a flexible box layout that arranges its children in rows or columns with automatic wrapping. It implements a CSS Flexbox-like layout model suitable for creating flexible, responsive UIs.
+`FlexboxLayout` is a flexible box layout that arranges its children in rows or columns with automatic wrapping. It implements a CSS Flexbox-like layout model suitable for creating flexible, responsive UIs.
 
 
 <CodeSnippetMD imagePath="/src/assets/generated/flexboxlayout-example1.png"  imageWidth="300" imageHeight="150"  imageAlt='flexboxlayout example with row direction'>
 
 ```slint playground
-// This example demonstrates FlexBoxLayout with row direction (default)
+// This example demonstrates FlexboxLayout with row direction (default)
 export component Foo inherits Window {
     width: 300px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         spacing: 8px;
         padding: 8px;
         flex-direction: row;
@@ -33,11 +33,11 @@ export component Foo inherits Window {
 <CodeSnippetMD imagePath="/src/assets/generated/flexboxlayout-example2.png"  imageWidth="150" imageHeight="250"  imageAlt='flexboxlayout example with column direction'>
 
 ```slint playground
-// This example demonstrates FlexBoxLayout with column direction
+// This example demonstrates FlexboxLayout with column direction
 export component Foo inherits Window {
     width: 300px;
     height: 300px;
-    FlexBoxLayout {
+    FlexboxLayout {
         spacing: 8px;
         padding: 8px;
         flex-direction: column;
@@ -99,7 +99,7 @@ To target specific sides with different values use the following properties:
 ### alignment
 <SlintProperty propName="alignment" typeName="enum" enumName="LayoutAlignment">
 Set the alignment of items along the main axis. CSS Flexbox calls this "justify-content".
-Note that the `stretch` value has no effect on FlexBoxLayout (main-axis stretching in CSS Flexbox is controlled by `flex-grow`).
+Note that the `stretch` value has no effect on FlexboxLayout (main-axis stretching in CSS Flexbox is controlled by `flex-grow`).
 </SlintProperty>
 
 ## Direction Properties
@@ -130,7 +130,7 @@ The default value is `stretch`.
 
 ## Per-Item Properties
 
-The following properties can be set on individual children of a `FlexBoxLayout`:
+The following properties can be set on individual children of a `FlexboxLayout`:
 
 ### flex-grow
 <SlintProperty propName="flex-grow" typeName="float">
@@ -165,8 +165,8 @@ The default value is `0`.
 
 ## Layout Behavior
 
-The layouting algorithm for FlexBoxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>
+The layouting algorithm for FlexboxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>
 
-You can learn more about the CSS FlexBox specification from
+You can learn more about the CSS Flexbox specification from
 - <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts">the Mozilla developer website</a>
 - <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">A Complete Guide To Flexbox by CSS Tricks</a>. This is detailed guide with illustrations and comprehensive written explanation of the different Flexbox properties and how they work.

--- a/docs/development/layout-system.md
+++ b/docs/development/layout-system.md
@@ -16,7 +16,7 @@ Layout types:
 - **HorizontalLayout / VerticalLayout** - Linear box layouts
 - **GridLayout** - 2D grid with row/column positioning, spans
 - **Dialog** - Special grid with platform-specific button ordering
-- **FlexBoxLayout** - CSS Flexbox layout
+- **FlexboxLayout** - CSS Flexbox layout
 
 ## Key Files
 
@@ -100,9 +100,9 @@ Grid layouts solve independently for each axis:
 
 Cells with `colspan`/`rowspan` > 1 require iterative constraint distribution.
 
-### FlexBox layout
+### Flexbox layout
 
-FlexBox layout is solved in both axes simultaneously.
+Flexbox layout is solved in both axes simultaneously.
 The layouting algorithm is provided by the `taffy` crate, which implements the CSS flexbox algorithm.
 
 ## Compile-Time Lowering
@@ -130,7 +130,7 @@ Child x/y/width/height bound to cache access expressions
 | `OrganizeGridLayout` | Compute cell row/column assignments |
 | `SolveBoxLayout`     | Compute positions and sizes for items in a box layout |
 | `SolveGridLayout`    | Compute positions and sizes for items in a grid layout |
-| `SolveFlexBoxLayout` | Compute positions and sizes for items in a flexbox layout |
+| `SolveFlexboxLayout` | Compute positions and sizes for items in a flexbox layout |
 | `ComputeLayoutInfo`  | Calculate combined constraints |
 | `LayoutCacheAccess`  | Read position/size from cache |
 | `GridRepeaterCacheAccess` | Two-level indirection cache read (for repeaters in grids) |
@@ -200,7 +200,7 @@ Access: `cache[index]` where `index = child_idx * 2` for pos, `child_idx * 2 + 1
 
 ### Standard cache (box layouts)
 
-Used by `HorizontalLayout`/`VerticalLayout`/`FlexBoxLayout` (via `LayoutCacheGenerator`).
+Used by `HorizontalLayout`/`VerticalLayout`/`FlexboxLayout` (via `LayoutCacheGenerator`).
 Static children occupy a fixed slot; each repeater instance contributes exactly one cell (one pos +
 one size). When repeaters are present, their instances are stored in a contiguous block at
 the end of the cache, with a jump cell in the static region pointing to the start of that

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -38,7 +38,7 @@ component FlexCell inherits Rectangle {
 }
 
 export component MainWindow inherits Window {
-    title: "FlexBox Layout - Direction Test";
+    title: "Flexbox Layout - Interactive Test";
     default-font-size: 20px;
 
     property <[string]> direction_options: ["Row", "RowReverse", "Column", "ColumnReverse"];
@@ -57,7 +57,15 @@ export component MainWindow inherits Window {
         LayoutAlignment.space-around,
         LayoutAlignment.space-evenly
     ];
-    property <[string]> align_content_options: ["Stretch", "Start", "End", "Center", "Space Between", "Space Around", "Space Evenly"];
+    property <[string]> align_content_options: [
+        "Stretch",
+        "Start",
+        "End",
+        "Center",
+        "Space Between",
+        "Space Around",
+        "Space Evenly"
+    ];
     property <[FlexAlignContent]> align_content_values: [
         FlexAlignContent.stretch,
         FlexAlignContent.start,
@@ -143,7 +151,7 @@ export component MainWindow inherits Window {
             background: white;
             vertical-stretch: 1;
 
-            FlexBoxLayout {
+            FlexboxLayout {
                 flex-direction: direction_values[direction_combo.current-index];
                 alignment: alignment_values[alignment_combo.current-index];
                 align-content: align_content_values[align_content_combo.current-index];
@@ -160,6 +168,7 @@ export component MainWindow inherits Window {
                     min-height: 40phx;
                     background: #4a90d9;
                 }
+
                 FlexCell {
                     cell_text: "B grow:2";
                     flex-grow: 2;
@@ -167,6 +176,7 @@ export component MainWindow inherits Window {
                     min-height: 40phx;
                     background: #2e6da4;
                 }
+
                 for text in ["C", "D", "E"]: Cell {
                     cell_text: text;
                     width: 80phx;
@@ -179,12 +189,14 @@ export component MainWindow inherits Window {
                     min-height: 40phx;
                     background: #27ae60;
                 }
+
                 FlexCell {
                     cell_text: "G basis:160";
                     flex-basis: 160phx;
                     min-height: 40phx;
                     background: #1e8449;
                 }
+
                 for text in ["H", "I", "J", "K", "L"]: Cell {
                     cell_text: text;
                     width: 80phx;
@@ -198,6 +210,7 @@ export component MainWindow inherits Window {
                     min-height: 40phx;
                     background: #d94a4a;
                 }
+
                 FlexCell {
                     cell_text: "N shrink:3";
                     flex-basis: 150phx;
@@ -205,6 +218,7 @@ export component MainWindow inherits Window {
                     min-height: 40phx;
                     background: #a93226;
                 }
+
                 for text in ["P", "Q", "R"]: Cell {
                     cell_text: text;
                     width: 80phx;
@@ -217,6 +231,7 @@ export component MainWindow inherits Window {
                     height: 30phx;
                     background: #e67e22;
                 }
+
                 FlexCell {
                     cell_text: "T self:center";
                     flex-align-self: center;
@@ -231,6 +246,7 @@ export component MainWindow inherits Window {
                     min-height: 40phx;
                     background: #8e44ad;
                 }
+
                 FlexCell {
                     cell_text: "V flex-order:99";
                     flex-order: 99;
@@ -238,6 +254,7 @@ export component MainWindow inherits Window {
                     min-height: 40phx;
                     background: #6c3483;
                 }
+
                 for text in ["W", "X", "Y"]: Cell {
                     cell_text: text;
                     width: 80phx;

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -36,7 +36,7 @@ pub enum LayoutKind {
     /// A `GridLayout`.
     GridLayout,
     /// A flex box layout.
-    FlexBox,
+    FlexboxLayout,
 }
 
 impl LayoutKind {
@@ -45,7 +45,7 @@ impl LayoutKind {
             "h-box" => Some(Self::HorizontalLayout),
             "v-box" => Some(Self::VerticalLayout),
             "grid" => Some(Self::GridLayout),
-            "flex-box" => Some(Self::FlexBox),
+            "flex-box" => Some(Self::FlexboxLayout),
             _ => None,
         }
     }

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -78,17 +78,17 @@ message WindowEvent {
     }
 }
 
-// Copied from enums.rs - can't be auto-generated :(
-// with one difference: None became Unknown, because None doesn't compile.
-// Upside: AccessKit also uses Unknown :)
 enum LayoutKind {
     NotALayout = 0;
     HorizontalLayout = 1;
     VerticalLayout = 2;
     GridLayout = 3;
-    FlexBox = 4;
+    FlexboxLayout = 4;
 }
 
+// Copied from enums.rs - can't be auto-generated :(
+// with one difference: None became Unknown, because None doesn't compile.
+// Upside: AccessKit also uses Unknown :)
 enum AccessibleRole {
     Unknown = 0;
     Button = 1;

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -383,7 +383,7 @@ impl TestingClient {
                 Some(LayoutKind::HorizontalLayout) => proto::LayoutKind::HorizontalLayout,
                 Some(LayoutKind::VerticalLayout) => proto::LayoutKind::VerticalLayout,
                 Some(LayoutKind::GridLayout) => proto::LayoutKind::GridLayout,
-                Some(LayoutKind::FlexBox) => proto::LayoutKind::FlexBox,
+                Some(LayoutKind::FlexboxLayout) => proto::LayoutKind::FlexboxLayout,
                 None => proto::LayoutKind::NotALayout,
             },
         })

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -462,7 +462,7 @@ export component HorizontalLayout {
     in property <LayoutAlignment> alignment;
 }
 
-export component FlexBoxLayout {
+export component FlexboxLayout {
     in property <length> spacing-horizontal;
     in property <length> spacing-vertical;
     in property <length> spacing;

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -838,10 +838,10 @@ pub enum Expression {
         layout: crate::layout::GridLayout,
         orientation: crate::layout::Orientation,
     },
-    /// Solve a FlexBoxLayout - returns positions for all items (x, y, width, height per item)
-    SolveFlexBoxLayout(crate::layout::FlexBoxLayout),
-    /// Compute the LayoutInfo for the given FlexBoxLayout
-    ComputeFlexBoxLayoutInfo(crate::layout::FlexBoxLayout, crate::layout::Orientation),
+    /// Solve a FlexboxLayout - returns positions for all items (x, y, width, height per item)
+    SolveFlexboxLayout(crate::layout::FlexboxLayout),
+    /// Compute the LayoutInfo for the given FlexboxLayout
+    ComputeFlexboxLayoutInfo(crate::layout::FlexboxLayout, crate::layout::Orientation),
 
     MinMax {
         ty: Type,
@@ -976,8 +976,8 @@ impl Expression {
             Expression::ComputeGridLayoutInfo { .. } => typeregister::layout_info_type().into(),
             Expression::SolveBoxLayout(..) => Type::LayoutCache,
             Expression::SolveGridLayout { .. } => Type::LayoutCache,
-            Expression::SolveFlexBoxLayout(..) => Type::LayoutCache,
-            Expression::ComputeFlexBoxLayoutInfo(..) => typeregister::layout_info_type().into(),
+            Expression::SolveFlexboxLayout(..) => Type::LayoutCache,
+            Expression::ComputeFlexboxLayoutInfo(..) => typeregister::layout_info_type().into(),
             Expression::MinMax { ty, .. } => ty.clone(),
             Expression::EmptyComponentFactory => Type::ComponentFactory,
             Expression::DebugHook { expression, .. } => expression.ty(),
@@ -1091,8 +1091,8 @@ impl Expression {
             Expression::ComputeGridLayoutInfo { .. } => {}
             Expression::SolveBoxLayout(..) => {}
             Expression::SolveGridLayout { .. } => {}
-            Expression::SolveFlexBoxLayout(..) => {}
-            Expression::ComputeFlexBoxLayoutInfo(..) => {}
+            Expression::SolveFlexboxLayout(..) => {}
+            Expression::ComputeFlexboxLayoutInfo(..) => {}
             Expression::MinMax { lhs, rhs, .. } => {
                 visitor(lhs);
                 visitor(rhs);
@@ -1211,8 +1211,8 @@ impl Expression {
             Expression::ComputeGridLayoutInfo { .. } => {}
             Expression::SolveBoxLayout(..) => {}
             Expression::SolveGridLayout { .. } => {}
-            Expression::SolveFlexBoxLayout(..) => {}
-            Expression::ComputeFlexBoxLayoutInfo(..) => {}
+            Expression::SolveFlexboxLayout(..) => {}
+            Expression::ComputeFlexboxLayoutInfo(..) => {}
             Expression::MinMax { lhs, rhs, .. } => {
                 visitor(lhs);
                 visitor(rhs);
@@ -1312,8 +1312,8 @@ impl Expression {
             Expression::ComputeGridLayoutInfo { .. } => false,
             Expression::SolveBoxLayout(..) => false,
             Expression::SolveGridLayout { .. } => false,
-            Expression::SolveFlexBoxLayout(..) => false,
-            Expression::ComputeFlexBoxLayoutInfo(..) => false,
+            Expression::SolveFlexboxLayout(..) => false,
+            Expression::ComputeFlexboxLayoutInfo(..) => false,
             Expression::MinMax { lhs, rhs, .. } => lhs.is_constant(ga) && rhs.is_constant(ga),
             Expression::EmptyComponentFactory => true,
             Expression::DebugHook { .. } => false,
@@ -2029,8 +2029,8 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
         Expression::ComputeGridLayoutInfo { .. } => write!(f, "grid_layout_info(..)"),
         Expression::SolveBoxLayout(..) => write!(f, "solve_box_layout(..)"),
         Expression::SolveGridLayout { .. } => write!(f, "solve_grid_layout(..)"),
-        Expression::SolveFlexBoxLayout(..) => write!(f, "solve_flexbox_layout(..)"),
-        Expression::ComputeFlexBoxLayoutInfo(..) => write!(f, "flexbox_layout_info(..)"),
+        Expression::SolveFlexboxLayout(..) => write!(f, "solve_flexbox_layout(..)"),
+        Expression::ComputeFlexboxLayoutInfo(..) => write!(f, "flexbox_layout_info(..)"),
         Expression::MinMax { ty: _, op, lhs, rhs } => {
             match op {
                 MinMaxOp::Min => write!(f, "min(")?,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2633,7 +2633,7 @@ fn generate_flexbox_layout_item_info_decl(
     root_sc: &llr::SubComponent,
     ctx: &EvaluationContext,
 ) -> Declaration {
-    const SIGNATURE: &str = "(slint::cbindgen_private::Orientation o, [[maybe_unused]] std::optional<size_t> child_index) const -> slint::cbindgen_private::FlexBoxLayoutItemInfo";
+    const SIGNATURE: &str = "(slint::cbindgen_private::Orientation o, [[maybe_unused]] std::optional<size_t> child_index) const -> slint::cbindgen_private::FlexboxLayoutItemInfo";
 
     let body = if let Some(expr) = &root_sc.flexbox_layout_item_info_for_repeated {
         let compiled = compile_expression(&expr.borrow(), ctx);
@@ -4044,7 +4044,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             sub_expression,
             ctx,
         ),
-        Expression::WithFlexBoxLayoutItemInfo {
+        Expression::WithFlexboxLayoutItemInfo {
             cells_h_variable,
             cells_v_variable,
             repeater_indices_var_name,
@@ -4819,7 +4819,7 @@ fn generate_with_flexbox_layout_item_info(
 ) -> String {
     let repeated_indices_var_name = repeated_indices_var_name.map(ident);
     let mut push_code =
-        "std::vector<slint::cbindgen_private::FlexBoxLayoutItemInfo> cells_vector_h; std::vector<slint::cbindgen_private::FlexBoxLayoutItemInfo> cells_vector_v;".to_owned();
+        "std::vector<slint::cbindgen_private::FlexboxLayoutItemInfo> cells_vector_h; std::vector<slint::cbindgen_private::FlexboxLayoutItemInfo> cells_vector_v;".to_owned();
     let mut repeater_idx = 0usize;
 
     for item in elements {
@@ -4872,7 +4872,7 @@ fn generate_with_flexbox_layout_item_info(
         format!("std::array<int, {}> {ri}_array;", 2 * repeater_idx)
     });
     format!(
-        "[&]{{ {ri} {push_code} [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexBoxLayoutItemInfo>{cells_h} = slint::private_api::make_slice(std::span(cells_vector_h)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexBoxLayoutItemInfo>{cells_v} = slint::private_api::make_slice(std::span(cells_vector_v)); return {}; }}()",
+        "[&]{{ {ri} {push_code} [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexboxLayoutItemInfo>{cells_h} = slint::private_api::make_slice(std::span(cells_vector_h)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexboxLayoutItemInfo>{cells_v} = slint::private_api::make_slice(std::span(cells_vector_v)); return {}; }}()",
         compile_expression(sub_expression, ctx),
         cells_h = ident(cells_h_variable),
         cells_v = ident(cells_v_variable),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1248,7 +1248,7 @@ fn generate_sub_component(
             quote! {
                 fn flexbox_layout_item_info_for_repeated(
                     self: ::core::pin::Pin<&Self>,
-                ) -> sp::FlexBoxLayoutItemInfo {
+                ) -> sp::FlexboxLayoutItemInfo {
                     #![allow(unused)]
                     let _self = self;
                     #expr
@@ -2184,7 +2184,7 @@ fn generate_repeated_component(
                         self: ::core::pin::Pin<&Self>,
                         o: sp::Orientation,
                         child_index: sp::Option<usize>,
-                    ) -> sp::FlexBoxLayoutItemInfo {
+                    ) -> sp::FlexboxLayoutItemInfo {
                         let mut info = self.as_ref().flexbox_layout_item_info_for_repeated();
                         info.constraint = self.layout_item_info(o, child_index).constraint;
                         info
@@ -3078,7 +3078,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             ctx,
         ),
 
-        Expression::WithFlexBoxLayoutItemInfo {
+        Expression::WithFlexboxLayoutItemInfo {
             cells_h_variable,
             cells_v_variable,
             repeater_indices_var_name,

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -662,9 +662,9 @@ pub enum BuiltinPrivateStruct {
     GridLayoutData,
     GridLayoutInputData,
     BoxLayoutData,
-    FlexBoxLayoutData,
+    FlexboxLayoutData,
     LayoutItemInfo,
-    FlexBoxLayoutItemInfo,
+    FlexboxLayoutItemInfo,
     Padding,
     LayoutInfo,
     FontMetrics,
@@ -685,7 +685,7 @@ impl BuiltinPrivateStruct {
             Self::GridLayoutInputData
                 | Self::GridLayoutData
                 | Self::BoxLayoutData
-                | Self::FlexBoxLayoutData
+                | Self::FlexboxLayoutData
         )
     }
     pub fn slint_name(&self) -> Option<SmolStr> {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -36,7 +36,7 @@ pub enum FlexDirection {
 pub enum Layout {
     GridLayout(GridLayout),
     BoxLayout(BoxLayout),
-    FlexBoxLayout(FlexBoxLayout),
+    FlexboxLayout(FlexboxLayout),
 }
 
 impl Layout {
@@ -45,7 +45,7 @@ impl Layout {
         match self {
             Layout::GridLayout(grid) => grid.visit_named_references(visitor),
             Layout::BoxLayout(l) => l.visit_named_references(visitor),
-            Layout::FlexBoxLayout(l) => l.visit_named_references(visitor),
+            Layout::FlexboxLayout(l) => l.visit_named_references(visitor),
         }
     }
 }
@@ -57,9 +57,9 @@ pub struct LayoutItem {
     pub constraints: LayoutConstraints,
 }
 
-/// A FlexBoxLayout child item, wrapping a LayoutItem with flex-specific properties.
+/// A FlexboxLayout child item, wrapping a LayoutItem with flex-specific properties.
 #[derive(Debug, Clone)]
-pub struct FlexBoxLayoutItem {
+pub struct FlexboxLayoutItem {
     pub item: LayoutItem,
     pub flex_grow: Option<NamedReference>,
     pub flex_shrink: Option<NamedReference>,
@@ -598,10 +598,10 @@ impl BoxLayout {
     }
 }
 
-/// Internal representation of a FlexBoxLayout (row or column direction with wrapping)
+/// Internal representation of a FlexboxLayout (row or column direction with wrapping)
 #[derive(Debug, Clone)]
-pub struct FlexBoxLayout {
-    pub elems: Vec<FlexBoxLayoutItem>,
+pub struct FlexboxLayout {
+    pub elems: Vec<FlexboxLayoutItem>,
     pub geometry: LayoutGeometry,
     pub direction: Option<NamedReference>,
     pub align_content: Option<NamedReference>,
@@ -609,7 +609,7 @@ pub struct FlexBoxLayout {
     pub flex_wrap: Option<NamedReference>,
 }
 
-impl FlexBoxLayout {
+impl FlexboxLayout {
     /// Returns true if the given orientation is the main axis, based on compile-time
     /// direction analysis. Returns false if direction is unknown at compile time
     /// (conservatively treating it as cross-axis).
@@ -766,7 +766,7 @@ pub fn is_layout(base_type: &ElementType) -> bool {
         ElementType::Builtin(be) => {
             matches!(
                 be.name.as_str(),
-                "GridLayout" | "HorizontalLayout" | "VerticalLayout" | "FlexBoxLayout"
+                "GridLayout" | "HorizontalLayout" | "VerticalLayout" | "FlexboxLayout"
             )
         }
         _ => false,

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -220,8 +220,8 @@ pub enum Expression {
         sub_expression: Box<Expression>,
     },
     /// Will call the sub_expression, with two cells variables (horizontal and vertical)
-    /// set to the arrays of LayoutItemInfo from the elements for FlexBoxLayout
-    WithFlexBoxLayoutItemInfo {
+    /// set to the arrays of LayoutItemInfo from the elements for FlexboxLayout
+    WithFlexboxLayoutItemInfo {
         /// The local variable for horizontal cells
         cells_h_variable: String,
         /// The local variable for vertical cells
@@ -379,7 +379,7 @@ impl Expression {
             Self::LayoutCacheAccess { .. } => Type::LogicalLength,
             Self::GridRepeaterCacheAccess { .. } => Type::LogicalLength,
             Self::WithLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
-            Self::WithFlexBoxLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
+            Self::WithFlexboxLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
             Self::WithGridInputData { sub_expression, .. } => sub_expression.ty(ctx),
             Self::MinMax { ty, .. } => ty.clone(),
             Self::EmptyComponentFactory => Type::ComponentFactory,
@@ -481,7 +481,7 @@ macro_rules! visit_impl {
                 $visitor(sub_expression);
                 elements.$iter().filter_map(|x| x.$as_ref().left()).for_each($visitor);
             }
-            Expression::WithFlexBoxLayoutItemInfo { elements, sub_expression, .. } => {
+            Expression::WithFlexboxLayoutItemInfo { elements, sub_expression, .. } => {
                 $visitor(sub_expression);
                 elements.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
                     $visitor(h);

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -411,7 +411,7 @@ pub struct SubComponent {
     pub layout_info_v: MutExpression,
     pub child_of_layout: bool,
     pub grid_layout_input_for_repeated: Option<MutExpression>,
-    /// Expression that builds a FlexBoxLayoutItemInfo for a repeated element in a FlexBoxLayout.
+    /// Expression that builds a FlexboxLayoutItemInfo for a repeated element in a FlexboxLayout.
     /// Contains property references to flex-grow, flex-shrink, flex-basis, align-self, order.
     pub flexbox_layout_item_info_for_repeated: Option<MutExpression>,
     /// True when this is a repeated Row in a GridLayout, meaning layout_item_info

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -296,8 +296,8 @@ pub fn lower_expression(
         tree_Expression::SolveGridLayout { layout_organized_data_prop, layout, orientation } => {
             solve_grid_layout(layout_organized_data_prop, layout, *orientation, ctx)
         }
-        tree_Expression::SolveFlexBoxLayout(l) => solve_flexbox_layout(l, ctx),
-        tree_Expression::ComputeFlexBoxLayoutInfo(l, o) => compute_flexbox_layout_info(l, *o, ctx),
+        tree_Expression::SolveFlexboxLayout(l) => solve_flexbox_layout(l, ctx),
+        tree_Expression::ComputeFlexboxLayoutInfo(l, o) => compute_flexbox_layout_info(l, *o, ctx),
         tree_Expression::MinMax { ty, op, lhs, rhs } => llr_Expression::MinMax {
             ty: ty.clone(),
             op: *op,

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -295,7 +295,7 @@ pub(super) fn solve_box_layout(
 }
 
 pub(super) fn solve_flexbox_layout(
-    layout: &crate::layout::FlexBoxLayout,
+    layout: &crate::layout::FlexboxLayout,
     ctx: &mut ExpressionLoweringCtx,
 ) -> llr_Expression {
     let (padding_h, spacing_h) =
@@ -306,7 +306,7 @@ pub(super) fn solve_flexbox_layout(
     let width = layout_geometry_size(&layout.geometry.rect, Orientation::Horizontal, ctx);
     let height = layout_geometry_size(&layout.geometry.rect, Orientation::Vertical, ctx);
     let data = make_struct(
-        BuiltinPrivateStruct::FlexBoxLayoutData,
+        BuiltinPrivateStruct::FlexboxLayoutData,
         [
             ("width", Type::Float32, width),
             ("height", Type::Float32, height),
@@ -348,7 +348,7 @@ pub(super) fn solve_flexbox_layout(
         ],
     );
     match fld.compute_cells {
-        Some((cells_h_var, cells_v_var, elements)) => llr_Expression::WithFlexBoxLayoutItemInfo {
+        Some((cells_h_var, cells_v_var, elements)) => llr_Expression::WithFlexboxLayoutItemInfo {
             cells_h_variable: cells_h_var,
             cells_v_variable: cells_v_var,
             repeater_indices_var_name: Some("repeated_indices".into()),
@@ -374,7 +374,7 @@ pub(super) fn solve_flexbox_layout(
 }
 
 pub(super) fn compute_flexbox_layout_info(
-    layout: &crate::layout::FlexBoxLayout,
+    layout: &crate::layout::FlexboxLayout,
     orientation: Orientation,
     ctx: &mut ExpressionLoweringCtx,
 ) -> llr_Expression {
@@ -462,10 +462,10 @@ pub(super) fn compute_flexbox_layout_info(
 }
 
 fn compute_flexbox_layout_info_for_direction(
-    layout: &crate::layout::FlexBoxLayout,
+    layout: &crate::layout::FlexboxLayout,
     orientation: Orientation,
     is_cross_axis: bool,
-    fld: FlexBoxLayoutDataResult,
+    fld: FlexboxLayoutDataResult,
     ctx: &mut ExpressionLoweringCtx,
 ) -> llr_Expression {
     let (padding_h, spacing_h) =
@@ -506,7 +506,7 @@ fn compute_flexbox_layout_info_for_direction(
 
         match fld.compute_cells {
             Some((cells_h_var, cells_v_var, elements)) => {
-                llr_Expression::WithFlexBoxLayoutItemInfo {
+                llr_Expression::WithFlexboxLayoutItemInfo {
                     cells_h_variable: cells_h_var,
                     cells_v_variable: cells_v_var,
                     repeater_indices_var_name: None,
@@ -544,7 +544,7 @@ fn compute_flexbox_layout_info_for_direction(
 
         match fld.compute_cells {
             Some((cells_h_var, cells_v_var, elements)) => {
-                llr_Expression::WithFlexBoxLayoutItemInfo {
+                llr_Expression::WithFlexboxLayoutItemInfo {
                     cells_h_variable: cells_h_var,
                     cells_v_variable: cells_v_var,
                     repeater_indices_var_name: None,
@@ -566,7 +566,7 @@ fn compute_flexbox_layout_info_for_direction(
 }
 
 #[derive(Clone)]
-struct FlexBoxLayoutDataResult {
+struct FlexboxLayoutDataResult {
     alignment: llr_Expression,
     direction: llr_Expression,
     align_content: llr_Expression,
@@ -574,7 +574,7 @@ struct FlexBoxLayoutDataResult {
     flex_wrap: llr_Expression,
     cells_h: llr_Expression,
     cells_v: llr_Expression,
-    /// When there are repeaters involved, we need to do a WithFlexBoxLayoutItemInfo with the
+    /// When there are repeaters involved, we need to do a WithFlexboxLayoutItemInfo with the
     /// given cells_h/cells_v variable names and elements (each static element has a tuple of (h, v) layout info)
     compute_cells: Option<(
         String,
@@ -584,9 +584,9 @@ struct FlexBoxLayoutDataResult {
 }
 
 fn flexbox_layout_data(
-    layout: &crate::layout::FlexBoxLayout,
+    layout: &crate::layout::FlexboxLayout,
     ctx: &mut ExpressionLoweringCtx,
-) -> FlexBoxLayoutDataResult {
+) -> FlexboxLayoutDataResult {
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
@@ -643,7 +643,7 @@ fn flexbox_layout_data(
     let element_ty = crate::typeregister::flexbox_layout_item_info_type();
 
     let flex_prop =
-        |li: &crate::layout::FlexBoxLayoutItem, ctx: &mut ExpressionLoweringCtx| -> FlexItemProps {
+        |li: &crate::layout::FlexboxLayoutItem, ctx: &mut ExpressionLoweringCtx| -> FlexItemProps {
             FlexItemProps {
                 grow: li
                     .flex_grow
@@ -710,7 +710,7 @@ fn flexbox_layout_data(
             element_ty,
             output: llr_ArrayOutput::Slice,
         };
-        FlexBoxLayoutDataResult {
+        FlexboxLayoutDataResult {
             alignment,
             direction,
             align_content,
@@ -766,7 +766,7 @@ fn flexbox_layout_data(
             name: "cells_v".into(),
             ty: Type::Array(Rc::new(crate::typeregister::flexbox_layout_item_info_type())),
         };
-        FlexBoxLayoutDataResult {
+        FlexboxLayoutDataResult {
             alignment,
             direction,
             align_content,
@@ -817,7 +817,7 @@ struct FlexItemProps {
 fn make_flexbox_cell_data_struct(layout_info: llr_Expression, fp: FlexItemProps) -> llr_Expression {
     let (align_self_ty, _) = default_align_self();
     make_struct(
-        BuiltinPrivateStruct::FlexBoxLayoutItemInfo,
+        BuiltinPrivateStruct::FlexboxLayoutItemInfo,
         [
             ("constraint", crate::typeregister::layout_info_type().into(), layout_info),
             ("flex-grow", Type::Float32, fp.grow),
@@ -1245,8 +1245,8 @@ fn get_row_child_templates(
     ctx.state.row_child_templates(&comp)
 }
 
-/// Generate an expression that builds a FlexBoxLayoutItemInfo for a repeated element
-/// in a FlexBoxLayout, reading flex properties from the component instance.
+/// Generate an expression that builds a FlexboxLayoutItemInfo for a repeated element
+/// in a FlexboxLayout, reading flex properties from the component instance.
 pub fn get_flexbox_layout_item_info_for_repeated(
     ctx: &mut ExpressionLoweringCtx,
     element: &ElementRc,
@@ -1265,7 +1265,7 @@ pub fn get_flexbox_layout_item_info_for_repeated(
     let order = prop_ref("flex-order").unwrap_or(llr_Expression::NumberLiteral(0.0));
 
     make_struct(
-        BuiltinPrivateStruct::FlexBoxLayoutItemInfo,
+        BuiltinPrivateStruct::FlexboxLayoutItemInfo,
         [
             (
                 "constraint",

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -589,7 +589,7 @@ fn lower_sub_component(
         crate::layout::Orientation::Vertical,
     )
     .into();
-    // For repeated elements in a FlexBoxLayout, generate code to read flex properties
+    // For repeated elements in a FlexboxLayout, generate code to read flex properties
     if sub_component.child_of_layout {
         let root_elem = &component.root_element;
         let has_flex_binding =

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -70,7 +70,7 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::LayoutCacheAccess { .. } => PROPERTY_ACCESS_COST,
         Expression::GridRepeaterCacheAccess { .. } => PROPERTY_ACCESS_COST,
         Expression::WithLayoutItemInfo { .. } => return isize::MAX,
-        Expression::WithFlexBoxLayoutItemInfo { .. } => return isize::MAX,
+        Expression::WithFlexboxLayoutItemInfo { .. } => return isize::MAX,
         Expression::WithGridInputData { .. } => return isize::MAX,
         Expression::MinMax { .. } => 10,
         Expression::EmptyComponentFactory => 10,

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -455,8 +455,8 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                 }
             }
             Expression::WithLayoutItemInfo { .. } => write!(f, "WithLayoutItemInfo(TODO)",),
-            Expression::WithFlexBoxLayoutItemInfo { .. } => {
-                write!(f, "WithFlexBoxLayoutItemInfo(TODO)",)
+            Expression::WithFlexboxLayoutItemInfo { .. } => {
+                write!(f, "WithFlexboxLayoutItemInfo(TODO)",)
             }
             Expression::WithGridInputData { .. } => write!(f, "WithGridInputData(TODO)",),
             Expression::MinMax { ty: _, op, lhs, rhs } => match op {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -758,7 +758,7 @@ impl ElementDebugInfo {
                     Orientation::Vertical => info.push_str("v-box"),
                 },
                 Layout::GridLayout(_) => info.push_str("grid"),
-                Layout::FlexBoxLayout(_) => info.push_str("flex-box"),
+                Layout::FlexboxLayout(_) => info.push_str("flex-box"),
             }
         }
         info
@@ -2067,10 +2067,10 @@ impl Element {
     }
 }
 
-/// For FlexBoxLayout, suggest Slint property names for CSS properties.
+/// For FlexboxLayout, suggest Slint property names for CSS properties.
 fn css_property_suggestion(property_name: &str, base_type: &ElementType) -> Option<String> {
     let base_name = base_type.to_smolstr();
-    if base_name != "FlexBoxLayout" {
+    if base_name != "FlexboxLayout" {
         return None;
     }
     match property_name {
@@ -2494,13 +2494,13 @@ pub fn visit_named_references_in_expression(
         Expression::GridRepeaterCacheAccess { layout_cache_prop, .. } => vis(layout_cache_prop),
         Expression::OrganizeGridLayout(l) => l.visit_named_references(vis),
         Expression::ComputeBoxLayoutInfo(l, _) => l.visit_named_references(vis),
-        Expression::ComputeFlexBoxLayoutInfo(l, _) => l.visit_named_references(vis),
+        Expression::ComputeFlexboxLayoutInfo(l, _) => l.visit_named_references(vis),
         Expression::ComputeGridLayoutInfo { layout_organized_data_prop, layout, .. } => {
             vis(layout_organized_data_prop);
             layout.visit_named_references(vis);
         }
         Expression::SolveBoxLayout(l, _) => l.visit_named_references(vis),
-        Expression::SolveFlexBoxLayout(l) => l.visit_named_references(vis),
+        Expression::SolveFlexboxLayout(l) => l.visit_named_references(vis),
         Expression::SolveGridLayout { layout_organized_data_prop, layout, .. } => {
             vis(layout_organized_data_prop);
             layout.visit_named_references(vis);

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -548,13 +548,13 @@ fn recurse_expression(
             g.rect = Default::default(); // already visited;
             g.visit_named_references(&mut |nr| vis(&nr.clone().into(), P))
         }
-        Expression::SolveFlexBoxLayout(layout)
-        | Expression::ComputeFlexBoxLayoutInfo(layout, _) => {
+        Expression::SolveFlexboxLayout(layout)
+        | Expression::ComputeFlexboxLayoutInfo(layout, _) => {
             if let Some(nr) = layout.direction.as_ref() {
                 vis(&nr.clone().into(), P);
             }
             // Visit layout geometry dependencies
-            if matches!(expr, Expression::SolveFlexBoxLayout(..)) {
+            if matches!(expr, Expression::SolveFlexboxLayout(..)) {
                 // The solve only needs the main-axis dimension (width for row, height for column).
                 // The cross-axis dimension is determined by the content, not constrained by
                 // the container (items overflow or wrap as needed).
@@ -575,7 +575,7 @@ fn recurse_expression(
                         vis(&nr.clone().into(), P);
                     }
                 }
-            } else if let Expression::ComputeFlexBoxLayoutInfo(_, orientation) = expr {
+            } else if let Expression::ComputeFlexboxLayoutInfo(_, orientation) = expr {
                 // Main-axis layout info only depends on same-axis item constraints,
                 // to avoid cross-axis binding loops. Cross-axis info needs both axes
                 // plus the perpendicular dimension (for wrapping).

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -602,8 +602,8 @@ fn fixup_element_references(expr: &mut Expression, mapping: &Mapping) {
                 fxe(&mut e.item.element);
             }
         }
-        Expression::SolveFlexBoxLayout(layout)
-        | Expression::ComputeFlexBoxLayoutInfo(layout, _) => {
+        Expression::SolveFlexboxLayout(layout)
+        | Expression::ComputeFlexboxLayoutInfo(layout, _) => {
             for e in &mut layout.elems {
                 fxe(&mut e.item.element);
             }

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -109,7 +109,7 @@ fn lower_element_layout(
         "GridLayout" => lower_grid_layout(component, elem, diag, type_register),
         "HorizontalLayout" => lower_box_layout(elem, diag, Orientation::Horizontal),
         "VerticalLayout" => lower_box_layout(elem, diag, Orientation::Vertical),
-        "FlexBoxLayout" => lower_flexbox_layout(elem, diag),
+        "FlexboxLayout" => lower_flexbox_layout(elem, diag),
         "Dialog" => {
             lower_dialog_layout(elem, style_metrics, diag);
             // return now, the Dialog stays in the tree as a Dialog
@@ -877,7 +877,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
                 && v.enumeration.values[v.value] == "stretch")
         {
             diag.push_warning(
-                "alignment: stretch has no effect on FlexBoxLayout".into(),
+                "alignment: stretch has no effect on FlexboxLayout".into(),
                 &*binding,
             );
         }
@@ -888,7 +888,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
     let align_items = crate::layout::binding_reference(layout_element, "align-items");
     let flex_wrap = crate::layout::binding_reference(layout_element, "flex-wrap");
 
-    let mut layout = crate::layout::FlexBoxLayout {
+    let mut layout = crate::layout::FlexboxLayout {
         elems: Default::default(),
         geometry: LayoutGeometry::new(layout_element),
         direction,
@@ -897,7 +897,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
         flex_wrap,
     };
 
-    // FlexBoxLayout needs 4 values per item: x, y, width, height
+    // FlexboxLayout needs 4 values per item: x, y, width, height
     let layout_cache_prop =
         create_new_prop(layout_element, SmolStr::new_static("layout-cache"), Type::LayoutCache);
     let layout_info_prop_v = create_new_prop(
@@ -952,7 +952,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
         let flex_basis = crate::layout::binding_reference(actual_elem, "flex-basis");
         let align_self = crate::layout::binding_reference(actual_elem, "flex-align-self");
         let order = crate::layout::binding_reference(actual_elem, "flex-order");
-        layout.elems.push(crate::layout::FlexBoxLayoutItem {
+        layout.elems.push(crate::layout::FlexboxLayoutItem {
             item: item.item,
             flex_grow,
             flex_shrink,
@@ -967,7 +967,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
     layout_cache_prop.element().borrow_mut().bindings.insert(
         layout_cache_prop.name().clone(),
         BindingExpression::new_with_span(
-            Expression::SolveFlexBoxLayout(layout.clone()),
+            Expression::SolveFlexboxLayout(layout.clone()),
             span.clone(),
         )
         .into(),
@@ -975,7 +975,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
     layout_info_prop_h.element().borrow_mut().bindings.insert(
         layout_info_prop_h.name().clone(),
         BindingExpression::new_with_span(
-            Expression::ComputeFlexBoxLayoutInfo(layout.clone(), Orientation::Horizontal),
+            Expression::ComputeFlexboxLayoutInfo(layout.clone(), Orientation::Horizontal),
             span.clone(),
         )
         .into(),
@@ -983,14 +983,14 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
     layout_info_prop_v.element().borrow_mut().bindings.insert(
         layout_info_prop_v.name().clone(),
         BindingExpression::new_with_span(
-            Expression::ComputeFlexBoxLayoutInfo(layout.clone(), Orientation::Vertical),
+            Expression::ComputeFlexboxLayoutInfo(layout.clone(), Orientation::Vertical),
             span,
         )
         .into(),
     );
     layout_element.borrow_mut().layout_info_prop = Some((layout_info_prop_h, layout_info_prop_v));
     for d in layout_element.borrow_mut().debug.iter_mut() {
-        d.layout = Some(Layout::FlexBoxLayout(layout.clone()));
+        d.layout = Some(Layout::FlexboxLayout(layout.clone()));
     }
 }
 
@@ -1583,7 +1583,7 @@ fn check_number_literal_is_positive_integer(
 }
 
 fn recognized_layout_types() -> &'static [&'static str] {
-    &["Row", "GridLayout", "HorizontalLayout", "VerticalLayout", "FlexBoxLayout", "Dialog"]
+    &["Row", "GridLayout", "HorizontalLayout", "VerticalLayout", "FlexboxLayout", "Dialog"]
 }
 
 /// Checks that there are no grid-layout specific properties used wrongly
@@ -1600,13 +1600,13 @@ fn check_no_layout_properties(
         {
             diag.push_error(format!("{prop} used outside of a GridLayout's cell"), &*expr.borrow());
         }
-        if parent_layout_type.as_deref() != Some("FlexBoxLayout")
+        if parent_layout_type.as_deref() != Some("FlexboxLayout")
             && matches!(
                 prop.as_ref(),
                 "flex-grow" | "flex-shrink" | "flex-basis" | "flex-align-self" | "flex-order"
             )
         {
-            diag.push_error(format!("{prop} used outside of a FlexBoxLayout"), &*expr.borrow());
+            diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
         }
         if parent_layout_type.as_deref() != Some("Dialog")
             && matches!(prop.as_ref(), "dialog-button-role")

--- a/internal/compiler/passes/resolving/remove_noop.rs
+++ b/internal/compiler/passes/resolving/remove_noop.rs
@@ -109,8 +109,8 @@ fn without_side_effects(expression: &Expression) -> bool {
         Expression::OrganizeGridLayout(_) => false,
         Expression::SolveBoxLayout(_, _) => false,
         Expression::SolveGridLayout { .. } => false,
-        Expression::SolveFlexBoxLayout(..) => false,
-        Expression::ComputeFlexBoxLayoutInfo(..) => false,
+        Expression::SolveFlexboxLayout(..) => false,
+        Expression::ComputeFlexboxLayoutInfo(..) => false,
         Expression::MinMax { ty: _, op: _, lhs, rhs } => {
             without_side_effects(lhs) && without_side_effects(rhs)
         }

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -3,7 +3,7 @@
 
 export component X inherits Rectangle {
 
-    flex := FlexBoxLayout {
+    flex := FlexboxLayout {
         alignment: center;
         align-content: stretch;
         align-items: stretch;

--- a/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
@@ -3,7 +3,7 @@
 
 export component X inherits Rectangle {
 
-    FlexBoxLayout {
+    FlexboxLayout {
         Text {
             flex-grow: 1;
             flex-shrink: 2;
@@ -14,46 +14,46 @@ export component X inherits Rectangle {
         Rectangle {
             Text {
                 flex-grow: 1;
-//                         ><error{flex-grow used outside of a FlexBoxLayout}
+//                         ><error{flex-grow used outside of a FlexboxLayout}
                 flex-shrink: 2;
-//                           ><error{flex-shrink used outside of a FlexBoxLayout}
+//                           ><error{flex-shrink used outside of a FlexboxLayout}
                 flex-basis: 100px;
-//                          >    <error{flex-basis used outside of a FlexBoxLayout}
+//                          >    <error{flex-basis used outside of a FlexboxLayout}
                 flex-align-self: center;
-//                               >     <error{flex-align-self used outside of a FlexBoxLayout}
+//                               >     <error{flex-align-self used outside of a FlexboxLayout}
                 flex-order: 3;
-//                          ><error{flex-order used outside of a FlexBoxLayout}
+//                          ><error{flex-order used outside of a FlexboxLayout}
             }
         }
     }
 
-    // flex properties used outside of FlexBoxLayout should error
+    // flex properties used outside of FlexboxLayout should error
     Text {
         flex-grow: 1;
-//                 ><error{flex-grow used outside of a FlexBoxLayout}
+//                 ><error{flex-grow used outside of a FlexboxLayout}
         flex-shrink: 2;
-//                   ><error{flex-shrink used outside of a FlexBoxLayout}
+//                   ><error{flex-shrink used outside of a FlexboxLayout}
         flex-basis: 100px;
-//                  >    <error{flex-basis used outside of a FlexBoxLayout}
+//                  >    <error{flex-basis used outside of a FlexboxLayout}
         flex-align-self: center;
-//                       >     <error{flex-align-self used outside of a FlexBoxLayout}
+//                       >     <error{flex-align-self used outside of a FlexboxLayout}
         flex-order: 3;
-//                  ><error{flex-order used outside of a FlexBoxLayout}
+//                  ><error{flex-order used outside of a FlexboxLayout}
     }
 
     GridLayout {
         Text {
             flex-grow: 1;
-//                     ><error{flex-grow used outside of a FlexBoxLayout}
+//                     ><error{flex-grow used outside of a FlexboxLayout}
         }
     }
 
     HorizontalLayout {
         Text {
             flex-grow: 1;
-//                     ><error{flex-grow used outside of a FlexBoxLayout}
+//                     ><error{flex-grow used outside of a FlexboxLayout}
             flex-order: 5;
-//                      ><error{flex-order used outside of a FlexBoxLayout}
+//                      ><error{flex-order used outside of a FlexboxLayout}
         }
     }
 }

--- a/internal/compiler/tests/syntax/layout/flexbox_stretch_warning.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_stretch_warning.slint
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component X inherits Rectangle {
-    FlexBoxLayout {
+    FlexboxLayout {
         alignment: stretch;
-//                 >      <warning{alignment: stretch has no effect on FlexBoxLayout}
+//                 >      <warning{alignment: stretch has no effect on FlexboxLayout}
         Rectangle {}
     }
 }

--- a/internal/compiler/tests/syntax/layout/grid_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/grid_layout_properties.slint
@@ -81,7 +81,7 @@ export X := Rectangle {
 //           ><error{col used outside of a GridLayout's cell}
     }
 
-    flex := FlexBoxLayout {
+    flex := FlexboxLayout {
         Text {
             colspan: 1 + 1;
 //                   >    <error{colspan used outside of a GridLayout's cell}

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -188,7 +188,7 @@ impl BuiltinTypes {
                     ("flex-order".into(), Type::Int32),
                 ])
                 .collect(),
-                name: BuiltinPrivateStruct::FlexBoxLayoutItemInfo.into(),
+                name: BuiltinPrivateStruct::FlexboxLayoutItemInfo.into(),
             })),
             gridlayout_input_data_type: Type::Struct(Rc::new(Struct {
                 fields: IntoIterator::into_iter([
@@ -882,7 +882,7 @@ pub fn layout_item_info_type() -> Type {
     BUILTIN.with(|types| types.layout_item_info_type.clone())
 }
 
-/// The [`Type`] for a runtime FlexBoxLayoutItemInfo structure
+/// The [`Type`] for a runtime FlexboxLayoutItemInfo structure
 pub fn flexbox_layout_item_info_type() -> Type {
     BUILTIN.with(|types| types.flexbox_layout_item_info_type.clone())
 }

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -56,7 +56,7 @@
     "Expressions": {
         "href": "guide/language/coding/expressions-and-statements/"
     },
-    "FlexBoxLayout": {
+    "FlexboxLayout": {
         "href": "reference/layouts/flexboxlayout/"
     },
     "float": {

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1127,8 +1127,8 @@ pub struct BoxLayoutData<'a> {
 
 #[repr(C)]
 #[derive(Debug)]
-/// The FlexBoxLayoutData is used for a flex layout.
-pub struct FlexBoxLayoutData<'a> {
+/// The FlexboxLayoutData is used for a flex layout.
+pub struct FlexboxLayoutData<'a> {
     pub width: Coord,
     pub height: Coord,
     pub spacing_h: Coord,
@@ -1141,9 +1141,9 @@ pub struct FlexBoxLayoutData<'a> {
     pub align_items: FlexAlignItems,
     pub flex_wrap: FlexWrap,
     /// Horizontal constraints (width) for each cell
-    pub cells_h: Slice<'a, FlexBoxLayoutItemInfo>,
+    pub cells_h: Slice<'a, FlexboxLayoutItemInfo>,
     /// Vertical constraints (height) for each cell
-    pub cells_v: Slice<'a, FlexBoxLayoutItemInfo>,
+    pub cells_v: Slice<'a, FlexboxLayoutItemInfo>,
 }
 
 #[repr(C)]
@@ -1156,7 +1156,7 @@ pub struct LayoutItemInfo {
 #[repr(C)]
 #[derive(Debug, Clone)]
 /// The information about a single item in a flexbox layout
-pub struct FlexBoxLayoutItemInfo {
+pub struct FlexboxLayoutItemInfo {
     pub constraint: LayoutInfo,
     /// Flex grow factor (0 = don't grow, default)
     pub flex_grow: f32,
@@ -1170,7 +1170,7 @@ pub struct FlexBoxLayoutItemInfo {
     pub flex_order: i32,
 }
 
-impl Default for FlexBoxLayoutItemInfo {
+impl Default for FlexboxLayoutItemInfo {
     fn default() -> Self {
         Self {
             constraint: LayoutInfo::default(),
@@ -1183,7 +1183,7 @@ impl Default for FlexBoxLayoutItemInfo {
     }
 }
 
-impl From<LayoutItemInfo> for FlexBoxLayoutItemInfo {
+impl From<LayoutItemInfo> for FlexboxLayoutItemInfo {
     fn from(info: LayoutItemInfo) -> Self {
         Self { constraint: info.constraint, ..Default::default() }
     }
@@ -1322,17 +1322,17 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, FlexAlignContent, FlexAlignItems, FlexAlignSelf, FlexBoxLayoutItemInfo,
-        FlexWrap as SlintFlexWrap, LayoutAlignment, Padding, Slice,
+        Coord, FlexAlignContent, FlexAlignItems, FlexAlignSelf, FlexWrap as SlintFlexWrap,
+        FlexboxLayoutItemInfo, LayoutAlignment, Padding, Slice,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
     use taffy::prelude::*;
 
     /// Parameters for FlexboxTaffyBuilder::new
-    pub struct FlexBoxLayoutParams<'a> {
-        pub cells_h: &'a Slice<'a, FlexBoxLayoutItemInfo>,
-        pub cells_v: &'a Slice<'a, FlexBoxLayoutItemInfo>,
+    pub struct FlexboxLayoutParams<'a> {
+        pub cells_h: &'a Slice<'a, FlexboxLayoutItemInfo>,
+        pub cells_v: &'a Slice<'a, FlexboxLayoutItemInfo>,
         pub spacing_h: Coord,
         pub spacing_v: Coord,
         pub padding_h: &'a Padding,
@@ -1357,7 +1357,7 @@ mod flexbox_taffy {
 
     impl FlexboxTaffyBuilder {
         /// Create a new flexbox layout tree from item constraints
-        pub fn new(params: FlexBoxLayoutParams) -> Self {
+        pub fn new(params: FlexboxLayoutParams) -> Self {
             let mut taffy = TaffyTree::<()>::new();
 
             // Create child nodes from Slint constraints
@@ -1551,7 +1551,7 @@ mod flexbox_taffy {
                     },
                 )
                 .unwrap_or_else(|e| {
-                    crate::debug_log!("FlexBox layout computation error: {}", e);
+                    crate::debug_log!("FlexboxLayout computation error: {}", e);
                 });
         }
 
@@ -1579,8 +1579,8 @@ mod flexbox_taffy {
     }
 }
 
-/// A cache generator for FlexBoxLayout that handles 4 values per item (x, y, width, height)
-struct FlexBoxLayoutCacheGenerator<'a> {
+/// A cache generator for FlexboxLayout that handles 4 values per item (x, y, width, height)
+struct FlexboxLayoutCacheGenerator<'a> {
     // Input
     repeater_indices: &'a [u32],
     // An always increasing counter, the index of the cell being added
@@ -1595,7 +1595,7 @@ struct FlexBoxLayoutCacheGenerator<'a> {
     result: &'a mut SharedVector<Coord>,
 }
 
-impl<'a> FlexBoxLayoutCacheGenerator<'a> {
+impl<'a> FlexboxLayoutCacheGenerator<'a> {
     fn new(repeater_indices: &'a [u32], result: &'a mut SharedVector<Coord>) -> Self {
         // Calculate total repeated cells (count for each repeater)
         let total_repeated_cells: usize = repeater_indices
@@ -1646,10 +1646,10 @@ impl<'a> FlexBoxLayoutCacheGenerator<'a> {
     }
 }
 
-/// Solve a FlexBoxLayout using Taffy
+/// Solve a FlexboxLayout using Taffy
 /// Returns: [x1, y1, w1, h1, x2, y2, w2, h2, ...] for each item
 pub fn solve_flexbox_layout(
-    data: &FlexBoxLayoutData,
+    data: &FlexboxLayoutData,
     repeater_indices: Slice<u32>,
 ) -> SharedVector<Coord> {
     // 4 values per item: x, y, width, height
@@ -1672,7 +1672,7 @@ pub fn solve_flexbox_layout(
         if data.height > 0 as Coord { Some(data.height) } else { None },
     );
 
-    let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexBoxLayoutParams {
+    let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
         cells_h: &data.cells_h,
         cells_v: &data.cells_v,
         spacing_h: data.spacing_h,
@@ -1699,7 +1699,7 @@ pub fn solve_flexbox_layout(
     // If `order` sorting was applied, we need to collect results by original index first,
     // because the cache generator expects items in their original declaration order.
     if builder.order_map.is_empty() {
-        let mut generator = FlexBoxLayoutCacheGenerator::new(&repeater_indices, &mut result);
+        let mut generator = FlexboxLayoutCacheGenerator::new(&repeater_indices, &mut result);
         for idx in 0..data.cells_h.len() {
             let (x, y, w, h) = builder.child_geometry(idx);
             generator.add(x, y, w, h);
@@ -1711,7 +1711,7 @@ pub fn solve_flexbox_layout(
             let orig_idx = builder.original_index(taffy_idx);
             geom[orig_idx] = builder.child_geometry(taffy_idx);
         }
-        let mut generator = FlexBoxLayoutCacheGenerator::new(&repeater_indices, &mut result);
+        let mut generator = FlexboxLayoutCacheGenerator::new(&repeater_indices, &mut result);
         for (x, y, w, h) in geom {
             generator.add(x, y, w, h);
         }
@@ -1720,7 +1720,7 @@ pub fn solve_flexbox_layout(
     result
 }
 
-/// Return LayoutInfo (i.e. min, preferred, max etc.) for a FlexBoxLayout
+/// Return LayoutInfo (i.e. min, preferred, max etc.) for a FlexboxLayout
 /// This handles both main-axis (simple) and cross-axis (wrapping-aware) cases.
 /// The constraint_size is the perpendicular dimension to orientation:
 /// - For Horizontal orientation: constraint_size is height
@@ -1728,8 +1728,8 @@ pub fn solve_flexbox_layout(
 ///
 /// The constraint_size is ignored for main-axis calculation.
 pub fn flexbox_layout_info(
-    cells_h: Slice<FlexBoxLayoutItemInfo>,
-    cells_v: Slice<FlexBoxLayoutItemInfo>,
+    cells_h: Slice<FlexboxLayoutItemInfo>,
+    cells_v: Slice<FlexboxLayoutItemInfo>,
     spacing_h: Coord,
     spacing_v: Coord,
     padding_h: &Padding,
@@ -1806,7 +1806,7 @@ pub fn flexbox_layout_info(
         FlexDirection::Column | FlexDirection::ColumnReverse => (None, Some(main_axis_constraint)),
     };
 
-    let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexBoxLayoutParams {
+    let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
         cells_h: &cells_h,
         cells_v: &cells_v,
         spacing_h,
@@ -1963,7 +1963,7 @@ pub(crate) mod ffi {
 
     #[unsafe(no_mangle)]
     pub extern "C" fn slint_solve_flexbox_layout(
-        data: &FlexBoxLayoutData,
+        data: &FlexboxLayoutData,
         repeater_indices: Slice<u32>,
         result: &mut SharedVector<Coord>,
     ) {
@@ -1971,10 +1971,10 @@ pub(crate) mod ffi {
     }
 
     #[unsafe(no_mangle)]
-    /// Return LayoutInfo for a FlexBoxLayout with runtime direction support.
+    /// Return LayoutInfo for a FlexboxLayout with runtime direction support.
     pub extern "C" fn slint_flexbox_layout_info(
-        cells_h: Slice<FlexBoxLayoutItemInfo>,
-        cells_v: Slice<FlexBoxLayoutItemInfo>,
+        cells_h: Slice<FlexboxLayoutItemInfo>,
+        cells_v: Slice<FlexboxLayoutItemInfo>,
         spacing_h: Coord,
         spacing_v: Coord,
         padding_h: &Padding,

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -867,13 +867,13 @@ pub trait RepeatedItemTree:
         crate::layout::LayoutItemInfo::default()
     }
 
-    /// Returns what's needed to perform a flexbox layout if this ItemTree is in a FlexBoxLayout.
+    /// Returns what's needed to perform a flexbox layout if this ItemTree is in a FlexboxLayout.
     /// Includes flex-specific properties (flex-grow, flex-shrink, flex-basis, align-self, order).
     fn flexbox_layout_item_info(
         self: Pin<&Self>,
         orientation: Orientation,
         child_index: Option<usize>,
-    ) -> crate::layout::FlexBoxLayoutItemInfo {
+    ) -> crate::layout::FlexboxLayoutItemInfo {
         self.layout_item_info(orientation, child_index).into()
     }
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -211,7 +211,7 @@ impl RepeatedItemTree for ErasedItemTreeBox {
         self: Pin<&Self>,
         o: Orientation,
         child_index: Option<usize>,
-    ) -> i_slint_core::layout::FlexBoxLayoutItemInfo {
+    ) -> i_slint_core::layout::FlexboxLayoutItemInfo {
         generativity::make_guard!(guard);
         let s = self.unerase(guard);
         let instance_ref = s.borrow_instance();
@@ -237,7 +237,7 @@ impl RepeatedItemTree for ErasedItemTreeBox {
             .unwrap_or(i_slint_core::items::FlexAlignSelf::Auto);
         let flex_order = load_f32("flex-order") as i32;
 
-        i_slint_core::layout::FlexBoxLayoutItemInfo {
+        i_slint_core::layout::FlexboxLayoutItemInfo {
             constraint: self.layout_item_info(o, child_index).constraint,
             flex_grow,
             flex_shrink,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -623,10 +623,10 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 panic!("invalid layout organized data cache")
             }
         }
-        Expression::SolveFlexBoxLayout(layout) => {
+        Expression::SolveFlexboxLayout(layout) => {
             crate::eval_layout::solve_flexbox_layout(layout, local_context)
         }
-        Expression::ComputeFlexBoxLayoutInfo(layout, orientation) => {
+        Expression::ComputeFlexboxLayoutInfo(layout, orientation) => {
             crate::eval_layout::compute_flexbox_layout_info(layout, *orientation, local_context)
         }
         Expression::MinMax { ty: _, op, lhs, rhs } => {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -180,7 +180,7 @@ pub(crate) fn solve_box_layout(
 }
 
 pub(crate) fn solve_flexbox_layout(
-    flexbox_layout: &i_slint_compiler::layout::FlexBoxLayout,
+    flexbox_layout: &i_slint_compiler::layout::FlexboxLayout,
     local_context: &mut EvalLocalContext,
 ) -> Value {
     let component = local_context.component_instance;
@@ -224,7 +224,7 @@ pub(crate) fn solve_flexbox_layout(
         padding_and_spacing(&flexbox_layout.geometry, Orientation::Vertical, &expr_eval);
 
     core_layout::solve_flexbox_layout(
-        &core_layout::FlexBoxLayoutData {
+        &core_layout::FlexboxLayoutData {
             width: width_ref.as_ref().map(&expr_eval).unwrap_or(0.),
             height: height_ref.as_ref().map(&expr_eval).unwrap_or(0.),
             spacing_h,
@@ -245,7 +245,7 @@ pub(crate) fn solve_flexbox_layout(
 }
 
 fn flexbox_layout_direction(
-    flexbox_layout: &i_slint_compiler::layout::FlexBoxLayout,
+    flexbox_layout: &i_slint_compiler::layout::FlexboxLayout,
     local_context: &EvalLocalContext,
 ) -> FlexDirection {
     flexbox_layout
@@ -271,7 +271,7 @@ fn flexbox_layout_direction(
 }
 
 pub(crate) fn compute_flexbox_layout_info(
-    flexbox_layout: &i_slint_compiler::layout::FlexBoxLayout,
+    flexbox_layout: &i_slint_compiler::layout::FlexboxLayout,
     orientation: Orientation,
     local_context: &mut EvalLocalContext,
 ) -> Value {
@@ -352,11 +352,11 @@ pub(crate) fn compute_flexbox_layout_info(
 }
 
 fn flexbox_layout_data(
-    flexbox_layout: &i_slint_compiler::layout::FlexBoxLayout,
+    flexbox_layout: &i_slint_compiler::layout::FlexboxLayout,
     component: InstanceRef,
     expr_eval: &impl Fn(&NamedReference) -> f32,
     _local_context: &mut EvalLocalContext,
-) -> (Vec<core_layout::FlexBoxLayoutItemInfo>, Vec<core_layout::FlexBoxLayoutItemInfo>, Vec<u32>) {
+) -> (Vec<core_layout::FlexboxLayoutItemInfo>, Vec<core_layout::FlexboxLayoutItemInfo>, Vec<u32>) {
     let window_adapter = component.window_adapter();
     let mut cells_h = Vec::with_capacity(flexbox_layout.elems.len());
     let mut cells_v = Vec::with_capacity(flexbox_layout.elems.len());
@@ -412,7 +412,7 @@ fn flexbox_layout_data(
                 })
                 .unwrap_or(i_slint_core::items::FlexAlignSelf::default());
             let order = layout_elem.order.as_ref().map(&expr_eval).unwrap_or(0.0) as i32;
-            let item_info = core_layout::FlexBoxLayoutItemInfo {
+            let item_info = core_layout::FlexboxLayoutItemInfo {
                 constraint: layout_info_h,
                 flex_grow,
                 flex_shrink,
@@ -421,7 +421,7 @@ fn flexbox_layout_data(
                 flex_order: order,
             };
             cells_h.push(item_info);
-            cells_v.push(core_layout::FlexBoxLayoutItemInfo {
+            cells_v.push(core_layout::FlexboxLayoutItemInfo {
                 constraint: layout_info_v,
                 flex_grow,
                 flex_shrink,

--- a/tests/cases/layout/empty_layout.slint
+++ b/tests/cases/layout/empty_layout.slint
@@ -23,8 +23,8 @@ export component TestCase inherits Window {
     }
     empty7 := Rectangle { GridLayout { } }
     empty8 := Rectangle { GridLayout { spacing: 3px; padding: 5px; } }
-    empty9 := Rectangle { FlexBoxLayout { } }
-    empty10 := Rectangle { FlexBoxLayout { spacing: 5px; padding: 10px; } }
+    empty9 := Rectangle { FlexboxLayout { } }
+    empty10 := Rectangle { FlexboxLayout { spacing: 5px; padding: 10px; } }
 
     out property <bool> t1: empty1.min-height == 0 && empty1.min-width == 0 && empty1.preferred-height == 0 && empty1.preferred-width == 0 && empty1.max-height > 10000px && empty1.max-width == 0;
     out property <bool> t2: empty2.min-height == 4px && empty2.min-width == 4px && empty2.preferred-height == 4px && empty2.preferred-width == 4px && empty2.max-height == 4px && empty2.max-width > 100000px;

--- a/tests/cases/layout/flexbox-inside-h-inside-v.slint
+++ b/tests/cases/layout/flexbox-inside-h-inside-v.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout inside another layout
+// Test FlexboxLayout inside another layout
 
 export component TestCase inherits Window {
     background: white;
@@ -12,7 +12,7 @@ export component TestCase inherits Window {
 
         HorizontalLayout {
 
-            FlexBoxLayout {
+            FlexboxLayout {
                 flex-direction: column;
                 spacing: 10px;
                 vertical-stretch: 0;

--- a/tests/cases/layout/flexbox-preferred-width.slint
+++ b/tests/cases/layout/flexbox-preferred-width.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout that's not in a layout, like in the printer demo
+// Test FlexboxLayout that's not in a layout, like in the printer demo
 
 export component TestCase inherits Window {
 
     min-width: 300px;
     min-height: 300px;
 
-    flex := FlexBoxLayout {
+    flex := FlexboxLayout {
         align-content: start;  // Don't stretch rows to fill the window height
         spacing: 10px;
         vertical-stretch: 0;

--- a/tests/cases/layout/flexbox_align_content.slint
+++ b/tests/cases/layout/flexbox_align_content.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout align-content property for row and column directions
+// Test FlexboxLayout align-content property for row and column directions
 // align-content controls how flex lines are distributed along the cross axis.
 
 component VisibleRect inherits Rectangle {
@@ -15,7 +15,7 @@ component VisibleRect inherits Rectangle {
 component TestAlignContentStartRow inherits VisibleRect {
     width: 200px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: start;
         spacing: 5px;
 
@@ -49,7 +49,7 @@ component TestAlignContentEndRow inherits VisibleRect {
     width: 200px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: end;
         spacing: 5px;
 
@@ -83,7 +83,7 @@ component TestAlignContentCenterRow inherits VisibleRect {
     width: 200px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: center;
         spacing: 5px;
 
@@ -119,7 +119,7 @@ component TestAlignContentStretchRow inherits VisibleRect {
     width: 200px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: stretch;
         spacing: 5px;
 
@@ -154,7 +154,7 @@ component TestAlignContentStartCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: start;
         spacing: 5px;
@@ -189,7 +189,7 @@ component TestAlignContentEndCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: end;
         spacing: 5px;
@@ -224,7 +224,7 @@ component TestAlignContentCenterCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: center;
         spacing: 5px;
@@ -261,7 +261,7 @@ component TestAlignContentStretchCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: stretch;
         spacing: 5px;
@@ -296,7 +296,7 @@ component TestAlignContentStretchCol inherits VisibleRect {
 component TestAlignContentSpaceBetweenRow inherits VisibleRect {
     width: 200px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: space-between;
 
         r1 := Rectangle {
@@ -326,7 +326,7 @@ component TestAlignContentSpaceBetweenRow inherits VisibleRect {
 component TestAlignContentSpaceAroundRow inherits VisibleRect {
     width: 200px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: space-around;
 
         r1 := Rectangle {
@@ -355,7 +355,7 @@ component TestAlignContentSpaceAroundRow inherits VisibleRect {
 component TestAlignContentSpaceEvenlyRow inherits VisibleRect {
     width: 200px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: space-evenly;
 
         r1 := Rectangle {
@@ -388,7 +388,7 @@ component TestAlignContentSpaceEvenlyRow inherits VisibleRect {
 component TestAlignContentSpaceBetweenCol inherits VisibleRect {
     width: 200px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: space-between;
 
@@ -419,7 +419,7 @@ component TestAlignContentSpaceBetweenCol inherits VisibleRect {
 component TestAlignContentSpaceAroundCol inherits VisibleRect {
     width: 200px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: space-around;
 
@@ -449,7 +449,7 @@ component TestAlignContentSpaceAroundCol inherits VisibleRect {
 component TestAlignContentSpaceEvenlyCol inherits VisibleRect {
     width: 200px;
     height: 200px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: space-evenly;
 

--- a/tests/cases/layout/flexbox_align_items.slint
+++ b/tests/cases/layout/flexbox_align_items.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout align-items property for row and column directions.
+// Test FlexboxLayout align-items property for row and column directions.
 // align-items controls how individual items are aligned along the cross axis
 // within each flex line.
 
@@ -17,7 +17,7 @@ component TestAlignItemsStartRow inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: start;
         align-items: start;
 
@@ -50,7 +50,7 @@ component TestAlignItemsEndRow inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: start;
         align-items: end;
 
@@ -83,7 +83,7 @@ component TestAlignItemsCenterRow inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: start;
         align-items: center;
 
@@ -116,7 +116,7 @@ component TestAlignItemsStretchRow inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         // align-content: stretch (default) — single line fills container height
         // align-items: stretch (default) — items stretch to line height
         r1 := Rectangle {
@@ -147,7 +147,7 @@ component TestAlignItemsStartColumn inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: start;
         align-items: start;
@@ -181,7 +181,7 @@ component TestAlignItemsEndColumn inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: start;
         align-items: end;
@@ -215,7 +215,7 @@ component TestAlignItemsCenterColumn inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         align-content: start;
         align-items: center;
@@ -249,7 +249,7 @@ component TestAlignItemsStretchColumn inherits VisibleRect {
     width: 300px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         // align-content: stretch (default) — single column fills container width
         // align-items: stretch (default) — items stretch to column width

--- a/tests/cases/layout/flexbox_align_self.slint
+++ b/tests/cases/layout/flexbox_align_self.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout align-self per-item property
+// Test FlexboxLayout align-self per-item property
 
 // Test 1: align-self overrides container align-items
 // Container has align-items: start, but r2 overrides to end
 component TestAlignSelfOverride inherits Rectangle {
     width: 300px;
     height: 100px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         align-items: start;
 
@@ -42,7 +42,7 @@ component TestAlignSelfOverride inherits Rectangle {
 component TestAlignSelfCenter inherits Rectangle {
     width: 300px;
     height: 100px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         align-items: start;
 
@@ -70,7 +70,7 @@ component TestAlignSelfCenter inherits Rectangle {
 component TestAlignSelfStretch inherits Rectangle {
     width: 300px;
     height: 100px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         align-items: start;
 
@@ -97,7 +97,7 @@ component TestAlignSelfStretch inherits Rectangle {
 component TestAlignSelfAuto inherits Rectangle {
     width: 300px;
     height: 100px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         align-items: end;
 

--- a/tests/cases/layout/flexbox_alignment.slint
+++ b/tests/cases/layout/flexbox_alignment.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout alignment (justify-content) property
+// Test FlexboxLayout alignment (justify-content) property
 
 export component TestCase inherits Window {
     width: 300px;
@@ -12,7 +12,7 @@ export component TestCase inherits Window {
         y: 0px;
         width: 300px;
         height: 100px;
-        FlexBoxLayout {
+        FlexboxLayout {
             alignment: center;
             r1 := Rectangle {
                 width: 50px;
@@ -33,7 +33,7 @@ export component TestCase inherits Window {
         y: 100px;
         width: 300px;
         height: 100px;
-        FlexBoxLayout {
+        FlexboxLayout {
             alignment: end;
             r3 := Rectangle {
                 width: 50px;
@@ -54,7 +54,7 @@ export component TestCase inherits Window {
         y: 200px;
         width: 300px;
         height: 100px;
-        FlexBoxLayout {
+        FlexboxLayout {
             alignment: space-between;
             r5 := Rectangle {
                 width: 50px;
@@ -81,7 +81,7 @@ export component TestCase inherits Window {
         y: 300px;
         width: 300px;
         height: 100px;
-        FlexBoxLayout {
+        FlexboxLayout {
             alignment: space-around;
             r8 := Rectangle {
                 width: 50px;
@@ -102,7 +102,7 @@ export component TestCase inherits Window {
         y: 400px;
         width: 300px;
         height: 100px;
-        FlexBoxLayout {
+        FlexboxLayout {
             alignment: space-evenly;
             r10 := Rectangle {
                 width: 50px;

--- a/tests/cases/layout/flexbox_column_multiple_columns.slint
+++ b/tests/cases/layout/flexbox_column_multiple_columns.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout column direction with multiple columns (more than 2)
+// Test FlexboxLayout column direction with multiple columns (more than 2)
 
 export component TestCase inherits Window {
     width: 250px;
     height: 150px;
 
     // Multiple columns in column direction
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         spacing: 5px;
         padding: 0px;

--- a/tests/cases/layout/flexbox_column_reverse.slint
+++ b/tests/cases/layout/flexbox_column_reverse.slint
@@ -1,13 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with column-reverse direction
+// Test FlexboxLayout with column-reverse direction
 
 export component TestCase inherits Window {
     width: 300px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column-reverse;
         spacing: 10px;
 

--- a/tests/cases/layout/flexbox_column_spacing_and_padding.slint
+++ b/tests/cases/layout/flexbox_column_spacing_and_padding.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout column direction with spacing and padding
+// Test FlexboxLayout column direction with spacing and padding
 
 export component TestCase inherits Window {
     width: 200px;
     height: 200px;
 
     // Test spacing and padding in column direction
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         spacing: 8px;
         padding: 10px;

--- a/tests/cases/layout/flexbox_column_varying_widths.slint
+++ b/tests/cases/layout/flexbox_column_varying_widths.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout column direction with varying item widths
+// Test FlexboxLayout column direction with varying item widths
 
 export component TestCase inherits Window {
     width: 200px;
     height: 250px;
 
     // Items with varying widths and multiple columns
-    flex := FlexBoxLayout {
+    flex := FlexboxLayout {
         flex-direction: column;
         spacing: 5px;
         padding: 0px;

--- a/tests/cases/layout/flexbox_flex_grow.slint
+++ b/tests/cases/layout/flexbox_flex_grow.slint
@@ -1,13 +1,13 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout flex-grow, flex-shrink, and flex-basis per-item properties
+// Test FlexboxLayout flex-grow, flex-shrink, and flex-basis per-item properties
 
 // Test 1: flex-grow — items grow proportionally to fill extra space
 component TestFlexGrowRow inherits Rectangle {
     width: 300px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         r1 := Rectangle {
             flex-basis: 50px;
@@ -42,7 +42,7 @@ component TestFlexGrowRow inherits Rectangle {
 component TestFlexGrowColumn inherits Rectangle {
     width: 50px;
     height: 300px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         flex-wrap: no-wrap;
         r1 := Rectangle {
@@ -71,7 +71,7 @@ component TestFlexGrowColumn inherits Rectangle {
 component TestFlexShrinkRow inherits Rectangle {
     width: 200px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         r1 := Rectangle {
             flex-basis: 150px;
@@ -99,7 +99,7 @@ component TestFlexShrinkRow inherits Rectangle {
 component TestFlexBasis inherits Rectangle {
     width: 300px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         r1 := Rectangle {
             flex-basis: 80px;
@@ -123,7 +123,7 @@ component TestFlexBasis inherits Rectangle {
 component TestFlexDefaults inherits Rectangle {
     width: 300px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         r1 := Rectangle {
             preferred-width: 80px;

--- a/tests/cases/layout/flexbox_image.slint
+++ b/tests/cases/layout/flexbox_image.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with an Image child (height-for-width behavior).
+// Test FlexboxLayout with an Image child (height-for-width behavior).
 // This used to trigger a binding loop because the Image's vertical layout info
 // depends on its width (aspect ratio), creating a cross-axis dependency cycle.
 
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
     width: 400px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         r := Rectangle {
             width: 100px;
             height: 50px;

--- a/tests/cases/layout/flexbox_in_vertical_layout.slint
+++ b/tests/cases/layout/flexbox_in_vertical_layout.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test that items below a FlexBoxLayout move down when the width decreases
+// Test that items below a FlexboxLayout move down when the width decreases
 // i.e. even a VerticalLayout ends up having a "height for width" behavior
 
 export component TestCase inherits Window {
@@ -12,7 +12,7 @@ export component TestCase inherits Window {
     VerticalLayout {
         spacing: 0px;
 
-        FlexBoxLayout {
+        FlexboxLayout {
             spacing: 10px;
             vertical-stretch: 0;
 

--- a/tests/cases/layout/flexbox_min_width.slint
+++ b/tests/cases/layout/flexbox_min_width.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout respects min-width and max-width constraints
-// Note: FlexBoxLayout does NOT support horizontal-stretch (items use their preferred width)
+// Test FlexboxLayout respects min-width and max-width constraints
+// Note: FlexboxLayout does NOT support horizontal-stretch (items use their preferred width)
 
 export component TestCase inherits Window {
     width: 200px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         spacing: 5px;
         padding: 0px;
 

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -1,13 +1,13 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with multiple rows (more than 2)
+// Test FlexboxLayout with multiple rows (more than 2)
 
 export component TestCase inherits Window {
     width: 200px;
     height: 300px;
 
-    flex := FlexBoxLayout {
+    flex := FlexboxLayout {
         align-content: start;
         padding: 2px;
         spacing: 5px;

--- a/tests/cases/layout/flexbox_order.slint
+++ b/tests/cases/layout/flexbox_order.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout order per-item property
+// Test FlexboxLayout order per-item property
 
 // Test 1: order changes visual placement (row direction)
 // Items declared A, B, C but ordered C(flex-order:-1), A(0), B(1)
 component TestOrderRow inherits Rectangle {
     width: 300px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
 
         r_a := Rectangle {
@@ -42,7 +42,7 @@ component TestOrderRow inherits Rectangle {
 component TestOrderDefault inherits Rectangle {
     width: 300px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
 
         r1 := Rectangle {
@@ -73,7 +73,7 @@ component TestOrderDefault inherits Rectangle {
 component TestOrderColumn inherits Rectangle {
     width: 50px;
     height: 300px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         flex-wrap: no-wrap;
 

--- a/tests/cases/layout/flexbox_oversized.slint
+++ b/tests/cases/layout/flexbox_oversized.slint
@@ -1,14 +1,14 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with wide items
+// Test FlexboxLayout with wide items
 
 export component TestCase inherits Window {
     width: 150px;
     height: 200px;
 
     // Test with wide items (one per row)
-    FlexBoxLayout {
+    FlexboxLayout {
         spacing: 5px;
         align-content: start;
 

--- a/tests/cases/layout/flexbox_repeater.slint
+++ b/tests/cases/layout/flexbox_repeater.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with a for repeater
+// Test FlexboxLayout with a for repeater
 
 export component TestCase inherits Window {
     width: 300px;
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
 
     property <[int]> items: [1, 2, 3];
 
-    FlexBoxLayout {
+    FlexboxLayout {
         spacing: 10px;
         padding: 5px;
         flex-direction: row;

--- a/tests/cases/layout/flexbox_repeater_column.slint
+++ b/tests/cases/layout/flexbox_repeater_column.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout column direction with a for repeater
+// Test FlexboxLayout column direction with a for repeater
 
 export component TestCase inherits Window {
     width: 200px;
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
 
     property <[int]> items: [1, 2, 3];
 
-    FlexBoxLayout {
+    FlexboxLayout {
         spacing: 10px;
         padding: 5px;
         flex-direction: column;

--- a/tests/cases/layout/flexbox_repeater_flex_props.slint
+++ b/tests/cases/layout/flexbox_repeater_flex_props.slint
@@ -9,7 +9,7 @@
 component TestFlexGrowRepeater inherits Rectangle {
     width: 300px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
 
         for item in [1]: Rectangle {
@@ -33,7 +33,7 @@ component TestFlexGrowRepeater inherits Rectangle {
 component TestOrderRepeater inherits Rectangle {
     width: 200px;
     height: 50px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
 
         r_static := Rectangle {
@@ -57,7 +57,7 @@ component TestOrderRepeater inherits Rectangle {
 component TestAlignSelfWithRepeater inherits Rectangle {
     width: 300px;
     height: 100px;
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
         align-items: start;
 

--- a/tests/cases/layout/flexbox_repeater_mixed.slint
+++ b/tests/cases/layout/flexbox_repeater_mixed.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with mixed static and repeated elements
+// Test FlexboxLayout with mixed static and repeated elements
 
 export component TestCase inherits Window {
     width: 400px;
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
 
     property <[int]> items: [1, 2];
 
-    FlexBoxLayout {
+    FlexboxLayout {
         spacing: 10px;
         padding: 5px;
         flex-direction: row;

--- a/tests/cases/layout/flexbox_row_reverse.slint
+++ b/tests/cases/layout/flexbox_row_reverse.slint
@@ -1,13 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with row-reverse direction
+// Test FlexboxLayout with row-reverse direction
 
 export component TestCase inherits Window {
     width: 300px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: row-reverse;
         spacing: 10px;
 

--- a/tests/cases/layout/flexbox_runtime_direction.slint
+++ b/tests/cases/layout/flexbox_runtime_direction.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with runtime direction change
+// Test FlexboxLayout with runtime direction change
 
 export component TestCase inherits Window {
     width: 300px;
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
 
     in-out property <bool> use-column: false;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: use-column ? FlexDirection.column : FlexDirection.row;
         spacing: 10px;
 

--- a/tests/cases/layout/flexbox_spacing_and_padding.slint
+++ b/tests/cases/layout/flexbox_spacing_and_padding.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with wrapping and spacing
+// Test FlexboxLayout with wrapping and spacing
 
 export component TestCase inherits Window {
     width: 200px;
@@ -13,7 +13,7 @@ export component TestCase inherits Window {
         height: 200px;
         border-color: black;
         border-width: 1px;
-        FlexBoxLayout {
+        FlexboxLayout {
             align-content: start;
             spacing: 5px;
             padding: 2px;
@@ -45,7 +45,7 @@ export component TestCase inherits Window {
         border-color: black;
         border-width: 1px;
 
-        FlexBoxLayout {
+        FlexboxLayout {
             align-content: start;
             spacing-vertical: 50px;
             spacing-horizontal: 10px;

--- a/tests/cases/layout/flexbox_varying_heights.slint
+++ b/tests/cases/layout/flexbox_varying_heights.slint
@@ -1,13 +1,13 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout with varying item heights (row height should be max of items in row)
+// Test FlexboxLayout with varying item heights (row height should be max of items in row)
 
 export component TestCase inherits Window {
     width: 250px;
     height: 200px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         align-content: start;
         spacing: 10px;
 

--- a/tests/cases/layout/flexbox_wrap.slint
+++ b/tests/cases/layout/flexbox_wrap.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexBoxLayout flex-wrap property.
+// Test FlexboxLayout flex-wrap property.
 // flex-wrap controls whether flex items wrap onto multiple lines.
 
 component VisibleRect inherits Rectangle {
@@ -16,7 +16,7 @@ component TestWrapRow inherits VisibleRect {
     width: 130px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: wrap;
         align-content: start;
 
@@ -49,7 +49,7 @@ component TestNoWrapRow inherits VisibleRect {
     width: 130px;
     height: 300px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: no-wrap;
 
         r1 := Rectangle {
@@ -81,7 +81,7 @@ component TestWrapReverseRow inherits VisibleRect {
     width: 130px;
     height: 80px;  // exactly 2 lines × 40px, so alignment doesn't affect positions
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-wrap: wrap-reverse;
 
         r1 := Rectangle {
@@ -115,7 +115,7 @@ component TestNoWrapColumn inherits VisibleRect {
     width: 300px;
     height: 130px;
 
-    FlexBoxLayout {
+    FlexboxLayout {
         flex-direction: column;
         flex-wrap: no-wrap;
 
@@ -151,7 +151,7 @@ component TestNoWrapColumnLayoutInfo inherits VisibleRect {
     width: 400px;
     height: 300px;
 
-    flex := FlexBoxLayout {
+    flex := FlexboxLayout {
         flex-direction: column;
         flex-wrap: no-wrap;
 

--- a/ui-libraries/material/docs/src/utils/link-data.json
+++ b/ui-libraries/material/docs/src/utils/link-data.json
@@ -47,7 +47,7 @@
     "Expressions": {
         "href": "guide/language/coding/expressions-and-statements/"
     },
-    "FlexBoxLayout": {
+    "FlexboxLayout": {
         "href": "reference/layouts/flexboxlayout/"
     },
     "float": {


### PR DESCRIPTION
and LayoutKind::FlexBox -> LayoutKind::FlexboxLayout
for consistency with the other enum values in LayoutKind

In internal/backends/testing/slint_systest.proto, move
the comment about Unknown to the AccessibleRole where it
initially belonged (commit 2cad49eb9b32c inserted
enum LayoutKind between the comment and the AccessibleRole enum)

Fixes #11152