### PR TITLE
doc: Make the StyledText markdown example readable

### DIFF
--- a/docs/astro/src/content/docs/reference/elements/styled-text.mdx
+++ b/docs/astro/src/content/docs/reference/elements/styled-text.mdx
@@ -16,7 +16,9 @@ export component Example inherits Window {
     width: 200px;
     height: 200px;
     StyledText {
-      text: @markdown("This is a piece of <u>Styled Text</u>\nwith a red value inserted: <font color=\"red\">\{value}</font>");
+      text: @markdown("This is a piece of <u>Styled Text</u>\n"
+                      "with a red value inserted:"
+                      "<font color=\"red\">\{value}</font>");
     }
 }
 ```


### PR DESCRIPTION
The one-liner was so long that it required a scrollbar.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

before:

<img width="824" height="268" alt="Bildschirmfoto 2026-04-01 um 17 18 33" src="https://github.com/user-attachments/assets/4c1eb2b9-082c-4b59-a497-853849aa604d" />

after:
<img width="824" height="268" alt="Bildschirmfoto 2026-04-01 um 17 18 52" src="https://github.com/user-attachments/assets/f1b21d95-7254-4f5a-b2ba-5f7f7857582b" />

