### PR TITLE
slint-tr-extractor: Fix bad default for plural rules in generated pot…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10209,8 +10209,10 @@ dependencies = [
  "clap",
  "i-slint-compiler",
  "itertools 0.14.0",
+ "rayon",
  "rspolib",
  "smol_str 0.3.2",
+ "tempfile",
 ]
 
 [[package]]

--- a/tools/tr-extractor/Cargo.toml
+++ b/tools/tr-extractor/Cargo.toml
@@ -23,6 +23,8 @@ smol_str = { workspace = true }
 
 [dev-dependencies]
 itertools = { workspace = true }
+rayon = { workspace = true }
+tempfile = "3"
 
 [[bin]]
 name = "slint-tr-extractor"

--- a/tools/tr-extractor/main.rs
+++ b/tools/tr-extractor/main.rs
@@ -80,7 +80,7 @@ fn main() -> std::io::Result<()> {
         file.metadata.insert("Content-Type".into(), "text/plain; charset=UTF-8".into());
         file.metadata.insert("Content-Transfer-Encoding".into(), "8bit".into());
         file.metadata.insert("Language".into(), String::new());
-        file.metadata.insert("Plural-Forms".into(), String::new());
+        file.metadata.insert("Plural-Forms".into(), "nplurals=1; plural=0;".into());
 
         file
     };

--- a/tools/tr-extractor/tests/fixtures/sample.expected.pot
+++ b/tools/tr-extractor/tests/fixtures/sample.expected.pot
@@ -1,0 +1,34 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: REDACTED\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. greeting shown on startup
+#: sample.slint:7
+msgctxt "Greeter"
+msgid "Hello"
+msgstr ""
+
+#: sample.slint:8
+msgctxt "menu"
+msgid "File"
+msgstr ""
+
+#: sample.slint:9
+msgctxt "Greeter"
+msgid "{n} file"
+msgid_plural "{n} files"
+msgstr[0] ""
+msgstr[1] ""

--- a/tools/tr-extractor/tests/fixtures/sample.slint
+++ b/tools/tr-extractor/tests/fixtures/sample.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Greeter {
+    in property <int> n;
+    // greeting shown on startup
+    a: @tr("Hello");
+    b: @tr("menu" => "File");
+    c: @tr("{n} file" | "{n} files" % n);
+}

--- a/tools/tr-extractor/tests/smoke.rs
+++ b/tools/tr-extractor/tests/smoke.rs
@@ -1,0 +1,78 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use rayon::prelude::*;
+use std::path::Path;
+use std::process::Command;
+
+// To add a new fixture: drop `<name>.slint` and `<name>.expected.pot` into
+// tests/fixtures/, then append the name here.
+const CASES: &[&str] = &["sample"];
+
+// Normalize a .pot file for comparison:
+// - strip the REUSE/SPDX header that reference files carry (but the extractor doesn't emit)
+// - redact the POT-Creation-Date value, which changes every run
+fn normalize(pot: &str) -> String {
+    let mut lines = pot.lines().peekable();
+    while let Some(line) = lines.peek() {
+        if line.starts_with("# Copyright") || line.starts_with("# SPDX-") || line.is_empty() {
+            lines.next();
+        } else {
+            break;
+        }
+    }
+    let mut out = String::with_capacity(pot.len());
+    for line in lines {
+        if line.starts_with("\"POT-Creation-Date:") {
+            out.push_str("\"POT-Creation-Date: REDACTED\\n\"");
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn run_case(fixtures: &Path, name: &str) -> Result<(), String> {
+    let bin = env!("CARGO_BIN_EXE_slint-tr-extractor");
+    let tmp = tempfile::tempdir().map_err(|e| format!("[{name}] tempdir: {e}"))?;
+    let out = tmp.path().join(format!("{name}.pot"));
+    let input = format!("{name}.slint");
+
+    let status = Command::new(bin)
+        .current_dir(fixtures)
+        .arg("-o")
+        .arg(&out)
+        .arg(&input)
+        .status()
+        .map_err(|e| format!("[{name}] spawn: {e}"))?;
+    if !status.success() {
+        return Err(format!("[{name}] extractor exited with {status}"));
+    }
+
+    let actual = normalize(
+        &std::fs::read_to_string(&out).map_err(|e| format!("[{name}] read output: {e}"))?,
+    );
+    let expected_path = fixtures.join(format!("{name}.expected.pot"));
+    let expected = normalize(
+        &std::fs::read_to_string(&expected_path)
+            .map_err(|e| format!("[{name}] read {}: {e}", expected_path.display()))?,
+    );
+
+    if actual != expected {
+        return Err(format!(
+            "[{name}] generated .pot does not match reference\n--- expected ---\n{expected}\n--- actual ---\n{actual}"
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn pot_fixtures() {
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures");
+
+    let failures: Vec<String> =
+        CASES.par_iter().filter_map(|name| run_case(&fixtures, name).err()).collect();
+
+    assert!(failures.is_empty(), "{}", failures.join("\n\n"));
+}


### PR DESCRIPTION
… file

Commit 348433f45fbee599a5e1ddfd0236c3339e83d7b7 regressed by replacing the previous default with an invalid entry. Restore the previous default.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
