### PR TITLE
Add pbjson-build to generate serde impls for proto types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5013,9 +5013,12 @@ dependencies = [
  "i-slint-core-macros",
  "image",
  "include_dir",
+ "pbjson",
+ "pbjson-build",
  "prost",
  "prost-build",
  "protox",
+ "serde",
  "slint",
  "vtable",
 ]
@@ -7885,6 +7888,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "pbjson"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -23,13 +23,16 @@ internal = ["include_dir"]
 ffi = []
 system-testing = [
   "prost",
-  "prost-build",
-  "protox",
+  "pbjson",
+  "serde",
   "generational-arena",
   "async-net",
   "futures-lite",
   "byteorder",
   "image",
+  "prost-build",
+  "pbjson-build",
+  "protox",
 ]
 
 [dependencies]
@@ -37,6 +40,8 @@ i-slint-core = { workspace = true, features = ["std", "shared-parley"] }
 i-slint-common = { workspace = true, features = ["shared-fontique"] }
 vtable = { workspace = true }
 prost = { version = "0.14", optional = true }
+pbjson = { version = "0.9", optional = true }
+serde = { version = "1", optional = true }
 generational-arena = { version = "0.2.9", optional = true }
 async-net = { version = "2.0.0", optional = true }
 futures-lite = { version = "2.3.0", optional = true }
@@ -45,7 +50,9 @@ image = { workspace = true, optional = true, features = ["png"] }
 include_dir = { version = "0.7", optional = true }
 
 [build-dependencies]
+prost = { version = "0.14", optional = true }
 prost-build = { version = "0.14", optional = true }
+pbjson-build = { version = "0.9", optional = true }
 protox = { version = "0.9", optional = true }
 
 [dev-dependencies]

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -4,13 +4,24 @@
 fn main() {
     #[cfg(feature = "system-testing")]
     {
+        use prost::Message;
         let manifest_dir =
             std::path::PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+        let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
         let proto_file = manifest_dir.join("slint_systest.proto");
         let fds = protox::compile([&proto_file], [&manifest_dir])
             .expect("failed to compile slint_systest.proto");
+        let descriptor_bytes = fds.encode_to_vec();
+
         prost_build::Config::new()
             .compile_fds(fds)
             .expect("failed to generate Rust code from proto descriptors");
+
+        pbjson_build::Builder::new()
+            .register_descriptors(&descriptor_bytes)
+            .expect("failed to register proto descriptors for pbjson")
+            .out_dir(&out_dir)
+            .build(&[".proto"])
+            .expect("failed to generate serde impls from proto descriptors");
     }
 }

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -29,6 +29,7 @@ impl super::Sealed for RootWrapper<'_> {}
 #[allow(non_snake_case, unused_imports, non_camel_case_types, clippy::all)]
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/proto.rs"));
+    include!(concat!(env!("OUT_DIR"), "/proto.serde.rs"));
 }
 
 struct TestedWindow {


### PR DESCRIPTION
## Summary

- Adds `pbjson` + `pbjson-build` to the `system-testing` build pipeline so all prost-generated proto types get `Serialize`/`Deserialize` impls following the canonical protobuf JSON mapping
- No behavioral changes — existing systest transport is unaffected
- Prepares for PR 3 which will use these serde impls to simplify the MCP server by eliminating hand-written JSON serialization

## Changes

- **Cargo.toml**: Added `pbjson`, `serde` as optional runtime deps; `prost` and `pbjson-build` as build deps; `serde_json` as dev dep for tests
- **build.rs**: Encode `FileDescriptorSet` to bytes, then feed to `pbjson_build::Builder` after prost codegen
- **systest.rs**: Include generated `proto.serde.rs` in proto module; added 3 round-trip tests

## Test plan

- [x] `cargo build -p i-slint-backend-testing --features system-testing` compiles
- [x] `cargo test -p i-slint-backend-testing --features system-testing` — all systest tests pass
- [x] Serde round-trip tests verify: simple message, oneof message, enum-as-string serialization, numeric enum deserialization