### PR TITLE
Use Servo v0.1.0 from crates.io

### DIFF
--- a/examples/servo/Cargo.toml
+++ b/examples/servo/Cargo.toml
@@ -44,7 +44,6 @@ wgpu-core = "28.0.0"
 wgpu = { version = "28.0.0", features = ["metal"] }
 
 surfman = { version = "0.11.0", features = ["chains"] }
-# Temporarily pinned until the next release to crates.io to fix seaquery build
 servo = "0.1.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/examples/servo/Cargo.toml
+++ b/examples/servo/Cargo.toml
@@ -45,7 +45,7 @@ wgpu = { version = "28.0.0", features = ["metal"] }
 
 surfman = { version = "0.11.0", features = ["chains"] }
 # Temporarily pinned until the next release to crates.io to fix seaquery build
-servo = { git = "https://github.com/servo/servo", rev = "34337273a36d5e0e67d429039987c785f9f7c7fc" }
+servo = "0.1.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 ash = "0.38.0"


### PR DESCRIPTION
Servo is now on crates.io, so let's use that version! Tested as working locally.