### PR TITLE
compiler: check builtin path by prefix instead of loading the file

### DIFF
--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -242,10 +242,7 @@ fn main() -> std::io::Result<()> {
         let resources: std::collections::BTreeSet<&str> = embedded
             .iter()
             .filter_map(|er| er.path.as_deref())
-            .filter(|resource| {
-                !fileaccess::load_file(std::path::Path::new(resource))
-                    .is_some_and(|f| f.is_builtin())
-            })
+            .filter(|resource| !resource.starts_with("builtin:/"))
             .collect();
         for resource in resources {
             write!(cursor, " {resource}")?;


### PR DESCRIPTION
fileaccess::load_file does a filesystem exists() call and path canonicalization for regular paths, and a builtin library lookup for builtin paths, just to answer whether the path starts with `builtin:/`. A direct prefix check is equivalent.

