### PR TITLE
parley: Fix strikethrough and underline rendering

### DIFF
--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -778,7 +778,8 @@ impl TextParagraph {
                 PhysicalRect::new(
                     PhysicalPoint::from_lengths(
                         PhysicalLength::new(glyph_run.offset()),
-                        para_y + PhysicalLength::new(run.font_size() - metrics.underline_offset),
+                        para_y
+                            + PhysicalLength::new(glyph_run.baseline() - metrics.underline_offset),
                     ),
                     PhysicalSize::new(glyph_run.advance(), metrics.underline_size),
                 ),
@@ -792,7 +793,9 @@ impl TextParagraph {
                     PhysicalPoint::from_lengths(
                         PhysicalLength::new(glyph_run.offset()),
                         para_y
-                            + PhysicalLength::new(run.font_size() - metrics.strikethrough_offset),
+                            + PhysicalLength::new(
+                                glyph_run.baseline() - metrics.strikethrough_offset,
+                            ),
                     ),
                     PhysicalSize::new(glyph_run.advance(), metrics.strikethrough_size),
                 ),


### PR DESCRIPTION
The strikethrough and underline offset from the run is relative to the glyph run's baseline.

Fixes #11320

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

FemtoVG before:

<img width="185" height="99" alt="Bildschirmfoto 2026-04-09 um 22 34 48" src="https://github.com/user-attachments/assets/63082dfd-7055-43b4-821c-335175fe07df" />

Skia before:

<img width="185" height="99" alt="Bildschirmfoto 2026-04-09 um 22 35 08" src="https://github.com/user-attachments/assets/8bf93716-77de-4e80-863e-94000926de0f" />

FemtoVG after:

<img width="185" height="99" alt="Bildschirmfoto 2026-04-09 um 22 35 31" src="https://github.com/user-attachments/assets/56433a7e-a038-44c7-a267-99f24c40945f" />

Skia after:

<img width="185" height="99" alt="Bildschirmfoto 2026-04-09 um 22 35 46" src="https://github.com/user-attachments/assets/8b1ae203-936e-46c9-8ccf-65cceb442375" />
