### PR TITLE
parley: Workaround assert when we have empty spans

### DIFF
--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -278,7 +278,7 @@ impl LayoutWithoutLineBreaksBuilder {
                 }
             }
 
-            // filter empty ranges otherwise parley asserts
+            // filter empty ranges otherwise parley will panic on assert
             for span in formatting.into_iter().filter(|s| !s.range.is_empty()) {
                 match span.style {
                     Style::Emphasis => {

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -279,6 +279,10 @@ impl LayoutWithoutLineBreaksBuilder {
             }
 
             for span in formatting {
+                // parley asserts style runs are non-empty.
+                if span.range.is_empty() {
+                    continue;
+                }
                 match span.style {
                     Style::Emphasis => {
                         builder.push(

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -278,11 +278,8 @@ impl LayoutWithoutLineBreaksBuilder {
                 }
             }
 
-            for span in formatting {
-                // parley asserts style runs are non-empty.
-                if span.range.is_empty() {
-                    continue;
-                }
+            // filter empty ranges otherwise parley asserts
+            for span in formatting.into_iter().filter(|s| !s.range.is_empty()) {
                 match span.style {
                     Style::Emphasis => {
                         builder.push(

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -22,6 +22,11 @@ export component TestCase inherits Window {
         s5 := StyledText {
             text: @markdown("*\{@markdown("**H\{"ello"}**")}* \{@markdown("*\{world}*")}");
         }
+        // Regression test for #11321: empty interpolation inside a styled span used to crash parley.
+        s6 := StyledText {
+            text: @markdown("Value : "
+                            "<font color=\"red\">\{""}</font> [\{""}](https://slint.dev)");
+        }
     }
 
     out property<styled-text> t1: s1.text;
@@ -33,8 +38,9 @@ export component TestCase inherits Window {
     out property<length> w3: s3.preferred-width;
     out property<length> w4: s4.preferred-width;
     out property<length> w5: s5.preferred-width;
+    out property<length> w6: s6.preferred-width;
 
-    property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px;
+    out property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px && w6 > 0px;
 }
 
 /*
@@ -49,6 +55,7 @@ assert_eq!(instance.get_w2(), 80.0);
 assert_eq!(instance.get_w3(), 64.0);
 assert_eq!(instance.get_w4(), 64.0);
 assert_eq!(instance.get_w5(), 65.0);
+assert!(instance.get_test());
 ```
 ```cpp
 auto handle = TestCase::create();
@@ -58,5 +65,6 @@ assert(instance.get_w2() == 80.0);
 assert(instance.get_w3() == 64.0);
 assert(instance.get_w4() == 64.0);
 assert(instance.get_w5() == 65.0);
+assert(instance.get_test());
 ```
 */


### PR DESCRIPTION
Fixes #11321