### PR TITLE
LSP: Detect when a missing import file is added

### DIFF
--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -990,7 +990,10 @@ impl TypeLoader {
                 return HashSet::new();
             }
         } else {
-            return HashSet::new();
+            // If a document is not in the TypeLoader, it may still have dependencies,
+            // as another document may have tried to import it, but it failed (e.g. the file didn't exist).
+            // So still invalidate all dependencies, even if the file is not in the TypeLoader.
+            // (Fallthrough)
         }
         let deps = self.all_documents.dependencies.remove(path).unwrap_or_default();
         let mut extra_deps = HashSet::new();
@@ -1100,7 +1103,18 @@ impl TypeLoader {
         std::future::poll_fn(|cx| {
             dependencies_futures.retain_mut(|fut| {
                 let core::task::Poll::Ready((mut import, doc_path)) = fut.as_mut().poll(cx) else { return true; };
-                let Some(doc_path) = doc_path else { return false };
+                let doc_path = match doc_path {
+                    Ok(doc_path) => doc_path,
+                    Err(Some(doc_path)) => {
+                        // Even if the import failed (e.g. the file doesn't exist), we need to add it to the document imports so that
+                        // the dependency graph is correct and we can retry loading the document if the imported file changes or is created.
+                        import.file = doc_path.to_string_lossy().into_owned();
+                        imports.push(import);
+
+                        return false;
+                    }
+                    Err(None) => return false,
+                };
                 let mut state = state.borrow_mut();
                 let state: &mut BorrowedTypeLoader<'a> = &mut state;
                 let Some(doc) = state.tl.get_document(&doc_path) else {
@@ -1187,8 +1201,8 @@ impl TypeLoader {
             match Self::ensure_document_loaded(&state, file_to_import, None, Default::default())
                 .await
             {
-                Some(doc_path) => doc_path,
-                None => return None,
+                Ok(doc_path) => doc_path,
+                Err(_) => return None,
             };
 
         let Some(doc) = self.get_document(&doc_path) else {
@@ -1225,13 +1239,15 @@ impl TypeLoader {
         }
     }
 
+    /// Returns whether the file was succesfully loaded.
+    /// If not, the path that was attempted to be loaded is returned (if any).
     #[allow(clippy::await_holding_refcell_ref)] // false positive: explicit drop() before await
     async fn ensure_document_loaded<'a: 'b, 'b>(
         state: &'a RefCell<BorrowedTypeLoader<'a>>,
         file_to_import: &'b str,
         import_token: Option<NodeOrToken>,
         mut import_stack: HashSet<PathBuf>,
-    ) -> Option<PathBuf> {
+    ) -> Result<PathBuf, Option<PathBuf>> {
         let mut borrowed_state = state.borrow_mut();
 
         let mut resolved = false;
@@ -1280,7 +1296,8 @@ impl TypeLoader {
                     let path = crate::pathutils::join(
                         &crate::pathutils::dirname(&base_path),
                         Path::new(file_to_import),
-                    )?;
+                    )
+                    .ok_or(None)?;
                     (path, None)
                 }
             }
@@ -1291,7 +1308,7 @@ impl TypeLoader {
                 format!("Recursive import of \"{}\"", path_canon.display()),
                 &import_token,
             );
-            return None;
+            return Err(Some(path_canon));
         }
 
         drop(borrowed_state);
@@ -1326,7 +1343,7 @@ impl TypeLoader {
         })
         .await;
         if is_loaded {
-            return Some(path_canon);
+            return Ok(path_canon);
         }
 
         let doc_node = if let Some((doc_node, errors)) = doc_node {
@@ -1359,18 +1376,14 @@ impl TypeLoader {
                     if !resolved
                         && matches!(err.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) =>
                 {
+                    let import_kind =
+                        if file_to_import.starts_with('@') { "library" } else { "include" };
                     state.borrow_mut().diag.push_error(
-                            if file_to_import.starts_with('@') {
-                                format!(
-                                    "Cannot find requested import \"{file_to_import}\" in the library search path",
-                                )
-                            } else {
-                                format!(
-                                    "Cannot find requested import \"{file_to_import}\" in the include search path",
-                                )
-                            },
-                            &import_token,
-                        );
+                        format!(
+                            "Cannot find requested import \"{file_to_import}\" in the {import_kind} search path",
+                        ),
+                        &import_token,
+                    );
                     None
                 }
                 Err(err) => {
@@ -1407,7 +1420,7 @@ impl TypeLoader {
             x.wake();
         }
 
-        ok.then_some(path_canon)
+        if ok { Ok(path_canon) } else { Err(Some(path_canon)) }
     }
 
     /// Load a file, and its dependency, running only the import passes.

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -362,7 +362,7 @@ impl DocumentCache {
     pub fn drop_document(&mut self, url: &Url) -> Result<HashSet<Url>> {
         let Some(path) = uri_to_file(url) else {
             // This isn't fatal, but we might want to learn about paths/schemes to support in the future.
-            eprintln!("Failed to convert path for dropping document: {url}");
+            tracing::error!("Failed to convert path for dropping document: {url}");
             return Ok(Default::default());
         };
         Ok(self

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -31,10 +31,10 @@ use lsp_types::request::{
 use lsp_types::{
     ClientCapabilities, CodeActionOrCommand, CodeActionProviderCapability, CodeLens,
     CodeLensOptions, Color, ColorInformation, ColorPresentation, Command, CompletionOptions,
-    DocumentSymbol, DocumentSymbolResponse, InitializeParams, InitializeResult, OneOf, Position,
-    PrepareRenameResponse, RenameOptions, SemanticTokensFullOptions, SemanticTokensLegend,
-    SemanticTokensOptions, ServerCapabilities, ServerInfo, TextDocumentSyncCapability, TextEdit,
-    Url, WorkDoneProgressOptions,
+    DocumentSymbol, DocumentSymbolResponse, FileChangeType, InitializeParams, InitializeResult,
+    OneOf, Position, PrepareRenameResponse, RenameOptions, SemanticTokensFullOptions,
+    SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, ServerInfo,
+    TextDocumentSyncCapability, TextEdit, Url, WorkDoneProgressOptions,
 };
 
 use std::collections::HashMap;
@@ -127,7 +127,11 @@ async fn register_file_watcher(ctx: &Context) -> common::Result<()> {
         let fs_watcher = lsp_types::DidChangeWatchedFilesRegistrationOptions {
             watchers: vec![lsp_types::FileSystemWatcher {
                 glob_pattern: lsp_types::GlobPattern::String("**/*".to_string()),
-                kind: Some(lsp_types::WatchKind::Change | lsp_types::WatchKind::Delete),
+                kind: Some(
+                    lsp_types::WatchKind::Change
+                        | lsp_types::WatchKind::Delete
+                        | lsp_types::WatchKind::Create,
+                ),
             }],
         };
         let server_notifier = { ctx.server_notifier.clone() };
@@ -929,10 +933,14 @@ pub async fn trigger_file_watcher(
 ) -> common::Result<()> {
     if !ctx.open_urls.contains(&url) {
         tracing::debug!("File watcher triggered for {url} (type: {:?})", typ);
-        if typ == lsp_types::FileChangeType::DELETED {
-            delete_document(ctx, url).await?;
-        } else {
-            drop_document(ctx, url).await?;
+        match typ {
+            FileChangeType::DELETED => delete_document(ctx, url).await?,
+            // If the file was newly created, we still need to drop it as another file may
+            // already depend on it by trying to import it before it exists.
+            // This is especially common on file renames.
+            // See also #11304
+            FileChangeType::CHANGED | FileChangeType::CREATED => drop_document(ctx, url).await?,
+            _ => tracing::warn!("Unknown file change type: {:?} for {url}", typ),
         }
     } else {
         tracing::trace!("Ignoring file watcher event for open document: {url}");

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -310,3 +310,65 @@ fn preview_file_recompiled_when_dependency_changes() {
         "Preview file should be in pending_recompile when its dependency changes"
     );
 }
+
+/// Test for issue #11304
+/// When a file is renamed in the editor first, and then is renamed on disk accordingly (i.e.
+/// "appears" as a new file).
+mod missing_imports {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn load_document_with_missing_import() -> (Context, PathBuf, Url) {
+        let mut ctx = mock_context();
+
+        let dir = std::env::current_dir().unwrap().join("xxx");
+
+        // Load main.slint that imports dep.slint, which does not yet exist.
+        let (main_url, diag) = load(
+            &mut ctx,
+            &dir.join("main.slint"),
+            r#"import { Dep } from "dep.slint"; export component Main { Dep { } }"#,
+        );
+        assert!(
+            !diag[&main_url].is_empty(),
+            "Expected diagnostics for missing import, got: {diag:?}"
+        );
+        (ctx, dir, main_url)
+    }
+
+    #[test]
+    fn created_in_editor() {
+        let (mut ctx, dir, main_url) = load_document_with_missing_import();
+
+        // Now "create" dep.slint by opening it (simulating a DidOpenTextDocument / file rename).
+        let (dep_url, diag) = load(&mut ctx, &dir.join("dep.slint"), r#"export component Dep { }"#);
+
+        assert!(diag[&dep_url].is_empty(), "dep.slint should have no errors");
+        assert!(
+            diag[&main_url].is_empty(),
+            "main.slint should have no errors after dep.slint is created"
+        );
+    }
+
+    #[test]
+    fn created_outside_editor() {
+        let (mut ctx, dir, main_url) = load_document_with_missing_import();
+
+        // Simulate that the file was opened via load_document
+        ctx.open_urls.insert(main_url.clone());
+
+        let dep_url = Url::from_file_path(dir.join("dep.slint")).unwrap();
+        spin_on::spin_on(crate::language::trigger_file_watcher(
+            &mut ctx,
+            dep_url,
+            lsp_types::FileChangeType::CREATED,
+        ))
+        .unwrap();
+
+        assert!(
+            ctx.pending_recompile.contains(&main_url),
+            "main.slint should be scheduled for recompilation when dep.slint is created outside the editor"
+        );
+    }
+}

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1194,20 +1194,21 @@ fn config_changed(config: PreviewConfig) {
 
 /// If the file is in the cache, returns it.
 ///
-/// If the file is not known, the return an empty string marked as "from disk". This is fine:
-/// The LSP side will load the file and inform us about it soon.
+/// If the file is not known, return a NotFound error:
+/// Usually the LSP side will load the file and inform us about it soon.
+/// Otherwise the file is indeed missing.
 ///
 /// In any way, register it as a dependency
-fn get_url_from_cache(url: &Url) -> (SourceFileVersion, String) {
+fn get_url_from_cache(url: &Url) -> std::io::Result<(SourceFileVersion, String)> {
     PREVIEW_STATE.with_borrow_mut(|preview_state| {
         preview_state.dependencies.insert(url.to_owned());
 
-        preview_state
-            .source_code
-            .get(url)
-            .map(|r| (r.version, r.code.clone()))
-            .unwrap_or_default()
-            .clone()
+        preview_state.source_code.get(url).map(|r| (r.version, r.code.clone())).ok_or(
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "File not registered in Live-Preview!",
+            ),
+        )
     })
 }
 
@@ -1215,7 +1216,7 @@ fn get_path_from_cache(path: &Path) -> std::io::Result<(SourceFileVersion, Strin
     let url = Url::from_file_path(path).map_err(|()| {
         std::io::Error::new(std::io::ErrorKind::NotFound, "Failed to convert path to URL")
     })?;
-    Ok(get_url_from_cache(&url))
+    get_url_from_cache(&url)
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -1451,11 +1452,10 @@ async fn reload_preview_impl(
     }
 
     let path = component.url.to_file_path().unwrap_or(PathBuf::from(&component.url.to_string()));
-    let (version, source) = get_url_from_cache(&component.url);
-
-    if source.is_empty() {
-        tracing::debug!("Preview: source is empty for {}", component.url);
-    }
+    let (version, source) = get_url_from_cache(&component.url).unwrap_or_else(|err| {
+        tracing::debug!("Preview: Failed to load source for url={}, error={}", component.url, err);
+        Default::default()
+    });
 
     let format =
         if config.format_utf8 { common::ByteFormat::Utf8 } else { common::ByteFormat::Utf16 };

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -348,7 +348,7 @@ pub fn insert_position_at_end(
         };
 
         let url = lsp_types::Url::from_file_path(node.source_file.path()).ok()?;
-        let (version, _) = preview::get_url_from_cache(&url);
+        let (version, _) = preview::get_url_from_cache(&url).ok()?;
 
         Some(InsertInformation {
             insertion_position: common::VersionedPosition::new(
@@ -406,7 +406,7 @@ pub fn insert_position_before_child(
             };
 
             let url = lsp_types::Url::from_file_path(child_node.source_file.path()).ok()?;
-            let (version, _) = preview::get_url_from_cache(&url);
+            let (version, _) = preview::get_url_from_cache(&url).ok()?;
 
             return Some(InsertInformation {
                 insertion_position: common::VersionedPosition::new(


### PR DESCRIPTION
- **TypeLoader: Keep ImportedTypes for unresolved paths**
- **LSP: Watch for file created events**
- **Live-Preview: Return FileNotFound if not in cache**
- **Add test for #11304**

Closes #11304
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
