### PR TITLE
slintpad: show a dialog when the wasm code panics

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yaml
@@ -18,6 +18,7 @@ body:
       If you have questions or need help with Slint, visit our ["Discussions" tab](https://github.com/slint-ui/slint/discussions).
 
 - type: textarea
+  id: bug-description
   attributes:
     label: Bug Description
     description: |
@@ -30,6 +31,7 @@ body:
     required: true
 
 - type: textarea
+  id: reproducible-code
   attributes:
     label: Reproducible Code (if applicable)
     description: |
@@ -44,6 +46,7 @@ body:
     required: false
 
 - type: textarea
+  id: environment-details
   attributes:
     label: Environment Details
     description: |
@@ -62,6 +65,7 @@ body:
     required: true
 
 - type: textarea
+  id: product-impact
   attributes:
     label: Product Impact
     description: |

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -56,7 +56,7 @@ thread_local! {static WASM_CALLBACKS: RefCell<Option<WasmCallbacks>> = Default::
 
 #[wasm_bindgen(start)]
 pub fn init_backend() -> Result<(), JsValue> {
-    console_error_panic_hook::set_once();
+    crate::install_panic_hook();
 
     // Initialize the winit backend when we're used in the browser's main thread.
     if web_sys::window().is_some() {
@@ -88,8 +88,6 @@ impl PreviewConnector {
         style: String,
         invoke_slintpad_callback: InvokeSlintpadCallback,
     ) -> Result<PreviewConnectorPromise, JsValue> {
-        console_error_panic_hook::set_once();
-
         WASM_CALLBACKS.set(Some(WasmCallbacks {
             lsp_notifier,
             resource_url_mapper,

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -177,6 +177,35 @@ type SendRequestFunction = (method: string, r: any) => Promise<any>;
 type HighlightInPreviewFunction = (file: string, offset: number) => void;
 "#;
 
+thread_local! {
+    static PANIC_CALLBACK: RefCell<Option<Function>> = const { RefCell::new(None) };
+}
+
+/// Chains `console_error_panic_hook` (so panics still show up in the browser
+/// console) with an optional JS callback registered via `set_panic_hook`.
+/// Idempotent — safe to call from multiple wasm entry points.
+pub(crate) fn install_panic_hook() {
+    static INSTALLED: std::sync::Once = std::sync::Once::new();
+    INSTALLED.call_once(|| {
+        std::panic::set_hook(Box::new(|info| {
+            console_error_panic_hook::hook(info);
+            PANIC_CALLBACK.with(|c| {
+                if let Some(cb) = c.borrow().as_ref() {
+                    let _ = cb.call1(&JsValue::UNDEFINED, &JsValue::from_str(&info.to_string()));
+                }
+            });
+        }));
+    });
+}
+
+/// Register a JS callback that receives the formatted panic message whenever
+/// the Rust side panics. Used by SlintPad to surface a user-visible dialog.
+#[wasm_bindgen]
+pub fn set_panic_hook(callback: Function) {
+    install_panic_hook();
+    PANIC_CALLBACK.with(|c| *c.borrow_mut() = Some(callback));
+}
+
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(typescript_type = "ImportCallbackFunction")]
@@ -211,7 +240,7 @@ pub fn create(
     send_request: SendRequestFunction,
     load_file: ImportCallbackFunction,
 ) -> JsResult<SlintServer> {
-    console_error_panic_hook::set_once();
+    install_panic_hook();
 
     let send_request = Function::from(send_request.clone());
     let server_notifier = ServerNotifier { send_notification, send_request };

--- a/tools/slintpad/src/dialogs.ts
+++ b/tools/slintpad/src/dialogs.ts
@@ -1,6 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import pkg from "../package.json";
+
+type PanicSource = "lsp" | "preview";
+
+let share_url_getter: (() => Promise<string>) | null = null;
+
+export function set_panic_share_url_getter(f: () => Promise<string>) {
+    share_url_getter = f;
+}
+
 export function modal_dialog(
     extra_class: string,
     content:
@@ -137,6 +147,92 @@ export async function export_gist_dialog(
         [description, is_public_div],
         "Export",
         () => exporter(description.value, is_public.checked),
+    );
+}
+
+let panic_dialog_shown = false;
+
+export function report_panic_dialog(source: PanicSource, message: string) {
+    if (panic_dialog_shown) {
+        return;
+    }
+    panic_dialog_shown = true;
+
+    const short_name = source === "lsp" ? "LSP" : "LivePreview";
+    const long_name = `The Slint ${short_name}`;
+
+    const headline = document.createElement("p");
+    headline.classList.add("panic_headline");
+    headline.innerText = `${long_name} has panicked.`;
+
+    const intro = document.createElement("p");
+    intro.innerText =
+        "SlintPad may no longer work. Please consider filing a bug report " +
+        "so we can fix it.";
+
+    const summary = message.trim();
+
+    const details_label = document.createElement("p");
+    details_label.innerText = "Panic message:";
+
+    const details = document.createElement("textarea");
+    details.classList.add("panic_details");
+    details.readOnly = true;
+    details.rows = 4;
+    details.cols = 70;
+    details.value = summary;
+
+    const environment_details = `SlintPad ${pkg.version}\nBrowser: ${navigator.userAgent}\n`;
+
+    function build_issue_url(share_url: string | null): string {
+        const bug_description =
+            `${long_name} panicked while running in SlintPad.\n\n` +
+            "**Steps to reproduce:**\n1. \n2. \n3. \n\n" +
+            "**Panic message:**\n```\n" +
+            summary +
+            "\n```\n" +
+            (share_url ? `\n**SlintPad link:** ${share_url}\n` : "");
+
+        const params = new URLSearchParams({
+            template: "1-bug-report.yaml",
+            title: `[SlintPad] ${short_name} panic: ${summary.split("\n").pop() ?? ""}`,
+            "bug-description": bug_description,
+            "environment-details": environment_details,
+        });
+        return `https://github.com/slint-ui/slint/issues/new?${params}`;
+    }
+
+    const link_anchor = document.createElement("a");
+    link_anchor.target = "_blank";
+    link_anchor.rel = "noopener noreferrer";
+    link_anchor.innerText = "Report this on GitHub";
+    link_anchor.href = build_issue_url(null);
+
+    const share_warning = document.createElement("p");
+    share_warning.classList.add("panic_warning");
+    share_warning.innerText =
+        "Heads up: the bug report will embed a link to your SlintPad code. " +
+        "Please remove anything private before submitting.";
+    share_warning.style.display = "none";
+
+    if (share_url_getter !== null) {
+        share_url_getter()
+            .then((share_url) => {
+                // GitHub rejects URLs over ~8000 chars; bail out if adding
+                // the share link would push us past a safe threshold.
+                const candidate = build_issue_url(share_url);
+                if (candidate.length <= 6000) {
+                    link_anchor.href = candidate;
+                    share_warning.style.display = "";
+                }
+            })
+            .catch(() => {});
+    }
+
+    modal_dialog(
+        "panic_dialog",
+        [headline, intro, details_label, details, link_anchor, share_warning],
+        "Close",
     );
 }
 

--- a/tools/slintpad/src/editor_widget.ts
+++ b/tools/slintpad/src/editor_widget.ts
@@ -737,6 +737,10 @@ export class EditorWidget extends Widget {
     }
 
     public async copy_permalink_to_clipboard() {
+        navigator.clipboard.writeText(await this.share_url());
+    }
+
+    public async share_url(): Promise<string> {
         const params = new URLSearchParams(window.location.search);
         params.delete("load_url");
         params.delete("load_demo");
@@ -745,7 +749,7 @@ export class EditorWidget extends Widget {
 
         const url = new URL(window.location.href);
         url.search = params.toString();
-        navigator.clipboard.writeText(url.toString());
+        return url.toString();
     }
 }
 

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -18,6 +18,7 @@ import {
     report_export_error_dialog,
     export_gist_dialog,
     about_dialog,
+    set_panic_share_url_getter,
 } from "./dialogs";
 
 import { CommandRegistry } from "@lumino/commands";
@@ -34,6 +35,7 @@ const url_style = url_params.get("style");
 
 function setup(lsp: Lsp) {
     const editor = new EditorWidget(lsp);
+    set_panic_share_url_getter(() => editor.share_url());
     const preview = new PreviewWidget(
         lsp,
         (url: string) => editor.map_url(url),

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -24,6 +24,8 @@ import type { Position as LspPosition } from "vscode-languageserver-types";
 
 import slint_init, * as slint_preview from "@lsp/slint_lsp_wasm.js";
 
+import { report_panic_dialog } from "./dialogs";
+
 import {
     type ResourceUrlMapperFunction,
     type InvokeSlintpadCallback,
@@ -109,13 +111,26 @@ export class LspWaiter {
             { type: "module" },
         );
         this.#lsp_promise = new Promise<Worker>((resolve) => {
-            worker.onmessage = (m) => {
+            worker.addEventListener("message", (m: MessageEvent) => {
+                const data = m.data;
                 // We cannot start sending messages to the client before we start listening which
                 // the server only does in a future after the wasm is loaded.
-                if (m.data === "OK") {
+                if (data === "OK") {
                     resolve(worker);
+                } else if (
+                    data &&
+                    typeof data === "object" &&
+                    data.type === "slintpad/panic"
+                ) {
+                    report_panic_dialog("lsp", data.message);
                 }
-            };
+            });
+        });
+        worker.addEventListener("error", (e: ErrorEvent) => {
+            report_panic_dialog(
+                "lsp",
+                e.message || "Uncaught error in LSP worker",
+            );
         });
 
         this.#previewer_promise = slint_init({});
@@ -131,7 +146,11 @@ export class LspWaiter {
 
         const [_1, worker] = await Promise.all([pp, lp]);
 
-        return Promise.resolve(new Lsp(worker));
+        slint_preview.set_panic_hook((message: string) => {
+            report_panic_dialog("preview", message);
+        });
+
+        return new Lsp(worker);
     }
 }
 
@@ -203,6 +222,10 @@ export class Lsp {
                             } as ResponseMessage);
                         });
 
+                    return true;
+                }
+                if ((data as { type?: string }).type === "slintpad/panic") {
+                    // Panic messages are handled by the LspWaiter listener.
                     return true;
                 }
                 return false;

--- a/tools/slintpad/src/worker/lsp_worker.ts
+++ b/tools/slintpad/src/worker/lsp_worker.ts
@@ -9,7 +9,22 @@ import {
     BrowserMessageWriter,
 } from "vscode-languageserver/browser";
 
+function post_panic(message: string) {
+    self.postMessage({ type: "slintpad/panic", message });
+}
+
+// Backstop: catch failures that happen before the Rust panic hook is armed
+// (e.g. the wasm module itself failing to instantiate).
+self.addEventListener("error", (e) =>
+    post_panic(e.message || "Uncaught error in LSP worker"),
+);
+self.addEventListener("unhandledrejection", (e) =>
+    post_panic(String(e.reason ?? "Unhandled rejection in LSP worker")),
+);
+
 slint_init({}).then(() => {
+    slint_lsp.set_panic_hook(post_panic);
+
     const reader = new BrowserMessageReader(self);
     const writer = new BrowserMessageWriter(self);
 

--- a/tools/slintpad/styles/content.css
+++ b/tools/slintpad/styles/content.css
@@ -206,3 +206,28 @@
 .dialog.about_dialog .slint-logo-link {
     display: inline-block;
 }
+
+.dialog.panic_dialog .panic_headline {
+    color: white;
+    background: #c0392b;
+    padding: 6px 10px;
+    margin: 0 0 8px 0;
+    font-weight: bold;
+    border-radius: 3px;
+}
+
+.dialog.panic_dialog .panic_details {
+    font-family: monospace;
+    width: 100%;
+    box-sizing: border-box;
+    white-space: pre;
+}
+
+.dialog.panic_dialog .panic_warning {
+    color: #8a6d3b;
+    background: #fcf8e3;
+    border: 1px solid #faebcc;
+    padding: 6px 10px;
+    border-radius: 3px;
+    font-size: 90%;
+}


### PR DESCRIPTION
Until now, a panic in the live preview or the LSP wasm would only land in the browser console and silently leave the page broken. Catch the panic and surface a modal that explains what happened and prefills a GitHub bug report with the panic message and, if it fits, a SlintPad link to the offending snippet.

Fixes: #6313

<img width="1334" height="866" alt="image" src="https://github.com/user-attachments/assets/a5b1697b-78c1-4583-b4c1-4e99323a9b04" />
