### PR TITLE
Build the node npm package with Xcode 26 so it gains the latest window UX

### DIFF
--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -65,7 +65,7 @@ jobs:
                     - os: ubuntu-22.04-arm
                       rust-target: aarch64-unknown-linux-gnu
                       napi-rs-target: linux-arm64-gnu
-                    - os: macos-14
+                    - os: macos-26
                       rust-target: aarch64-apple-darwin
                       napi-rs-target: darwin-arm64
                     - os: windows-2022


### PR DESCRIPTION
Much like the earlier issue with the live-preview the window you get on
MacOS 26 when running a node app is the MacOS 15 look.

This is the simplest fix which just bumps the build image to MacOS-26. But another
option would be to bump to macOS-15 and use the setup xcode action to
use Xcode 26 https://github.com/marketplace/actions/setup-xcode-version
if its important to build this with an earlier MacOS?