### PR TITLE
lsp: Attempt to make stderr closure by the host more robust

### DIFF
--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -1152,24 +1152,24 @@ mod tests {
         document_cache: &common::DocumentCache,
         edit: &lsp_types::WorkspaceEdit,
     ) -> Vec<text_edit::EditedText> {
-        eprintln!("Edit:");
+        tracing::debug!("Edit:");
         for it in text_edit::EditIterator::new(edit) {
-            eprintln!("   {} => {:?}", it.0.uri, it.1);
+            tracing::debug!("   {} => {:?}", it.0.uri, it.1);
         }
-        eprintln!("*** All edits reported ***");
+        tracing::debug!("*** All edits reported ***");
 
         let changed_text = text_edit::apply_workspace_edit(document_cache, edit).unwrap();
         assert!(!changed_text.is_empty()); // there was a change!
 
-        eprintln!("After changes were applied:");
+        tracing::debug!("After changes were applied:");
         for ct in &changed_text {
-            eprintln!("File {}:", ct.url);
+            tracing::debug!("File {}:", ct.url);
             for (count, line) in ct.contents.split('\n').enumerate() {
-                eprintln!("    {:3}: {line}", count + 1);
+                tracing::debug!("    {:3}: {line}", count + 1);
             }
-            eprintln!("=========");
+            tracing::debug!("=========");
         }
-        eprintln!("*** All changes reported ***");
+        tracing::debug!("*** All changes reported ***");
 
         changed_text
     }

--- a/tools/lsp/common/test.rs
+++ b/tools/lsp/common/test.rs
@@ -115,9 +115,9 @@ pub fn recompile_test_with_sources(
         },
     ));
 
-    eprintln!("Test source diagnostics:");
+    tracing::debug!("Test source diagnostics:");
     for d in diagnostics.iter() {
-        eprintln!("    {:?}: {d}", d.level());
+        tracing::debug!("    {:?}: {d}", d.level());
     }
     assert!(!diagnostics.has_errors());
     if !allow_warnings {

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -348,14 +348,14 @@ fn whitespace_to_one_of(
                 return Ok(SyntaxMatch::Found(expected_kind));
             }
             _ => {
-                eprintln!("Inconsistency: expected {elements:?},  found {n:?}");
+                tracing::warn!("Inconsistency: expected {elements:?},  found {n:?}");
                 fold(n, writer, state)?;
                 return Ok(SyntaxMatch::NotFound);
             }
         }
         fold(n, writer, state)?;
     }
-    eprintln!("Inconsistency: expected {elements:?},  not found");
+    tracing::warn!("Inconsistency: expected {elements:?},  not found");
     Ok(SyntaxMatch::NotFound)
 }
 
@@ -1093,7 +1093,7 @@ fn format_array(
                 }
             }
             SyntaxMatch::NotFound | SyntaxMatch::Found(_) => {
-                eprintln!("Inconsistency: unexpected syntax in array.");
+                tracing::warn!("Inconsistency: unexpected syntax in array.");
                 break;
             }
         }
@@ -1169,7 +1169,7 @@ fn format_states(
         && whitespace_to(&mut sub, SyntaxKind::LBracket, writer, state, " ")?;
 
     if !ok {
-        eprintln!("Inconsistency: Expect states and ']'");
+        tracing::warn!("Inconsistency: Expect states and ']'");
         return Ok(());
     }
 
@@ -1365,7 +1365,7 @@ fn format_object_literal(
         } else if let SyntaxMatch::Found(SyntaxKind::RBrace) = el {
             break;
         } else {
-            eprintln!("Inconsistency: unexpected syntax in object literal.");
+            tracing::warn!("Inconsistency: unexpected syntax in object literal.");
             break;
         }
     }
@@ -1452,7 +1452,7 @@ fn format_object_type(
         } else if let SyntaxMatch::Found(SyntaxKind::RBrace) = el {
             break;
         } else {
-            eprintln!("Inconsistency: unexpected syntax in object type.");
+            tracing::warn!("Inconsistency: unexpected syntax in object type.");
             break;
         }
     }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -1943,7 +1943,7 @@ mod tests {
         let source6 = "{ property<int> xyz; changed t🔺 \n enabled: true; }  ";
         let source7 = "{ changed t🔺 => {} property<int> xyz; ";
         for s in [source1, source2, source3, source4, source5, source6, source7] {
-            eprintln!("changed_completion: {s:?}");
+            tracing::debug!("changed_completion: {s:?}");
             let s = format!(
                 "component Bar inherits TextInput {{ property <int> nope; out property <int> from_bar; }} component Foo {{ Bar {s} }}"
             );
@@ -2047,7 +2047,7 @@ mod tests {
             "component Bar in🔺 Window {}",
         ];
         for source in sources {
-            eprintln!("Test for inherits in {source:?}");
+            tracing::debug!("Test for inherits in {source:?}");
             let res = get_completions(source).unwrap();
             res.iter().find(|ci| ci.label == "inherits").unwrap();
         }
@@ -2071,7 +2071,7 @@ mod tests {
             "component X { property<string> prop; elem := Text{} prop <=> e🔺; }",
         ];
         for source in sources {
-            eprintln!("Test for two ways in {source:?}");
+            tracing::debug!("Test for two ways in {source:?}");
             let res = get_completions(source).unwrap();
             res.iter().find(|ci| ci.label == "prop").unwrap();
             res.iter().find(|ci| ci.label == "self").unwrap();
@@ -2087,7 +2087,7 @@ mod tests {
             "component X { elem := Text{ property<string> prop; } title <=> elem.🔺; }",
         ];
         for source in sources {
-            eprintln!("Test for two ways in {source:?}");
+            tracing::debug!("Test for two ways in {source:?}");
             let res = get_completions(source).unwrap();
             res.iter().find(|ci| ci.label == "text").unwrap();
             res.iter().find(|ci| ci.label == "prop").unwrap();

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -217,6 +217,7 @@ impl RequestHandler {
 
 fn main() {
     tracing_subscriber::fmt()
+        .log_internal_errors(false)
         .with_writer(std::io::stderr)
         .with_ansi(false)
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -268,7 +269,7 @@ fn main() {
             Commands::Format(fmt) => match fmt::tool::run(&fmt.paths, fmt.inline) {
                 Ok(()) => std::process::exit(0),
                 Err(e) => {
-                    eprintln!("Format Error: {e}");
+                    tracing::error!("Format Error: {e}");
                     std::process::exit(1)
                 }
             },
@@ -276,7 +277,7 @@ fn main() {
             Commands::LivePreview(live_preview) => match preview::run(live_preview) {
                 Ok(()) => std::process::exit(0),
                 Err(e) => {
-                    eprintln!("Preview Error: {e}");
+                    tracing::error!("Preview Error: {e}");
                     std::process::exit(2);
                 }
             },
@@ -291,7 +292,7 @@ fn main() {
         match local_set.block_on(&rt, run_lsp_server(args)) {
             Ok(threads) => threads.join().unwrap(),
             Err(error) => {
-                eprintln!("Error running LSP server: {error}");
+                tracing::error!("Error running LSP server: {error}");
                 std::process::exit(3);
             }
         }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -3,6 +3,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 #![allow(clippy::await_holding_refcell_ref)]
+#![deny(clippy::print_stderr, clippy::print_stdout)]
 
 #[cfg(all(feature = "preview-engine", not(feature = "preview-builtin")))]
 compile_error!(

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1274,7 +1274,7 @@ async fn reload_timer_function() {
                 PREVIEW_STATE.with_borrow_mut(|preview_state| {
                     preview_state.loading_state = PreviewFutureState::Pending;
                 });
-                eprintln!("{e}");
+                tracing::error!("{e}");
                 std::process::exit(3);
             }
         }

--- a/tools/lsp/preview/connector/native.rs
+++ b/tools/lsp/preview/connector/native.rs
@@ -284,6 +284,7 @@ impl RemoteControlledPreviewToLsp {
 }
 
 impl common::PreviewToLsp for RemoteControlledPreviewToLsp {
+    #[allow(clippy::print_stdout)]
     fn send(&self, message: &common::PreviewToLspMessage) -> common::Result<()> {
         let message = serde_json::to_string(message).map_err(|e| e.to_string())?;
         println!("{message}");

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -687,7 +687,7 @@ export component Entry inherits Main { /* @lsp:ignore-node */ } // 401
 
         tracing::debug!("Covers:");
         for (i, (p, ts)) in covers_center.iter().enumerate() {
-            println!("   {i}: {p:?}:{ts:?}");
+            tracing::debug!("   {i}: {p:?}:{ts:?}");
         }
         tracing::debug!("Done");
 

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -685,11 +685,11 @@ export component Entry inherits Main { /* @lsp:ignore-node */ } // 401
         .map(|en| en.path_and_offset())
         .collect::<Vec<_>>();
 
-        eprintln!("Covers:");
+        tracing::debug!("Covers:");
         for (i, (p, ts)) in covers_center.iter().enumerate() {
             println!("   {i}: {p:?}:{ts:?}");
         }
-        eprintln!("Done");
+        tracing::debug!("Done");
 
         // Select without crossing boundaries
         // --------------------------------------------------------------------

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -1064,11 +1064,11 @@ pub mod tests {
         ec: u32,
     ) {
         for (i, l) in content.split('\n').enumerate() {
-            println!("{i:2}: {l}");
+            tracing::debug!("{i:2}: {l}");
         }
-        println!("-------------------------------------------------------------------");
-        println!("   :           1         2         3         4         5");
-        println!("   : 012345678901234567890123456789012345678901234567890123456789");
+        tracing::debug!("-------------------------------------------------------------------");
+        tracing::debug!("   :           1         2         3         4         5");
+        tracing::debug!("   : 012345678901234567890123456789012345678901234567890123456789");
 
         let (dc, url, _) = loaded_document_cache(content);
         let source_file = dc.get_document(&url).unwrap().node.as_ref().unwrap().source_file.clone();
@@ -1082,7 +1082,7 @@ pub mod tests {
 
         let sel_range =
             util::text_range_to_lsp_range(&source_file, definition.selection_range, dc.format);
-        println!(
+        tracing::debug!(
             "Actual: (l: {}, c: {}) - (l: {}, c: {}) --- Expected: (l: {sl}, c: {sc}) - (l: {el}, c: {ec})",
             sel_range.start.line,
             sel_range.start.character,

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -1505,8 +1505,8 @@ export component Tester {{
     }
 
     fn compare_pv(r: &super::PropertyValue, e: &PropertyValue) {
-        eprintln!("Received: {r:?}");
-        eprintln!("Expected: {e:?}");
+        tracing::debug!("Received: {r:?}");
+        tracing::debug!("Expected: {e:?}");
 
         assert_eq!(r.value_bool, e.value_bool);
         assert_eq!(r.is_translatable, e.is_translatable);
@@ -1536,15 +1536,15 @@ export component Tester {{
         let (key, value) = generate_preview_data(visibility, type_def, type_name, code);
         let rp = super::map_preview_data_property(&key, &value).unwrap();
 
-        eprintln!("*** Validating PreviewData: Received: {rp:?}");
-        eprintln!("*** Validating PreviewData: Expected: {expected_data:?}");
+        tracing::debug!("*** Validating PreviewData: Received: {rp:?}");
+        tracing::debug!("*** Validating PreviewData: Expected: {expected_data:?}");
 
         assert_eq!(rp.name, expected_data.name);
         assert_eq!(rp.has_getter, expected_data.has_getter);
         assert_eq!(rp.has_setter, expected_data.has_setter);
         assert_eq!(rp.kind, expected_data.kind);
 
-        eprintln!("*** PreviewData is as expected...");
+        tracing::debug!("*** PreviewData is as expected...");
 
         (key, value)
     }
@@ -1599,7 +1599,7 @@ export component Tester {{
         assert_eq!(is_array, expected_is_array);
 
         for (idx, h) in headers.iter().enumerate() {
-            eprintln!("Header {idx}: \"{h}\"");
+            tracing::debug!("Header {idx}: \"{h}\"");
         }
         assert_eq!(headers.len(), expected_headers.len());
         assert!(headers.iter().zip(expected_headers.iter()).all(|(rh, eh)| rh == eh));

--- a/tools/lsp/preview/ui/log_messages.rs
+++ b/tools/lsp/preview/ui/log_messages.rs
@@ -58,7 +58,7 @@ pub fn filter_log_messages(
     pattern: SharedString,
 ) -> ModelRc<ui::LogMessage> {
     let pattern = pattern.to_string();
-    eprintln!("messages: row_count: {}", messages.row_count());
+    tracing::debug!("messages: row_count: {}", messages.row_count());
     Rc::new(VecModel::from(common::fuzzy_filter_iter(
         &mut messages.iter(),
         |lm| format!("{} %level:{:?} %file:{}", lm.message, lm.level, lm.file,),

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -305,9 +305,9 @@ mod tests {
             if diag.is_empty() {
                 continue;
             }
-            eprintln!("Diags for {u}");
+            tracing::debug!("Diags for {u}");
             for d in diag {
-                eprintln!("{d:#?}");
+                tracing::debug!("{d:#?}");
                 assert!(!matches!(d.severity, Some(lsp_types::DiagnosticSeverity::ERROR)));
             }
         }
@@ -328,7 +328,7 @@ mod tests {
 
     #[track_caller]
     fn compare_brush(entry: &PaletteEntry, name: &str, brush: &slint::Brush) {
-        eprintln!("\n\n\n{name}:\n{entry:#?}");
+        tracing::debug!("\n\n\n{name}:\n{entry:#?}");
         assert_eq!(entry.name, name);
         assert_eq!(entry.value.display_string, name);
         assert_eq!(entry.value.code, name);

--- a/tools/lsp/preview/ui/property_view.rs
+++ b/tools/lsp/preview/ui/property_view.rs
@@ -397,9 +397,9 @@ mod tests {
             if diag.is_empty() {
                 continue;
             }
-            eprintln!("Diags for {u}");
+            tracing::debug!("Diags for {u}");
             for d in diag {
-                eprintln!("{d:#?}");
+                tracing::debug!("{d:#?}");
             }
         }
         if let Some((e, p)) =
@@ -412,7 +412,7 @@ mod tests {
     }
 
     fn property_conversion_test(contents: &str, property_line: u32) -> ui::PropertyValue {
-        eprintln!("\n\n\n{contents}:");
+        tracing::debug!("\n\n\n{contents}:");
         let (e, pi, dc, _) = properties_at_position(contents, property_line, 30).unwrap();
         let test1 = pi.iter().find(|pi| pi.name == "test1").unwrap();
         super::map_property_to_ui(&dc, &e.element, test1, None).0

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -486,9 +486,10 @@ component MainWindow inherits Window {
                 u32::from(original_offset).into(),
                 ByteFormat::Utf16,
             );
-            eprintln!(
+            tracing::debug!(
                 "c: {c} <offset: {offset:?}> => {line}:{pos_8} => mapped {}:{}",
-                mapped_8.line, mapped_8.character
+                mapped_8.line,
+                mapped_8.character
             );
             assert_eq!(mapped_8.line, (line as u32));
             assert_eq!(mapped_8.character, (pos_8 as u32));

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #![cfg(target_arch = "wasm32")]
+#![deny(clippy::print_stderr, clippy::print_stdout)]
 
 pub mod common;
 mod fmt;


### PR DESCRIPTION
Replace direct use of eprintln! with tracing and forbit eprintln! and print! via clippy ;)

cc #11398