### PR TITLE
cpp: use C++26 `delete("reason")` when available

### DIFF
--- a/api/cpp/include/private/slint_config.h
+++ b/api/cpp/include/private/slint_config.h
@@ -24,3 +24,9 @@
 #        define SLINT_DLL_IMPORT
 #    endif
 #endif // !defined(DOXYGEN)
+
+#if defined(__cpp_deleted_function) && __cpp_deleted_function >= 202403L
+#    define SLINT_DELETED_FUNCTION(reason) delete (reason)
+#else
+#    define SLINT_DELETED_FUNCTION(reason) delete
+#endif

--- a/api/cpp/include/slint-interpreter.h
+++ b/api/cpp/include/slint-interpreter.h
@@ -396,7 +396,8 @@ public:
     }
 
 private:
-    inline Value(const void *) = delete; // Avoid that for example Value("foo") turns to Value(bool)
+    inline Value(const void *) =
+            SLINT_DELETED_FUNCTION("pointers would otherwise implicitly convert to Value(bool)");
     slint::cbindgen_private::Value *inner;
     friend struct Struct;
     friend class ComponentInstance;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3204,7 +3204,7 @@ fn generate_public_api_for_properties(
                     Declaration::Function(Function {
                         name: format_smolstr!("set_{}", &prop_ident),
                         signature: format!(
-                            "(const {cpp_property_type} &) const = delete /* property '{}' is declared as 'out' (read-only). Declare it as 'in' or 'in-out' to enable the setter */", p.name
+                            "(const {cpp_property_type} &) const = SLINT_DELETED_FUNCTION(\"property '{}' is declared as 'out' (read-only). Declare it as 'in' or 'in-out' to enable the setter\")", p.name
                         ),
                         ..Default::default()
                     }),
@@ -3223,7 +3223,7 @@ fn generate_public_api_for_properties(
                 Declaration::Function(Function {
                     name: format_smolstr!("invoke_{prop_ident}"),
                     signature: format!(
-                        "({param_types}) const = delete /* the function '{name}' is declared as private. Declare it as 'public' */",
+                        "({param_types}) const = SLINT_DELETED_FUNCTION(\"the function '{name}' is declared as private. Declare it as 'public'\")",
                     ),
                     ..Default::default()
                 }),
@@ -3234,7 +3234,7 @@ fn generate_public_api_for_properties(
                 Declaration::Function(Function {
                     name: format_smolstr!("get_{prop_ident}"),
                     signature: format!(
-                        "() const = delete /* the property '{name}' is declared as private. Declare it as 'in', 'out', or 'in-out' to make it public */",
+                        "() const = SLINT_DELETED_FUNCTION(\"the property '{name}' is declared as private. Declare it as 'in', 'out', or 'in-out' to make it public\")",
                     ),
                     ..Default::default()
                 }),
@@ -3244,7 +3244,7 @@ fn generate_public_api_for_properties(
                 Declaration::Function(Function {
                     name: format_smolstr!("set_{}", &prop_ident),
                     signature: format!(
-                        "(const auto &) const = delete /* property '{name}' is declared as private. Declare it as 'in' or 'in-out' to make it public */",
+                        "(const auto &) const = SLINT_DELETED_FUNCTION(\"property '{name}' is declared as private. Declare it as 'in' or 'in-out' to make it public\")",
                     ),
                     ..Default::default()
                 }),


### PR DESCRIPTION
Add a private `SLINT_DELETED_FUNCTION(reason)` macro that expands to `delete(reason)` on compilers implementing P2573R2, and plain `delete` otherwise. The generated C++ code for read-only and private properties now carries the reason as a string literal instead of a trailing comment, so the diagnostic surfaces it on supported compilers.
