### PR TITLE
Add position-independent diagnostic syntax to syntax tests

### DIFF
--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -123,8 +123,7 @@ fn extract_expected_diags(source: &str) -> Vec<ExpectedDiagnostic> {
 
     // Position-independent diagnostics: `//-error{message}` or `//-warning{message}`
     // matches by message and level only, regardless of source location.
-    let pos_independent_re =
-        regex::Regex::new(r"\n *//-(error|warning|note)\{([^\n]*)\}").unwrap();
+    let pos_independent_re = regex::Regex::new(r"\n *//-(error|warning|note)\{([^\n]*)\}").unwrap();
     for m in pos_independent_re.captures_iter(source) {
         let level = match m.get(1).unwrap().as_str() {
             "warning" => DiagnosticLevel::Warning,


### PR DESCRIPTION
## Summary

- Add `//-error{message}` and `//-warning{message}` syntax for matching diagnostics by message and level only, ignoring source position
- Useful for layout-related binding loop warnings where the diagnostic position varies across platforms due to analysis traversal order differences
- Includes self-tests verifying the new syntax works (positive match, wrong message, wrong level)

This is needed by #10552 (binding loop detection for callbacks), where several syntax tests fail on CI because layout binding loop warnings are emitted at platform-dependent source locations.

## Test plan

- [x] `self_test` passes — 3 new assertions (positive, wrong message, wrong level)
- [x] `syntax_tests` passes — no regressions in existing tests
- [ ] CI passes