### PR TITLE
Document limitations of gestures more prominently

### DIFF
--- a/docs/astro/src/content/docs/reference/gestures/scalerotategesturehandler.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/scalerotategesturehandler.mdx
@@ -5,8 +5,10 @@ description: ScaleRotateGestureHandler element api.
 
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 
-Use the `ScaleRotateGestureHandler` to handle pinch and rotation gestures from trackpads or touchscreens.
+Use the `ScaleRotateGestureHandler` to handle pinch and rotation gestures.
 Recognition is limited to the element's geometry.
+
+The `ScaleRoteGestureHandler` supports touchscreens on all platforms, and additionally supports trackpad gestures on macOS and iOS.
 
 ```slint playground
 export component Example inherits Window {
@@ -49,9 +51,6 @@ export component Example inherits Window {
 The `scale` property provides a cumulative scale factor relative to the start of the gesture (starting at `1.0`).
 The `rotation` property provides a cumulative rotation angle (starting at `0deg`).
 Use the `started` callback to capture your initial state, then multiply by `scale` and add `rotation` in the `updated` callback to apply the gesture.
-
-On macOS and iOS, the handler responds to trackpad pinch and rotation gestures (platform gesture events).
-On other platforms, it processes raw two-finger touch input for pinch and rotation.
 
 ## Properties
 

--- a/docs/astro/src/content/docs/reference/gestures/swipegesturehandler.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/swipegesturehandler.mdx
@@ -8,6 +8,8 @@ import SlintProperty from '@slint/common-files/src/components/SlintProperty.astr
 Use the `SwipeGestureHandler` to handle swipe gesture in some particular direction.
 Recognition is limited to the element's geometry.
 
+The `SwipeGestureHandler` recognizes touchscreen swipes and mouse drags.
+
 ```slint playground
 export component Example inherits Window {
     width: 270px;
@@ -48,7 +50,6 @@ export component Example inherits Window {
     }
 }
 ```
-
 
 Specify the different swipe directions you'd like to handle by setting the `handle-swipe-left/right/up/down` properties and react to the gesture in the `swiped` callback.
 


### PR DESCRIPTION
Currently, our gesture implementation is limited to touch screens and
only works with trackpads on macOS and iOS. I think this should be
displayed more prominently.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
