### PR TITLE
LineEdit: keep show-password icon visible after focus loss

### DIFF
--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -165,12 +165,14 @@ export component LineEditPasswordIcon inherits Image {
     in-out property <bool> show-password;
     in property <image> show-password-image;
     in property <image> hide-password-image;
+    callback clicked();
 
     source: show-password ? hide-password-image : show-password-image;
     vertical-alignment: center;
     TouchArea {
         clicked => {
             root.show-password = !root.show-password;
+            root.clicked();
         }
     }
 }

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -10,9 +10,18 @@ export component LineEditBase implements LineEditInterface inherits Rectangle {
     text <=> text-input.text;
     enabled <=> text-input.enabled;
     has-focus: text-input.has-focus;
-    input-type <=> text-input.input-type;
+    in property <InputType> input-type;
+    // When true, the password input shows as plain text.
+    // Cleared automatically on focus loss.
+    in-out property <bool> password-revealed: false;
     horizontal-alignment <=> text-input.horizontal-alignment;
     read-only <=> text-input.read-only;
+
+    changed has-focus => {
+        if !self.has-focus {
+            self.password-revealed = false;
+        }
+    }
 
     in-out property <brush> placeholder-color;
     in property <int> font-weight <=> text-input.font-weight;
@@ -111,6 +120,7 @@ export component LineEditBase implements LineEditInterface inherits Rectangle {
             vertical-alignment: center;
             single-line: true;
             color: root.text-color;
+            input-type: root.password-revealed ? InputType.text : root.input-type;
             // Disable TextInput's built-in accessibility support as the widget takes care of that.
             accessible-role: none;
 
@@ -152,8 +162,7 @@ export component LineEditClearIcon inherits Image {
 }
 
 export component LineEditPasswordIcon inherits Image {
-    callback show-password-changed(bool);
-    in property <bool> show-password;
+    in-out property <bool> show-password;
     in property <image> show-password-image;
     in property <image> hide-password-image;
 
@@ -161,7 +170,7 @@ export component LineEditPasswordIcon inherits Image {
     vertical-alignment: center;
     TouchArea {
         clicked => {
-            root.show-password-changed(!show-password);
+            root.show-password = !root.show-password;
         }
     }
 }

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -65,11 +65,7 @@ export component LineEdit uses { LineEditInterface from base } {
                 show-password-image: @image-url("_view_reveal.svg");
                 hide-password-image: @image-url("_view_conceal.svg");
                 colorize: base.text-color;
-                show-password: base.input-type != InputType.password;
-                show-password-changed(show) => {
-                    base.input-type = show ? InputType.text : root.input-type;
-                    base.focus();
-                }
+                show-password <=> base.password-revealed;
             }
         }
 

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -66,6 +66,7 @@ export component LineEdit uses { LineEditInterface from base } {
                 hide-password-image: @image-url("_view_conceal.svg");
                 colorize: base.text-color;
                 show-password <=> base.password-revealed;
+                clicked => { base.focus(); }
             }
         }
 

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -71,6 +71,7 @@ export component LineEdit uses { LineEditInterface from base } {
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;
                 show-password <=> base.password-revealed;
+                clicked => { base.focus(); }
             }
         }
     }

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -70,11 +70,7 @@ export component LineEdit uses { LineEditInterface from base } {
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;
-                show-password: base.input-type != InputType.password;
-                show-password-changed(show) => {
-                    base.input-type = show ? InputType.text : root.input-type;
-                    base.focus();
-                }
+                show-password <=> base.password-revealed;
             }
         }
     }

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -72,11 +72,7 @@ export component LineEdit uses { LineEditInterface from base } {
                 show-password-image: @image-url("_eye_show.svg");
                 hide-password-image: @image-url("_eye_hide.svg");
                 colorize: base.text-color;
-                show-password: base.input-type != InputType.password;
-                show-password-changed(show) => {
-                    base.input-type = show ? InputType.text : root.input-type;
-                    base.focus();
-                }
+                show-password <=> base.password-revealed;
             }
         }
 

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -72,6 +72,7 @@ export component LineEdit uses { LineEditInterface from base } {
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;
                 show-password <=> base.password-revealed;
+                clicked => { base.focus(); }
             }
         }
     }

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -71,11 +71,7 @@ export component LineEdit uses { LineEditInterface from base } {
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;
-                show-password: base.input-type != InputType.password;
-                show-password-changed(show) => {
-                    base.input-type = show ? InputType.text : root.input-type;
-                    base.focus();
-                }
+                show-password <=> base.password-revealed;
             }
         }
     }

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -61,11 +61,7 @@ export component LineEdit uses { LineEditInterface from inner } {
             show-password-image: @image-url("_visibility.svg");
             hide-password-image: @image-url("_visibility_off.svg");
             colorize: inner.text-color;
-            show-password: inner.input-type != InputType.password;
-            show-password-changed(show) => {
-                inner.input-type = show ? InputType.text : root.input-type;
-                inner.focus();
-            }
+            show-password <=> inner.password-revealed;
         }
     }
 }

--- a/tests/cases/widgets/lineedit_password.slint
+++ b/tests/cases/widgets/lineedit_password.slint
@@ -1,0 +1,99 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { LineEdit } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+
+    forward-focus: edit1;
+
+    VerticalLayout {
+        edit1 := LineEdit {
+            input-type: password;
+            text: "secret";
+            edited(t) => { root.edit1-edited-count += 1; }
+        }
+
+        edit2 := LineEdit {
+            text: "other";
+        }
+    }
+
+    in-out property <string> edit1-text <=> edit1.text;
+    out property <InputType> edit1-input-type: edit1.input-type;
+    out property <bool> edit1-has-focus: edit1.has-focus;
+    out property <int> edit1-edited-count: 0;
+
+    public function focus-edit1() { edit1.focus(); }
+    public function focus-edit2() { edit2.focus(); }
+}
+
+/*
+```rust
+use slint::platform::{Key, PointerEventButton};
+use slint::private_unstable_api::re_exports::InputType;
+use slint::SharedString;
+
+let instance = TestCase::new().unwrap();
+slint_testing::mock_elapsed_time(50);
+
+instance.invoke_focus_edit1();
+slint_testing::mock_elapsed_time(50);
+assert!(instance.get_edit1_has_focus(), "edit1 should be focused");
+assert_eq!(instance.get_edit1_input_type(), InputType::Password);
+assert_eq!(instance.get_edit1_text(), "secret");
+
+// The show-password icon should be present (focused, has text, password type).
+let icon_query = || slint_testing::ElementHandle::find_by_element_type_name(&instance, "LineEditPasswordIcon").collect::<Vec<_>>();
+assert_eq!(icon_query().len(), 1, "show-password icon should be visible while edit1 is focused");
+
+// Click the icon to reveal the password.
+icon_query()[0].mock_single_click(PointerEventButton::Left);
+slint_testing::mock_elapsed_time(50);
+
+// The user-facing input-type must NOT be modified by toggling password visibility.
+assert_eq!(instance.get_edit1_input_type(), InputType::Password,
+    "toggling show-password must not corrupt LineEdit.input-type");
+// edit1 should still be focused (clicking the icon must not steal focus from the text input).
+assert!(instance.get_edit1_has_focus(), "clicking the icon must not steal focus");
+
+// The icon must still be present so the user can hide the password again.
+assert_eq!(icon_query().len(), 1, "show-password icon should remain visible after toggling");
+
+// Typing should still update the text. Cursor starts at position 0 after focus.
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("X"));
+slint_testing::mock_elapsed_time(50);
+assert_eq!(instance.get_edit1_text(), "Xsecret");
+assert_eq!(instance.get_edit1_edited_count(), 1, "edited callback should fire on typing");
+
+// Backspace works in password mode too.
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backspace));
+slint_testing::mock_elapsed_time(50);
+assert_eq!(instance.get_edit1_text(), "secret");
+assert_eq!(instance.get_edit1_edited_count(), 2);
+
+// Setting the text from outside should be reflected.
+instance.set_edit1_text("hunter2".into());
+assert_eq!(instance.get_edit1_text(), "hunter2");
+// Programmatic set does not fire `edited`.
+assert_eq!(instance.get_edit1_edited_count(), 2);
+
+// Move focus away to edit2.
+instance.invoke_focus_edit2();
+slint_testing::mock_elapsed_time(50);
+assert!(!instance.get_edit1_has_focus());
+assert_eq!(instance.get_edit1_input_type(), InputType::Password,
+    "input-type must remain Password after focus loss");
+assert_eq!(instance.get_edit1_text(), "hunter2",
+    "text must survive focus loss");
+
+// And back to edit1: icon is back.
+instance.invoke_focus_edit1();
+slint_testing::mock_elapsed_time(50);
+assert!(instance.get_edit1_has_focus());
+assert_eq!(icon_query().len(), 1, "show-password icon should be visible after re-focusing");
+assert_eq!(instance.get_edit1_input_type(), InputType::Password);
+```
+*/

--- a/tests/cases/widgets/lineedit_password.slint
+++ b/tests/cases/widgets/lineedit_password.slint
@@ -95,5 +95,19 @@ slint_testing::mock_elapsed_time(50);
 assert!(instance.get_edit1_has_focus());
 assert_eq!(icon_query().len(), 1, "show-password icon should be visible after re-focusing");
 assert_eq!(instance.get_edit1_input_type(), InputType::Password);
+
+// For styles where the password icon is visible without focus (cupertino, material, cosmic),
+// clicking it from an unfocused state should focus the LineEdit.
+// In fluent and qt the icon is conditional on `has-focus`, so it won't be found here
+// and the click-to-focus check is skipped.
+instance.invoke_focus_edit2();
+slint_testing::mock_elapsed_time(50);
+assert!(!instance.get_edit1_has_focus());
+if let Some(icon) = icon_query().into_iter().next() {
+    icon.mock_single_click(PointerEventButton::Left);
+    slint_testing::mock_elapsed_time(50);
+    assert!(instance.get_edit1_has_focus(),
+        "clicking the password icon on an unfocused LineEdit should focus it");
+}
 ```
 */


### PR DESCRIPTION
Toggling the icon used to set base.input-type, which propagated back to root.input-type through the LineEditInterface two-way binding. That made the icon disappear and the password stay visible forever.

Use a separate password-revealed property on LineEditBase, and reset it on focus loss so the password hides again when focus returns.

Fixes: #11261
