### PR TITLE
ci: restrict versions.txt to X.Y.Z directories

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -503,7 +503,7 @@ jobs:
             - name: Update versions.txt
               if: github.event.inputs.release == 'true'
               working-directory: www-releases/releases
-              run: ls -1d */ | cut -f1 -d'/' | sort --version-sort -r > versions.txt
+              run: ls -1d */ | cut -f1 -d'/' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort --version-sort -r > versions.txt
 
             - name: Print contents before update
               if: github.event.inputs.release == 'true'


### PR DESCRIPTION
The www-releases/releases tree now contains non-version directories (e.g. material-1.0) alongside Slint releases. Filter the directory listing to strict semver names so they don't leak into versions.txt.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
