### PR TITLE
Disable parley metric quantization to fix text vertical alignment

### DIFF
--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -190,7 +190,7 @@ impl LayoutWithoutLineBreaksBuilder {
         font_ctx: &'a mut parley::FontContext,
         text: &'a str,
     ) -> parley::RangedBuilder<'a, Brush> {
-        let mut builder = layout_ctx.ranged_builder(font_ctx, text, self.scale_factor.get(), true);
+        let mut builder = layout_ctx.ranged_builder(font_ctx, text, self.scale_factor.get(), false);
 
         if let Some(ref font_request) = self.font_request {
             let mut fallback_family_iter = sharedfontique::FALLBACK_FAMILIES


### PR DESCRIPTION
Parley's quantization rounds ascent and descent independently before computing leading. For fractional metrics like ascent=19.896 and descent=5.942 (line_height=25.838), this overshoots line_height:

    // parley/src/layout/line_break.rs
    let (ascent, descent) = if quantize {
        (line.metrics.ascent.round(), line.metrics.descent.round())
        // 19.896.round() = 20, 5.942.round() = 6
    };

    let leading = line.metrics.line_height - (ascent + descent);
    // 25.838 - 26 = -0.162
    let above = (leading * 0.5).floor();
    // (-0.081).floor() = -1
    baseline = ascent + leading_above;
    // 20 + (-1) = 19

This shifts the baseline down by 1px compared to the unquantized baseline of 19.896.

This is particularly triggered by our widget styles which specify font sizes as rem multiplications (e.g. `14 * 0.0769rem`), producing fractional physical pixel sizes that lead to fractional metrics.

Since we already round glyph positions to pixel boundaries in the renderers, parley's quantization is redundant and causes this artifact.

Fixes #9751

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
