### PR TITLE
Add application-side Keys construction support

### DIFF
--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -16,6 +16,10 @@ import {
 const filename = fileURLToPath(import.meta.url).replace("build", "__test__");
 const dirname = path.dirname(filename);
 
+function ctrlPlusShortcutText() {
+    return process.platform === "darwin" ? "⌘+" : "Ctrl++";
+}
+
 function createNonNullInstance(definition: {
     App?: { create(): private_api.ComponentInstance | null };
 }): private_api.ComponentInstance {
@@ -145,6 +149,39 @@ test("get/set bool properties", () => {
         expect(thrownError.code).toBe("BooleanExpected");
         expect(thrownError.message).toContain("Boolean");
     }
+});
+
+test("get/set keys properties", () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `export component App {
+            in-out property <keys> shortcut: @keys(Control + Plus);
+            out property <string> shortcut-text: shortcut.to-string();
+        }`,
+        "",
+    );
+    const instance = createNonNullInstance(definition);
+
+    expect(instance.getProperty("shortcut-text")).toBe(ctrlPlusShortcutText());
+
+    instance.setProperty("shortcut", "Escape");
+    expect(instance.getProperty("shortcut-text")).toBe("Escape");
+
+    instance.setProperty("shortcut", {
+        key: "Plus",
+        control: true,
+        ignoreShift: true,
+    });
+    expect(instance.getProperty("shortcut-text")).toBe(ctrlPlusShortcutText());
+
+    let thrownError: any;
+    try {
+        instance.setProperty("shortcut", "");
+    } catch (error) {
+        thrownError = error;
+    }
+    expect(thrownError).toBeDefined();
+    expect(thrownError.message).toContain("must not be empty");
 });
 
 test("set struct properties", () => {

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use i_slint_compiler::langtype::Type;
 use i_slint_core::graphics::{Image, Rgba8Pixel, SharedPixelBuffer};
+use i_slint_core::input::{KeyboardModifiers, Keys};
 use i_slint_core::model::{ModelRc, SharedVectorModel};
 use i_slint_core::{Brush, Color, SharedVector};
 use napi::bindgen_prelude::*;
@@ -314,12 +315,7 @@ pub fn to_value(env: &Env, unknown: Unknown<'_>, typ: &Type) -> Result<Value> {
 
             Ok(Value::EnumerationValue(e.name.to_string(), value.to_string()))
         }
-        Type::Keys => {
-            let obj = unknown.coerce_to_object()?;
-            let keys_instance: ClassInstance<SlintKeys> =
-                ClassInstance::from_unknown(obj.into_unknown(env)?)?;
-            Ok(Value::Keys(keys_instance.inner.clone()))
-        }
+        Type::Keys => Ok(Value::Keys(js_into_keys(unknown)?)),
         Type::Invalid
         | Type::Model
         | Type::Void
@@ -334,6 +330,44 @@ pub fn to_value(env: &Env, unknown: Unknown<'_>, typ: &Type) -> Result<Value> {
         | Type::ArrayOfU16
         | Type::ElementReference
         | Type::StyledText => Err(napi::Error::from_reason("reason")),
+    }
+}
+
+fn js_into_keys(unknown: Unknown<'_>) -> Result<Keys> {
+    match unknown.get_type()? {
+        ValueType::String => Keys::from_key_name_or_string(&expect_string(unknown)?)
+            .map_err(|err| napi::Error::from_reason(err.to_string())),
+        ValueType::Object => {
+            if let Ok(keys_instance) = ClassInstance::<SlintKeys>::from_unknown(unknown) {
+                return Ok(keys_instance.inner.clone());
+            }
+
+            let obj = unknown.coerce_to_object()?;
+            let key = obj
+                .get::<String>("key")?
+                .ok_or_else(|| napi::Error::from_reason("Property key is missing"))?;
+            let mut keys = Keys::from_key_name_or_string(&key)
+                .map_err(|err| napi::Error::from_reason(err.to_string()))?;
+            let mut modifiers = KeyboardModifiers::default();
+            modifiers.alt = obj.get::<bool>("alt")?.unwrap_or(false);
+            modifiers.control = obj.get::<bool>("control")?.unwrap_or(false);
+            modifiers.shift = obj.get::<bool>("shift")?.unwrap_or(false);
+            modifiers.meta = obj.get::<bool>("meta")?.unwrap_or(false);
+            keys = keys.with_modifiers(modifiers);
+
+            if obj.get::<bool>("ignoreShift")?.unwrap_or(false) {
+                keys = keys.ignoring_shift();
+            }
+            if obj.get::<bool>("ignoreAlt")?.unwrap_or(false) {
+                keys = keys.ignoring_alt();
+            }
+
+            Ok(keys)
+        }
+        vt => Err(napi::Error::new(
+            napi::Status::InvalidArg,
+            format!("expect String or Object, got: {vt:?}"),
+        )),
     }
 }
 

--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -412,8 +412,20 @@ impl ComponentInstance {
     }
 
     fn set_property(&self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
-        let pv =
-            TypeCollection::slint_value_from_py_value_bound(&value, Some(&self.type_collection))?;
+        let normalized_name = normalize_identifier(name);
+        let ty = self
+            .instance
+            .definition()
+            .properties_and_callbacks()
+            .find_map(|(prop_name, (ty, _))| {
+                (normalize_identifier(&prop_name) == normalized_name).then_some(ty)
+            })
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("no such property"))?;
+        let pv = TypeCollection::slint_value_from_py_value_bound_for_type(
+            &value,
+            &ty,
+            Some(&self.type_collection),
+        )?;
         Ok(self.instance.set_property(name, pv).map_err(|e| PySetPropertyError(e))?)
     }
 
@@ -433,8 +445,22 @@ impl ComponentInstance {
         prop_name: &str,
         value: Bound<'_, PyAny>,
     ) -> PyResult<()> {
-        let pv =
-            TypeCollection::slint_value_from_py_value_bound(&value, Some(&self.type_collection))?;
+        let normalized_prop_name = normalize_identifier(prop_name);
+        let ty = self
+            .instance
+            .definition()
+            .global_properties_and_callbacks(global_name)
+            .and_then(|mut props| {
+                props.find_map(|(name, (ty, _))| {
+                    (normalize_identifier(&name) == normalized_prop_name).then_some(ty)
+                })
+            })
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("no such property"))?;
+        let pv = TypeCollection::slint_value_from_py_value_bound_for_type(
+            &value,
+            &ty,
+            Some(&self.type_collection),
+        )?;
         Ok(self
             .instance
             .set_global_property(global_name, prop_name, pv)

--- a/api/python/slint/slint/models.py
+++ b/api/python/slint/slint/models.py
@@ -5,7 +5,7 @@ from . import slint as native
 from collections.abc import Iterable
 from abc import abstractmethod
 import typing
-from typing import Any, cast, Iterator
+from typing import Any, Self, cast, Iterator
 
 
 class Model[T](native.PyModelBase, Iterable[T]):
@@ -15,7 +15,7 @@ class Model[T](native.PyModelBase, Iterable[T]):
 
     Models are iterable and can be used in for loops."""
 
-    def __new__(cls, *args: Any) -> "Model[T]":
+    def __new__(cls, *args: Any) -> Self:
         return super().__new__(cls)
 
     def __init__(self) -> None:

--- a/api/python/slint/tests/test_instance.py
+++ b/api/python/slint/tests/test_instance.py
@@ -5,7 +5,12 @@ import pytest
 from slint import slint as native
 from slint.slint import Image, Color, Brush
 import os
+import sys
 from pathlib import Path
+
+
+def ctrl_plus_shortcut_text() -> str:
+    return "⌘+" if sys.platform == "darwin" else "Ctrl++"
 
 
 def test_property_access() -> None:
@@ -29,6 +34,7 @@ def test_property_access() -> None:
             in property <int> intprop: 42;
             in property <float> floatprop: 100;
             in property <bool> boolprop: true;
+            in property <keys> keysprop: @keys(Control + Plus);
             in property <image> imgprop;
             in property <brush> brushprop: Colors.rgb(255, 0, 255);
             in property <color> colprop: Colors.rgb(0, 255, 0);
@@ -38,6 +44,7 @@ def test_property_access() -> None:
                 finished: true,
                 dash-prop: true,
             };
+            out property <string> keysproptext: keysprop.to-string();
             in property <image> imageprop: @image-url("../../../../demos/printerdemo/ui/images/cat.jpg");
 
             callback test-callback();
@@ -76,6 +83,14 @@ def test_property_access() -> None:
     assert not instance.get_property("boolprop")
     with pytest.raises(ValueError, match="wrong type"):
         instance.set_property("boolprop", 0)
+
+    assert instance.get_property("keysproptext") == ctrl_plus_shortcut_text()
+    instance.set_property("keysprop", "Escape")
+    assert instance.get_property("keysproptext") == "Escape"
+    instance.set_property(
+        "keysprop", {"key": "Plus", "control": True, "ignore_shift": True}
+    )
+    assert instance.get_property("keysproptext") == ctrl_plus_shortcut_text()
 
     structval = instance.get_property("structprop")
     assert isinstance(structval, native.PyStruct)

--- a/api/python/slint/value.rs
+++ b/api/python/slint/value.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 
 use i_slint_compiler::langtype::Type;
 
+use i_slint_core::input::{KeyboardModifiers, Keys};
 use i_slint_core::model::{Model, ModelRc};
 
 use crate::keys::PyKeys;
@@ -392,4 +393,67 @@ impl TypeCollection {
         }
         model
     }
+
+    pub fn slint_value_from_py_value_bound_for_type(
+        ob: &Bound<'_, PyAny>,
+        expected_type: &Type,
+        type_collection: Option<&Self>,
+    ) -> PyResult<slint_interpreter::Value> {
+        if let Type::Keys = expected_type {
+            return py_value_to_keys(ob).map(slint_interpreter::Value::Keys);
+        }
+
+        Self::slint_value_from_py_value_bound(ob, type_collection)
+    }
+}
+
+fn py_value_to_keys(ob: &Bound<'_, PyAny>) -> PyResult<Keys> {
+    if let Ok(keys) = ob.extract::<PyRef<'_, PyKeys>>() {
+        return Ok(keys.keys.clone());
+    }
+
+    if let Ok(key) = ob.extract::<&str>() {
+        return Keys::from_key_name_or_string(key)
+            .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()));
+    }
+
+    let dict = ob.cast::<PyDict>().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err("Keys values must be strings or dicts")
+    })?;
+
+    let key = dict
+        .get_item("key")?
+        .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("Keys dict requires a key field"))?
+        .extract::<String>()?;
+    let mut keys = Keys::from_key_name_or_string(&key)
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+
+    let mut modifiers = KeyboardModifiers::default();
+    if let Some(value) = dict.get_item("alt")? {
+        modifiers.alt = value.extract::<bool>()?;
+    }
+    if let Some(value) = dict.get_item("control")? {
+        modifiers.control = value.extract::<bool>()?;
+    }
+    if let Some(value) = dict.get_item("shift")? {
+        modifiers.shift = value.extract::<bool>()?;
+    }
+    if let Some(value) = dict.get_item("meta")? {
+        modifiers.meta = value.extract::<bool>()?;
+    }
+
+    keys = keys.with_modifiers(modifiers);
+
+    if let Some(value) = dict.get_item("ignore_shift")?
+        && value.extract::<bool>()?
+    {
+        keys = keys.ignoring_shift();
+    }
+    if let Some(value) = dict.get_item("ignore_alt")?
+        && value.extract::<bool>()?
+    {
+        keys = keys.ignoring_alt();
+    }
+
+    Ok(keys)
 }

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -219,6 +219,7 @@ pub use i_slint_core::api::*;
 pub use i_slint_core::component_factory::ComponentFactory;
 #[cfg(not(target_arch = "wasm32"))]
 pub use i_slint_core::graphics::{BorrowedOpenGLTextureBuilder, BorrowedOpenGLTextureOrigin};
+pub use i_slint_core::input::{KeyboardModifiers, Keys, KeysError};
 pub use i_slint_core::items::{StandardListViewItem, TableColumn};
 pub use i_slint_core::model::{
     FilterModel, MapModel, Model, ModelExt, ModelNotify, ModelPeer, ModelRc, ModelTracker,

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -14,12 +14,14 @@ use crate::timers::Timer;
 use crate::window::{WindowAdapter, WindowInner};
 use crate::{Coord, Property, SharedString};
 use alloc::rc::Rc;
+use alloc::string::String;
 use alloc::vec::Vec;
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
 use core::fmt::Display;
 use core::pin::Pin;
 use core::time::Duration;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// A mouse or touch event
 ///
@@ -353,6 +355,93 @@ pub struct Keys {
     inner: KeysInner,
 }
 
+/// An error returned when creating a [`Keys`] value from a string.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KeysError {
+    /// The provided key string was empty.
+    EmptyString,
+    /// The provided key string contained more than one grapheme cluster.
+    MultipleGraphemeClusters(usize),
+}
+
+impl core::fmt::Display for KeysError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::EmptyString => f.write_str("key string literal must not be empty"),
+            Self::MultipleGraphemeClusters(count) => {
+                write!(
+                    f,
+                    "key string literal must contain exactly one grapheme cluster, found {count}"
+                )
+            }
+        }
+    }
+}
+
+fn key_has_shift_variant(key_name: &str) -> Option<bool> {
+    macro_rules! shifted_key_variant {
+        ($keycode:literal # $ident:ident # $shifted:ident) => {
+            (stringify!($ident), true)
+        };
+        ($keycode:literal # $ident:ident # $shifted:literal) => {
+            (stringify!($ident), true)
+        };
+        ($keycode:literal # $ident:ident # ) => {
+            (stringify!($ident), false)
+        };
+    }
+    macro_rules! generate_key_map {
+        [ $($char:literal # $name:ident # $($shifted:literal)?$($shifted_name:ident)? # $($_muda:ident)? $(=> $($qt:ident)|* # $($winit:ident $(($_pos:ident))?)|* # $($_xkb:ident)|*)?;)* ] => {
+            match key_name {
+                $(
+                    stringify!($name) => Some(shifted_key_variant!(
+                        $char # $name # $($shifted)?$($shifted_name)?
+                    ).1),
+                )*
+                _ => None,
+            }
+        };
+    }
+
+    i_slint_common::for_each_keys!(generate_key_map)
+}
+
+fn lookup_named_key(key_name: &str) -> Option<(char, bool)> {
+    macro_rules! generate_key_map {
+        [ $($char:literal # $name:ident # $($shifted:literal)?$($shifted_name:ident)? # $($_muda:ident)? $(=> $($qt:ident)|* # $($winit:ident $(($_pos:ident))?)|* # $($_xkb:ident)|*)?;)* ] => {
+            match key_name {
+                $(
+                    stringify!($name) => Some((
+                        $char,
+                        key_has_shift_variant(stringify!($name)).unwrap_or(false),
+                    )),
+                )*
+                _ => None,
+            }
+        };
+    }
+
+    i_slint_common::for_each_keys!(generate_key_map)
+}
+
+fn normalize_key_string(key: &str) -> Result<SharedString, KeysError> {
+    #[cfg(feature = "shared-parley")]
+    let key: String = icu_normalizer::ComposingNormalizer::new_nfc().normalize(key).into();
+    #[cfg(not(feature = "shared-parley"))]
+    let key = String::from(key);
+
+    let key: SharedString = key.to_lowercase().into();
+    let grapheme_count = key.graphemes(true).count();
+
+    if grapheme_count == 0 {
+        Err(KeysError::EmptyString)
+    } else if grapheme_count > 1 {
+        Err(KeysError::MultipleGraphemeClusters(grapheme_count))
+    } else {
+        Ok(key)
+    }
+}
+
 /// Re-exported in private_unstable_api to create a Keys struct.
 pub fn make_keys(
     key: SharedString,
@@ -427,6 +516,34 @@ impl KeysInner {
 }
 
 impl Keys {
+    /// Create a `Keys` value from either a key name such as `"Escape"` or a single-grapheme
+    /// string literal such as `"a"` or `"+"`.
+    pub fn from_key_name_or_string(key: &str) -> Result<Self, KeysError> {
+        if let Some((key, ignore_shift)) = lookup_named_key(key) {
+            Ok(make_keys(key.into(), Default::default(), ignore_shift, false))
+        } else {
+            Ok(make_keys(normalize_key_string(key)?, Default::default(), false, false))
+        }
+    }
+
+    /// Set the modifier state that needs to be pressed for this key combination.
+    pub fn with_modifiers(mut self, modifiers: KeyboardModifiers) -> Self {
+        self.inner.modifiers = modifiers;
+        self
+    }
+
+    /// Ignore the state of the Shift modifier when matching this key combination.
+    pub fn ignoring_shift(mut self) -> Self {
+        self.inner.ignore_shift = true;
+        self
+    }
+
+    /// Ignore the state of the Alt modifier when matching this key combination.
+    pub fn ignoring_alt(mut self) -> Self {
+        self.inner.ignore_alt = true;
+        self
+    }
+
     /// Check whether a `Keys` can be triggered by the given `KeyEvent`
     pub(crate) fn matches(&self, key_event: &KeyEvent) -> bool {
         let inner = &self.inner;
@@ -2219,6 +2336,29 @@ mod touch_tests {
 mod tests {
     use super::*;
     extern crate alloc;
+
+    #[test]
+    fn test_keys_from_key_name_or_string() {
+        let escape = Keys::from_key_name_or_string("Escape").unwrap();
+        assert_eq!(KeysInner::from_pub(&escape).key, SharedString::from(key_codes::Escape));
+        assert!(!KeysInner::from_pub(&escape).ignore_shift);
+
+        let plus = Keys::from_key_name_or_string("Plus").unwrap();
+        assert_eq!(KeysInner::from_pub(&plus).key, SharedString::from(key_codes::Plus));
+        assert!(KeysInner::from_pub(&plus).ignore_shift);
+
+        let lowercase = Keys::from_key_name_or_string("A").unwrap();
+        assert_eq!(KeysInner::from_pub(&lowercase).key, SharedString::from(key_codes::A));
+
+        let literal = Keys::from_key_name_or_string("Ä").unwrap();
+        assert_eq!(KeysInner::from_pub(&literal).key, SharedString::from("ä"));
+
+        assert_eq!(Keys::from_key_name_or_string("").unwrap_err(), KeysError::EmptyString);
+        assert_eq!(
+            Keys::from_key_name_or_string("ab").unwrap_err(),
+            KeysError::MultipleGraphemeClusters(2)
+        );
+    }
 
     #[test]
     fn test_to_string() {


### PR DESCRIPTION
## Summary

add a public constructor path for `Keys` values from application code and support setting `keys` properties from the Node and Python interpreter APIs

This adds `Keys::from_key_name_or_string(...)` plus modifier builder helpers in core and re exports from the Rust API.
Node accepts either a string such as `"Escape"` or an object such as `{ key: "Plus", control: true, ignoreShift: true }` when assigning to a `keys` property. python accepts either a string or a dict with the corresponding fields.

## Tests

- `cargo test -p i-slint-core test_keys_from_key_name_or_string`