### PR TITLE
compiler: store embedded resource path inside the struct

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -603,8 +603,10 @@ pub fn compile_with_output_path(
     write!(code_formatter, "{generated}").map_err(CompileError::SaveError)?;
     dependencies.push(input_slint_file_path.as_ref().to_path_buf());
 
-    for resource in doc.embedded_file_resources.borrow().keys() {
-        if !resource.starts_with("builtin:") {
+    for er in doc.embedded_file_resources.borrow().iter() {
+        if let Some(resource) = er.path.as_deref()
+            && !resource.starts_with("builtin:")
+        {
             dependencies.push(Path::new(resource).to_path_buf());
         }
     }

--- a/internal/compiler/embedded_resources.rs
+++ b/internal/compiler/embedded_resources.rs
@@ -107,8 +107,22 @@ pub enum EmbeddedResourcesKind {
 
 #[derive(Debug, Clone)]
 pub struct EmbeddedResources {
-    /// unique integer id, that can be used by the generator for symbol generation.
-    pub id: usize,
+    /// Path on disk of the resource, or `None` for in-memory payloads such as data URIs.
+    pub path: Option<smol_str::SmolStr>,
 
     pub kind: EmbeddedResourcesKind,
 }
+
+/// Index of an [`EmbeddedResources`] entry in [`crate::object_tree::Document::embedded_file_resources`].
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    derive_more::Into,
+    derive_more::From,
+    derive_more::Display,
+)]
+pub struct EmbeddedResourcesIdx(pub usize);

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1836,8 +1836,8 @@ pub enum EasingCurve {
 pub enum ImageReference {
     None,
     AbsolutePath(SmolStr),
-    EmbeddedData { resource_id: usize, extension: String },
-    EmbeddedTexture { resource_id: usize },
+    EmbeddedData { resource_id: crate::embedded_resources::EmbeddedResourcesIdx, extension: String },
+    EmbeddedTexture { resource_id: crate::embedded_resources::EmbeddedResourcesIdx },
 }
 
 /// Print the expression as a .slint code (not necessarily valid .slint)

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -717,8 +717,8 @@ pub fn generate(
 
     let mut file = generate_types(&doc.used_types.borrow().structs_and_enums, &config);
 
-    for (path, er) in doc.embedded_file_resources.borrow().iter() {
-        embed_resource(er, path, &mut file.resources);
+    for (resource_id, er) in doc.embedded_file_resources.borrow().iter_enumerated() {
+        embed_resource(er, resource_id, &mut file.resources);
     }
 
     let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
@@ -958,18 +958,21 @@ fn expand_data_to_cpp_u8_array(data: &[u8]) -> String {
 
 fn embed_resource(
     resource: &crate::embedded_resources::EmbeddedResources,
-    path: &SmolStr,
+    resource_id: crate::embedded_resources::EmbeddedResourcesIdx,
     declarations: &mut Vec<Declaration>,
 ) {
     match &resource.kind {
         crate::embedded_resources::EmbeddedResourcesKind::ListOnly => {}
         crate::embedded_resources::EmbeddedResourcesKind::FileData => {
-            let resource_file = crate::fileaccess::load_file(std::path::Path::new(path)).unwrap(); // embedding pass ensured that the file exists
+            let resource_file = crate::fileaccess::load_file(std::path::Path::new(
+                resource.path.as_deref().unwrap(),
+            ))
+            .unwrap(); // embedding pass ensured that the file exists
             let data = resource_file.read();
 
             declarations.push(Declaration::Var(Var {
                 ty: "const uint8_t".into(),
-                name: format_smolstr!("slint_embedded_resource_{}", resource.id),
+                name: format_smolstr!("slint_embedded_resource_{}", resource_id),
                 array_size: Some(data.len()),
                 init: Some(expand_data_to_cpp_u8_array(data.as_ref())),
                 ..Default::default()
@@ -978,7 +981,7 @@ fn embed_resource(
         crate::embedded_resources::EmbeddedResourcesKind::DataUriPayload(data, _) => {
             declarations.push(Declaration::Var(Var {
                 ty: "const uint8_t".into(),
-                name: format_smolstr!("slint_embedded_resource_{}", resource.id),
+                name: format_smolstr!("slint_embedded_resource_{}", resource_id),
                 array_size: Some(data.len()),
                 init: Some(expand_data_to_cpp_u8_array(data)),
                 ..Default::default()
@@ -1004,7 +1007,7 @@ fn embed_resource(
             };
             let count = data.len();
             let data = data.iter().map(ToString::to_string).join(", ");
-            let data_name = format_smolstr!("slint_embedded_resource_{}_data", resource.id);
+            let data_name = format_smolstr!("slint_embedded_resource_{}_data", resource_id);
             declarations.push(Declaration::Var(Var {
                 ty: "const uint8_t".into(),
                 name: data_name.clone(),
@@ -1012,7 +1015,7 @@ fn embed_resource(
                 init: Some(format!("{{ {data} }}")),
                 ..Default::default()
             }));
-            let texture_name = format_smolstr!("slint_embedded_resource_{}_texture", resource.id);
+            let texture_name = format_smolstr!("slint_embedded_resource_{}_texture", resource_id);
             declarations.push(Declaration::Var(Var {
                 ty: "const slint::cbindgen_private::types::StaticTexture".into(),
                 name: texture_name.clone(),
@@ -1037,7 +1040,7 @@ fn embed_resource(
             );
             declarations.push(Declaration::Var(Var {
                 ty: "const slint::cbindgen_private::types::StaticTextures".into(),
-                name: format_smolstr!("slint_embedded_resource_{}", resource.id),
+                name: format_smolstr!("slint_embedded_resource_{}", resource_id),
                 array_size: None,
                 init: Some(init),
                 ..Default::default()
@@ -1060,7 +1063,7 @@ fn embed_resource(
             },
         ) => {
             let family_name_var =
-                format_smolstr!("slint_embedded_resource_{}_family_name", resource.id);
+                format_smolstr!("slint_embedded_resource_{}_family_name", resource_id);
             let family_name_size = family_name.len();
             declarations.push(Declaration::Var(Var {
                 ty: "const uint8_t".into(),
@@ -1073,7 +1076,7 @@ fn embed_resource(
                 ..Default::default()
             }));
 
-            let charmap_var = format_smolstr!("slint_embedded_resource_{}_charmap", resource.id);
+            let charmap_var = format_smolstr!("slint_embedded_resource_{}_charmap", resource_id);
             let charmap_size = character_map.len();
             declarations.push(Declaration::Var(Var {
                 ty: "const slint::cbindgen_private::CharacterMapEntry".into(),
@@ -1098,7 +1101,7 @@ fn embed_resource(
                         ty: "const uint8_t".into(),
                         name: format_smolstr!(
                             "slint_embedded_resource_{}_gs_{}_gd_{}",
-                            resource.id,
+                            resource_id,
                             glyphset_index,
                             glyph_index
                         ),
@@ -1113,12 +1116,12 @@ fn embed_resource(
 
                 declarations.push(Declaration::Var(Var{
                     ty: "const slint::cbindgen_private::BitmapGlyph".into(),
-                    name: format_smolstr!("slint_embedded_resource_{}_glyphset_{}", resource.id, glyphset_index),
+                    name: format_smolstr!("slint_embedded_resource_{}_glyphset_{}", resource_id, glyphset_index),
                     array_size: Some(glyphset.glyph_data.len()),
                     init: Some(format!("{{ {} }}", glyphset.glyph_data.iter().enumerate().map(|(glyph_index, glyph)| {
                         format!("{{ .x = {}, .y = {}, .width = {}, .height = {}, .x_advance = {}, .data = slint::private_api::make_slice({}, {}) }}",
                         glyph.x, glyph.y, glyph.width, glyph.height, glyph.x_advance,
-                        format_args!("slint_embedded_resource_{}_gs_{}_gd_{}", resource.id, glyphset_index, glyph_index),
+                        format_args!("slint_embedded_resource_{}_gs_{}_gd_{}", resource_id, glyphset_index, glyph_index),
                         glyph.data.len()
                     )
                     }).join(", \n"))),
@@ -1127,7 +1130,7 @@ fn embed_resource(
             }
 
             let glyphsets_var =
-                format_smolstr!("slint_embedded_resource_{}_glyphsets", resource.id);
+                format_smolstr!("slint_embedded_resource_{}_glyphsets", resource_id);
             let glyphsets_size = glyphs.len();
             declarations.push(Declaration::Var(Var {
                 ty: "const slint::cbindgen_private::BitmapGlyphs".into(),
@@ -1140,7 +1143,7 @@ fn embed_resource(
                         .enumerate()
                         .map(|(glyphset_index, glyphset)| format!(
                             "{{ .pixel_size = {}, .glyph_data = slint::private_api::make_slice({}, {}) }}",
-                            glyphset.pixel_size, format_args!("slint_embedded_resource_{}_glyphset_{}", resource.id, glyphset_index), glyphset.glyph_data.len()
+                            glyphset.pixel_size, format_args!("slint_embedded_resource_{}_glyphset_{}", resource_id, glyphset_index), glyphset.glyph_data.len()
                         ))
                         .join(", \n")
                 )),
@@ -1165,7 +1168,7 @@ fn embed_resource(
 
             declarations.push(Declaration::Var(Var {
                 ty: "const slint::cbindgen_private::BitmapFont".into(),
-                name: format_smolstr!("slint_embedded_resource_{}", resource.id),
+                name: format_smolstr!("slint_embedded_resource_{}", resource_id),
                 array_size: None,
                 init: Some(init),
                 ..Default::default()

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2922,12 +2922,12 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     quote!(sp::Image::load_from_path(::std::path::Path::new(#path)).unwrap_or_default())
                 }
                 crate::expression_tree::ImageReference::EmbeddedData { resource_id, extension } => {
-                    let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);
+                    let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id.0);
                     let format = proc_macro2::Literal::byte_string(extension.as_bytes());
                     quote!(sp::load_image_from_embedded_data(#symbol.into(), sp::Slice::from_slice(#format)))
                 }
                 crate::expression_tree::ImageReference::EmbeddedTexture { resource_id } => {
-                    let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);
+                    let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id.0);
                     quote!(
                         sp::Image::from(sp::ImageInner::StaticTextures(&#symbol))
                     )
@@ -4372,15 +4372,16 @@ fn generate_resources(doc: &Document) -> Vec<TokenStream> {
 
     doc.embedded_file_resources
         .borrow()
-        .iter()
-        .map(|(path, er)| {
-            let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", er.id);
+        .iter_enumerated()
+        .map(|(resource_id, er)| {
+            let resource_id = resource_id.0;
+            let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);
             match &er.kind {
                 &crate::embedded_resources::EmbeddedResourcesKind::ListOnly => {
                     quote!()
                 },
                 crate::embedded_resources::EmbeddedResourcesKind::FileData => {
-                    let data = embedded_file_tokens(path);
+                    let data = embedded_file_tokens(er.path.as_deref().unwrap());
                     quote!(static #symbol: &'static [u8] = #data;)
                 }
                 crate::embedded_resources::EmbeddedResourcesKind::DataUriPayload(bytes, _) => {
@@ -4398,7 +4399,7 @@ fn generate_resources(doc: &Document) -> Vec<TokenStream> {
                     } else {
                         quote!(sp::Color::from_argb_encoded(0))
                     };
-                    let symbol_data = format_ident!("SLINT_EMBEDDED_RESOURCE_{}_DATA", er.id);
+                    let symbol_data = format_ident!("SLINT_EMBEDDED_RESOURCE_{}_DATA", resource_id);
                     let data_size = data.len();
                     quote!(
                         #link_section

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -57,10 +57,16 @@ pub struct Document {
     pub imports: Vec<ImportedTypes>,
     pub library_exports: HashMap<String, LibraryInfo>,
 
-    /// Map of resources that should be embedded in the generated code, indexed by their absolute path on
-    /// disk on the build system
-    pub embedded_file_resources:
-        RefCell<BTreeMap<SmolStr, crate::embedded_resources::EmbeddedResources>>,
+    /// Resources to embed in the generated code.
+    ///
+    /// The [`crate::embedded_resources::EmbeddedResourcesIdx`] is the identifier used by code generators.
+    /// Each entry's `path` is the absolute path on disk, or `None` for in-memory data URI payloads.
+    pub embedded_file_resources: RefCell<
+        typed_index_collections::TiVec<
+            crate::embedded_resources::EmbeddedResourcesIdx,
+            crate::embedded_resources::EmbeddedResources,
+        >,
+    >,
 
     #[cfg(feature = "bundle-translations")]
     pub translation_builder: Option<crate::translations::TranslationsBuilder>,

--- a/internal/compiler/passes/collect_custom_fonts.rs
+++ b/internal/compiler/passes/collect_custom_fonts.rs
@@ -3,12 +3,13 @@
 
 //! This pass extends the init code with font registration
 
+use crate::embedded_resources::EmbeddedResourcesIdx;
 use crate::{
     expression_tree::{BuiltinFunction, Expression, Unit},
     object_tree::*,
 };
 use smol_str::SmolStr;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 pub fn collect_custom_fonts<'a>(
     doc: &Document,
@@ -27,34 +28,23 @@ pub fn collect_custom_fonts<'a>(
         BuiltinFunction::RegisterCustomFontByPath
     };
 
-    let prepare_font_registration_argument: Box<dyn Fn(&SmolStr) -> Expression> = if embed_fonts {
-        Box::new(|font_path| {
-            Expression::NumberLiteral(
-                {
-                    let mut resources = doc.embedded_file_resources.borrow_mut();
-                    let resource_id = match resources.get(font_path) {
-                        Some(r) => r.id,
-                        None => {
-                            let id = resources.len();
-                            resources.insert(
-                                font_path.clone(),
-                                crate::embedded_resources::EmbeddedResources {
-                                    id,
-                                    kind:
-                                        crate::embedded_resources::EmbeddedResourcesKind::FileData,
-                                },
-                            );
-                            id
-                        }
-                    };
-                    resource_id as _
-                },
-                Unit::None,
-            )
-        })
-    } else {
-        Box::new(|font_path| Expression::StringLiteral(font_path.clone()))
-    };
+    let mut path_to_id = HashMap::<SmolStr, EmbeddedResourcesIdx>::new();
+    let mut prepare_font_registration_argument: Box<dyn FnMut(&SmolStr) -> Expression> =
+        if embed_fonts {
+            Box::new(|font_path| {
+                let resource_id = *path_to_id.entry(font_path.clone()).or_insert_with(|| {
+                    doc.embedded_file_resources.borrow_mut().push_and_get_key(
+                        crate::embedded_resources::EmbeddedResources {
+                            path: Some(font_path.clone()),
+                            kind: crate::embedded_resources::EmbeddedResourcesKind::FileData,
+                        },
+                    )
+                });
+                Expression::NumberLiteral(resource_id.0 as _, Unit::None)
+            })
+        } else {
+            Box::new(|font_path| Expression::StringLiteral(font_path.clone()))
+        };
 
     for c in doc.exported_roots() {
         c.init_code.borrow_mut().font_registration_code.extend(all_fonts.iter().map(|font_path| {

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -211,11 +211,9 @@ pub fn embed_glyphs<'a>(
     }
 
     let register_embedded_font = |path: &std::path::Path, embedded_bitmap_font: BitmapFont| {
-        let resource_id = doc.embedded_file_resources.borrow().len();
-        doc.embedded_file_resources.borrow_mut().insert(
-            format!("{}@w{}", path.to_string_lossy(), embedded_bitmap_font.weight).into(),
+        let resource_id = doc.embedded_file_resources.borrow_mut().push_and_get_key(
             crate::embedded_resources::EmbeddedResources {
-                id: resource_id,
+                path: Some(path.to_string_lossy().as_ref().into()),
                 kind: crate::embedded_resources::EmbeddedResourcesKind::BitmapFontData(
                     embedded_bitmap_font,
                 ),
@@ -225,7 +223,7 @@ pub fn embed_glyphs<'a>(
         for c in doc.exported_roots() {
             c.init_code.borrow_mut().font_registration_code.push(Expression::FunctionCall {
                 function: BuiltinFunction::RegisterBitmapFont.into(),
-                arguments: vec![Expression::NumberLiteral(resource_id as _, Unit::None)],
+                arguments: vec![Expression::NumberLiteral(resource_id.0 as _, Unit::None)],
                 source_location: None,
             });
         }

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -10,10 +10,11 @@ use crate::object_tree::*;
 use image::GenericImageView;
 use smol_str::SmolStr;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use typed_index_collections::TiVec;
 
 pub async fn embed_images(
     doc: &Document,
@@ -27,6 +28,7 @@ pub async fn embed_images(
     }
 
     let global_embedded_resources = &doc.embedded_file_resources;
+    let mut path_to_id = HashMap::<SmolStr, EmbeddedResourcesIdx>::new();
 
     let mut all_components = Vec::new();
     doc.visit_all_used_components(|c| all_components.push(c.clone()));
@@ -59,6 +61,7 @@ pub async fn embed_images(
                 e,
                 &mapped_urls,
                 global_embedded_resources,
+                &mut path_to_id,
                 embed_files,
                 scale_factor,
                 diag,
@@ -83,7 +86,8 @@ fn collect_image_urls_from_expression(
 fn embed_images_from_expression(
     e: &mut Expression,
     urls: &HashMap<SmolStr, Option<SmolStr>>,
-    global_embedded_resources: &RefCell<BTreeMap<SmolStr, EmbeddedResources>>,
+    global_embedded_resources: &RefCell<TiVec<EmbeddedResourcesIdx, EmbeddedResources>>,
+    path_to_id: &mut HashMap<SmolStr, EmbeddedResourcesIdx>,
     embed_files: EmbedResourcesKind,
     scale_factor: f32,
     diag: &mut BuildDiagnostics,
@@ -114,6 +118,7 @@ fn embed_images_from_expression(
         {
             let image_ref = embed_image(
                 global_embedded_resources,
+                path_to_id,
                 embed_files,
                 path,
                 scale_factor,
@@ -131,6 +136,7 @@ fn embed_images_from_expression(
             e,
             urls,
             global_embedded_resources,
+            path_to_id,
             embed_files,
             scale_factor,
             diag,
@@ -139,72 +145,69 @@ fn embed_images_from_expression(
 }
 
 fn embed_image(
-    global_embedded_resources: &RefCell<BTreeMap<SmolStr, EmbeddedResources>>,
+    global_embedded_resources: &RefCell<TiVec<EmbeddedResourcesIdx, EmbeddedResources>>,
+    path_to_id: &mut HashMap<SmolStr, EmbeddedResourcesIdx>,
     embed_files: EmbedResourcesKind,
     path: &str,
     _scale_factor: f32,
     diag: &mut BuildDiagnostics,
     source_location: &Option<crate::diagnostics::SourceLocation>,
 ) -> ImageReference {
-    let mut resources = global_embedded_resources.borrow_mut();
-    let maybe_id = resources.len();
-    let e = match resources.entry(path.into()) {
-        std::collections::btree_map::Entry::Occupied(e) => e.into_mut(),
-        std::collections::btree_map::Entry::Vacant(e) => {
-            // Check that the file exists, so that later we can unwrap safely in the generators, etc.
-            if embed_files == EmbedResourcesKind::ListAllResources {
-                // Really do nothing with the image!
-                e.insert(EmbeddedResources { id: maybe_id, kind: EmbeddedResourcesKind::ListOnly });
-                return ImageReference::None;
-            }
-
-            let Some(_file) = crate::fileaccess::load_file(std::path::Path::new(path)) else {
-                diag.push_error(format!("Cannot find image file {path}"), source_location);
-                return ImageReference::None;
-            };
-
-            #[cfg(feature = "software-renderer")]
-            if embed_files == EmbedResourcesKind::EmbedTextures {
-                match load_image(_file, _scale_factor) {
-                    Ok((img, source_format, original_size)) => {
-                        e.insert(EmbeddedResources {
-                            id: maybe_id,
-                            kind: EmbeddedResourcesKind::TextureData(generate_texture(
-                                img,
-                                source_format,
-                                original_size,
-                            )),
-                        });
-                        return ImageReference::EmbeddedTexture { resource_id: maybe_id };
-                    }
-                    Err(err) => {
-                        diag.push_error(
-                            format!("Cannot load image file {path}: {err}"),
-                            source_location,
-                        );
-                        return ImageReference::None;
-                    }
-                }
-            }
-
-            e.insert(EmbeddedResources { id: maybe_id, kind: EmbeddedResourcesKind::FileData })
-        }
+    let extension = || {
+        std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|x| x.to_string())
+            .unwrap_or_default()
     };
 
-    match e.kind {
-        #[cfg(feature = "software-renderer")]
-        EmbeddedResourcesKind::TextureData { .. } => {
-            ImageReference::EmbeddedTexture { resource_id: e.id }
-        }
-        _ => ImageReference::EmbeddedData {
-            resource_id: e.id,
-            extension: std::path::Path::new(path)
-                .extension()
-                .and_then(|e| e.to_str())
-                .map(|x| x.to_string())
-                .unwrap_or_default(),
-        },
+    if let Some(&resource_id) = path_to_id.get(path) {
+        return match global_embedded_resources.borrow()[resource_id].kind {
+            #[cfg(feature = "software-renderer")]
+            EmbeddedResourcesKind::TextureData { .. } => {
+                ImageReference::EmbeddedTexture { resource_id }
+            }
+            _ => ImageReference::EmbeddedData { resource_id, extension: extension() },
+        };
     }
+
+    let mut resources = global_embedded_resources.borrow_mut();
+    let mut push = |kind| {
+        let id = resources.push_and_get_key(EmbeddedResources { path: Some(path.into()), kind });
+        path_to_id.insert(path.into(), id);
+        id
+    };
+
+    if embed_files == EmbedResourcesKind::ListAllResources {
+        push(EmbeddedResourcesKind::ListOnly);
+        return ImageReference::None;
+    }
+
+    let Some(_file) = crate::fileaccess::load_file(std::path::Path::new(path)) else {
+        diag.push_error(format!("Cannot find image file {path}"), source_location);
+        return ImageReference::None;
+    };
+
+    #[cfg(feature = "software-renderer")]
+    if embed_files == EmbedResourcesKind::EmbedTextures {
+        return match load_image(_file, _scale_factor) {
+            Ok((img, source_format, original_size)) => {
+                let resource_id = push(EmbeddedResourcesKind::TextureData(generate_texture(
+                    img,
+                    source_format,
+                    original_size,
+                )));
+                ImageReference::EmbeddedTexture { resource_id }
+            }
+            Err(err) => {
+                diag.push_error(format!("Cannot load image file {path}: {err}"), source_location);
+                ImageReference::None
+            }
+        };
+    }
+
+    let resource_id = push(EmbeddedResourcesKind::FileData);
+    ImageReference::EmbeddedData { resource_id, extension: extension() }
 }
 
 #[cfg(feature = "software-renderer")]
@@ -474,7 +477,7 @@ fn load_image_from_data_uri(
 }
 
 fn embed_data_uri(
-    global_embedded_resources: &RefCell<BTreeMap<SmolStr, EmbeddedResources>>,
+    global_embedded_resources: &RefCell<TiVec<EmbeddedResourcesIdx, EmbeddedResources>>,
     data_uri: &str,
     _embed_files: EmbedResourcesKind,
     _scale_factor: f32,
@@ -490,9 +493,6 @@ fn embed_data_uri(
     };
 
     let mut resources = global_embedded_resources.borrow_mut();
-    let resource_id = resources.len();
-
-    let unique_key: SmolStr = format!("data:{}:{}", resource_id, extension).into();
 
     #[cfg(feature = "software-renderer")]
     if _embed_files == EmbedResourcesKind::EmbedTextures {
@@ -501,17 +501,14 @@ fn embed_data_uri(
             .map_err(|e| e.to_string())
         {
             Ok((img, source_format, original_size)) => {
-                resources.insert(
-                    unique_key,
-                    EmbeddedResources {
-                        id: resource_id,
-                        kind: EmbeddedResourcesKind::TextureData(generate_texture(
-                            img,
-                            source_format,
-                            original_size,
-                        )),
-                    },
-                );
+                let resource_id = resources.push_and_get_key(EmbeddedResources {
+                    path: None,
+                    kind: EmbeddedResourcesKind::TextureData(generate_texture(
+                        img,
+                        source_format,
+                        original_size,
+                    )),
+                });
                 return ImageReference::EmbeddedTexture { resource_id };
             }
             Err(err) => {
@@ -521,13 +518,10 @@ fn embed_data_uri(
         }
     }
 
-    resources.insert(
-        unique_key,
-        EmbeddedResources {
-            id: resource_id,
-            kind: EmbeddedResourcesKind::DataUriPayload(decoded_data, extension.clone()),
-        },
-    );
+    let resource_id = resources.push_and_get_key(EmbeddedResources {
+        path: None,
+        kind: EmbeddedResourcesKind::DataUriPayload(decoded_data, extension.clone()),
+    });
 
     ImageReference::EmbeddedData { resource_id, extension }
 }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -237,9 +237,10 @@ fn main() -> std::io::Result<()> {
                 write!(cursor, " {}", x.display())?;
             }
         }
-        for resource in doc.embedded_file_resources.borrow().keys() {
-            if !fileaccess::load_file(std::path::Path::new(resource))
-                .is_some_and(|f| f.is_builtin())
+        for er in doc.embedded_file_resources.borrow().iter() {
+            if let Some(resource) = er.path.as_deref()
+                && !fileaccess::load_file(std::path::Path::new(resource))
+                    .is_some_and(|f| f.is_builtin())
             {
                 write!(cursor, " {resource}")?;
             }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -237,13 +237,18 @@ fn main() -> std::io::Result<()> {
                 write!(cursor, " {}", x.display())?;
             }
         }
-        for er in doc.embedded_file_resources.borrow().iter() {
-            if let Some(resource) = er.path.as_deref()
-                && !fileaccess::load_file(std::path::Path::new(resource))
+        // A variable font is stored once per weight, so dedupe here.
+        let embedded = doc.embedded_file_resources.borrow();
+        let resources: std::collections::BTreeSet<&str> = embedded
+            .iter()
+            .filter_map(|er| er.path.as_deref())
+            .filter(|resource| {
+                !fileaccess::load_file(std::path::Path::new(resource))
                     .is_some_and(|f| f.is_builtin())
-            {
-                write!(cursor, " {resource}")?;
-            }
+            })
+            .collect();
+        for resource in resources {
+            write!(cursor, " {resource}")?;
         }
         writeln!(cursor)?;
         fileaccess::write_file_if_changed(&depfile, &cursor.into_inner())?;

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1061,8 +1061,8 @@ fn extract_resources(
         result.extend(
             doc.embedded_file_resources
                 .borrow()
-                .keys()
-                .filter_map(|fp| Url::from_file_path(fp).ok()),
+                .iter()
+                .filter_map(|er| Url::from_file_path(er.path.as_deref()?).ok()),
         );
     }
 


### PR DESCRIPTION
Change Document::embedded_file_resources from a BTreeMap keyed by path to a TiVec indexed by a typed EmbeddedResourcesIdx. The path moves into the EmbeddedResources struct itself.

Variable-font embedding pushed several entries for the same font file (one per weight) and worked around the unique-key requirement by appending an "@w{weight}" suffix to the path.
That suffix leaked into consumers that expected real file paths. Fixes: #11360

Data URI payloads aren't file-backed and previously had a synthetic "data:{id}:{ext}" path that only existed to keep the BTreeMap key unique. The path field is now Option<SmolStr> and data URI entries store None; consumers iterating dependencies skip entries without a path.
