### PR TITLE
Simplify MCP server setup documentation

### DIFF
--- a/docs/development/mcp-server.md
+++ b/docs/development/mcp-server.md
@@ -32,19 +32,7 @@ The MCP server is controlled by two layers:
 
 ### Enabling for a Slint Application
 
-Since the `mcp` feature is not plumbed through the public `slint` crate, users enable it directly on the backend selector:
-
-```toml
-[dependencies]
-slint = "x.y.z"
-i-slint-backend-selector = { version = "=x.y.z", features = ["mcp"] }
-```
-
-Then run with:
-
-```sh
-SLINT_MCP_PORT=8080 cargo run -p my-app
-```
+See the [README](../../internal/backends/testing/README.md#enabling-the-mcp-server) for setup instructions.
 
 ## Initialization Flow
 
@@ -109,9 +97,7 @@ The HTTP server is built directly on `async-net` (async TCP) and `httparse` (HTT
 
 ### Tool Dispatch
 
-Tool calls arrive as `tools/call` JSON-RPC methods. The `handle_tool_call()` function dispatches by tool name. Most tools deserialize parameters into proto types (leveraging `pbjson`-generated `Deserialize` impls), call methods on `IntrospectionState`, and serialize the response back to JSON.
-
-Two tools (`get_element_tree` and `dispatch_key_event`) use custom parameter handling rather than proto types, since they don't have direct protobuf equivalents.
+Tool calls arrive as `tools/call` JSON-RPC methods. The `handle_tool_call()` function dispatches by tool name. All tools deserialize parameters into proto request types (leveraging `pbjson`-generated `Deserialize` impls), call methods on `IntrospectionState`, and serialize the response back to JSON.
 
 ### MCP Instructions
 
@@ -129,8 +115,8 @@ The MCP transport uses the `serde_json`-based serialization, while the system-te
 
 ## Adding a New Tool
 
-1. If the tool maps to a proto request/response, add the message types to `slint_systest.proto`. Otherwise, handle parameters manually in `handle_tool_call()`.
-2. Add a tool definition entry in `tool_definitions()` with name, description, and input schema.
+1. Add request and response message types to `slint_systest.proto`. The build pipeline will auto-generate the JSON schema for the MCP tool's `inputSchema`.
+2. Add a `ToolDef` entry to the `TOOLS` table in `mcp_server.rs` with name, description, proto request type, and optional fields.
 3. Add a match arm in `handle_tool_call()`.
 4. If the tool needs new introspection capabilities, add methods to `IntrospectionState` in `introspection.rs` so both transports can use them.
 5. Update the `instructions` string in the `initialize` response if the new tool changes the recommended workflow.

--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -204,13 +204,14 @@ will keep running the event loop until the click is complete, and then continue 
 ## Embedded MCP Server
 
 The testing backend includes an embedded [MCP (Model Context Protocol)](https://modelcontextprotocol.io/)
-server that allows MCP clients — such as Claude Code — to inspect and interact with a running Slint
-application in real time over HTTP.
+server that allows AI agents to inspect and interact with a running Slint application in real time.
+The server provides tools for exploring the UI tree, taking screenshots, clicking elements, dragging,
+typing, and more. Agents discover the available tools and usage instructions automatically via the
+MCP protocol — no additional configuration is needed beyond enabling the server.
 
 ### Enabling the MCP Server
 
-The MCP server requires the `mcp` Cargo feature on the backend selector crate. Since this feature is
-not exposed through the public `slint` crate, enable it on `i-slint-backend-selector` directly:
+Add the `mcp` feature to the backend selector crate:
 
 ```toml
 [dependencies]
@@ -218,20 +219,25 @@ slint = "x.y.z"
 i-slint-backend-selector = { version = "=x.y.z", features = ["mcp"] }
 ```
 
-Then set the `SLINT_MCP_PORT` environment variable when running your application:
+Then set `SLINT_MCP_PORT` when running your application:
 
 ```sh
 SLINT_MCP_PORT=8080 cargo run -p my-slint-app
 ```
 
-The server starts automatically when the backend initializes. If `SLINT_MCP_PORT` is not set,
-the server is not started and there is no runtime overhead.
+The server binds to `localhost:<port>/mcp` using MCP's Streamable HTTP transport. If
+`SLINT_MCP_PORT` is not set, no server is started and there is no runtime overhead.
 
-### Connecting an MCP Client
+### Usage with AI Agents
 
-Once the application is running with the MCP server enabled, connect any MCP client to
-`http://localhost:<port>/mcp` using the Streamable HTTP transport. For example, in Claude Code's
-MCP configuration:
+The simplest approach is to tell the agent to run the application with the environment variable
+set and then interact with it. For example, in Claude Code:
+
+> "Run `SLINT_MCP_PORT=8080 cargo run -p my-app` in the background. The app includes a built-in
+> MCP server. Connect to it and toggle the dark mode switch."
+
+The agent will discover the MCP endpoint, connect, and use the tools to accomplish the task.
+You can also register the server in your MCP client's configuration if you prefer:
 
 ```json
 {
@@ -244,34 +250,6 @@ MCP configuration:
 }
 ```
 
-### Available Tools
-
-The MCP server exposes 12 tools for UI introspection and interaction:
-
-| Tool | Description |
-|------|-------------|
-| `list_windows` | List all open windows and their handles |
-| `get_window_properties` | Get window size, position, state, and root element handle |
-| `get_element_tree` | Get a flat list of elements in a subtree with types, IDs, and accessibility info |
-| `get_element_properties` | Get full details of a single element |
-| `find_elements_by_id` | Find elements by qualified ID (e.g. `App::my-button`) |
-| `query_element_descendants` | Search descendants using a query pipeline (by type, ID, or role) |
-| `take_screenshot` | Capture a PNG screenshot of a window |
-| `click_element` | Simulate a mouse click on an element |
-| `drag_element` | Simulate a drag gesture from an element's center to a target position |
-| `invoke_accessibility_action` | Invoke a semantic action (Default, Increment, Decrement, Expand) |
-| `set_element_value` | Set the accessible value of an element (text, slider value, etc.) |
-| `dispatch_key_event` | Send a keyboard event to a window |
-
-### Typical Workflow
-
-1. `list_windows` → discover available windows
-2. `get_window_properties` → get the `rootElementHandle`
-3. `get_element_tree` → explore the UI hierarchy
-4. `query_element_descendants` or `find_elements_by_id` → locate specific elements
-5. `click_element` / `drag_element` / `set_element_value` / `invoke_accessibility_action` → interact
-6. `take_screenshot` → verify the visual result
-
-For a detailed description of the architecture and internals, see
+For architecture and internals, see
 [docs/development/mcp-server.md](../../../docs/development/mcp-server.md).
 

--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -219,22 +219,23 @@ slint = "x.y.z"
 i-slint-backend-selector = { version = "=x.y.z", features = ["mcp"] }
 ```
 
-Then set `SLINT_MCP_PORT` when running your application:
+Then set the following environment variables when running your application:
 
 ```sh
-SLINT_MCP_PORT=8080 cargo run -p my-slint-app
+SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=8080 cargo run -p my-slint-app
 ```
 
-The server binds to `localhost:<port>/mcp` using MCP's Streamable HTTP transport. If
-`SLINT_MCP_PORT` is not set, no server is started and there is no runtime overhead.
+`SLINT_EMIT_DEBUG_INFO=1` is required for element introspection to work (it embeds element
+metadata into the compiled UI). `SLINT_MCP_PORT` controls which port the MCP server listens on.
+If `SLINT_MCP_PORT` is not set, no server is started and there is no runtime overhead.
 
 ### Usage with AI Agents
 
-The simplest approach is to tell the agent to run the application with the environment variable
+The simplest approach is to tell the agent to run the application with both environment variables
 set and then interact with it. For example, in Claude Code:
 
-> "Run `SLINT_MCP_PORT=8080 cargo run -p my-app` in the background. The app includes a built-in
-> MCP server. Connect to it and toggle the dark mode switch."
+> "Run `SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=8080 cargo run -p my-app` in the background. The
+> app includes a built-in MCP server. Connect to it and toggle the dark mode switch."
 
 The agent will discover the MCP endpoint, connect, and use the tools to accomplish the task.
 You can also register the server in your MCP client's configuration if you prefer:


### PR DESCRIPTION
## Summary

Simplifies the MCP server documentation based on feedback that the setup ceremony was overkill — agents discover tools and usage via the MCP protocol itself.

- **README**: Replace the tool table, workflow steps, and detailed MCP client config with a concise "enable the feature, set the env var, tell the agent to connect" guide. Add an example of the simplest workflow (just tell the agent to run the app and interact with it).
- **Dev docs**: Update stale reference about custom parameter handling (all tools now use proto-driven dispatch). Deduplicate setup instructions by linking to README. Update "Adding a New Tool" to reflect proto-driven schema generation.

Net: -58 lines, +22 lines across both files.

## Context

From @tronical's feedback on the MCP setup experience:
> I've just told claude that when running the app, make sure to do this and that and that this will include a built-in mcp server. [...] I think the idea of treating mcp just as a protocol instead of hooking into the "mcp service" mechanism is easier to set up.

The in-protocol `instructions` string (sent during MCP `initialize`) already provides agents with the workflow, handle format, enum values, and query syntax. The external docs were duplicating what the protocol delivers automatically.

## Test plan

- Documentation-only change, no code affected