### PR TITLE
LSP: Graceful shutdown of the live-preview process

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -46,6 +46,9 @@ pub trait LspToPreview {
     fn send(&self, message: &LspToPreviewMessage);
     fn set_preview_target(&self, target: PreviewTarget) -> Result<()>;
     fn preview_target(&self) -> PreviewTarget;
+    fn shutdown<'a>(&'a self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>> {
+        Box::pin(async {})
+    }
 }
 
 #[derive(Default, Clone)]

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -347,16 +347,20 @@ async fn main_loop(
         )
     };
 
-    run_main_loop(
+    let result = run_main_loop(
         connection,
         init_param,
         cli_args,
         request_queue,
         server_notifier,
         preview_to_lsp_receiver,
-        to_preview,
+        to_preview.clone(),
     )
-    .await
+    .await;
+
+    to_preview.shutdown().await;
+
+    result
 }
 
 async fn run_main_loop(

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -317,12 +317,9 @@ async fn main_loop(
     init_param: InitializeParams,
     cli_args: Cli,
 ) -> Result<()> {
-    let mut rh = RequestHandler::default();
-    register_request_handlers(&mut rh);
-
     let request_queue = OutgoingRequestQueue::default();
     #[cfg_attr(not(feature = "preview-engine"), allow(unused))]
-    let (preview_to_lsp_sender, mut preview_to_lsp_receiver) =
+    let (preview_to_lsp_sender, preview_to_lsp_receiver) =
         mpsc::unbounded_channel::<crate::common::PreviewToLspMessage>();
 
     let server_notifier =
@@ -349,6 +346,31 @@ async fn main_loop(
             .unwrap(),
         )
     };
+
+    run_main_loop(
+        connection,
+        init_param,
+        cli_args,
+        request_queue,
+        server_notifier,
+        preview_to_lsp_receiver,
+        to_preview,
+    )
+    .await
+}
+
+async fn run_main_loop(
+    connection: Connection,
+    init_param: InitializeParams,
+    cli_args: Cli,
+    request_queue: OutgoingRequestQueue,
+    server_notifier: ServerNotifier,
+    #[cfg_attr(not(feature = "preview-engine"), allow(unused_mut))]
+    mut preview_to_lsp_receiver: mpsc::UnboundedReceiver<crate::common::PreviewToLspMessage>,
+    to_preview: Rc<dyn LspToPreview>,
+) -> Result<()> {
+    let mut rh = RequestHandler::default();
+    register_request_handlers(&mut rh);
 
     let to_preview_clone = to_preview.clone();
     let compiler_config = CompilerConfiguration {

--- a/tools/lsp/preview/connector/native.rs
+++ b/tools/lsp/preview/connector/native.rs
@@ -145,9 +145,12 @@ impl common::LspToPreview for ChildProcessLspToPreview {
             let message = serde_json::to_string(&common::LspToPreviewMessage::Quit).unwrap();
             let _ = inner.to_child_sender.send(message);
             drop(inner.to_child_sender);
-            let _ =
-                tokio::time::timeout(std::time::Duration::from_secs(5), inner.communication_handle)
-                    .await;
+            if tokio::time::timeout(std::time::Duration::from_secs(5), inner.communication_handle)
+                .await
+                .is_err()
+            {
+                tracing::warn!("Timed out waiting for preview child process to exit");
+            }
         })
     }
 }

--- a/tools/lsp/preview/connector/native.rs
+++ b/tools/lsp/preview/connector/native.rs
@@ -136,6 +136,20 @@ impl common::LspToPreview for ChildProcessLspToPreview {
     fn set_preview_target(&self, _: common::PreviewTarget) -> common::Result<()> {
         Err("Can not change the preview target".into())
     }
+
+    fn shutdown<'a>(&'a self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>> {
+        Box::pin(async move {
+            let Some(inner) = self.inner.borrow_mut().take() else {
+                return;
+            };
+            let message = serde_json::to_string(&common::LspToPreviewMessage::Quit).unwrap();
+            let _ = inner.to_child_sender.send(message);
+            drop(inner.to_child_sender);
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(5), inner.communication_handle)
+                    .await;
+        })
+    }
 }
 
 pub struct EmbeddedLspToPreview {
@@ -197,6 +211,14 @@ impl common::LspToPreview for SwitchableLspToPreview {
         } else {
             Err("Target not found".into())
         }
+    }
+
+    fn shutdown<'a>(&'a self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>> {
+        Box::pin(async move {
+            for child in self.lsp_to_previews.values() {
+                child.shutdown().await;
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Wait for the child process to exit gracefully, to avoid a possible race where the child process still writes to stderr but the parent (lsp) has already exited.

cc #10778