### PR TITLE
docs: serve plain markdown for AI agents

### DIFF
--- a/docs/astro/package.json
+++ b/docs/astro/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "astro check && astro build && node scripts/validate-md-links.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "format": "biome format",
@@ -26,10 +26,13 @@
     "astro-embed": "catalog:",
     "playwright-ctrf-json-reporter": "catalog:",
     "rehype-external-links": "catalog:",
+    "remark-parse": "catalog:",
     "sharp": "catalog:",
     "starlight-links-validator": "catalog:",
     "starlight-sidebar-topics": "0.7.1",
     "typescript": "catalog:",
+    "unified": "catalog:",
+    "unist-util-visit": "catalog:",
     "@slint/common-files": "workspace:*"
   },
   "devDependencies": {

--- a/docs/astro/scripts/validate-md-links.mjs
+++ b/docs/astro/scripts/validate-md-links.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// Walks dist/**/*.md and verifies every internal link points to a real file
+// in dist/. Catches typos in the linkMap and stale targets after page renames.
+// Anchor fragments are not validated yet — file existence only.
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import { visit } from "unist-util-visit";
+
+// Must match BASE_PATH in docs/common/src/utils/site-config.ts.
+const BASE_PATH = "/docs/";
+const DIST = "dist";
+
+const parser = unified().use(remarkParse);
+
+async function* walk(dir) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const p = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            yield* walk(p);
+        } else if (entry.isFile() && p.endsWith(".md")) {
+            yield p;
+        }
+    }
+}
+
+async function collectLinks(file) {
+    const text = await readFile(file, "utf8");
+    const tree = parser.parse(text);
+
+    // Reference-style `[text][ref]` links carry the URL on the matching
+    // definition node — gather those into a map first.
+    const definitions = new Map();
+    visit(tree, "definition", (node) => {
+        definitions.set(node.identifier, node.url);
+    });
+
+    const links = [];
+    visit(tree, (node) => {
+        if (node.type === "link") {
+            links.push({ url: node.url, line: node.position?.start.line });
+        } else if (node.type === "linkReference") {
+            const url = definitions.get(node.identifier);
+            if (url) {
+                links.push({ url, line: node.position?.start.line });
+            }
+        }
+    });
+    return links;
+}
+
+const errors = [];
+
+for await (const file of walk(DIST)) {
+    for (const { url, line } of await collectLinks(file)) {
+        if (!url.startsWith(BASE_PATH)) {
+            continue;
+        }
+        const path = url.slice(BASE_PATH.length).split("#")[0];
+        if (path === "") {
+            continue;
+        }
+        const target = join(DIST, path);
+        let ok = false;
+        try {
+            ok = (await stat(target)).isFile();
+        } catch {
+            ok = false;
+        }
+        if (!ok) {
+            errors.push({ file, line: line ?? "?", url });
+        }
+    }
+}
+
+if (errors.length > 0) {
+    console.error(`\n${errors.length} broken markdown link(s):`);
+    for (const e of errors) {
+        console.error(`  ${e.file}:${e.line} -> ${e.url}`);
+    }
+    process.exit(1);
+}
+
+console.log("validate-md-links: all internal markdown links resolve");

--- a/docs/astro/src/pages/[...slug].md.ts
+++ b/docs/astro/src/pages/[...slug].md.ts
@@ -8,6 +8,8 @@
 
 import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection, type CollectionEntry } from "astro:content";
+import { linkMap } from "@slint/common-files/src/utils/utils";
+import { BASE_PATH } from "@slint/common-files/src/utils/site-config";
 
 export const getStaticPaths: GetStaticPaths = async () => {
     const entries = await getCollection("docs");
@@ -23,7 +25,7 @@ type Props = { entry: CollectionEntry<"docs"> };
 export const GET: APIRoute<Props> = ({ props }) => {
     const { entry } = props;
     const data = entry.data as Record<string, unknown>;
-    const body = entry.body ?? "";
+    const body = resolveLinkComponents(entry.body ?? "");
 
     const fm: string[] = ["---"];
     if (typeof data.title === "string") {
@@ -47,4 +49,39 @@ export const GET: APIRoute<Props> = ({ props }) => {
 // YAML-safe double-quoting for single-line scalar values.
 function quote(s: string): string {
     return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+// Replace `<Link type="X" label="Y" />` (the in-prose linking component used
+// across the docs) with a real markdown link. The resolved URL points at the
+// target page's .md sibling so an agent can chain markdown fetches without
+// having to rewrite URLs itself. Unknown link types are left as-is so the
+// build still surfaces them via existing checks.
+const LINK_RE = /<Link\b([^/>]*)\/>/g;
+const ATTR_RE = /(\w+)\s*=\s*"([^"]*)"/g;
+
+function resolveLinkComponents(body: string): string {
+    return body.replace(LINK_RE, (whole, attrs: string) => {
+        const parsed: Record<string, string> = {};
+        for (const m of attrs.matchAll(ATTR_RE)) {
+            parsed[m[1]] = m[2];
+        }
+
+        const type = parsed.type;
+        if (!type || !(type in linkMap)) {
+            return whole;
+        }
+
+        const label = parsed.label ?? type;
+        return `[${label}](${BASE_PATH}${toMarkdownHref(linkMap[type].href)})`;
+    });
+}
+
+// Convert an HTML page href like "reference/common/#anchor" into the
+// corresponding .md sibling: "reference/common.md#anchor".
+function toMarkdownHref(href: string): string {
+    const hashIdx = href.indexOf("#");
+    const path = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
+    const hash = hashIdx >= 0 ? href.slice(hashIdx) : "";
+    const trimmed = path.endsWith("/") ? path.slice(0, -1) : path;
+    return `${trimmed}.md${hash}`;
 }

--- a/docs/astro/src/pages/[...slug].md.ts
+++ b/docs/astro/src/pages/[...slug].md.ts
@@ -1,0 +1,50 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// Serves a plain-markdown sibling for every doc page so AI agents can fetch
+// docs without paying the HTML/JS overhead. Example:
+//   /docs/guide/language/coding/properties/      -> rendered HTML page
+//   /docs/guide/language/coding/properties.md    -> this endpoint, raw markdown
+
+import type { APIRoute, GetStaticPaths } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+    const entries = await getCollection("docs");
+    return entries.map((entry) => ({
+        // Empty id (the root index.mdx) becomes /docs/index.md
+        params: { slug: entry.id === "" ? "index" : entry.id },
+        props: { entry },
+    }));
+};
+
+type Props = { entry: CollectionEntry<"docs"> };
+
+export const GET: APIRoute<Props> = ({ props }) => {
+    const { entry } = props;
+    const data = entry.data as Record<string, unknown>;
+    const body = entry.body ?? "";
+
+    const fm: string[] = ["---"];
+    if (typeof data.title === "string") {
+        fm.push(`title: ${quote(data.title)}`);
+    }
+    if (typeof data.description === "string") {
+        fm.push(`description: ${quote(data.description)}`);
+    }
+    fm.push("---", "");
+
+    return new Response(fm.join("\n") + body, {
+        headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+            // Lets a future edge function vary the HTML route on Accept
+            // without poisoning shared caches.
+            Vary: "Accept",
+        },
+    });
+};
+
+// YAML-safe double-quoting for single-line scalar values.
+function quote(s: string): string {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/docs/astro/tests/markdown-endpoint.spec.ts
+++ b/docs/astro/tests/markdown-endpoint.spec.ts
@@ -20,3 +20,31 @@ test("root index has a markdown sibling at index.md", async ({ request }) => {
     const body = await res.text();
     expect(body).toMatch(/^---\ntitle: "Overview"/);
 });
+
+// properties.mdx contains: <Link type="Expressions" />
+// After Link-component resolution, that should appear in the markdown body
+// as a real markdown link pointing at the Expressions page's .md sibling,
+// so an agent can chain markdown fetches without rewriting URLs.
+test("Link components resolve to a followable markdown link", async ({
+    request,
+}) => {
+    const page = await request.get("guide/language/coding/properties.md");
+    expect(page.status()).toBe(200);
+    const body = await page.text();
+
+    const match = body.match(
+        /\[Expressions\]\((?<url>[^)]*expressions-and-statements[^)]*)\)/,
+    );
+    expect(
+        match,
+        "expected a [Expressions](...) markdown link in the body — " +
+            "the <Link/> component should have been resolved",
+    ).not.toBeNull();
+
+    const url = match!.groups!.url;
+    expect(url).toMatch(/\.md$/);
+
+    const target = await request.get(url);
+    expect(target.status()).toBe(200);
+    expect(target.headers()["content-type"]).toContain("text/markdown");
+});

--- a/docs/astro/tests/markdown-endpoint.spec.ts
+++ b/docs/astro/tests/markdown-endpoint.spec.ts
@@ -1,0 +1,22 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+import { test, expect } from "@playwright/test";
+
+test("doc page has a markdown sibling", async ({ request }) => {
+    const res = await request.get("guide/language/coding/properties.md");
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("text/markdown");
+
+    const body = await res.text();
+    expect(body).toMatch(/^---\ntitle: "Properties"/);
+    expect(body).toContain("## Assigning bindings");
+});
+
+test("root index has a markdown sibling at index.md", async ({ request }) => {
+    const res = await request.get("index.md");
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("text/markdown");
+
+    const body = await res.text();
+    expect(body).toMatch(/^---\ntitle: "Overview"/);
+});

--- a/docs/astro/tests/markdown-no-leaks.spec.ts
+++ b/docs/astro/tests/markdown-no-leaks.spec.ts
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+import { test, expect } from "@playwright/test";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const DIST = "dist";
+
+async function* walk(dir: string): AsyncGenerator<string> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const p = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            yield* walk(p);
+        } else if (entry.isFile() && p.endsWith(".md")) {
+            yield p;
+        }
+    }
+}
+
+// Any in-prose component the markdown endpoint hasn't been taught to resolve
+// will leak into the output as a literal tag, leaving the agent with no link
+// to follow. List the components we know about here so a regression fails
+// loudly rather than silently shipping unresolved tags.
+const FORBIDDEN = [/<Link\b/];
+
+test("no MDX components leak into the .md output", async () => {
+    const offenders: { file: string; pattern: string }[] = [];
+    for await (const file of walk(DIST)) {
+        const body = await readFile(file, "utf8");
+        for (const re of FORBIDDEN) {
+            if (re.test(body)) {
+                offenders.push({ file, pattern: re.source });
+            }
+        }
+    }
+    expect(offenders, "files contain unresolved MDX components").toEqual([]);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     rehype-external-links:
       specifier: 3.0.0
       version: 3.0.0
+    remark-parse:
+      specifier: 11.0.0
+      version: 11.0.0
     sharp:
       specifier: 0.34.5
       version: 0.34.5
@@ -48,6 +51,12 @@ catalogs:
     typescript:
       specifier: 6.0.3
       version: 6.0.3
+    unified:
+      specifier: 11.0.5
+      version: 11.0.5
+    unist-util-visit:
+      specifier: 5.1.0
+      version: 5.1.0
     vite:
       specifier: 8.0.8
       version: 8.0.8
@@ -146,6 +155,9 @@ importers:
       rehype-external-links:
         specifier: 'catalog:'
         version: 3.0.0
+      remark-parse:
+        specifier: 'catalog:'
+        version: 11.0.0
       sharp:
         specifier: 'catalog:'
         version: 0.34.5
@@ -158,6 +170,12 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unified:
+        specifier: 'catalog:'
+        version: 11.0.5
+      unist-util-visit:
+        specifier: 'catalog:'
+        version: 5.1.0
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     rehype-external-links:
       specifier: 3.0.0
       version: 3.0.0
+    remark-parse:
+      specifier: 11.0.0
+      version: 11.0.0
     sharp:
       specifier: 0.34.5
       version: 0.34.5
@@ -48,6 +51,12 @@ catalogs:
     typescript:
       specifier: 6.0.2
       version: 6.0.2
+    unified:
+      specifier: 11.0.5
+      version: 11.0.5
+    unist-util-visit:
+      specifier: 5.1.0
+      version: 5.1.0
     vite:
       specifier: 8.0.8
       version: 8.0.8
@@ -146,6 +155,9 @@ importers:
       rehype-external-links:
         specifier: 'catalog:'
         version: 3.0.0
+      remark-parse:
+        specifier: 'catalog:'
+        version: 11.0.0
       sharp:
         specifier: 'catalog:'
         version: 0.34.5
@@ -158,6 +170,12 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
+      unified:
+        specifier: 'catalog:'
+        version: 11.0.5
+      unist-util-visit:
+        specifier: 'catalog:'
+        version: 5.1.0
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,9 @@ catalog:
   rehype-external-links: 3.0.0
   sharp: 0.34.5
   starlight-links-validator: 0.23.0
+  remark-parse: 11.0.0
   typescript: 6.0.3
+  unified: 11.0.5
+  unist-util-visit: 5.1.0
   vite: 8.0.8
   vitest: 4.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,9 @@ catalog:
   rehype-external-links: 3.0.0
   sharp: 0.34.5
   starlight-links-validator: 0.23.0
+  remark-parse: 11.0.0
   typescript: 6.0.2
+  unified: 11.0.5
+  unist-util-visit: 5.1.0
   vite: 8.0.8
   vitest: 4.1.4


### PR DESCRIPTION
Publishes a plain-markdown sibling for every doc page (e.g. `/docs/guide/language/coding/properties.md` next to `/docs/guide/language/coding/properties/`) so AI agents can consume the docs without paying the HTML/JS token overhead. The `<Link/>` component is resolved into real markdown links pointing at the target page's `.md` sibling so an agent can chain markdown fetches without rewriting URLs. A post-build script + Playwright spec keep the output honest (no leaked components, all internal links resolve).

Discoverability is the next decision, not done here. Two paths from this point: (a) dynamic content negotiation via Cloudflare Pages / Netlify Edge functions on the canonical URL, or (b) advertise the convention out-of-band — e.g. our `/slint` skill tells the agent to append `.md` to any docs URL. The static `.md` files are the substrate either approach builds on.