### PR TITLE
Add drag gesture simulation to testing backend and MCP server

### DIFF
--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -246,7 +246,7 @@ MCP configuration:
 
 ### Available Tools
 
-The MCP server exposes 11 tools for UI introspection and interaction:
+The MCP server exposes 12 tools for UI introspection and interaction:
 
 | Tool | Description |
 |------|-------------|
@@ -258,6 +258,7 @@ The MCP server exposes 11 tools for UI introspection and interaction:
 | `query_element_descendants` | Search descendants using a query pipeline (by type, ID, or role) |
 | `take_screenshot` | Capture a PNG screenshot of a window |
 | `click_element` | Simulate a mouse click on an element |
+| `drag_element` | Simulate a drag gesture from an element's center to a target position |
 | `invoke_accessibility_action` | Invoke a semantic action (Default, Increment, Decrement, Expand) |
 | `set_element_value` | Set the accessible value of an element (text, slider value, etc.) |
 | `dispatch_key_event` | Send a keyboard event to a window |
@@ -268,7 +269,7 @@ The MCP server exposes 11 tools for UI introspection and interaction:
 2. `get_window_properties` → get the `rootElementHandle`
 3. `get_element_tree` → explore the UI hierarchy
 4. `query_element_descendants` or `find_elements_by_id` → locate specific elements
-5. `click_element` / `set_element_value` / `invoke_accessibility_action` → interact
+5. `click_element` / `drag_element` / `set_element_value` / `invoke_accessibility_action` → interact
 6. `take_screenshot` → verify the visual result
 
 For a detailed description of the architecture and internals, see

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -132,6 +132,20 @@ fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "drag_element",
+                "description": "Simulate a drag gesture from the element's center to a target position (logical coordinates). The pointer is pressed at the element center, moved in interpolated steps to the target, then released. Use for sliders, scrollable areas, drag handles, or any element that responds to pointer movement while pressed.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "elementHandle": handle_schema.clone(),
+                        "targetX": { "type": "number", "description": "Target X position in logical coordinates." },
+                        "targetY": { "type": "number", "description": "Target Y position in logical coordinates." },
+                        "button": { "type": "string", "description": "'Left' (default), 'Right', or 'Middle'." }
+                    },
+                    "required": ["elementHandle", "targetX", "targetY"]
+                }
+            },
+            {
                 "name": "invoke_accessibility_action",
                 "description": "Invoke an accessibility action: 'Default_' (activate buttons, toggle checkboxes), 'Increment'/'Decrement' (sliders, spinboxes), 'Expand' (combo boxes). Preferred over click_element when the element's role suggests a semantic action.",
                 "inputSchema": {
@@ -340,6 +354,40 @@ async fn handle_tool_call(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
         }
+        // Custom tool: manual parameter parsing because the MCP schema uses flat
+        // targetX/targetY fields rather than the proto's nested LogicalPosition target.
+        "drag_element" => {
+            let element_handle: proto::Handle = args
+                .get("elementHandle")
+                .ok_or_else(|| "missing elementHandle".to_string())
+                .and_then(|v| {
+                    serde_json::from_value(v.clone())
+                        .map_err(|e| format!("invalid elementHandle: {e}"))
+                })?;
+            let target_x: f32 = args
+                .get("targetX")
+                .and_then(|v| v.as_f64())
+                .ok_or_else(|| "missing targetX".to_string())? as f32;
+            let target_y: f32 = args
+                .get("targetY")
+                .and_then(|v| v.as_f64())
+                .ok_or_else(|| "missing targetY".to_string())? as f32;
+            let button_str = args.get("button").and_then(|v| v.as_str()).unwrap_or("Left");
+            let button = match button_str {
+                "Left" => i_slint_core::platform::PointerEventButton::Left,
+                "Right" => i_slint_core::platform::PointerEventButton::Right,
+                "Middle" => i_slint_core::platform::PointerEventButton::Middle,
+                other => return Err(format!("Unknown button: {other}. Use 'Left', 'Right', or 'Middle'.")),
+            };
+            let element_index = handle_to_index(element_handle);
+            let element = state.element("drag_element", element_index)?;
+            let target = i_slint_core::api::LogicalPosition::new(target_x, target_y);
+            element.drag(target, button).await;
+            let response = proto::ElementDragResponse {};
+            Ok(ToolResult::Json(
+                serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
+            ))
+        }
         "invoke_accessibility_action" => {
             let p: proto::RequestInvokeElementAccessibilityAction = deserialize_params(args)?;
             let element_index = handle_to_index(
@@ -467,7 +515,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "4. Drill down: use query_element_descendants to search by type, ID, or accessible role; or find_elements_by_id for known IDs\n",
                     "5. get_element_properties → full details on a specific element\n",
                     "6. take_screenshot → visual snapshot (returned as inline image)\n",
-                    "7. Interact: click_element, set_element_value, invoke_accessibility_action, dispatch_key_event\n",
+                    "7. Interact: click_element, drag_element, set_element_value, invoke_accessibility_action, dispatch_key_event\n",
                     "8. take_screenshot again to verify the effect\n\n",
 
                     "# Handle format\n\n",
@@ -500,7 +548,8 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "- After clicking or setting values, take a screenshot to verify the visual result.\n",
                     "- For text input: find the TextInput element, then use set_element_value to set its content.\n",
                     "- For buttons: use click_element, or invoke_accessibility_action with 'Default_' for the default action.\n",
-                    "- For sliders: use invoke_accessibility_action with 'Increment'/'Decrement', or set_element_value with the numeric value as a string.\n",
+                    "- For sliders: use invoke_accessibility_action with 'Increment'/'Decrement', set_element_value with the numeric value as a string, or drag_element to drag the thumb to a position.\n",
+                    "- For drag gestures (scrollable areas, drag handles, custom sliders): use drag_element with the target position in logical coordinates.\n",
                     "- For checkboxes/switches: use click_element or invoke_accessibility_action with 'Default_'.\n"
                 )
             }),

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -1101,7 +1101,7 @@ mod tests {
     fn test_tool_definitions_structure() {
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 11);
+        assert_eq!(tools.len(), 12);
         for tool in tools {
             assert!(tool.get("name").and_then(|v| v.as_str()).is_some());
             assert!(tool.get("description").and_then(|v| v.as_str()).is_some());

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -364,20 +364,24 @@ async fn handle_tool_call(
                     serde_json::from_value(v.clone())
                         .map_err(|e| format!("invalid elementHandle: {e}"))
                 })?;
-            let target_x: f32 = args
-                .get("targetX")
-                .and_then(|v| v.as_f64())
-                .ok_or_else(|| "missing targetX".to_string())? as f32;
-            let target_y: f32 = args
-                .get("targetY")
-                .and_then(|v| v.as_f64())
-                .ok_or_else(|| "missing targetY".to_string())? as f32;
+            let target_x: f32 =
+                args.get("targetX")
+                    .and_then(|v| v.as_f64())
+                    .ok_or_else(|| "missing targetX".to_string())? as f32;
+            let target_y: f32 =
+                args.get("targetY")
+                    .and_then(|v| v.as_f64())
+                    .ok_or_else(|| "missing targetY".to_string())? as f32;
             let button_str = args.get("button").and_then(|v| v.as_str()).unwrap_or("Left");
             let button = match button_str {
                 "Left" => i_slint_core::platform::PointerEventButton::Left,
                 "Right" => i_slint_core::platform::PointerEventButton::Right,
                 "Middle" => i_slint_core::platform::PointerEventButton::Middle,
-                other => return Err(format!("Unknown button: {other}. Use 'Left', 'Right', or 'Middle'.")),
+                other => {
+                    return Err(format!(
+                        "Unknown button: {other}. Use 'Left', 'Right', or 'Middle'."
+                    ));
+                }
             };
             let element_index = handle_to_index(element_handle);
             let element = state.element("drag_element", element_index)?;

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -13,6 +13,15 @@ use i_slint_core::window::WindowInner;
 use std::rc::Rc;
 use std::time::Duration;
 
+/// Delay in milliseconds between interpolated PointerMoved events during drag simulation
+/// (~one frame at 60 fps).
+const DRAG_STEP_DELAY_MS: u64 = 16;
+
+/// Distance in logical pixels between interpolated PointerMoved events during drag
+/// simulation. Chosen to be below the 8 px `DISTANCE_THRESHOLD` (see `flickable.rs`)
+/// so that every intermediate position is reported to the element.
+const DRAG_STEP_SIZE: f32 = 5.0;
+
 fn warn_missing_debug_info() {
     i_slint_core::debug_log!(
         "The use of the ElementHandle API requires the presence of debug info in Slint compiler generated code. Set the `SLINT_EMIT_DEBUG_INFO=1` environment variable at application build time or use `compile_with_config` and `with_debug_info` with `slint_build`'s `CompilerConfiguration`"
@@ -936,6 +945,86 @@ impl ElementHandle {
         self.pointer_released(button);
     }
 
+    /// Simulates a drag gesture from the element's center to the given target position.
+    ///
+    /// The sequence is:
+    /// 1. `PointerMoved` + `PointerPressed` at the element center
+    /// 2. Interpolated `PointerMoved` events from center to `target` (step size ~5 logical
+    ///    pixels, with a 16 ms delay between steps)
+    /// 3. `PointerMoved` + `PointerReleased` at `target`
+    ///
+    /// The step size is chosen to be smaller than the 8 px drag/flick detection threshold
+    /// so that intermediate positions are always reported.
+    pub async fn drag(&self, target: LogicalPosition, button: PointerEventButton) {
+        let Some(window_adapter) = self.window_adapter() else {
+            return;
+        };
+        let window = window_adapter.window();
+        let start = self.absolute_center();
+
+        // Press at element center.
+        window.dispatch_event(WindowEvent::PointerMoved { position: start });
+        window.dispatch_event(WindowEvent::PointerPressed { position: start, button });
+
+        // Interpolate intermediate moves.
+        let dx = target.x - start.x;
+        let dy = target.y - start.y;
+        let distance = (dx * dx + dy * dy).sqrt();
+
+        if distance > f32::EPSILON {
+            // At least 2 steps to guarantee the drag threshold is crossed.
+            let steps = ((distance / DRAG_STEP_SIZE).ceil() as usize).max(2);
+
+            for i in 1..steps {
+                let t = i as f32 / steps as f32;
+                let pos = LogicalPosition::new(start.x + dx * t, start.y + dy * t);
+                wait_for(Duration::from_millis(DRAG_STEP_DELAY_MS)).await;
+                window.dispatch_event(WindowEvent::PointerMoved { position: pos });
+            }
+
+            // Final move to exact target.
+            wait_for(Duration::from_millis(DRAG_STEP_DELAY_MS)).await;
+            window.dispatch_event(WindowEvent::PointerMoved { position: target });
+        }
+
+        window.dispatch_event(WindowEvent::PointerReleased { position: target, button });
+    }
+
+    /// Simulates a drag gesture from the element's center to the given target position.
+    ///
+    /// Compared to [Self::drag()], this function uses slint_mock_elapsed_time instead
+    /// of an actual timer, so that it can be used in internal tests without an event loop.
+    pub fn mock_drag(&self, target: LogicalPosition, button: PointerEventButton) {
+        let Some(window_adapter) = self.window_adapter() else {
+            return;
+        };
+        let window = window_adapter.window();
+        let start = self.absolute_center();
+
+        window.dispatch_event(WindowEvent::PointerMoved { position: start });
+        window.dispatch_event(WindowEvent::PointerPressed { position: start, button });
+
+        let dx = target.x - start.x;
+        let dy = target.y - start.y;
+        let distance = (dx * dx + dy * dy).sqrt();
+
+        if distance > f32::EPSILON {
+            let steps = ((distance / DRAG_STEP_SIZE).ceil() as usize).max(2);
+
+            for i in 1..steps {
+                let t = i as f32 / steps as f32;
+                let pos = LogicalPosition::new(start.x + dx * t, start.y + dy * t);
+                slint_mock_elapsed_time(DRAG_STEP_DELAY_MS);
+                window.dispatch_event(WindowEvent::PointerMoved { position: pos });
+            }
+
+            slint_mock_elapsed_time(DRAG_STEP_DELAY_MS);
+            window.dispatch_event(WindowEvent::PointerMoved { position: target });
+        }
+
+        window.dispatch_event(WindowEvent::PointerReleased { position: target, button });
+    }
+
     fn absolute_center(&self) -> LogicalPosition {
         let item_pos = self.absolute_position();
         let item_size = self.size();
@@ -1318,4 +1407,95 @@ fn test_popups() {
             .collect::<Vec<_>>(),
         ["Nested", "Ok"]
     );
+}
+
+#[test]
+fn test_drag_touch_area() {
+    crate::init_no_event_loop();
+
+    slint::slint! {
+        export component App inherits Window {
+            width: 200px;
+            height: 200px;
+            out property <int> move-count: 0;
+            out property <float> last-x: 0;
+            out property <float> last-y: 0;
+            ta := TouchArea {
+                width: 100%;
+                height: 100%;
+                moved => {
+                    root.move-count += 1;
+                    root.last-x = self.mouse-x / 1px;
+                    root.last-y = self.mouse-y / 1px;
+                }
+            }
+        }
+    }
+
+    let app = App::new().unwrap();
+    let ta = ElementHandle::find_by_element_id(&app, "App::ta").next().unwrap();
+
+    // Drag from center (100,100) to (150,100) — 50px horizontal drag.
+    ta.mock_drag(
+        LogicalPosition::new(150.0, 100.0),
+        PointerEventButton::Left,
+    );
+
+    assert!(app.get_move_count() > 0, "moved callback should have fired");
+    // The last move should land at the target position (within the element, so
+    // target minus element origin = 150 - 0 = 150).
+    let last_x = app.get_last_x();
+    assert!(
+        (last_x - 150.0).abs() < 1.0,
+        "last mouse-x should be near 150, got {last_x}"
+    );
+}
+
+#[test]
+fn test_drag_zero_distance() {
+    crate::init_no_event_loop();
+
+    slint::slint! {
+        export component App inherits Window {
+            width: 100px;
+            height: 100px;
+            out property <bool> was-pressed: false;
+            out property <bool> was-released: false;
+            out property <int> move-count: 0;
+            ta := TouchArea {
+                width: 100%;
+                height: 100%;
+                pointer-event(e) => {
+                    if e.kind == PointerEventKind.down {
+                        root.was-pressed = true;
+                    }
+                    if e.kind == PointerEventKind.up {
+                        root.was-released = true;
+                    }
+                }
+                moved => {
+                    root.move-count += 1;
+                }
+            }
+        }
+    }
+
+    let app = App::new().unwrap();
+    let ta = ElementHandle::find_by_element_id(&app, "App::ta").next().unwrap();
+
+    // Drag to the element's own center — zero distance.
+    let center = ta.absolute_position();
+    let sz = ta.size();
+    let target = LogicalPosition::new(
+        center.x + sz.width / 2.0,
+        center.y + sz.height / 2.0,
+    );
+    ta.mock_drag(target, PointerEventButton::Left);
+
+    assert!(app.get_was_pressed(), "press event should have fired");
+    assert!(app.get_was_released(), "release event should have fired");
+    // Zero-distance drag should skip interpolation — no moved events from the
+    // drag itself (the initial PointerMoved before press doesn't trigger `moved`
+    // because the button isn't down yet).
+    assert_eq!(app.get_move_count(), 0, "no moved events expected for zero-distance drag");
 }

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -1436,19 +1436,13 @@ fn test_drag_touch_area() {
     let ta = ElementHandle::find_by_element_id(&app, "App::ta").next().unwrap();
 
     // Drag from center (100,100) to (150,100) — 50px horizontal drag.
-    ta.mock_drag(
-        LogicalPosition::new(150.0, 100.0),
-        PointerEventButton::Left,
-    );
+    ta.mock_drag(LogicalPosition::new(150.0, 100.0), PointerEventButton::Left);
 
     assert!(app.get_move_count() > 0, "moved callback should have fired");
     // The last move should land at the target position (within the element, so
     // target minus element origin = 150 - 0 = 150).
     let last_x = app.get_last_x();
-    assert!(
-        (last_x - 150.0).abs() < 1.0,
-        "last mouse-x should be near 150, got {last_x}"
-    );
+    assert!((last_x - 150.0).abs() < 1.0, "last mouse-x should be near 150, got {last_x}");
 }
 
 #[test]
@@ -1486,10 +1480,7 @@ fn test_drag_zero_distance() {
     // Drag to the element's own center — zero distance.
     let center = ta.absolute_position();
     let sz = ta.size();
-    let target = LogicalPosition::new(
-        center.x + sz.width / 2.0,
-        center.y + sz.height / 2.0,
-    );
+    let target = LogicalPosition::new(center.x + sz.width / 2.0, center.y + sz.height / 2.0);
     ta.mock_drag(target, PointerEventButton::Left);
 
     assert!(app.get_was_pressed(), "press event should have fired");

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -161,6 +161,12 @@ message RequestElementClick {
     PointerEventButton button = 3;
 }
 
+message RequestElementDrag {
+    Handle element_handle = 1;
+    LogicalPosition target = 2;
+    PointerEventButton button = 3;
+}
+
 message RequestDispatchWindowEvent {
     Handle window_handle = 1;
     WindowEvent event = 2;
@@ -184,6 +190,7 @@ message RequestToAUT {
         RequestElementClick request_element_click = 8;
         RequestDispatchWindowEvent request_dispatch_window_event = 9;
         RequestQueryElementDescendants request_query_element_descendants = 10;
+        RequestElementDrag request_element_drag = 11;
     }
 }
 
@@ -268,6 +275,9 @@ message TakeSnapshotResponse {
 message ElementClickResponse {
 }
 
+message ElementDragResponse {
+}
+
 message DispatchWindowEventResponse {
 }
 
@@ -288,5 +298,6 @@ message AUTResponse {
         ElementClickResponse element_click_response = 9;
         DispatchWindowEventResponse dispatch_window_event_response = 10;
         ElementQueryResponse element_query_response = 11;
+        ElementDragResponse element_drag_response = 12;
     }
 }

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -151,6 +151,21 @@ impl TestingClient {
                 }
                 Resp::ElementClickResponse(proto::ElementClickResponse {})
             }
+            Req::RequestElementDrag(proto::RequestElementDrag {
+                element_handle,
+                target,
+                button,
+            }) => {
+                let element = self.element("element drag request", element_handle)?;
+                let button = introspection::convert_pointer_event_button(
+                    proto::PointerEventButton::try_from(button)
+                        .map_err(|_| format!("invalid PointerEventButton value: {button}"))?,
+                );
+                let target = target.ok_or_else(|| "element drag request missing target".to_string())?;
+                let target = i_slint_core::api::LogicalPosition::new(target.x, target.y);
+                element.drag(target, button).await;
+                Resp::ElementDragResponse(proto::ElementDragResponse {})
+            }
             Req::RequestDispatchWindowEvent(proto::RequestDispatchWindowEvent {
                 window_handle,
                 event,

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -161,7 +161,8 @@ impl TestingClient {
                     proto::PointerEventButton::try_from(button)
                         .map_err(|_| format!("invalid PointerEventButton value: {button}"))?,
                 );
-                let target = target.ok_or_else(|| "element drag request missing target".to_string())?;
+                let target =
+                    target.ok_or_else(|| "element drag request missing target".to_string())?;
                 let target = i_slint_core::api::LogicalPosition::new(target.x, target.y);
                 element.drag(target, button).await;
                 Resp::ElementDragResponse(proto::ElementDragResponse {})


### PR DESCRIPTION
## Summary

- Add `drag()` (async) and `mock_drag()` (mock-time) methods to `ElementHandle` for simulating pointer drag gestures with interpolated moves in ~5px steps
- Add `RequestElementDrag` / `ElementDragResponse` proto messages and systest transport handler
- Add `drag_element` MCP tool with `targetX`, `targetY`, and optional `button` parameters
- Add MCP server documentation section to the testing backend README
- Zero-distance drags short-circuit to press-release without spurious move events

## Test plan

- [x] `test_drag_touch_area` — verifies `moved` callback fires and coordinates land at target
- [x] `test_drag_zero_distance` — verifies press/release fire, no moved events on zero-distance drag
- [x] Build with `--features mcp,system-testing` passes
- [x] Pre-existing tests unaffected (6 failures require `SLINT_EMIT_DEBUG_INFO`, same on clean master)