### PR TITLE
StyledText: Add default-font-size and default-font-family properties

### DIFF
--- a/docs/astro/src/content/docs/reference/elements/styled-text.mdx
+++ b/docs/astro/src/content/docs/reference/elements/styled-text.mdx
@@ -60,6 +60,16 @@ Other HTML tags  |
 The default color of the text, used when no color is specified via markup.
 </SlintProperty>
 
+### default-font-family
+<SlintProperty propName="default-font-family" typeName="string">
+The default font family used to render the text, when no font is specified via markup. If left empty, the value falls back to the enclosing `Window`'s `default-font-family`.
+</SlintProperty>
+
+### default-font-size
+<SlintProperty propName="default-font-size" typeName="length">
+The default font size used to render the text, when no size is specified via markup. If unset (or zero), the value falls back to the enclosing `Window`'s `default-font-size`.
+</SlintProperty>
+
 ### horizontal-alignment
 <SlintProperty propName="horizontal-alignment" typeName="enum" enumName="TextHorizontalAlignment">
 The horizontal alignment of the text.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -125,6 +125,8 @@ component StyledTextItem inherits Empty {
     in property <length> height;
     in property <styled-text> text;
     in property <brush> default-color;
+    in property <length> default-font-size;
+    in property <string> default-font-family;
     in property <TextHorizontalAlignment> horizontal-alignment;
     in property <TextVerticalAlignment> vertical-alignment;
     callback link-clicked(link: string);

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -238,6 +238,8 @@ pub struct StyledTextItem {
     pub height: Property<LogicalLength>,
     pub text: Property<crate::styled_text::StyledText>,
     pub default_color: Property<Brush>,
+    pub default_font_size: Property<LogicalLength>,
+    pub default_font_family: Property<SharedString>,
     pub horizontal_alignment: Property<TextHorizontalAlignment>,
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub link_clicked: Callback<StringArg>,
@@ -388,9 +390,9 @@ impl HasFont for StyledTextItem {
     fn font_request(self: Pin<&Self>, self_rc: &crate::items::ItemRc) -> FontRequest {
         crate::items::WindowItem::resolved_font_request(
             self_rc,
+            self.default_font_family(),
             Default::default(),
-            Default::default(),
-            Default::default(),
+            self.default_font_size(),
             Default::default(),
             Default::default(),
         )

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -27,6 +27,10 @@ export component TestCase inherits Window {
             text: @markdown("Value : "
                             "<font color=\"red\">\{""}</font> [\{""}](https://slint.dev)");
         }
+        s7 := StyledText {
+            text: @markdown("Hello \{world}");
+            default-font-size: 24px;
+        }
     }
 
     out property<styled-text> t1: s1.text;
@@ -39,8 +43,9 @@ export component TestCase inherits Window {
     out property<length> w4: s4.preferred-width;
     out property<length> w5: s5.preferred-width;
     out property<length> w6: s6.preferred-width;
+    out property<length> w7: s7.preferred-width;
 
-    out property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px && w6 > 0px;
+    out property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px && w6 > 0px && w7 > w1;
 }
 
 /*


### PR DESCRIPTION
As discussed with Nigel and Olivier, this makes it easier to transition from Text to StyledText in UI.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
