### PR TITLE
FlexboxLayout: set up taffy's measure feature

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -202,7 +202,7 @@ inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexboxL
     SharedVector<float> result;
     cbindgen_private::Slice<uint32_t> ri =
             make_slice(reinterpret_cast<uint32_t *>(repeater_indices.ptr), repeater_indices.len);
-    cbindgen_private::slint_solve_flexbox_layout(&data, ri, &result);
+    cbindgen_private::slint_solve_flexbox_layout(&data, ri, &result, nullptr, nullptr);
     return result;
 }
 

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1347,9 +1347,10 @@ mod flexbox_taffy {
         pub container_height: Option<Coord>,
     }
 
-    /// Build a taffy tree from Slint layout constraints
+    /// Build a taffy tree from Slint layout constraints.
+    /// The NodeContext (usize) stores the original child index for measure callbacks.
     pub struct FlexboxTaffyBuilder {
-        pub taffy: TaffyTree<()>,
+        pub taffy: TaffyTree<usize>,
         pub children: Vec<NodeId>,
         pub container: NodeId,
         /// Maps taffy child position -> original cell index (empty if no reordering needed)
@@ -1359,7 +1360,7 @@ mod flexbox_taffy {
     impl FlexboxTaffyBuilder {
         /// Create a new flexbox layout tree from item constraints
         pub fn new(params: FlexboxLayoutParams) -> Self {
-            let mut taffy = TaffyTree::<()>::new();
+            let mut taffy = TaffyTree::<usize>::new();
 
             // Create child nodes from Slint constraints
             let mut children: Vec<NodeId> = params
@@ -1391,64 +1392,68 @@ mod flexbox_taffy {
                     };
 
                     taffy
-                        .new_leaf(Style {
-                            flex_basis,
-                            size: Size {
-                                width: match params.flex_direction {
-                                    TaffyFlexDirection::Column
-                                    | TaffyFlexDirection::ColumnReverse => {
-                                        if preferred_width > 0 as Coord {
-                                            Dimension::length(preferred_width as _)
-                                        } else {
-                                            Dimension::auto()
+                        .new_leaf_with_context(
+                            Style {
+                                flex_basis,
+                                size: Size {
+                                    width: match params.flex_direction {
+                                        TaffyFlexDirection::Column
+                                        | TaffyFlexDirection::ColumnReverse => {
+                                            if preferred_width > 0 as Coord {
+                                                Dimension::length(preferred_width as _)
+                                            } else {
+                                                Dimension::auto()
+                                            }
                                         }
-                                    }
-                                    _ => Dimension::auto(),
-                                },
-                                height: match params.flex_direction {
-                                    TaffyFlexDirection::Row | TaffyFlexDirection::RowReverse => {
-                                        if preferred_height > 0 as Coord {
-                                            Dimension::length(preferred_height as _)
-                                        } else {
-                                            Dimension::auto()
+                                        _ => Dimension::auto(),
+                                    },
+                                    height: match params.flex_direction {
+                                        TaffyFlexDirection::Row
+                                        | TaffyFlexDirection::RowReverse => {
+                                            if preferred_height > 0 as Coord {
+                                                Dimension::length(preferred_height as _)
+                                            } else {
+                                                Dimension::auto()
+                                            }
                                         }
-                                    }
-                                    _ => Dimension::auto(),
+                                        _ => Dimension::auto(),
+                                    },
                                 },
-                            },
-                            min_size: Size {
-                                width: Dimension::length(h_constraint.min as _),
-                                height: Dimension::length(
-                                    v_constraint.map(|vc| vc.min as f32).unwrap_or(0.0),
-                                ),
-                            },
-                            max_size: Size {
-                                width: if h_constraint.max < Coord::MAX {
-                                    Dimension::length(h_constraint.max as _)
-                                } else {
-                                    Dimension::auto()
+                                min_size: Size {
+                                    width: Dimension::length(h_constraint.min as _),
+                                    height: Dimension::length(
+                                        v_constraint.map(|vc| vc.min as f32).unwrap_or(0.0),
+                                    ),
                                 },
-                                height: if let Some(vc) = v_constraint {
-                                    if vc.max < Coord::MAX {
-                                        Dimension::length(vc.max as _)
+                                max_size: Size {
+                                    width: if h_constraint.max < Coord::MAX {
+                                        Dimension::length(h_constraint.max as _)
                                     } else {
                                         Dimension::auto()
-                                    }
-                                } else {
-                                    Dimension::auto()
+                                    },
+                                    height: if let Some(vc) = v_constraint {
+                                        if vc.max < Coord::MAX {
+                                            Dimension::length(vc.max as _)
+                                        } else {
+                                            Dimension::auto()
+                                        }
+                                    } else {
+                                        Dimension::auto()
+                                    },
                                 },
+                                flex_grow: cell_h.flex_grow,
+                                flex_shrink: cell_h.flex_shrink,
+                                align_self: match cell_h.flex_align_self {
+                                    FlexboxLayoutAlignSelf::Auto => None,
+                                    FlexboxLayoutAlignSelf::Stretch => Some(AlignSelf::Stretch),
+                                    FlexboxLayoutAlignSelf::Start => Some(AlignSelf::FlexStart),
+                                    FlexboxLayoutAlignSelf::End => Some(AlignSelf::FlexEnd),
+                                    FlexboxLayoutAlignSelf::Center => Some(AlignSelf::Center),
+                                },
+                                ..Default::default()
                             },
-                            flex_grow: cell_h.flex_grow,
-                            flex_shrink: cell_h.flex_shrink,
-                            align_self: match cell_h.flex_align_self {
-                                FlexboxLayoutAlignSelf::Auto => None,
-                                FlexboxLayoutAlignSelf::Stretch => Some(AlignSelf::Stretch),
-                                FlexboxLayoutAlignSelf::Start => Some(AlignSelf::FlexStart),
-                                FlexboxLayoutAlignSelf::End => Some(AlignSelf::FlexEnd),
-                                FlexboxLayoutAlignSelf::Center => Some(AlignSelf::Center),
-                            },
-                            ..Default::default()
-                        })
+                            idx,
+                        )
                         .unwrap() // cannot fail
                 })
                 .collect();
@@ -1533,27 +1538,64 @@ mod flexbox_taffy {
             Self { taffy, children, container, order_map }
         }
 
-        /// Compute the layout with the given available space
-        pub fn compute_layout(&mut self, available_width: Coord, available_height: Coord) {
-            self.taffy
-                .compute_layout(
-                    self.container,
-                    taffy::prelude::Size {
-                        width: if available_width < Coord::MAX {
-                            AvailableSpace::Definite(available_width as _)
-                        } else {
-                            AvailableSpace::MaxContent
+        /// Compute the layout with the given available space.
+        ///
+        /// The optional `measure` callback is called by taffy for leaf nodes
+        /// that need dynamic height-for-width (or width-for-height) measurement.
+        /// It receives `(child_index, known_width, known_height)` where `known_width`
+        /// / `known_height` are `Some` if taffy has already determined that dimension,
+        /// and returns `(width, height)`.
+        pub fn compute_layout(
+            &mut self,
+            available_width: Coord,
+            available_height: Coord,
+            measure: Option<&mut dyn FnMut(usize, Option<Coord>, Option<Coord>) -> (Coord, Coord)>,
+        ) {
+            let available_space = taffy::prelude::Size {
+                width: if available_width < Coord::MAX {
+                    AvailableSpace::Definite(available_width as _)
+                } else {
+                    AvailableSpace::MaxContent
+                },
+                height: if available_height < Coord::MAX {
+                    AvailableSpace::Definite(available_height as _)
+                } else {
+                    AvailableSpace::MaxContent
+                },
+            };
+
+            if let Some(measure) = measure {
+                self.taffy
+                    .compute_layout_with_measure(
+                        self.container,
+                        available_space,
+                        |known_dimensions, _available_space, _node_id, node_context, _style| {
+                            if let Some(&mut child_index) = node_context {
+                                let known_w = known_dimensions.width.map(|w| w as Coord);
+                                let known_h = known_dimensions.height.map(|h| h as Coord);
+                                let (w, h) = measure(child_index, known_w, known_h);
+                                taffy::prelude::Size { width: w as f32, height: h as f32 }
+                            } else {
+                                taffy::prelude::Size::ZERO
+                            }
                         },
-                        height: if available_height < Coord::MAX {
-                            AvailableSpace::Definite(available_height as _)
-                        } else {
-                            AvailableSpace::MaxContent
+                    )
+                    .unwrap_or_else(|e| {
+                        crate::debug_log!("FlexboxLayout computation error: {}", e);
+                    });
+            } else {
+                self.taffy
+                    .compute_layout_with_measure(
+                        self.container,
+                        available_space,
+                        |_known_dimensions, _available_space, _node_id, _node_context, _style| {
+                            taffy::prelude::Size::ZERO
                         },
-                    },
-                )
-                .unwrap_or_else(|e| {
-                    crate::debug_log!("FlexboxLayout computation error: {}", e);
-                });
+                    )
+                    .unwrap_or_else(|e| {
+                        crate::debug_log!("FlexboxLayout computation error: {}", e);
+                    });
+            }
         }
 
         /// Get the computed container size
@@ -1698,7 +1740,7 @@ pub fn solve_flexbox_layout(
         }
     };
 
-    builder.compute_layout(available_width, available_height);
+    builder.compute_layout(available_width, available_height, None);
 
     // Extract results using the cache generator to handle repeaters.
     // If `order` sorting was applied, we need to collect results by original index first,
@@ -1843,7 +1885,7 @@ pub fn flexbox_layout_info(
         }
     };
 
-    builder.compute_layout(available_width, available_height);
+    builder.compute_layout(available_width, available_height, None);
 
     let preferred = if is_main_axis {
         // For main-axis, container_size() returns max(content, available_space) for

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1549,7 +1549,9 @@ mod flexbox_taffy {
             &mut self,
             available_width: Coord,
             available_height: Coord,
-            measure: Option<&mut dyn FnMut(usize, Option<Coord>, Option<Coord>) -> (Coord, Coord)>,
+            mut measure: Option<
+                &mut dyn FnMut(usize, Option<Coord>, Option<Coord>) -> (Coord, Coord),
+            >,
         ) {
             let available_space = taffy::prelude::Size {
                 width: if available_width < Coord::MAX {
@@ -1563,39 +1565,26 @@ mod flexbox_taffy {
                     AvailableSpace::MaxContent
                 },
             };
-
-            if let Some(measure) = measure {
-                self.taffy
-                    .compute_layout_with_measure(
-                        self.container,
-                        available_space,
-                        |known_dimensions, _available_space, _node_id, node_context, _style| {
-                            if let Some(&mut child_index) = node_context {
-                                let known_w = known_dimensions.width.map(|w| w as Coord);
-                                let known_h = known_dimensions.height.map(|h| h as Coord);
-                                let (w, h) = measure(child_index, known_w, known_h);
-                                taffy::prelude::Size { width: w as f32, height: h as f32 }
-                            } else {
-                                taffy::prelude::Size::ZERO
-                            }
-                        },
-                    )
-                    .unwrap_or_else(|e| {
-                        crate::debug_log!("FlexboxLayout computation error: {}", e);
-                    });
-            } else {
-                self.taffy
-                    .compute_layout_with_measure(
-                        self.container,
-                        available_space,
-                        |_known_dimensions, _available_space, _node_id, _node_context, _style| {
+            self.taffy
+                .compute_layout_with_measure(
+                    self.container,
+                    available_space,
+                    |known_dimensions, _available_space, _node_id, node_context, _style| {
+                        if let (Some(measure), Some(&mut child_index)) =
+                            (measure.as_deref_mut(), node_context)
+                        {
+                            let known_w = known_dimensions.width.map(|w| w as Coord);
+                            let known_h = known_dimensions.height.map(|h| h as Coord);
+                            let (w, h) = measure(child_index, known_w, known_h);
+                            taffy::prelude::Size { width: w as f32, height: h as f32 }
+                        } else {
                             taffy::prelude::Size::ZERO
-                        },
-                    )
-                    .unwrap_or_else(|e| {
-                        crate::debug_log!("FlexboxLayout computation error: {}", e);
-                    });
-            }
+                        }
+                    },
+                )
+                .unwrap_or_else(|e| {
+                    crate::debug_log!("FlexboxLayout computation error: {}", e);
+                });
         }
 
         /// Get the computed container size
@@ -1689,11 +1678,28 @@ impl<'a> FlexboxLayoutCacheGenerator<'a> {
     }
 }
 
-/// Solve a FlexboxLayout using Taffy
-/// Returns: [x1, y1, w1, h1, x2, y2, w2, h2, ...] for each item
+/// Measure callback for height-for-width items in a FlexboxLayout.
+///
+/// Called by taffy during the flex solve for items that need dynamic sizing.
+/// Receives `(child_index, known_width, known_height)` where `known_width`/`known_height`
+/// are `Some` if taffy has already determined that dimension.
+/// Returns `(width, height)`.
+pub type FlexboxMeasureFn<'a> =
+    Option<&'a mut dyn FnMut(usize, Option<Coord>, Option<Coord>) -> (Coord, Coord)>;
+
 pub fn solve_flexbox_layout(
     data: &FlexboxLayoutData,
     repeater_indices: Slice<u32>,
+) -> SharedVector<Coord> {
+    solve_flexbox_layout_with_measure(data, repeater_indices, None)
+}
+
+/// Solve a FlexboxLayout using Taffy
+/// Returns: [x1, y1, w1, h1, x2, y2, w2, h2, ...] for each item
+pub fn solve_flexbox_layout_with_measure(
+    data: &FlexboxLayoutData,
+    repeater_indices: Slice<u32>,
+    measure: FlexboxMeasureFn<'_>,
 ) -> SharedVector<Coord> {
     // 4 values per item: x, y, width, height
     let mut result = SharedVector::<Coord>::default();
@@ -1740,7 +1746,7 @@ pub fn solve_flexbox_layout(
         }
     };
 
-    builder.compute_layout(available_width, available_height, None);
+    builder.compute_layout(available_width, available_height, measure);
 
     // Extract results using the cache generator to handle repeaters.
     // If `order` sorting was applied, we need to collect results by original index first,
@@ -2019,13 +2025,71 @@ pub(crate) mod ffi {
         super::box_layout_info_ortho(cells, padding)
     }
 
+    /// The measure callback for C FFI. Returns (width, height) via out pointers.
+    /// `known_width`/`known_height` are negative if not determined yet.
+    /// A null function pointer means no measure callback.
+    pub type FlexboxMeasureFnC = unsafe extern "C" fn(
+        user_data: *mut core::ffi::c_void,
+        child_index: usize,
+        known_width: Coord,
+        known_height: Coord,
+        out_width: *mut Coord,
+        out_height: *mut Coord,
+    );
+
     #[unsafe(no_mangle)]
+    #[allow(unsafe_code)]
     pub extern "C" fn slint_solve_flexbox_layout(
         data: &FlexboxLayoutData,
         repeater_indices: Slice<u32>,
         result: &mut SharedVector<Coord>,
+        measure_fn: *const core::ffi::c_void,
+        measure_user_data: *mut core::ffi::c_void,
     ) {
-        *result = super::solve_flexbox_layout(data, repeater_indices)
+        // Safety: measure_fn, when non-null, is a valid FlexboxMeasureFnC function pointer
+        // passed as *const c_void because cbindgen can't represent Option<fn pointer> in C++.
+        const {
+            assert!(
+                core::mem::size_of::<*const core::ffi::c_void>()
+                    == core::mem::size_of::<FlexboxMeasureFnC>()
+            );
+        }
+        let measure_fn: Option<FlexboxMeasureFnC> = if measure_fn.is_null() {
+            None
+        } else {
+            Some(unsafe {
+                core::mem::transmute::<*const core::ffi::c_void, FlexboxMeasureFnC>(measure_fn)
+            })
+        };
+        if let Some(c_measure) = measure_fn {
+            let mut measure = |child_index: usize,
+                               known_w: Option<Coord>,
+                               known_h: Option<Coord>|
+             -> (Coord, Coord) {
+                let mut out_w: Coord = 0 as _;
+                let mut out_h: Coord = 0 as _;
+                // Safety: c_measure is a valid function pointer provided by the caller,
+                // and out_w/out_h are valid mutable pointers.
+                unsafe {
+                    c_measure(
+                        measure_user_data,
+                        child_index,
+                        known_w.unwrap_or(-1 as _),
+                        known_h.unwrap_or(-1 as _),
+                        &mut out_w,
+                        &mut out_h,
+                    );
+                }
+                (out_w, out_h)
+            };
+            *result = super::solve_flexbox_layout_with_measure(
+                data,
+                repeater_indices,
+                Some(&mut measure),
+            );
+        } else {
+            *result = super::solve_flexbox_layout(data, repeater_indices);
+        }
     }
 
     #[unsafe(no_mangle)]


### PR DESCRIPTION
* use taffy NodeContext and compute_layout_with_measure
    
Prepare the taffy integration for height-for-width support by switching from TaffyTree<()> to TaffyTree<usize> (storing child indices as context) and from compute_layout to compute_layout_with_measure.
   
* plumb measure callback through solve_flexbox_layout
    
 Add FlexboxMeasureFn type and solve_flexbox_layout_with_measure that accepts an optional measure callback for height-for-width items. The existing solve_flexbox_layout (2-arg) is kept as a convenience wrapper for generated code. The FFI function accepts a C function pointer + user_data. 

At this point no callers pass a measure function, so there is no behavior change yet.

This is step 2/3 of fixing binding loops and recursion issues when having height-for-width items in a FlexboxLayout.
Step 3 is big, so this split out to help reviewing.
https://github.com/slint-ui/slint/issues/11311 https://github.com/slint-ui/slint/issues/11168