### PR TITLE
FlexboxLayout: change flex-shrink default from 0 to 1 to match CSS

### DIFF
--- a/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/flexboxlayout.mdx
@@ -142,7 +142,7 @@ A value of `0` (default) means the item does not grow. Items with higher values 
 ### flex-shrink
 <SlintProperty propName="flex-shrink" typeName="float">
 Controls how much an item shrinks relative to other flex items when items overflow the container along the main axis.
-A value of `0` (default) means the item does not shrink. Items with higher values shrink proportionally more.
+Default is `1` (matching CSS behavior). A value of `0` means the item does not shrink. Items with higher values shrink proportionally more.
 </SlintProperty>
 
 ### flex-basis

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1266,7 +1266,7 @@ pub fn get_flexbox_layout_item_info_for_repeated(
     let (align_self_ty, align_self_default) = default_align_self();
 
     let grow = prop_ref("flex-grow").unwrap_or(llr_Expression::NumberLiteral(0.0));
-    let shrink = prop_ref("flex-shrink").unwrap_or(llr_Expression::NumberLiteral(0.0));
+    let shrink = prop_ref("flex-shrink").unwrap_or(llr_Expression::NumberLiteral(1.0));
     let basis = prop_ref("flex-basis").unwrap_or(llr_Expression::NumberLiteral(-1.0));
     let align_self = prop_ref("flex-align-self").unwrap_or(align_self_default);
     let order = prop_ref("flex-order").unwrap_or(llr_Expression::NumberLiteral(0.0));

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1175,7 +1175,7 @@ impl Default for FlexboxLayoutItemInfo {
         Self {
             constraint: LayoutInfo::default(),
             flex_grow: 0.0,
-            flex_shrink: 0.0,
+            flex_shrink: 1.0,
             flex_basis: -1 as _,
             flex_align_self: FlexboxLayoutAlignSelf::Auto,
             flex_order: 0,

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -406,7 +406,7 @@ fn flexbox_layout_data(
                 &expr_eval,
             );
             let flex_grow = layout_elem.flex_grow.as_ref().map(&expr_eval).unwrap_or(0.0);
-            let flex_shrink = layout_elem.flex_shrink.as_ref().map(&expr_eval).unwrap_or(0.0);
+            let flex_shrink = layout_elem.flex_shrink.as_ref().map(&expr_eval).unwrap_or(1.0);
             let flex_basis = layout_elem.flex_basis.as_ref().map(&expr_eval).unwrap_or(-1.0);
             let align_self = layout_elem
                 .align_self

--- a/tests/cases/layout/flexbox_in_vertical_layout.slint
+++ b/tests/cases/layout/flexbox_in_vertical_layout.slint
@@ -2,12 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // Test that items below a FlexboxLayout move down when the width decreases
-// i.e. even a VerticalLayout ends up having a "height for width" behavior
+// i.e. even a VerticalLayout ends up having a "height for width" behavior.
+// Starts wide (all items on one row), then switches to narrow (items wrap into a column).
 
 export component TestCase inherits Window {
     background: white;
-    width: 150px;
-    height: 500px;
+
+    property <length> width_wide: 400px;
+    property <length> height_wide: 500px;
+    property <length> width_narrow: 150px;
+    property <length> height_narrow: 500px;
+
+    width: width_wide;
+    height: height_wide;
 
     VerticalLayout {
         spacing: 0px;
@@ -40,30 +47,53 @@ export component TestCase inherits Window {
 
         Rectangle {
             vertical-stretch: 1;
+            // Interactive testing, not used by the test framework
+            TouchArea {
+                clicked => {
+                    root.width = root.width == width_narrow ? width_wide : width_narrow;
+                    root.height = root.height == height_narrow ? height_wide : height_narrow;
+                }
+            }
         }
     }
 
-    // Check positions:
-    // All flexbox's item are laid out vertically (150px width for 100px items)
-    // and "text" should be below them (that's the main point of this test)
-    out property <bool> test_r1_x: r1.x == 0px;
-    out property <bool> test_r1_y: r1.y == 0px;
-    out property <bool> test_r2_x: r2.x == 0px;
-    out property <bool> test_r2_y: r2.y == 60px;
-    out property <bool> test_r3_x: r3.x == 0px;
-    out property <bool> test_r3_y: r3.y == 120px;
-    out property <bool> test_text_x: text.x == 0px;
-    out property <bool> test_text_y: text.y == 170px;
-    out property <int> test_text_y_debug: text.y / 1px;
+    // --- Wide state: all items fit on one row ---
+    out property <bool> wide_r1_ok: r1.x == 0px && r1.y == 0px;
+    out property <bool> wide_r2_ok: r2.x == 110px && r2.y == 0px;
+    out property <bool> wide_r3_ok: r3.x == 220px && r3.y == 0px;
+    out property <bool> wide_text_ok: text.x == 0px && text.y == 50px;
+    out property <bool> wide_ok: wide_r1_ok && wide_r2_ok && wide_r3_ok && wide_text_ok;
 
-    out property <bool> test:
-        test_r1_x && test_r1_y && test_r2_x && test_r2_y && test_r3_x && test_r3_y && test_text_x && test_text_y;
+    // --- Narrow state: each item gets its own row ---
+    out property <bool> narrow_r1_ok: r1.x == 0px && r1.y == 0px;
+    out property <bool> narrow_r2_ok: r2.x == 0px && r2.y == 60px;
+    out property <bool> narrow_r3_ok: r3.x == 0px && r3.y == 120px;
+    out property <bool> narrow_text_ok: text.x == 0px && text.y == 170px;
+    out property <bool> narrow_ok: narrow_r1_ok && narrow_r2_ok && narrow_r3_ok && narrow_text_ok;
+
+    init => {
+        root.init-called = true;
+        if !wide_ok {
+            root.error = "wide state failed: r1=" + (r1.x / 1px) + "," + (r1.y / 1px)
+                + " r2=" + (r2.x / 1px) + "," + (r2.y / 1px)
+                + " r3=" + (r3.x / 1px) + "," + (r3.y / 1px)
+                + " text.y=" + (text.y / 1px);
+        }
+        root.width = width_narrow;
+        root.height = height_narrow;
+    }
+    out property <string> error;
+    out property <bool> init-called;
+    out property <int> test_text_y_debug: text.y / 1px;
+    out property <bool> test: init-called && error == "" && narrow_ok;
 }
 
 /*
+
 ```cpp
 auto handle = TestCase::create();
-assert(handle->get_test());
+const TestCase &instance = *handle;
+assert(instance.get_test());
 ```
 
 


### PR DESCRIPTION
Further testing during the investigation of the height-for-width bugs found this unrelated issue: items in a flexbox layout would overflow out of the container rather than shrink in order to fit into it.

Also extend a crucial test "flexbox layout inside a vertical layout" to test two cases: wide and narrow. In both cases the next item in the vertical layout is "just below" the items in the flexbox layout (which is easily broken if the flexbox layout doesn't provide correct layoutinfo_v values).