### PR TITLE
Add documentation for the embedded MCP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ SLINT_CREATE_SCREENSHOTS=1 cargo test -p test-driver-screenshots  # Generate ref
   - `android-activity/` - Android platform support
   - `linuxkms/` - Linux KMS/DRM direct rendering
   - `selector/` - Runtime backend selection
-  - `testing/` - Testing backend for automated tests
+  - `testing/` - Testing backend for automated tests, system testing (protobuf/TCP), and embedded MCP server for AI-assisted UI introspection
 
 - **`internal/renderers/`** - Rendering engines:
   - `femtovg/` - OpenGL ES 2.0
@@ -179,4 +179,5 @@ For tasks requiring deeper architectural understanding, see:
 - **`docs/development/text-layout.md`** - Text shaping, line breaking, paragraph layout, styled text parsing. Load when working on `internal/core/textlayout/` or text rendering.
 - **`docs/development/window-backend-integration.md`** - WindowAdapter trait, Platform trait, WindowEvent, popup management, backend implementations. Load when working on `internal/core/window.rs` or `internal/backends/`.
 - **`docs/development/lsp-architecture.md`** - LSP server, code completion, hover, semantic tokens, live preview. Load when working on `tools/lsp/` or IDE tooling.
+- **`docs/development/mcp-server.md`** - Embedded MCP server architecture, shared introspection layer, handle/arena system, HTTP transport, adding tools. Load when working on `internal/backends/testing/mcp_server.rs`, `introspection.rs`, or MCP-related features.
 - **`docs/development/ffi-language-bindings.md`** - C++/Node.js/Python bindings, cbindgen, FFI patterns, adding new cross-language APIs. Load when working on `api/` or internal FFI modules.

--- a/docs/development/mcp-server.md
+++ b/docs/development/mcp-server.md
@@ -1,0 +1,147 @@
+# Embedded MCP Server
+
+The testing backend includes an embedded [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that allows MCP-compatible clients (e.g. Claude Code) to inspect and interact with a running Slint application over HTTP. This document covers the architecture and internals for developers working on `internal/backends/testing/`.
+
+## Overview
+
+The MCP server shares a common introspection layer with the system-testing (protobuf/TCP) transport. Both transports use the same `IntrospectionState` for window and element tracking, the same protobuf-derived types for data structures, and the same `ElementHandle` API for interacting with the UI. The MCP transport adds a thin JSON-RPC/HTTP wrapper on top.
+
+```
+┌─────────────────────────────────────────────┐
+│         Slint Application (event loop)      │
+├──────────────────┬──────────────────────────┤
+│                  │  introspection.rs         │
+│                  │  IntrospectionState       │
+│                  │  (window/element arenas)  │
+│       ┌──────────┴──────────┐               │
+│       │                     │               │
+│  systest.rs            mcp_server.rs        │
+│  (TCP/protobuf)        (HTTP/JSON-RPC)      │
+│  system-testing        mcp feature          │
+│  feature                                    │
+└───────┴─────────────────────┴───────────────┘
+```
+
+## Feature Gating
+
+The MCP server is controlled by two layers:
+
+1. **Cargo feature `mcp`** — Compiles the MCP server code. Defined in `internal/backends/testing/Cargo.toml` and forwarded through `internal/backends/selector/Cargo.toml`. Not currently exposed through the public `slint` crate.
+
+2. **Environment variable `SLINT_MCP_PORT`** — Controls whether the server actually starts at runtime. If not set, `mcp_server::init()` returns immediately with no overhead.
+
+### Enabling for a Slint Application
+
+Since the `mcp` feature is not plumbed through the public `slint` crate, users enable it directly on the backend selector:
+
+```toml
+[dependencies]
+slint = "x.y.z"
+i-slint-backend-selector = { version = "=x.y.z", features = ["mcp"] }
+```
+
+Then run with:
+
+```sh
+SLINT_MCP_PORT=8080 cargo run -p my-app
+```
+
+## Initialization Flow
+
+Initialization is triggered from the backend selector (`internal/backends/selector/lib.rs`) after the platform is successfully created:
+
+1. `mcp_server::init()` checks `SLINT_MCP_PORT`. If absent, returns early.
+2. Calls `introspection::ensure_window_tracking()` to install a window-shown hook that registers windows with the shared `IntrospectionState`.
+3. Installs a second window-shown hook that lazily starts the TCP listener on the first window show. The server task is spawned onto the Slint event loop via `context.spawn_local()`.
+
+The lazy start via `OnceCell` ensures the server only binds the port once the application has an event loop running and a window to inspect.
+
+## Shared Introspection Layer (`introspection.rs`)
+
+### IntrospectionState
+
+The central data structure, stored as a thread-local `Rc<IntrospectionState>`:
+
+- **`windows`** — `Arena<TrackedWindow>`: tracks live windows via weak references to their `WindowAdapter`.
+- **`element_handles`** — `Arena<ElementHandle>`: maps arena indices to `ElementHandle` instances.
+- **`element_handle_order`** — `VecDeque<Index>`: tracks insertion order for FIFO eviction.
+
+### Handle System
+
+Both transports use `generational_arena::Index` internally. The proto `Handle` type (`{index, generation}`) is the wire format — `index_to_handle()` and `handle_to_index()` convert between them.
+
+Handles are generational: if an element is evicted and its arena slot reused, stale handles are detected because the generation won't match.
+
+### FIFO Eviction
+
+The element arena is capped at 10,000 entries (`ELEMENT_HANDLE_CAP`). When the cap is exceeded, the oldest handles are evicted (FIFO order), with one exception: root element handles for tracked windows are never evicted — they are pushed to the back of the queue instead.
+
+### Validity Checking
+
+When a handle is resolved via `IntrospectionState::element()`, the returned `ElementHandle` is checked with `is_valid()`. If the underlying UI element has been destroyed (e.g. the component was removed), the stale handle is cleaned up and an error is returned.
+
+## MCP Transport (`mcp_server.rs`)
+
+### Protocol
+
+The server implements MCP's [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http):
+
+- Endpoint: `POST /mcp` (or `POST /`)
+- Content-Type: `application/json`
+- JSON-RPC 2.0 messages
+
+The server is stateless (no session management). Each request is a single JSON-RPC call — batch requests are rejected.
+
+### HTTP Server
+
+The HTTP server is built directly on `async-net` (async TCP) and `httparse` (HTTP/1.1 parsing), with no framework dependency. It supports:
+
+- HTTP/1.1 keep-alive (persistent connections)
+- CORS preflight (`OPTIONS`) for browser-based clients
+- Origin validation: only `localhost`, `127.0.0.1`, and `::1` origins are accepted
+- 4 MB maximum body size
+
+### Security
+
+- **Localhost only**: the server binds to `127.0.0.1`, not `0.0.0.0`.
+- **Origin validation**: cross-origin requests from non-localhost origins are rejected with 403.
+- **No authentication**: since the server is localhost-only and intended for development/testing, there is no auth mechanism.
+
+### Tool Dispatch
+
+Tool calls arrive as `tools/call` JSON-RPC methods. The `handle_tool_call()` function dispatches by tool name. Most tools deserialize parameters into proto types (leveraging `pbjson`-generated `Deserialize` impls), call methods on `IntrospectionState`, and serialize the response back to JSON.
+
+Two tools (`get_element_tree` and `dispatch_key_event`) use custom parameter handling rather than proto types, since they don't have direct protobuf equivalents.
+
+### MCP Instructions
+
+The `initialize` response includes a detailed `instructions` field that guides MCP clients through the workflow, handle format, enum values, and query syntax. This is the primary documentation that AI clients see when connecting.
+
+## Proto Build Pipeline (`build.rs`)
+
+Both `system-testing` and `mcp` features trigger the same build pipeline:
+
+1. `protox` compiles `slint_systest.proto` (pure-Rust, no external `protoc` needed)
+2. `prost-build` generates Rust structs from the proto descriptors → `proto.rs`
+3. `pbjson-build` generates `Serialize`/`Deserialize` impls → `proto.serde.rs`
+
+The MCP transport uses the `serde_json`-based serialization, while the system-testing transport uses prost's binary encoding. Both share the same proto types.
+
+## Adding a New Tool
+
+1. If the tool maps to a proto request/response, add the message types to `slint_systest.proto`. Otherwise, handle parameters manually in `handle_tool_call()`.
+2. Add a tool definition entry in `tool_definitions()` with name, description, and input schema.
+3. Add a match arm in `handle_tool_call()`.
+4. If the tool needs new introspection capabilities, add methods to `IntrospectionState` in `introspection.rs` so both transports can use them.
+5. Update the `instructions` string in the `initialize` response if the new tool changes the recommended workflow.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `internal/backends/testing/introspection.rs` | Shared `IntrospectionState`, arena management, window/element operations |
+| `internal/backends/testing/mcp_server.rs` | HTTP server, JSON-RPC dispatch, MCP tool definitions |
+| `internal/backends/testing/systest.rs` | System-testing TCP/protobuf transport (shares introspection layer) |
+| `internal/backends/testing/slint_systest.proto` | Protobuf definitions (source of truth for data types) |
+| `internal/backends/testing/build.rs` | Proto compilation pipeline |
+| `internal/backends/selector/lib.rs` | Backend initialization, MCP server startup hook |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -132,6 +132,16 @@ To start the tests run and compare images:
 cargo test -p test-driver-screenshots
 ```
 
+## Embedded MCP Server
+
+The testing backend includes an embedded MCP (Model Context Protocol) server that allows
+AI coding tools (e.g. Claude Code) to inspect and interact with a running Slint application
+in real time. Enable the `mcp` Cargo feature on `i-slint-backend-selector` and set the
+`SLINT_MCP_PORT` environment variable to start the server.
+
+See the [testing backend README](../internal/backends/testing/README.md) for usage instructions
+and [docs/development/mcp-server.md](development/mcp-server.md) for architecture details.
+
 ## Doctests
 
 ```

--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -201,3 +201,76 @@ the event loop is started, and that will start polling the async closure passed 
 In this closure we can now call `.await` on the future [`ElementHandle::single_click()`] returns, which
 will keep running the event loop until the click is complete, and then continue with the test function.
 
+## Embedded MCP Server
+
+The testing backend includes an embedded [MCP (Model Context Protocol)](https://modelcontextprotocol.io/)
+server that allows MCP clients — such as Claude Code — to inspect and interact with a running Slint
+application in real time over HTTP.
+
+### Enabling the MCP Server
+
+The MCP server requires the `mcp` Cargo feature on the backend selector crate. Since this feature is
+not exposed through the public `slint` crate, enable it on `i-slint-backend-selector` directly:
+
+```toml
+[dependencies]
+slint = "x.y.z"
+i-slint-backend-selector = { version = "=x.y.z", features = ["mcp"] }
+```
+
+Then set the `SLINT_MCP_PORT` environment variable when running your application:
+
+```sh
+SLINT_MCP_PORT=8080 cargo run -p my-slint-app
+```
+
+The server starts automatically when the backend initializes. If `SLINT_MCP_PORT` is not set,
+the server is not started and there is no runtime overhead.
+
+### Connecting an MCP Client
+
+Once the application is running with the MCP server enabled, connect any MCP client to
+`http://localhost:<port>/mcp` using the Streamable HTTP transport. For example, in Claude Code's
+MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "my-slint-app": {
+      "type": "streamable-http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+### Available Tools
+
+The MCP server exposes 11 tools for UI introspection and interaction:
+
+| Tool | Description |
+|------|-------------|
+| `list_windows` | List all open windows and their handles |
+| `get_window_properties` | Get window size, position, state, and root element handle |
+| `get_element_tree` | Get a flat list of elements in a subtree with types, IDs, and accessibility info |
+| `get_element_properties` | Get full details of a single element |
+| `find_elements_by_id` | Find elements by qualified ID (e.g. `App::my-button`) |
+| `query_element_descendants` | Search descendants using a query pipeline (by type, ID, or role) |
+| `take_screenshot` | Capture a PNG screenshot of a window |
+| `click_element` | Simulate a mouse click on an element |
+| `invoke_accessibility_action` | Invoke a semantic action (Default, Increment, Decrement, Expand) |
+| `set_element_value` | Set the accessible value of an element (text, slider value, etc.) |
+| `dispatch_key_event` | Send a keyboard event to a window |
+
+### Typical Workflow
+
+1. `list_windows` → discover available windows
+2. `get_window_properties` → get the `rootElementHandle`
+3. `get_element_tree` → explore the UI hierarchy
+4. `query_element_descendants` or `find_elements_by_id` → locate specific elements
+5. `click_element` / `set_element_value` / `invoke_accessibility_action` → interact
+6. `take_screenshot` → verify the visual result
+
+For a detailed description of the architecture and internals, see
+[docs/development/mcp-server.md](../../../docs/development/mcp-server.md).
+


### PR DESCRIPTION
## Summary

- **Testing backend README**: Added usage guide covering Cargo feature flags, `SLINT_MCP_PORT` env var, MCP client configuration example (Claude Code), tool reference table (all 11 tools), and typical workflow
- **`docs/development/mcp-server.md`**: New architecture deep-dive covering the shared introspection layer, arena-based handle system with FIFO eviction, HTTP/JSON-RPC transport, security model, proto build pipeline, and guide for adding new tools
- **`AGENTS.md`**: Updated testing backend description to mention MCP/introspection; added deep-dive doc reference so AI assistants load it when working on MCP code
- **`docs/testing.md`**: Brief section pointing to the detailed docs

Documents the MCP server feature added in #11217.

## Test plan

- [ ] Verify all cross-references between docs resolve correctly
- [ ] Confirm no user-facing API docs (Astro) were modified