### PR TITLE
Drive MCP tool definitions and dispatch from proto messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5020,6 +5020,7 @@ dependencies = [
  "pbjson-build",
  "prost",
  "prost-build",
+ "prost-types",
  "protox",
  "serde",
  "serde_json",

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -31,6 +31,7 @@ system-testing = [
   "byteorder",
   "image",
   "prost-build",
+  "prost-types",
   "pbjson-build",
   "protox",
 ]
@@ -46,6 +47,7 @@ mcp = [
   "base64",
   "httparse",
   "prost-build",
+  "prost-types",
   "pbjson-build",
   "protox",
 ]
@@ -70,6 +72,7 @@ include_dir = { version = "0.7", optional = true }
 [build-dependencies]
 prost = { version = "0.14", optional = true }
 prost-build = { version = "0.14", optional = true }
+prost-types = { version = "0.14", optional = true }
 pbjson-build = { version = "0.9", optional = true }
 protox = { version = "0.9", optional = true }
 

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -13,6 +13,9 @@ fn main() {
             .expect("failed to compile slint_systest.proto");
         let descriptor_bytes = fds.encode_to_vec();
 
+        #[cfg(feature = "mcp")]
+        generate_mcp_schemas(&fds, &out_dir);
+
         prost_build::Config::new()
             .compile_fds(fds)
             .expect("failed to generate Rust code from proto descriptors");
@@ -24,4 +27,209 @@ fn main() {
             .build(&[".proto"])
             .expect("failed to generate serde impls from proto descriptors");
     }
+}
+
+/// Generate JSON schemas for proto Request* messages, used by the MCP server
+/// to build tool definitions from the proto source of truth.
+#[cfg(any(feature = "system-testing", feature = "mcp"))]
+fn generate_mcp_schemas(
+    fds: &prost_types::FileDescriptorSet,
+    out_dir: &std::path::Path,
+) {
+    use std::fmt::Write;
+
+    let file_desc = fds
+        .file
+        .iter()
+        .find(|f| f.name.as_deref() == Some("slint_systest.proto"))
+        .expect("slint_systest.proto descriptor not found");
+
+    // Collect enum definitions: name -> list of variant names
+    let mut enums = std::collections::HashMap::new();
+    for e in &file_desc.enum_type {
+        let name = e.name.as_deref().unwrap_or_default();
+        let variants: Vec<String> =
+            e.value.iter().filter_map(|v| v.name.clone()).collect();
+        enums.insert(name.to_string(), variants);
+    }
+
+    // Collect message definitions for nested lookups
+    let messages: std::collections::HashMap<String, &prost_types::DescriptorProto> = file_desc
+        .message_type
+        .iter()
+        .filter_map(|m: &prost_types::DescriptorProto| m.name.as_ref().map(|n| (n.clone(), m)))
+        .collect();
+
+    // Generate JSON schema strings for each Request* message
+    let mut code = String::new();
+    writeln!(
+        &mut code,
+        "/// Auto-generated from slint_systest.proto — do not edit."
+    )
+    .unwrap();
+    writeln!(
+        &mut code,
+        "pub fn proto_input_schema(message_name: &str) -> Option<serde_json::Value> {{"
+    )
+    .unwrap();
+    writeln!(&mut code, "    match message_name {{").unwrap();
+
+    for msg in &file_desc.message_type {
+        let msg_name = msg.name.as_deref().unwrap_or_default();
+        if !msg_name.starts_with("Request") {
+            continue;
+        }
+
+        let schema = message_to_json_schema(msg, &messages, &enums);
+        writeln!(
+            &mut code,
+            "        {msg_name:?} => Some(serde_json::json!({schema})),"
+        )
+        .unwrap();
+    }
+
+    writeln!(&mut code, "        _ => None,").unwrap();
+    writeln!(&mut code, "    }}").unwrap();
+    writeln!(&mut code, "}}").unwrap();
+
+    // Also generate a list of field names (camelCase) for each message
+    writeln!(&mut code).unwrap();
+    writeln!(
+        &mut code,
+        "/// Returns the camelCase field names of a proto request message."
+    )
+    .unwrap();
+    writeln!(
+        &mut code,
+        "pub fn proto_field_names(message_name: &str) -> Option<&'static [&'static str]> {{"
+    )
+    .unwrap();
+    writeln!(&mut code, "    match message_name {{").unwrap();
+
+    for msg in &file_desc.message_type {
+        let msg_name = msg.name.as_deref().unwrap_or_default();
+        if !msg_name.starts_with("Request") {
+            continue;
+        }
+        let fields: Vec<String> = msg
+            .field
+            .iter()
+            .filter_map(|f| f.name.as_ref().map(|n| snake_to_camel(n)))
+            .collect();
+        let fields_str: Vec<String> = fields.iter().map(|f| format!("{f:?}")).collect();
+        writeln!(
+            &mut code,
+            "        {msg_name:?} => Some(&[{}]),",
+            fields_str.join(", ")
+        )
+        .unwrap();
+    }
+
+    writeln!(&mut code, "        _ => None,").unwrap();
+    writeln!(&mut code, "    }}").unwrap();
+    writeln!(&mut code, "}}").unwrap();
+
+    std::fs::write(out_dir.join("mcp_schemas.rs"), code)
+        .expect("failed to write mcp_schemas.rs");
+}
+
+#[cfg(any(feature = "system-testing", feature = "mcp"))]
+fn message_to_json_schema(
+    msg: &prost_types::DescriptorProto,
+    messages: &std::collections::HashMap<String, &prost_types::DescriptorProto>,
+    enums: &std::collections::HashMap<String, Vec<String>>,
+) -> String {
+    use std::fmt::Write;
+
+    let mut props = String::new();
+    let mut first = true;
+    for field in &msg.field {
+        let name = field.name.as_deref().unwrap_or_default();
+        let camel_name = snake_to_camel(name);
+        let field_type = field.r#type();
+        let is_repeated =
+            field.label == Some(prost_types::field_descriptor_proto::Label::Repeated as i32);
+
+        let mut type_schema = match field_type {
+            prost_types::field_descriptor_proto::Type::Double
+            | prost_types::field_descriptor_proto::Type::Float => {
+                r#"{"type": "number"}"#.to_string()
+            }
+            prost_types::field_descriptor_proto::Type::Int32
+            | prost_types::field_descriptor_proto::Type::Uint32
+            | prost_types::field_descriptor_proto::Type::Sint32
+            | prost_types::field_descriptor_proto::Type::Fixed32
+            | prost_types::field_descriptor_proto::Type::Sfixed32 => {
+                r#"{"type": "integer"}"#.to_string()
+            }
+            prost_types::field_descriptor_proto::Type::Int64
+            | prost_types::field_descriptor_proto::Type::Uint64
+            | prost_types::field_descriptor_proto::Type::Sint64
+            | prost_types::field_descriptor_proto::Type::Fixed64
+            | prost_types::field_descriptor_proto::Type::Sfixed64 => {
+                // pbjson serializes 64-bit integers as strings
+                r#"{"type": "string"}"#.to_string()
+            }
+            prost_types::field_descriptor_proto::Type::Bool => {
+                r#"{"type": "boolean"}"#.to_string()
+            }
+            prost_types::field_descriptor_proto::Type::String => {
+                r#"{"type": "string"}"#.to_string()
+            }
+            prost_types::field_descriptor_proto::Type::Bytes => {
+                r#"{"type": "string"}"#.to_string()
+            }
+            prost_types::field_descriptor_proto::Type::Enum => {
+                let type_name = field.type_name.as_deref().unwrap_or_default();
+                let short_name = type_name.rsplit('.').next().unwrap_or(type_name);
+                if let Some(variants) = enums.get(short_name) {
+                    let vs: Vec<String> =
+                        variants.iter().map(|v| format!("{v:?}")).collect();
+                    format!(r#"{{"type": "string", "enum": [{}]}}"#, vs.join(", "))
+                } else {
+                    r#"{"type": "string"}"#.to_string()
+                }
+            }
+            prost_types::field_descriptor_proto::Type::Message => {
+                let type_name = field.type_name.as_deref().unwrap_or_default();
+                let short_name = type_name.rsplit('.').next().unwrap_or(type_name);
+                if let Some(nested_msg) = messages.get(short_name) {
+                    message_to_json_schema(nested_msg, messages, enums)
+                } else {
+                    r#"{"type": "object"}"#.to_string()
+                }
+            }
+            _ => r#"{"type": "string"}"#.to_string(),
+        };
+
+        if is_repeated {
+            type_schema = format!(r#"{{"type": "array", "items": {type_schema}}}"#);
+        }
+
+        if !first {
+            write!(&mut props, ", ").unwrap();
+        }
+        first = false;
+        write!(&mut props, "{camel_name:?}: {type_schema}").unwrap();
+    }
+
+    // Required fields are handled at runtime by the tool metadata table.
+    format!(r#"{{"type": "object", "properties": {{{props}}}}}"#)
+}
+
+#[cfg(any(feature = "system-testing", feature = "mcp"))]
+fn snake_to_camel(s: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = false;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
+        }
+    }
+    result
 }

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -32,10 +32,7 @@ fn main() {
 /// Generate JSON schemas for proto Request* messages, used by the MCP server
 /// to build tool definitions from the proto source of truth.
 #[cfg(any(feature = "system-testing", feature = "mcp"))]
-fn generate_mcp_schemas(
-    fds: &prost_types::FileDescriptorSet,
-    out_dir: &std::path::Path,
-) {
+fn generate_mcp_schemas(fds: &prost_types::FileDescriptorSet, out_dir: &std::path::Path) {
     use std::fmt::Write;
 
     let file_desc = fds
@@ -48,8 +45,7 @@ fn generate_mcp_schemas(
     let mut enums = std::collections::HashMap::new();
     for e in &file_desc.enum_type {
         let name = e.name.as_deref().unwrap_or_default();
-        let variants: Vec<String> =
-            e.value.iter().filter_map(|v| v.name.clone()).collect();
+        let variants: Vec<String> = e.value.iter().filter_map(|v| v.name.clone()).collect();
         enums.insert(name.to_string(), variants);
     }
 
@@ -62,11 +58,7 @@ fn generate_mcp_schemas(
 
     // Generate JSON schema strings for each Request* message
     let mut code = String::new();
-    writeln!(
-        &mut code,
-        "/// Auto-generated from slint_systest.proto — do not edit."
-    )
-    .unwrap();
+    writeln!(&mut code, "/// Auto-generated from slint_systest.proto — do not edit.").unwrap();
     writeln!(
         &mut code,
         "pub fn proto_input_schema(message_name: &str) -> Option<serde_json::Value> {{"
@@ -81,11 +73,7 @@ fn generate_mcp_schemas(
         }
 
         let schema = message_to_json_schema(msg, &messages, &enums);
-        writeln!(
-            &mut code,
-            "        {msg_name:?} => Some(serde_json::json!({schema})),"
-        )
-        .unwrap();
+        writeln!(&mut code, "        {msg_name:?} => Some(serde_json::json!({schema})),").unwrap();
     }
 
     writeln!(&mut code, "        _ => None,").unwrap();
@@ -94,11 +82,8 @@ fn generate_mcp_schemas(
 
     // Also generate a list of field names (camelCase) for each message
     writeln!(&mut code).unwrap();
-    writeln!(
-        &mut code,
-        "/// Returns the camelCase field names of a proto request message."
-    )
-    .unwrap();
+    writeln!(&mut code, "/// Returns the camelCase field names of a proto request message.")
+        .unwrap();
     writeln!(
         &mut code,
         "pub fn proto_field_names(message_name: &str) -> Option<&'static [&'static str]> {{"
@@ -111,26 +96,17 @@ fn generate_mcp_schemas(
         if !msg_name.starts_with("Request") {
             continue;
         }
-        let fields: Vec<String> = msg
-            .field
-            .iter()
-            .filter_map(|f| f.name.as_ref().map(|n| snake_to_camel(n)))
-            .collect();
+        let fields: Vec<String> =
+            msg.field.iter().filter_map(|f| f.name.as_ref().map(|n| snake_to_camel(n))).collect();
         let fields_str: Vec<String> = fields.iter().map(|f| format!("{f:?}")).collect();
-        writeln!(
-            &mut code,
-            "        {msg_name:?} => Some(&[{}]),",
-            fields_str.join(", ")
-        )
-        .unwrap();
+        writeln!(&mut code, "        {msg_name:?} => Some(&[{}]),", fields_str.join(", ")).unwrap();
     }
 
     writeln!(&mut code, "        _ => None,").unwrap();
     writeln!(&mut code, "    }}").unwrap();
     writeln!(&mut code, "}}").unwrap();
 
-    std::fs::write(out_dir.join("mcp_schemas.rs"), code)
-        .expect("failed to write mcp_schemas.rs");
+    std::fs::write(out_dir.join("mcp_schemas.rs"), code).expect("failed to write mcp_schemas.rs");
 }
 
 #[cfg(any(feature = "system-testing", feature = "mcp"))]
@@ -170,21 +146,16 @@ fn message_to_json_schema(
                 // pbjson serializes 64-bit integers as strings
                 r#"{"type": "string"}"#.to_string()
             }
-            prost_types::field_descriptor_proto::Type::Bool => {
-                r#"{"type": "boolean"}"#.to_string()
-            }
+            prost_types::field_descriptor_proto::Type::Bool => r#"{"type": "boolean"}"#.to_string(),
             prost_types::field_descriptor_proto::Type::String => {
                 r#"{"type": "string"}"#.to_string()
             }
-            prost_types::field_descriptor_proto::Type::Bytes => {
-                r#"{"type": "string"}"#.to_string()
-            }
+            prost_types::field_descriptor_proto::Type::Bytes => r#"{"type": "string"}"#.to_string(),
             prost_types::field_descriptor_proto::Type::Enum => {
                 let type_name = field.type_name.as_deref().unwrap_or_default();
                 let short_name = type_name.rsplit('.').next().unwrap_or(type_name);
                 if let Some(variants) = enums.get(short_name) {
-                    let vs: Vec<String> =
-                        variants.iter().map(|v| format!("{v:?}")).collect();
+                    let vs: Vec<String> = variants.iter().map(|v| format!("{v:?}")).collect();
                     format!(r#"{{"type": "string", "enum": [{}]}}"#, vs.join(", "))
                 } else {
                     r#"{"type": "string"}"#.to_string()

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -24,166 +24,131 @@ use crate::introspection::{self, IntrospectionState, proto};
 use introspection::{handle_to_index, index_to_handle};
 
 // ============================================================================
-// Tool definitions (schema for tools/list)
+// Tool definitions (schema driven by proto messages)
 // ============================================================================
 
-fn tool_definitions() -> Value {
-    let handle_schema = serde_json::json!({
-        "type": "object",
-        "properties": {
-            "index": { "type": "string", "description": "Arena index (uint64 as string)" },
-            "generation": { "type": "string", "description": "Arena generation (uint64 as string)" }
-        },
-        "required": ["index", "generation"]
-    });
+mod mcp_schemas {
+    include!(concat!(env!("OUT_DIR"), "/mcp_schemas.rs"));
+}
 
-    serde_json::json!({
-        "tools": [
-            {
-                "name": "list_windows",
-                "description": "List all open windows. Returns an array of window handles. Call this first to discover available windows.",
-                "inputSchema": { "type": "object", "properties": {} }
-            },
-            {
-                "name": "get_window_properties",
-                "description": "Get a window's physical size (pixels), position, fullscreen/maximized/minimized state, and rootElementHandle — the entry point for element tree traversal.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "windowHandle": handle_schema.clone()
-                    },
-                    "required": ["windowHandle"]
-                }
-            },
-            {
-                "name": "get_element_tree",
-                "description": "Get a flat list of elements in the subtree rooted at the given element. Each entry includes type names, IDs, accessibility properties, geometry, and a handle for further queries. Use maxElements to control the result size (default: 200, max: 1000). If truncated is true, there are more elements — use query_element_descendants for targeted searches instead.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "elementHandle": handle_schema.clone(),
-                        "maxElements": { "type": "integer", "description": "Maximum elements to return (default: 200, max: 1000)." }
-                    },
-                    "required": ["elementHandle"]
-                }
-            },
-            {
-                "name": "get_element_properties",
-                "description": "Get full details of a single element: type names and IDs (including inherited bases), all accessible properties (role, label, value, description, checked, enabled, read-only, placeholder, value min/max/step), logical size and position, computed opacity, and layout kind.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "elementHandle": handle_schema.clone()
-                    },
-                    "required": ["elementHandle"]
-                }
-            },
-            {
-                "name": "find_elements_by_id",
-                "description": "Find elements by qualified ID (format: 'ComponentName::element-id', e.g. 'App::my-button'). Returns element handles. Use get_element_tree first to discover available IDs.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "windowHandle": handle_schema.clone(),
-                        "elementsId": { "type": "string", "description": "Qualified element ID (e.g. 'App::my-button')." }
-                    },
-                    "required": ["windowHandle", "elementsId"]
-                }
-            },
-            {
-                "name": "query_element_descendants",
-                "description": "Search descendants of an element using a query pipeline. Pass an array of instructions applied in order: {\"matchDescendants\": true} to recurse, then filter by {\"matchElementId\": \"...\"}, {\"matchElementTypeName\": \"...\"}, {\"matchElementTypeNameOrBase\": \"...\"}, or {\"matchElementAccessibleRole\": \"Button\"}. More efficient than get_element_tree for targeted lookups.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "elementHandle": handle_schema.clone(),
-                        "queryStack": {
-                            "type": "array",
-                            "description": "Query pipeline: array of objects, each with exactly one instruction field.",
-                            "items": { "type": "object" }
-                        },
-                        "findAll": { "type": "boolean", "description": "Return all matches (default: true). Set to false for first match only." }
-                    },
-                    "required": ["elementHandle", "queryStack"]
-                }
-            },
-            {
-                "name": "take_screenshot",
-                "description": "Capture a PNG screenshot of a window. Returns an MCP image content block rendered inline by the client. Use after interactions to verify visual results.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "windowHandle": handle_schema.clone()
-                    },
-                    "required": ["windowHandle"]
-                }
-            },
-            {
-                "name": "click_element",
-                "description": "Simulate a mouse click at the center of an element. Omit action/button for a left single-click (the most common case).",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "elementHandle": handle_schema.clone(),
-                        "action": { "type": "string", "description": "'SingleClick' (default) or 'DoubleClick'." },
-                        "button": { "type": "string", "description": "'Left' (default), 'Right', or 'Middle'." }
-                    },
-                    "required": ["elementHandle"]
-                }
-            },
-            {
-                "name": "drag_element",
-                "description": "Simulate a drag gesture from the element's center to a target position (logical coordinates). The pointer is pressed at the element center, moved in interpolated steps to the target, then released. Use for sliders, scrollable areas, drag handles, or any element that responds to pointer movement while pressed.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "elementHandle": handle_schema.clone(),
-                        "targetX": { "type": "number", "description": "Target X position in logical coordinates." },
-                        "targetY": { "type": "number", "description": "Target Y position in logical coordinates." },
-                        "button": { "type": "string", "description": "'Left' (default), 'Right', or 'Middle'." }
-                    },
-                    "required": ["elementHandle", "targetX", "targetY"]
-                }
-            },
-            {
-                "name": "invoke_accessibility_action",
-                "description": "Invoke an accessibility action: 'Default_' (activate buttons, toggle checkboxes), 'Increment'/'Decrement' (sliders, spinboxes), 'Expand' (combo boxes). Preferred over click_element when the element's role suggests a semantic action.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "elementHandle": handle_schema.clone(),
-                        "action": { "type": "string", "description": "'Default_', 'Increment', 'Decrement', or 'Expand'." }
-                    },
-                    "required": ["elementHandle", "action"]
-                }
-            },
-            {
-                "name": "set_element_value",
-                "description": "Set the accessible value of an element. For text inputs: sets the text content. For sliders: pass the numeric value as a string (e.g. '42'). For other elements: sets whatever the element exposes as its accessible value.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "elementHandle": handle_schema.clone(),
-                        "value": { "type": "string", "description": "The value to set (always a string, even for numeric values)." }
-                    },
-                    "required": ["elementHandle", "value"]
-                }
-            },
-            {
-                "name": "dispatch_key_event",
-                "description": "Send a keyboard event to a window. Use 'press_and_release' (default) for typing characters. Use 'press'/'release' separately for modifier keys or key combinations.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "windowHandle": handle_schema.clone(),
-                        "text": { "type": "string", "description": "The key text (e.g. 'a', 'Enter', '\\t' for tab)." },
-                        "eventType": { "type": "string", "description": "'press_and_release' (default), 'press', or 'release'." }
-                    },
-                    "required": ["windowHandle", "text"]
+/// Metadata for each MCP tool, mapping it to its proto request message.
+struct ToolDef {
+    name: &'static str,
+    description: &'static str,
+    /// Name of the proto Request* message whose fields define the input schema.
+    request_type: &'static str,
+    /// camelCase field names that are optional (everything else is required).
+    optional_fields: &'static [&'static str],
+}
+
+const TOOLS: &[ToolDef] = &[
+    ToolDef {
+        name: "list_windows",
+        description: "List all open windows. Returns an array of window handles. Call this first to discover available windows.",
+        request_type: "RequestWindowListMessage",
+        optional_fields: &[],
+    },
+    ToolDef {
+        name: "get_window_properties",
+        description: "Get a window's physical size (pixels), position, fullscreen/maximized/minimized state, and rootElementHandle — the entry point for element tree traversal.",
+        request_type: "RequestWindowProperties",
+        optional_fields: &[],
+    },
+    ToolDef {
+        name: "get_element_tree",
+        description: "Get a flat list of elements in the subtree rooted at the given element. Each entry includes type names, IDs, accessibility properties, geometry, and a handle for further queries. Use maxElements to control the result size (default: 200, max: 1000). If truncated is true, there are more elements — use query_element_descendants for targeted searches instead.",
+        request_type: "RequestGetElementTree",
+        optional_fields: &["maxElements"],
+    },
+    ToolDef {
+        name: "get_element_properties",
+        description: "Get full details of a single element: type names and IDs (including inherited bases), all accessible properties (role, label, value, description, checked, enabled, read-only, placeholder, value min/max/step), logical size and position, computed opacity, and layout kind.",
+        request_type: "RequestElementProperties",
+        optional_fields: &[],
+    },
+    ToolDef {
+        name: "find_elements_by_id",
+        description: "Find elements by qualified ID (format: 'ComponentName::element-id', e.g. 'App::my-button'). Returns element handles. Use get_element_tree first to discover available IDs.",
+        request_type: "RequestFindElementsById",
+        optional_fields: &[],
+    },
+    ToolDef {
+        name: "query_element_descendants",
+        description: "Search descendants of an element using a query pipeline. Pass an array of instructions applied in order: {\"matchDescendants\": true} to recurse, then filter by {\"matchElementId\": \"...\"}, {\"matchElementTypeName\": \"...\"}, {\"matchElementTypeNameOrBase\": \"...\"}, or {\"matchElementAccessibleRole\": \"Button\"}. More efficient than get_element_tree for targeted lookups.",
+        request_type: "RequestQueryElementDescendants",
+        optional_fields: &["findAll"],
+    },
+    ToolDef {
+        name: "take_screenshot",
+        description: "Capture a PNG screenshot of a window. Returns an MCP image content block rendered inline by the client. Use after interactions to verify visual results.",
+        request_type: "RequestTakeSnapshot",
+        optional_fields: &["imageMimeType"],
+    },
+    ToolDef {
+        name: "click_element",
+        description: "Simulate a mouse click at the center of an element. Omit action/button for a left single-click (the most common case).",
+        request_type: "RequestElementClick",
+        optional_fields: &["action", "button"],
+    },
+    ToolDef {
+        name: "drag_element",
+        description: "Simulate a drag gesture from the element's center to a target position (logical coordinates). The pointer is pressed at the element center, moved in interpolated steps to the target, then released. Use for sliders, scrollable areas, drag handles, or any element that responds to pointer movement while pressed.",
+        request_type: "RequestElementDrag",
+        optional_fields: &["button"],
+    },
+    ToolDef {
+        name: "invoke_accessibility_action",
+        description: "Invoke an accessibility action: 'Default_' (activate buttons, toggle checkboxes), 'Increment'/'Decrement' (sliders, spinboxes), 'Expand' (combo boxes). Preferred over click_element when the element's role suggests a semantic action.",
+        request_type: "RequestInvokeElementAccessibilityAction",
+        optional_fields: &[],
+    },
+    ToolDef {
+        name: "set_element_value",
+        description: "Set the accessible value of an element. For text inputs: sets the text content. For sliders: pass the numeric value as a string (e.g. '42'). For other elements: sets whatever the element exposes as its accessible value.",
+        request_type: "RequestSetElementAccessibleValue",
+        optional_fields: &[],
+    },
+    ToolDef {
+        name: "dispatch_key_event",
+        description: "Send a keyboard event to a window. Use 'PressAndRelease' (default) for typing characters. Use 'Press'/'Release' separately for modifier keys or key combinations.",
+        request_type: "RequestDispatchKeyEvent",
+        optional_fields: &["eventType"],
+    },
+];
+
+fn tool_definitions() -> Value {
+    let tools: Vec<Value> = TOOLS
+        .iter()
+        .map(|def| {
+            let mut schema =
+                mcp_schemas::proto_input_schema(def.request_type).unwrap_or_else(|| {
+                    panic!("no proto schema for {}", def.request_type);
+                });
+
+            // Add "required" array: all fields except those listed as optional
+            if let Some(all_fields) = mcp_schemas::proto_field_names(def.request_type) {
+                let required: Vec<&str> = all_fields
+                    .iter()
+                    .filter(|f| !def.optional_fields.contains(f))
+                    .copied()
+                    .collect();
+                if !required.is_empty() {
+                    schema.as_object_mut().unwrap().insert(
+                        "required".to_string(),
+                        Value::Array(required.into_iter().map(|s| Value::String(s.into())).collect()),
+                    );
                 }
             }
-        ]
-    })
+
+            serde_json::json!({
+                "name": def.name,
+                "description": def.description,
+                "inputSchema": schema,
+            })
+        })
+        .collect();
+
+    serde_json::json!({ "tools": tools })
 }
 
 // ============================================================================
@@ -268,17 +233,11 @@ async fn handle_tool_call(
             ))
         }
         "get_element_tree" => {
-            // Custom tool not in proto — returns flat list of element properties with handles.
-            let element_handle: proto::Handle = args
-                .get("elementHandle")
-                .ok_or_else(|| "missing elementHandle".to_string())
-                .and_then(|v| {
-                    serde_json::from_value(v.clone())
-                        .map_err(|e| format!("invalid elementHandle: {e}"))
-                })?;
+            let p: proto::RequestGetElementTree = deserialize_params(args)?;
+            let element_handle =
+                p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?;
             let max_elements: usize =
-                args.get("maxElements").and_then(|v| v.as_u64()).unwrap_or(200).clamp(1, 1000)
-                    as usize;
+                if p.max_elements == 0 { 200 } else { (p.max_elements as usize).clamp(1, 1000) };
 
             let root_index = handle_to_index(element_handle);
             let root_element = state.element("get_element_tree", root_index)?;
@@ -354,38 +313,19 @@ async fn handle_tool_call(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
         }
-        // Custom tool: manual parameter parsing because the MCP schema uses flat
-        // targetX/targetY fields rather than the proto's nested LogicalPosition target.
         "drag_element" => {
-            let element_handle: proto::Handle = args
-                .get("elementHandle")
-                .ok_or_else(|| "missing elementHandle".to_string())
-                .and_then(|v| {
-                    serde_json::from_value(v.clone())
-                        .map_err(|e| format!("invalid elementHandle: {e}"))
-                })?;
-            let target_x: f32 =
-                args.get("targetX")
-                    .and_then(|v| v.as_f64())
-                    .ok_or_else(|| "missing targetX".to_string())? as f32;
-            let target_y: f32 =
-                args.get("targetY")
-                    .and_then(|v| v.as_f64())
-                    .ok_or_else(|| "missing targetY".to_string())? as f32;
-            let button_str = args.get("button").and_then(|v| v.as_str()).unwrap_or("Left");
-            let button = match button_str {
-                "Left" => i_slint_core::platform::PointerEventButton::Left,
-                "Right" => i_slint_core::platform::PointerEventButton::Right,
-                "Middle" => i_slint_core::platform::PointerEventButton::Middle,
-                other => {
-                    return Err(format!(
-                        "Unknown button: {other}. Use 'Left', 'Right', or 'Middle'."
-                    ));
-                }
-            };
-            let element_index = handle_to_index(element_handle);
+            let p: proto::RequestElementDrag = deserialize_params(args)?;
+            let element_index = handle_to_index(
+                p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
+            );
             let element = state.element("drag_element", element_index)?;
-            let target = i_slint_core::api::LogicalPosition::new(target_x, target_y);
+            let target_pos =
+                p.target.ok_or_else(|| "missing target position".to_string())?;
+            let target =
+                i_slint_core::api::LogicalPosition::new(target_pos.x, target_pos.y);
+            let button = proto::PointerEventButton::try_from(p.button)
+                .map_err(|_| format!("invalid button value: {}", p.button))?;
+            let button = introspection::convert_pointer_event_button(button);
             element.drag(target, button).await;
             let response = proto::ElementDragResponse {};
             Ok(ToolResult::Json(
@@ -419,40 +359,37 @@ async fn handle_tool_call(
             ))
         }
         "dispatch_key_event" => {
-            // Custom tool: simplified key event dispatch (not a direct proto mapping).
-            let window_handle: proto::Handle = args
-                .get("windowHandle")
-                .ok_or_else(|| "missing windowHandle".to_string())
-                .and_then(|v| {
-                    serde_json::from_value(v.clone())
-                        .map_err(|e| format!("invalid windowHandle: {e}"))
-                })?;
-            let text: String = args
-                .get("text")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| "missing text".to_string())?
-                .to_string();
-            let event_type =
-                args.get("eventType").and_then(|v| v.as_str()).unwrap_or("press_and_release");
-
-            let window_index = handle_to_index(window_handle);
+            let p: proto::RequestDispatchKeyEvent = deserialize_params(args)?;
+            let window_index = handle_to_index(
+                p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
+            );
+            let event_type = proto::KeyEventType::try_from(p.event_type)
+                .map_err(|_| format!("invalid eventType value: {}", p.event_type))?;
             let events: Vec<i_slint_core::platform::WindowEvent> = match event_type {
-                "press" => {
-                    vec![i_slint_core::platform::WindowEvent::KeyPressed { text: text.into() }]
+                proto::KeyEventType::Press => {
+                    vec![i_slint_core::platform::WindowEvent::KeyPressed {
+                        text: p.text.into(),
+                    }]
                 }
-                "release" => {
-                    vec![i_slint_core::platform::WindowEvent::KeyReleased { text: text.into() }]
+                proto::KeyEventType::Release => {
+                    vec![i_slint_core::platform::WindowEvent::KeyReleased {
+                        text: p.text.into(),
+                    }]
                 }
-                "press_and_release" => vec![
-                    i_slint_core::platform::WindowEvent::KeyPressed { text: text.clone().into() },
-                    i_slint_core::platform::WindowEvent::KeyReleased { text: text.into() },
+                proto::KeyEventType::PressAndRelease => vec![
+                    i_slint_core::platform::WindowEvent::KeyPressed {
+                        text: p.text.clone().into(),
+                    },
+                    i_slint_core::platform::WindowEvent::KeyReleased { text: p.text.into() },
                 ],
-                other => return Err(format!("Unknown eventType: {other}")),
             };
             for event in events {
                 state.dispatch_window_event(window_index, event)?;
             }
-            Ok(ToolResult::Json(serde_json::json!({ "success": true })))
+            let response = proto::DispatchKeyEventResponse {};
+            Ok(ToolResult::Json(
+                serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
+            ))
         }
         _ => Err(format!("Unknown tool: {name}")),
     }
@@ -534,8 +471,9 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "- PointerEventButton: Left, Right, Middle\n",
                     "- ClickAction: SingleClick, DoubleClick\n",
                     "- ElementAccessibilityAction: Default_, Increment, Decrement, Expand\n",
+                    "- KeyEventType: PressAndRelease, Press, Release\n",
                     "- LayoutKind: NotALayout, HorizontalLayout, VerticalLayout, GridLayout, FlexboxLayout\n",
-                    "Omitted enum fields default to the first value (e.g. Left, SingleClick).\n\n",
+                    "Omitted enum fields default to the first value (e.g. Left, SingleClick, PressAndRelease).\n\n",
 
                     "# Query instructions\n\n",
                     "query_element_descendants takes a queryStack array. Each entry is an object with exactly one field:\n",
@@ -1106,6 +1044,36 @@ mod tests {
             assert!(tool.get("name").and_then(|v| v.as_str()).is_some());
             assert!(tool.get("description").and_then(|v| v.as_str()).is_some());
             assert_eq!(tool["inputSchema"]["type"], "object");
+        }
+    }
+
+    #[test]
+    fn test_all_tools_have_proto_schemas() {
+        for def in TOOLS {
+            assert!(
+                mcp_schemas::proto_input_schema(def.request_type).is_some(),
+                "tool {:?} references unknown proto message {:?}",
+                def.name,
+                def.request_type,
+            );
+            assert!(
+                mcp_schemas::proto_field_names(def.request_type).is_some(),
+                "tool {:?} has no field names for {:?}",
+                def.name,
+                def.request_type,
+            );
+            // Verify optional_fields are actual fields of the message
+            let field_names = mcp_schemas::proto_field_names(def.request_type).unwrap();
+            for opt in def.optional_fields {
+                assert!(
+                    field_names.contains(opt),
+                    "tool {:?} lists optional field {:?} not in proto message {:?} (fields: {:?})",
+                    def.name,
+                    opt,
+                    def.request_type,
+                    field_names,
+                );
+            }
         }
     }
 

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -135,7 +135,9 @@ fn tool_definitions() -> Value {
                 if !required.is_empty() {
                     schema.as_object_mut().unwrap().insert(
                         "required".to_string(),
-                        Value::Array(required.into_iter().map(|s| Value::String(s.into())).collect()),
+                        Value::Array(
+                            required.into_iter().map(|s| Value::String(s.into())).collect(),
+                        ),
                     );
                 }
             }
@@ -319,10 +321,8 @@ async fn handle_tool_call(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             );
             let element = state.element("drag_element", element_index)?;
-            let target_pos =
-                p.target.ok_or_else(|| "missing target position".to_string())?;
-            let target =
-                i_slint_core::api::LogicalPosition::new(target_pos.x, target_pos.y);
+            let target_pos = p.target.ok_or_else(|| "missing target position".to_string())?;
+            let target = i_slint_core::api::LogicalPosition::new(target_pos.x, target_pos.y);
             let button = proto::PointerEventButton::try_from(p.button)
                 .map_err(|_| format!("invalid button value: {}", p.button))?;
             let button = introspection::convert_pointer_event_button(button);
@@ -360,26 +360,19 @@ async fn handle_tool_call(
         }
         "dispatch_key_event" => {
             let p: proto::RequestDispatchKeyEvent = deserialize_params(args)?;
-            let window_index = handle_to_index(
-                p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
-            );
+            let window_index =
+                handle_to_index(p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?);
             let event_type = proto::KeyEventType::try_from(p.event_type)
                 .map_err(|_| format!("invalid eventType value: {}", p.event_type))?;
             let events: Vec<i_slint_core::platform::WindowEvent> = match event_type {
                 proto::KeyEventType::Press => {
-                    vec![i_slint_core::platform::WindowEvent::KeyPressed {
-                        text: p.text.into(),
-                    }]
+                    vec![i_slint_core::platform::WindowEvent::KeyPressed { text: p.text.into() }]
                 }
                 proto::KeyEventType::Release => {
-                    vec![i_slint_core::platform::WindowEvent::KeyReleased {
-                        text: p.text.into(),
-                    }]
+                    vec![i_slint_core::platform::WindowEvent::KeyReleased { text: p.text.into() }]
                 }
                 proto::KeyEventType::PressAndRelease => vec![
-                    i_slint_core::platform::WindowEvent::KeyPressed {
-                        text: p.text.clone().into(),
-                    },
+                    i_slint_core::platform::WindowEvent::KeyPressed { text: p.text.clone().into() },
                     i_slint_core::platform::WindowEvent::KeyReleased { text: p.text.into() },
                 ],
             };

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -78,6 +78,12 @@ message WindowEvent {
     }
 }
 
+enum KeyEventType {
+    PressAndRelease = 0;
+    Press = 1;
+    Release = 2;
+}
+
 enum LayoutKind {
     NotALayout = 0;
     HorizontalLayout = 1;
@@ -172,6 +178,17 @@ message RequestDispatchWindowEvent {
     WindowEvent event = 2;
 }
 
+message RequestDispatchKeyEvent {
+    Handle window_handle = 1;
+    string text = 2;
+    KeyEventType event_type = 3;
+}
+
+message RequestGetElementTree {
+    Handle element_handle = 1;
+    uint32 max_elements = 2;
+}
+
 message RequestQueryElementDescendants {
     Handle element_handle = 1;
     repeated ElementQueryInstruction query_stack = 2;
@@ -191,6 +208,8 @@ message RequestToAUT {
         RequestDispatchWindowEvent request_dispatch_window_event = 9;
         RequestQueryElementDescendants request_query_element_descendants = 10;
         RequestElementDrag request_element_drag = 11;
+        RequestDispatchKeyEvent request_dispatch_key_event = 12;
+        RequestGetElementTree request_get_element_tree = 13;
     }
 }
 
@@ -281,6 +300,12 @@ message ElementDragResponse {
 message DispatchWindowEventResponse {
 }
 
+message DispatchKeyEventResponse {
+}
+
+message GetElementTreeResponse {
+}
+
 message ElementQueryResponse {
     repeated Handle element_handles = 1;
 }
@@ -299,5 +324,7 @@ message AUTResponse {
         DispatchWindowEventResponse dispatch_window_event_response = 10;
         ElementQueryResponse element_query_response = 11;
         ElementDragResponse element_drag_response = 12;
+        DispatchKeyEventResponse dispatch_key_event_response = 13;
+        GetElementTreeResponse get_element_tree_response = 14;
     }
 }

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -196,6 +196,10 @@ impl TestingClient {
                         .collect(),
                 })
             }
+            // MCP-only tools — not supported over the binary system-testing transport
+            Req::RequestDispatchKeyEvent(..) | Req::RequestGetElementTree(..) => {
+                return Err("this request is only supported via the MCP transport".into());
+            }
         })
     }
 


### PR DESCRIPTION
## Summary

Addresses review feedback from #11340: replace hand-written JSON schemas and manual string parsing in the MCP server with proto-driven generation.

- Add `RequestGetElementTree`, `RequestDispatchKeyEvent`, and `KeyEventType` enum to `slint_systest.proto` so all 12 MCP tools have proto request counterparts
- Generate JSON schemas from proto file descriptors at build time in `build.rs`
- Replace ~160 lines of hand-written JSON tool definitions with a compact declarative `TOOLS` table mapping tool names to proto request types
- Unify all tool handlers to use `deserialize_params` with proto types, eliminating manual string matching for enums and manual JSON field extraction

**Breaking change for MCP clients:** `drag_element` now takes `target: { x, y }` (matching the proto `LogicalPosition`) instead of flat `targetX`/`targetY`. `dispatch_key_event` enum values changed from snake_case (`press_and_release`) to PascalCase (`PressAndRelease`) to match proto conventions.

## Test plan

- [x] `cargo build -p i-slint-backend-testing --features mcp` compiles
- [x] `cargo test -p i-slint-backend-testing --features mcp -- mcp` — all 19 tests pass
- [x] New `test_all_tools_have_proto_schemas` validates every tool's `request_type` resolves to a generated schema and all `optional_fields` are real proto fields