### PR TITLE
FlexboxLayout: implement support for width-for-height

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -255,7 +255,7 @@ item_layout_info(VT *itemvtable, ItemType *item_ptr, cbindgen_private::Orientati
                  uint32_t item_index)
 {
     cbindgen_private::ItemRc item_rc { component_rc, item_index };
-    return itemvtable->layout_info({ itemvtable, item_ptr }, orientation, window_adapter, &item_rc);
+    return itemvtable->layout_info({ itemvtable, item_ptr }, orientation, -1., window_adapter, &item_rc);
 }
 } // namespace private_api
 

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -251,11 +251,12 @@ inline T layout_cache_grid_repeater_access(const SharedVector<T> &cache, size_t 
 template<typename VT, typename ItemType>
 inline cbindgen_private::LayoutInfo
 item_layout_info(VT *itemvtable, ItemType *item_ptr, cbindgen_private::Orientation orientation,
-                 WindowAdapterRc *window_adapter, const ItemTreeRc &component_rc,
-                 uint32_t item_index)
+                 float cross_axis_constraint, WindowAdapterRc *window_adapter,
+                 const ItemTreeRc &component_rc, uint32_t item_index)
 {
     cbindgen_private::ItemRc item_rc { component_rc, item_index };
-    return itemvtable->layout_info({ itemvtable, item_ptr }, orientation, -1., window_adapter, &item_rc);
+    return itemvtable->layout_info({ itemvtable, item_ptr }, orientation, cross_axis_constraint,
+                                   window_adapter, &item_rc);
 }
 } // namespace private_api
 

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -35,7 +35,7 @@ use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSiz
 use i_slint_core::rtti::*;
 use i_slint_core::window::{WindowAdapter, WindowAdapterRc, WindowInner};
 use i_slint_core::{
-    Callback, ItemVTable_static, Property, SharedString, SharedVector, declare_item_vtable,
+    Callback, Coord, ItemVTable_static, Property, SharedString, SharedVector, declare_item_vtable,
 };
 use i_slint_core_macros::*;
 use std::ptr::NonNull;

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -218,6 +218,7 @@ impl Item for NativeButton {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -33,6 +33,7 @@ impl Item for NativeCheckBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -32,6 +32,7 @@ impl Item for NativeComboBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -198,6 +199,7 @@ impl Item for NativeComboBoxPopup {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -146,6 +146,7 @@ impl Item for NativeGroupBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -113,6 +113,7 @@ impl Item for NativeLineEdit {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -37,6 +37,7 @@ impl Item for NativeStandardListViewItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -30,6 +30,7 @@ impl Item for NativeProgressIndicator {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -94,6 +94,7 @@ impl Item for NativeScrollView {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -79,6 +79,7 @@ impl Item for NativeSlider {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -77,6 +77,7 @@ impl Item for NativeSpinBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/tableheadersection.rs
+++ b/internal/backends/qt/qt_widgets/tableheadersection.rs
@@ -32,6 +32,7 @@ impl Item for NativeTableHeaderSection {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -188,6 +188,7 @@ impl Item for NativeTabWidget {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -394,6 +395,7 @@ impl Item for NativeTab {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -216,7 +216,7 @@ declare_builtin_function_types!(
     StringToLowercase: (Type::String) -> Type::String,
     StringToUppercase: (Type::String) -> Type::String,
     KeysToString: (Type::Keys) -> Type::String,
-    ImplicitLayoutInfo(..): (Type::ElementReference) -> typeregister::layout_info_type().into(),
+    ImplicitLayoutInfo(..): (Type::ElementReference, Type::Float32) -> typeregister::layout_info_type().into(),
     ColorRgbaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
         fields: IntoIterator::into_iter([
             (SmolStr::new_static("red"), Type::Int32),

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4603,12 +4603,13 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
-            if let [llr::Expression::PropertyReference(pr)] = arguments {
+            if let [llr::Expression::PropertyReference(pr), constraint_expr] = arguments {
                 let native = native_prop_info(pr, ctx).0;
                 let item_rc = access_item_rc(pr, ctx);
+                let constraint = compile_expression(constraint_expr, ctx);
                 access_member(pr, ctx).then(|item|
                 format!(
-                    "slint::private_api::item_layout_info({vt}, const_cast<slint::cbindgen_private::{ty}*>(&{item}), {o}, &{window}, {item_rc})",
+                    "slint::private_api::item_layout_info({vt}, const_cast<slint::cbindgen_private::{ty}*>(&{item}), {o}, {constraint}, &{window}, {item_rc})",
                     vt = native.cpp_vtable_getter,
                     ty = native.class_name,
                     o = to_cpp_orientation(orient),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3524,7 +3524,7 @@ fn compile_builtin_function_call(
                 item.then(|item| {
                     let item_rc = access_item_rc(pr, ctx);
                     quote!(
-                        sp::Item::layout_info(#item, #orient, #window_adapter_tokens, &#item_rc)
+                        sp::Item::layout_info(#item, #orient, -1., #window_adapter_tokens, &#item_rc)
                     )
                 })
             } else {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3518,13 +3518,14 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
-            if let [Expression::PropertyReference(pr)] = arguments {
+            if let [Expression::PropertyReference(pr), constraint_expr] = arguments {
                 let item = access_member(pr, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
+                let constraint = compile_expression(constraint_expr, ctx);
                 item.then(|item| {
                     let item_rc = access_item_rc(pr, ctx);
                     quote!(
-                        sp::Item::layout_info(#item, #orient, -1., #window_adapter_tokens, &#item_rc)
+                        sp::Item::layout_info(#item, #orient, #constraint as _, #window_adapter_tokens, &#item_rc)
                     )
                 })
             } else {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -723,6 +723,18 @@ pub fn implicit_layout_info_call(
     orientation: Orientation,
     filter: BuiltinFilter,
 ) -> Option<Expression> {
+    implicit_layout_info_call_with_constraint(elem, orientation, filter, None)
+}
+
+/// Like `implicit_layout_info_call`, but with an optional cross-axis constraint.
+/// When `constraint` is Some, it's passed as the cross_axis_constraint parameter
+/// to Item::layout_info for height-for-width support.
+pub fn implicit_layout_info_call_with_constraint(
+    elem: &ElementRc,
+    orientation: Orientation,
+    filter: BuiltinFilter,
+    constraint: Option<Expression>,
+) -> Option<Expression> {
     let mut elem_it = elem.clone();
     loop {
         return match &elem_it.clone().borrow().base_type {
@@ -790,7 +802,10 @@ pub fn implicit_layout_info_call(
             }
             _ => Some(Expression::FunctionCall {
                 function: BuiltinFunction::ImplicitLayoutInfo(orientation).into(),
-                arguments: vec![Expression::ElementReference(Rc::downgrade(elem))],
+                arguments: vec![
+                    Expression::ElementReference(Rc::downgrade(elem)),
+                    constraint.unwrap_or(Expression::NumberLiteral(-1., Unit::None)),
+                ],
                 source_location: None,
             }),
         };

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -670,16 +670,31 @@ fn flexbox_layout_data(
             element_ty: element_ty.clone(),
             output: llr_ArrayOutput::Slice,
         };
+        // For cells_v, pass each child's horizontal preferred size as the
+        // cross-axis constraint. This enables height-for-width for Text with
+        // word-wrap and Image with aspect ratio, without circular dependencies.
         let cells_v = llr_Expression::Array {
             values: layout
                 .elems
                 .iter()
                 .map(|li| {
-                    let layout_info_v = get_layout_info(
+                    // Get the horizontal layout_info expression to extract preferred size
+                    let h_info = crate::layout::implicit_layout_info_call(
+                        &li.item.element,
+                        Orientation::Horizontal,
+                        crate::layout::BuiltinFilter::All,
+                    );
+                    let constraint =
+                        h_info.map(|expr| crate::expression_tree::Expression::StructFieldAccess {
+                            base: Box::new(expr),
+                            name: "preferred".into(),
+                        });
+                    let layout_info_v = get_layout_info_with_constraint(
                         &li.item.element,
                         ctx,
                         &li.item.constraints,
                         Orientation::Vertical,
+                        constraint,
                     );
                     let flex_props = flex_prop(li, ctx);
                     make_flexbox_cell_data_struct(layout_info_v, flex_props)
@@ -723,11 +738,23 @@ fn flexbox_layout_data(
                     &item.item.constraints,
                     Orientation::Horizontal,
                 );
-                let layout_info_v = get_layout_info(
+                // Pass horizontal preferred size as constraint for vertical
+                let h_info = crate::layout::implicit_layout_info_call(
+                    &item.item.element,
+                    Orientation::Horizontal,
+                    crate::layout::BuiltinFilter::All,
+                );
+                let constraint =
+                    h_info.map(|expr| crate::expression_tree::Expression::StructFieldAccess {
+                        base: Box::new(expr),
+                        name: "preferred".into(),
+                    });
+                let layout_info_v = get_layout_info_with_constraint(
                     &item.item.element,
                     ctx,
                     &item.item.constraints,
                     Orientation::Vertical,
+                    constraint,
                 );
                 let flex_props = flex_prop(item, ctx);
                 elements.push(Either::Left((
@@ -1086,14 +1113,25 @@ pub fn get_layout_info(
     constraints: &crate::layout::LayoutConstraints,
     orientation: Orientation,
 ) -> llr_Expression {
+    get_layout_info_with_constraint(elem, ctx, constraints, orientation, None)
+}
+
+fn get_layout_info_with_constraint(
+    elem: &ElementRc,
+    ctx: &mut ExpressionLoweringCtx,
+    constraints: &crate::layout::LayoutConstraints,
+    orientation: Orientation,
+    constraint: Option<crate::expression_tree::Expression>,
+) -> llr_Expression {
     let layout_info = if let Some(layout_info_prop) = &elem.borrow().layout_info_prop(orientation) {
         llr_Expression::PropertyReference(ctx.map_property_reference(layout_info_prop))
     } else {
         super::lower_expression::lower_expression(
-            &crate::layout::implicit_layout_info_call(
+            &crate::layout::implicit_layout_info_call_with_constraint(
                 elem,
                 orientation,
                 crate::layout::BuiltinFilter::All,
+                constraint,
             )
             .unwrap(),
             ctx,

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -671,24 +671,15 @@ fn flexbox_layout_data(
             output: llr_ArrayOutput::Slice,
         };
         // For cells_v, pass each child's horizontal preferred size as the
-        // cross-axis constraint. This enables height-for-width for Text with
-        // word-wrap and Image with aspect ratio, without circular dependencies.
+        // cross-axis constraint for items that need height-for-width (Text with
+        // word-wrap, Image with aspect ratio). Only do this for builtin items
+        // with implicit sizing — not for components, which would create cycles.
         let cells_v = llr_Expression::Array {
             values: layout
                 .elems
                 .iter()
                 .map(|li| {
-                    // Get the horizontal layout_info expression to extract preferred size
-                    let h_info = crate::layout::implicit_layout_info_call(
-                        &li.item.element,
-                        Orientation::Horizontal,
-                        crate::layout::BuiltinFilter::All,
-                    );
-                    let constraint =
-                        h_info.map(|expr| crate::expression_tree::Expression::StructFieldAccess {
-                            base: Box::new(expr),
-                            name: "preferred".into(),
-                        });
+                    let constraint = cross_axis_constraint_expr(&li.item.element);
                     let layout_info_v = get_layout_info_with_constraint(
                         &li.item.element,
                         ctx,
@@ -738,17 +729,7 @@ fn flexbox_layout_data(
                     &item.item.constraints,
                     Orientation::Horizontal,
                 );
-                // Pass horizontal preferred size as constraint for vertical
-                let h_info = crate::layout::implicit_layout_info_call(
-                    &item.item.element,
-                    Orientation::Horizontal,
-                    crate::layout::BuiltinFilter::All,
-                );
-                let constraint =
-                    h_info.map(|expr| crate::expression_tree::Expression::StructFieldAccess {
-                        base: Box::new(expr),
-                        name: "preferred".into(),
-                    });
+                let constraint = cross_axis_constraint_expr(&item.item.element);
                 let layout_info_v = get_layout_info_with_constraint(
                     &item.item.element,
                     ctx,
@@ -1094,6 +1075,35 @@ fn generate_layout_padding_and_spacing(
     );
 
     (padding, spacing)
+}
+
+/// For elements that benefit from a cross-axis constraint (Text with word-wrap,
+/// Image with aspect ratio), returns the horizontal preferred size expression
+/// to use as the constraint. Returns None for components with layout_info_prop
+/// (which would create cycles) and items with hardcoded layout info.
+fn cross_axis_constraint_expr(elem: &ElementRc) -> Option<crate::expression_tree::Expression> {
+    if elem.borrow().layout_info_prop(Orientation::Vertical).is_some() {
+        return None;
+    }
+    if !matches!(
+        crate::layout::implicit_layout_info_call(
+            elem,
+            Orientation::Vertical,
+            crate::layout::BuiltinFilter::All,
+        ),
+        Some(crate::expression_tree::Expression::FunctionCall { .. })
+    ) {
+        return None;
+    }
+    crate::layout::implicit_layout_info_call(
+        elem,
+        Orientation::Horizontal,
+        crate::layout::BuiltinFilter::All,
+    )
+    .map(|expr| crate::expression_tree::Expression::StructFieldAccess {
+        base: Box::new(expr),
+        name: "preferred".into(),
+    })
 }
 
 fn layout_geometry_size(

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -657,7 +657,7 @@ fn recurse_expression(
         } => vis(&nr.clone().into(), P),
         Expression::FunctionCall { function: Callable::Builtin(b), arguments, .. } => match b {
             BuiltinFunction::ImplicitLayoutInfo(orientation) => {
-                if let [Expression::ElementReference(item)] = arguments.as_slice() {
+                if let [Expression::ElementReference(item), ..] = arguments.as_slice() {
                     visit_implicit_layout_info_dependencies(
                         *orientation,
                         &item.upgrade().unwrap(),

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -553,14 +553,32 @@ fn recurse_expression(
             if let Some(nr) = layout.direction.as_ref() {
                 vis(&nr.clone().into(), P);
             }
-            // Visit all layout geometry dependencies
+            // Visit layout geometry dependencies
             if matches!(expr, Expression::SolveFlexboxLayout(..)) {
-                // FlexboxLayout needs both width and height
-                if let Some(nr) = layout.geometry.rect.width_reference.as_ref() {
-                    vis(&nr.clone().into(), P);
-                }
-                if let Some(nr) = layout.geometry.rect.height_reference.as_ref() {
-                    vis(&nr.clone().into(), P);
+                // The solve only needs the main-axis dimension (width for row,
+                // height for column). The cross-axis dimension is determined by
+                // the content, not constrained by the container.
+                use crate::layout::FlexboxAxisRelation;
+                match layout.axis_relation(Orientation::Horizontal) {
+                    FlexboxAxisRelation::MainAxis => {
+                        if let Some(nr) = layout.geometry.rect.width_reference.as_ref() {
+                            vis(&nr.clone().into(), P);
+                        }
+                    }
+                    FlexboxAxisRelation::CrossAxis => {
+                        if let Some(nr) = layout.geometry.rect.height_reference.as_ref() {
+                            vis(&nr.clone().into(), P);
+                        }
+                    }
+                    FlexboxAxisRelation::Unknown => {
+                        // Runtime direction: conservatively depend on both
+                        if let Some(nr) = layout.geometry.rect.width_reference.as_ref() {
+                            vis(&nr.clone().into(), P);
+                        }
+                        if let Some(nr) = layout.geometry.rect.height_reference.as_ref() {
+                            vis(&nr.clone().into(), P);
+                        }
+                    }
                 }
             } else if let Expression::ComputeFlexboxLayoutInfo(_, orientation) = expr {
                 use crate::layout::FlexboxAxisRelation;

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -616,18 +616,9 @@ fn recurse_expression(
                         );
                     }
                     FlexboxAxisRelation::Unknown => {
-                        // Unknown direction: conservatively visit both orientations
-                        // and perpendicular dimensions
-                        if *orientation == Orientation::Vertical
-                            && let Some(nr) = layout.geometry.rect.width_reference.as_ref()
-                        {
-                            vis(&nr.clone().into(), P);
-                        }
-                        if *orientation == Orientation::Horizontal
-                            && let Some(nr) = layout.geometry.rect.height_reference.as_ref()
-                        {
-                            vis(&nr.clone().into(), P);
-                        }
+                        // Unknown direction: visit both orientations' item
+                        // dependencies but NOT perpendicular dimensions (adding
+                        // those leads to binding loops for runtime direction).
                         visit_layout_items_dependencies(
                             layout.elems.iter().map(|fi| &fi.item),
                             Orientation::Horizontal,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -132,10 +132,14 @@ pub struct ItemVTable {
     #[field_offset(CachedRenderingData)]
     pub cached_rendering_data_offset: usize,
 
-    /// We would need max/min/preferred size, and all layout info
+    /// We would need max/min/preferred size, and all layout info.
+    /// `cross_axis_constraint` is the available width when querying vertical
+    /// layout info, enabling height-for-width (Text word-wrap, Image aspect
+    /// ratio). Negative values mean unconstrained.
     pub layout_info: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         orientation: Orientation,
+        cross_axis_constraint: Coord,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> LayoutInfo,
@@ -226,6 +230,7 @@ impl Item for Empty {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -329,6 +334,7 @@ impl Item for Rectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -441,6 +447,7 @@ impl Item for BasicBorderRectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -566,6 +573,7 @@ impl Item for BorderRectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -714,6 +722,7 @@ impl Item for Clip {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -837,6 +846,7 @@ impl Item for Opacity {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -966,6 +976,7 @@ impl Item for Layer {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -1072,6 +1083,7 @@ impl Item for Transform {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -1241,6 +1253,7 @@ impl Item for WindowItem {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -1486,6 +1499,7 @@ impl Item for ContextMenu {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -1686,6 +1700,7 @@ impl Item for BoxShadow {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -8,6 +8,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 Lookup the [`crate::items`] module documentation.
 */
 use super::{Item, ItemConsts, ItemRc, RenderingResult};
+use crate::Coord;
 use crate::component_factory::{ComponentFactory, FactoryContext};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, InternalKeyEvent,
@@ -169,6 +170,7 @@ impl Item for ComponentContainer {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -4,6 +4,7 @@
 use super::{
     DropEvent, Item, ItemConsts, ItemRc, MouseCursor, PointerEventButton, RenderingResult,
 };
+use crate::Coord;
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, InternalKeyEvent,
     KeyEventResult, MouseEvent,
@@ -42,6 +43,7 @@ impl Item for DragArea {
     fn layout_info(
         self: Pin<&Self>,
         _: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -228,6 +230,7 @@ impl Item for DropArea {
     fn layout_info(
         self: Pin<&Self>,
         _: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -119,6 +119,7 @@ impl Item for Flickable {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -48,6 +48,7 @@ impl Item for ImageItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -57,7 +58,12 @@ impl Item for ImageItem {
                 _ if natural_size.width == 0 || natural_size.height == 0 => 0 as Coord,
                 Orientation::Horizontal => natural_size.width as Coord,
                 Orientation::Vertical => {
-                    natural_size.height as Coord * self.width().get() / natural_size.width as Coord
+                    let w = if cross_axis_constraint >= 0 as Coord {
+                        cross_axis_constraint
+                    } else {
+                        self.width().get()
+                    };
+                    natural_size.height as Coord * w / natural_size.width as Coord
                 }
             },
             ..Default::default()
@@ -206,6 +212,7 @@ impl Item for ClippedImage {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -217,8 +224,12 @@ impl Item for ClippedImage {
                     if source_clip_width == 0 {
                         0 as Coord
                     } else {
-                        self.source_clip_height() as Coord * self.width().get()
-                            / source_clip_width as Coord
+                        let w = if cross_axis_constraint >= 0 as Coord {
+                            cross_axis_constraint
+                        } else {
+                            self.width().get()
+                        };
+                        self.source_clip_height() as Coord * w / source_clip_width as Coord
                     }
                 }
             },

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -62,6 +62,7 @@ impl Item for TouchArea {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -295,6 +296,7 @@ impl Item for KeyBinding {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: crate::items::Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> crate::layout::LayoutInfo {
@@ -505,6 +507,7 @@ impl Item for FocusScope {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -722,6 +725,7 @@ impl Item for SwipeGestureHandler {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -998,6 +1002,7 @@ impl Item for ScaleRotateGestureHandler {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -62,6 +62,7 @@ impl Item for Path {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
+        _cross_axis_constraint: Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> LayoutInfo {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -69,6 +69,7 @@ impl Item for ComplexText {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        cross_axis_constraint: Coord,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -78,6 +79,7 @@ impl Item for ComplexText {
             window_adapter,
             orientation,
             Self::FIELD_OFFSETS.width().apply_pin(self),
+            cross_axis_constraint,
         )
     }
 
@@ -247,6 +249,7 @@ impl Item for StyledTextItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        cross_axis_constraint: Coord,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -256,6 +259,7 @@ impl Item for StyledTextItem {
             window_adapter,
             orientation,
             Self::FIELD_OFFSETS.width().apply_pin(self),
+            cross_axis_constraint,
         )
     }
 
@@ -465,6 +469,7 @@ impl Item for SimpleText {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        cross_axis_constraint: Coord,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -474,6 +479,7 @@ impl Item for SimpleText {
             window_adapter,
             orientation,
             Self::FIELD_OFFSETS.width().apply_pin(self),
+            cross_axis_constraint,
         )
     }
 
@@ -626,6 +632,7 @@ fn text_layout_info(
     window_adapter: &Rc<dyn WindowAdapter>,
     orientation: Orientation,
     width: Pin<&Property<LogicalLength>>,
+    cross_axis_constraint: Coord,
 ) -> LayoutInfo {
     let implicit_size = |max_width, text_wrap| {
         window_adapter.renderer().text_size(text, self_rc, max_width, text_wrap)
@@ -655,8 +662,14 @@ fn text_layout_info(
         Orientation::Vertical => {
             let h = match text.wrap() {
                 TextWrap::NoWrap => implicit_size(None, TextWrap::NoWrap).height,
-                TextWrap::WordWrap => implicit_size(Some(width.get()), TextWrap::WordWrap).height,
-                TextWrap::CharWrap => implicit_size(Some(width.get()), TextWrap::CharWrap).height,
+                wrap @ (TextWrap::WordWrap | TextWrap::CharWrap) => {
+                    let w = if cross_axis_constraint >= 0 as Coord {
+                        LogicalLength::new(cross_axis_constraint)
+                    } else {
+                        width.get()
+                    };
+                    implicit_size(Some(w), wrap).height
+                }
             }
             .ceil();
             LayoutInfo { min: h, preferred: h, ..LayoutInfo::default() }
@@ -757,6 +770,7 @@ impl Item for TextInput {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
+        cross_axis_constraint: Coord,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> LayoutInfo {
@@ -783,11 +797,13 @@ impl Item for TextInput {
             Orientation::Vertical => {
                 let h = match self.wrap() {
                     TextWrap::NoWrap => implicit_size(None, TextWrap::NoWrap).height,
-                    TextWrap::WordWrap => {
-                        implicit_size(Some(self.width()), TextWrap::WordWrap).height
-                    }
-                    TextWrap::CharWrap => {
-                        implicit_size(Some(self.width()), TextWrap::CharWrap).height
+                    wrap @ (TextWrap::WordWrap | TextWrap::CharWrap) => {
+                        let w = if cross_axis_constraint >= 0 as Coord {
+                            LogicalLength::new(cross_axis_constraint)
+                        } else {
+                            self.width()
+                        };
+                        implicit_size(Some(w), wrap).height
                     }
                 }
                 .ceil();

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1345,6 +1345,9 @@ mod flexbox_taffy {
         pub flex_direction: TaffyFlexDirection,
         pub container_width: Option<Coord>,
         pub container_height: Option<Coord>,
+        /// When true, set the cross-axis dimension to `auto` for all items
+        /// so that the measure callback can compute it dynamically (height-for-width).
+        pub use_measure_for_cross_axis: bool,
     }
 
     /// Build a taffy tree from Slint layout constraints.
@@ -1399,7 +1402,11 @@ mod flexbox_taffy {
                                     width: match params.flex_direction {
                                         TaffyFlexDirection::Column
                                         | TaffyFlexDirection::ColumnReverse => {
-                                            if preferred_width > 0 as Coord {
+                                            // Cross-axis for column: use auto when measure
+                                            // callback will compute it dynamically
+                                            if params.use_measure_for_cross_axis {
+                                                Dimension::auto()
+                                            } else if preferred_width > 0 as Coord {
                                                 Dimension::length(preferred_width as _)
                                             } else {
                                                 Dimension::auto()
@@ -1410,7 +1417,11 @@ mod flexbox_taffy {
                                     height: match params.flex_direction {
                                         TaffyFlexDirection::Row
                                         | TaffyFlexDirection::RowReverse => {
-                                            if preferred_height > 0 as Coord {
+                                            // Cross-axis for row: use auto when measure
+                                            // callback will compute it dynamically
+                                            if params.use_measure_for_cross_axis {
+                                                Dimension::auto()
+                                            } else if preferred_height > 0 as Coord {
                                                 Dimension::length(preferred_height as _)
                                             } else {
                                                 Dimension::auto()
@@ -1721,6 +1732,7 @@ pub fn solve_flexbox_layout_with_measure(
         if data.height > 0 as Coord { Some(data.height) } else { None },
     );
 
+    let use_measure = measure.is_some();
     let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
         cells_h: &data.cells_h,
         cells_v: &data.cells_v,
@@ -1735,6 +1747,7 @@ pub fn solve_flexbox_layout_with_measure(
         flex_direction: taffy_direction,
         container_width,
         container_height,
+        use_measure_for_cross_axis: use_measure,
     });
 
     let (available_width, available_height) = match data.direction {
@@ -1936,6 +1949,7 @@ pub fn flexbox_layout_info_cross_axis(
         flex_direction: taffy_direction,
         container_width,
         container_height,
+        use_measure_for_cross_axis: false,
     });
 
     let (available_width, available_height) = match direction {

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1702,7 +1702,24 @@ pub fn solve_flexbox_layout(
     data: &FlexboxLayoutData,
     repeater_indices: Slice<u32>,
 ) -> SharedVector<Coord> {
-    solve_flexbox_layout_with_measure(data, repeater_indices, None)
+    // Build a simple measure callback from the pre-computed cells data.
+    // This enables height-for-width: taffy calls back with the actual
+    // assigned width, and we return the pre-computed height from cells_v.
+    // The cells_v heights were computed with the horizontal preferred size
+    // as constraint, which is a good approximation.
+    let mut measure = |child_index: usize,
+                       known_w: Option<Coord>,
+                       known_h: Option<Coord>|
+     -> (Coord, Coord) {
+        let w = known_w.unwrap_or_else(|| {
+            data.cells_h.get(child_index).map_or(0 as Coord, |c| c.constraint.preferred_bounded())
+        });
+        let h = known_h.unwrap_or_else(|| {
+            data.cells_v.get(child_index).map_or(0 as Coord, |c| c.constraint.preferred_bounded())
+        });
+        (w, h)
+    };
+    solve_flexbox_layout_with_measure(data, repeater_indices, Some(&mut measure))
 }
 
 /// Solve a FlexboxLayout using Taffy

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -205,6 +205,7 @@ impl crate::items::Item for MenuItem {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: crate::items::Orientation,
+        _cross_axis_constraint: crate::Coord,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> crate::layout::LayoutInfo {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1537,8 +1537,11 @@ fn call_builtin_function(
         }
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
             let component = local_context.component_instance;
-            if let [Expression::ElementReference(item)] = arguments {
+            if let [Expression::ElementReference(item), constraint_expr] = arguments {
                 generativity::make_guard!(guard);
+
+                let constraint: f32 =
+                    eval_expression(constraint_expr, local_context).try_into().unwrap_or(-1.);
 
                 let item = item.upgrade().unwrap();
                 let enclosing_component = enclosing_component_for_element(&item, component, guard);
@@ -1552,7 +1555,7 @@ fn call_builtin_function(
                     .as_ref()
                     .layout_info(
                         crate::eval_layout::to_runtime(orient),
-                        -1., // unconstrained
+                        constraint,
                         &window_adapter,
                         &ItemRc::new(vtable::VRc::into_dyn(item_comp), item_info.item_index()),
                     )

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1552,6 +1552,7 @@ fn call_builtin_function(
                     .as_ref()
                     .layout_info(
                         crate::eval_layout::to_runtime(orient),
+                        -1., // unconstrained
                         &window_adapter,
                         &ItemRc::new(vtable::VRc::into_dyn(item_comp), item_info.item_index()),
                     )

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -424,6 +424,17 @@ fn flexbox_layout_data(
     let mut cells_v = Vec::with_capacity(flexbox_layout.elems.len());
     let mut repeated_indices = Vec::new();
 
+    // First pass: collect horizontal layout_info for all children (no cycle risk)
+    // and flex properties. Store element refs for the second pass.
+    struct ChildInfo {
+        flex_grow: f32,
+        flex_shrink: f32,
+        flex_basis: f32,
+        flex_align_self: i_slint_core::items::FlexboxLayoutAlignSelf,
+        flex_order: i32,
+    }
+    let mut static_children: Vec<Option<ChildInfo>> = Vec::new(); // None = repeater
+
     for layout_elem in &flexbox_layout.elems {
         if layout_elem.item.element.borrow().repeated.is_some() {
             let component_vec = repeater_instances(component, &layout_elem.item.element);
@@ -435,6 +446,9 @@ fn flexbox_layout_data(
             cells_v.extend(component_vec.iter().map(|x| {
                 x.as_pin_ref().flexbox_layout_item_info(to_runtime(Orientation::Vertical), None)
             }));
+            for _ in 0..component_vec.len() {
+                static_children.push(None);
+            }
         } else {
             let mut layout_info_h = get_layout_info(
                 &layout_elem.item.element,
@@ -446,20 +460,11 @@ fn flexbox_layout_data(
                 &mut layout_info_h,
                 &layout_elem.item.constraints,
                 Orientation::Horizontal,
-                &expr_eval,
+                expr_eval,
             );
-            let mut layout_info_v = get_layout_info(
-                &layout_elem.item.element,
-                component,
-                &window_adapter,
-                Orientation::Vertical,
-            );
-            fill_layout_info_constraints(
-                &mut layout_info_v,
-                &layout_elem.item.constraints,
-                Orientation::Vertical,
-                &expr_eval,
-            );
+            // Don't collect cells_v in the first pass — it may trigger a circular
+            // dependency for height-for-width items (Text with wrap, Image).
+            // The second pass fills in cells_v with the width constraint.
             let flex_grow = layout_elem.flex_grow.as_ref().map(&expr_eval).unwrap_or(0.0);
             let flex_shrink = layout_elem.flex_shrink.as_ref().map(&expr_eval).unwrap_or(1.0);
             let flex_basis = layout_elem.flex_basis.as_ref().map(&expr_eval).unwrap_or(-1.0);
@@ -473,24 +478,62 @@ fn flexbox_layout_data(
                         .unwrap()
                 })
                 .unwrap_or(i_slint_core::items::FlexboxLayoutAlignSelf::default());
-            let order = layout_elem.order.as_ref().map(&expr_eval).unwrap_or(0.0) as i32;
-            let item_info = core_layout::FlexboxLayoutItemInfo {
+            let order = layout_elem.order.as_ref().map(expr_eval).unwrap_or(0.0) as i32;
+            cells_h.push(core_layout::FlexboxLayoutItemInfo {
                 constraint: layout_info_h,
                 flex_grow,
                 flex_shrink,
                 flex_basis,
                 flex_align_self: align_self,
                 flex_order: order,
-            };
-            cells_h.push(item_info);
-            cells_v.push(core_layout::FlexboxLayoutItemInfo {
-                constraint: layout_info_v,
+            });
+            // Placeholder for cells_v — filled in second pass
+            cells_v.push(core_layout::FlexboxLayoutItemInfo::default());
+            static_children.push(Some(ChildInfo {
                 flex_grow,
                 flex_shrink,
                 flex_basis,
                 flex_align_self: align_self,
                 flex_order: order,
-            });
+            }));
+        }
+    }
+
+    // Second pass: collect vertical layout_info with the horizontal preferred
+    // size as constraint. This allows Text with word-wrap and Image with aspect
+    // ratio to compute their height correctly without reading the width property.
+    let mut cell_idx = 0usize;
+    for layout_elem in &flexbox_layout.elems {
+        if layout_elem.item.element.borrow().repeated.is_some() {
+            let component_vec = repeater_instances(component, &layout_elem.item.element);
+            cell_idx += component_vec.len();
+            // repeater cells_v already filled in first pass
+        } else {
+            let width_constraint = cells_h[cell_idx].constraint.preferred_bounded();
+            let mut layout_info_v = get_layout_info_with_constraint(
+                &layout_elem.item.element,
+                component,
+                &window_adapter,
+                Orientation::Vertical,
+                width_constraint,
+            );
+            fill_layout_info_constraints(
+                &mut layout_info_v,
+                &layout_elem.item.constraints,
+                Orientation::Vertical,
+                expr_eval,
+            );
+            if let Some(info) = &static_children[cell_idx] {
+                cells_v[cell_idx] = core_layout::FlexboxLayoutItemInfo {
+                    constraint: layout_info_v,
+                    flex_grow: info.flex_grow,
+                    flex_shrink: info.flex_shrink,
+                    flex_basis: info.flex_basis,
+                    flex_align_self: info.flex_align_self,
+                    flex_order: info.flex_order,
+                };
+            }
+            cell_idx += 1;
         }
     }
 
@@ -973,6 +1016,16 @@ pub(crate) fn get_layout_info(
     window_adapter: &Rc<dyn WindowAdapter>,
     orientation: Orientation,
 ) -> core_layout::LayoutInfo {
+    get_layout_info_with_constraint(elem, component, window_adapter, orientation, -1.)
+}
+
+fn get_layout_info_with_constraint(
+    elem: &ElementRc,
+    component: InstanceRef,
+    window_adapter: &Rc<dyn WindowAdapter>,
+    orientation: Orientation,
+    cross_axis_constraint: f32,
+) -> core_layout::LayoutInfo {
     let elem = elem.borrow();
     if let Some(nr) = elem.layout_info_prop(orientation) {
         eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
@@ -987,7 +1040,7 @@ pub(crate) fn get_layout_info(
         unsafe {
             item.item_from_item_tree(component.as_ptr()).as_ref().layout_info(
                 to_runtime(orientation),
-                -1., // unconstrained
+                cross_axis_constraint,
                 window_adapter,
                 &ItemRc::new(vtable::VRc::into_dyn(item_comp), item.item_index()),
             )

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -224,25 +224,88 @@ pub(crate) fn solve_flexbox_layout(
     let (padding_v, spacing_v) =
         padding_and_spacing(&flexbox_layout.geometry, Orientation::Vertical, &expr_eval);
 
-    core_layout::solve_flexbox_layout(
-        &core_layout::FlexboxLayoutData {
-            width: width_ref.as_ref().map(&expr_eval).unwrap_or(0.),
-            height: height_ref.as_ref().map(&expr_eval).unwrap_or(0.),
-            spacing_h,
-            spacing_v,
-            padding_h,
-            padding_v,
-            alignment,
-            direction,
-            align_content,
-            align_items,
-            flex_wrap,
-            cells_h: Slice::from(cells_h.as_slice()),
-            cells_v: Slice::from(cells_v.as_slice()),
-        },
-        Slice::from(repeated_indices.as_slice()),
-    )
-    .into()
+    let data = core_layout::FlexboxLayoutData {
+        width: width_ref.as_ref().map(&expr_eval).unwrap_or(0.),
+        height: height_ref.as_ref().map(&expr_eval).unwrap_or(0.),
+        spacing_h,
+        spacing_v,
+        padding_h,
+        padding_v,
+        alignment,
+        direction,
+        align_content,
+        align_items,
+        flex_wrap,
+        cells_h: Slice::from(cells_h.as_slice()),
+        cells_v: Slice::from(cells_v.as_slice()),
+    };
+    let ri = Slice::from(repeated_indices.as_slice());
+
+    // Collect element info for measure callbacks (height-for-width support).
+    let window_adapter = component.window_adapter();
+    let mut child_elem_ids: Vec<Option<smol_str::SmolStr>> = Vec::new();
+    for layout_elem in &flexbox_layout.elems {
+        if layout_elem.item.element.borrow().repeated.is_some() {
+            let component_vec = repeater_instances(component, &layout_elem.item.element);
+            for _ in 0..component_vec.len() {
+                child_elem_ids.push(None);
+            }
+        } else {
+            child_elem_ids.push(Some(layout_elem.item.element.borrow().id.clone()));
+        }
+    }
+
+    // Build measure callback that computes constrained layout_info for items
+    // that support height-for-width (Text with wrap, Image with aspect ratio).
+    // This avoids the circular dependency where layout_info reads the item's
+    // width property, which itself comes from the layout cache being computed.
+    let mut measure = |child_index: usize,
+                       known_w: Option<f32>,
+                       known_h: Option<f32>|
+     -> (f32, f32) {
+        let default_w = cells_h.get(child_index).map_or(0., |c| c.constraint.preferred_bounded());
+        let default_h = cells_v.get(child_index).map_or(0., |c| c.constraint.preferred_bounded());
+        let w = known_w.unwrap_or(default_w);
+        let h = known_h.unwrap_or(default_h);
+
+        let elem_id = match child_elem_ids.get(child_index) {
+            Some(Some(id)) => id,
+            _ => return (w, h),
+        };
+        let item_within = match component.description.items.get(elem_id.as_str()) {
+            Some(i) => i,
+            None => return (w, h),
+        };
+
+        // Call layout_info with cross-axis constraint through the VTable
+        if known_w.is_some() && known_h.is_none() {
+            let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
+            let item_rc = ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
+            let item = unsafe { item_within.item_from_item_tree(component.as_ptr()) };
+            let v_info = item.as_ref().layout_info(
+                to_runtime(Orientation::Vertical),
+                w,
+                &window_adapter,
+                &item_rc,
+            );
+            return (w, v_info.preferred_bounded());
+        }
+        if known_h.is_some() && known_w.is_none() {
+            let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
+            let item_rc = ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
+            let item = unsafe { item_within.item_from_item_tree(component.as_ptr()) };
+            let h_info = item.as_ref().layout_info(
+                to_runtime(Orientation::Horizontal),
+                h,
+                &window_adapter,
+                &item_rc,
+            );
+            return (h_info.preferred_bounded(), h);
+        }
+        (w, h)
+    };
+
+    core_layout::solve_flexbox_layout_with_measure(&data, ri, Some(&mut measure)).into()
 }
 
 fn flexbox_layout_direction(
@@ -924,6 +987,7 @@ pub(crate) fn get_layout_info(
         unsafe {
             item.item_from_item_tree(component.as_ptr()).as_ref().layout_info(
                 to_runtime(orientation),
+                -1., // unconstrained
                 window_adapter,
                 &ItemRc::new(vtable::VRc::into_dyn(item_comp), item.item_index()),
             )

--- a/tests/cases/layout/flexbox_image.slint
+++ b/tests/cases/layout/flexbox_image.slint
@@ -1,0 +1,77 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test FlexboxLayout with an Image child (height-for-width behavior).
+// The Image preserves its aspect ratio, so its height depends on its width.
+// Tests two states: wide (image at natural size beside rect) and narrow (image shrunk).
+
+export component TestCase inherits Window {
+
+    property <length> width_wide: 300px;
+    property <length> height_wide: 100px;
+    property <length> width_narrow: 150px;
+    property <length> height_narrow: 200px;
+
+    width: width_wide;
+    height: height_wide;
+
+    FlexboxLayout {
+        spacing: 10px;
+
+        r := Rectangle {
+            width: 100px;
+            height: 50px;
+            background: red;
+            flex-shrink: 0;
+        }
+        // 128x128 square image: aspect ratio means width == height
+        img := Image {
+            source: @image-url("../../../logo/slint-logo-square-light-128x128.png");
+            // Interactive testing, not used by the test framework
+            TouchArea {
+                clicked => {
+                    root.width = root.width == width_narrow ? width_wide : width_narrow;
+                    root.height = root.height == height_narrow ? height_wide : height_narrow;
+                }
+            }
+        }
+    }
+
+    // --- Wide state: image beside rectangle at natural 128px size ---
+    out property <bool> wide_r_ok: r.x == 0px && r.width == 100px;
+    out property <bool> wide_img_ok: img.x == 110px && img.width == 128px;
+    out property <bool> wide_ok: wide_r_ok && wide_img_ok;
+
+    // --- Narrow state: image should shrink ---
+    out property <bool> narrow_img_ok: img.width > 0px && img.width <= 128px;
+    out property <bool> narrow_ok: narrow_img_ok;
+
+    init => {
+        root.init-called = true;
+        if !wide_ok {
+            root.error = "wide state failed: r.x=" + (r.x / 1px) + " img.x=" + (img.x / 1px) + " img.w=" + (img.width / 1px);
+        }
+        root.width = width_narrow;
+        root.height = height_narrow;
+    }
+    out property <string> error;
+    out property <bool> init-called;
+    out property <bool> test: init-called && error == "" && narrow_ok;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -40,7 +40,7 @@ export component TestCase inherits Window {
     out property <int> max_w: flex.max-width / 1px;
     // Main-axis preferred-width uses sqrt(sum of w²) heuristic ≈ 199px.
     // Cross-axis preferred-height uses taffy with the actual container width (200px) ≈ 129px.
-    out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width > 190px && flex.preferred-width < 210px;
+    out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width > 198px && flex.preferred-width < 200px;
     out property <bool> flex_minmax_height_ok: flex.min-height == 44px && flex.preferred-height > 128px && flex.preferred-height < 130px;
 
     out property <bool> test: test_r1 && test_r2 && test_r3 && test_r4 && test_r5 && test_r6 && flex_minmax_width_ok && flex_minmax_height_ok;

--- a/tests/cases/layout/flexbox_text_wrap.slint
+++ b/tests/cases/layout/flexbox_text_wrap.slint
@@ -1,0 +1,52 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test FlexboxLayout containing Text with word-wrap (height-for-width behavior).
+// The text should wrap within its assigned width, producing a multi-line layout.
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 300px;
+
+    FlexboxLayout {
+        spacing: 10px;
+        flex-wrap: no-wrap;
+
+        r := Rectangle {
+            width: 50px;
+            height: 50px;
+            background: red;
+            flex-shrink: 0;
+        }
+        t := Text {
+            text: "This is a text with word-wrap inside a FlexboxLayout";
+            wrap: word-wrap;
+            horizontal-alignment: left;
+            flex-shrink: 1;
+        }
+    }
+
+    // Text should be beside the rectangle (x=60) and wrapping (height > single line)
+    out property <bool> test_r: r.x == 0px && r.width == 50px;
+    out property <bool> test_t_pos: t.x == 60px;
+    out property <bool> test_t_wrap: t.height > 20px;
+
+    out property <bool> test: test_r && test_t_pos && test_t_wrap;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
* Add cross_axis_constraint parameter to Item::layout_info VTable
* Interpreter: two-pass flexbox_layout_data with cross-axis constraint
* Compiler: pass cross-axis constraint through ImplicitLayoutInfo
* Fix binding loop regression and cross-axis constraint detection
* Enable measure callback in compiled flex solve for height-for-width

See individual commit logs for more details