### PR TITLE
Implements `align-items` on HorizontalLayout / VerticalLayout

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -126,6 +126,16 @@ inline SharedVector<float> solve_box_layout(const cbindgen_private::BoxLayoutDat
     return result;
 }
 
+inline SharedVector<float> solve_box_layout_ortho(const cbindgen_private::BoxLayoutOrthoData &data,
+                                                  cbindgen_private::Slice<int> repeater_indices)
+{
+    SharedVector<float> result;
+    cbindgen_private::Slice<uint32_t> ri =
+            make_slice(reinterpret_cast<uint32_t *>(repeater_indices.ptr), repeater_indices.len);
+    cbindgen_private::slint_solve_box_layout_ortho(&data, ri, &result);
+    return result;
+}
+
 inline SharedVector<uint16_t>
 organize_grid_layout(cbindgen_private::Slice<cbindgen_private::GridLayoutInputData> input_data,
                      cbindgen_private::Slice<int> repeater_indices,

--- a/demos/energy-monitor/ui/widgets/menu.slint
+++ b/demos/energy-monitor/ui/widgets/menu.slint
@@ -76,17 +76,14 @@ export component Menu {
         if(menu-button-visible || container-visibility == 1.0 || stays-open) : HorizontalLayout {
             y:  -i-menu-button.height / 2;
             alignment: center;
+            align-items: start;
 
-            VerticalLayout {
-                alignment: start;
-
-                i-menu-button := MenuButton {
-                    clicked => {
-                        if(open) {
-                            hide();
-                        } else {
-                            open-menu();
-                        }
+            i-menu-button := MenuButton {
+                clicked => {
+                    if(open) {
+                        hide();
+                    } else {
+                        open-menu();
                     }
                 }
             }

--- a/docs/astro/src/content/docs/guide/experimental/flexboxlayout.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/flexboxlayout.mdx
@@ -126,7 +126,7 @@ The default value is `stretch`.
 </SlintProperty>
 
 ### align-items
-<SlintProperty propName="align-items" typeName="enum" enumName="FlexboxLayoutAlignItems">
+<SlintProperty propName="align-items" typeName="enum" enumName="LayoutAlignItems">
 Set the alignment of individual items along the cross axis within each flex line.
 The default value is `stretch`.
 </SlintProperty>

--- a/docs/astro/src/content/docs/reference/layouts/horizontallayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/horizontallayout.mdx
@@ -55,6 +55,28 @@ To target specific sides with different values use the following properties:
 
 ### alignment
 <SlintProperty propName="alignment" typeName="enum" enumName="LayoutAlignment">
-Set the alignment. Matches the CSS flex box.
+Set the alignment along the main (horizontal) axis. Matches the CSS flex box.
+</SlintProperty>
+
+### align-items
+<SlintProperty propName="align-items" typeName="enum" enumName="LayoutAlignItems">
+Set the alignment of items along the cross (vertical) axis.
+The default is `stretch`, meaning each item fills the full height of the layout.
+The other values (`start`, `end`, `center`) size each
+item to its preferred height, clamped to its min/max, and position it at the
+top, bottom, or center of the layout's content box.
+
+```slint
+export component Example inherits Window {
+    width: 200px;
+    height: 100px;
+    HorizontalLayout {
+        align-items: center;
+        Rectangle { background: red; preferred-width: 30px; preferred-height: 20px; }
+        Rectangle { background: blue; preferred-width: 30px; preferred-height: 40px; }
+        Rectangle { background: green; preferred-width: 30px; preferred-height: 60px; }
+    }
+}
+```
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/layouts/verticallayout.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/verticallayout.mdx
@@ -52,5 +52,27 @@ To target specific sides with different values use the following properties:
 ## Alignment Properties
 ### alignment
 <SlintProperty propName="alignment" typeName="enum" enumName="LayoutAlignment">
-Set the alignment. Matches the CSS flex box.
+Set the alignment along the main (vertical) axis. Matches the CSS flex box.
+</SlintProperty>
+
+### align-items
+<SlintProperty propName="align-items" typeName="enum" enumName="LayoutAlignItems">
+Set the alignment of items along the cross (horizontal) axis.
+The default is `stretch`, meaning each item fills the full width of the layout.
+The other values (`start`, `end`, `center`) size each
+item to its preferred width, clamped to its min/max, and position it at the
+left, right, or center of the layout's content box.
+
+```slint
+export component Example inherits Window {
+    width: 200px;
+    height: 100px;
+    VerticalLayout {
+        align-items: end;
+        Rectangle { background: red; preferred-width: 30px; preferred-height: 20px; }
+        Rectangle { background: blue; preferred-width: 60px; preferred-height: 20px; }
+        Rectangle { background: green; preferred-width: 90px; preferred-height: 20px; }
+    }
+}
+```
 </SlintProperty>

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -76,11 +76,11 @@ export component MainWindow inherits Window {
         FlexboxLayoutAlignContent.space-evenly
     ];
     property <[string]> align_items_options: ["Stretch", "Start", "End", "Center"];
-    property <[FlexboxLayoutAlignItems]> align_items_values: [
-        FlexboxLayoutAlignItems.stretch,
-        FlexboxLayoutAlignItems.start,
-        FlexboxLayoutAlignItems.end,
-        FlexboxLayoutAlignItems.center
+    property <[LayoutAlignItems]> align_items_values: [
+        LayoutAlignItems.stretch,
+        LayoutAlignItems.start,
+        LayoutAlignItems.end,
+        LayoutAlignItems.center
     ];
     property <[string]> flex_wrap_options: ["Wrap", "NoWrap", "WrapReverse"];
     property <[FlexboxLayoutWrap]> flex_wrap_values: [FlexboxLayoutWrap.wrap, FlexboxLayoutWrap.no-wrap, FlexboxLayoutWrap.wrap-reverse];

--- a/examples/todo-mvc/ui/widgets/action_button.slint
+++ b/examples/todo-mvc/ui/widgets/action_button.slint
@@ -46,11 +46,11 @@ export component ActionButton {
 
     content-layer := HorizontalLayout {
         alignment: center;
+        align-items: center;
 
         icon-image := Image {
             source: root.icon;
             height: SizeSettings.control-icon-big-height;
-            y: (parent.height - self.height) / 2;
             colorize: TodoPalette.accent-foreground;
         }
    }

--- a/examples/todo-mvc/ui/widgets/icon_button.slint
+++ b/examples/todo-mvc/ui/widgets/icon_button.slint
@@ -39,11 +39,11 @@ export component IconButton {
 
     content-layer := HorizontalLayout {
         alignment: center;
+        align-items: center;
 
         icon-image := Image {
             source: root.icon;
             height: SizeSettings.control-icon-height;
-            y: (parent.height - self.height) / 2;
             colorize: TodoPalette.foreground;
         }
     }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -396,7 +396,7 @@ macro_rules! for_each_enums {
 
             /// Controls the alignment of individual items along the cross axis within each flex line.
             #[non_exhaustive]
-            enum FlexboxLayoutAlignItems {
+            enum LayoutAlignItems {
                 /// Items are stretched to fill the line along the cross axis.
                 Stretch,
                 /// Items are placed at the start of the cross axis.

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -394,10 +394,12 @@ macro_rules! for_each_enums {
                 SpaceEvenly,
             }
 
-            /// Controls the alignment of individual items along the cross axis within each flex line.
+            /// Controls the alignment of individual items along the cross axis of a layout.
+            /// Used as the `align-items` property of `HorizontalLayout`, `VerticalLayout`,
+            /// and `FlexboxLayout`.
             #[non_exhaustive]
             enum LayoutAlignItems {
-                /// Items are stretched to fill the line along the cross axis.
+                /// Items are stretched to fill the cross axis.
                 Stretch,
                 /// Items are placed at the start of the cross axis.
                 Start,

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -447,11 +447,13 @@ export component GridLayout {
 export component VerticalLayout {
     in property <length> spacing;
     in property <LayoutAlignment> alignment;
+    in property <LayoutAlignItems> align-items;
 }
 
 export component HorizontalLayout {
     in property <length> spacing;
     in property <LayoutAlignment> alignment;
+    in property <LayoutAlignItems> align-items;
 }
 
 export component FlexboxLayout {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -461,7 +461,7 @@ export component FlexboxLayout {
     in property <LayoutAlignment> alignment: LayoutAlignment.start;  // CSS default is flex-start
     in property <FlexboxLayoutDirection> flex-direction;
     in property <FlexboxLayoutAlignContent> align-content;
-    in property <FlexboxLayoutAlignItems> align-items;
+    in property <LayoutAlignItems> align-items;
     in property <FlexboxLayoutWrap> flex-wrap;
 }
 

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -835,7 +835,7 @@ pub enum Expression {
         layout: crate::layout::GridLayout,
         orientation: crate::layout::Orientation,
     },
-    /// Determine the coordinates of the items
+    /// Determine the coordinates of the items in the given orientation.
     SolveBoxLayout(crate::layout::BoxLayout, crate::layout::Orientation),
     SolveGridLayout {
         layout_organized_data_prop: NamedReference,

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -662,6 +662,7 @@ pub enum BuiltinPrivateStruct {
     GridLayoutData,
     GridLayoutInputData,
     BoxLayoutData,
+    BoxLayoutOrthoData,
     FlexboxLayoutData,
     LayoutItemInfo,
     FlexboxLayoutItemInfo,
@@ -685,6 +686,7 @@ impl BuiltinPrivateStruct {
             Self::GridLayoutInputData
                 | Self::GridLayoutData
                 | Self::BoxLayoutData
+                | Self::BoxLayoutOrthoData
                 | Self::FlexboxLayoutData
         )
     }

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -19,6 +19,15 @@ pub enum Orientation {
     Vertical,
 }
 
+impl Orientation {
+    pub fn orthogonal(self) -> Self {
+        match self {
+            Orientation::Horizontal => Orientation::Vertical,
+            Orientation::Vertical => Orientation::Horizontal,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Default)]
 pub enum FlexboxLayoutDirection {
     /// Items are laid out in rows (horizontal primary axis)
@@ -606,6 +615,8 @@ pub struct BoxLayout {
     pub orientation: Orientation,
     pub elems: Vec<LayoutItem>,
     pub geometry: LayoutGeometry,
+    /// The `align-items` property, if set.
+    pub cross_alignment: Option<NamedReference>,
 }
 
 impl BoxLayout {
@@ -614,6 +625,9 @@ impl BoxLayout {
             cell.constraints.visit_named_references(visitor);
         }
         self.geometry.visit_named_references(visitor);
+        if let Some(e) = self.cross_alignment.as_mut() {
+            visitor(&mut *e);
+        }
     }
 }
 

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -335,7 +335,7 @@ pub(super) fn solve_flexbox_layout(
             (
                 "align_items",
                 crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutAlignItems.clone())),
+                    .with(|e| Type::Enumeration(e.enums.LayoutAlignItems.clone())),
                 fld.align_items,
             ),
             (
@@ -609,7 +609,7 @@ fn flexbox_layout_data(
     let align_items = if let Some(expr) = &layout.align_items {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutAlignItems.clone());
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.LayoutAlignItems.clone());
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -252,21 +252,46 @@ pub(super) fn solve_box_layout(
     let (padding, spacing) = generate_layout_padding_and_spacing(&layout.geometry, o, ctx);
     let bld = box_layout_data(layout, o, ctx);
     let size = layout_geometry_size(&layout.geometry.rect, o, ctx);
-    let data = make_struct(
-        BuiltinPrivateStruct::BoxLayoutData,
-        [
-            ("size", Type::Float32, size),
-            ("spacing", Type::Float32, spacing),
-            ("padding", padding.ty(ctx), padding),
-            (
-                "alignment",
-                crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.LayoutAlignment.clone())),
-                bld.alignment,
-            ),
-            ("cells", bld.cells.ty(ctx), bld.cells),
-        ],
-    );
+    let (data, function) = if o == layout.orientation {
+        let data = make_struct(
+            BuiltinPrivateStruct::BoxLayoutData,
+            [
+                ("size", Type::Float32, size),
+                ("spacing", Type::Float32, spacing),
+                ("padding", padding.ty(ctx), padding),
+                (
+                    "alignment",
+                    crate::typeregister::BUILTIN
+                        .with(|e| Type::Enumeration(e.enums.LayoutAlignment.clone())),
+                    bld.alignment,
+                ),
+                ("cells", bld.cells.ty(ctx), bld.cells),
+            ],
+        );
+        (data, "solve_box_layout")
+    } else {
+        let align_items_ty = crate::typeregister::BUILTIN
+            .with(|e| Type::Enumeration(e.enums.LayoutAlignItems.clone()));
+        let align_items = if let Some(nr) = &layout.cross_alignment {
+            llr_Expression::PropertyReference(ctx.map_property_reference(nr))
+        } else {
+            let e = crate::typeregister::BUILTIN.with(|e| e.enums.LayoutAlignItems.clone());
+            llr_Expression::EnumerationValue(EnumerationValue {
+                value: e.default_value,
+                enumeration: e,
+            })
+        };
+        let data = make_struct(
+            BuiltinPrivateStruct::BoxLayoutOrthoData,
+            [
+                ("size", Type::Float32, size),
+                ("padding", padding.ty(ctx), padding),
+                ("align_items", align_items_ty, align_items),
+                ("cells", bld.cells.ty(ctx), bld.cells),
+            ],
+        );
+        (data, "solve_box_layout_ortho")
+    };
     match bld.compute_cells {
         Some((cells_variable, elements)) => llr_Expression::WithLayoutItemInfo {
             cells_variable,
@@ -275,7 +300,7 @@ pub(super) fn solve_box_layout(
             elements,
             orientation: o,
             sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
-                function: "solve_box_layout".into(),
+                function: function.into(),
                 arguments: vec![
                     data,
                     llr_Expression::ReadLocalVariable {
@@ -287,7 +312,7 @@ pub(super) fn solve_box_layout(
             }),
         },
         None => llr_Expression::ExtraBuiltinFunctionCall {
-            function: "solve_box_layout".into(),
+            function: function.into(),
             arguments: vec![data, empty_int32_slice()],
             return_ty: Type::LayoutCache,
         },

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -544,6 +544,14 @@ fn recurse_expression(
             }
             visit_layout_items_dependencies(l.elems.iter(), *o, vis);
 
+            // The orthogonal solve depends on `align-items`.
+            if matches!(expr, Expression::SolveBoxLayout(..))
+                && *o != l.orientation
+                && let Some(nr) = l.cross_alignment.as_ref()
+            {
+                vis(&nr.clone().into(), P);
+            }
+
             let mut g = l.geometry.clone();
             g.rect = Default::default(); // already visited;
             g.visit_named_references(&mut |nr| vis(&nr.clone().into(), P))

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -761,10 +761,18 @@ fn lower_box_layout(
         orientation,
         elems: Default::default(),
         geometry: LayoutGeometry::new(layout_element),
+        cross_alignment: binding_reference(layout_element, "align-items"),
     };
 
     let layout_cache_prop =
         create_new_prop(layout_element, SmolStr::new_static("layout-cache"), Type::LayoutCache);
+    let layout_cache_ortho_prop = layout.cross_alignment.is_some().then(|| {
+        create_new_prop(
+            layout_element,
+            SmolStr::new_static("layout-cache-ortho"),
+            Type::LayoutCache,
+        )
+    });
     let layout_info_prop_v = create_new_prop(
         layout_element,
         SmolStr::new_static("layoutinfo-v"),
@@ -778,33 +786,34 @@ fn lower_box_layout(
 
     let layout_children = std::mem::take(&mut layout_element.borrow_mut().children);
 
-    let (begin_padding, end_padding) = match orientation {
-        Orientation::Horizontal => (&layout.geometry.padding.top, &layout.geometry.padding.bottom),
-        Orientation::Vertical => (&layout.geometry.padding.left, &layout.geometry.padding.right),
-    };
     let (pos, size, pad, ortho) = match orientation {
         Orientation::Horizontal => ("x", "width", "y", "height"),
         Orientation::Vertical => ("y", "height", "x", "width"),
     };
-    let pad_expr = begin_padding.clone().map(Expression::PropertyReference);
-    let mut size_expr = Expression::PropertyReference(NamedReference::new(
-        layout_element,
-        SmolStr::new_static(ortho),
-    ));
-    if let Some(p) = begin_padding {
-        size_expr = Expression::BinaryExpression {
-            lhs: Box::new(std::mem::take(&mut size_expr)),
-            rhs: Box::new(Expression::PropertyReference(p.clone())),
-            op: '-',
+    // Default stretch bindings, only used when there is no `align-items`.
+    let stretch_bindings = layout_cache_ortho_prop.is_none().then(|| {
+        let (begin_padding, end_padding) = match orientation {
+            Orientation::Horizontal => {
+                (&layout.geometry.padding.top, &layout.geometry.padding.bottom)
+            }
+            Orientation::Vertical => {
+                (&layout.geometry.padding.left, &layout.geometry.padding.right)
+            }
+        };
+        let pad_expr = begin_padding.clone().map(Expression::PropertyReference);
+        let mut size_expr = Expression::PropertyReference(NamedReference::new(
+            layout_element,
+            SmolStr::new_static(ortho),
+        ));
+        for p in [begin_padding, end_padding].into_iter().flatten() {
+            size_expr = Expression::BinaryExpression {
+                lhs: Box::new(std::mem::take(&mut size_expr)),
+                rhs: Box::new(Expression::PropertyReference(p.clone())),
+                op: '-',
+            };
         }
-    }
-    if let Some(p) = end_padding {
-        size_expr = Expression::BinaryExpression {
-            lhs: Box::new(std::mem::take(&mut size_expr)),
-            rhs: Box::new(Expression::PropertyReference(p.clone())),
-            op: '-',
-        }
-    }
+        (pad_expr, size_expr)
+    });
 
     for layout_child in &layout_children {
         let item = create_layout_item(layout_child, diag);
@@ -819,19 +828,29 @@ fn lower_box_layout(
             }
         };
         let actual_elem = &item.elem;
-        // step=1 for box layout items (single element per repeater iteration)
         set_prop_from_cache(actual_elem, pos, &layout_cache_prop, index, rep_idx, 2, diag);
         if !fixed_size {
             set_prop_from_cache(actual_elem, size, &layout_cache_prop, index + 1, rep_idx, 2, diag);
         }
-        if let Some(pad_expr) = pad_expr.clone() {
-            actual_elem.borrow_mut().bindings.insert(pad.into(), RefCell::new(pad_expr.into()));
-        }
-        if !fixed_ortho {
-            actual_elem
-                .borrow_mut()
-                .bindings
-                .insert(ortho.into(), RefCell::new(size_expr.clone().into()));
+        if let Some(cache_ortho) = &layout_cache_ortho_prop {
+            set_prop_from_cache(actual_elem, pad, cache_ortho, index, rep_idx, 2, diag);
+            if !fixed_ortho {
+                set_prop_from_cache(actual_elem, ortho, cache_ortho, index + 1, rep_idx, 2, diag);
+            }
+        } else {
+            let (pad_expr, size_expr) = stretch_bindings.as_ref().unwrap();
+            if let Some(pad_expr) = pad_expr {
+                actual_elem
+                    .borrow_mut()
+                    .bindings
+                    .insert(pad.into(), RefCell::new(pad_expr.clone().into()));
+            }
+            if !fixed_ortho {
+                actual_elem
+                    .borrow_mut()
+                    .bindings
+                    .insert(ortho.into(), RefCell::new(size_expr.clone().into()));
+            }
         }
         layout.elems.push(item.item);
     }
@@ -845,6 +864,16 @@ fn lower_box_layout(
         )
         .into(),
     );
+    if let Some(cache_ortho) = &layout_cache_ortho_prop {
+        cache_ortho.element().borrow_mut().bindings.insert(
+            cache_ortho.name().clone(),
+            BindingExpression::new_with_span(
+                Expression::SolveBoxLayout(layout.clone(), orientation.orthogonal()),
+                span.clone(),
+            )
+            .into(),
+        );
+    }
     layout_info_prop_h.element().borrow_mut().bindings.insert(
         layout_info_prop_h.name().clone(),
         BindingExpression::new_with_span(

--- a/internal/compiler/tests/syntax/analysis/binding_loop_align_items.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_align_items.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test {
+    VerticalLayout {
+//  >             <error{The binding for the property 'layout-cache-ortho' is part of a binding loop (align-items -> layout-cache-ortho -> r.x -> align-items)}
+//  >             <^error{The binding for the property 'x' is part of a binding loop (align-items -> layout-cache-ortho -> r.x -> align-items)}
+        align-items: r.x > 10px ? start : end;
+//                   >                       <error{The binding for the property 'align-items' is part of a binding loop (align-items -> layout-cache-ortho -> r.x -> align-items)}
+        r := Rectangle {
+            preferred-width: 50px;
+        }
+    }
+}

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -633,7 +633,7 @@ impl TypeRegister {
         register.elements.remove("FlexboxLayout").unwrap();
         register.types.remove("FlexboxLayoutDirection").unwrap();
         register.types.remove("FlexboxLayoutAlignContent").unwrap();
-        register.types.remove("FlexboxLayoutAlignItems").unwrap();
+        register.types.remove("LayoutAlignItems").unwrap();
         register.types.remove("FlexboxLayoutWrap").unwrap();
         register.types.remove("FlexboxLayoutAlignSelf").unwrap();
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -633,7 +633,6 @@ impl TypeRegister {
         register.elements.remove("FlexboxLayout").unwrap();
         register.types.remove("FlexboxLayoutDirection").unwrap();
         register.types.remove("FlexboxLayoutAlignContent").unwrap();
-        register.types.remove("LayoutAlignItems").unwrap();
         register.types.remove("FlexboxLayoutWrap").unwrap();
         register.types.remove("FlexboxLayoutAlignSelf").unwrap();
 

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1125,6 +1125,16 @@ pub struct BoxLayoutData<'a> {
     pub cells: Slice<'a, LayoutItemInfo>,
 }
 
+/// Input for `solve_box_layout_ortho`.
+#[repr(C)]
+#[derive(Debug)]
+pub struct BoxLayoutOrthoData<'a> {
+    pub size: Coord,
+    pub padding: Padding,
+    pub align_items: LayoutAlignItems,
+    pub cells: Slice<'a, LayoutItemInfo>,
+}
+
 #[repr(C)]
 #[derive(Debug)]
 /// The FlexboxLayoutData is used for a flex layout.
@@ -1271,6 +1281,41 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indices: Slice<u32>) -> S
     let mut generator = LayoutCacheGenerator::new(&repeater_indices, &mut result);
     for layout in layout_data.iter() {
         generator.add(layout.pos, layout.size);
+    }
+    result
+}
+
+/// Cross-axis solve: returns (position, size) per cell, like [`solve_box_layout`].
+pub fn solve_box_layout_ortho(
+    data: &BoxLayoutOrthoData,
+    repeater_indices: Slice<u32>,
+) -> SharedVector<Coord> {
+    let mut result = SharedVector::<Coord>::default();
+    result.resize(data.cells.len() * 2 + repeater_indices.len(), 0 as _);
+    if data.cells.is_empty() {
+        return result;
+    }
+    let size_without_padding = data.size - data.padding.begin - data.padding.end;
+    let mut generator = LayoutCacheGenerator::new(&repeater_indices, &mut result);
+    for c in data.cells.iter() {
+        let min =
+            c.constraint.min.max(c.constraint.min_percent * size_without_padding / 100 as Coord);
+        let max =
+            c.constraint.max.min(c.constraint.max_percent * size_without_padding / 100 as Coord);
+        let size = match data.align_items {
+            LayoutAlignItems::Stretch => size_without_padding,
+            _ => c.constraint.preferred,
+        }
+        .min(max)
+        .max(min);
+        let pos = match data.align_items {
+            LayoutAlignItems::Stretch | LayoutAlignItems::Start => data.padding.begin,
+            LayoutAlignItems::End => data.padding.begin + size_without_padding - size,
+            LayoutAlignItems::Center => {
+                data.padding.begin + (size_without_padding - size) / 2 as Coord
+            }
+        };
+        generator.add(pos, size);
     }
     result
 }
@@ -2063,6 +2108,15 @@ pub(crate) mod ffi {
         result: &mut SharedVector<Coord>,
     ) {
         *result = super::solve_box_layout(data, repeater_indices)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn slint_solve_box_layout_ortho(
+        data: &BoxLayoutOrthoData,
+        repeater_indices: Slice<u32>,
+        result: &mut SharedVector<Coord>,
+    ) {
+        *result = super::solve_box_layout_ortho(data, repeater_indices)
     }
 
     #[unsafe(no_mangle)]

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,8 +6,8 @@
 // cspell:ignore coord
 
 use crate::items::{
-    DialogButtonRole, FlexboxLayoutAlignContent, FlexboxLayoutAlignItems, FlexboxLayoutAlignSelf,
-    FlexboxLayoutDirection, FlexboxLayoutWrap, LayoutAlignment,
+    DialogButtonRole, FlexboxLayoutAlignContent, FlexboxLayoutAlignSelf, FlexboxLayoutDirection,
+    FlexboxLayoutWrap, LayoutAlignItems, LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
 use alloc::format;
@@ -1138,7 +1138,7 @@ pub struct FlexboxLayoutData<'a> {
     pub alignment: LayoutAlignment,
     pub direction: FlexboxLayoutDirection,
     pub align_content: FlexboxLayoutAlignContent,
-    pub align_items: FlexboxLayoutAlignItems,
+    pub align_items: LayoutAlignItems,
     pub flex_wrap: FlexboxLayoutWrap,
     /// Horizontal constraints (width) for each cell
     pub cells_h: Slice<'a, FlexboxLayoutItemInfo>,
@@ -1322,9 +1322,9 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, FlexboxLayoutAlignContent, FlexboxLayoutAlignItems, FlexboxLayoutAlignSelf,
-        FlexboxLayoutItemInfo, FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment,
-        Padding, Slice,
+        Coord, FlexboxLayoutAlignContent, FlexboxLayoutAlignSelf, FlexboxLayoutItemInfo,
+        FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignItems, LayoutAlignment, Padding,
+        Slice,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
@@ -1340,7 +1340,7 @@ mod flexbox_taffy {
         pub padding_v: &'a Padding,
         pub alignment: LayoutAlignment,
         pub align_content: FlexboxLayoutAlignContent,
-        pub align_items: FlexboxLayoutAlignItems,
+        pub align_items: LayoutAlignItems,
         pub flex_wrap: SlintFlexboxLayoutWrap,
         pub flex_direction: TaffyFlexDirection,
         pub container_width: Option<Coord>,
@@ -1508,10 +1508,10 @@ mod flexbox_taffy {
                             LayoutAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
                         }),
                         align_items: Some(match params.align_items {
-                            FlexboxLayoutAlignItems::Stretch => AlignItems::Stretch,
-                            FlexboxLayoutAlignItems::Start => AlignItems::FlexStart,
-                            FlexboxLayoutAlignItems::End => AlignItems::FlexEnd,
-                            FlexboxLayoutAlignItems::Center => AlignItems::Center,
+                            LayoutAlignItems::Stretch => AlignItems::Stretch,
+                            LayoutAlignItems::Start => AlignItems::FlexStart,
+                            LayoutAlignItems::End => AlignItems::FlexEnd,
+                            LayoutAlignItems::Center => AlignItems::Center,
                         }),
                         align_content: Some(match params.align_content {
                             FlexboxLayoutAlignContent::Stretch => AlignContent::Stretch,
@@ -1957,7 +1957,7 @@ pub fn flexbox_layout_info_cross_axis(
         padding_v,
         alignment: LayoutAlignment::Start,
         align_content: FlexboxLayoutAlignContent::Stretch,
-        align_items: FlexboxLayoutAlignItems::Stretch,
+        align_items: LayoutAlignItems::Stretch,
         flex_wrap,
         flex_direction: taffy_direction,
         container_width,

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -161,21 +161,41 @@ pub(crate) fn solve_box_layout(
         Some(&mut repeated_indices),
     );
     let (padding, spacing) = padding_and_spacing(&box_layout.geometry, orientation, &expr_eval);
-    let size_ref = match orientation {
-        Orientation::Horizontal => &box_layout.geometry.rect.width_reference,
-        Orientation::Vertical => &box_layout.geometry.rect.height_reference,
-    };
-    core_layout::solve_box_layout(
-        &core_layout::BoxLayoutData {
-            size: size_ref.as_ref().map(expr_eval).unwrap_or(0.),
-            spacing,
-            padding,
-            alignment,
-            cells: Slice::from(cells.as_slice()),
-        },
-        Slice::from(repeated_indices.as_slice()),
-    )
-    .into()
+    let size = box_layout.geometry.rect.size_reference(orientation).map(&expr_eval).unwrap_or(0.);
+    if orientation == box_layout.orientation {
+        core_layout::solve_box_layout(
+            &core_layout::BoxLayoutData {
+                size,
+                spacing,
+                padding,
+                alignment,
+                cells: Slice::from(cells.as_slice()),
+            },
+            Slice::from(repeated_indices.as_slice()),
+        )
+        .into()
+    } else {
+        let align_items = box_layout
+            .cross_alignment
+            .as_ref()
+            .map(|nr| {
+                eval::load_property(component, &nr.element(), nr.name())
+                    .unwrap()
+                    .try_into()
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+        core_layout::solve_box_layout_ortho(
+            &core_layout::BoxLayoutOrthoData {
+                size,
+                padding,
+                align_items,
+                cells: Slice::from(cells.as_slice()),
+            },
+            Slice::from(repeated_indices.as_slice()),
+        )
+        .into()
+    }
 }
 
 pub(crate) fn solve_flexbox_layout(

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -225,7 +225,7 @@ pub(crate) fn solve_flexbox_layout(
     let align_items = flexbox_layout
         .align_items
         .as_ref()
-        .map_or(i_slint_core::items::FlexboxLayoutAlignItems::default(), |nr| {
+        .map_or(i_slint_core::items::LayoutAlignItems::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
     let flex_wrap = flexbox_layout

--- a/tests/cases/layout/box_cross_alignment.slint
+++ b/tests/cases/layout/box_cross_alignment.slint
@@ -1,0 +1,354 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Tests for the `align-items` property on HorizontalLayout and VerticalLayout.
+
+component TestHStretch inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        align-items: stretch;
+        r1 := Rectangle { background: red; }
+        r2 := Rectangle { background: green; }
+    }
+
+    out property <bool> test:
+        r1.y == 0phx && r1.height == 200phx
+        && r2.y == 0phx && r2.height == 200phx;
+}
+
+component TestHStart inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        align-items: start;
+        r1 := Rectangle { background: red; preferred-height: 40phx; }
+        r2 := Rectangle { background: green; preferred-height: 80phx; }
+    }
+
+    out property <bool> test:
+        r1.y == 0phx && r1.height == 40phx
+        && r2.y == 0phx && r2.height == 80phx;
+}
+
+component TestHEnd inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        align-items: end;
+        r1 := Rectangle { background: red; preferred-height: 40phx; }
+        r2 := Rectangle { background: green; preferred-height: 80phx; }
+    }
+
+    out property <bool> test:
+        r1.y == 200phx - 40phx && r1.height == 40phx
+        && r2.y == 200phx - 80phx && r2.height == 80phx;
+}
+
+component TestHCenter inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        align-items: center;
+        r1 := Rectangle { background: red; preferred-height: 40phx; }
+        r2 := Rectangle { background: green; preferred-height: 80phx; }
+    }
+
+    out property <bool> test:
+        r1.y == (200phx - 40phx) / 2 && r1.height == 40phx
+        && r2.y == (200phx - 80phx) / 2 && r2.height == 80phx;
+}
+
+component TestVStretch inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: stretch;
+        r1 := Rectangle { background: red; }
+        r2 := Rectangle { background: green; }
+    }
+
+    out property <bool> test:
+        r1.x == 0phx && r1.width == 300phx
+        && r2.x == 0phx && r2.width == 300phx;
+}
+
+component TestVStart inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: start;
+        r1 := Rectangle { background: red; preferred-width: 60phx; }
+        r2 := Rectangle { background: green; preferred-width: 120phx; }
+    }
+
+    out property <bool> test:
+        r1.x == 0phx && r1.width == 60phx
+        && r2.x == 0phx && r2.width == 120phx;
+}
+
+component TestVEnd inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: end;
+        r1 := Rectangle { background: red; preferred-width: 60phx; }
+        r2 := Rectangle { background: green; preferred-width: 120phx; }
+    }
+
+    out property <bool> test:
+        r1.x == 300phx - 60phx && r1.width == 60phx
+        && r2.x == 300phx - 120phx && r2.width == 120phx;
+}
+
+component TestVCenter inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: center;
+        r1 := Rectangle { background: red; preferred-width: 60phx; }
+        r2 := Rectangle { background: green; preferred-width: 120phx; }
+    }
+
+    out property <bool> test:
+        r1.x == (300phx - 60phx) / 2 && r1.width == 60phx
+        && r2.x == (300phx - 120phx) / 2 && r2.width == 120phx;
+}
+
+// Centering happens within the padded content box.
+component TestHCenterWithPadding inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding-top: 30phx;
+        padding-bottom: 10phx;
+        padding-left: 0phx;
+        padding-right: 0phx;
+        align-items: center;
+        r1 := Rectangle { background: red; preferred-height: 40phx; }
+    }
+
+    // content box: 200 - 30 - 10 = 160phx, offset by 30phx
+    out property <bool> test: r1.y == 30phx + (160phx - 40phx) / 2 && r1.height == 40phx;
+}
+
+component TestVEndWithPadding inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding-left: 40phx;
+        padding-right: 20phx;
+        padding-top: 0phx;
+        padding-bottom: 0phx;
+        align-items: end;
+        r1 := Rectangle { background: red; preferred-width: 60phx; }
+    }
+
+    // content box: 300 - 40 - 20 = 240phx, starting at x=40
+    out property <bool> test: r1.x == 40phx + 240phx - 60phx && r1.width == 60phx;
+}
+
+// max-width clamps the cross-axis size when not stretching.
+component TestVCenterMaxWidth inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: center;
+        r1 := Rectangle {
+            background: red;
+            preferred-width: 1000phx;
+            max-width: 80phx;
+        }
+    }
+
+    out property <bool> test: r1.x == (300phx - 80phx) / 2 && r1.width == 80phx;
+}
+
+// stretch with a max-width clamps the size but stays at the start.
+component TestVStretchMinWidthWins inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: stretch;
+        r1 := Rectangle {
+            background: red;
+            max-width: 100phx;
+        }
+    }
+
+    out property <bool> test: r1.x == 0phx && r1.width == 100phx;
+}
+
+// Inner layout's align-items doesn't affect the outer layout.
+component TestNestedInStretch inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        inner := HorizontalLayout {
+            padding: 0phx;
+            align-items: center;
+            r1 := Rectangle { background: red; preferred-height: 40phx; }
+        }
+    }
+
+    out property <bool> test: inner.height == 200phx && r1.y == (200phx - 40phx) / 2 && r1.height == 40phx;
+}
+
+component TestNestedOuterCenter inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: center;
+        inner := HorizontalLayout {
+            padding: 0phx;
+            spacing: 0phx;
+            max-width: 100phx;
+            Rectangle { background: red; min-width: 40phx; max-width: 40phx; }
+            Rectangle { background: blue; min-width: 60phx; max-width: 60phx; }
+        }
+    }
+
+    out property <bool> test: inner.width == 100phx && inner.x == (300phx - 100phx) / 2;
+}
+
+component TestNestedSameOrientation inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        align-items: end;
+        spacing: 0phx;
+        inner := HorizontalLayout {
+            padding: 0phx;
+            spacing: 0phx;
+            preferred-height: 40phx;
+            max-height: 40phx;
+            Rectangle { background: red; min-width: 30phx; max-width: 30phx; }
+            Rectangle { background: blue; min-width: 50phx; max-width: 50phx; }
+        }
+        r2 := Rectangle { background: green; preferred-height: 60phx; max-height: 60phx; }
+    }
+
+    out property <bool> test:
+        inner.height == 40phx && inner.y == 200phx - 40phx && inner.width == 80phx
+        && r2.height == 60phx && r2.y == 200phx - 60phx;
+}
+
+component TestNestedHInV inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: end;
+        inner := HorizontalLayout {
+            padding: 0phx;
+            spacing: 0phx;
+            max-width: 110phx;
+            Rectangle { background: red; min-width: 50phx; max-width: 50phx; }
+            Rectangle { background: blue; min-width: 60phx; max-width: 60phx; }
+        }
+    }
+
+    out property <bool> test: inner.width == 110phx && inner.x == 300phx - 110phx;
+}
+
+component TestTripleNesting inherits Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        align-items: stretch;
+        middle := HorizontalLayout {
+            padding: 0phx;
+            preferred-height: 100phx;
+            max-height: 100phx;
+            align-items: start;
+            inner := Rectangle {
+                background: red;
+                preferred-height: 30phx;
+                max-height: 30phx;
+            }
+        }
+    }
+
+    out property <bool> test:
+        middle.height == 100phx && inner.height == 30phx && inner.y == 0phx;
+}
+
+export component TestCase inherits Rectangle {
+    h_stretch := TestHStretch {}
+    h_start := TestHStart {}
+    h_end := TestHEnd {}
+    h_center := TestHCenter {}
+    v_stretch := TestVStretch {}
+    v_start := TestVStart {}
+    v_end := TestVEnd {}
+    v_center := TestVCenter {}
+    h_center_pad := TestHCenterWithPadding {}
+    v_end_pad := TestVEndWithPadding {}
+    v_max := TestVCenterMaxWidth {}
+    v_stretch_min := TestVStretchMinWidthWins {}
+    nested := TestNestedInStretch {}
+    nested_outer_center := TestNestedOuterCenter {}
+    nested_same := TestNestedSameOrientation {}
+    nested_h_in_v := TestNestedHInV {}
+    triple := TestTripleNesting {}
+
+    out property <bool> test:
+        h_stretch.test && h_start.test && h_end.test && h_center.test
+        && v_stretch.test && v_start.test && v_end.test && v_center.test
+        && h_center_pad.test && v_end_pad.test
+        && v_max.test && v_stretch_min.test
+        && nested.test && nested_outer_center.test && nested_same.test
+        && nested_h_in_v.test && triple.test;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
Rename the FlexboxAlignItems enum and re-use it.

Fixes: https://github.com/slint-ui/slint/issues/2587

What this PR doesn't to yet is to add a `self-align` property on items within a layout. But this can still be added later.