### PR TITLE
testing: replace generational-arena with slotmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,15 +3872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
-name = "generational-arena"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "generativity"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5016,7 +5007,6 @@ dependencies = [
  "base64 0.22.1",
  "byteorder",
  "futures-lite",
- "generational-arena",
  "httparse",
  "i-slint-common",
  "i-slint-core",
@@ -5032,6 +5022,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slint",
+ "slotmap",
  "vtable",
 ]
 

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -25,7 +25,7 @@ system-testing = [
   "prost",
   "pbjson",
   "serde",
-  "generational-arena",
+  "slotmap",
   "async-net",
   "futures-lite",
   "byteorder",
@@ -40,7 +40,7 @@ mcp = [
   "pbjson",
   "serde",
   "serde_json",
-  "generational-arena",
+  "slotmap",
   "async-net",
   "futures-lite",
   "image",
@@ -62,7 +62,7 @@ serde = { version = "1", optional = true }
 serde_json = { workspace = true, optional = true }
 base64 = { version = "0.22", optional = true }
 httparse = { version = "1", optional = true }
-generational-arena = { version = "0.2.9", optional = true }
+slotmap = { version = "1.1", optional = true }
 async-net = { version = "2.0.0", optional = true }
 futures-lite = { version = "2.3.0", optional = true }
 byteorder = { version = "1.5.0", optional = true }

--- a/internal/backends/testing/introspection.rs
+++ b/internal/backends/testing/introspection.rs
@@ -7,11 +7,16 @@
 use i_slint_core::item_tree::ItemTreeRc;
 use i_slint_core::window::WindowAdapter;
 use i_slint_core::window::WindowInner;
+use slotmap::{Key, KeyData, SlotMap};
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::rc::{Rc, Weak};
 
 use crate::{ElementHandle, ElementRoot, LayoutKind};
+
+slotmap::new_key_type! {
+    pub(crate) struct ArenaIndex;
+}
 
 #[allow(non_snake_case, unused_imports, non_camel_case_types, clippy::all)]
 pub(crate) mod proto {
@@ -81,14 +86,14 @@ impl super::Sealed for RootWrapper<'_> {}
 /// A tracked window with its adapter and cached root element handle.
 pub(crate) struct TrackedWindow {
     pub window_adapter: Weak<dyn WindowAdapter>,
-    pub root_element_handle: generational_arena::Index,
+    pub root_element_handle: ArenaIndex,
 }
 
 /// Shared introspection state: window and element handle arenas.
 pub(crate) struct IntrospectionState {
-    pub windows: RefCell<generational_arena::Arena<TrackedWindow>>,
-    pub element_handles: RefCell<generational_arena::Arena<ElementHandle>>,
-    element_handle_order: RefCell<VecDeque<generational_arena::Index>>,
+    pub windows: RefCell<SlotMap<ArenaIndex, TrackedWindow>>,
+    pub element_handles: RefCell<SlotMap<ArenaIndex, ElementHandle>>,
+    element_handle_order: RefCell<VecDeque<ArenaIndex>>,
 }
 
 impl IntrospectionState {
@@ -112,13 +117,13 @@ impl IntrospectionState {
             .insert(TrackedWindow { window_adapter: Rc::downgrade(adapter), root_element_handle });
     }
 
-    pub fn window_handles(&self) -> Vec<generational_arena::Index> {
+    pub fn window_handles(&self) -> Vec<ArenaIndex> {
         self.windows.borrow().iter().map(|(index, _)| index).collect()
     }
 
     pub fn window_adapter(
         &self,
-        window_index: generational_arena::Index,
+        window_index: ArenaIndex,
     ) -> Result<Rc<dyn WindowAdapter>, String> {
         self.windows
             .borrow()
@@ -131,8 +136,8 @@ impl IntrospectionState {
 
     pub fn root_element_handle(
         &self,
-        window_index: generational_arena::Index,
-    ) -> Result<generational_arena::Index, String> {
+        window_index: ArenaIndex,
+    ) -> Result<ArenaIndex, String> {
         Ok(self
             .windows
             .borrow()
@@ -141,19 +146,19 @@ impl IntrospectionState {
             .root_element_handle)
     }
 
-    pub fn element_to_handle(&self, element: ElementHandle) -> generational_arena::Index {
+    pub fn element_to_handle(&self, element: ElementHandle) -> ArenaIndex {
         let mut arena = self.element_handles.borrow_mut();
         let index = arena.insert(element);
         let mut order = self.element_handle_order.borrow_mut();
         order.push_back(index);
         if arena.len() > ELEMENT_HANDLE_CAP {
-            let root_indices: std::collections::HashSet<generational_arena::Index> =
+            let root_indices: std::collections::HashSet<ArenaIndex> =
                 self.windows.borrow().iter().map(|(_, w)| w.root_element_handle).collect();
             let mut budget = order.len();
             while arena.len() > ELEMENT_HANDLE_CAP && budget > 0 {
                 budget -= 1;
                 let Some(oldest) = order.pop_front() else { break };
-                if !arena.contains(oldest) {
+                if !arena.contains_key(oldest) {
                     continue;
                 }
                 if root_indices.contains(&oldest) {
@@ -169,7 +174,7 @@ impl IntrospectionState {
     pub fn element(
         &self,
         request: &str,
-        index: generational_arena::Index,
+        index: ArenaIndex,
     ) -> Result<ElementHandle, String> {
         let element = self
             .element_handles
@@ -188,7 +193,7 @@ impl IntrospectionState {
 
     pub fn find_elements_by_id(
         &self,
-        window_index: generational_arena::Index,
+        window_index: ArenaIndex,
         elements_id: &str,
     ) -> Result<Vec<ElementHandle>, String> {
         let adapter = self.window_adapter(window_index)?;
@@ -200,7 +205,7 @@ impl IntrospectionState {
 
     pub fn take_snapshot(
         &self,
-        window_index: generational_arena::Index,
+        window_index: ArenaIndex,
         image_mime_type: &str,
     ) -> Result<Vec<u8>, String> {
         let adapter = self.window_adapter(window_index)?;
@@ -232,7 +237,7 @@ impl IntrospectionState {
 
     pub fn dispatch_window_event(
         &self,
-        window_index: generational_arena::Index,
+        window_index: ArenaIndex,
         event: i_slint_core::platform::WindowEvent,
     ) -> Result<(), String> {
         let adapter = self.window_adapter(window_index)?;
@@ -243,7 +248,7 @@ impl IntrospectionState {
 
     pub fn window_properties(
         &self,
-        window_index: generational_arena::Index,
+        window_index: ArenaIndex,
     ) -> Result<proto::WindowPropertiesResponse, String> {
         let adapter = self.window_adapter(window_index)?;
         let window = adapter.window();
@@ -265,7 +270,7 @@ impl IntrospectionState {
 
     pub fn take_snapshot_response(
         &self,
-        window_index: generational_arena::Index,
+        window_index: ArenaIndex,
         image_mime_type: &str,
     ) -> Result<proto::TakeSnapshotResponse, String> {
         let window_contents_as_encoded_image = self.take_snapshot(window_index, image_mime_type)?;
@@ -451,13 +456,13 @@ pub(crate) fn convert_pointer_event_button(
 // Index ↔ parts conversion
 // ============================================================================
 
-pub(crate) fn index_to_handle(index: generational_arena::Index) -> proto::Handle {
-    let (idx, generation) = index.into_raw_parts();
-    proto::Handle { index: idx as u64, generation }
+pub(crate) fn index_to_handle(index: ArenaIndex) -> proto::Handle {
+    let ffi = index.data().as_ffi();
+    proto::Handle { index: ffi & 0xffff_ffff, generation: ffi >> 32 }
 }
 
-pub(crate) fn handle_to_index(handle: proto::Handle) -> generational_arena::Index {
-    generational_arena::Index::from_raw_parts(handle.index as usize, handle.generation)
+pub(crate) fn handle_to_index(handle: proto::Handle) -> ArenaIndex {
+    KeyData::from_ffi((handle.generation << 32) | (handle.index & 0xffff_ffff)).into()
 }
 
 #[test]

--- a/internal/backends/testing/introspection.rs
+++ b/internal/backends/testing/introspection.rs
@@ -134,10 +134,7 @@ impl IntrospectionState {
             .ok_or_else(|| "Attempting to access deleted window".to_string())
     }
 
-    pub fn root_element_handle(
-        &self,
-        window_index: ArenaIndex,
-    ) -> Result<ArenaIndex, String> {
+    pub fn root_element_handle(&self, window_index: ArenaIndex) -> Result<ArenaIndex, String> {
         Ok(self
             .windows
             .borrow()
@@ -171,11 +168,7 @@ impl IntrospectionState {
         index
     }
 
-    pub fn element(
-        &self,
-        request: &str,
-        index: ArenaIndex,
-    ) -> Result<ElementHandle, String> {
+    pub fn element(&self, request: &str, index: ArenaIndex) -> Result<ElementHandle, String> {
         let element = self
             .element_handles
             .borrow()

--- a/internal/backends/testing/introspection.rs
+++ b/internal/backends/testing/introspection.rs
@@ -454,8 +454,35 @@ pub(crate) fn index_to_handle(index: ArenaIndex) -> proto::Handle {
     proto::Handle { index: ffi & 0xffff_ffff, generation: ffi >> 32 }
 }
 
-pub(crate) fn handle_to_index(handle: proto::Handle) -> ArenaIndex {
-    KeyData::from_ffi((handle.generation << 32) | (handle.index & 0xffff_ffff)).into()
+pub(crate) fn handle_to_index(handle: proto::Handle) -> Result<ArenaIndex, String> {
+    if handle.index > u64::from(u32::MAX) || handle.generation > u64::from(u32::MAX) {
+        return Err("Invalid handle".to_string());
+    }
+
+    let ffi = (handle.generation << 32) | handle.index;
+    let index: ArenaIndex = KeyData::from_ffi(ffi).into();
+
+    // Reject malformed handles instead of accepting slotmap's normalization.
+    if index.data().as_ffi() != ffi {
+        return Err("Invalid handle".to_string());
+    }
+
+    Ok(index)
+}
+
+#[test]
+fn test_handle_to_index_rejects_noncanonical_generation() {
+    assert!(handle_to_index(proto::Handle { index: 42, generation: 6 }).is_err());
+}
+
+#[test]
+fn test_handle_to_index_rejects_out_of_range_parts() {
+    assert!(
+        handle_to_index(proto::Handle { index: u64::from(u32::MAX) + 1, generation: 7 }).is_err()
+    );
+    assert!(
+        handle_to_index(proto::Handle { index: 42, generation: u64::from(u32::MAX) + 1 }).is_err()
+    );
 }
 
 #[test]

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -183,8 +183,9 @@ async fn handle_tool_call(
         }
         "get_window_properties" => {
             let p: proto::RequestWindowProperties = deserialize_params(args)?;
-            let window_index =
-                handle_to_index(p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?);
+            let window_index = handle_to_index(
+                p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
+            )?;
             let response = state.window_properties(window_index)?;
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
@@ -192,8 +193,9 @@ async fn handle_tool_call(
         }
         "find_elements_by_id" => {
             let p: proto::RequestFindElementsById = deserialize_params(args)?;
-            let window_index =
-                handle_to_index(p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?);
+            let window_index = handle_to_index(
+                p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
+            )?;
             let elements = state.find_elements_by_id(window_index, &p.elements_id)?;
             let response = proto::ElementsResponse {
                 element_handles: elements
@@ -209,7 +211,7 @@ async fn handle_tool_call(
             let p: proto::RequestElementProperties = deserialize_params(args)?;
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
-            );
+            )?;
             let element = state.element("get_element_properties", element_index)?;
             let response = introspection::element_properties(&element);
             Ok(ToolResult::Json(
@@ -220,7 +222,7 @@ async fn handle_tool_call(
             let p: proto::RequestQueryElementDescendants = deserialize_params(args)?;
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
-            );
+            )?;
             let element = state.element("query_element_descendants", element_index)?;
             let results =
                 introspection::query_element_descendants(element, p.query_stack, p.find_all)?;
@@ -241,7 +243,7 @@ async fn handle_tool_call(
             let max_elements: usize =
                 if p.max_elements == 0 { 200 } else { (p.max_elements as usize).clamp(1, 1000) };
 
-            let root_index = handle_to_index(element_handle);
+            let root_index = handle_to_index(element_handle)?;
             let root_element = state.element("get_element_tree", root_index)?;
 
             let mut elements: Vec<Value> = Vec::new();
@@ -286,8 +288,9 @@ async fn handle_tool_call(
         }
         "take_screenshot" => {
             let p: proto::RequestTakeSnapshot = deserialize_params(args)?;
-            let window_index =
-                handle_to_index(p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?);
+            let window_index = handle_to_index(
+                p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
+            )?;
             let response = state.take_snapshot_response(window_index, "image/png")?;
             let png_data = response.window_contents_as_encoded_image;
             Ok(ToolResult::Image {
@@ -299,7 +302,7 @@ async fn handle_tool_call(
             let p: proto::RequestElementClick = deserialize_params(args)?;
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
-            );
+            )?;
             let element = state.element("click_element", element_index)?;
             let button = proto::PointerEventButton::try_from(p.button)
                 .map_err(|_| format!("invalid button value: {}", p.button))?;
@@ -319,7 +322,7 @@ async fn handle_tool_call(
             let p: proto::RequestElementDrag = deserialize_params(args)?;
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
-            );
+            )?;
             let element = state.element("drag_element", element_index)?;
             let target_pos = p.target.ok_or_else(|| "missing target position".to_string())?;
             let target = i_slint_core::api::LogicalPosition::new(target_pos.x, target_pos.y);
@@ -336,7 +339,7 @@ async fn handle_tool_call(
             let p: proto::RequestInvokeElementAccessibilityAction = deserialize_params(args)?;
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
-            );
+            )?;
             let element = state.element("invoke_accessibility_action", element_index)?;
             let action = proto::ElementAccessibilityAction::try_from(p.action)
                 .map_err(|_| format!("invalid action value: {}", p.action))?;
@@ -350,7 +353,7 @@ async fn handle_tool_call(
             let p: proto::RequestSetElementAccessibleValue = deserialize_params(args)?;
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
-            );
+            )?;
             let element = state.element("set_element_value", element_index)?;
             element.set_accessible_value(p.value);
             let response = proto::SetElementAccessibleValueResponse {};
@@ -360,8 +363,9 @@ async fn handle_tool_call(
         }
         "dispatch_key_event" => {
             let p: proto::RequestDispatchKeyEvent = deserialize_params(args)?;
-            let window_index =
-                handle_to_index(p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?);
+            let window_index = handle_to_index(
+                p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
+            )?;
             let event_type = proto::KeyEventType::try_from(p.event_type)
                 .map_err(|_| format!("invalid eventType value: {}", p.event_type))?;
             let events: Vec<i_slint_core::platform::WindowEvent> = match event_type {
@@ -886,11 +890,23 @@ mod tests {
 
     #[test]
     fn test_handle_roundtrip() {
-        let index = introspection::ArenaIndex::from_raw_parts(42, 7);
+        let index = handle_to_index(proto::Handle { index: 42, generation: 7 }).unwrap();
         let handle = index_to_handle(index);
         assert_eq!(handle.index, 42);
         assert_eq!(handle.generation, 7);
-        assert_eq!(index, handle_to_index(handle));
+        assert_eq!(index, handle_to_index(handle).unwrap());
+    }
+
+    #[test]
+    fn test_mcp_rejects_noncanonical_handle() {
+        let state = make_state();
+        let resp = block_on(handle_mcp_request(
+            &state,
+            r#"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"get_window_properties","arguments":{"windowHandle":{"index":"42","generation":"6"}}}}"#,
+        ));
+        let resp = resp.unwrap();
+        assert!(resp["result"]["isError"].as_bool().unwrap_or(false));
+        assert!(resp["result"]["content"][0]["text"].as_str().unwrap().contains("Invalid handle"));
     }
 
     #[test]

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -886,7 +886,7 @@ mod tests {
 
     #[test]
     fn test_handle_roundtrip() {
-        let index = generational_arena::Index::from_raw_parts(42, 7);
+        let index = introspection::ArenaIndex::from_raw_parts(42, 7);
         let handle = index_to_handle(index);
         assert_eq!(handle.index, 42);
         assert_eq!(handle.generation, 7);

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -74,7 +74,7 @@ impl TestingClient {
                     window_handle.ok_or_else(|| {
                         "window properties request missing window handle".to_string()
                     })?,
-                ))?)
+                )?)?)
             }
             Req::RequestFindElementsById(proto::RequestFindElementsById {
                 window_handle,
@@ -83,7 +83,7 @@ impl TestingClient {
                 let elements = self.state.find_elements_by_id(
                     handle_to_index(window_handle.ok_or_else(|| {
                         "find elements by id request missing window handle".to_string()
-                    })?),
+                    })?)?,
                     &elements_id,
                 )?;
                 Resp::Elements(proto::ElementsResponse {
@@ -129,7 +129,7 @@ impl TestingClient {
                         window_handle.ok_or_else(|| {
                             "grab window request missing window handle".to_string()
                         })?,
-                    ),
+                    )?,
                     &image_mime_type,
                 )?)
             }
@@ -174,7 +174,7 @@ impl TestingClient {
                 self.state.dispatch_window_event(
                     handle_to_index(window_handle.ok_or_else(|| {
                         "window event dispatch request missing window handle".to_string()
-                    })?),
+                    })?)?,
                     convert_window_event(event.ok_or_else(|| {
                         "window event dispatch request missing event".to_string()
                     })?)?,
@@ -210,7 +210,7 @@ impl TestingClient {
     ) -> Result<ElementHandle, String> {
         let index = handle_to_index(
             element_handle.ok_or_else(|| format!("{request} missing element handle"))?,
-        );
+        )?;
         self.state.element(request, index)
     }
 


### PR DESCRIPTION
## Summary

Replace `generational-arena` with `slotmap` in the internal testing backend while keeping the existing MCP and system-testing handle wire format.

Follow up on the slotmap migration by fixing the broken roundtrip test and rejecting malformed wire handles before they can normalize into live slotmap keys.

## Changes

- switch the testing backend mcp and system-testing features from generational-arena to slotmap
- migrate introspection handle storage to `slotmap::SlotMap`
- keep the existing MCP and system-testing handle wire format when converting handles to and from slotmap keys
- fix the slotmap migration roundtrip test to use the production handle conversion helpers
- reject malformed handles during decoding in introspection, MCP, and system-testing
- add focused tests for malformed handle decoding and MCP error propagation
- refresh `Cargo.lock` to drop `generational-arena`

## Verification

- `cargo check -p i-slint-backend-testing --features mcp,system-testing`
- `cargo test -p i-slint-backend-testing --features mcp --lib introspection::test_handle_to_index_rejects_noncanonical_generation -- --exact`
- `cargo test -p i-slint-backend-testing --features mcp --lib introspection::test_handle_to_index_rejects_out_of_range_parts -- --exact`
- `cargo test -p i-slint-backend-testing --features mcp --lib mcp_server::tests::test_handle_roundtrip -- --exact`
- `cargo test -p i-slint-backend-testing --features mcp --lib mcp_server::tests::test_mcp_rejects_noncanonical_handle -- --exact`
- `cargo test -p i-slint-backend-testing --features system-testing --lib --no-run`
- `cargo audit`