### PR TITLE
Fix password field text layout calculations

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1306,7 +1306,7 @@ impl HasFont for TextInput {
 
 impl RenderString for TextInput {
     fn text(self: Pin<&Self>) -> PlainOrStyledText {
-        PlainOrStyledText::Plain(self.as_ref().text())
+        PlainOrStyledText::Plain(self.as_ref().visual_representation(None).text.into())
     }
 }
 
@@ -1458,6 +1458,17 @@ impl TextInputVisualRepresentation {
                 .char_indices()
                 .nth(byte_offset / self.password_character.len_utf8())
                 .map_or(text_without_password.len(), |(r, _)| r)
+        } else {
+            byte_offset
+        }
+    }
+
+    /// Map the byte_offset inside the TextInput's text to the byte offset in the visual text.
+    /// This is the opposite of `map_byte_offset_from_byte_offset_in_visual_text`.
+    pub fn map_byte_offset_from_byte_offset_in_actual_text(&self, byte_offset: usize) -> usize {
+        if let Some(text_without_password) = self.text_without_password.as_ref() {
+            text_without_password[..byte_offset].chars().count()
+                * self.password_character.len_utf8()
         } else {
             byte_offset
         }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -28,8 +28,10 @@ use crate::platform::Clipboard;
 use crate::rtti::*;
 use crate::window::{InputMethodProperties, InputMethodRequest, WindowAdapter, WindowInner};
 use crate::{Callback, Coord, Property, SharedString, SharedVector};
-use alloc::rc::Rc;
-use alloc::string::String;
+use alloc::{
+    rc::Rc,
+    string::{String, ToString},
+};
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
 use core::pin::Pin;
@@ -1306,7 +1308,7 @@ impl HasFont for TextInput {
 
 impl RenderString for TextInput {
     fn text(self: Pin<&Self>) -> PlainOrStyledText {
-        PlainOrStyledText::Plain(self.as_ref().visual_representation(None).text.into())
+        PlainOrStyledText::Plain(self.as_ref().visual_representation(None).text.clone())
     }
 }
 
@@ -1399,7 +1401,7 @@ fn safe_byte_offset(unsafe_byte_offset: i32, text: &str) -> usize {
 #[derive(Debug)]
 pub struct TextInputVisualRepresentation {
     /// The text to be rendered including any pre-edit string
-    pub text: String,
+    pub text: SharedString,
     /// If set, this field specifies the range as byte offsets within the text field where the composition
     /// is in progress. Renderers typically provide visual feedback for the currently composed text, such as
     /// by using underlines.
@@ -1412,7 +1414,7 @@ pub struct TextInputVisualRepresentation {
     pub text_color: Brush,
     /// The color of the blinking cursor
     pub cursor_color: Color,
-    text_without_password: Option<String>,
+    text_without_password: Option<SharedString>,
     password_character: char,
 }
 
@@ -2006,13 +2008,18 @@ impl TextInput {
         self: Pin<&Self>,
         password_character_fn: Option<fn() -> char>,
     ) -> TextInputVisualRepresentation {
-        let mut text: String = self.text().into();
+        let mut text = self.text();
 
         let preedit_text = self.preedit_text();
         let (preedit_range, selection_range, cursor_position) = if !preedit_text.is_empty() {
             let cursor_position = self.cursor_position(&text);
 
-            text.insert_str(cursor_position, &preedit_text);
+            // FIXME: Ideally we should get rid of this String conversion.
+            // But SharedString currently doesn't have an insert_str function.
+            // But this is a rather rare case anyway.
+            let mut string = text.to_string();
+            string.insert_str(cursor_position, &preedit_text);
+            text = string.into();
             let preedit_range = cursor_position..cursor_position + preedit_text.len();
 
             if let Some(preedit_sel) = self.preedit_selection().as_option() {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -28,10 +28,7 @@ use crate::platform::Clipboard;
 use crate::rtti::*;
 use crate::window::{InputMethodProperties, InputMethodRequest, WindowAdapter, WindowInner};
 use crate::{Callback, Coord, Property, SharedString, SharedVector};
-use alloc::{
-    rc::Rc,
-    string::{String, ToString},
-};
+use alloc::{rc::Rc, string::String};
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
 use core::pin::Pin;
@@ -1452,9 +1449,9 @@ impl TextInputVisualRepresentation {
         self.password_character = password_character;
     }
 
-    /// Use this function to make a byte offset in the text used for rendering back to a byte offset in the
+    /// Use this function to make a byte offset in the visual text (used for rendering) back to a byte offset in the
     /// TextInput's text. The offsets might differ for example for password text input fields.
-    pub fn map_byte_offset_from_byte_offset_in_visual_text(&self, byte_offset: usize) -> usize {
+    pub fn map_byte_offset_from_visual_text_to_actual_text(&self, byte_offset: usize) -> usize {
         if let Some(text_without_password) = self.text_without_password.as_ref() {
             text_without_password
                 .char_indices()
@@ -1467,7 +1464,7 @@ impl TextInputVisualRepresentation {
 
     /// Map the byte_offset inside the TextInput's text to the byte offset in the visual text.
     /// This is the opposite of `map_byte_offset_from_byte_offset_in_visual_text`.
-    pub fn map_byte_offset_from_byte_offset_in_actual_text(&self, byte_offset: usize) -> usize {
+    pub fn map_byte_offset_from_actual_to_visual_text(&self, byte_offset: usize) -> usize {
         if let Some(text_without_password) = self.text_without_password.as_ref() {
             text_without_password[..byte_offset].chars().count()
                 * self.password_character.len_utf8()
@@ -2014,12 +2011,8 @@ impl TextInput {
         let (preedit_range, selection_range, cursor_position) = if !preedit_text.is_empty() {
             let cursor_position = self.cursor_position(&text);
 
-            // FIXME: Ideally we should get rid of this String conversion.
-            // But SharedString currently doesn't have an insert_str function.
-            // But this is a rather rare case anyway.
-            let mut string = text.to_string();
-            string.insert_str(cursor_position, &preedit_text);
-            text = string.into();
+            text =
+                [&text[..cursor_position], &preedit_text, &text[cursor_position..]].concat().into();
             let preedit_range = cursor_position..cursor_position + preedit_text.len();
 
             if let Some(preedit_sel) = self.preedit_selection().as_option() {

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1474,7 +1474,7 @@ pub fn text_input_byte_offset_for_position(
         LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
     );
     let byte_offset = layout.byte_offset_from_point(pos);
-    visual_representation.map_byte_offset_from_byte_offset_in_visual_text(byte_offset)
+    visual_representation.map_byte_offset_from_visual_text_to_actual_text(byte_offset)
 }
 
 pub fn text_input_cursor_rect_for_byte_offset(
@@ -1510,8 +1510,7 @@ pub fn text_input_cursor_rect_for_byte_offset(
     let mut font_ctx = ctx.font_context().borrow_mut();
 
     let visual_representation = text_input.visual_representation(None);
-    let byte_offset =
-        visual_representation.map_byte_offset_from_byte_offset_in_actual_text(byte_offset);
+    let byte_offset = visual_representation.map_byte_offset_from_actual_to_visual_text(byte_offset);
 
     let paragraphs_without_linebreaks = create_text_paragraphs(
         &layout_builder,

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -12,7 +12,7 @@ use skrifa::MetadataProvider as _;
 use std::cell::RefCell;
 
 use crate::{
-    Color, SharedString,
+    Color,
     graphics::FontRequest,
     item_rendering::PlainOrStyledText,
     items::TextStrokeStyle,
@@ -1238,7 +1238,7 @@ pub fn draw_text_input(
         scale_factor,
     );
 
-    let text: SharedString = visual_representation.text.into();
+    let text = visual_representation.text.clone();
 
     // When a piece of text is first selected, it gets an empty range like `Some(1..1)`.
     // If the text starts with a multi-byte character then this selection will be within
@@ -1457,11 +1457,10 @@ pub fn text_input_byte_offset_for_position(
     );
 
     let visual_representation = text_input.visual_representation(None);
-    let text = SharedString::from(&visual_representation.text);
     let paragraphs_without_linebreaks = create_text_paragraphs(
         &layout_builder,
         &mut font_ctx,
-        PlainOrStyledText::Plain(text),
+        PlainOrStyledText::Plain(visual_representation.text.clone()),
         None,
         Color::default(),
     );
@@ -1510,15 +1509,14 @@ pub fn text_input_cursor_rect_for_byte_offset(
 
     let mut font_ctx = ctx.font_context().borrow_mut();
 
-    let text = SharedString::from(&text_input.visual_representation(None).text);
-    let byte_offset = text_input
-        .visual_representation(None)
-        .map_byte_offset_from_byte_offset_in_actual_text(byte_offset);
+    let visual_representation = text_input.visual_representation(None);
+    let byte_offset =
+        visual_representation.map_byte_offset_from_byte_offset_in_actual_text(byte_offset);
 
     let paragraphs_without_linebreaks = create_text_paragraphs(
         &layout_builder,
         &mut font_ctx,
-        PlainOrStyledText::Plain(text),
+        PlainOrStyledText::Plain(visual_representation.text),
         None,
         Color::default(),
     );

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1456,7 +1456,8 @@ pub fn text_input_byte_offset_for_position(
         scale_factor,
     );
 
-    let text = text_input.text();
+    let visual_representation = text_input.visual_representation(None);
+    let text = SharedString::from(&visual_representation.text);
     let paragraphs_without_linebreaks = create_text_paragraphs(
         &layout_builder,
         &mut font_ctx,
@@ -1474,7 +1475,6 @@ pub fn text_input_byte_offset_for_position(
         LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
     );
     let byte_offset = layout.byte_offset_from_point(pos);
-    let visual_representation = text_input.visual_representation(None);
     visual_representation.map_byte_offset_from_byte_offset_in_visual_text(byte_offset)
 }
 
@@ -1507,9 +1507,14 @@ pub fn text_input_cursor_rect_for_byte_offset(
     let Some(ctx) = renderer.slint_context() else {
         return LogicalRect::default();
     };
+
     let mut font_ctx = ctx.font_context().borrow_mut();
 
-    let text = text_input.text();
+    let text = SharedString::from(&text_input.visual_representation(None).text);
+    let byte_offset = text_input
+        .visual_representation(None)
+        .map_byte_offset_from_byte_offset_in_actual_text(byte_offset);
+
     let paragraphs_without_linebreaks = create_text_paragraphs(
         &layout_builder,
         &mut font_ctx,

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -999,7 +999,7 @@ impl RendererSealed for SoftwareRenderer {
                     single_line: false,
                 };
 
-                visual_representation.map_byte_offset_from_byte_offset_in_visual_text(
+                visual_representation.map_byte_offset_from_visual_text_to_actual_text(
                     paragraph.byte_offset_for_position((pos.x_length(), pos.y_length())),
                 )
             }
@@ -1027,7 +1027,7 @@ impl RendererSealed for SoftwareRenderer {
                     single_line: false,
                 };
 
-                visual_representation.map_byte_offset_from_byte_offset_in_visual_text(
+                visual_representation.map_byte_offset_from_visual_text_to_actual_text(
                     paragraph.byte_offset_for_position((pos.x_length(), pos.y_length())),
                 )
             }

--- a/tests/cases/text/input_type.slint
+++ b/tests/cases/text/input_type.slint
@@ -1,8 +1,0 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
-
-TestCase := TextInput {
-    text: "hello";
-    input-type: InputType.password;
-}
-

--- a/tests/cases/text/input_type_password.slint
+++ b/tests/cases/text/input_type_password.slint
@@ -11,7 +11,6 @@ export component TestCase inherits Window {
 
     text-input := TextInput {
         text: "iiiii";
-        font-family: "Noto Sans Regular";
         cursor-position-changed(position) => {
             root.cursor-position = position;
         }
@@ -34,15 +33,17 @@ instance.set_input_type(InputType::Password);
 let password_text_width = instance.get_text_width();
 assert!(password_text_width > clear_text_width, "{password_text_width} should be greater than {clear_text_width}");
 
-use slint::private_unstable_api::re_exports::Key;
-let float_eq = |a: f32, b: f32| (a - b).abs() < 0.1;
+use slint::platform::Key;
+use slint::private_unstable_api::re_exports::ApproxEq;
 
 assert_eq!(instance.get_cursor_position().x, 0., "Cursor should be at 0");
 for i in 1..5 {
+    const PASSWORD_CHAR_WIDTH: f32 = 7.2;
+
     slint_testing::send_key_combo(&instance, [Key::RightArrow]);
     let cursor = instance.get_cursor_position().x;
-    let expected = i as f32 * 7.2;
-    assert!(float_eq(cursor, expected), "After {i} steps cursor should be at {cursor}, was {expected}");
+    let expected = i as f32 * PASSWORD_CHAR_WIDTH;
+    assert!(cursor.approx_eq_eps(&expected, &0.1), "After {i} steps cursor should be at {cursor}, was {expected}");
 }
 ```
 */

--- a/tests/cases/text/input_type_password.slint
+++ b/tests/cases/text/input_type_password.slint
@@ -36,13 +36,15 @@ assert!(password_text_width > clear_text_width, "{password_text_width} should be
 use slint::platform::Key;
 use slint::private_unstable_api::re_exports::ApproxEq;
 
+// The password char is not necessarily part of our testing font (Noto Sans), so we don't know its exact width.
+// But we should be able to guesstimate its size from the size of the text field
+let password_char_width: f32 = password_text_width / 5.;
+assert!(password_char_width > 0.);
 assert_eq!(instance.get_cursor_position().x, 0., "Cursor should be at 0");
 for i in 1..5 {
-    const PASSWORD_CHAR_WIDTH: f32 = 7.2;
-
     slint_testing::send_key_combo(&instance, [Key::RightArrow]);
     let cursor = instance.get_cursor_position().x;
-    let expected = i as f32 * PASSWORD_CHAR_WIDTH;
+    let expected = i as f32 * password_char_width;
     assert!(cursor.approx_eq_eps(&expected, &0.1), "After {i} steps cursor should be at {cursor}, was {expected}");
 }
 ```

--- a/tests/cases/text/input_type_password.slint
+++ b/tests/cases/text/input_type_password.slint
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    in property input-type <=> text-input.input-type;
+    out property text-width <=> text-input.min-width;
+    out property text-height <=> text-input.min-height;
+    out property <Point> cursor-position;
+
+    forward-focus: text-input;
+
+    text-input := TextInput {
+        text: "iiiii";
+        font-family: "Noto Sans Regular";
+        cursor-position-changed(position) => {
+            root.cursor-position = position;
+        }
+    }
+}
+
+
+/*
+```rust
+use i_slint_core::items::InputType;
+
+let instance = TestCase::new().unwrap();
+
+let clear_text_width = instance.get_text_width();
+instance.set_input_type(InputType::Password);
+
+// The characters used for password input should be wider than the "i" characters.
+// Make sure this is respected by the implementation, otherwise the password input
+// might be too narrow to show the password characters.
+let password_text_width = instance.get_text_width();
+assert!(password_text_width > clear_text_width, "{password_text_width} should be greater than {clear_text_width}");
+
+use slint::private_unstable_api::re_exports::Key;
+let float_eq = |a: f32, b: f32| (a - b).abs() < 0.1;
+
+assert_eq!(instance.get_cursor_position().x, 0., "Cursor should be at 0");
+for i in 1..5 {
+    slint_testing::send_key_combo(&instance, [Key::RightArrow]);
+    let cursor = instance.get_cursor_position().x;
+    let expected = i as f32 * 7.2;
+    assert!(float_eq(cursor, expected), "After {i} steps cursor should be at {cursor}, was {expected}");
+}
+```
+*/


### PR DESCRIPTION
- **Fix offset/size calculations on password TextInput**
- **Use SharedString in TextInput  VisualRepresentation**

Closes #11401

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
