### PR TITLE
compiler: propagate interface API to derived components' public API

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -576,6 +576,8 @@ pub struct PropertyDeclaration {
     pub visibility: PropertyVisibility,
     /// For function or callback: whether it is declared as `pure` (None for private function for which this has to be deduced)
     pub pure: Option<bool>,
+    /// Whether this declaration is part of an interface and therefore exposed in the native API language
+    pub is_from_interface: bool,
 }
 
 impl PropertyDeclaration {
@@ -1230,6 +1232,7 @@ impl Element {
                     property_type: prop_type,
                     node: Some(prop_decl.clone().into()),
                     visibility,
+                    is_from_interface: base_type == ElementType::Interface,
                     ..Default::default()
                 },
             );
@@ -1449,6 +1452,7 @@ impl Element {
                 node: Some(func.clone().into()),
                 visibility,
                 pure,
+                is_from_interface: base_type == ElementType::Interface,
                 ..Default::default()
             };
 
@@ -1764,7 +1768,11 @@ impl Element {
         }
 
         interfaces::apply_default_property_values(&r, &implemented_interface);
-        interfaces::validate_function_implementations(&r.borrow(), &implemented_interface, diag);
+        interfaces::validate_function_implementations(
+            &mut r.borrow_mut(),
+            &implemented_interface,
+            diag,
+        );
 
         r
     }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -5,6 +5,7 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 use std::fmt::Display;
 use std::rc::Rc;
 
@@ -258,7 +259,11 @@ fn apply_interface_property_declaration(
     if lookup_result.property_type != Type::Invalid {
         match property_matches_interface(&lookup_result, prop_decl) {
             Ok(()) => {
-                // The property already exists and matches the interface declaration, so we don't need to do anything.
+                // The property already exists and matches the interface declaration. Ensure `is_from_interface` is set
+                // so it is exposed in the public API. Don't insert a new local declaration if the property comes from
+                // a native/builtin base type — that would shadow the native property and break its behavior.
+                let insert_if_missing = matches!(e.base_type, ElementType::Component(..));
+                set_is_from_interface(e, unresolved_prop_name, prop_decl, insert_if_missing);
                 return;
             }
             Err(error) => {
@@ -289,7 +294,7 @@ fn apply_interface_property_declaration(
         return;
     }
 
-    e.property_declarations.insert(unresolved_prop_name.clone(), prop_decl.clone());
+    set_is_from_interface(e, unresolved_prop_name, prop_decl, true);
 }
 
 /// Apply default property values defined in the interface to the element.
@@ -337,8 +342,9 @@ pub(super) fn apply_default_property_values(
 }
 
 /// Validate that the functions declared in the interface are correctly implemented in the element. Emits diagnostics if not.
+/// Also marks validated functions with `is_from_interface` so they are exposed in the public API.
 pub(super) fn validate_function_implementations(
-    e: &Element,
+    e: &mut Element,
     implemented_interface: &Option<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
@@ -454,6 +460,34 @@ pub(super) fn validate_function_implementations(
                     function_impl.return_type,
                 ),
             );
+        }
+
+        let insert_if_missing = matches!(e.base_type, ElementType::Component(..))
+            || found_function.is_local_to_component;
+        set_is_from_interface(e, function_name, function_property_decl, insert_if_missing);
+    }
+}
+
+/// Set the `is_from_interface` flag for the given property declaration on the element.
+/// When `insert_if_missing` is true and no local declaration exists, a new one is inserted.
+/// When false, only existing local declarations are updated (to avoid shadowing base type properties).
+/// This is used to mark properties as being from an interface so that they are exposed in the public API.
+fn set_is_from_interface(
+    e: &mut Element,
+    name: &SmolStr,
+    property_decl: &PropertyDeclaration,
+    insert_if_missing: bool,
+) {
+    match e.property_declarations.entry(name.clone()) {
+        Entry::Occupied(mut entry) => {
+            entry.get_mut().is_from_interface = true;
+        }
+        Entry::Vacant(entry) => {
+            if insert_if_missing {
+                let mut decl = property_decl.clone();
+                decl.is_from_interface = true;
+                entry.insert(decl);
+            }
         }
     }
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -137,6 +137,7 @@ pub async fn run_passes(
     });
 
     inlining::inline(doc, inlining::InlineSelection::InlineOnlyRequiredComponents, diag);
+    check_public_api::expose_inherited_interface_properties(doc);
     collect_subcomponents::collect_subcomponents(doc);
 
     for root_component in doc.exported_roots() {
@@ -194,6 +195,7 @@ pub async fn run_passes(
 
     if type_loader.compiler_config.inline_all_elements {
         inlining::inline(doc, inlining::InlineSelection::InlineAllComponents, diag);
+        check_public_api::expose_inherited_interface_properties(doc);
         doc.used_types.borrow_mut().sub_components.clear();
     }
 

--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -115,3 +115,207 @@ fn check_public_api_component(root_component: &Rc<Component>, diag: &mut BuildDi
         }
     });
 }
+
+/// After inlining, interface API inherited from base components may have been added to exported roots with
+/// `is_from_interface` set but `expose_in_public_api` still false. This function marks them for the public API.
+pub fn expose_inherited_interface_properties(doc: &Document) {
+    for c in doc.exported_roots() {
+        let mut root_elem = c.root_element.borrow_mut();
+        let root_elem = &mut *root_elem;
+        let mut pa = root_elem.property_analysis.borrow_mut();
+        for (n, d) in root_elem.property_declarations.iter_mut() {
+            if d.is_from_interface
+                && !d.expose_in_public_api
+                && d.property_type.ok_for_public_api()
+                && d.visibility != PropertyVisibility::Private
+            {
+                d.expose_in_public_api = true;
+                if d.visibility != PropertyVisibility::Output {
+                    pa.entry(n.clone()).or_default().is_set = true;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    /// Verify that when a  component implements an interface, the exported component exposes only
+    /// the interface API (properties, callbacks, functions) and not other non-interface properties
+    /// from the base.
+    fn component_exposes_only_interface_api_impl(slint: &str) {
+        let mut compiler_config =
+            crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        compiler_config.enable_experimental = true;
+        compiler_config.style = Some("fluent".into());
+        let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+        test_diags.enable_experimental = true;
+        let doc_node =
+            crate::parser::parse(slint.into(), Some(std::path::Path::new("TEST")), &mut test_diags);
+        let (doc, diag, _) =
+            spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+        assert!(!diag.has_errors(), "compile errors: {:#?}", diag.to_string_vec());
+
+        let cu = crate::llr::lower_to_item_tree::lower_to_item_tree(
+            &doc,
+            &crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter),
+        );
+        assert_eq!(cu.public_components.len(), 1);
+        let props: Vec<&str> =
+            cu.public_components[0].public_properties.iter().map(|p| p.name.as_str()).collect();
+
+        // Interface properties/callbacks/functions must be exposed
+        assert!(
+            props.contains(&"text"),
+            "interface property 'text' should be in public API, got: {props:?}"
+        );
+        assert!(
+            props.contains(&"enabled"),
+            "interface property 'enabled' should be in public API, got: {props:?}"
+        );
+        assert!(
+            props.contains(&"checked"),
+            "interface callback 'checked' should be in public API, got: {props:?}"
+        );
+        assert!(
+            props.contains(&"length"),
+            "interface function 'length' should be in public API, got: {props:?}"
+        );
+
+        // TestCase's own public property must be exposed
+        assert!(props.contains(&"test"), "'test' should be in public API, got: {props:?}");
+        assert!(
+            props.contains(&"test-case-callback"),
+            "'test-case-callback' should be in public API, got: {props:?}"
+        );
+        assert!(
+            props.contains(&"test-case-function"),
+            "'test-case-function' should be in public API, got: {props:?}"
+        );
+
+        // Non-interface properties from Base must NOT be exposed
+        assert!(
+            !props.contains(&"base-unrelated-property"),
+            "'base-unrelated-property' should NOT be in public API, got: {props:?}"
+        );
+        assert!(
+            !props.contains(&"base-unrelated-callback"),
+            "'base-unrelated-callback' should NOT be in public API, got: {props:?}"
+        );
+        assert!(
+            !props.contains(&"base-unrelated-function"),
+            "'base-unrelated-function' should NOT be in public API, got: {props:?}"
+        );
+    }
+
+    #[test]
+    fn derived_component_exposes_only_interface_api() {
+        let slint = r#"
+interface MyInterface {
+    in-out property <string> text: "Hello";
+    out property <bool> enabled: true;
+    public pure function length(text: string) -> int;
+    callback checked();
+}
+
+component Base implements MyInterface {
+    public pure function length(text: string) -> int {
+        text.character-count
+    }
+    out property <int> base-unrelated-property: 42;
+    callback base-unrelated-callback();
+    public pure function base-unrelated-function() -> int {
+        42
+    }
+}
+
+export component TestCase inherits Base {
+    out property <bool> test: true;
+    callback test-case-callback();
+    public pure function test-case-function() -> int {
+        42
+    }
+}
+"#;
+
+        component_exposes_only_interface_api_impl(slint);
+    }
+
+    #[test]
+    fn derived_component_with_implementation_exposes_only_interface_api() {
+        let slint = r#"
+interface MyInterface {
+    in-out property <string> text: "Hello";
+    out property <bool> enabled: true;
+    public pure function length(text: string) -> int;
+    callback checked();
+}
+
+component Impl {
+    in-out property <string> text: "Hello";
+    out property <bool> enabled: true;
+    public pure function length(text: string) -> int {
+        text.character-count
+    }
+    callback checked();
+
+    out property <int> base-unrelated-property: 42;
+    callback base-unrelated-callback();
+    public pure function base-unrelated-function() -> int {
+        42
+    }
+
+    @children
+}
+
+component Base implements MyInterface inherits Impl {
+}
+
+export component TestCase inherits Base {
+    out property <bool> test: true;
+    callback test-case-callback();
+    public pure function test-case-function() -> int {
+        42
+    }
+}
+"#;
+
+        component_exposes_only_interface_api_impl(slint);
+    }
+
+    #[test]
+    fn component_exposes_only_interface_api_via_uses() {
+        let slint = r#"
+interface MyInterface {
+    in-out property <string> text: "Hello";
+    out property <bool> enabled: true;
+    public pure function length(text: string) -> int;
+    callback checked();
+}
+
+component Base implements MyInterface {
+    public pure function length(text: string) -> int {
+        text.character-count
+    }
+    out property <int> base-unrelated-property: 42;
+    callback base-unrelated-callback();
+    public pure function base-unrelated-function() -> int {
+        42
+    }
+}
+
+export component TestCase uses { MyInterface from base } {
+    out property <bool> test: true;
+    callback test-case-callback();
+    public pure function test-case-function() -> int {
+        42
+    }
+
+    base := Base { }
+}
+"#;
+
+        component_exposes_only_interface_api_impl(slint);
+    }
+}

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -97,13 +97,17 @@ fn inline_element(
     let mut elem_mut = elem.borrow_mut();
     let priority_delta = 1 + elem_mut.inline_depth;
     elem_mut.base_type = inlined_component.root_element.borrow().base_type.clone();
-    elem_mut.property_declarations.extend(
-        inlined_component.root_element.borrow().property_declarations.iter().map(|(name, decl)| {
-            let mut decl = decl.clone();
+    for (name, decl) in inlined_component.root_element.borrow().property_declarations.iter() {
+        if elem_mut.property_declarations.get(name).is_some_and(|d| d.is_from_interface) {
+            continue;
+        }
+
+        let mut decl = decl.clone();
+        if !decl.is_from_interface {
             decl.expose_in_public_api = false;
-            (name.clone(), decl)
-        }),
-    );
+        }
+        elem_mut.property_declarations.insert(name.clone(), decl);
+    }
 
     for (p, a) in inlined_component.root_element.borrow().property_analysis.borrow().iter() {
         elem_mut.property_analysis.borrow_mut().entry(p.clone()).or_default().merge_with_base(a);

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1172,6 +1172,7 @@ fn lower_dialog_layout(
                                         )),
                                         visibility: PropertyVisibility::InOut,
                                         pure: None,
+                                        is_from_interface: false,
                                     });
                             }
                         }

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -541,6 +541,7 @@ impl Snapshotter {
                     is_alias: v.is_alias.as_ref().map(|a| a.snapshot(self)),
                     visibility: v.visibility,
                     pure: v.pure,
+                    is_from_interface: v.is_from_interface,
                 };
                 (k.clone(), decl)
             })

--- a/tests/cases/interfaces/derived_implements_defaults.slint
+++ b/tests/cases/interfaces/derived_implements_defaults.slint
@@ -29,32 +29,29 @@ export component TestCase inherits Base {
 /*
 ```rust
 let instance = TestCase::new().unwrap();
-// TODO: Interface properties aren't part of the public API
-// assert_eq!(instance.get_text(), "Hello");
-// assert_eq!(instance.get_enabled(), true);
-// assert_eq!(instance.get_precision(), 2);
-// assert_eq!(instance.get_confidence(), 0.5);
+assert_eq!(instance.get_text(), "Hello");
+assert_eq!(instance.get_enabled(), true);
+assert_eq!(instance.get_precision(), 2);
+assert_eq!(instance.get_confidence(), 0.5);
 assert!(instance.get_test());
 ```
 
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-// TODO: Interface properties aren't part of the public API
-// assert_eq(instance.get_text(), "Hello");
-// assert_eq(instance.get_enabled(), true);
-// assert_eq(instance.get_precision(), 2);
-// assert_eq(instance.get_confidence(), 0.5);
+assert_eq(instance.get_text(), "Hello");
+assert_eq(instance.get_enabled(), true);
+assert_eq(instance.get_precision(), 2);
+assert_eq(instance.get_confidence(), 0.5);
 assert(instance.get_test());
 ```
 
 ```js
 var instance = new slint.TestCase({});
-// TODO: Interface properties aren't part of the public API
-// assert.equal(instance.text, "Hello");
-// assert.equal(instance.enabled, true);
-// assert.equal(instance.precision, 2);
-// assert.equal(instance.confidence, 0.5);
+assert.equal(instance.text, "Hello");
+assert.equal(instance.enabled, true);
+assert.equal(instance.precision, 2);
+assert.equal(instance.confidence, 0.5);
 assert(instance.test);
 ```
 */

--- a/tests/cases/interfaces/derived_implicitly_implements.slint
+++ b/tests/cases/interfaces/derived_implicitly_implements.slint
@@ -41,32 +41,29 @@ export component TestCase implements InterfaceWithDefaults inherits Base {
 /*
 ```rust
 let instance = TestCase::new().unwrap();
-// TODO: Interface properties aren't part of the public API
-// assert_eq!(instance.get_text(), "Hello");
-// assert_eq!(instance.get_enabled(), true);
-// assert_eq!(instance.get_precision(), 2);
-// assert_eq!(instance.get_confidence(), 0.5);
+assert_eq!(instance.get_text(), "Hello");
+assert_eq!(instance.get_enabled(), true);
+assert_eq!(instance.get_precision(), 3);
+assert_eq!(instance.get_confidence(), 0.5);
 assert!(instance.get_test());
 ```
 
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-// TODO: Interface properties aren't part of the public API
-// assert_eq(instance.get_text(), "Hello");
-// assert_eq(instance.get_enabled(), true);
-// assert_eq(instance.get_precision(), 2);
-// assert_eq(instance.get_confidence(), 0.5);
+assert_eq(instance.get_text(), "Hello");
+assert_eq(instance.get_enabled(), true);
+assert_eq(instance.get_precision(), 3);
+assert_eq(instance.get_confidence(), 0.5);
 assert(instance.get_test());
 ```
 
 ```js
 var instance = new slint.TestCase({});
-// TODO: Interface properties aren't part of the public API
-// assert.equal(instance.text, "Hello");
-// assert.equal(instance.enabled, true);
-// assert.equal(instance.precision, 2);
-// assert.equal(instance.confidence, 0.5);
+assert.equal(instance.text, "Hello");
+assert.equal(instance.enabled, true);
+assert.equal(instance.precision, 3);
+assert.equal(instance.confidence, 0.5);
 assert(instance.test);
 ```
 */

--- a/tests/cases/interfaces/uses_exposes_api.slint
+++ b/tests/cases/interfaces/uses_exposes_api.slint
@@ -1,0 +1,44 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface InterfaceA {
+    in-out property <bool> a: true;
+}
+
+interface InterfaceB {
+    in-out property <bool> b: false;
+}
+
+component A implements InterfaceA inherits Rectangle { }
+
+component B implements InterfaceB inherits Rectangle { }
+
+component Base uses { InterfaceA from a-impl, InterfaceB from b-impl } {
+    a-impl := A { }
+
+    b-impl := B { }
+}
+
+export component TestCase inherits Base { }
+
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_a(), true);
+assert_eq!(instance.get_b(), false);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_a(), true);
+assert_eq(instance.get_b(), false);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.a, true);
+assert.equal(instance.b, false);
+```
+*/


### PR DESCRIPTION
This might not be desired behaviour. I found it odd that I could not access inherited interface API in my tests, but if that is how Slint is supposed to work then I'd be happy to just fix the tests that had TODO comments by adding required properties.

----

Add `is_from_interface` flag to `PropertyDeclaration` to track properties, callbacks, and functions originating from interfaces. During inlining, interface-sourced declarations preserve their `expose_in_public_api` status while non-interface base properties are correctly hidden. After inlining, `expose_inherited_interface_properties` marks any remaining interface declarations for public API exposure.

This ensures that when a base component implements an interface, derived exported components expose the interface API (but not other non-interface properties from the base).

Relates to #1870.
