### PR TITLE
FlexboxLayout: fix column-direction text wrapping

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -302,7 +302,7 @@ pub(super) fn solve_flexbox_layout(
         generate_layout_padding_and_spacing(&layout.geometry, Orientation::Horizontal, ctx);
     let (padding_v, spacing_v) =
         generate_layout_padding_and_spacing(&layout.geometry, Orientation::Vertical, ctx);
-    let fld = flexbox_layout_data(layout, ctx);
+    let fld = flexbox_layout_data(layout, ctx, CellsVConstraint::ContainerWidth);
     let width = layout_geometry_size(&layout.geometry.rect, Orientation::Horizontal, ctx);
     let height = layout_geometry_size(&layout.geometry.rect, Orientation::Vertical, ctx);
     let data = make_struct(
@@ -379,7 +379,7 @@ pub(super) fn compute_flexbox_layout_info(
     orientation: Orientation,
     ctx: &mut ExpressionLoweringCtx,
 ) -> llr_Expression {
-    let fld = flexbox_layout_data(layout, ctx);
+    let fld = flexbox_layout_data(layout, ctx, CellsVConstraint::ItemPreferredWidth);
 
     match layout.axis_relation(orientation) {
         crate::layout::FlexboxAxisRelation::MainAxis => {
@@ -561,9 +561,20 @@ struct FlexboxLayoutDataResult {
     )>,
 }
 
+/// Controls how cells_v width constraint is determined for column-direction flex.
+enum CellsVConstraint {
+    /// Use the item's own preferred width (safe for ComputeFlexboxLayoutInfo,
+    /// avoids cycle when parent queries the flex's preferred width).
+    ItemPreferredWidth,
+    /// Use the container's width (accurate for SolveFlexboxLayout, since the
+    /// container width is already set by the parent at solve time).
+    ContainerWidth,
+}
+
 fn flexbox_layout_data(
     layout: &crate::layout::FlexboxLayout,
     ctx: &mut ExpressionLoweringCtx,
+    cells_v_constraint: CellsVConstraint,
 ) -> FlexboxLayoutDataResult {
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
@@ -651,6 +662,12 @@ fn flexbox_layout_data(
             }
         };
 
+    let use_container_width = matches!(cells_v_constraint, CellsVConstraint::ContainerWidth)
+        && matches!(
+            layout.axis_relation(Orientation::Vertical),
+            crate::layout::FlexboxAxisRelation::MainAxis
+        );
+
     if repeater_count == 0 {
         let cells_h = llr_Expression::Array {
             values: layout
@@ -670,16 +687,25 @@ fn flexbox_layout_data(
             element_ty: element_ty.clone(),
             output: llr_ArrayOutput::Slice,
         };
-        // For cells_v, pass each child's horizontal preferred size as the
-        // cross-axis constraint for items that need height-for-width (Text with
-        // word-wrap, Image with aspect ratio). Only do this for builtin items
-        // with implicit sizing — not for components, which would create cycles.
+        // For cells_v, pass a width constraint for items that need
+        // height-for-width (Text with word-wrap, Image with aspect ratio).
+        // In column direction, items get stretched to the container's width,
+        // so use that as the constraint. Otherwise use the item's own
+        // preferred horizontal size.
         let cells_v = llr_Expression::Array {
             values: layout
                 .elems
                 .iter()
                 .map(|li| {
-                    let constraint = cross_axis_constraint_expr(&li.item.element);
+                    let constraint = if use_container_width {
+                        cross_axis_constraint_expr(&li.item.element).and_then(|_| {
+                            layout.geometry.rect.width_reference.as_ref().map(|nr| {
+                                crate::expression_tree::Expression::PropertyReference(nr.clone())
+                            })
+                        })
+                    } else {
+                        cross_axis_constraint_expr(&li.item.element)
+                    };
                     let layout_info_v = get_layout_info_with_constraint(
                         &li.item.element,
                         ctx,
@@ -729,7 +755,15 @@ fn flexbox_layout_data(
                     &item.item.constraints,
                     Orientation::Horizontal,
                 );
-                let constraint = cross_axis_constraint_expr(&item.item.element);
+                let constraint = if use_container_width {
+                    cross_axis_constraint_expr(&item.item.element).and_then(|_| {
+                        layout.geometry.rect.width_reference.as_ref().map(|nr| {
+                            crate::expression_tree::Expression::PropertyReference(nr.clone())
+                        })
+                    })
+                } else {
+                    cross_axis_constraint_expr(&item.item.element)
+                };
                 let layout_info_v = get_layout_info_with_constraint(
                     &item.item.element,
                     ctx,

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -555,9 +555,11 @@ fn recurse_expression(
             }
             // Visit layout geometry dependencies
             if matches!(expr, Expression::SolveFlexboxLayout(..)) {
-                // The solve only needs the main-axis dimension (width for row,
-                // height for column). The cross-axis dimension is determined by
-                // the content, not constrained by the container.
+                // The solve needs the main-axis dimension (width for row,
+                // height for column). For column direction, it also needs
+                // the cross-axis width for height-for-width items, but that
+                // dependency is safe (set by parent before solve) and doesn't
+                // need to be declared here.
                 use crate::layout::FlexboxAxisRelation;
                 match layout.axis_relation(Orientation::Horizontal) {
                     FlexboxAxisRelation::MainAxis => {

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1402,10 +1402,8 @@ mod flexbox_taffy {
                                     width: match params.flex_direction {
                                         TaffyFlexDirection::Column
                                         | TaffyFlexDirection::ColumnReverse => {
-                                            // Cross-axis for column: use auto when measure
-                                            // callback will compute it dynamically
-                                            if params.use_measure_for_cross_axis {
-                                                Dimension::auto()
+                                            if let Some(cw) = params.container_width {
+                                                Dimension::length(cw as _)
                                             } else if preferred_width > 0 as Coord {
                                                 Dimension::length(preferred_width as _)
                                             } else {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -187,11 +187,28 @@ pub(crate) fn solve_flexbox_layout(
         eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
     };
 
-    let (cells_h, cells_v, repeated_indices) =
-        flexbox_layout_data(flexbox_layout, component, &expr_eval, local_context);
-
     let width_ref = &flexbox_layout.geometry.rect.width_reference;
     let height_ref = &flexbox_layout.geometry.rect.height_reference;
+    let direction = flexbox_layout_direction(flexbox_layout, local_context);
+
+    // For column direction, pass the container width so cells_v can use it
+    // as the constraint for height-for-width items (items stretch to it).
+    let container_width_for_cells = match direction {
+        i_slint_core::items::FlexboxLayoutDirection::Column
+        | i_slint_core::items::FlexboxLayoutDirection::ColumnReverse => {
+            width_ref.as_ref().map(&expr_eval)
+        }
+        _ => None,
+    };
+
+    let (cells_h, cells_v, repeated_indices) = flexbox_layout_data(
+        flexbox_layout,
+        component,
+        &expr_eval,
+        local_context,
+        container_width_for_cells,
+    );
+
     let alignment = flexbox_layout
         .geometry
         .alignment
@@ -199,7 +216,6 @@ pub(crate) fn solve_flexbox_layout(
         .map_or(i_slint_core::items::LayoutAlignment::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
-    let direction = flexbox_layout_direction(flexbox_layout, local_context);
     let align_content = flexbox_layout
         .align_content
         .as_ref()
@@ -345,7 +361,7 @@ pub(crate) fn compute_flexbox_layout_info(
     };
 
     let (cells_h, cells_v, _repeated_indices) =
-        flexbox_layout_data(flexbox_layout, component, &expr_eval, local_context);
+        flexbox_layout_data(flexbox_layout, component, &expr_eval, local_context, None);
 
     // Get the direction from the property binding
     let direction = flexbox_layout_direction(flexbox_layout, local_context);
@@ -418,6 +434,7 @@ fn flexbox_layout_data(
     component: InstanceRef,
     expr_eval: &impl Fn(&NamedReference) -> f32,
     _local_context: &mut EvalLocalContext,
+    container_width: Option<f32>,
 ) -> (Vec<core_layout::FlexboxLayoutItemInfo>, Vec<core_layout::FlexboxLayoutItemInfo>, Vec<u32>) {
     let window_adapter = component.window_adapter();
     let mut cells_h = Vec::with_capacity(flexbox_layout.elems.len());
@@ -499,9 +516,9 @@ fn flexbox_layout_data(
         }
     }
 
-    // Second pass: collect vertical layout_info with the horizontal preferred
-    // size as constraint. This allows Text with word-wrap and Image with aspect
-    // ratio to compute their height correctly without reading the width property.
+    // Second pass: collect vertical layout_info with a width constraint.
+    // For column direction, use the container width (items get stretched to it).
+    // Otherwise use the item's horizontal preferred size.
     let mut cell_idx = 0usize;
     for layout_elem in &flexbox_layout.elems {
         if layout_elem.item.element.borrow().repeated.is_some() {
@@ -509,7 +526,8 @@ fn flexbox_layout_data(
             cell_idx += component_vec.len();
             // repeater cells_v already filled in first pass
         } else {
-            let width_constraint = cells_h[cell_idx].constraint.preferred_bounded();
+            let width_constraint =
+                container_width.unwrap_or_else(|| cells_h[cell_idx].constraint.preferred_bounded());
             let mut layout_info_v = get_layout_info_with_constraint(
                 &layout_elem.item.element,
                 component,

--- a/tests/cases/layout/flexbox_column_text_wrap.slint
+++ b/tests/cases/layout/flexbox_column_text_wrap.slint
@@ -1,0 +1,50 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test column-direction FlexboxLayout with Text word-wrap.
+// In column direction, the main axis is vertical and the cross axis is horizontal.
+// The text gets the container's width and should wrap within it.
+
+export component TestCase inherits Window {
+    width: 150px;
+    height: 300px;
+
+    FlexboxLayout {
+        flex-direction: column;
+        spacing: 10px;
+
+        r := Rectangle {
+            height: 50px;
+            background: red;
+        }
+        t := Text {
+            text: "This is a long text that should word-wrap inside a column FlexboxLayout";
+            wrap: word-wrap;
+            horizontal-alignment: left;
+        }
+    }
+
+    // In column direction, items stack vertically.
+    // The text should be below the rectangle and wrap within the container width.
+    out property <bool> test_r: r.height == 50px;
+    out property <bool> test_t: t.y == 60px && t.width <= 150px && t.height > 30px;
+
+    out property <bool> test: test_r && test_t;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
Add a test for Text with word-wrap inside a column-direction
FlexboxLayout, and fix the three issues it uncovered.

Height-for-width items (Text with word-wrap, Image with aspect ratio)
need the actual container width to compute their wrapped height. In
column direction, the main axis is vertical and heights are assigned
first, but computing text height requires knowing the width first.

1. cells_v constraint (compiler + interpreter): the vertical layout
   info for each item was pre-computed using the item's own preferred
   width (the natural unwrapped text width). For column direction,
   use the container's width instead, since items stretch to it.
   This is only done for SolveFlexboxLayout; ComputeFlexboxLayoutInfo
   still uses the item's preferred width to avoid binding cycles when
   a parent layout queries the flex's preferred size.

2. Taffy item width (runtime): setting the cross-axis width to
   Dimension::auto() caused taffy to use the measure-returned natural
   width (e.g. 406px) instead of the container width (150px), because
   taffy's stretch doesn't shrink items below their measured size.
   Fix: explicitly set each item's width to the container width.

3. Test assertion: the original test only checked t.height > 30px,
   which passed even when the text wasn't actually wrapping (the
   pre-computed cells_v height was correct, but taffy assigned the
   wrong width). Now also checks t.width <= 150px.