### PR TITLE
Upgrade muda

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6647,9 +6647,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "b20e2339ef964849496bd6dab1bcd8ceb7a3a5a268dc64c8b84c833e75d66dab"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -7431,7 +7431,6 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
- "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -10133,9 +10132,7 @@ dependencies = [
  "js-sys",
  "lsp-server",
  "lsp-types",
- "muda",
  "nucleo-matcher",
- "objc2-foundation 0.3.2",
  "send_wrapper",
  "serde",
  "serde-wasm-bindgen",

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -6312,9 +6312,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "b20e2339ef964849496bd6dab1bcd8ceb7a3a5a268dc64c8b84c833e75d66dab"
 dependencies = [
  "crossbeam-channel",
  "dpi",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -93,7 +93,7 @@ bytemuck = { workspace = true, optional = true, features = ["derive"] }
 webbrowser = "1.2.0"
 
 [target.'cfg(any(target_os = "macos", target_family = "windows"))'.dependencies]
-muda = { version = "0.17.0", optional = true, default-features = false }
+muda = { version = "0.18.0", optional = true, default-features = false }
 vtable = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -74,9 +74,6 @@ preview-engine = [
   "dep:i-slint-core",
   "dep:i-slint-backend-selector",
   "dep:slint-build",
-  "dep:i-slint-backend-winit",
-  "dep:muda",
-  "dep:objc2-foundation",
 ]
 ## Build in the actual code to act as a preview for slint files. Does nothing in WASM!
 preview-builtin = ["preview-engine"]
@@ -129,11 +126,6 @@ wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
 i-slint-backend-winit = { workspace = true }
 tokio = { version = "1.50.0", features = ["rt", "sync", "macros"] }
-
-[target.'cfg(target_vendor = "apple")'.dependencies]
-i-slint-backend-winit = { workspace = true, optional = true }
-muda = { version = "0.17.0", optional = true, default-features = false }
-objc2-foundation = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 i-slint-backend-testing = { path = "../../internal/backends/testing" }


### PR DESCRIPTION
This also removes the unnecessary muda & related dependencies in the lsp.

The muda upgrade addresses the potenial menubar crashes on windows when toggling visibility:

https://github.com/slint-ui/slint/pull/11297#issuecomment-4239279467

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
