### PR TITLE
Popup: Set correct window adapter for the component

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -579,6 +579,7 @@ fn gen_corelib(
             "slint_windowrc_set_component",
             "slint_windowrc_show_popup",
             "slint_windowrc_close_popup",
+            "slint_windowrc_create_popup_window_adapter",
             "slint_windowrc_set_rendering_notifier",
             "slint_windowrc_request_redraw",
             "slint_windowrc_on_close_requested",

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -181,6 +181,20 @@ public:
         }
     }
 
+    /// Try to create a window adapter for a popup window.
+    /// Returns std::nullopt if the backend renders popups as child windows.
+    std::optional<WindowAdapterRc> create_popup_window_adapter() const
+    {
+        cbindgen_private::WindowAdapterRcOpaque raw_result;
+        if (cbindgen_private::slint_windowrc_create_popup_window_adapter(&inner, &raw_result)) {
+            std::optional<WindowAdapterRc> result;
+            result.emplace(raw_result); // clone: refcount = 2
+            cbindgen_private::slint_windowrc_drop(&raw_result); // drop original: refcount = 1
+            return result;
+        }
+        return std::nullopt;
+    }
+
     template<typename Component, typename SharedGlobals, typename InitFn>
     uint32_t show_popup_menu(
             SharedGlobals *globals, LogicalPosition pos, cbindgen_private::ItemRc context_menu_rc,

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -166,7 +166,7 @@ public:
                         cbindgen_private::ItemRc parent_item) const
     {
         using SharedGlobals = decltype(parent_component->globals);
-        SharedGlobals _own_globals;
+        SharedGlobals _own_globals = nullptr;
         if (auto _popup_adapter = create_popup_window_adapter()) {
             _own_globals = parent_component->globals->clone_with_window_adapter(*_popup_adapter);
         }

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -165,13 +165,12 @@ public:
                         cbindgen_private::PopupClosePolicy close_policy,
                         cbindgen_private::ItemRc parent_item) const
     {
-        // using OwnGlobals = decltype(parent_component->globals->clone_with_window_adapter(
-        //         std::declval<WindowAdapterRc>()));
-        auto _own_globals;
+        using SharedGlobals = decltype(parent_component->globals);
+        SharedGlobals _own_globals;
         if (auto _popup_adapter = create_popup_window_adapter()) {
             _own_globals = parent_component->globals->clone_with_window_adapter(*_popup_adapter);
         } else {
-            _own_globals = parent_component->globals->get();
+            _own_globals = parent_component->globals;
         }
 
         auto popup = Component::create(parent_component, _own_globals);

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -165,7 +165,14 @@ public:
                         cbindgen_private::PopupClosePolicy close_policy,
                         cbindgen_private::ItemRc parent_item) const
     {
-        auto popup = Component::create(parent_component);
+        std::unique_ptr<SharedGlobals> _own_globals;
+        if (auto _popup_adapter = create_popup_window_adapter()) {
+            _own_globals = parent_component->globals->clone_with_window_adapter(*_popup_adapter);
+        } else {
+            _own_globals = parent_component->globals->clone();
+        }
+
+        auto popup = Component::create(parent_component, _own_globals);
         auto p = pos(popup);
         auto popup_dyn = popup.into_dyn();
         auto id = cbindgen_private::slint_windowrc_show_popup(&inner, &popup_dyn, p, close_policy,

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -165,9 +165,9 @@ public:
                         cbindgen_private::PopupClosePolicy close_policy,
                         cbindgen_private::ItemRc parent_item) const
     {
-        using OwnGlobals = decltype(parent_component->globals->clone_with_window_adapter(
-                std::declval<WindowAdapterRc>()));
-        OwnGlobals _own_globals;
+        // using OwnGlobals = decltype(parent_component->globals->clone_with_window_adapter(
+        //         std::declval<WindowAdapterRc>()));
+        auto _own_globals;
         if (auto _popup_adapter = create_popup_window_adapter()) {
             _own_globals = parent_component->globals->clone_with_window_adapter(*_popup_adapter);
         } else {

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -165,11 +165,13 @@ public:
                         cbindgen_private::PopupClosePolicy close_policy,
                         cbindgen_private::ItemRc parent_item) const
     {
-        std::unique_ptr<SharedGlobals> _own_globals;
+        using OwnGlobals = decltype(parent_component->globals->clone_with_window_adapter(
+                std::declval<WindowAdapterRc>()));
+        OwnGlobals _own_globals;
         if (auto _popup_adapter = create_popup_window_adapter()) {
             _own_globals = parent_component->globals->clone_with_window_adapter(*_popup_adapter);
         } else {
-            _own_globals = parent_component->globals->clone();
+            _own_globals = parent_component->globals->get();
         }
 
         auto popup = Component::create(parent_component, _own_globals);

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -169,7 +169,8 @@ public:
         SharedGlobals _own_globals;
         if (auto _popup_adapter = create_popup_window_adapter()) {
             _own_globals = parent_component->globals->clone_with_window_adapter(*_popup_adapter);
-        } else {
+        }
+        if (!_own_globals) {
             _own_globals = parent_component->globals;
         }
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2227,20 +2227,30 @@ impl WindowAdapterInternal for QtWindow {
         self.tree_structure_changed.replace(true);
     }
 
-    fn create_popup(&self, geometry: LogicalRect) -> Option<Rc<dyn WindowAdapter>> {
+    fn create_popup_window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
         let popup_window = QtWindow::new();
+        let popup_ptr = popup_window.widget_ptr();
+        let widget_ptr = self.widget_ptr();
+        cpp! {unsafe [widget_ptr as "QWidget*", popup_ptr as "QWidget*"] {
+            popup_ptr->setParent(widget_ptr, Qt::Popup);
+        }};
+        Some(popup_window as _)
+    }
 
-        let size = qttypes::QSize { width: geometry.width() as _, height: geometry.height() as _ };
-
+    fn show_popup(&self, window_adapter: Rc<dyn WindowAdapter>, geometry: LogicalRect) {
+        let popup_window: Rc<QtWindow> = window_adapter
+            .internal(i_slint_core::InternalToken)
+            .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<QtWindow>())
+            .and_then(|qt| qt.self_weak.upgrade())
+            .unwrap();
         let popup_ptr = popup_window.widget_ptr();
         let pos = qttypes::QPoint { x: geometry.origin.x as _, y: geometry.origin.y as _ };
+        let size = qttypes::QSize { width: geometry.width() as _, height: geometry.height() as _ };
         let widget_ptr = self.widget_ptr();
         cpp! {unsafe [widget_ptr as "QWidget*", popup_ptr as "QWidget*", pos as "QPoint", size as "QSize"] {
-            popup_ptr->setParent(widget_ptr, Qt::Popup);
             popup_ptr->setGeometry(QRect(pos + widget_ptr->mapToGlobal(QPoint(0,0)), size));
             popup_ptr->show();
         }};
-        Some(popup_window as _)
     }
 
     fn set_mouse_cursor(&self, cursor: MouseCursor) {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2237,22 +2237,6 @@ impl WindowAdapterInternal for QtWindow {
         Some(popup_window as _)
     }
 
-    fn show_popup(&self, window_adapter: Rc<dyn WindowAdapter>, geometry: LogicalRect) {
-        let popup_window: Rc<QtWindow> = window_adapter
-            .internal(i_slint_core::InternalToken)
-            .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<QtWindow>())
-            .and_then(|qt| qt.self_weak.upgrade())
-            .unwrap();
-        let popup_ptr = popup_window.widget_ptr();
-        let pos = qttypes::QPoint { x: geometry.origin.x as _, y: geometry.origin.y as _ };
-        let size = qttypes::QSize { width: geometry.width() as _, height: geometry.height() as _ };
-        let widget_ptr = self.widget_ptr();
-        cpp! {unsafe [widget_ptr as "QWidget*", popup_ptr as "QWidget*", pos as "QPoint", size as "QSize"] {
-            popup_ptr->setGeometry(QRect(pos + widget_ptr->mapToGlobal(QPoint(0,0)), size));
-            popup_ptr->show();
-        }};
-    }
-
     fn set_mouse_cursor(&self, cursor: MouseCursor) {
         let widget_ptr = self.widget_ptr();
         //unidirectional resize cursors are replaced with bidirectional ones

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -818,6 +818,7 @@ pub fn generate(
     ));
 
     let mut init_global = Vec::new();
+    let mut global_names: Vec<SmolStr> = Vec::new();
 
     for (idx, glob) in llr.globals.iter_enumerated() {
         if !glob.must_generate() {
@@ -836,6 +837,8 @@ pub fn generate(
         file.definitions.extend(glob.aliases.iter().map(|name| {
             Declaration::TypeAlias(TypeAlias { old_name: ident(&glob.name), new_name: ident(name) })
         }));
+
+        global_names.push(name.clone());
 
         globals_struct.members.push((
             Access::Public,
@@ -858,6 +861,42 @@ pub fn generate(
             ..Default::default()
         }),
     ));
+
+    // Build initializer-list string for the clone_with_window_adapter constructor
+    {
+        let global_inits = std::iter::once("root_weak(source.root_weak)".to_string())
+            .chain(global_names.iter().map(|n| format!("{n}(source.{n})")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let init_list =
+            if global_inits.is_empty() { String::new() } else { format!(" : {global_inits}") };
+
+        // A private constructor for cloning with a different window adapter
+        globals_struct.members.push((
+                Access::Private,
+                Declaration::Function(Function {
+                    name: globals_struct.name.clone(),
+                    is_constructor_or_destructor: true,
+                    signature: format!(
+                        "(const {SHARED_GLOBAL_CLASS}& source, const slint::private_api::WindowAdapterRc& adapter){init_list}"
+                    ),
+                    statements: Some(vec!["m_window.emplace(adapter);".into()]),
+                    ..Default::default()
+                }),
+            ));
+
+        globals_struct.members.push((
+                Access::Public,
+                Declaration::Function(Function {
+                    name: "clone_with_window_adapter".into(),
+                    signature: format!("(const slint::private_api::WindowAdapterRc& adapter) const -> std::unique_ptr<{SHARED_GLOBAL_CLASS}>"),
+                    statements: Some(vec![format!(
+                        "return std::unique_ptr<{SHARED_GLOBAL_CLASS}>(new {SHARED_GLOBAL_CLASS}(*this, adapter));"
+                    )]),
+                    ..Default::default()
+                }),
+            ));
+    }
 
     file.declarations.push(Declaration::Struct(globals_struct));
 
@@ -1406,7 +1445,7 @@ fn generate_item_tree(
     sub_tree: &llr::ItemTree,
     root: &llr::CompilationUnit,
     parent_ctx: Option<&ParentScope>,
-    is_popup_menu: bool,
+    is_popup: bool,
     item_tree_class_name: SmolStr,
     field_access: Access,
     file: &mut File,
@@ -1833,9 +1872,30 @@ fn generate_item_tree(
         "self->self_weak = vtable::VWeak(self_rc).into_dyn();".into(),
     ];
 
+    let is_popup_window = is_popup && parent_ctx.is_some();
+    let is_popup_menu = is_popup && parent_ctx.is_none();
+
+    if is_popup_window {
+        target_struct.members.push((
+            field_access,
+            Declaration::Var(Var {
+                ty: "std::unique_ptr<SharedGlobals>".into(),
+                name: "m_own_globals".into(),
+                ..Default::default()
+            }),
+        ));
+    }
+
     if is_popup_menu {
         create_code.push("self->globals = globals;".into());
         create_parameters.push("const SharedGlobals *globals".into());
+    } else if is_popup_window {
+        create_code.push("self->m_own_globals = std::move(own_globals);".into());
+        create_code.push(
+            "self->globals = self->m_own_globals ? self->m_own_globals.get() : parent->globals;"
+                .into(),
+        );
+        create_parameters.push("std::unique_ptr<SharedGlobals> own_globals".into());
     } else if parent_ctx.is_none() {
         create_code.push("slint::cbindgen_private::slint_ensure_backend();".into());
 
@@ -1857,7 +1917,8 @@ fn generate_item_tree(
         create_code.push("self->m_globals.root_weak = self->self_weak;".into());
     }
 
-    let global_access = if parent_ctx.is_some() { "parent->globals" } else { "self->globals" };
+    let global_access =
+        if !is_popup && parent_ctx.is_some() { "parent->globals" } else { "self->globals" };
     create_code.extend([
         format!(
             "slint::private_api::register_item_tree(&self_rc.into_dyn(), {global_access}->m_window);",
@@ -1867,7 +1928,7 @@ fn generate_item_tree(
 
     // Repeaters run their user_init() code from Repeater::ensure_updated() after update() initialized model_data/index.
     // And in PopupWindow this is also called by the runtime
-    if parent_ctx.is_none() && !is_popup_menu {
+    if parent_ctx.is_none() && !is_popup {
         create_code.push("self->user_init();".to_string());
         // initialize the Window in this point to be consistent with Rust
         create_code.push("self->window();".to_string())
@@ -2004,7 +2065,7 @@ fn generate_sub_component(
             &popup.item_tree,
             root,
             Some(&parent_ctx),
-            false,
+            true,
             component_id,
             Access::Public,
             file,
@@ -4436,7 +4497,21 @@ fn compile_builtin_function_call(
                 let position = compile_expression(&popup.position.borrow(), &popup_ctx);
                 let close_policy = compile_expression(close_policy, ctx);
                 component_access.then(|component_access| format!(
-                    "{window}.close_popup({component_access}->popup_id_{popup_index}); {component_access}->popup_id_{popup_index} = {window}.template show_popup<{popup_window_id}>(&*({component_access}), [=](auto self) {{ return {position}; }}, {close_policy}, {{ {parent_component} }})"
+                    // Use a block statement to create own globals and popup instance
+                    "{window}.close_popup({component_access}->popup_id_{popup_index}); \
+                    {{ \
+                        std::unique_ptr<SharedGlobals> _own_globals; \
+                        if (auto _popup_adapter = {window}.create_popup_window_adapter()) {{ \
+                            _own_globals = {component_access}->globals->clone_with_window_adapter(*_popup_adapter); \
+                        }} \
+                        auto _popup_inst = {popup_window_id}::create(&*({component_access}), std::move(_own_globals)); \
+                        auto _popup_dyn = _popup_inst.into_dyn(); \
+                        auto _pos = [=]([[maybe_unused]] auto self) {{ return {position}; }}(_popup_inst); \
+                        auto _parent_item = slint::cbindgen_private::ItemRc{{ {parent_component} }}; \
+                        {component_access}->popup_id_{popup_index} = slint::cbindgen_private::slint_windowrc_show_popup(\
+&({window}.handle()), &_popup_dyn, _pos, {close_policy}, &_parent_item, false); \
+                        _popup_inst->user_init(); \
+                    }}"
                 ))
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -818,7 +818,7 @@ pub fn generate(
     ));
 
     let mut init_global = Vec::new();
-    let mut global_names: Vec<SmolStr> = Vec::new();
+    let mut clone_constructor_global_inits = Vec::new();
 
     for (idx, glob) in llr.globals.iter_enumerated() {
         if !glob.must_generate() {
@@ -838,7 +838,7 @@ pub fn generate(
             Declaration::TypeAlias(TypeAlias { old_name: ident(&glob.name), new_name: ident(name) })
         }));
 
-        global_names.push(name.clone());
+        clone_constructor_global_inits.push(format!("{name}(source.{name})"));
 
         globals_struct.members.push((
             Access::Public,
@@ -865,7 +865,7 @@ pub fn generate(
     // Build initializer-list string for the clone_with_window_adapter constructor
     {
         let global_inits = std::iter::once("root_weak(source.root_weak)".to_string())
-            .chain(global_names.iter().map(|n| format!("{n}(source.{n})")))
+            .chain(clone_constructor_global_inits)
             .collect::<Vec<_>>()
             .join(", ");
         let init_list =

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1886,16 +1886,9 @@ fn generate_item_tree(
         ));
     }
 
-    if is_popup_menu {
+    if is_popup_menu || is_popup_window {
         create_code.push("self->globals = globals;".into());
         create_parameters.push("const SharedGlobals *globals".into());
-    } else if is_popup_window {
-        create_code.push("self->m_own_globals = std::move(own_globals);".into());
-        create_code.push(
-            "self->globals = self->m_own_globals ? self->m_own_globals.get() : parent->globals;"
-                .into(),
-        );
-        create_parameters.push("std::unique_ptr<SharedGlobals> own_globals".into());
     } else if parent_ctx.is_none() {
         create_code.push("slint::cbindgen_private::slint_ensure_backend();".into());
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4499,19 +4499,11 @@ fn compile_builtin_function_call(
                 component_access.then(|component_access| format!(
                     // Use a block statement to create own globals and popup instance
                     "{window}.close_popup({component_access}->popup_id_{popup_index}); \
-                    {{ \
-                        std::unique_ptr<SharedGlobals> _own_globals; \
-                        if (auto _popup_adapter = {window}.create_popup_window_adapter()) {{ \
-                            _own_globals = {component_access}->globals->clone_with_window_adapter(*_popup_adapter); \
-                        }} \
-                        auto _popup_inst = {popup_window_id}::create(&*({component_access}), std::move(_own_globals)); \
-                        auto _popup_dyn = _popup_inst.into_dyn(); \
-                        auto _pos = [=]([[maybe_unused]] auto self) {{ return {position}; }}(_popup_inst); \
-                        auto _parent_item = slint::cbindgen_private::ItemRc{{ {parent_component} }}; \
-                        {component_access}->popup_id_{popup_index} = slint::cbindgen_private::slint_windowrc_show_popup(\
-&({window}.handle()), &_popup_dyn, _pos, {close_policy}, &_parent_item, false); \
-                        _popup_inst->user_init(); \
-                    }}"
+                    {component_access}->popup_id_{popup_index} =  \
+                        {window}.template show_popup<{popup_window_id}>(&*({component_access}),  \
+                                                                        [=](auto self) {{ return {position}; }},  \
+                                                                        {close_policy},  \
+                                                                        {{ {parent_component} }})"
                 ))
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1872,21 +1872,7 @@ fn generate_item_tree(
         "self->self_weak = vtable::VWeak(self_rc).into_dyn();".into(),
     ];
 
-    let is_popup_window = is_popup && parent_ctx.is_some();
-    let is_popup_menu = is_popup && parent_ctx.is_none();
-
-    if is_popup_window {
-        target_struct.members.push((
-            field_access,
-            Declaration::Var(Var {
-                ty: "std::unique_ptr<SharedGlobals>".into(),
-                name: "m_own_globals".into(),
-                ..Default::default()
-            }),
-        ));
-    }
-
-    if is_popup_menu || is_popup_window {
+    if is_popup {
         create_code.push("self->globals = globals;".into());
         create_parameters.push("const SharedGlobals *globals".into());
     } else if parent_ctx.is_none() {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -889,9 +889,9 @@ pub fn generate(
                 Access::Public,
                 Declaration::Function(Function {
                     name: "clone_with_window_adapter".into(),
-                    signature: format!("(const slint::private_api::WindowAdapterRc& adapter) const -> std::unique_ptr<{SHARED_GLOBAL_CLASS}>"),
+                    signature: format!("(const slint::private_api::WindowAdapterRc& adapter) const -> {SHARED_GLOBAL_CLASS}*"),
                     statements: Some(vec![format!(
-                        "return std::unique_ptr<{SHARED_GLOBAL_CLASS}>(new {SHARED_GLOBAL_CLASS}(*this, adapter));"
+                        "return new {SHARED_GLOBAL_CLASS}(*this, adapter);"
                     )]),
                     ..Default::default()
                 }),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -517,6 +517,7 @@ fn generate_shared_globals(
             }
 
             // Clone the SharedGlobals struct but use a different window adapter. This is for example used for popup windows, because they need access to the globals, but need their own window adapter
+            #[allow(dead_code)]
             #pub_token fn clone_with_window_adapter(&self, window_adapter: sp::WindowAdapterRc) -> sp::Rc<Self> {
                 let _self = sp::Rc::new(Self {
                     #(#global_names : self.#global_names.clone(),)*

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -516,6 +516,22 @@ fn generate_shared_globals(
                 _self
             }
 
+            // Clone the SharedGlobals struct but use a different window adapter. This is for example used for popup windows, because they need access to the globals, but need their own window adapter
+            #pub_token fn clone_with_window_adapter(&self, window_adapter: sp::WindowAdapterRc) -> sp::Rc<Self> {
+                let _self = sp::Rc::new(Self {
+                    #(#global_names : self.#global_names.clone(),)*
+                    #(#from_library_global_names : self.#from_library_global_names.clone(),)*
+                    window_adapter: ::core::default::Default::default(),
+                    root_item_tree_weak: self.root_item_tree_weak.clone(),
+                    #(#library_shared_globals_names: self.#library_shared_globals_names.clone(),)*
+                });
+                _self.window_adapter
+                    .set(window_adapter)
+                    .map_err(|_| ())
+                    .expect("The window adapter should not be initialized before this call");
+                _self
+            }
+
             fn window_adapter_impl(&self) -> sp::Rc<dyn sp::WindowAdapter> {
                 sp::Rc::clone(self.window_adapter_ref().unwrap())
             }
@@ -841,7 +857,7 @@ fn generate_sub_component(
                 root,
                 Some(&ParentScope::new(&ctx, None)),
                 None,
-                false,
+                true,
             )
         })
         .chain(component.menu_item_trees.iter().map(|tree| {
@@ -1716,7 +1732,7 @@ fn generate_item_tree(
     root: &llr::CompilationUnit,
     parent_ctx: Option<&ParentScope>,
     index_property: Option<llr::PropertyIdx>,
-    is_popup_menu: bool,
+    is_popup: bool,
 ) -> TokenStream {
     let sub_comp = generate_sub_component(sub_tree.root, root, parent_ctx, index_property, true);
     let inner_component_id = self::inner_component_id(&root.sub_components[sub_tree.root]);
@@ -1729,14 +1745,14 @@ fn generate_item_tree(
         })
         .collect::<Vec<_>>();
 
-    let globals = if is_popup_menu {
+    let globals = if is_popup {
         quote!(globals)
     } else if parent_ctx.is_some() {
         quote!(parent.upgrade().unwrap().globals.get().unwrap().clone())
     } else {
         quote!(SharedGlobals::new(sp::VRc::downgrade(&self_dyn_rc)))
     };
-    let globals_arg = is_popup_menu.then(|| quote!(globals: sp::Rc<SharedGlobals>));
+    let globals_arg = is_popup.then(|| quote!(globals: sp::Rc<SharedGlobals>));
 
     let embedding_function = if parent_ctx.is_some() {
         quote!(todo!("Components written in Rust can not get embedded yet."))
@@ -3286,7 +3302,15 @@ fn compile_builtin_function_call(
                 let popup_id_name = internal_popup_id(*popup_index as usize);
                 component_access_tokens.then(|component_access_tokens| quote!({
                     let parent_item = #parent_item;
-                    let popup_instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone()).unwrap();
+                    // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one
+                    let globals = if let Some(window_adapter) = sp::WindowInner::from_pub(#window_adapter_tokens.window()).create_popup_window_adapter() {
+                        let globals = #component_access_tokens.globals.get().unwrap().clone_with_window_adapter(window_adapter);
+                        globals
+                    } else {
+                        #component_access_tokens.globals.get().unwrap().clone()
+                    };
+
+                    let popup_instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone(), globals).unwrap();
                     let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);
                     let position = { let _self = popup_instance_vrc.as_pin_ref(); #position };
                     if let Some(current_id) = #component_access_tokens.#popup_id_name.take() {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -523,7 +523,8 @@ fn generate_shared_globals(
                     #(#global_names : self.#global_names.clone(),)*
                     #(#from_library_global_names : self.#from_library_global_names.clone(),)*
                     window_adapter: window_adapter.into(),
-                    root_item_tree_weak: self.root_item_tree_weak.clone(),
+                    // `root_item_tree_weak` is only used to init the window_adapter. Since we have the window_adapter here already we don't need this variable
+                    root_item_tree_weak: ::core::default::Default::default(),
                     #(#library_shared_globals_names: self.#library_shared_globals_names.clone(),)*
                 })
             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3304,11 +3304,11 @@ fn compile_builtin_function_call(
                 component_access_tokens.then(|component_access_tokens| quote!({
                     let parent_item = #parent_item;
                     // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one
+                    let shared_global = #component_access_tokens.globals.get().unwrap();
                     let globals = if let Some(popup_window_adapter) = sp::WindowInner::from_pub(#window_adapter_tokens.window()).create_popup_window_adapter() {
-                        let globals = #component_access_tokens.globals.get().unwrap().clone_with_window_adapter(popup_window_adapter);
-                        globals
+                        shared_global.clone_with_window_adapter(popup_window_adapter)
                     } else {
-                        #component_access_tokens.globals.get().unwrap().clone()
+                        shared_global.clone()
                     };
 
                     let popup_instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone(), globals).unwrap();

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -519,18 +519,13 @@ fn generate_shared_globals(
             // Clone the SharedGlobals struct but use a different window adapter. This is for example used for popup windows, because they need access to the globals, but need their own window adapter
             #[allow(dead_code)]
             #pub_token fn clone_with_window_adapter(&self, window_adapter: sp::WindowAdapterRc) -> sp::Rc<Self> {
-                let _self = sp::Rc::new(Self {
+                sp::Rc::new(Self {
                     #(#global_names : self.#global_names.clone(),)*
                     #(#from_library_global_names : self.#from_library_global_names.clone(),)*
-                    window_adapter: ::core::default::Default::default(),
+                    window_adapter: window_adapter.into(),
                     root_item_tree_weak: self.root_item_tree_weak.clone(),
                     #(#library_shared_globals_names: self.#library_shared_globals_names.clone(),)*
-                });
-                _self.window_adapter
-                    .set(window_adapter)
-                    .map_err(|_| ())
-                    .expect("The window adapter should not be initialized before this call");
-                _self
+                })
             }
 
             fn window_adapter_impl(&self) -> sp::Rc<dyn sp::WindowAdapter> {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3304,8 +3304,8 @@ fn compile_builtin_function_call(
                 component_access_tokens.then(|component_access_tokens| quote!({
                     let parent_item = #parent_item;
                     // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one
-                    let globals = if let Some(window_adapter) = sp::WindowInner::from_pub(#window_adapter_tokens.window()).create_popup_window_adapter() {
-                        let globals = #component_access_tokens.globals.get().unwrap().clone_with_window_adapter(window_adapter);
+                    let globals = if let Some(popup_window_adapter) = sp::WindowInner::from_pub(#window_adapter_tokens.window()).create_popup_window_adapter() {
+                        let globals = #component_access_tokens.globals.get().unwrap().clone_with_window_adapter(popup_window_adapter);
                         globals
                     } else {
                         #component_access_tokens.globals.get().unwrap().clone()

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1449,7 +1449,8 @@ impl WindowInner {
         ItemTreeRc::borrow_pin(popup_componentrc)
             .as_ref()
             .window_adapter(false, &mut popup_window_adapter);
-        let popup_window_adapter = popup_window_adapter.unwrap(); // It must be there because we set the global
+        let popup_window_adapter =
+            popup_window_adapter.expect("It must be there because we set the global");
 
         // If a popup can be created it is at TopLevel, otherwise it is a ChildWindow
         // of the current window

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1966,6 +1966,26 @@ pub mod ffi {
         }
     }
 
+    /// Create a popup window adapter. Returns true if a new adapter was created and written to result.
+    /// Returns false if the backend does not support top-level popups.
+    /// This can be used to set the correct window adapter on a popup component before showing it.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slint_windowrc_create_popup_window_adapter(
+        handle: *const WindowAdapterRcOpaque,
+        result: *mut WindowAdapterRcOpaque,
+    ) -> bool {
+        unsafe {
+            let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
+            match WindowInner::from_pub(window_adapter.window()).create_popup_window_adapter() {
+                Some(wa) => {
+                    core::ptr::write(result as *mut Rc<dyn WindowAdapter>, wa);
+                    true
+                }
+                None => false,
+            }
+        }
+    }
+
     /// Close the popup by the given ID.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_close_popup(

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -6,8 +6,8 @@
 #![warn(missing_docs)]
 //! Exposed Window API
 use crate::api::{
-    CloseRequestResponse, LogicalPosition, PhysicalPosition, PhysicalSize, PlatformError, Window,
-    WindowPosition, WindowSize,
+    CloseRequestResponse, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize,
+    PlatformError, Window, WindowPosition, WindowSize,
 };
 use crate::graphics::Color;
 use crate::input::{
@@ -1462,12 +1462,10 @@ impl WindowInner {
             PopupWindowLocation::ChildWindow(rect.origin)
         } else {
             WindowInner::from_pub(popup_window_adapter.window()).set_component(popup_componentrc);
+            popup_window_adapter.window().set_position(LogicalPosition::from_euclid(position));
             popup_window_adapter
                 .window()
-                .set_position(LogicalPosition::new(position.x, position.y));
-            popup_window_adapter.window().set_size(WindowSize::Logical(
-                crate::api::LogicalSize::new(size.width, size.height),
-            ));
+                .set_size(WindowSize::Logical(LogicalSize::from_euclid(size)));
 
             popup_window_adapter.set_visible(true).expect("Unable to show popup");
             PopupWindowLocation::TopLevel(popup_window_adapter)

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -179,17 +179,13 @@ pub trait WindowAdapterInternal: core::any::Any {
 
     /// Create a window for a popup.
     /// This function will create only the window adapter but does not show the popup it self
-    /// Pass the result to show_popup
+    /// Use this window adapter to create a new popup window and show it with `show_popup()`
     ///
     /// If this function return None (the default implementation), then the
     /// popup will be rendered within the window itself.
     fn create_popup_window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
         None
     }
-
-    /// Shows the popup created with create_popup_window_adapter()
-    /// `geometry` is the location and size of the popup in the window coordinate
-    fn show_popup(&self, _window_adapter: Rc<dyn WindowAdapter>, _geometry: LogicalRect) {}
 
     /// Set the mouse cursor
     // TODO: Make the enum public and make public
@@ -1466,10 +1462,14 @@ impl WindowInner {
             PopupWindowLocation::ChildWindow(rect.origin)
         } else {
             WindowInner::from_pub(popup_window_adapter.window()).set_component(popup_componentrc);
-            parent_window_adapter
-                .internal(crate::InternalToken)
-                .unwrap()
-                .show_popup(popup_window_adapter.clone(), LogicalRect::new(position, size));
+            popup_window_adapter
+                .window()
+                .set_position(LogicalPosition::new(position.x, position.y));
+            popup_window_adapter.window().set_size(WindowSize::Logical(
+                crate::api::LogicalSize::new(size.width, size.height),
+            ));
+
+            popup_window_adapter.set_visible(true).expect("Unable to show popup");
             PopupWindowLocation::TopLevel(popup_window_adapter)
         };
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -178,14 +178,18 @@ pub trait WindowAdapterInternal: core::any::Any {
     }
 
     /// Create a window for a popup.
-    ///
-    /// `geometry` is the location of the popup in the window coordinate
+    /// This function will create only the window adapter but does not show the popup it self
+    /// Pass the result to show_popup
     ///
     /// If this function return None (the default implementation), then the
     /// popup will be rendered within the window itself.
-    fn create_popup(&self, _geometry: LogicalRect) -> Option<Rc<dyn WindowAdapter>> {
+    fn create_popup_window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
         None
     }
+
+    /// Shows the popup created with create_popup_window_adapter()
+    /// `geometry` is the location and size of the popup in the window coordinate
+    fn show_popup(&self, _window_adapter: Rc<dyn WindowAdapter>, _geometry: LogicalRect) {}
 
     /// Set the mouse cursor
     // TODO: Make the enum public and make public
@@ -1338,6 +1342,14 @@ impl WindowInner {
                 .collect()
         });
     }
+    /// Create a new popup window adapter
+    /// This window adapter can be used on a popup component and shown with show_popup()
+    pub fn create_popup_window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        if let Some(s) = self.window_adapter().internal(crate::InternalToken) {
+            return s.create_popup_window_adapter();
+        }
+        None
+    }
 
     /// Show a popup at the given position relative to the `parent_item` and returns its ID.
     /// The returned ID will always be non-zero.
@@ -1433,28 +1445,32 @@ impl WindowInner {
             self.window_adapter()
         };
 
+        let mut popup_window_adapter = None;
+        ItemTreeRc::borrow_pin(popup_componentrc)
+            .as_ref()
+            .window_adapter(false, &mut popup_window_adapter);
+        let popup_window_adapter = popup_window_adapter.unwrap(); // TODO: it must be there because we set the global
+
         // If a popup can be created it is at TopLevel, otherwise it is a ChildWindow
         // of the current window
-        let location = match parent_window_adapter
-            .internal(crate::InternalToken)
-            .and_then(|x| x.create_popup(LogicalRect::new(position, size)))
-        {
-            None => {
-                let clip = LogicalRect::new(
-                    LogicalPoint::new(0.0 as crate::Coord, 0.0 as crate::Coord),
-                    self.window_adapter().size().to_logical(self.scale_factor()).to_euclid(),
-                );
-                let rect = popup::place_popup(
-                    popup::Placement::Fixed(LogicalRect::new(position, size)),
-                    &Some(clip),
-                );
-                self.window_adapter().request_redraw();
-                PopupWindowLocation::ChildWindow(rect.origin)
-            }
-            Some(window_adapter) => {
-                WindowInner::from_pub(window_adapter.window()).set_component(popup_componentrc);
-                PopupWindowLocation::TopLevel(window_adapter)
-            }
+        let location = if Rc::ptr_eq(&parent_window_adapter, &popup_window_adapter) {
+            let clip = LogicalRect::new(
+                LogicalPoint::new(0.0 as crate::Coord, 0.0 as crate::Coord),
+                self.window_adapter().size().to_logical(self.scale_factor()).to_euclid(),
+            );
+            let rect = popup::place_popup(
+                popup::Placement::Fixed(LogicalRect::new(position, size)),
+                &Some(clip),
+            );
+            self.window_adapter().request_redraw();
+            PopupWindowLocation::ChildWindow(rect.origin)
+        } else {
+            WindowInner::from_pub(popup_window_adapter.window()).set_component(popup_componentrc);
+            parent_window_adapter
+                .internal(crate::InternalToken)
+                .unwrap()
+                .show_popup(popup_window_adapter.clone(), LogicalRect::new(position, size));
+            PopupWindowLocation::TopLevel(popup_window_adapter)
         };
 
         let focus_item = self

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1449,7 +1449,7 @@ impl WindowInner {
         ItemTreeRc::borrow_pin(popup_componentrc)
             .as_ref()
             .window_adapter(false, &mut popup_window_adapter);
-        let popup_window_adapter = popup_window_adapter.unwrap(); // TODO: it must be there because we set the global
+        let popup_window_adapter = popup_window_adapter.unwrap(); // It must be there because we set the global
 
         // If a popup can be created it is at TopLevel, otherwise it is a ChildWindow
         // of the current window

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1345,10 +1345,9 @@ impl WindowInner {
     /// Create a new popup window adapter
     /// This window adapter can be used on a popup component and shown with show_popup()
     pub fn create_popup_window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
-        if let Some(s) = self.window_adapter().internal(crate::InternalToken) {
-            return s.create_popup_window_adapter();
-        }
-        None
+        self.window_adapter()
+            .internal(crate::InternalToken)
+            .and_then(|s| s.create_popup_window_adapter())
     }
 
     /// Show a popup at the given position relative to the `parent_item` and returns its ID.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1461,11 +1461,10 @@ impl WindowInner {
             self.window_adapter().request_redraw();
             PopupWindowLocation::ChildWindow(rect.origin)
         } else {
-            WindowInner::from_pub(popup_window_adapter.window()).set_component(popup_componentrc);
-            popup_window_adapter.window().set_position(LogicalPosition::from_euclid(position));
-            popup_window_adapter
-                .window()
-                .set_size(WindowSize::Logical(LogicalSize::from_euclid(size)));
+            let popup_window = popup_window_adapter.window();
+            WindowInner::from_pub(popup_window).set_component(popup_componentrc);
+            popup_window.set_position(LogicalPosition::from_euclid(position));
+            popup_window.set_size(WindowSize::Logical(LogicalSize::from_euclid(size)));
 
             popup_window_adapter.set_visible(true).expect("Unable to show popup");
             PopupWindowLocation::TopLevel(popup_window_adapter)

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1447,8 +1447,8 @@ impl WindowInner {
         let popup_window_adapter =
             popup_window_adapter.expect("It must be there because we set the global");
 
-        // If a popup can be created it is at TopLevel, otherwise it is a ChildWindow
-        // of the current window
+        // If the window adapter of the popup window and the parent window are equal means that a ChildWindow shall be created
+        // because we weren't able to create a window adapter for the popup window (for example if the backend does not support it)
         let location = if Rc::ptr_eq(&parent_window_adapter, &popup_window_adapter) {
             let clip = LogicalRect::new(
                 LogicalPoint::new(0.0 as crate::Coord, 0.0 as crate::Coord),

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2631,12 +2631,26 @@ pub fn show_popup(
     compiled.recursively_set_debug_handler(debug_handler);
 
     let extra_data = instance.description.extra_data_offset.apply(instance.as_ref());
+    // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one.
+    let globals = if let Some(window_adapter) =
+        WindowInner::from_pub(parent_window_adapter.window()).create_popup_window_adapter()
+    {
+        extra_data.globals.get().unwrap().clone_with_window_adapter(window_adapter)
+    } else {
+        extra_data.globals.get().unwrap().clone()
+    };
+
+    let popup_window_adapter = globals
+        .window_adapter()
+        .and_then(|window_adapter| window_adapter.get().cloned())
+        .unwrap_or_else(|| parent_window_adapter.clone());
+
     let inst = instantiate(
         compiled,
         Some(parent_comp),
         None,
-        Some(&WindowOptions::UseExistingWindow(parent_window_adapter.clone())),
-        extra_data.globals.get().unwrap().clone(),
+        Some(&WindowOptions::UseExistingWindow(popup_window_adapter)),
+        globals,
     );
     let pos = {
         generativity::make_guard!(guard);

--- a/internal/interpreter/global_component.rs
+++ b/internal/interpreter/global_component.rs
@@ -88,6 +88,27 @@ impl GlobalStorage {
             GlobalStorage::Weak(_) => None,
         }
     }
+
+    /// Clone this GlobalStorage but with a different window adapter.
+    /// Used for popup windows so they get their own window adapter but share global instances.
+    pub fn clone_with_window_adapter(
+        &self,
+        window_adapter: i_slint_core::window::WindowAdapterRc,
+    ) -> GlobalStorage {
+        let GlobalStorage::Strong(storage) = self else {
+            panic!("Cannot clone_with_window_adapter on a Weak GlobalStorage")
+        };
+        let new_storage = Rc::new(GlobalStorageInner {
+            globals: RefCell::new(storage.globals.borrow().clone()),
+            window_adapter: OnceCell::new(),
+        });
+        new_storage
+            .window_adapter
+            .set(window_adapter)
+            .map_err(|_| ())
+            .expect("The window adapter should not be initialized before this call");
+        GlobalStorage::Strong(new_storage)
+    }
 }
 
 impl Default for GlobalStorage {

--- a/tests/cases/elements/popupwindow_global_state.slint
+++ b/tests/cases/elements/popupwindow_global_state.slint
@@ -1,0 +1,71 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export global PopupGlobal {
+    in-out property <int> counter: 0;
+}
+
+export component TestCase {
+    width: 300px;
+    height: 300px;
+
+    popup := PopupWindow {
+        x: 10px;
+        y: 10px;
+        width: 30px;
+        height: 30px;
+
+        init => {
+            PopupGlobal.counter += 1;
+        }
+
+        TouchArea {
+            clicked => {
+                PopupGlobal.counter += 10;
+            }
+        }
+    }
+
+    public function show-popup() {
+        popup.show();
+    }
+
+    out property <int> popup-counter: PopupGlobal.counter;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_popup_counter(), 0);
+instance.invoke_show_popup();
+assert_eq!(instance.get_popup_counter(), 1);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_popup_counter(), 11);
+
+instance.invoke_show_popup();
+assert_eq!(instance.get_popup_counter(), 12);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_popup_counter(), 22);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_popup_counter(), 0);
+instance.invoke_show_popup();
+assert_eq(instance.get_popup_counter(), 1);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_popup_counter(), 11);
+
+instance.invoke_show_popup();
+assert_eq(instance.get_popup_counter(), 12);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_popup_counter(), 22);
+```
+*/

--- a/tests/cases/elements/popupwindow_global_state.slint
+++ b/tests/cases/elements/popupwindow_global_state.slint
@@ -68,4 +68,21 @@ assert_eq(instance.get_popup_counter(), 12);
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_popup_counter(), 22);
 ```
+
+```js
+let instance = new slint.TestCase({});
+
+assert.equal(instance.popup_counter, 0);
+instance.show_popup();
+assert.equal(instance.popup_counter, 1);
+
+slintlib.private_api.send_mouse_click(instance, 15., 15.);
+assert.equal(instance.popup_counter, 11);
+
+instance.show_popup();
+assert.equal(instance.popup_counter, 12);
+
+slintlib.private_api.send_mouse_click(instance, 15., 15.);
+assert.equal(instance.popup_counter, 22);
+```
 */


### PR DESCRIPTION
Reason: Previously always the main window adapter is used for popups as well. This is not correct, because then acting on the wrong renderer caches is done and the application might crash or memory gets not freed. 
To solve this problem, showing the popup is split up in multiple steps. 
1) Creating the window adapter for the popup if possible. 
2) Assigning this window adapter to the popup instance so that the tree will be setup with the newly created window adapter. 
3) Determine the popup location and show the created popup 

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
