### PR TITLE
Remove redundant *-font-weight property indirections

### DIFF
--- a/demos/usecases/ui/widgets/styling.slint
+++ b/demos/usecases/ui/widgets/styling.slint
@@ -47,20 +47,17 @@ export struct TextStyle {
 }
 
 export global CosmicFontSettings {
-    out property <int> light-font-weight: FontWeight.light;
-    out property <int> regular-font-weight: FontWeight.normal;
-    out property <int> semibold-font-weight: FontWeight.semi-bold;
     out property <TextStyle> body: {
         font-size: 14 * 0.0769rem,
-        font-weight: regular-font-weight
+        font-weight: FontWeight.normal
     };
     out property <TextStyle> body-strong: {
         font-size: 14 * 0.0769rem,
-        font-weight: semibold-font-weight
+        font-weight: FontWeight.semi-bold
     };
 
     out property <TextStyle> title-2: {
         font-size: 28 * 0.0769rem,
-        font-weight: regular-font-weight
+        font-weight: FontWeight.normal
     };
 }

--- a/examples/todo-mvc/ui/widgets/styling.slint
+++ b/examples/todo-mvc/ui/widgets/styling.slint
@@ -26,16 +26,13 @@ export struct TextStyle {
 }
 
 export global FontSettings {
-    out property <int> light-font-weight: FontWeight.light;
-    out property <int> regular-font-weight: FontWeight.medium;
-    out property <int> semi-bold-font-weight: FontWeight.semi-bold;
     out property <TextStyle> body: {
         font-size: 14 * 0.0769rem,
-        font-weight: root.light-font-weight,
+        font-weight: FontWeight.light,
     };
     out property <TextStyle> body-strong: {
         font-size: 16 * 0.0769rem,
-        font-weight: root.semi-bold-font-weight,
+        font-weight: FontWeight.semi-bold,
     };
 }
 

--- a/internal/compiler/widgets/cosmic/styling.slint
+++ b/internal/compiler/widgets/cosmic/styling.slint
@@ -9,20 +9,17 @@ export struct TextStyle {
 }
 
 export global CosmicFontSettings {
-    out property <int> light-font-weight: FontWeight.light;
-    out property <int> regular-font-weight: FontWeight.normal;
-    out property <int> semibold-font-weight: FontWeight.semi-bold;
     out property <TextStyle> body: {
         font-size: 14 * 0.0769rem,
-        font-weight: regular-font-weight
+        font-weight: FontWeight.normal
     };
     out property <TextStyle> body-strong: {
         font-size: 14 * 0.0769rem,
-        font-weight: semibold-font-weight
+        font-weight: FontWeight.semi-bold
     };
     out property <TextStyle> title: {
         font-size: 24 * 0.0769rem,
-        font-weight: light-font-weight
+        font-weight: FontWeight.light
     };
 }
 

--- a/internal/compiler/widgets/cupertino/styling.slint
+++ b/internal/compiler/widgets/cupertino/styling.slint
@@ -9,25 +9,21 @@ export struct TextStyle {
 }
 
 export global CupertinoFontSettings {
-    out property <int> light-font-weight: FontWeight.light;
-    out property <int> regular-font-weight: FontWeight.normal;
-    out property <int> semibold-font-weight: FontWeight.semi-bold;
-
     out property <TextStyle> body: {
         font-size: 13 * 0.0769rem,
-        font-weight: regular-font-weight
+        font-weight: FontWeight.normal
     };
 
 
     out property <TextStyle> title: {
         font-size: 28 * 0.0769rem,
-        font-weight: light-font-weight
+        font-weight: FontWeight.light
     };
 
     // needed?
     out property <TextStyle> body-strong: {
         font-size: 14 * 0.0769rem,
-        font-weight: semibold-font-weight
+        font-weight: FontWeight.semi-bold
     };
 }
 export global CupertinoColors {

--- a/internal/compiler/widgets/fluent/styling.slint
+++ b/internal/compiler/widgets/fluent/styling.slint
@@ -9,20 +9,17 @@ export struct TextStyle {
 }
 
 export global FluentFontSettings {
-    out property <int> light-font-weight: FontWeight.light;
-    out property <int> regular-font-weight: FontWeight.normal;
-    out property <int> semibold-font-weight: FontWeight.semi-bold;
     out property <TextStyle> body: {
         font-size: 14 * 0.0769rem,
-        font-weight: regular-font-weight
+        font-weight: FontWeight.normal
     };
     out property <TextStyle> body-strong: {
         font-size: 14 * 0.0769rem,
-        font-weight: semibold-font-weight
+        font-weight: FontWeight.semi-bold
     };
     out property <TextStyle> title: {
         font-size: 28 * 0.0769rem,
-        font-weight: semibold-font-weight
+        font-weight: FontWeight.semi-bold
     };
 }
 

--- a/tools/lsp/ui/components/selection-popup.slint
+++ b/tools/lsp/ui/components/selection-popup.slint
@@ -425,7 +425,7 @@ component PopupInner inherits Rectangle {
                                             text: frame.id;
                                             overflow: elide;
                                             color: frame.is-selected ? Palette.accent-foreground : Palette.foreground;
-                                            font-weight: EditorFontSettings.bold-font-weight;
+                                            font-weight: FontWeight.black;
                                             font-size: EditorFontSettings.label.font-size;
                                         }
 

--- a/tools/lsp/ui/components/styling.slint
+++ b/tools/lsp/ui/components/styling.slint
@@ -35,18 +35,13 @@ export struct TextStyle {
 }
 
 export global EditorFontSettings {
-    out property <int> light-font-weight: FontWeight.thin;
-    out property <int> regular-font-weight: FontWeight.normal;
-    out property <int> semibold-font-weight: FontWeight.bold;
-    out property <int> bold-font-weight: FontWeight.black;
+    out property <TextStyle> header: { font-size: 18 * 0.0769rem, font-weight: FontWeight.bold };
 
-    out property <TextStyle> header: { font-size: 18 * 0.0769rem, font-weight: root.semibold-font-weight };
+    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: FontWeight.normal };
+    out property <TextStyle> label: { font-size: 12 * 0.0769rem, font-weight: FontWeight.black };
+    out property <TextStyle> label-sub: { font-size: 14 * 0.0769rem, font-weight: FontWeight.thin };
 
-    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: root.regular-font-weight };
-    out property <TextStyle> label: { font-size: 12 * 0.0769rem, font-weight: root.bold-font-weight };
-    out property <TextStyle> label-sub: { font-size: 14 * 0.0769rem, font-weight: root.light-font-weight };
-
-    out property <TextStyle> body-strong: { font-size: 16 * 0.0769rem, font-weight: root.bold-font-weight };
+    out property <TextStyle> body-strong: { font-size: 16 * 0.0769rem, font-weight: FontWeight.black };
 }
 
 export global EditorSpaceSettings {

--- a/tools/lsp/ui/components/widgets/basics.slint
+++ b/tools/lsp/ui/components/widgets/basics.slint
@@ -25,7 +25,7 @@ export component NameLabel inherits HorizontalLayout {
         height: root.property-name != "" ? self.preferred-height : 0;
         text: root.property-name;
         font-size: 1rem;
-        font-weight: root.property-value.code != "" ? EditorFontSettings.regular-font-weight : EditorFontSettings.light-font-weight;
+        font-weight: root.property-value.code != "" ? FontWeight.normal : FontWeight.thin;
         font-italic: root.property-value.code == "";
         opacity: root.property-value.code != "" ? 1.0 : 0.5;
 

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -49,7 +49,7 @@ export component PropertyView inherits VerticalLayout {
                     spacing: EditorSpaceSettings.default-spacing / 4;
                     Text {
                         text: "id";
-                        font-weight: element-information.id != "" ? EditorFontSettings.regular-font-weight : EditorFontSettings.light-font-weight;
+                        font-weight: element-information.id != "" ? FontWeight.normal : FontWeight.thin;
                         font-italic: element-information.id != "" ? false : true;
                         opacity: element-information.id != "" ? 1.0 : 0.5;
                     }


### PR DESCRIPTION
Use FontWeight.* constants directly instead of going through intermediate property <int> declarations.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
