### PR TITLE
android: Try to fix IME keyboard not appearing on some OEM ROMs

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -411,32 +411,21 @@ public class SlintAndroidJavaHelper {
             }
         });
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            activity.getWindow().getDecorView().getRootView()
-                    .setWindowInsetsAnimationCallback(
-                            new WindowInsetsAnimation.Callback(
-                                    WindowInsetsAnimation.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
-                                @Override
-                                public WindowInsets onProgress(WindowInsets insets,
-                                        java.util.List<WindowInsetsAnimation> runningAnimations) {
-                                    mActivity.runOnUiThread(new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            Insets safeAreaInsets = insets.getInsets(WindowInsets.Type.systemBars());
-                                            Insets keyboardAreaInsets = insets.getInsets(WindowInsets.Type.ime());
-                                            Rect windowRect = get_view_rect();
+            View rootView = activity.getWindow().getDecorView().getRootView();
 
-                                            SlintAndroidJavaHelper.setInsets(
-                                                    windowRect.top, windowRect.left,
-                                                    windowRect.bottom, windowRect.right,
-                                                    safeAreaInsets.top, safeAreaInsets.left,
-                                                    safeAreaInsets.bottom, safeAreaInsets.right,
-                                                    keyboardAreaInsets.top, keyboardAreaInsets.left,
-                                                    keyboardAreaInsets.bottom, keyboardAreaInsets.right);
-                                        }
-                                    });
-                                    return insets;
-                                }
-                            });
+            // Some OEM ROMs hide the IME surface if the only inset source is the animation
+            // callback below, so install a plain listener as well.
+            rootView.setOnApplyWindowInsetsListener((v, insets) -> dispatchInsets(insets));
+
+            rootView.setWindowInsetsAnimationCallback(
+                    new WindowInsetsAnimation.Callback(
+                            WindowInsetsAnimation.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
+                        @Override
+                        public WindowInsets onProgress(WindowInsets insets,
+                                java.util.List<WindowInsetsAnimation> runningAnimations) {
+                            return dispatchInsets(insets);
+                        }
+                    });
         } else {
             activity.getWindow().getDecorView().getRootView().getViewTreeObserver()
                     .addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -491,6 +480,20 @@ public class SlintAndroidJavaHelper {
                         }
                     });
         }
+    }
+
+    private WindowInsets dispatchInsets(WindowInsets insets) {
+        Insets safeAreaInsets = insets.getInsets(WindowInsets.Type.systemBars());
+        Insets keyboardAreaInsets = insets.getInsets(WindowInsets.Type.ime());
+        Rect windowRect = get_view_rect();
+        SlintAndroidJavaHelper.setInsets(
+                windowRect.top, windowRect.left,
+                windowRect.bottom, windowRect.right,
+                safeAreaInsets.top, safeAreaInsets.left,
+                safeAreaInsets.bottom, safeAreaInsets.right,
+                keyboardAreaInsets.top, keyboardAreaInsets.left,
+                keyboardAreaInsets.bottom, keyboardAreaInsets.right);
+        return insets;
     }
 
     public void show_keyboard() {

--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -408,25 +408,25 @@ public class SlintAndroidJavaHelper {
                         FrameLayout.LayoutParams.MATCH_PARENT);
                 mActivity.addContentView(mInputView, params);
                 mInputView.setVisibility(View.VISIBLE);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    mActivity.getWindow().getDecorView().getRootView()
+                            .setOnApplyWindowInsetsListener((v, insets) -> dispatchInsets(insets));
+                    // Attach the IME animation callback to the input view rather than the
+                    // decor root: some OEM ROMs fail to render the IME surface when an
+                    // animation callback is installed on the window's root view.
+                    mInputView.setWindowInsetsAnimationCallback(
+                            new WindowInsetsAnimation.Callback(
+                                    WindowInsetsAnimation.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
+                                @Override
+                                public WindowInsets onProgress(WindowInsets insets,
+                                        java.util.List<WindowInsetsAnimation> runningAnimations) {
+                                    return dispatchInsets(insets);
+                                }
+                            });
+                }
             }
         });
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            View rootView = activity.getWindow().getDecorView().getRootView();
-
-            // Some OEM ROMs hide the IME surface if the only inset source is the animation
-            // callback below, so install a plain listener as well.
-            rootView.setOnApplyWindowInsetsListener((v, insets) -> dispatchInsets(insets));
-
-            rootView.setWindowInsetsAnimationCallback(
-                    new WindowInsetsAnimation.Callback(
-                            WindowInsetsAnimation.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
-                        @Override
-                        public WindowInsets onProgress(WindowInsets insets,
-                                java.util.List<WindowInsetsAnimation> runningAnimations) {
-                            return dispatchInsets(insets);
-                        }
-                    });
-        } else {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             activity.getWindow().getDecorView().getRootView().getViewTreeObserver()
                     .addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
                         @Override


### PR DESCRIPTION
Some OEM Android ROMs only show the IME chrome (provider switch button, collapse button) but not the keyboard surface itself when the only inset source on the root view is a WindowInsetsAnimationCallback.

Install an OnApplyWindowInsetsListener as the primary inset source as well, and keep the animation callback for per-frame progress reporting.

Issue: #11344
