### PR TITLE
android: Use the native surface size as the window size

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -515,14 +515,7 @@ impl AndroidWindowAdapter {
 
     fn resize(&self) -> Result<(), PlatformError> {
         let Some(win) = self.app.native_window() else { return Ok(()) };
-        let (offset, size) = if self.fullscreen.get() {
-            (
-                Default::default(),
-                PhysicalSize { width: win.width() as u32, height: win.height() as u32 },
-            )
-        } else {
-            self.java_helper.get_view_rect().unwrap_or_else(|e| print_jni_error(&self.app, e))
-        };
+        let size = PhysicalSize { width: win.width() as u32, height: win.height() as u32 };
 
         let scale_factor = self.window.scale_factor();
         self.window
@@ -532,7 +525,7 @@ impl AndroidWindowAdapter {
                 .map(|internal| internal.safe_area_inset().to_logical(scale_factor))
                 .unwrap_or_default(),
         );
-        self.offset.set(offset);
+        self.offset.set(Default::default());
         Ok(())
     }
 

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -430,17 +430,6 @@ impl JavaHelper {
         })
     }
 
-    pub fn get_view_rect(&self) -> Result<(PhysicalPosition, PhysicalSize), jni::errors::Error> {
-        self.with_jni_env(|env, helper| {
-            let rect = helper.get_view_rect(env)?;
-            let x = rect.left(env)?;
-            let y = rect.top(env)?;
-            let width = rect.right(env)? - x;
-            let height = rect.bottom(env)? - y;
-            Ok((PhysicalPosition::new(x as _, y as _), PhysicalSize::new(width as _, height as _)))
-        })
-    }
-
     pub fn get_safe_area(&self) -> Result<PhysicalEdges, jni::errors::Error> {
         self.with_jni_env(|env, helper| {
             let rect = helper.get_safe_area(env)?;


### PR DESCRIPTION
resize() was dispatching a Resized event with the activity-bounds size from get_view_rect(), while WindowAdapter::size() already reported the native window's dimensions. The two diverge on devices that lay out the surface differently from the activity window (e.g. with a camera cutout in landscape), so the safe area was computed against the wrong rectangle.

Always use the native window size, matching what size() reports and what do_render() draws into.


