### PR TITLE
fix renamed enum and struct re-exports in rust codegen

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -118,7 +118,6 @@ futures = { version = "0.3.31" }
 objc2 = { workspace = true }
 # For GL rendering
 objc2-app-kit = { version = "0.3.2", features = ["NSColor", "objc2-core-foundation"] }
-objc2 = "0.6.3"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "block2", "NSString", "NSNotification"] }
 block2 = "0.6.2"
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -195,7 +195,7 @@ pub fn generate(
             .collect::<Vec<_>>()
     };
 
-    let (structs_and_enums_ids, inner_module) =
+    let (mut structs_and_enums_ids, inner_module) =
         generate_types(&doc.used_types.borrow().structs_and_enums);
 
     let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
@@ -238,6 +238,13 @@ pub fn generate(
 
     let resource_symbols = generate_resources(doc);
     let named_exports = generate_named_exports(&doc.exports);
+    let deprecated_named_export_aliases = generate_deprecated_named_export_aliases(&doc.exports);
+    let deprecated_aliases = deprecated_named_export_aliases.aliases;
+    structs_and_enums_ids.retain(|id| {
+        let id = id.to_string();
+        let id = id.strip_prefix("r#").unwrap_or(&id);
+        !deprecated_named_export_aliases.hidden_type_exports.contains(id)
+    });
     // The inner module was meant to be internal private, but projects have been reaching into it
     // so we can't change the name of this module
     let generated_mod = doc
@@ -266,6 +273,7 @@ pub fn generate(
         }
         #[allow(unused_imports)]
         pub use #generated_mod::{#(#compo_ids,)* #(#structs_and_enums_ids,)* #(#globals_ids,)* #(#named_exports,)* #(#global_exports,)*};
+        #(#deprecated_aliases)*
         #[allow(unused_imports)]
         pub use slint::{ComponentHandle as _, Global as _, ModelExt as _};
     })
@@ -4529,6 +4537,45 @@ pub fn generate_named_exports(exports: &crate::object_tree::Exports) -> Vec<Toke
             quote!(#type_id as #export_id)
         })
         .collect::<Vec<_>>()
+}
+
+pub struct DeprecatedNamedExportAliases {
+    aliases: Vec<TokenStream>,
+    hidden_type_exports: BTreeSet<SmolStr>,
+}
+
+pub fn generate_deprecated_named_export_aliases(
+    exports: &crate::object_tree::Exports,
+) -> DeprecatedNamedExportAliases {
+    let mut aliases = Vec::new();
+    let mut hidden_type_exports = BTreeSet::new();
+
+    for export in exports.iter() {
+        let (original_name, export_name) = match &export.1 {
+            Either::Right(Type::Struct(s)) if s.node().is_some() => {
+                let StructName::User { name, .. } = &s.name else { continue };
+                (name, &export.0.name)
+            }
+            Either::Right(Type::Enumeration(en)) => (&en.name, &export.0.name),
+            _ => continue,
+        };
+
+        if original_name == export_name || exports.find(original_name.as_str()).is_some() {
+            continue;
+        }
+
+        hidden_type_exports.insert(original_name.clone());
+
+        let original_id = ident(original_name);
+        let export_id = ident(export_name);
+        let message = format!("'{original_name}' is re-exported as '{export_name}'");
+        aliases.push(quote! {
+            #[deprecated(note = #message)]
+            pub type #original_id = #export_id;
+        });
+    }
+
+    DeprecatedNamedExportAliases { aliases, hidden_type_exports }
 }
 
 fn remove_parenthesis(

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -10,6 +10,7 @@ use itertools::Itertools;
 
 use smol_str::SmolStr;
 
+use crate::diagnostics::Spanned;
 use crate::expression_tree::{BuiltinFunction, Expression, Unit};
 use crate::object_tree::{Component, PropertyVisibility};
 use crate::parser::syntax_nodes;
@@ -263,6 +264,15 @@ impl Type {
         };
         match (self, other) {
             (a, b) if a == b => true,
+            (Type::Enumeration(a), Type::Enumeration(b)) => {
+                a.node.as_ref().zip(b.node.as_ref()).is_some_and(|(a, b)| {
+                    let a = a.to_source_location();
+                    let b = b.to_source_location();
+                    a.span == b.span
+                        && a.source_file.as_ref().map(|sf| sf.path())
+                            == b.source_file.as_ref().map(|sf| sf.path())
+                })
+            }
             (_, Type::Invalid)
             | (_, Type::Void)
             | (Type::Float32, Type::Int32)
@@ -1017,6 +1027,27 @@ impl Enumeration {
                 None
             }
         })
+    }
+}
+
+pub fn renamed_type_for_public_export(ty: &Type, name: &SmolStr) -> Type {
+    match ty {
+        Type::Struct(s) => match &s.name {
+            StructName::User { name: current_name, node } if current_name != name => {
+                Type::Struct(Rc::new(Struct {
+                    fields: s.fields.clone(),
+                    name: StructName::User { name: name.clone(), node: node.clone() },
+                }))
+            }
+            _ => ty.clone(),
+        },
+        Type::Enumeration(en) if en.name != *name => Type::Enumeration(Rc::new(Enumeration {
+            name: name.clone(),
+            values: en.values.clone(),
+            default_value: en.default_value,
+            node: en.node.clone(),
+        })),
+        _ => ty.clone(),
     }
 }
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2286,7 +2286,12 @@ pub fn resolve_two_way_binding(
                 }
             }
             if let Some(result) = unwrap_fields(&expression) {
-                if report_error && expression.ty() != ctx.property_type {
+                let expr_ty = expression.ty();
+                if report_error
+                    && expr_ty != ctx.property_type
+                    && !(expr_ty.can_convert(&ctx.property_type)
+                        && ctx.property_type.can_convert(&expr_ty))
+                {
                     ctx.diag.push_error(
                         "The property does not have the same type as the bound property".into(),
                         &node,

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1153,6 +1153,15 @@ impl TypeLoader {
                                         state.diag.push_error(format!("No exported type called '{imported_name}' found in \"{}\"", doc_path.display()), &e);
                                         return None;
                                     };
+                                    let r = match r {
+                                        itertools::Either::Right(ty) => itertools::Either::Right(
+                                            crate::langtype::renamed_type_for_public_export(
+                                                &ty,
+                                                &exported_name.name,
+                                            ),
+                                        ),
+                                        component => component,
+                                    };
                                     Some((exported_name, r))
                                 })
                                 .collect::<Vec<_>>();
@@ -1590,9 +1599,19 @@ impl TypeLoader {
                 itertools::Either::Left(c) => {
                     registry_to_populate.borrow_mut().add_with_name(import_name.internal_name, c)
                 }
-                itertools::Either::Right(ty) => registry_to_populate
-                    .borrow_mut()
-                    .insert_type_with_name(ty, import_name.internal_name),
+                itertools::Either::Right(ty) => {
+                    let ty = if import_name.internal_name == import_name.external_name {
+                        crate::langtype::renamed_type_for_public_export(
+                            &ty,
+                            &import_name.internal_name,
+                        )
+                    } else {
+                        ty
+                    };
+                    registry_to_populate
+                        .borrow_mut()
+                        .insert_type_with_name(ty, import_name.internal_name)
+                }
             };
         }
     }
@@ -2238,4 +2257,62 @@ fn test_snapshotting() {
     assert_eq!(c.id, "Foobar");
     let root_element = c.root_element.clone();
     assert_eq!(root_element.borrow().base_type.to_string(), "Rectangle");
+}
+
+#[cfg(feature = "rust")]
+#[test]
+fn test_renamed_enum_reexport_generates_distinct_rust_types() {
+    let mut compiler_config = CompilerConfiguration::new(crate::generator::OutputFormat::Rust);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.open_import_callback = Some(Rc::new(move |path| {
+        Box::pin(async move {
+            assert_eq!(path.replace('\\', "/"), "other.slint");
+            Some(Ok(r#"
+export enum SomeEnum { Alpha, Beta, Gamma }
+export { SomeEnum as SomeOtherEnum }
+"#
+            .to_owned()))
+        })
+    }));
+
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+import { SomeOtherEnum } from "other.slint";
+
+export enum SomeEnum { One, Two, Three }
+export component App inherits Window {
+    in property <SomeEnum> local-enum;
+    in property <SomeOtherEnum> imported-enum;
+}
+export { SomeOtherEnum } from "other.slint";
+"#
+        .into(),
+        Some(std::path::Path::new("main.slint")),
+        &mut test_diags,
+    );
+
+    let (doc, build_diagnostics, _) = spin_on::spin_on(crate::compile_syntax_node(
+        doc_node,
+        BuildDiagnostics::default(),
+        compiler_config,
+    ));
+
+    assert!(!test_diags.has_errors());
+    assert!(!build_diagnostics.has_errors(), "{:?}", build_diagnostics.to_string_vec());
+
+    let generated = crate::generator::rust::generate(
+        &doc,
+        &CompilerConfiguration::new(crate::generator::OutputFormat::Rust),
+    )
+    .unwrap()
+    .to_string();
+
+    assert!(generated.contains("pub enum r#SomeEnum"));
+    assert!(generated.contains("pub enum r#SomeOtherEnum"));
+    assert!(generated.contains("r#One"));
+    assert!(generated.contains("r#Alpha"));
+    assert!(generated.contains("get_imported_enum"));
+    assert!(generated.contains("-> r#SomeOtherEnum"));
+    assert!(!generated.contains("r#SomeEnum as r#SomeOtherEnum"));
 }

--- a/tests/cases/exports/named_exports.slint
+++ b/tests/cases/exports/named_exports.slint
@@ -16,14 +16,40 @@ export { TestCase as NamedTestCase }
 /*
 
 ```cpp
+ExportedStruct deprecated_value;
+(void)deprecated_value;
+assert(ExportEnum::Bonjour == NamedEnum::Bonjour);
+
+struct ExportedStruct { };
+enum class ExportEnum { Hello, Bonjour };
+
 auto handle = NamedTestCase::create();
 const TestCase &instance = *handle;
 assert(instance.get_en() == NamedEnum::Bonjour);
+NamedStruct value;
+instance.set_st(value);
 ```
 
 ```rust
-let instance = NamedTestCase::new().unwrap();
-assert_eq!(instance.get_en(), NamedEnum::Bonjour);
+#[allow(deprecated)]
+{
+    let deprecated_value: ExportedStruct = NamedStruct::default();
+    let deprecated_enum = ExportEnum::Bonjour;
+    assert_eq!(deprecated_value, NamedStruct::default());
+    assert_eq!(deprecated_enum, NamedEnum::Bonjour);
+}
+
+{
+    fn assert_named_exports_still_work<ExportedStruct, ExportEnum>() {
+        let _ = core::marker::PhantomData::<ExportedStruct>;
+        let _ = core::marker::PhantomData::<ExportEnum>;
+        let instance = NamedTestCase::new().unwrap();
+        assert_eq!(instance.get_en(), NamedEnum::Bonjour);
+        instance.set_st(NamedStruct::default());
+    }
+
+    assert_named_exports_still_work::<(), ()>();
+}
 ```
 
 */


### PR DESCRIPTION
## Summary

  Fix a compiler issue where renamed exported enums and structs could lose their public identity during
  import or re-export resolution.
  
  Fixes #9094
  
  ## Update
  
  The major problem was that renamed public identities are needed for Rust codegen but plain alias imports must still remain semantically.