### PR TITLE
Rename FlexboxLayout enums to fully-qualify them

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -211,8 +211,8 @@ flexbox_layout_info(cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemI
                     float spacing_h, float spacing_v, const cbindgen_private::Padding &padding_h,
                     const cbindgen_private::Padding &padding_v,
                     cbindgen_private::Orientation orientation,
-                    cbindgen_private::FlexDirection direction, float constraint_size,
-                    cbindgen_private::FlexWrap flex_wrap)
+                    cbindgen_private::FlexboxLayoutDirection direction, float constraint_size,
+                    cbindgen_private::FlexboxLayoutWrap flex_wrap)
 {
     return cbindgen_private::slint_flexbox_layout_info(cells_h, cells_v, spacing_h, spacing_v,
                                                        &padding_h, &padding_v, orientation,

--- a/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
@@ -105,25 +105,25 @@ Note that the `stretch` value has no effect on FlexboxLayout (main-axis stretchi
 ## Direction Properties
 
 ### flex-direction
-<SlintProperty propName="flex-direction" typeName="enum" enumName="FlexDirection">
+<SlintProperty propName="flex-direction" typeName="enum" enumName="FlexboxLayoutDirection">
 The primary direction in which items are placed. Set to `row` to place items horizontally left-to-right (default), or `column` to place items vertically top-to-bottom.
 It also supports `row-reverse` and `column-reverse` which invert the flow: `row-reverse` places items right-to-left (starting at the right edge), and `column-reverse` places items bottom-to-top (starting at the bottom edge).
 </SlintProperty>
 
 ### flex-wrap
-<SlintProperty propName="flex-wrap" typeName="enum" enumName="FlexWrap">
+<SlintProperty propName="flex-wrap" typeName="enum" enumName="FlexboxLayoutWrap">
 Controls whether flex items wrap onto multiple lines when they don't fit in the container.
 The default value is `wrap`.
 </SlintProperty>
 
 ### align-content
-<SlintProperty propName="align-content" typeName="enum" enumName="FlexAlignContent">
+<SlintProperty propName="align-content" typeName="enum" enumName="FlexboxLayoutAlignContent">
 Set the distribution of flex lines along the cross axis.
 The default value is `stretch`.
 </SlintProperty>
 
 ### align-items
-<SlintProperty propName="align-items" typeName="enum" enumName="FlexAlignItems">
+<SlintProperty propName="align-items" typeName="enum" enumName="FlexboxLayoutAlignItems">
 Set the alignment of individual items along the cross axis within each flex line.
 The default value is `stretch`.
 </SlintProperty>
@@ -151,7 +151,7 @@ If not set, the item's `preferred-width` (row) or `preferred-height` (column) is
 </SlintProperty>
 
 ### flex-align-self
-<SlintProperty propName="flex-align-self" typeName="enum" enumName="FlexAlignSelf">
+<SlintProperty propName="flex-align-self" typeName="enum" enumName="FlexboxLayoutAlignSelf">
 Overrides the container's `align-items` for this specific item.
 The default value is `auto`, which inherits the container's `align-items` setting.
 </SlintProperty>

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -42,11 +42,11 @@ export component MainWindow inherits Window {
     default-font-size: 20px;
 
     property <[string]> direction_options: ["Row", "RowReverse", "Column", "ColumnReverse"];
-    property <[FlexDirection]> direction_values: [
-        FlexDirection.row,
-        FlexDirection.row-reverse,
-        FlexDirection.column,
-        FlexDirection.column-reverse
+    property <[FlexboxLayoutDirection]> direction_values: [
+        FlexboxLayoutDirection.row,
+        FlexboxLayoutDirection.row-reverse,
+        FlexboxLayoutDirection.column,
+        FlexboxLayoutDirection.column-reverse
     ];
     property <[string]> alignment_options: ["Start", "End", "Center", "SpaceBetween", "SpaceAround", "SpaceEvenly"];
     property <[LayoutAlignment]> alignment_values: [
@@ -66,24 +66,24 @@ export component MainWindow inherits Window {
         "Space Around",
         "Space Evenly"
     ];
-    property <[FlexAlignContent]> align_content_values: [
-        FlexAlignContent.stretch,
-        FlexAlignContent.start,
-        FlexAlignContent.end,
-        FlexAlignContent.center,
-        FlexAlignContent.space-between,
-        FlexAlignContent.space-around,
-        FlexAlignContent.space-evenly
+    property <[FlexboxLayoutAlignContent]> align_content_values: [
+        FlexboxLayoutAlignContent.stretch,
+        FlexboxLayoutAlignContent.start,
+        FlexboxLayoutAlignContent.end,
+        FlexboxLayoutAlignContent.center,
+        FlexboxLayoutAlignContent.space-between,
+        FlexboxLayoutAlignContent.space-around,
+        FlexboxLayoutAlignContent.space-evenly
     ];
     property <[string]> align_items_options: ["Stretch", "Start", "End", "Center"];
-    property <[FlexAlignItems]> align_items_values: [
-        FlexAlignItems.stretch,
-        FlexAlignItems.start,
-        FlexAlignItems.end,
-        FlexAlignItems.center
+    property <[FlexboxLayoutAlignItems]> align_items_values: [
+        FlexboxLayoutAlignItems.stretch,
+        FlexboxLayoutAlignItems.start,
+        FlexboxLayoutAlignItems.end,
+        FlexboxLayoutAlignItems.center
     ];
     property <[string]> flex_wrap_options: ["Wrap", "NoWrap", "WrapReverse"];
-    property <[FlexWrap]> flex_wrap_values: [FlexWrap.wrap, FlexWrap.no-wrap, FlexWrap.wrap-reverse];
+    property <[FlexboxLayoutWrap]> flex_wrap_values: [FlexboxLayoutWrap.wrap, FlexboxLayoutWrap.no-wrap, FlexboxLayoutWrap.wrap-reverse];
 
     VerticalLayout {
         padding: 20phx;

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -364,7 +364,7 @@ macro_rules! for_each_enums {
 
             /// The direction in which flex items are placed in a flex container.
             #[non_exhaustive]
-            enum FlexDirection {
+            enum FlexboxLayoutDirection {
                 /// Items are placed in a row, from left to right.
                 Row,
                 /// Items are placed in a row in reverse order, from right to left.
@@ -377,7 +377,7 @@ macro_rules! for_each_enums {
 
             /// Controls the distribution of flex lines along the cross axis in a flex container.
             #[non_exhaustive]
-            enum FlexAlignContent {
+            enum FlexboxLayoutAlignContent {
                 /// Lines are stretched to fill the container along the cross axis.
                 Stretch,
                 /// Lines are placed at the start of the cross axis.
@@ -396,7 +396,7 @@ macro_rules! for_each_enums {
 
             /// Controls the alignment of individual items along the cross axis within each flex line.
             #[non_exhaustive]
-            enum FlexAlignItems {
+            enum FlexboxLayoutAlignItems {
                 /// Items are stretched to fill the line along the cross axis.
                 Stretch,
                 /// Items are placed at the start of the cross axis.
@@ -409,7 +409,7 @@ macro_rules! for_each_enums {
 
             /// Overrides the container's `align-items` for a specific flex item.
             #[non_exhaustive]
-            enum FlexAlignSelf {
+            enum FlexboxLayoutAlignSelf {
                 /// Use the container's `align-items` value (default).
                 Auto,
                 /// The item is stretched to fill the line along the cross axis.
@@ -424,7 +424,7 @@ macro_rules! for_each_enums {
 
             /// Controls whether flex items wrap onto multiple lines.
             #[non_exhaustive]
-            enum FlexWrap {
+            enum FlexboxLayoutWrap {
                 /// Flex items wrap onto multiple lines, from top to bottom (for row direction) or left to right (for column direction).
                 Wrap,
                 /// All flex items are laid out on a single line (default for CSS, but Slint defaults to `wrap`).

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -456,10 +456,10 @@ export component FlexboxLayout {
     in property <length> spacing-vertical;
     in property <length> spacing;
     in property <LayoutAlignment> alignment: LayoutAlignment.start;  // CSS default is flex-start
-    in property <FlexDirection> flex-direction;
-    in property <FlexAlignContent> align-content;
-    in property <FlexAlignItems> align-items;
-    in property <FlexWrap> flex-wrap;
+    in property <FlexboxLayoutDirection> flex-direction;
+    in property <FlexboxLayoutAlignContent> align-content;
+    in property <FlexboxLayoutAlignItems> align-items;
+    in property <FlexboxLayoutWrap> flex-wrap;
 }
 
 component MoveTo {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2645,7 +2645,7 @@ fn generate_flexbox_layout_item_info_decl(
         )
     } else {
         "auto base = layout_item_info(o, child_index); \
-         return { base.constraint, 0.0f, 0.0f, -1.0f, slint::cbindgen_private::FlexAlignSelf::Auto, 0 };"
+         return { base.constraint, 0.0f, 0.0f, -1.0f, slint::cbindgen_private::FlexboxLayoutAlignSelf::Auto, 0 };"
             .to_owned()
     };
 

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -20,7 +20,7 @@ pub enum Orientation {
 }
 
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Default)]
-pub enum FlexDirection {
+pub enum FlexboxLayoutDirection {
     /// Items are laid out in rows (horizontal primary axis)
     #[default]
     Row,
@@ -616,14 +616,14 @@ impl FlexboxLayout {
     pub fn is_main_axis(&self, orientation: Orientation) -> bool {
         use crate::expression_tree::Expression;
         let direction = match self.direction.as_ref() {
-            None => Some(FlexDirection::Row), // default
+            None => Some(FlexboxLayoutDirection::Row), // default
             Some(nr) => nr.element().borrow().bindings.get(nr.name()).and_then(|binding| {
                 match &binding.borrow().expression {
                     Expression::EnumerationValue(ev) => match ev.value {
-                        0 => Some(FlexDirection::Row),
-                        1 => Some(FlexDirection::RowReverse),
-                        2 => Some(FlexDirection::Column),
-                        3 => Some(FlexDirection::ColumnReverse),
+                        0 => Some(FlexboxLayoutDirection::Row),
+                        1 => Some(FlexboxLayoutDirection::RowReverse),
+                        2 => Some(FlexboxLayoutDirection::Column),
+                        3 => Some(FlexboxLayoutDirection::ColumnReverse),
                         _ => None,
                     },
                     _ => None,
@@ -632,11 +632,13 @@ impl FlexboxLayout {
         };
         matches!(
             (direction, orientation),
-            (Some(FlexDirection::Row | FlexDirection::RowReverse), Orientation::Horizontal)
-                | (
-                    Some(FlexDirection::Column | FlexDirection::ColumnReverse),
-                    Orientation::Vertical
-                )
+            (
+                Some(FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse),
+                Orientation::Horizontal
+            ) | (
+                Some(FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse),
+                Orientation::Vertical
+            )
         )
     }
 

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -323,24 +323,25 @@ pub(super) fn solve_flexbox_layout(
             (
                 "direction",
                 crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.FlexDirection.clone())),
+                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutDirection.clone())),
                 fld.direction,
             ),
             (
                 "align_content",
                 crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.FlexAlignContent.clone())),
+                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutAlignContent.clone())),
                 fld.align_content,
             ),
             (
                 "align_items",
                 crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.FlexAlignItems.clone())),
+                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutAlignItems.clone())),
                 fld.align_items,
             ),
             (
                 "flex_wrap",
-                crate::typeregister::BUILTIN.with(|e| Type::Enumeration(e.enums.FlexWrap.clone())),
+                crate::typeregister::BUILTIN
+                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutWrap.clone())),
                 fld.flex_wrap,
             ),
             ("cells_h", fld.cells_h.ty(ctx), fld.cells_h),
@@ -383,14 +384,14 @@ pub(super) fn compute_flexbox_layout_info(
     // Try to determine direction at compile time from constant binding.
     let compile_time_direction =
         match layout.direction.as_ref() {
-            None => Some(crate::layout::FlexDirection::Row),
+            None => Some(crate::layout::FlexboxLayoutDirection::Row),
             Some(nr) => nr.element().borrow().bindings.get(nr.name()).and_then(|binding| {
                 match &binding.borrow().expression {
                     crate::expression_tree::Expression::EnumerationValue(ev) => match ev.value {
-                        0 => Some(crate::layout::FlexDirection::Row),
-                        1 => Some(crate::layout::FlexDirection::RowReverse),
-                        2 => Some(crate::layout::FlexDirection::Column),
-                        3 => Some(crate::layout::FlexDirection::ColumnReverse),
+                        0 => Some(crate::layout::FlexboxLayoutDirection::Row),
+                        1 => Some(crate::layout::FlexboxLayoutDirection::RowReverse),
+                        2 => Some(crate::layout::FlexboxLayoutDirection::Column),
+                        3 => Some(crate::layout::FlexboxLayoutDirection::ColumnReverse),
                         _ => None,
                     },
                     _ => None,
@@ -402,10 +403,10 @@ pub(super) fn compute_flexbox_layout_info(
         // If direction is known at compile time, we can optimize by only generating
         let is_cross_axis = matches!(
             (direction, orientation),
-            (crate::layout::FlexDirection::Row, Orientation::Vertical)
-                | (crate::layout::FlexDirection::RowReverse, Orientation::Vertical)
-                | (crate::layout::FlexDirection::Column, Orientation::Horizontal)
-                | (crate::layout::FlexDirection::ColumnReverse, Orientation::Horizontal)
+            (crate::layout::FlexboxLayoutDirection::Row, Orientation::Vertical)
+                | (crate::layout::FlexboxLayoutDirection::RowReverse, Orientation::Vertical)
+                | (crate::layout::FlexboxLayoutDirection::Column, Orientation::Horizontal)
+                | (crate::layout::FlexboxLayoutDirection::ColumnReverse, Orientation::Horizontal)
         );
         compute_flexbox_layout_info_for_direction(layout, orientation, is_cross_axis, fld, ctx)
     } else {
@@ -428,7 +429,8 @@ pub(super) fn compute_flexbox_layout_info(
         );
 
         // Condition: direction == Row || direction == RowReverse
-        let direction_enum = crate::typeregister::BUILTIN.with(|e| e.enums.FlexDirection.clone());
+        let direction_enum =
+            crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
         let direction_ref = llr_Expression::PropertyReference(
             ctx.map_property_reference(layout.direction.as_ref().unwrap()),
         );
@@ -437,7 +439,7 @@ pub(super) fn compute_flexbox_layout_info(
             lhs: Box::new(llr_Expression::BinaryExpression {
                 lhs: Box::new(direction_ref.clone()),
                 rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
-                    value: 0, // FlexDirection::Row
+                    value: 0, // FlexboxLayoutDirection::Row
                     enumeration: direction_enum.clone(),
                 })),
                 op: '=',
@@ -445,7 +447,7 @@ pub(super) fn compute_flexbox_layout_info(
             rhs: Box::new(llr_Expression::BinaryExpression {
                 lhs: Box::new(direction_ref),
                 rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
-                    value: 1, // FlexDirection::RowReverse
+                    value: 1, // FlexboxLayoutDirection::RowReverse
                     enumeration: direction_enum,
                 })),
                 op: '=',
@@ -600,7 +602,7 @@ fn flexbox_layout_data(
     let direction = if let Some(expr) = &layout.direction {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexDirection.clone());
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -610,7 +612,7 @@ fn flexbox_layout_data(
     let align_content = if let Some(expr) = &layout.align_content {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexAlignContent.clone());
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutAlignContent.clone());
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -620,7 +622,7 @@ fn flexbox_layout_data(
     let align_items = if let Some(expr) = &layout.align_items {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexAlignItems.clone());
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutAlignItems.clone());
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -630,7 +632,7 @@ fn flexbox_layout_data(
     let flex_wrap = if let Some(expr) = &layout.flex_wrap {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexWrap.clone());
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutWrap.clone());
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -788,7 +790,7 @@ struct BoxLayoutDataResult {
 }
 
 fn default_align_self() -> (Type, llr_Expression) {
-    let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexAlignSelf.clone());
+    let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutAlignSelf.clone());
     (
         Type::Enumeration(e.clone()),
         llr_Expression::EnumerationValue(EnumerationValue {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -117,7 +117,7 @@ impl BuiltinTypes {
             name: BuiltinPrivateStruct::LayoutInfo.into(),
         });
         let enums = BuiltinEnums::new();
-        let flex_align_self_type = Type::Enumeration(enums.FlexAlignSelf.clone());
+        let flex_align_self_type = Type::Enumeration(enums.FlexboxLayoutAlignSelf.clone());
         Self {
             enums,
             logical_point_type: Rc::new(Struct {
@@ -304,7 +304,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
         // because Type::Enumeration requires a runtime Rc allocation.
         .chain(std::iter::once((
             "flex-align-self",
-            Type::Enumeration(BUILTIN.with(|e| e.enums.FlexAlignSelf.clone())),
+            Type::Enumeration(BUILTIN.with(|e| e.enums.FlexboxLayoutAlignSelf.clone())),
             PropertyVisibility::Input,
         )))
         .chain(IntoIterator::into_iter([

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,8 +6,8 @@
 // cspell:ignore coord
 
 use crate::items::{
-    DialogButtonRole, FlexAlignContent, FlexAlignItems, FlexAlignSelf, FlexDirection, FlexWrap,
-    LayoutAlignment,
+    DialogButtonRole, FlexboxLayoutAlignContent, FlexboxLayoutAlignItems, FlexboxLayoutAlignSelf,
+    FlexboxLayoutDirection, FlexboxLayoutWrap, LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
 use alloc::format;
@@ -1136,10 +1136,10 @@ pub struct FlexboxLayoutData<'a> {
     pub padding_h: Padding,
     pub padding_v: Padding,
     pub alignment: LayoutAlignment,
-    pub direction: FlexDirection,
-    pub align_content: FlexAlignContent,
-    pub align_items: FlexAlignItems,
-    pub flex_wrap: FlexWrap,
+    pub direction: FlexboxLayoutDirection,
+    pub align_content: FlexboxLayoutAlignContent,
+    pub align_items: FlexboxLayoutAlignItems,
+    pub flex_wrap: FlexboxLayoutWrap,
     /// Horizontal constraints (width) for each cell
     pub cells_h: Slice<'a, FlexboxLayoutItemInfo>,
     /// Vertical constraints (height) for each cell
@@ -1165,7 +1165,7 @@ pub struct FlexboxLayoutItemInfo {
     /// Flex basis in logical pixels (-1 = auto, meaning use preferred size; default)
     pub flex_basis: Coord,
     /// Per-item cross-axis alignment override (Auto = use container's align-items)
-    pub flex_align_self: FlexAlignSelf,
+    pub flex_align_self: FlexboxLayoutAlignSelf,
     /// Visual ordering of flex items (lower values appear first, default 0)
     pub flex_order: i32,
 }
@@ -1177,7 +1177,7 @@ impl Default for FlexboxLayoutItemInfo {
             flex_grow: 0.0,
             flex_shrink: 0.0,
             flex_basis: -1 as _,
-            flex_align_self: FlexAlignSelf::Auto,
+            flex_align_self: FlexboxLayoutAlignSelf::Auto,
             flex_order: 0,
         }
     }
@@ -1322,8 +1322,9 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, FlexAlignContent, FlexAlignItems, FlexAlignSelf, FlexWrap as SlintFlexWrap,
-        FlexboxLayoutItemInfo, LayoutAlignment, Padding, Slice,
+        Coord, FlexboxLayoutAlignContent, FlexboxLayoutAlignItems, FlexboxLayoutAlignSelf,
+        FlexboxLayoutItemInfo, FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment,
+        Padding, Slice,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
@@ -1338,9 +1339,9 @@ mod flexbox_taffy {
         pub padding_h: &'a Padding,
         pub padding_v: &'a Padding,
         pub alignment: LayoutAlignment,
-        pub align_content: FlexAlignContent,
-        pub align_items: FlexAlignItems,
-        pub flex_wrap: SlintFlexWrap,
+        pub align_content: FlexboxLayoutAlignContent,
+        pub align_items: FlexboxLayoutAlignItems,
+        pub flex_wrap: SlintFlexboxLayoutWrap,
         pub flex_direction: TaffyFlexDirection,
         pub container_width: Option<Coord>,
         pub container_height: Option<Coord>,
@@ -1440,11 +1441,11 @@ mod flexbox_taffy {
                             flex_grow: cell_h.flex_grow,
                             flex_shrink: cell_h.flex_shrink,
                             align_self: match cell_h.flex_align_self {
-                                FlexAlignSelf::Auto => None,
-                                FlexAlignSelf::Stretch => Some(AlignSelf::Stretch),
-                                FlexAlignSelf::Start => Some(AlignSelf::FlexStart),
-                                FlexAlignSelf::End => Some(AlignSelf::FlexEnd),
-                                FlexAlignSelf::Center => Some(AlignSelf::Center),
+                                FlexboxLayoutAlignSelf::Auto => None,
+                                FlexboxLayoutAlignSelf::Stretch => Some(AlignSelf::Stretch),
+                                FlexboxLayoutAlignSelf::Start => Some(AlignSelf::FlexStart),
+                                FlexboxLayoutAlignSelf::End => Some(AlignSelf::FlexEnd),
+                                FlexboxLayoutAlignSelf::Center => Some(AlignSelf::Center),
                             },
                             ..Default::default()
                         })
@@ -1473,9 +1474,9 @@ mod flexbox_taffy {
                         display: Display::Flex,
                         flex_direction: params.flex_direction,
                         flex_wrap: match params.flex_wrap {
-                            SlintFlexWrap::Wrap => FlexWrap::Wrap,
-                            SlintFlexWrap::NoWrap => FlexWrap::NoWrap,
-                            SlintFlexWrap::WrapReverse => FlexWrap::WrapReverse,
+                            SlintFlexboxLayoutWrap::Wrap => FlexWrap::Wrap,
+                            SlintFlexboxLayoutWrap::NoWrap => FlexWrap::NoWrap,
+                            SlintFlexboxLayoutWrap::WrapReverse => FlexWrap::WrapReverse,
                         },
                         justify_content: Some(match params.alignment {
                             // Start/End map to FlexStart/FlexEnd to respect flex direction (including reverse)
@@ -1489,19 +1490,19 @@ mod flexbox_taffy {
                             LayoutAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
                         }),
                         align_items: Some(match params.align_items {
-                            FlexAlignItems::Stretch => AlignItems::Stretch,
-                            FlexAlignItems::Start => AlignItems::FlexStart,
-                            FlexAlignItems::End => AlignItems::FlexEnd,
-                            FlexAlignItems::Center => AlignItems::Center,
+                            FlexboxLayoutAlignItems::Stretch => AlignItems::Stretch,
+                            FlexboxLayoutAlignItems::Start => AlignItems::FlexStart,
+                            FlexboxLayoutAlignItems::End => AlignItems::FlexEnd,
+                            FlexboxLayoutAlignItems::Center => AlignItems::Center,
                         }),
                         align_content: Some(match params.align_content {
-                            FlexAlignContent::Stretch => AlignContent::Stretch,
-                            FlexAlignContent::Start => AlignContent::FlexStart,
-                            FlexAlignContent::End => AlignContent::FlexEnd,
-                            FlexAlignContent::Center => AlignContent::Center,
-                            FlexAlignContent::SpaceBetween => AlignContent::SpaceBetween,
-                            FlexAlignContent::SpaceAround => AlignContent::SpaceAround,
-                            FlexAlignContent::SpaceEvenly => AlignContent::SpaceEvenly,
+                            FlexboxLayoutAlignContent::Stretch => AlignContent::Stretch,
+                            FlexboxLayoutAlignContent::Start => AlignContent::FlexStart,
+                            FlexboxLayoutAlignContent::End => AlignContent::FlexEnd,
+                            FlexboxLayoutAlignContent::Center => AlignContent::Center,
+                            FlexboxLayoutAlignContent::SpaceBetween => AlignContent::SpaceBetween,
+                            FlexboxLayoutAlignContent::SpaceAround => AlignContent::SpaceAround,
+                            FlexboxLayoutAlignContent::SpaceEvenly => AlignContent::SpaceEvenly,
                         }),
                         gap: Size {
                             width: LengthPercentage::length(params.spacing_h as _),
@@ -1661,10 +1662,10 @@ pub fn solve_flexbox_layout(
     }
 
     let taffy_direction = match data.direction {
-        FlexDirection::Row => flexbox_taffy::TaffyFlexDirection::Row,
-        FlexDirection::RowReverse => flexbox_taffy::TaffyFlexDirection::RowReverse,
-        FlexDirection::Column => flexbox_taffy::TaffyFlexDirection::Column,
-        FlexDirection::ColumnReverse => flexbox_taffy::TaffyFlexDirection::ColumnReverse,
+        FlexboxLayoutDirection::Row => flexbox_taffy::TaffyFlexDirection::Row,
+        FlexboxLayoutDirection::RowReverse => flexbox_taffy::TaffyFlexDirection::RowReverse,
+        FlexboxLayoutDirection::Column => flexbox_taffy::TaffyFlexDirection::Column,
+        FlexboxLayoutDirection::ColumnReverse => flexbox_taffy::TaffyFlexDirection::ColumnReverse,
     };
 
     let (container_width, container_height) = (
@@ -1689,8 +1690,12 @@ pub fn solve_flexbox_layout(
     });
 
     let (available_width, available_height) = match data.direction {
-        FlexDirection::Row | FlexDirection::RowReverse => (data.width, Coord::MAX),
-        FlexDirection::Column | FlexDirection::ColumnReverse => (Coord::MAX, data.height),
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => {
+            (data.width, Coord::MAX)
+        }
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+            (Coord::MAX, data.height)
+        }
     };
 
     builder.compute_layout(available_width, available_height);
@@ -1735,9 +1740,9 @@ pub fn flexbox_layout_info(
     padding_h: &Padding,
     padding_v: &Padding,
     orientation: Orientation,
-    direction: FlexDirection,
+    direction: FlexboxLayoutDirection,
     constraint_size: Coord,
-    flex_wrap: FlexWrap,
+    flex_wrap: FlexboxLayoutWrap,
 ) -> LayoutInfo {
     if cells_h.is_empty() {
         assert!(cells_v.is_empty());
@@ -1758,11 +1763,14 @@ pub fn flexbox_layout_info(
     // Determine if we're asking for main-axis or cross-axis
     let is_main_axis = matches!(
         (direction, orientation),
-        (FlexDirection::Row | FlexDirection::RowReverse, Orientation::Horizontal)
-            | (FlexDirection::Column | FlexDirection::ColumnReverse, Orientation::Vertical)
+        (FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse, Orientation::Horizontal)
+            | (
+                FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse,
+                Orientation::Vertical
+            )
     );
 
-    let min = if matches!(flex_wrap, FlexWrap::NoWrap) && is_main_axis {
+    let min = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) && is_main_axis {
         // No wrapping: items must all fit in one line, min = sum of minimums + spacing
         cells.iter().map(|c| c.constraint.min).sum::<Coord>()
             + spacing * (cells.len().saturating_sub(1)) as Coord
@@ -1775,7 +1783,7 @@ pub fn flexbox_layout_info(
     // The main-axis constraint determines how items wrap.
     let main_axis_constraint = if is_main_axis {
         // Note that constraint_size is not used for the main axis
-        if matches!(flex_wrap, FlexWrap::NoWrap) {
+        if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
             // No wrapping: items won't wrap regardless of size, use max content
             Coord::MAX
         } else {
@@ -1795,15 +1803,19 @@ pub fn flexbox_layout_info(
     };
 
     let taffy_direction = match direction {
-        FlexDirection::Row => flexbox_taffy::TaffyFlexDirection::Row,
-        FlexDirection::RowReverse => flexbox_taffy::TaffyFlexDirection::RowReverse,
-        FlexDirection::Column => flexbox_taffy::TaffyFlexDirection::Column,
-        FlexDirection::ColumnReverse => flexbox_taffy::TaffyFlexDirection::ColumnReverse,
+        FlexboxLayoutDirection::Row => flexbox_taffy::TaffyFlexDirection::Row,
+        FlexboxLayoutDirection::RowReverse => flexbox_taffy::TaffyFlexDirection::RowReverse,
+        FlexboxLayoutDirection::Column => flexbox_taffy::TaffyFlexDirection::Column,
+        FlexboxLayoutDirection::ColumnReverse => flexbox_taffy::TaffyFlexDirection::ColumnReverse,
     };
 
     let (container_width, container_height) = match direction {
-        FlexDirection::Row | FlexDirection::RowReverse => (Some(main_axis_constraint), None),
-        FlexDirection::Column | FlexDirection::ColumnReverse => (None, Some(main_axis_constraint)),
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => {
+            (Some(main_axis_constraint), None)
+        }
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+            (None, Some(main_axis_constraint))
+        }
     };
 
     let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
@@ -1814,8 +1826,8 @@ pub fn flexbox_layout_info(
         padding_h,
         padding_v,
         alignment: LayoutAlignment::Start,
-        align_content: FlexAlignContent::Stretch,
-        align_items: FlexAlignItems::Stretch,
+        align_content: FlexboxLayoutAlignContent::Stretch,
+        align_items: FlexboxLayoutAlignItems::Stretch,
         flex_wrap,
         flex_direction: taffy_direction,
         container_width,
@@ -1823,8 +1835,12 @@ pub fn flexbox_layout_info(
     });
 
     let (available_width, available_height) = match direction {
-        FlexDirection::Row | FlexDirection::RowReverse => (main_axis_constraint, Coord::MAX),
-        FlexDirection::Column | FlexDirection::ColumnReverse => (Coord::MAX, main_axis_constraint),
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => {
+            (main_axis_constraint, Coord::MAX)
+        }
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+            (Coord::MAX, main_axis_constraint)
+        }
     };
 
     builder.compute_layout(available_width, available_height);
@@ -1980,9 +1996,9 @@ pub(crate) mod ffi {
         padding_h: &Padding,
         padding_v: &Padding,
         orientation: Orientation,
-        direction: FlexDirection,
+        direction: FlexboxLayoutDirection,
         constraint_size: Coord,
-        flex_wrap: FlexWrap,
+        flex_wrap: FlexboxLayoutWrap,
     ) -> LayoutInfo {
         super::flexbox_layout_info(
             cells_h,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -234,7 +234,7 @@ impl RepeatedItemTree for ErasedItemTreeBox {
         let flex_align_self = eval::load_property(instance_ref, root_element, "flex-align-self")
             .ok()
             .and_then(|v| v.try_into().ok())
-            .unwrap_or(i_slint_core::items::FlexAlignSelf::Auto);
+            .unwrap_or(i_slint_core::items::FlexboxLayoutAlignSelf::Auto);
         let flex_order = load_f32("flex-order") as i32;
 
         i_slint_core::layout::FlexboxLayoutItemInfo {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -12,7 +12,7 @@ use i_slint_compiler::layout::{
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_core::Coord;
-use i_slint_core::items::{DialogButtonRole, FlexDirection, ItemRc};
+use i_slint_core::items::{DialogButtonRole, FlexboxLayoutDirection, ItemRc};
 use i_slint_core::layout::{self as core_layout, GridLayoutInputData, GridLayoutOrganizedData};
 use i_slint_core::model::RepeatedItemTree;
 use i_slint_core::slice::Slice;
@@ -204,17 +204,19 @@ pub(crate) fn solve_flexbox_layout(
     let align_content = flexbox_layout
         .align_content
         .as_ref()
-        .map_or(i_slint_core::items::FlexAlignContent::default(), |nr| {
+        .map_or(i_slint_core::items::FlexboxLayoutAlignContent::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
     let align_items = flexbox_layout
         .align_items
         .as_ref()
-        .map_or(i_slint_core::items::FlexAlignItems::default(), |nr| {
+        .map_or(i_slint_core::items::FlexboxLayoutAlignItems::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
-    let flex_wrap =
-        flexbox_layout.flex_wrap.as_ref().map_or(i_slint_core::items::FlexWrap::default(), |nr| {
+    let flex_wrap = flexbox_layout
+        .flex_wrap
+        .as_ref()
+        .map_or(i_slint_core::items::FlexboxLayoutWrap::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
 
@@ -247,7 +249,7 @@ pub(crate) fn solve_flexbox_layout(
 fn flexbox_layout_direction(
     flexbox_layout: &i_slint_compiler::layout::FlexboxLayout,
     local_context: &EvalLocalContext,
-) -> FlexDirection {
+) -> FlexboxLayoutDirection {
     flexbox_layout
         .direction
         .as_ref()
@@ -257,17 +259,17 @@ fn flexbox_layout_direction(
                     .ok()?;
             if let Value::EnumerationValue(_, variant) = &value {
                 match variant.as_str() {
-                    "row" => Some(FlexDirection::Row),
-                    "row-reverse" => Some(FlexDirection::RowReverse),
-                    "column" => Some(FlexDirection::Column),
-                    "column-reverse" => Some(FlexDirection::ColumnReverse),
+                    "row" => Some(FlexboxLayoutDirection::Row),
+                    "row-reverse" => Some(FlexboxLayoutDirection::RowReverse),
+                    "column" => Some(FlexboxLayoutDirection::Column),
+                    "column-reverse" => Some(FlexboxLayoutDirection::ColumnReverse),
                     _ => None,
                 }
             } else {
                 None
             }
         })
-        .unwrap_or(FlexDirection::Row)
+        .unwrap_or(FlexboxLayoutDirection::Row)
 }
 
 pub(crate) fn compute_flexbox_layout_info(
@@ -289,8 +291,11 @@ pub(crate) fn compute_flexbox_layout_info(
     // Determine if we're on the main axis or cross axis
     let is_main_axis = matches!(
         (direction, orientation),
-        (FlexDirection::Row | FlexDirection::RowReverse, Orientation::Horizontal)
-            | (FlexDirection::Column | FlexDirection::ColumnReverse, Orientation::Vertical)
+        (FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse, Orientation::Horizontal)
+            | (
+                FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse,
+                Orientation::Vertical
+            )
     );
 
     let (padding_h, spacing_h) =
@@ -298,8 +303,10 @@ pub(crate) fn compute_flexbox_layout_info(
     let (padding_v, spacing_v) =
         padding_and_spacing(&flexbox_layout.geometry, Orientation::Vertical, &expr_eval);
 
-    let flex_wrap =
-        flexbox_layout.flex_wrap.as_ref().map_or(i_slint_core::items::FlexWrap::default(), |nr| {
+    let flex_wrap = flexbox_layout
+        .flex_wrap
+        .as_ref()
+        .map_or(i_slint_core::items::FlexboxLayoutWrap::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
 
@@ -410,7 +417,7 @@ fn flexbox_layout_data(
                         .try_into()
                         .unwrap()
                 })
-                .unwrap_or(i_slint_core::items::FlexAlignSelf::default());
+                .unwrap_or(i_slint_core::items::FlexboxLayoutAlignSelf::default());
             let order = layout_elem.order.as_ref().map(&expr_eval).unwrap_or(0.0) as i32;
             let item_info = core_layout::FlexboxLayoutItemInfo {
                 constraint: layout_info_h,

--- a/tests/cases/layout/flexbox_runtime_direction.slint
+++ b/tests/cases/layout/flexbox_runtime_direction.slint
@@ -10,7 +10,7 @@ export component TestCase inherits Window {
     in-out property <bool> use-column: false;
 
     FlexboxLayout {
-        flex-direction: use-column ? FlexDirection.column : FlexDirection.row;
+        flex-direction: use-column ? FlexboxLayoutDirection.column : FlexboxLayoutDirection.row;
         spacing: 10px;
 
         r1 := Rectangle {


### PR DESCRIPTION
FlexDirection -> FlexboxLayoutDirection
FlexAlignItems -> FlexboxLayoutAlignItems
FlexAlignContent -> FlexboxLayoutAlignContent
FlexWrap -> FlexboxLayoutWrap
FlexAlignSelf -> FlexboxLayoutAlignSelf

Fixes #11152