### PR TITLE
Make compiler deterministic: use BTreeMap for property_analysis

### DIFF
--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -237,13 +237,13 @@ pub(crate) fn mark_property_set_derived_in_base(mut element: ElementRc, name: &s
                 return;
             };
             match c.root_element.borrow().property_analysis.borrow_mut().entry(name.into()) {
-                std::collections::hash_map::Entry::Occupied(e) if e.get().is_set_externally => {
+                std::collections::btree_map::Entry::Occupied(e) if e.get().is_set_externally => {
                     return;
                 }
-                std::collections::hash_map::Entry::Occupied(mut e) => {
+                std::collections::btree_map::Entry::Occupied(mut e) => {
                     e.get_mut().is_set_externally = true;
                 }
-                std::collections::hash_map::Entry::Vacant(e) => {
+                std::collections::btree_map::Entry::Vacant(e) => {
                     e.insert(PropertyAnalysis { is_set_externally: true, ..Default::default() });
                 }
             }
@@ -263,13 +263,13 @@ pub(crate) fn mark_property_read_derived_in_base(mut element: ElementRc, name: &
                 return;
             };
             match c.root_element.borrow().property_analysis.borrow_mut().entry(name.into()) {
-                std::collections::hash_map::Entry::Occupied(e) if e.get().is_read_externally => {
+                std::collections::btree_map::Entry::Occupied(e) if e.get().is_read_externally => {
                     return;
                 }
-                std::collections::hash_map::Entry::Occupied(mut e) => {
+                std::collections::btree_map::Entry::Occupied(mut e) => {
                     e.get_mut().is_read_externally = true;
                 }
-                std::collections::hash_map::Entry::Vacant(e) => {
+                std::collections::btree_map::Entry::Vacant(e) => {
                     e.insert(PropertyAnalysis { is_read_externally: true, ..Default::default() });
                 }
             }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -779,7 +779,7 @@ pub struct Element {
     /// Currently contains also the callbacks. FIXME: should that be changed?
     pub bindings: BindingsMap,
     pub change_callbacks: BTreeMap<SmolStr, RefCell<Vec<Expression>>>,
-    pub property_analysis: RefCell<HashMap<SmolStr, PropertyAnalysis>>,
+    pub property_analysis: RefCell<BTreeMap<SmolStr, PropertyAnalysis>>,
 
     pub children: Vec<ElementRc>,
     /// The component which contains this element.

--- a/internal/compiler/passes/move_declarations.rs
+++ b/internal/compiler/passes/move_declarations.rs
@@ -32,7 +32,7 @@ fn do_move_declarations(component: &Rc<Component>) {
 
     let mut new_root_bindings = HashMap::new();
     let mut new_root_change_callbacks = HashMap::new();
-    let mut new_root_property_analysis = HashMap::new();
+    let mut new_root_property_analysis = BTreeMap::new();
 
     let move_bindings_and_animations = &mut |elem: &ElementRc| {
         visit_all_named_references_in_element(elem, fixup_reference);
@@ -66,7 +66,7 @@ fn do_move_declarations(component: &Rc<Component>) {
         elem.borrow_mut().bindings = new_bindings;
 
         let property_analysis = elem.borrow().property_analysis.take();
-        let mut new_property_analysis = HashMap::with_capacity(property_analysis.len());
+        let mut new_property_analysis = BTreeMap::new();
         for (prop, a) in property_analysis {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&prop);
             if will_be_moved {


### PR DESCRIPTION
## Summary

- Replace `HashMap<SmolStr, PropertyAnalysis>` with `BTreeMap` in `Element::property_analysis` to ensure deterministic iteration order
- Update `namedreference.rs` to use `btree_map::Entry` instead of `hash_map::Entry`
- Update `move_declarations.rs` to use `BTreeMap` for local property analysis collections

The `HashMap` was iterated in several passes (`inlining`, `move_declarations`, `optimize_useless_rectangles`, `resolve_native_classes`). Since `HashMap` uses Rust's default `RandomState` hasher, iteration order varied between runs, which is a source of non-determinism in the compiler.

This is a standalone improvement — a deterministic compiler is desirable regardless. It may or may not be sufficient to resolve the cross-platform diagnostic position differences seen in #10552; that would need to be validated by merging this and re-running CI on that branch.

Related: #11188

## Test plan

- [x] `cargo check -p slint-compiler` passes
- [ ] CI passes