### PR TITLE
Respect SLINT_STYLE env variable in slint-viewer

### DIFF
--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -241,11 +241,13 @@ impl CompilerConfiguration {
             _ => None,
         };
 
+        let style = std::env::var("SLINT_STYLE").ok();
+
         Self {
             embed_resources,
             include_paths: Default::default(),
             library_paths: Default::default(),
-            style: Default::default(),
+            style,
             open_import_callback: None,
             resource_url_mapper: None,
             inline_all_elements,

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -908,11 +908,7 @@ struct BorrowedTypeLoader<'a> {
 
 impl TypeLoader {
     pub fn new(compiler_config: CompilerConfiguration, diag: &mut BuildDiagnostics) -> Self {
-        let mut style = compiler_config
-            .style
-            .clone()
-            .or_else(|| std::env::var("SLINT_STYLE").ok())
-            .unwrap_or_else(|| "fluent".into());
+        let mut style = compiler_config.style.clone().unwrap_or_else(|| "fluent".into());
 
         if style == "native" {
             style = get_native_style(&mut diag.all_loaded_files);

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -913,10 +913,7 @@ pub async fn load(
     mut compiler_config: CompilerConfiguration,
 ) -> CompilationResult {
     // If the native style should be Qt, resolve it here as we know that we have it
-    let is_native = match &compiler_config.style {
-        Some(s) => s == "native",
-        None => std::env::var("SLINT_STYLE").is_ok_and(|s| s == "native"),
-    };
+    let is_native = compiler_config.style.as_deref() == Some("native");
     if is_native {
         // On wasm, look at the browser user agent
         #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Borth @murmele, @tronical and I ran into this at some point over the
last few days...

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
