### PR TITLE
fix: elide long selected ComboBox values

### DIFF
--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -61,12 +61,14 @@ export component ComboBox {
             spacing: 10px;
 
             text := Text {
+                horizontal-stretch: 1;
                 horizontal-alignment: left;
                 vertical-alignment: center;
                 font-size: CosmicFontSettings.body.font-size;
                 font-weight: CosmicFontSettings.body.font-weight;
                 color: CosmicPalette.control-foreground;
                 text: root.current-value;
+                overflow: elide;
                 accessible-role: none;
             }
 

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -103,6 +103,7 @@ export component ComboBox {
             font-weight: CupertinoFontSettings.body.font-weight;
             color: CupertinoPalette.foreground;
             text: root.current-value;
+            overflow: elide;
             accessible-role: none;
         }
 

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -76,12 +76,14 @@ export component ComboBox {
             spacing: 8px;
 
             text := Text {
+                horizontal-stretch: 1;
                 horizontal-alignment: left;
                 vertical-alignment: center;
                 font-size: FluentFontSettings.body.font-size;
                 font-weight: FluentFontSettings.body.font-weight;
                 color: FluentPalette.control-foreground;
                 text: root.current-value;
+                overflow: elide;
                 accessible-role: none;
             }
 

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -72,6 +72,7 @@ export component ComboBox {
         spacing: 16px;
 
         label := Text {
+            horizontal-stretch: 1;
             text <=> root.current-value;
             color: MaterialPalette.control-foreground;
             vertical-alignment: center;
@@ -79,6 +80,7 @@ export component ComboBox {
             // font-family: MaterialFontSettings.body-large.font;
             font-size: MaterialFontSettings.body-large.font-size;
             font-weight: MaterialFontSettings.body-large.font-weight;
+            overflow: elide;
             accessible-role: none;
         }
 


### PR DESCRIPTION
Fix ComboBox rendering when the selected item text is longer than the available width
Fixes #11332.