### PR TITLE
ListView: refresh rows when items are added or removed above the visible range

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -904,14 +904,20 @@ class Repeater
 
         void row_added(size_t index, size_t count) override
         {
-            const auto offset = layout_state.offset;
-            if (index < offset) {
-                if (index + count <= offset)
+            if (index < layout_state.offset) {
+                if (index + count <= layout_state.offset) {
+                    // Entirely before the visible range: shift the offset.
+                    layout_state.offset += count;
+                    is_dirty.set(true);
+                    for (auto &c : data) {
+                        c.state = State::Dirty;
+                    }
                     return;
-                count -= offset - index;
+                }
+                count -= layout_state.offset - index;
                 index = 0;
             } else {
-                index -= offset;
+                index -= layout_state.offset;
             }
             if (count == 0 || index > data.size()) {
                 return;
@@ -941,14 +947,21 @@ class Repeater
         }
         void row_removed(size_t index, size_t count) override
         {
-            const auto offset = layout_state.offset;
-            if (index < offset) {
-                if (index + count <= offset)
+            if (index < layout_state.offset) {
+                if (index + count <= layout_state.offset) {
+                    // Entirely before the visible range: shift the offset.
+                    layout_state.offset -= count;
+                    is_dirty.set(true);
+                    for (auto &c : data) {
+                        c.state = State::Dirty;
+                    }
                     return;
-                count -= offset - index;
+                }
+                count -= layout_state.offset - index;
+                layout_state.offset = index;
                 index = 0;
             } else {
-                index -= offset;
+                index -= layout_state.offset;
             }
             if (count == 0 || index >= data.size()) {
                 return;

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -454,7 +454,13 @@ impl<T: RepeatedItemTree> ModelChangeListener for RepeaterTracker<T> {
     fn row_added(self: Pin<&Self>, mut index: usize, mut count: usize) {
         let mut inner = self.inner.borrow_mut();
         if index < inner.layout_state.offset {
-            if index + count < inner.layout_state.offset {
+            if index + count <= inner.layout_state.offset {
+                // Entirely before the visible range: shift the offset.
+                inner.layout_state.offset += count;
+                self.is_dirty.set(true);
+                for c in inner.instances.iter_mut() {
+                    c.0 = RepeatedInstanceState::Dirty;
+                }
                 return;
             }
             count -= inner.layout_state.offset - index;
@@ -479,10 +485,17 @@ impl<T: RepeatedItemTree> ModelChangeListener for RepeaterTracker<T> {
     fn row_removed(self: Pin<&Self>, mut index: usize, mut count: usize) {
         let mut inner = self.inner.borrow_mut();
         if index < inner.layout_state.offset {
-            if index + count < inner.layout_state.offset {
+            if index + count <= inner.layout_state.offset {
+                // Entirely before the visible range: shift the offset.
+                inner.layout_state.offset -= count;
+                self.is_dirty.set(true);
+                for c in inner.instances.iter_mut() {
+                    c.0 = RepeatedInstanceState::Dirty;
+                }
                 return;
             }
             count -= inner.layout_state.offset - index;
+            inner.layout_state.offset = index;
             index = 0;
         } else {
             index -= inner.layout_state.offset;

--- a/tests/cases/models/listview_remove_above.slint
+++ b/tests/cases/models/listview_remove_above.slint
@@ -1,0 +1,332 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #11319: when a row is removed from a model above the
+// visible range of a ListView (typically while scrolled to the bottom), the
+// existing repeater instances must update their model row indices and data,
+// otherwise they keep showing stale values.
+
+import { ListView } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+
+    in-out property <[int]> model;
+    in-out property <length> viewport-y <=> lv.viewport-y;
+    out property <length> viewport-height <=> lv.viewport-height;
+
+    out property <string> clicked-values;
+
+    public function reset-clicked-values() {
+        clicked-values = "";
+    }
+
+    lv := ListView {
+        for value[idx] in root.model: TouchArea {
+            height: 20px;
+            clicked => {
+                root.clicked-values += "[" + idx + "=" + value + "]";
+            }
+        }
+    }
+}
+
+/*
+```rust
+use slint::{Model, VecModel, SharedString};
+use std::rc::Rc;
+
+let instance = TestCase::new().unwrap();
+let model = Rc::new(VecModel::from((0..100).collect::<Vec<i32>>()));
+instance.set_model(model.clone().into());
+
+// Helper that clicks every visible row.
+let click_all = |inst: &TestCase| {
+    inst.invoke_reset_clicked_values();
+    for row in 0..10 {
+        let y = 10.0 + row as f32 * 20.0;
+        slint_testing::send_mouse_click(inst, 50., y);
+    }
+};
+
+// Initial layout: model is [0..100], viewport at top, items 0..9 visible.
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[0=0][1=1][2=2][3=3][4=4][5=5][6=6][7=7][8=8][9=9]")
+);
+assert_eq!(instance.get_viewport_height(), 100. * 20.);
+assert_eq!(instance.get_viewport_y(), 0.);
+
+// Scroll to the bottom: items 90..99 should be visible.
+instance.set_viewport_y(-1800.);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[90=90][91=91][92=92][93=93][94=94][95=95][96=96][97=97][98=98][99=99]")
+);
+assert_eq!(instance.get_viewport_y(), -1800.);
+
+// Remove the very first row. After the removal, indices have shifted by one:
+// row 89 contains value 90, ..., row 98 contains value 99. The viewport stays
+// anchored to the bottom and clamps to the new max scroll position.
+model.remove(0);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[89=90][90=91][91=92][92=93][93=94][94=95][95=96][96=97][97=98][98=99]")
+);
+assert_eq!(instance.get_viewport_height(), 99. * 20.);
+assert_eq!(instance.get_viewport_y(), -1780.);
+
+// Removing further rows from the top should keep the visible range consistent.
+model.remove(0);
+model.remove(0);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[87=90][88=91][89=92][90=93][91=94][92=95][93=96][94=97][95=98][96=99]")
+);
+assert_eq!(instance.get_viewport_height(), 97. * 20.);
+assert_eq!(instance.get_viewport_y(), -1740.);
+
+// === Coverage for the other model mutations ===
+// Reset to a fresh model and scroll to the middle so we can exercise
+// row_changed / row_added / row_removed in different positions.
+let model2 = Rc::new(VecModel::from((0..100).collect::<Vec<i32>>()));
+instance.set_model(model2.clone().into());
+instance.set_viewport_y(-800.);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[40=40][41=41][42=42][43=43][44=44][45=45][46=46][47=47][48=48][49=49]")
+);
+assert_eq!(instance.get_viewport_y(), -800.);
+
+// row_changed on a visible row.
+model2.set_row_data(45, 999);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]")
+);
+
+// row_changed on a row above the visible range: must not affect the display.
+model2.set_row_data(10, 8888);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]")
+);
+
+// row_added in the middle of the visible range.
+model2.insert(45, -1);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[40=40][41=41][42=42][43=43][44=44][45=-1][46=999][47=46][48=47][49=48]")
+);
+
+// row_removed from the middle of the visible range, undoing the insert above.
+model2.remove(45);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]")
+);
+
+// row_removed entirely below the visible range: no visible change.
+model2.remove(99);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]")
+);
+assert_eq!(instance.get_viewport_y(), -800.);
+
+// row_added entirely before the visible range (mirror of #11319): existing
+// instances stay anchored to the same values, but their model row index
+// shifts up by one.
+model2.insert(0, -10);
+click_all(&instance);
+assert_eq!(
+    instance.get_clicked_values(),
+    SharedString::from("[41=40][42=41][43=42][44=43][45=44][46=999][47=46][48=47][49=48][50=49]")
+);
+assert_eq!(instance.get_viewport_y(), -820.);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+std::vector<int> initial;
+for (int i = 0; i < 100; ++i) initial.push_back(i);
+auto model = std::make_shared<slint::VectorModel<int>>(std::move(initial));
+instance.set_model(model);
+
+auto click_all = [&]() {
+    instance.invoke_reset_clicked_values();
+    for (int row = 0; row < 10; ++row) {
+        slint_testing::send_mouse_click(&instance, 50., 10. + row * 20.);
+    }
+};
+
+click_all();
+assert_eq(instance.get_clicked_values(), "[0=0][1=1][2=2][3=3][4=4][5=5][6=6][7=7][8=8][9=9]");
+assert_eq(instance.get_viewport_height(), 100. * 20.);
+assert_eq(instance.get_viewport_y(), 0.);
+
+instance.set_viewport_y(-1800.);
+click_all();
+assert_eq(instance.get_clicked_values(), "[90=90][91=91][92=92][93=93][94=94][95=95][96=96][97=97][98=98][99=99]");
+assert_eq(instance.get_viewport_y(), -1800.);
+
+model->erase(0);
+click_all();
+assert_eq(instance.get_clicked_values(), "[89=90][90=91][91=92][92=93][93=94][94=95][95=96][96=97][97=98][98=99]");
+assert_eq(instance.get_viewport_height(), 99. * 20.);
+assert_eq(instance.get_viewport_y(), -1780.);
+
+model->erase(0);
+model->erase(0);
+click_all();
+assert_eq(instance.get_clicked_values(), "[87=90][88=91][89=92][90=93][91=94][92=95][93=96][94=97][95=98][96=99]");
+assert_eq(instance.get_viewport_height(), 97. * 20.);
+assert_eq(instance.get_viewport_y(), -1740.);
+
+// === Coverage for the other model mutations ===
+std::vector<int> initial2;
+for (int i = 0; i < 100; ++i) initial2.push_back(i);
+auto model2 = std::make_shared<slint::VectorModel<int>>(std::move(initial2));
+instance.set_model(model2);
+instance.set_viewport_y(-800.);
+click_all();
+assert_eq(instance.get_clicked_values(), "[40=40][41=41][42=42][43=43][44=44][45=45][46=46][47=47][48=48][49=49]");
+assert_eq(instance.get_viewport_y(), -800.);
+
+// row_changed on a visible row.
+model2->set_row_data(45, 999);
+click_all();
+assert_eq(instance.get_clicked_values(), "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+
+// row_changed on a row above the visible range: must not affect the display.
+model2->set_row_data(10, 8888);
+click_all();
+assert_eq(instance.get_clicked_values(), "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+
+// row_added in the middle of the visible range.
+model2->insert(45, -1);
+click_all();
+assert_eq(instance.get_clicked_values(), "[40=40][41=41][42=42][43=43][44=44][45=-1][46=999][47=46][48=47][49=48]");
+
+// row_removed from the middle of the visible range.
+model2->erase(45);
+click_all();
+assert_eq(instance.get_clicked_values(), "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+
+// row_removed entirely below the visible range: no visible change.
+model2->erase(99);
+click_all();
+assert_eq(instance.get_clicked_values(), "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+assert_eq(instance.get_viewport_y(), -800.);
+
+// row_added entirely before the visible range (mirror of #11319).
+model2->insert(0, -10);
+click_all();
+assert_eq(instance.get_clicked_values(), "[41=40][42=41][43=42][44=43][45=44][46=999][47=46][48=47][49=48][50=49]");
+assert_eq(instance.get_viewport_y(), -820.);
+```
+
+```js
+var instance = new slint.TestCase({});
+let initial = [];
+for (let i = 0; i < 100; ++i) initial.push(i);
+let model = new slintlib.ArrayModel(initial);
+instance.model = model;
+
+function click_all() {
+    instance.reset_clicked_values();
+    for (let row = 0; row < 10; ++row) {
+        slintlib.private_api.send_mouse_click(instance, 50., 10. + row * 20.);
+    }
+}
+
+click_all();
+assert.equal(instance.clicked_values, "[0=0][1=1][2=2][3=3][4=4][5=5][6=6][7=7][8=8][9=9]");
+assert.equal(instance.viewport_height, 100. * 20.);
+assert.equal(instance.viewport_y, 0.);
+
+instance.viewport_y = -1800.;
+click_all();
+assert.equal(instance.clicked_values, "[90=90][91=91][92=92][93=93][94=94][95=95][96=96][97=97][98=98][99=99]");
+assert.equal(instance.viewport_y, -1800.);
+
+model.remove(0, 1);
+click_all();
+assert.equal(instance.clicked_values, "[89=90][90=91][91=92][92=93][93=94][94=95][95=96][96=97][97=98][98=99]");
+assert.equal(instance.viewport_height, 99. * 20.);
+assert.equal(instance.viewport_y, -1780.);
+
+model.remove(0, 1);
+model.remove(0, 1);
+click_all();
+assert.equal(instance.clicked_values, "[87=90][88=91][89=92][90=93][91=94][92=95][93=96][94=97][95=98][96=99]");
+assert.equal(instance.viewport_height, 97. * 20.);
+assert.equal(instance.viewport_y, -1740.);
+
+// === Coverage for the other model mutations ===
+// A small Model subclass to exercise row_added in arbitrary positions
+// (slintlib.ArrayModel only supports push at the end and remove).
+class ListModel extends slintlib.Model {
+    constructor(items) { super(); this.items = items; }
+    rowCount() { return this.items.length; }
+    rowData(row) { return this.items[row]; }
+    setRowData(row, data) { this.items[row] = data; this.notifyRowDataChanged(row); }
+    insert(index, value) { this.items.splice(index, 0, value); this.notifyRowAdded(index, 1); }
+    remove(index) { this.items.splice(index, 1); this.notifyRowRemoved(index, 1); }
+}
+
+let initial2 = [];
+for (let i = 0; i < 100; ++i) initial2.push(i);
+let model2 = new ListModel(initial2);
+instance.model = model2;
+instance.viewport_y = -800.;
+click_all();
+assert.equal(instance.clicked_values, "[40=40][41=41][42=42][43=43][44=44][45=45][46=46][47=47][48=48][49=49]");
+assert.equal(instance.viewport_y, -800.);
+
+// row_changed on a visible row.
+model2.setRowData(45, 999);
+click_all();
+assert.equal(instance.clicked_values, "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+
+// row_changed on a row above the visible range: must not affect the display.
+model2.setRowData(10, 8888);
+click_all();
+assert.equal(instance.clicked_values, "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+
+// row_added in the middle of the visible range.
+model2.insert(45, -1);
+click_all();
+assert.equal(instance.clicked_values, "[40=40][41=41][42=42][43=43][44=44][45=-1][46=999][47=46][48=47][49=48]");
+
+// row_removed from the middle of the visible range.
+model2.remove(45);
+click_all();
+assert.equal(instance.clicked_values, "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+
+// row_removed entirely below the visible range: no visible change.
+model2.remove(99);
+click_all();
+assert.equal(instance.clicked_values, "[40=40][41=41][42=42][43=43][44=44][45=999][46=46][47=47][48=48][49=49]");
+assert.equal(instance.viewport_y, -800.);
+
+// row_added entirely before the visible range (mirror of #11319).
+model2.insert(0, -10);
+click_all();
+assert.equal(instance.clicked_values, "[41=40][42=41][43=42][44=43][45=44][46=999][47=46][48=47][49=48][50=49]");
+assert.equal(instance.viewport_y, -820.);
+```
+*/


### PR DESCRIPTION
Without this, the repeater instances kept their old model row index and the listview showed stale values. Fix both row_added and row_removed.

Fixes: #11319