### PR TITLE
Docs: some uniformization of the builtin element docs

### DIFF
--- a/docs/astro/src/content/docs/reference/elements/image.mdx
+++ b/docs/astro/src/content/docs/reference/elements/image.mdx
@@ -33,23 +33,24 @@ Image {
 </SlintProperty>
 
 ### horizontal-alignment
-<SlintProperty propName="horizontal-alignment" typeName="enum" enumName="ImageHorizontalAlignment" defaultValue='center'>
+<SlintProperty propName="horizontal-alignment" typeName="enum" enumName="ImageHorizontalAlignment" defaultValue="center">
 The horizontal alignment of the image within the element.
 </SlintProperty>
+
 ### vertical-alignment
-<SlintProperty propName="vertical-alignment" typeName="enum" enumName="ImageVerticalAlignment" defaultValue='center'>
+<SlintProperty propName="vertical-alignment" typeName="enum" enumName="ImageVerticalAlignment" defaultValue="center">
 The vertical alignment of the image within the element.
 </SlintProperty>
 
-
 ## Image Tiling
+
 ### horizontal-tiling
-<SlintProperty propName="horizontal-tiling" typeName="enum" enumName="ImageTiling" defaultValue='none'>
+<SlintProperty propName="horizontal-tiling" typeName="enum" enumName="ImageTiling" defaultValue="none">
 How the image is tiled horizontally.
 </SlintProperty>
 
 ### vertical-tiling
-<SlintProperty propName="vertical-tiling" typeName="enum" enumName="ImageTiling" defaultValue='none'>
+<SlintProperty propName="vertical-tiling" typeName="enum" enumName="ImageTiling" defaultValue="none">
 
 <CodeSnippetMD imagePath="/src/assets/generated/image-horizontal-repeat.png"  imageWidth="400" imageHeight="400"  imageAlt='image horizontal tiling repeat example'>
 ```slint
@@ -108,7 +109,7 @@ Image {
 </SlintProperty>
 
 ### image-fit
-<SlintProperty propName="image-fit" typeName="enum" defaultValue="`contain` when the `Image` element is part of a layout, `fill` otherwise" enumName="ImageFit">
+<SlintProperty propName="image-fit" typeName="enum" enumName="ImageFit" defaultValue="`contain` when the `Image` element is part of a layout, `fill` otherwise">
 <CodeSnippetMD imagePath="/src/assets/generated/image-fill.png"  imageWidth="300" imageHeight="200"  imageAlt='image fill example'>
 ```slint
 Image {
@@ -148,10 +149,10 @@ Image {
 }
 ```
 </CodeSnippetMD>
-
 </SlintProperty>
+
 ### image-rendering
-<SlintProperty propName="image-rendering" typeName="enum" enumName="ImageRendering" defaultValue='smooth'>
+<SlintProperty propName="image-rendering" typeName="enum" enumName="ImageRendering" defaultValue="smooth">
 
 <CodeSnippetMD imagePath="/src/assets/generated/image-smooth.png"  imageWidth="300" imageHeight="300"  imageAlt='image smooth example'>
 ```slint
@@ -172,7 +173,6 @@ Image {
 }
 ```
 </CodeSnippetMD>
-
 </SlintProperty>
 
 ## Source Properties
@@ -219,13 +219,15 @@ export component Example inherits Window {
 Use the <Link type="ImageType" label="`@image-url` macro" /> to specify the image's path.
 </SlintProperty>
 
-
 ### source-clip-x
 <SlintProperty propName="source-clip-x" typeName="int"/>
+
 ### source-clip-y
 <SlintProperty propName="source-clip-y" typeName="int"/>
+
 ### source-clip-width
 <SlintProperty propName="source-clip-width" typeName="int" defaultValue="source.width - source.clip-x"/>
+
 ### source-clip-height
 <SlintProperty propName="source-clip-height" typeName="int" defaultValue="source.height - source.clip-y"/>
 

--- a/docs/astro/src/content/docs/reference/elements/path.mdx
+++ b/docs/astro/src/content/docs/reference/elements/path.mdx
@@ -2,6 +2,7 @@
 title: Path
 description: Path element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
 The `Path` element allows rendering a generic shape, composed of different geometric commands. A path
@@ -27,7 +28,7 @@ The color for filling the shape of the path.
 </SlintProperty>
 
 ### fill-rule
-<SlintProperty propName="fill-rule" typeName="enum" enumName="FillRule" defaultValue='nonzero'>
+<SlintProperty propName="fill-rule" typeName="enum" enumName="FillRule" defaultValue="nonzero">
 The fill rule to use for the path.
 </SlintProperty>
 
@@ -42,12 +43,12 @@ The width of the outline.
 </SlintProperty>
 
 ### stroke-line-cap
-<SlintProperty propName="stroke-line-cap" typeName="enum" enumName="LineCap" defaultValue='butt'>
+<SlintProperty propName="stroke-line-cap" typeName="enum" enumName="LineCap" defaultValue="butt">
 The appearance of the ends of the path's outline.
 </SlintProperty>
 
 ### stroke-line-join
-<SlintProperty propName="stroke-line-join" typeName="enum" enumName="LineJoin" defaultValue='miter'>
+<SlintProperty propName="stroke-line-join" typeName="enum" enumName="LineJoin" defaultValue="miter">
 The appearance of the joins between segments of stroked paths.
 </SlintProperty>
 
@@ -240,7 +241,6 @@ The target x position of the line.
 <SlintProperty propName="y" typeName="float">
 The target y position of the line.
 </SlintProperty>
-
 
 ## CubicTo Sub-Element for `Path`
 

--- a/docs/astro/src/content/docs/reference/elements/rectangle.mdx
+++ b/docs/astro/src/content/docs/reference/elements/rectangle.mdx
@@ -2,6 +2,7 @@
 title: Rectangle
 description: Rectangle element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 
@@ -55,7 +56,6 @@ export component ExampleRectangle inherits Window {
 }
 ```
 </CodeSnippetMD>
-
 
 ## Properties
 

--- a/docs/astro/src/content/docs/reference/elements/styled-text.mdx
+++ b/docs/astro/src/content/docs/reference/elements/styled-text.mdx
@@ -1,6 +1,6 @@
 ---
-title: Styled Text
-description: Styled Text
+title: StyledText
+description: StyledText element api.
 ---
 
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
@@ -54,13 +54,12 @@ Other HTML tags  |
 ## Properties
 
 ### color
-
 <SlintProperty propName="color" typeName="brush" defaultValue="<depends on theme>">
 The color of the text.
 </SlintProperty>
 
 ### font-family
-<SlintProperty propName="font-family" typeName="string" >
+<SlintProperty propName="font-family" typeName="string">
 The name of the font family selected for rendering the text.
 
 :::note[Note]
@@ -80,12 +79,12 @@ The weight of the font. The values range from 100 (lightest) to 900 (thickest). 
 </SlintProperty>
 
 ### font-italic
-<SlintProperty propName="font-italic" typeName="bool" defaultValue="false" >
+<SlintProperty propName="font-italic" typeName="bool" defaultValue="false">
 Whether or not the font face should be drawn italicized or not.
 </SlintProperty>
 
 ### horizontal-alignment
-<SlintProperty propName="horizontal-alignment" typeName="enum" enumName='TextHorizontalAlignment' >
+<SlintProperty propName="horizontal-alignment" typeName="enum" enumName="TextHorizontalAlignment">
 The horizontal alignment of the text.
 </SlintProperty>
 
@@ -100,9 +99,8 @@ How the text should behave when it exceeds the available space.
 </SlintProperty>
 
 ### text
-<SlintProperty propName="text" typeName="styled-text" defaultValue='""' >
+<SlintProperty propName="text" typeName="styled-text" defaultValue="&quot;&quot;">
 The styled text rendered, using CommonMark markup with additional HTML tags for styling.
-
 </SlintProperty>
 
 ### vertical-alignment
@@ -120,21 +118,20 @@ How the text should wrap when it exceeds the available width.
 The brush used for the text outline.
 </SlintProperty>
 
-###  stroke-width
-<SlintProperty propName="stroke-width" typeName="length" >
+### stroke-width
+<SlintProperty propName="stroke-width" typeName="length">
 The width of the text outline. If the width is zero, then a hairline stroke (1 physical pixel) will be rendered.
 </SlintProperty>
 
-###  stroke-style
+### stroke-style
 <SlintProperty propName="stroke-style" typeName="enum" enumName="TextStrokeStyle">
 The style of the text outline.
 </SlintProperty>
 
-### link-clicked
-<SlintProperty propName="link-clicked" typeName="callback" >
-A callback that's invoked when a link in the text is clicked. The parameter contains the clicked link as a string.
-</SlintProperty>
+## Callbacks
 
+### link-clicked(link: string)
+A callback that's invoked when a link in the text is clicked. The parameter contains the clicked link as a string.
 
 ### link-color
 <SlintProperty propName="link-color" typeName="color" defaultValue="#00f">

--- a/docs/astro/src/content/docs/reference/elements/text.mdx
+++ b/docs/astro/src/content/docs/reference/elements/text.mdx
@@ -41,7 +41,6 @@ while the `preferred-width` and `preferred-height` remain unchanged.
 ## Properties
 
 ### color
-
 <SlintProperty propName="color" typeName="brush" defaultValue="<depends on theme>">
     The color of the text.
 
@@ -114,7 +113,7 @@ Text {
 </SlintProperty>
 
 ### font-italic
-<SlintProperty propName="font-italic" typeName="bool" defaultValue="false" >
+<SlintProperty propName="font-italic" typeName="bool" defaultValue="false">
 Whether or not the font face should be drawn italicized or not.
 
 <CodeSnippetMD imagePath="/src/assets/generated/text-font-italic.png" needsBackground="true" imageWidth="200" imageHeight="200" imageAlt='text font-family'>
@@ -130,7 +129,7 @@ Text {
 </SlintProperty>
 
 ### font-metrics
-<SlintProperty propName="font-metrics" typeName="struct" structName="FontMetrics">
+<SlintProperty propName="font-metrics" typeName="struct" structName="FontMetrics" propertyVisibility="out">
 The design metrics of the font scaled to the font pixel size used by the element.
 </SlintProperty>
 
@@ -214,12 +213,12 @@ Text {
 </CodeSnippetMD>
 </SlintProperty>
 
-###  stroke-width
-<SlintProperty propName="stroke-width" typeName="length" >
+### stroke-width
+<SlintProperty propName="stroke-width" typeName="length">
 The width of the text outline. If the width is zero, then a hairline stroke (1 physical pixel) will be rendered.
 </SlintProperty>
 
-###  stroke-style
+### stroke-style
 <SlintProperty propName="stroke-style" typeName="enum" enumName="TextStrokeStyle">
 <CodeSnippetMD imagePath="/src/assets/generated/text-stroke-style.png" needsBackground="true" imageWidth="200" imageHeight="200" imageAlt='stroke-style'>
 

--- a/docs/astro/src/content/docs/reference/gestures/flickable.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/flickable.mdx
@@ -2,6 +2,7 @@
 title: Flickable
 description: Flickable element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 import Link from '@slint/common-files/src/components/Link.astro';
@@ -93,15 +94,13 @@ The total width of the scrollable element.
 The total height of the scrollable element.
 </SlintProperty>
 
-
 ### viewport-x
-<SlintProperty propName="viewport-x" typeName="length">
+<SlintProperty propName="viewport-x" typeName="length" propertyVisibility="in-out">
 The position of the scrollable element relative to the `Flickable`. This is usually a negative value.
 </SlintProperty>
 
-
 ### viewport-y
-<SlintProperty propName="viewport-y" typeName="length">
+<SlintProperty propName="viewport-y" typeName="length" propertyVisibility="in-out">
 The position of the scrollable element relative to the `Flickable`. This is usually a negative value.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/gestures/scalerotategesturehandler.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/scalerotategesturehandler.mdx
@@ -2,8 +2,8 @@
 title: ScaleRotateGestureHandler
 description: ScaleRotateGestureHandler element api.
 ---
-import SlintProperty  from '@slint/common-files/src/components/SlintProperty.astro';
 
+import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
 Use the `ScaleRotateGestureHandler` to handle pinch and rotation gestures from trackpads or touchscreens.
 Recognition is limited to the element's geometry.
@@ -88,7 +88,15 @@ For trackpad gestures, this is the mouse cursor position.
 
 ## Callbacks
 
--   **`started()`**: Invoked when a gesture begins. Use this to capture the initial state you want to transform.
--   **`updated()`**: Invoked whenever the `scale`, `rotation`, or `center` changes during the gesture.
--   **`ended()`**: Invoked when the gesture completes normally (fingers lifted).
--   **`cancelled()`**: Invoked when the gesture is cancelled, for example when the handler is disabled during an active gesture or the window loses focus.
+### started()
+Invoked when a gesture begins. Use this to capture the initial state you want to transform.
+
+### updated()
+Invoked whenever the `scale`, `rotation`, or `center` changes during the gesture.
+
+### ended()
+Invoked when the gesture completes normally (fingers lifted).
+
+### cancelled()
+Invoked when the gesture is cancelled, for example when the handler is disabled during an active gesture or the window loses focus.
+

--- a/docs/astro/src/content/docs/reference/gestures/swipegesturehandler.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/swipegesturehandler.mdx
@@ -2,8 +2,8 @@
 title: SwipeGestureHandler
 description: SwipeGestureHandler element api.
 ---
-import SlintProperty  from '@slint/common-files/src/components/SlintProperty.astro';
 
+import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
 Use the `SwipeGestureHandler` to handle swipe gesture in some particular direction.
 Recognition is limited to the element's geometry.
@@ -77,29 +77,33 @@ The current pointer position.
 `true` while the gesture is recognized, false otherwise.
 </SlintProperty>
 
-
 ### Handle swipe directions properties
 
-#### handle-swipe-left
+### handle-swipe-left
 <SlintProperty propName="handle-swipe-left" typeName="bool" defaultValue="false"/>
 
-#### handle-swipe-right
+### handle-swipe-right
 <SlintProperty propName="handle-swipe-right" typeName="bool" defaultValue="false"/>
 
-#### handle-swipe-up
+### handle-swipe-up
 <SlintProperty propName="handle-swipe-up" typeName="bool" defaultValue="false"/>
 
-#### handle-swipe-down
+### handle-swipe-down
 <SlintProperty propName="handle-swipe-down" typeName="bool" defaultValue="false"/>
-
-
 
 ## Callbacks
 
--   **`moved()`**: Invoked when the pointer is moved.
--   **`swiped()`**: Invoked after the swipe gesture was recognized and the pointer was released.
--   **`cancelled()`**: Invoked when the swipe is cancelled programmatically or if the window loses focus.
+### moved()
+Invoked when the pointer is moved.
+
+### swiped()
+Invoked after the swipe gesture was recognized and the pointer was released.
+
+### cancelled()
+Invoked when the swipe is cancelled programmatically or if the window loses focus.
 
 ## Functions
 
--   **`cancel()`**: Cancel any on-going swipe gesture recognition.
+### cancel()
+Cancel any on-going swipe gesture recognition.
+

--- a/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
@@ -2,11 +2,12 @@
 title: TouchArea
 description: TouchArea element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
+import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 import PointerEvent from '/src/content/collections/structs/PointerEvent.md';
 import PointerScrollEvent from '/src/content/collections/structs/PointerScrollEvent.md';
 import EventResult from '/src/content/collections/enums/EventResult.md';
-import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 
 Use `TouchArea` to control what happens when the region it covers is touched or interacted with
 using the mouse.
@@ -111,7 +112,6 @@ Set by the `TouchArea` to the position of the mouse at the moment it was last pr
 Set to `true` by the `TouchArea` when the mouse is pressed over it.
 </SlintProperty>
 
-
 ## Callbacks
 
 ### clicked()
@@ -125,14 +125,14 @@ period of time, or the same is done with a finger. The `clicked()` callbacks wil
 The mouse or finger has been moved. This will only be called if the mouse is also pressed or the finger continues to touch
 the display. See also **pointer-event(PointerEvent)**.
 
-### pointer-event(PointerEvent)
+### pointer-event(event: PointerEvent)
 <PointerEvent />
 
-
-### scroll-event(PointerScrollEvent) -> EventResult
+### scroll-event(event: PointerScrollEvent) -> EventResult
 Invoked when the mouse wheel was rotated or another scroll gesture was made.
 The `PointerScrollEvent` argument contains information about how much to scroll in what direction.
 <PointerScrollEvent />
 The returned `EventResult`indicates whether to accept or ignore the event. Ignored events are
 forwarded to the parent element.
 <EventResult />
+

--- a/docs/astro/src/content/docs/reference/global-namespaces/platform.mdx
+++ b/docs/astro/src/content/docs/reference/global-namespaces/platform.mdx
@@ -37,7 +37,6 @@ determine the currently used scheme.
 ## Functions
 
 ### open-url(url: string)
-
 Opens the specified URL in an external browser. This function invokes the platform's URL opening mechanism.
 
 ```slint playground

--- a/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
@@ -2,6 +2,7 @@
 title: FocusScope
 description: FocusScope element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import Link from '@slint/common-files/src/components/Link.astro';
 
@@ -55,7 +56,7 @@ to deliver the key event to the parent element.
 ## Properties
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out">
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out">
 Is `true` when the element has keyboard focus.
 </SlintProperty>
 
@@ -90,29 +91,29 @@ Call this function to remove keyboard focus from this `FocusScope` if it current
 
 ## Callbacks
 
-### capture-key-pressed(KeyEvent) -> EventResult
+### capture-key-pressed(event: KeyEvent) -> EventResult
 This function is called during key event handling, *before* `key-pressed` is called. Use this to intercept key press events. The returned <Link type="EventResult" />
 indicates whether to accept or reject the event. Rejected events are forwarded to the parent element.
 
-### capture-key-released(KeyEvent) -> EventResult
+### capture-key-released(event: KeyEvent) -> EventResult
 This function is called during key event handling, *before* `key-released` is called. Use this to intercept key release events. The returned <Link type="EventResult" />
 indicates whether to accept or reject the event. Rejected events are forwarded to the parent element.
 
-### key-pressed(KeyEvent) -> EventResult
+### key-pressed(event: KeyEvent) -> EventResult
 Invoked when a key is pressed, the argument is a <Link type="KeyEvent" /> struct. The returned <Link type="EventResult" />
 indicates whether to accept or reject the event. Rejected events are forwarded to the parent element.
 
-### key-released(KeyEvent) -> EventResult
+### key-released(event: KeyEvent) -> EventResult
 Invoked when a key is released, the argument is a <Link type="KeyEvent" /> struct. The returned <Link type="EventResult" />
 indicates whether to accept or reject the event. Rejected events are forwarded to the parent element.
 
-### focus-changed-event(FocusReason)
+### focus-changed-event(reason: FocusReason)
 Invoked when the focus on the `FocusScope` has changed. The argument is a a <Link type="FocusReason" /> enum containing the reason for focus change.
 
-### focus-gained(FocusReason)
+### focus-gained(reason: FocusReason)
 Invoked when the `FocusScope` gains focus. The argument is a a <Link type="FocusReason" /> enum containing the reason for focus gain.
 
-### focus-lost(FocusReason)
+### focus-lost(reason: FocusReason)
 Invoked when the `FocusScope` loses focus. The argument is a a <Link type="FocusReason" /> enum containing the reason for focus loss.
 
 ## `KeyBinding`
@@ -125,7 +126,6 @@ See <Link type="KeyBindingOverview" label="Key Bindings"/> for details.
 ### Properties of `KeyBinding`
 
 #### keys
-
 <SlintProperty propName="keys" typeName="keys">
 The <Link type="keys" label="keys" /> to match against incoming key events.
 </SlintProperty>
@@ -138,5 +138,5 @@ Whether this KeyBinding is currently enabled. Disabled KeyBinding elements don't
 ### Callbacks of `KeyBinding`
 
 #### activated()
-
 Invoked when the parent `FocusScope` receives a key event that matches the `keys` of this `KeyBinding`.
+

--- a/docs/astro/src/content/docs/reference/keyboard-input/textinput.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/textinput.mdx
@@ -2,6 +2,7 @@
 title: TextInput
 description: TextInput element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import Link from '@slint/common-files/src/components/Link.astro';
 
@@ -68,7 +69,7 @@ Whether or not the font face should be drawn italicized or not.
 </SlintProperty>
 
 ### font-metrics
-<SlintProperty propName="font-metrics" typeName="struct" structName="FontMetrics">
+<SlintProperty propName="font-metrics" typeName="struct" structName="FontMetrics" propertyVisibility="out">
 The design metrics of the font scaled to the font pixel size used by the element.
 </SlintProperty>
 
@@ -123,7 +124,7 @@ The width of the text cursor.
 </SlintProperty>
 
 ### text
-<SlintProperty propName="text" typeName="string" defaultValue='""'>
+<SlintProperty propName="text" typeName="string" propertyVisibility="in-out" defaultValue="&quot;&quot;">
 The text rendered and editable by the user.
 </SlintProperty>
 
@@ -145,7 +146,7 @@ Call this function to focus the text input and make it receive future keyboard e
 ### clear-focus()
 Call this function to remove keyboard focus from this `TextInput` if it currently has the focus. See also <Link type="FocusHandling" />.
 
-### set-selection-offsets(int, int)
+### set-selection-offsets(start: int, end: int)
 Selects the text between two UTF-8 offsets.
 
 ### select-all()
@@ -168,23 +169,21 @@ Pastes the text content of the clipboard at the cursor position.
 ### accepted()
 Invoked when the enter key is pressed.
 
-### cursor-position-changed(Point)
-The cursor was moved to the new (x, y) position
-described by the `Point` argument.
+### cursor-position-changed(position: Point)
+The cursor was moved to the new (x, y) position described by the `Point` argument.
 
 ### edited()
 Invoked when the text has changed because the user modified it.
 
-### key-pressed(KeyEvent) -> EventResult
+### key-pressed(event: KeyEvent) -> EventResult
 Invoked when a key is pressed, the argument is a <Link type="KeyEvent" /> struct. Use this callback to
 handle keys before `TextInput` does. Return `accept` to indicate that you've handled the event, or return
 `reject` to let `TextInput` handle it.
 
-### key-released(KeyEvent) -> EventResult
+### key-released(event: KeyEvent) -> EventResult
 Invoked when a key is released, the argument is a <Link type="KeyEvent" /> struct. Use this callback to
 handle keys before `TextInput` does. Return `accept` to indicate that you've handled the event, or return
 `reject` to let `TextInput` handle it.
-
 
 ## Accessibility
 

--- a/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
@@ -2,6 +2,7 @@
 title: FlexboxLayout
 description: FlexboxLayout element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 

--- a/docs/astro/src/content/docs/reference/layouts/gridlayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/gridlayout.mdx
@@ -2,6 +2,7 @@
 title: GridLayout
 description: GridLayout element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 
@@ -63,6 +64,7 @@ The distance between the elements in the layout. This single value is applied to
 </SlintProperty>
 
 To target specific axis with different values use the following properties:
+
 ### spacing-horizontal
 <SlintProperty propName="spacing-horizontal" typeName="length"/>
 
@@ -77,6 +79,7 @@ The padding around the grid structure as a whole. This single value is applied t
 </SlintProperty>
 
 To target specific sides with different values use the following properties:
+
 ### padding-left
 <SlintProperty propName="padding-left" typeName="length"/>
 

--- a/docs/astro/src/content/docs/reference/layouts/horizontallayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/horizontallayout.mdx
@@ -2,6 +2,7 @@
 title: HorizontalLayout
 description: HorizontalLayout element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
 ```slint
@@ -30,12 +31,14 @@ The distance between the elements in the layout.
 </SlintProperty>
 
 ## Padding Properties
+
 ### padding
 <SlintProperty propName="padding" typeName="length">
 The padding within the layout as a whole. This single value is applied to all sides.
 </SlintProperty>
 
 To target specific sides with different values use the following properties:
+
 ### padding-left
 <SlintProperty propName="padding-left" typeName="length"/>
 
@@ -49,7 +52,9 @@ To target specific sides with different values use the following properties:
 <SlintProperty propName="padding-bottom" typeName="length"/>
 
 ## Alignment Properties
+
 ### alignment
 <SlintProperty propName="alignment" typeName="enum" enumName="LayoutAlignment">
 Set the alignment. Matches the CSS flex box.
 </SlintProperty>
+

--- a/docs/astro/src/content/docs/reference/layouts/verticallayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/verticallayout.mdx
@@ -2,6 +2,7 @@
 title: VerticalLayout
 description: VerticalLayout element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
 ```slint

--- a/docs/astro/src/content/docs/reference/window/dialog.mdx
+++ b/docs/astro/src/content/docs/reference/window/dialog.mdx
@@ -2,12 +2,12 @@
 title: Dialog
 description: Dialog element api.
 ---
+
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';
 import Link from '@slint/common-files/src/components/Link.astro';
 
 <CodeSnippetMD imagePath="/src/assets/generated/dialog-example.png"  imageWidth="200" imageHeight="100"  imageAlt='dialog example'>
-
 ```slint playground
 import { StandardButton, Button } from "std-widgets.slint";
 export component Example inherits Dialog {

--- a/docs/astro/src/content/docs/reference/window/popupwindow.mdx
+++ b/docs/astro/src/content/docs/reference/window/popupwindow.mdx
@@ -2,8 +2,8 @@
 title: PopupWindow
 description: PopupWindow element api.
 ---
-import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
+import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
 ```slint playground
 export component Example inherits Window {

--- a/docs/astro/src/content/docs/reference/window/window.mdx
+++ b/docs/astro/src/content/docs/reference/window/window.mdx
@@ -2,7 +2,8 @@
 title: Window
 description: Window element api.
 ---
-import SlintProperty  from '@slint/common-files/src/components/SlintProperty.astro';
+
+import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import Link from '@slint/common-files/src/components/Link.astro';
 
 `Window` is the root of the tree of elements that are visible on the screen.
@@ -21,7 +22,7 @@ Whether the window should be placed above all other windows on window managers s
 </SlintProperty>
 
 ### full-screen
-<SlintProperty propName="full-screen" typeName="bool" defaultValue="true if 'SLINT_FULLSCREEN' environment variable is set, otherwise false ">
+<SlintProperty propName="full-screen" typeName="bool" propertyVisibility="in-out" defaultValue="true if 'SLINT_FULLSCREEN' environment variable is set, otherwise false">
 Whether to display the Window in full-screen mode. In full-screen mode the Window will occupy the entire screen, it will not be resizable, and it will not display the title bar.
 </SlintProperty>
 
@@ -36,12 +37,12 @@ The font family to use as default in text elements inside this window, that don'
 </SlintProperty>
 
 ### default-font-size
-<SlintProperty propName="default-font-size" typeName="length" defaultValue="0" propertyVisibility="in">
+<SlintProperty propName="default-font-size" typeName="length" defaultValue="0">
 The font size to use as default in text elements inside this window, that don't have their `font-size` property set. The value of this property also forms the basis for relative font sizes.
 </SlintProperty>
 
 ### default-font-weight
-<SlintProperty propName="default-font-weight" typeName="int"  >
+<SlintProperty propName="default-font-weight" typeName="int">
 The font weight to use as default in text elements inside this window, that don't have their `font-weight` property set. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 </SlintProperty>
 
@@ -69,17 +70,17 @@ The window title that is shown in the title bar.
 </SlintProperty>
 
 ### safe-area-insets
-<SlintProperty propName="safe-area-insets" typeName="Edges" propertyVisibility="out">
+<SlintProperty propName="safe-area-insets" typeName="struct" structName="Edges" propertyVisibility="out">
 Some devices, such as mobile phones, allow programs to overlap the system UI. A few examples for this are the notch on iPhones, the window buttons on macOS on windows that extend their content over the titlebar and the system bar on Android. This property exposes the amount of space at the edges of the window that can be drawn to but where no interactive elements should be placed. On most devices, this is 0 for all sides.
 </SlintProperty>
 
 ### virtual-keyboard-position
-<SlintProperty propName="virtual-keyboard-position" typeName="Point" propertyVisibility="out">
+<SlintProperty propName="virtual-keyboard-position" typeName="struct" structName="Point" propertyVisibility="out">
 On mobile devices, virtual keyboards (aka software keyboards or onscreen keyboards) are displayed on top of the application. When such a keyboard is shown, this property denotes the position of the top left boundary of the rectangle covered by it in window coordinates.
 </SlintProperty>
 
 ### virtual-keyboard-size
-<SlintProperty propName="virtual-keyboard-size" typeName="Size" propertyVisibility="out">
+<SlintProperty propName="virtual-keyboard-size" typeName="struct" structName="Size" propertyVisibility="out">
 On mobile devices, virtual keyboards (aka software keyboards or onscreen keyboards) are displayed on top of the application. When such a keyboard is shown, this property denotes the width and height of the rectangle covered by it in window coordinates.
 </SlintProperty>
 


### PR DESCRIPTION
 - use always `"` instead of `'` in the HTML tags
 - don't use lists for callback, give each callback a section
 - Some properties gets the `propertyVisibility` fixed
 - Some more cosmetics change

Background: I've been playing with the possibility of auto-generating these files from comments in builtins.slint, this helps to reduce the diff.

