### PR TITLE
FlexboxLayout: compute cross-axis min-height from actual wrapping

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1893,16 +1893,10 @@ pub fn flexbox_layout_info_cross_axis(
     }
 
     // Determine which axis is cross
-    let (cross_cells, cross_padding) = match direction {
-        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => (&cells_v, padding_v),
-        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
-            (&cells_h, padding_h)
-        }
+    let cross_cells = match direction {
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => &cells_v,
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => &cells_h,
     };
-    let cross_extra_pad = cross_padding.begin + cross_padding.end;
-
-    let min = cross_cells.iter().map(|c| c.constraint.min).fold(0.0 as Coord, |a, b| a.max(b))
-        + cross_extra_pad;
 
     // Compute the main-axis preferred size to use as the constraint for taffy,
     // using the same heuristic as flexbox_layout_info_main_axis.
@@ -1979,23 +1973,17 @@ pub fn flexbox_layout_info_cross_axis(
     builder.compute_layout(available_width, available_height, None);
 
     let (total_width, total_height) = builder.container_size();
-    let cross_orientation = match direction {
-        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => Orientation::Vertical,
-        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
-            Orientation::Horizontal
-        }
-    };
-    let preferred = match cross_orientation {
-        Orientation::Horizontal => total_width,
-        Orientation::Vertical => total_height,
+    let cross_size = match direction {
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => total_height,
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => total_width,
     };
 
     LayoutInfo {
-        min,
+        min: cross_size,
         max: Coord::MAX,
         min_percent: 0 as _,
         max_percent: 100 as _,
-        preferred,
+        preferred: cross_size,
         stretch: 0.0,
     }
 }

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -41,7 +41,9 @@ export component TestCase inherits Window {
     // Main-axis preferred-width uses sqrt(sum of w²) heuristic ≈ 199px.
     // Cross-axis preferred-height uses taffy with the actual container width (200px) ≈ 129px.
     out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width > 198px && flex.preferred-width < 200px;
-    out property <bool> flex_minmax_height_ok: flex.min-height == 44px && flex.preferred-height > 128px && flex.preferred-height < 130px;
+    // min-height and preferred-height are both computed at the actual container
+    // width (200px), giving the same wrapping layout ≈ 129px.
+    out property <bool> flex_minmax_height_ok: flex.min-height > 128px && flex.min-height < 130px && flex.preferred-height > 128px && flex.preferred-height < 130px;
 
     out property <bool> test: test_r1 && test_r2 && test_r3 && test_r4 && test_r5 && test_r6 && flex_minmax_width_ok && flex_minmax_height_ok;
 }


### PR DESCRIPTION
The cross-axis min and preferred height were computed differently:
preferred used a taffy layout pass, but min was just the tallest
single item. This meant a wrapping FlexboxLayout could be shrunk
vertically past its content, hiding wrapped rows.

Fix: compute both min and preferred from a single taffy pass at
the current main-axis constraint width. This gives the actual
wrapped height, preventing the window from shrinking below it.