### PR TITLE
Add font-size and font-weight properties to CheckBox

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/checkbox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/checkbox.mdx
@@ -43,6 +43,16 @@ CheckBox {
 Defaults to true. When false, the checkbox can't be pressed.
 </SlintProperty>
 
+### font-size
+<SlintProperty propName="font-size" typeName="length">
+The size of the font of the label text.
+</SlintProperty>
+
+### font-weight
+<SlintProperty propName="font-weight" typeName="int">
+The weight of the font of the label text.
+</SlintProperty>
+
 ### has-focus
 <SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out" >
 Set to true when the checkbox has keyboard focus.

--- a/internal/compiler/widgets/cosmic/checkbox.slint
+++ b/internal/compiler/widgets/cosmic/checkbox.slint
@@ -7,6 +7,8 @@ import { StateLayer } from "components.slint";
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> state-layer.enabled;
+    in property <length> font-size: CosmicFontSettings.body.font-size;
+    in property <int> font-weight: CosmicFontSettings.body.font-weight;
     out property <bool> has-focus: state-layer.has-focus;
     in-out property <bool> checked;
 
@@ -86,8 +88,8 @@ export component CheckBox {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
+            font-size: root.font-size;
+            font-weight: root.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cupertino/checkbox.slint
+++ b/internal/compiler/widgets/cupertino/checkbox.slint
@@ -7,6 +7,8 @@ import { FocusBorder } from "components.slint";
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> i-touch-area.enabled;
+    in property <length> font-size: CupertinoFontSettings.body.font-size;
+    in property <int> font-weight: CupertinoFontSettings.body.font-weight;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 
@@ -121,8 +123,8 @@ export component CheckBox {
         if (root.text != "") : Text {
             text: root.text;
             color: CupertinoPalette.foreground;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
+            font-size: root.font-size;
+            font-weight: root.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/fluent/checkbox.slint
+++ b/internal/compiler/widgets/fluent/checkbox.slint
@@ -7,6 +7,8 @@ import { FocusBorder } from "components.slint";
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> touch-area.enabled;
+    in property <length> font-size: FluentFontSettings.body.font-size;
+    in property <int> font-weight: FluentFontSettings.body.font-weight;
     out property <bool> has-focus: focus-scope.has-focus;
     in-out property <bool> checked;
 
@@ -83,8 +85,8 @@ export component CheckBox {
         if root.text != "" : Text {
             text: root.text;
             color: root.text-color;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
+            font-size: root.font-size;
+            font-weight: root.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/material/checkbox.slint
+++ b/internal/compiler/widgets/material/checkbox.slint
@@ -7,6 +7,8 @@ import { MaterialPalette, MaterialFontSettings, Icons } from "styling.slint";
 export component CheckBox {
     in property <string> text <=> i-text.text;
     in property <bool> enabled: true;
+    in property <length> font-size: MaterialFontSettings.title-small.font-size;
+    in property <int> font-weight: MaterialFontSettings.title-small.font-weight;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 
@@ -131,8 +133,8 @@ export component CheckBox {
             horizontal-alignment: left;
             vertical-alignment: center;
             vertical-stretch: 1;
-            font-size: MaterialFontSettings.title-small.font-size;
-            font-weight: MaterialFontSettings.title-small.font-weight;
+            font-size: root.font-size;
+            font-weight: root.font-weight;
         }
     }
 

--- a/internal/compiler/widgets/qt/checkbox.slint
+++ b/internal/compiler/widgets/qt/checkbox.slint
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component CheckBox inherits NativeCheckBox {
+    in property <length> font-size; // not implemented
+    in property <int> font-weight; // not implemented
+
     accessible-enabled: root.enabled;
     accessible-checkable: true;
     accessible-checked <=> root.checked;

--- a/tests/cases/widgets/checkbox.slint
+++ b/tests/cases/widgets/checkbox.slint
@@ -16,6 +16,11 @@ export component TestCase inherits Window {
                 root.toggled += "a";
             }
         }
+        CheckBox {
+            text: "Custom font";
+            font-size: 24px;
+            font-weight: 700;
+        }
     }
 }
 


### PR DESCRIPTION
Expose font-size and font-weight as input properties on CheckBox across
all non-native styles (fluent, material, cupertino, cosmic), defaulting
to each style's existing font settings. This matches the pattern already
used by TextEdit, TextInput, and LineEdit.

These properties have no effect when using the Qt style, where the
entire widget (including text rendering) is delegated to NativeCheckBox
which paints via QStyle::drawControl.