### PR TITLE
FlexboxLayout: Split flexbox_layout_info into main-axis and cross-axis functions

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -207,17 +207,26 @@ inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexboxL
 }
 
 inline cbindgen_private::LayoutInfo
-flexbox_layout_info(cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_h,
-                    cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_v,
-                    float spacing_h, float spacing_v, const cbindgen_private::Padding &padding_h,
-                    const cbindgen_private::Padding &padding_v,
-                    cbindgen_private::Orientation orientation,
-                    cbindgen_private::FlexboxLayoutDirection direction, float constraint_size,
-                    cbindgen_private::FlexboxLayoutWrap flex_wrap)
+flexbox_layout_info_main_axis(cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells,
+                              float spacing, const cbindgen_private::Padding &padding,
+                              cbindgen_private::FlexboxLayoutWrap flex_wrap)
 {
-    return cbindgen_private::slint_flexbox_layout_info(cells_h, cells_v, spacing_h, spacing_v,
-                                                       &padding_h, &padding_v, orientation,
-                                                       direction, constraint_size, flex_wrap);
+    return cbindgen_private::slint_flexbox_layout_info_main_axis(cells, spacing, &padding,
+                                                                  flex_wrap);
+}
+
+inline cbindgen_private::LayoutInfo
+flexbox_layout_info_cross_axis(cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_h,
+                               cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_v,
+                               float spacing_h, float spacing_v,
+                               const cbindgen_private::Padding &padding_h,
+                               const cbindgen_private::Padding &padding_v,
+                               cbindgen_private::FlexboxLayoutDirection direction,
+                               cbindgen_private::FlexboxLayoutWrap flex_wrap)
+{
+    return cbindgen_private::slint_flexbox_layout_info_cross_axis(cells_h, cells_v, spacing_h,
+                                                                   spacing_v, &padding_h, &padding_v,
+                                                                   direction, flex_wrap);
 }
 
 /// Access the layout cache of an item within a repeater (standard cache)

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -222,11 +222,13 @@ flexbox_layout_info_cross_axis(cbindgen_private::Slice<cbindgen_private::Flexbox
                                const cbindgen_private::Padding &padding_h,
                                const cbindgen_private::Padding &padding_v,
                                cbindgen_private::FlexboxLayoutDirection direction,
-                               cbindgen_private::FlexboxLayoutWrap flex_wrap)
+                               cbindgen_private::FlexboxLayoutWrap flex_wrap,
+                               float constraint_size)
 {
     return cbindgen_private::slint_flexbox_layout_info_cross_axis(cells_h, cells_v, spacing_h,
                                                                    spacing_v, &padding_h, &padding_v,
-                                                                   direction, flex_wrap);
+                                                                   direction, flex_wrap,
+                                                                   constraint_size);
 }
 
 /// Access the layout cache of an item within a repeater (standard cache)

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -206,29 +206,25 @@ inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexboxL
     return result;
 }
 
-inline cbindgen_private::LayoutInfo
-flexbox_layout_info_main_axis(cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells,
-                              float spacing, const cbindgen_private::Padding &padding,
-                              cbindgen_private::FlexboxLayoutWrap flex_wrap)
+inline cbindgen_private::LayoutInfo flexbox_layout_info_main_axis(
+        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells, float spacing,
+        const cbindgen_private::Padding &padding, cbindgen_private::FlexboxLayoutWrap flex_wrap)
 {
     return cbindgen_private::slint_flexbox_layout_info_main_axis(cells, spacing, &padding,
-                                                                  flex_wrap);
+                                                                 flex_wrap);
 }
 
-inline cbindgen_private::LayoutInfo
-flexbox_layout_info_cross_axis(cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_h,
-                               cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_v,
-                               float spacing_h, float spacing_v,
-                               const cbindgen_private::Padding &padding_h,
-                               const cbindgen_private::Padding &padding_v,
-                               cbindgen_private::FlexboxLayoutDirection direction,
-                               cbindgen_private::FlexboxLayoutWrap flex_wrap,
-                               float constraint_size)
+inline cbindgen_private::LayoutInfo flexbox_layout_info_cross_axis(
+        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_h,
+        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_v, float spacing_h,
+        float spacing_v, const cbindgen_private::Padding &padding_h,
+        const cbindgen_private::Padding &padding_v,
+        cbindgen_private::FlexboxLayoutDirection direction,
+        cbindgen_private::FlexboxLayoutWrap flex_wrap, float constraint_size)
 {
-    return cbindgen_private::slint_flexbox_layout_info_cross_axis(cells_h, cells_v, spacing_h,
-                                                                   spacing_v, &padding_h, &padding_v,
-                                                                   direction, flex_wrap,
-                                                                   constraint_size);
+    return cbindgen_private::slint_flexbox_layout_info_cross_axis(
+            cells_h, cells_v, spacing_h, spacing_v, &padding_h, &padding_v, direction, flex_wrap,
+            constraint_size);
 }
 
 /// Access the layout cache of an item within a repeater (standard cache)

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -32,6 +32,17 @@ pub enum FlexboxLayoutDirection {
     ColumnReverse,
 }
 
+/// Relationship between a queried orientation and a FlexboxLayout's direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlexboxAxisRelation {
+    /// The queried orientation is the main axis (e.g., Horizontal for a Row flex)
+    MainAxis,
+    /// The queried orientation is the cross axis (e.g., Vertical for a Row flex)
+    CrossAxis,
+    /// The flex direction is not known at compile time
+    Unknown,
+}
+
 #[derive(Clone, Debug, derive_more::From)]
 pub enum Layout {
     GridLayout(GridLayout),
@@ -618,6 +629,49 @@ pub struct FlexboxLayout {
 }
 
 impl FlexboxLayout {
+    /// Try to determine the flex direction at compile time from a constant binding.
+    /// Returns None if the direction is set at runtime.
+    fn compile_time_direction(&self) -> Option<FlexboxLayoutDirection> {
+        match self.direction.as_ref() {
+            None => Some(FlexboxLayoutDirection::Row),
+            Some(nr) => nr.element().borrow().bindings.get(nr.name()).and_then(|binding| {
+                if let crate::expression_tree::Expression::EnumerationValue(ev) =
+                    &binding.borrow().expression
+                {
+                    match ev.enumeration.values[ev.value].as_str() {
+                        "row" => Some(FlexboxLayoutDirection::Row),
+                        "row-reverse" => Some(FlexboxLayoutDirection::RowReverse),
+                        "column" => Some(FlexboxLayoutDirection::Column),
+                        "column-reverse" => Some(FlexboxLayoutDirection::ColumnReverse),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            }),
+        }
+    }
+
+    /// Determine the relationship between a queried orientation and this flex's direction.
+    pub fn axis_relation(&self, orientation: Orientation) -> FlexboxAxisRelation {
+        match self.compile_time_direction() {
+            None => FlexboxAxisRelation::Unknown,
+            Some(dir) => {
+                let is_main = matches!(
+                    (dir, orientation),
+                    (
+                        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse,
+                        Orientation::Horizontal
+                    ) | (
+                        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse,
+                        Orientation::Vertical
+                    )
+                );
+                if is_main { FlexboxAxisRelation::MainAxis } else { FlexboxAxisRelation::CrossAxis }
+            }
+        }
+    }
+
     pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
         for cell in &mut self.elems {
             cell.item.constraints.visit_named_references(visitor);

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -381,84 +381,63 @@ pub(super) fn compute_flexbox_layout_info(
 ) -> llr_Expression {
     let fld = flexbox_layout_data(layout, ctx);
 
-    // Try to determine direction at compile time from constant binding.
-    let compile_time_direction =
-        match layout.direction.as_ref() {
-            None => Some(crate::layout::FlexboxLayoutDirection::Row),
-            Some(nr) => nr.element().borrow().bindings.get(nr.name()).and_then(|binding| {
-                match &binding.borrow().expression {
-                    crate::expression_tree::Expression::EnumerationValue(ev) => match ev.value {
-                        0 => Some(crate::layout::FlexboxLayoutDirection::Row),
-                        1 => Some(crate::layout::FlexboxLayoutDirection::RowReverse),
-                        2 => Some(crate::layout::FlexboxLayoutDirection::Column),
-                        3 => Some(crate::layout::FlexboxLayoutDirection::ColumnReverse),
-                        _ => None,
-                    },
-                    _ => None,
-                }
-            }),
-        };
+    match layout.axis_relation(orientation) {
+        crate::layout::FlexboxAxisRelation::MainAxis => {
+            compute_flexbox_layout_info_for_direction(layout, orientation, false, fld, ctx)
+        }
+        crate::layout::FlexboxAxisRelation::CrossAxis => {
+            compute_flexbox_layout_info_for_direction(layout, orientation, true, fld, ctx)
+        }
+        crate::layout::FlexboxAxisRelation::Unknown => {
+            // Direction is not known at compile time - generate runtime conditional
+            // This ensures we only read the constraint (width/height) in the branch where it's needed
+            let row_expr = compute_flexbox_layout_info_for_direction(
+                layout,
+                orientation,
+                orientation == Orientation::Vertical, // cross-axis if orientation is vertical
+                fld.clone(),
+                ctx,
+            );
+            let col_expr = compute_flexbox_layout_info_for_direction(
+                layout,
+                orientation,
+                orientation == Orientation::Horizontal, // cross-axis if orientation is horizontal
+                fld,
+                ctx,
+            );
 
-    if let Some(direction) = compile_time_direction {
-        // If direction is known at compile time, we can optimize by only generating
-        let is_cross_axis = matches!(
-            (direction, orientation),
-            (crate::layout::FlexboxLayoutDirection::Row, Orientation::Vertical)
-                | (crate::layout::FlexboxLayoutDirection::RowReverse, Orientation::Vertical)
-                | (crate::layout::FlexboxLayoutDirection::Column, Orientation::Horizontal)
-                | (crate::layout::FlexboxLayoutDirection::ColumnReverse, Orientation::Horizontal)
-        );
-        compute_flexbox_layout_info_for_direction(layout, orientation, is_cross_axis, fld, ctx)
-    } else {
-        // Direction is not known at compile time - generate runtime conditional
-        // This ensures we only read the constraint (width/height) in the branch where it's needed
+            // Condition: direction == Row || direction == RowReverse
+            let direction_enum =
+                crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
+            let direction_ref = llr_Expression::PropertyReference(
+                ctx.map_property_reference(layout.direction.as_ref().unwrap()),
+            );
 
-        let row_expr = compute_flexbox_layout_info_for_direction(
-            layout,
-            orientation,
-            orientation == Orientation::Vertical, // cross-axis if orientation is vertical
-            fld.clone(),
-            ctx,
-        );
-        let col_expr = compute_flexbox_layout_info_for_direction(
-            layout,
-            orientation,
-            orientation == Orientation::Horizontal, // cross-axis if orientation is horizontal
-            fld,
-            ctx,
-        );
+            let is_row_condition = llr_Expression::BinaryExpression {
+                lhs: Box::new(llr_Expression::BinaryExpression {
+                    lhs: Box::new(direction_ref.clone()),
+                    rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
+                        value: 0, // FlexboxLayoutDirection::Row
+                        enumeration: direction_enum.clone(),
+                    })),
+                    op: '=',
+                }),
+                rhs: Box::new(llr_Expression::BinaryExpression {
+                    lhs: Box::new(direction_ref),
+                    rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
+                        value: 1, // FlexboxLayoutDirection::RowReverse
+                        enumeration: direction_enum,
+                    })),
+                    op: '=',
+                }),
+                op: '|',
+            };
 
-        // Condition: direction == Row || direction == RowReverse
-        let direction_enum =
-            crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
-        let direction_ref = llr_Expression::PropertyReference(
-            ctx.map_property_reference(layout.direction.as_ref().unwrap()),
-        );
-
-        let is_row_condition = llr_Expression::BinaryExpression {
-            lhs: Box::new(llr_Expression::BinaryExpression {
-                lhs: Box::new(direction_ref.clone()),
-                rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
-                    value: 0, // FlexboxLayoutDirection::Row
-                    enumeration: direction_enum.clone(),
-                })),
-                op: '=',
-            }),
-            rhs: Box::new(llr_Expression::BinaryExpression {
-                lhs: Box::new(direction_ref),
-                rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
-                    value: 1, // FlexboxLayoutDirection::RowReverse
-                    enumeration: direction_enum,
-                })),
-                op: '=',
-            }),
-            op: '|',
-        };
-
-        llr_Expression::Condition {
-            condition: Box::new(is_row_condition),
-            true_expr: Box::new(row_expr),
-            false_expr: Box::new(col_expr),
+            llr_Expression::Condition {
+                condition: Box::new(is_row_condition),
+                true_expr: Box::new(row_expr),
+                false_expr: Box::new(col_expr),
+            }
         }
     }
 }
@@ -476,23 +455,9 @@ fn compute_flexbox_layout_info_for_direction(
         generate_layout_padding_and_spacing(&layout.geometry, Orientation::Vertical, ctx);
 
     if is_cross_axis {
-        // Cross-axis: need constraint to handle wrapping
-
-        // For cross-axis, pass the perpendicular dimension as constraint
-        let constraint_size = match orientation {
-            Orientation::Horizontal => {
-                layout_geometry_size(&layout.geometry.rect, Orientation::Vertical, ctx)
-            }
-            Orientation::Vertical => {
-                layout_geometry_size(&layout.geometry.rect, Orientation::Horizontal, ctx)
-            }
-        };
-
-        let orientation_expr = llr_Expression::EnumerationValue(EnumerationValue {
-            value: orientation as usize,
-            enumeration: crate::typeregister::BUILTIN.with(|e| e.enums.Orientation.clone()),
-        });
-
+        // Cross-axis layout info: uses both axes' cells and computes the main-axis
+        // preferred size internally as the taffy constraint, avoiding any dependency
+        // on the parent's solved dimensions.
         let arguments = vec![
             fld.cells_h,
             fld.cells_v,
@@ -500,9 +465,7 @@ fn compute_flexbox_layout_info_for_direction(
             spacing_v,
             padding_h,
             padding_v,
-            orientation_expr,
             fld.direction,
-            constraint_size,
             fld.flex_wrap,
         ];
 
@@ -514,53 +477,56 @@ fn compute_flexbox_layout_info_for_direction(
                     repeater_indices_var_name: None,
                     elements,
                     sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
-                        function: "flexbox_layout_info".into(),
+                        function: "flexbox_layout_info_cross_axis".into(),
                         arguments,
                         return_ty: crate::typeregister::layout_info_type().into(),
                     }),
                 }
             }
             None => llr_Expression::ExtraBuiltinFunctionCall {
-                function: "flexbox_layout_info".into(),
+                function: "flexbox_layout_info_cross_axis".into(),
                 arguments,
                 return_ty: crate::typeregister::layout_info_type().into(),
             },
         }
     } else {
-        // Main axis: determine minimum size
-        let arguments = vec![
-            fld.cells_h,
-            fld.cells_v,
-            spacing_h,
-            spacing_v,
-            padding_h,
-            padding_v,
-            llr_Expression::EnumerationValue(EnumerationValue {
-                value: orientation as usize,
-                enumeration: crate::typeregister::BUILTIN.with(|e| e.enums.Orientation.clone()),
-            }),
-            fld.direction,
-            llr_Expression::NumberLiteral(f32::MAX.into()),
-            fld.flex_wrap,
-        ];
+        // Main axis: only needs same-axis cells, avoiding cross-axis binding loop.
+        let (cells, spacing, padding) = match orientation {
+            Orientation::Horizontal => (fld.cells_h, spacing_h, padding_h),
+            Orientation::Vertical => (fld.cells_v, spacing_v, padding_v),
+        };
 
         match fld.compute_cells {
             Some((cells_h_var, cells_v_var, elements)) => {
+                let cells_var = match orientation {
+                    Orientation::Horizontal => cells_h_var.clone(),
+                    Orientation::Vertical => cells_v_var.clone(),
+                };
                 llr_Expression::WithFlexboxLayoutItemInfo {
                     cells_h_variable: cells_h_var,
                     cells_v_variable: cells_v_var,
                     repeater_indices_var_name: None,
                     elements,
                     sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
-                        function: "flexbox_layout_info".into(),
-                        arguments,
+                        function: "flexbox_layout_info_main_axis".into(),
+                        arguments: vec![
+                            llr_Expression::ReadLocalVariable {
+                                name: cells_var.into(),
+                                ty: Type::Array(Rc::new(
+                                    crate::typeregister::flexbox_layout_item_info_type(),
+                                )),
+                            },
+                            spacing,
+                            padding,
+                            fld.flex_wrap,
+                        ],
                         return_ty: crate::typeregister::layout_info_type().into(),
                     }),
                 }
             }
             None => llr_Expression::ExtraBuiltinFunctionCall {
-                function: "flexbox_layout_info".into(),
-                arguments,
+                function: "flexbox_layout_info_main_axis".into(),
+                arguments: vec![cells, spacing, padding, fld.flex_wrap],
                 return_ty: crate::typeregister::layout_info_type().into(),
             },
         }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -455,9 +455,18 @@ fn compute_flexbox_layout_info_for_direction(
         generate_layout_padding_and_spacing(&layout.geometry, Orientation::Vertical, ctx);
 
     if is_cross_axis {
-        // Cross-axis layout info: uses both axes' cells and computes the main-axis
-        // preferred size internally as the taffy constraint, avoiding any dependency
-        // on the parent's solved dimensions.
+        // Cross-axis layout info: pass the main-axis container dimension as constraint
+        // for accurate wrapping. Falls back to heuristic if the constraint is unavailable
+        // (e.g., due to circular dependency in nested perpendicular flexboxes).
+        let constraint_size = match orientation {
+            Orientation::Horizontal => {
+                layout_geometry_size(&layout.geometry.rect, Orientation::Vertical, ctx)
+            }
+            Orientation::Vertical => {
+                layout_geometry_size(&layout.geometry.rect, Orientation::Horizontal, ctx)
+            }
+        };
+
         let arguments = vec![
             fld.cells_h,
             fld.cells_v,
@@ -467,6 +476,7 @@ fn compute_flexbox_layout_info_for_direction(
             padding_v,
             fld.direction,
             fld.flex_wrap,
+            constraint_size,
         ];
 
         match fld.compute_cells {

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -574,10 +574,18 @@ fn recurse_expression(
                         );
                     }
                     FlexboxAxisRelation::CrossAxis => {
-                        // Cross axis: the runtime uses a heuristic for the main-axis
-                        // constraint (no dependency on the perpendicular dimension).
-                        // Visit both orientations' item dependencies (taffy needs both
-                        // for the heuristic wrapping computation).
+                        // Cross axis: depends on the perpendicular (main-axis) dimension
+                        // for accurate wrapping.
+                        if *orientation == Orientation::Vertical
+                            && let Some(nr) = layout.geometry.rect.width_reference.as_ref()
+                        {
+                            vis(&nr.clone().into(), P);
+                        }
+                        if *orientation == Orientation::Horizontal
+                            && let Some(nr) = layout.geometry.rect.height_reference.as_ref()
+                        {
+                            vis(&nr.clone().into(), P);
+                        }
                         visit_layout_items_dependencies(
                             layout.elems.iter().map(|fi| &fi.item),
                             Orientation::Horizontal,

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -562,34 +562,58 @@ fn recurse_expression(
                 if let Some(nr) = layout.geometry.rect.height_reference.as_ref() {
                     vis(&nr.clone().into(), P);
                 }
-            } else if let Expression::ComputeFlexboxLayoutInfo(_, _orientation) = expr {
-                // Technically, due to wrapping, there's a dependency on width for the vertical orientation (for Rows/RowsReverse)
-                // or a dependency on height for the horizontal orientation (for Columns/ColumnsReverse).
-                // But since the flex direction, which can be changed at runtime, we don't know which one will apply.
-                // And doing both leads to binding loops...
-                // We could detect the case of a constant flex direction (like in lower_layout_expression.rs) but
-                // that still wouldn't fix the case of runtime direction changes...
-                /*if *orientation == Orientation::Vertical
-                    && let Some(nr) = layout.geometry.rect.width_reference.as_ref()
-                {
-                    vis(&nr.clone().into(), P);
+            } else if let Expression::ComputeFlexboxLayoutInfo(_, orientation) = expr {
+                use crate::layout::FlexboxAxisRelation;
+                match layout.axis_relation(*orientation) {
+                    FlexboxAxisRelation::MainAxis => {
+                        // Main axis: only visit same-axis item dependencies
+                        visit_layout_items_dependencies(
+                            layout.elems.iter().map(|fi| &fi.item),
+                            *orientation,
+                            vis,
+                        );
+                    }
+                    FlexboxAxisRelation::CrossAxis => {
+                        // Cross axis: the runtime uses a heuristic for the main-axis
+                        // constraint (no dependency on the perpendicular dimension).
+                        // Visit both orientations' item dependencies (taffy needs both
+                        // for the heuristic wrapping computation).
+                        visit_layout_items_dependencies(
+                            layout.elems.iter().map(|fi| &fi.item),
+                            Orientation::Horizontal,
+                            vis,
+                        );
+                        visit_layout_items_dependencies(
+                            layout.elems.iter().map(|fi| &fi.item),
+                            Orientation::Vertical,
+                            vis,
+                        );
+                    }
+                    FlexboxAxisRelation::Unknown => {
+                        // Unknown direction: conservatively visit both orientations
+                        // and perpendicular dimensions
+                        if *orientation == Orientation::Vertical
+                            && let Some(nr) = layout.geometry.rect.width_reference.as_ref()
+                        {
+                            vis(&nr.clone().into(), P);
+                        }
+                        if *orientation == Orientation::Horizontal
+                            && let Some(nr) = layout.geometry.rect.height_reference.as_ref()
+                        {
+                            vis(&nr.clone().into(), P);
+                        }
+                        visit_layout_items_dependencies(
+                            layout.elems.iter().map(|fi| &fi.item),
+                            Orientation::Horizontal,
+                            vis,
+                        );
+                        visit_layout_items_dependencies(
+                            layout.elems.iter().map(|fi| &fi.item),
+                            Orientation::Vertical,
+                            vis,
+                        );
+                    }
                 }
-                if *orientation == Orientation::Horizontal
-                    && let Some(nr) = layout.geometry.rect.height_reference.as_ref()
-                {
-                    vis(&nr.clone().into(), P);
-                }*/
-                // Visit item dependencies for relevant orientations
-                visit_layout_items_dependencies(
-                    layout.elems.iter().map(|fi| &fi.item),
-                    Orientation::Horizontal,
-                    vis,
-                );
-                visit_layout_items_dependencies(
-                    layout.elems.iter().map(|fi| &fi.item),
-                    Orientation::Vertical,
-                    vis,
-                );
             }
             let mut g = layout.geometry.clone();
             g.rect = Default::default(); // already visited;

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1781,12 +1781,12 @@ pub fn flexbox_layout_info_main_axis(
 
 /// Return cross-axis LayoutInfo for a FlexboxLayout.
 ///
-/// This computes the intrinsic cross-axis size without depending on the
-/// parent's solved dimensions, avoiding circular dependencies when layouts
-/// query a FlexboxLayout child's preferred size. Instead of reading the
-/// parent's assigned width/height, it computes the main-axis preferred size
-/// internally (via the same heuristic as `flexbox_layout_info_main_axis`)
-/// and uses that as the constraint for taffy's wrapping calculation.
+/// `constraint_size` is the main-axis container dimension (width for row,
+/// height for column). When valid (> 0 and < MAX), it's used as the taffy
+/// constraint for accurate wrapping. When invalid (e.g. 0, negative, or
+/// MAX — which can happen due to circular dependencies in nested
+/// perpendicular flexboxes), falls back to a heuristic based on
+/// `flexbox_layout_info_main_axis`.
 pub fn flexbox_layout_info_cross_axis(
     cells_h: Slice<FlexboxLayoutItemInfo>,
     cells_v: Slice<FlexboxLayoutItemInfo>,
@@ -1796,6 +1796,7 @@ pub fn flexbox_layout_info_cross_axis(
     padding_v: &Padding,
     direction: FlexboxLayoutDirection,
     flex_wrap: FlexboxLayoutWrap,
+    constraint_size: Coord,
 ) -> LayoutInfo {
     if cells_h.is_empty() {
         assert!(cells_v.is_empty());
@@ -1838,7 +1839,10 @@ pub fn flexbox_layout_info_cross_axis(
         }
     };
     let main_extra_pad = main_padding.begin + main_padding.end;
-    let main_axis_constraint = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
+    let main_axis_constraint = if constraint_size > 0 as Coord && constraint_size < Coord::MAX {
+        // Use the actual container main-axis dimension (accurate)
+        constraint_size
+    } else if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
         Coord::MAX
     } else {
         // Use actual item areas (main * cross) for the heuristic, since both
@@ -2043,9 +2047,18 @@ pub(crate) mod ffi {
         padding_v: &Padding,
         direction: FlexboxLayoutDirection,
         flex_wrap: FlexboxLayoutWrap,
+        constraint_size: Coord,
     ) -> LayoutInfo {
         super::flexbox_layout_info_cross_axis(
-            cells_h, cells_v, spacing_h, spacing_v, padding_h, padding_v, direction, flex_wrap,
+            cells_h,
+            cells_v,
+            spacing_h,
+            spacing_v,
+            padding_h,
+            padding_v,
+            direction,
+            flex_wrap,
+            constraint_size,
         )
     }
 }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1725,27 +1725,88 @@ pub fn solve_flexbox_layout(
     result
 }
 
-/// Return LayoutInfo (i.e. min, preferred, max etc.) for a FlexboxLayout
-/// This handles both main-axis (simple) and cross-axis (wrapping-aware) cases.
-/// The constraint_size is the perpendicular dimension to orientation:
-/// - For Horizontal orientation: constraint_size is height
-/// - For Vertical orientation: constraint_size is width
+/// Return main-axis LayoutInfo for a FlexboxLayout.
+/// Only needs the same-axis cells, avoiding a cross-axis binding loop.
+pub fn flexbox_layout_info_main_axis(
+    cells: Slice<FlexboxLayoutItemInfo>,
+    spacing: Coord,
+    padding: &Padding,
+    flex_wrap: FlexboxLayoutWrap,
+) -> LayoutInfo {
+    let extra_pad = padding.begin + padding.end;
+    if cells.is_empty() {
+        return LayoutInfo {
+            min: extra_pad,
+            preferred: extra_pad,
+            max: extra_pad,
+            ..Default::default()
+        };
+    }
+    let num_spacings = cells.len().saturating_sub(1) as Coord;
+    let min = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
+        cells.iter().map(|c| c.constraint.min).sum::<Coord>() + spacing * num_spacings + extra_pad
+    } else {
+        // Wrapping: the widest single item must fit
+        cells.iter().map(|c| c.constraint.min).fold(0.0 as Coord, |a, b| a.max(b)) + extra_pad
+    };
+    let preferred = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
+        // No wrapping: all items on one line
+        cells.iter().map(|c| c.constraint.preferred_bounded()).sum::<Coord>()
+            + spacing * num_spacings
+            + extra_pad
+    } else {
+        // Wrapping: estimate a roughly square layout using only main-axis sizes.
+        // Approximate total area assuming each item is square (width == height),
+        // then take sqrt to get a reasonable main-axis extent.
+        let total_area: Coord = cells
+            .iter()
+            .map(|c| {
+                let w = c.constraint.preferred_bounded();
+                w * w
+            })
+            .sum();
+        let count = cells.len();
+        Float::sqrt(total_area as f32) as Coord + spacing * (count - 1) as Coord + extra_pad
+    };
+    let stretch = cells.iter().map(|c| c.constraint.stretch).sum::<f32>();
+    LayoutInfo {
+        min,
+        max: Coord::MAX,
+        min_percent: 0 as _,
+        max_percent: 100 as _,
+        preferred,
+        stretch,
+    }
+}
+
+/// Return cross-axis LayoutInfo for a FlexboxLayout.
 ///
-/// The constraint_size is ignored for main-axis calculation.
-pub fn flexbox_layout_info(
+/// This computes the intrinsic cross-axis size without depending on the
+/// parent's solved dimensions, avoiding circular dependencies when layouts
+/// query a FlexboxLayout child's preferred size. Instead of reading the
+/// parent's assigned width/height, it computes the main-axis preferred size
+/// internally (via the same heuristic as `flexbox_layout_info_main_axis`)
+/// and uses that as the constraint for taffy's wrapping calculation.
+pub fn flexbox_layout_info_cross_axis(
     cells_h: Slice<FlexboxLayoutItemInfo>,
     cells_v: Slice<FlexboxLayoutItemInfo>,
     spacing_h: Coord,
     spacing_v: Coord,
     padding_h: &Padding,
     padding_v: &Padding,
-    orientation: Orientation,
     direction: FlexboxLayoutDirection,
-    constraint_size: Coord,
     flex_wrap: FlexboxLayoutWrap,
 ) -> LayoutInfo {
     if cells_h.is_empty() {
         assert!(cells_v.is_empty());
+        let orientation = match direction {
+            FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => {
+                Orientation::Vertical
+            }
+            FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+                Orientation::Horizontal
+            }
+        };
         let padding = match orientation {
             Orientation::Horizontal => padding_h,
             Orientation::Vertical => padding_v,
@@ -1754,52 +1815,43 @@ pub fn flexbox_layout_info(
         return LayoutInfo { min: pad, preferred: pad, max: pad, ..Default::default() };
     }
 
-    let (cells, padding, spacing) = match orientation {
-        Orientation::Horizontal => (&cells_h, padding_h, spacing_h),
-        Orientation::Vertical => (&cells_v, padding_v, spacing_v),
-    };
-    let extra_pad = padding.begin + padding.end;
-
-    // Determine if we're asking for main-axis or cross-axis
-    let is_main_axis = matches!(
-        (direction, orientation),
-        (FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse, Orientation::Horizontal)
-            | (
-                FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse,
-                Orientation::Vertical
-            )
-    );
-
-    let min = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) && is_main_axis {
-        // No wrapping: items must all fit in one line, min = sum of minimums + spacing
-        cells.iter().map(|c| c.constraint.min).sum::<Coord>()
-            + spacing * (cells.len().saturating_sub(1)) as Coord
-            + extra_pad
-    } else {
-        // Wrapping (or cross-axis): the widest/tallest single item must fit
-        cells.iter().map(|c| c.constraint.min).fold(0.0 as Coord, |a, b| a.max(b)) + extra_pad
-    };
-
-    // The main-axis constraint determines how items wrap.
-    let main_axis_constraint = if is_main_axis {
-        // Note that constraint_size is not used for the main axis
-        if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
-            // No wrapping: items won't wrap regardless of size, use max content
-            Coord::MAX
-        } else {
-            // Use sqrt of total item area as an approximation.
-            let total_area = cells_h
-                .iter()
-                .map(|c| c.constraint.preferred_bounded())
-                .zip(cells_v.iter().map(|c| c.constraint.preferred_bounded()))
-                .map(|(h, v)| h * v)
-                .sum::<Coord>();
-            let count = cells.len();
-            Float::sqrt(total_area as f32) as Coord + spacing * (count - 1) as Coord + extra_pad
+    // Determine which axis is cross
+    let (cross_cells, cross_padding) = match direction {
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => (&cells_v, padding_v),
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+            (&cells_h, padding_h)
         }
+    };
+    let cross_extra_pad = cross_padding.begin + cross_padding.end;
+
+    let min = cross_cells.iter().map(|c| c.constraint.min).fold(0.0 as Coord, |a, b| a.max(b))
+        + cross_extra_pad;
+
+    // Compute the main-axis preferred size to use as the constraint for taffy,
+    // using the same heuristic as flexbox_layout_info_main_axis.
+    let (main_cells, main_spacing, main_padding) = match direction {
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => {
+            (&cells_h, spacing_h, padding_h)
+        }
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+            (&cells_v, spacing_v, padding_v)
+        }
+    };
+    let main_extra_pad = main_padding.begin + main_padding.end;
+    let main_axis_constraint = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
+        Coord::MAX
     } else {
-        // For cross-axis queries, use the provided constraint_size.
-        constraint_size
+        // Use actual item areas (main * cross) for the heuristic, since both
+        // axes' cells are available here (unlike flexbox_layout_info_main_axis).
+        let total_area: Coord = main_cells
+            .iter()
+            .zip(cross_cells.iter())
+            .map(|(m, c)| m.constraint.preferred_bounded() * c.constraint.preferred_bounded())
+            .sum();
+        let count = main_cells.len();
+        Float::sqrt(total_area as f32) as Coord
+            + main_spacing * (count - 1) as Coord
+            + main_extra_pad
     };
 
     let taffy_direction = match direction {
@@ -1845,42 +1897,25 @@ pub fn flexbox_layout_info(
 
     builder.compute_layout(available_width, available_height);
 
-    let preferred = if is_main_axis {
-        // For main-axis, container_size() returns max(content, available_space) for
-        // multi-line layouts, giving back our approximation unchanged. Scan child
-        // positions to find the actual extent of the widest row.
-        let mut min_pos = Coord::MAX;
-        let mut max_end = 0.0 as Coord;
-        for i in 0..cells_h.len() {
-            let (x, y, w, h) = builder.child_geometry(i);
-            let (pos, size) = match orientation {
-                Orientation::Horizontal => (x, w),
-                Orientation::Vertical => (y, h),
-            };
-            min_pos = min_pos.min(pos);
-            max_end = max_end.max(pos + size);
-        }
-        (max_end - min_pos) + padding.begin + padding.end
-    } else {
-        // For cross-axis, the queried dimension is Auto so container_size() returns
-        // the content-based size directly.
-        let (total_width, total_height) = builder.container_size();
-        match orientation {
-            Orientation::Horizontal => total_width,
-            Orientation::Vertical => total_height,
+    let (total_width, total_height) = builder.container_size();
+    let cross_orientation = match direction {
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => Orientation::Vertical,
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+            Orientation::Horizontal
         }
     };
-
-    let stretch =
-        if is_main_axis { cells.iter().map(|c| c.constraint.stretch).sum::<f32>() } else { 0.0 };
+    let preferred = match cross_orientation {
+        Orientation::Horizontal => total_width,
+        Orientation::Vertical => total_height,
+    };
 
     LayoutInfo {
         min,
-        max: Coord::MAX, // TODO?
+        max: Coord::MAX,
         min_percent: 0 as _,
         max_percent: 100 as _,
         preferred,
-        stretch,
+        stretch: 0.0,
     }
 }
 
@@ -1987,30 +2022,30 @@ pub(crate) mod ffi {
     }
 
     #[unsafe(no_mangle)]
-    /// Return LayoutInfo for a FlexboxLayout with runtime direction support.
-    pub extern "C" fn slint_flexbox_layout_info(
+    /// Return main-axis LayoutInfo for a FlexboxLayout (single-axis, no cross-axis dependency).
+    pub extern "C" fn slint_flexbox_layout_info_main_axis(
+        cells: Slice<FlexboxLayoutItemInfo>,
+        spacing: Coord,
+        padding: &Padding,
+        flex_wrap: FlexboxLayoutWrap,
+    ) -> LayoutInfo {
+        super::flexbox_layout_info_main_axis(cells, spacing, padding, flex_wrap)
+    }
+
+    #[unsafe(no_mangle)]
+    /// Return cross-axis LayoutInfo for a FlexboxLayout.
+    pub extern "C" fn slint_flexbox_layout_info_cross_axis(
         cells_h: Slice<FlexboxLayoutItemInfo>,
         cells_v: Slice<FlexboxLayoutItemInfo>,
         spacing_h: Coord,
         spacing_v: Coord,
         padding_h: &Padding,
         padding_v: &Padding,
-        orientation: Orientation,
         direction: FlexboxLayoutDirection,
-        constraint_size: Coord,
         flex_wrap: FlexboxLayoutWrap,
     ) -> LayoutInfo {
-        super::flexbox_layout_info(
-            cells_h,
-            cells_v,
-            spacing_h,
-            spacing_v,
-            padding_h,
-            padding_v,
-            orientation,
-            direction,
-            constraint_size,
-            flex_wrap,
+        super::flexbox_layout_info_cross_axis(
+            cells_h, cells_v, spacing_h, spacing_v, padding_h, padding_v, direction, flex_wrap,
         )
     }
 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -322,6 +322,19 @@ pub(crate) fn compute_flexbox_layout_info(
         )
         .into()
     } else {
+        // Read the perpendicular (main-axis) dimension as constraint for cross-axis info.
+        // For row flex, cross-axis is vertical, perpendicular is width.
+        // For column flex, cross-axis is horizontal, perpendicular is height.
+        let constraint_size = match orientation {
+            Orientation::Horizontal => {
+                let height_ref = &flexbox_layout.geometry.rect.height_reference;
+                height_ref.as_ref().map(&expr_eval).unwrap_or(0.)
+            }
+            Orientation::Vertical => {
+                let width_ref = &flexbox_layout.geometry.rect.width_reference;
+                width_ref.as_ref().map(&expr_eval).unwrap_or(0.)
+            }
+        };
         core_layout::flexbox_layout_info_cross_axis(
             Slice::from(cells_h.as_slice()),
             Slice::from(cells_v.as_slice()),
@@ -331,6 +344,7 @@ pub(crate) fn compute_flexbox_layout_info(
             &padding_v,
             direction,
             flex_wrap,
+            constraint_size,
         )
         .into()
     }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -11,7 +11,6 @@ use i_slint_compiler::layout::{
 };
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
-use i_slint_core::Coord;
 use i_slint_core::items::{DialogButtonRole, FlexboxLayoutDirection, ItemRc};
 use i_slint_core::layout::{self as core_layout, GridLayoutInputData, GridLayoutOrganizedData};
 use i_slint_core::model::RepeatedItemTree;
@@ -311,47 +310,26 @@ pub(crate) fn compute_flexbox_layout_info(
         });
 
     if is_main_axis {
-        // Main axis: use simple layout info (no constraint needed)
-        // This avoids reading the perpendicular dimension and prevents circular dependencies
-        core_layout::flexbox_layout_info(
-            Slice::from(cells_h.as_slice()),
-            Slice::from(cells_v.as_slice()),
-            spacing_h,
-            spacing_v,
-            &padding_h,
-            &padding_v,
-            to_runtime(orientation),
-            direction,
-            Coord::MAX,
+        let (cells, spacing, padding) = match orientation {
+            Orientation::Horizontal => (&cells_h, spacing_h, &padding_h),
+            Orientation::Vertical => (&cells_v, spacing_v, &padding_v),
+        };
+        core_layout::flexbox_layout_info_main_axis(
+            Slice::from(cells.as_slice()),
+            spacing,
+            padding,
             flex_wrap,
         )
         .into()
     } else {
-        // Cross axis: need constraint to handle wrapping
-        // Only read the constraint dimension here (the main-axis dimension of the flexbox)
-        let constraint_size = match orientation {
-            Orientation::Horizontal => {
-                // Cross-axis for Column: need height
-                let height_ref = &flexbox_layout.geometry.rect.height_reference;
-                height_ref.as_ref().map(&expr_eval).unwrap_or(0.)
-            }
-            Orientation::Vertical => {
-                // Cross-axis for Row: need width
-                let width_ref = &flexbox_layout.geometry.rect.width_reference;
-                width_ref.as_ref().map(&expr_eval).unwrap_or(0.)
-            }
-        };
-
-        core_layout::flexbox_layout_info(
+        core_layout::flexbox_layout_info_cross_axis(
             Slice::from(cells_h.as_slice()),
             Slice::from(cells_v.as_slice()),
             spacing_h,
             spacing_v,
             &padding_h,
             &padding_v,
-            to_runtime(orientation),
             direction,
-            constraint_size,
             flex_wrap,
         )
         .into()

--- a/tests/cases/layout/flexbox_in_vertical_layout.slint
+++ b/tests/cases/layout/flexbox_in_vertical_layout.slint
@@ -58,15 +58,10 @@ export component TestCase inherits Window {
     }
 
     // --- Wide state: all items fit on one row ---
-    // Note: the flex items are correctly positioned on one row, but the
-    // VerticalLayout may allocate more height than needed because the
-    // flex's preferred-height uses a heuristic (no actual width available
-    // at layout_info time). We check that text.y >= 50px (below the flex
-    // items) but don't require the exact value.
     out property <bool> wide_r1_ok: r1.x == 0px && r1.y == 0px;
     out property <bool> wide_r2_ok: r2.x == 110px && r2.y == 0px;
     out property <bool> wide_r3_ok: r3.x == 220px && r3.y == 0px;
-    out property <bool> wide_text_ok: text.y >= 50px;
+    out property <bool> wide_text_ok: text.x == 0px && text.y == 50px;
     out property <bool> wide_ok: wide_r1_ok && wide_r2_ok && wide_r3_ok && wide_text_ok;
 
     // --- Narrow state: each item gets its own row ---

--- a/tests/cases/layout/flexbox_in_vertical_layout.slint
+++ b/tests/cases/layout/flexbox_in_vertical_layout.slint
@@ -58,10 +58,15 @@ export component TestCase inherits Window {
     }
 
     // --- Wide state: all items fit on one row ---
+    // Note: the flex items are correctly positioned on one row, but the
+    // VerticalLayout may allocate more height than needed because the
+    // flex's preferred-height uses a heuristic (no actual width available
+    // at layout_info time). We check that text.y >= 50px (below the flex
+    // items) but don't require the exact value.
     out property <bool> wide_r1_ok: r1.x == 0px && r1.y == 0px;
     out property <bool> wide_r2_ok: r2.x == 110px && r2.y == 0px;
     out property <bool> wide_r3_ok: r3.x == 220px && r3.y == 0px;
-    out property <bool> wide_text_ok: text.x == 0px && text.y == 50px;
+    out property <bool> wide_text_ok: text.y >= 50px;
     out property <bool> wide_ok: wide_r1_ok && wide_r2_ok && wide_r3_ok && wide_text_ok;
 
     // --- Narrow state: each item gets its own row ---

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -38,8 +38,10 @@ export component TestCase inherits Window {
     out property <int> min_w: flex.min-width / 1px;
     out property <int> preferred_w: flex.preferred-width / 1px;
     out property <int> max_w: flex.max-width / 1px;
-    out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width > 128px && flex.preferred-width < 130px;
-    out property <bool> flex_minmax_height_ok: flex.min-height == 44px && flex.preferred-height > 128px && flex.preferred-height < 130px;
+    // Main-axis preferred-width uses sqrt(sum of w²) heuristic ≈ 199px.
+    // Cross-axis preferred-height uses taffy with sqrt(sum of w*h) heuristic ≈ 149px.
+    out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width > 190px && flex.preferred-width < 210px;
+    out property <bool> flex_minmax_height_ok: flex.min-height == 44px && flex.preferred-height > 140px && flex.preferred-height < 160px;
 
     out property <bool> test: test_r1 && test_r2 && test_r3 && test_r4 && test_r5 && test_r6 && flex_minmax_width_ok && flex_minmax_height_ok;
 }

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -39,9 +39,9 @@ export component TestCase inherits Window {
     out property <int> preferred_w: flex.preferred-width / 1px;
     out property <int> max_w: flex.max-width / 1px;
     // Main-axis preferred-width uses sqrt(sum of w²) heuristic ≈ 199px.
-    // Cross-axis preferred-height uses taffy with sqrt(sum of w*h) heuristic ≈ 149px.
+    // Cross-axis preferred-height uses taffy with the actual container width (200px) ≈ 129px.
     out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width > 190px && flex.preferred-width < 210px;
-    out property <bool> flex_minmax_height_ok: flex.min-height == 44px && flex.preferred-height > 140px && flex.preferred-height < 160px;
+    out property <bool> flex_minmax_height_ok: flex.min-height == 44px && flex.preferred-height > 128px && flex.preferred-height < 130px;
 
     out property <bool> test: test_r1 && test_r2 && test_r3 && test_r4 && test_r5 && test_r6 && flex_minmax_width_ok && flex_minmax_height_ok;
 }


### PR DESCRIPTION
... and pass perpendicular dimension to cross-axis layout_info.

This is just step 1/3 of fixing binding loops and recursion issues when having height-for-width items in a FlexboxLayout.
See commit logs for details.
#11311 #11168