### PR TITLE
FlexboxLayout: subtract padding when setting column-direction child width

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1402,8 +1402,12 @@ mod flexbox_taffy {
                                     width: match params.flex_direction {
                                         TaffyFlexDirection::Column
                                         | TaffyFlexDirection::ColumnReverse => {
+                                            // Cross-axis for column
                                             if let Some(cw) = params.container_width {
-                                                Dimension::length(cw as _)
+                                                // Fit inside the container's content box (subtract padding)
+                                                let pad =
+                                                    params.padding_h.begin + params.padding_h.end;
+                                                Dimension::length((cw - pad).max(0 as Coord) as _)
                                             } else if preferred_width > 0 as Coord {
                                                 Dimension::length(preferred_width as _)
                                             } else {

--- a/tests/cases/layout/flexbox_column_spacing_and_padding.slint
+++ b/tests/cases/layout/flexbox_column_spacing_and_padding.slint
@@ -25,8 +25,9 @@ export component TestCase inherits Window {
             background: green;
         }
 
+        // No explicit width → cross-axis stretch should size to
+        // content box (container_width - padding_h), i.e. 180px.
         r3 := Rectangle {
-            width: 40px;
             height: 40px;
             background: blue;
         }
@@ -38,7 +39,8 @@ export component TestCase inherits Window {
     // r2: starts at y=53px (10 + 35 + 8 = 53)
     // r3: starts at y=96px (10 + 35 + 8 + 35 + 8 = 96)
     // All items stay in first column at x=10px (left padding)
-    out property <bool> test: r1.x >= 9px && r1.x <= 11px && r1.y >= 9px && r1.y <= 11px && r2.x >= 9px && r2.x <= 11px && r2.y >= 51px && r2.y <= 55px && r3.x >= 9px && r3.x <= 11px && r3.y >= 94px && r3.y <= 98px;
+    // r3 stretches to content-box width (must not overflow right padding):
+    out property <bool> test: r1.x >= 9px && r1.x <= 11px && r1.y >= 9px && r1.y <= 11px && r2.x >= 9px && r2.x <= 11px && r2.y >= 51px && r2.y <= 55px && r3.x >= 9px && r3.x <= 11px && r3.y >= 94px && r3.y <= 98px && r3.x + r3.width <= 190px;
 }
 
 /*


### PR DESCRIPTION
A column-direction FlexboxLayout was giving each child `size.width =
container_width` on the cross axis, which is the border-box width and
doesn't account for the container's own horizontal padding. With
`align-items: stretch` (the default) taffy then positioned each child at
`padding_left` and made it `container_width` wide, so the child spilled
past the right edge by `padding_left + padding_right` total.

Subtract the horizontal padding so the child fits inside the container's
content box, mirroring how BoxLayout and GridLayout already allocate
their cross-axis children.