### PR TITLE
refactor: Optimize adapter selection and backend synchronization

### DIFF
--- a/examples/servo/src/lib.rs
+++ b/examples/servo/src/lib.rs
@@ -54,7 +54,7 @@ pub fn android_main(android_app: slint::android::AndroidApp) {
 }
 
 fn setup_slint_with_wgpu() {
-    use slint::wgpu_28::{WGPUConfiguration, WGPUSettings};
+    use slint::wgpu_28::{self, WGPUConfiguration, WGPUSettings};
 
     #[allow(unused_mut)]
     let mut wgpu_settings = WGPUSettings::default();

--- a/examples/servo/src/lib.rs
+++ b/examples/servo/src/lib.rs
@@ -54,14 +54,15 @@ pub fn android_main(android_app: slint::android::AndroidApp) {
 }
 
 fn setup_slint_with_wgpu() {
-    use slint::wgpu_28::{WGPUConfiguration, WGPUSettings, wgpu::Backends};
+    use slint::wgpu_28::{WGPUConfiguration, WGPUSettings};
 
+    #[allow(unused_mut)]
     let mut wgpu_settings = WGPUSettings::default();
 
     #[cfg(target_os = "windows")]
     {
         // Must be DX12 on Windows to support texture sharing from ANGLE's D3D11 via NT handles.
-        wgpu_settings.backends = Backends::DX12;
+        wgpu_settings.backends = wgpu_28::wgpu::Backends::DX12;
     }
 
     slint::BackendSelector::new()

--- a/examples/servo/src/lib.rs
+++ b/examples/servo/src/lib.rs
@@ -54,17 +54,18 @@ pub fn android_main(android_app: slint::android::AndroidApp) {
 }
 
 fn setup_slint_with_wgpu() {
-    #[allow(unused_mut)]
-    let mut wgpu_settings = slint::wgpu_28::WGPUSettings::default();
+    use slint::wgpu_28::{WGPUConfiguration, WGPUSettings, wgpu::Backends};
+
+    let mut wgpu_settings = WGPUSettings::default();
 
     #[cfg(target_os = "windows")]
     {
         // Must be DX12 on Windows to support texture sharing from ANGLE's D3D11 via NT handles.
-        wgpu_settings.backends = slint::wgpu_28::wgpu::Backends::DX12;
+        wgpu_settings.backends = Backends::DX12;
     }
 
     slint::BackendSelector::new()
-        .require_wgpu_28(slint::wgpu_28::WGPUConfiguration::Automatic(wgpu_settings))
+        .require_wgpu_28(WGPUConfiguration::Automatic(wgpu_settings))
         .select()
         .expect(
             "Failed to create Slint backend with WGPU based renderer - \

--- a/examples/servo/src/webview/rendering_context/directx.rs
+++ b/examples/servo/src/webview/rendering_context/directx.rs
@@ -184,7 +184,8 @@ impl super::GPURenderingContext {
                 Some(&mut dx12_texture_ptr),
             )?;
 
-            let d3d11_dx12_texture = dx12_texture_ptr.unwrap();
+            let d3d11_dx12_texture = dx12_texture_ptr
+                .expect("D3D11 failed to return the shared DX12-compatible texture");
 
             let hal_device =
                 wgpu_device.as_hal::<Dx12>().ok_or(DirectXTextureError::WgpuNotDx12)?;
@@ -196,7 +197,8 @@ impl super::GPURenderingContext {
 
             let mut dx12_resource_ptr: Option<Direct3D12::ID3D12Resource> = None;
             dx12_device.OpenSharedHandle(nt_handle, &mut dx12_resource_ptr)?;
-            let dx12_resource = dx12_resource_ptr.unwrap();
+            let dx12_resource = dx12_resource_ptr
+                .expect("D3D12 failed to open the shared handle from the D3D11 resource");
 
             Foundation::CloseHandle(nt_handle)?;
 

--- a/examples/servo/src/webview/rendering_context/directx.rs
+++ b/examples/servo/src/webview/rendering_context/directx.rs
@@ -30,9 +30,6 @@ struct D3D11SizeDependentState {
 
 pub struct D3D11SharedState {
     d3d11_device: ID3D11Device,
-    /// Recreated whenever the surface size changes; wrapped in a `RefCell` because
-    /// `get_wgpu_texture_from_directx` holds a shared `&self` borrow while needing
-    /// to swap this out on resize.
     size_dependent: RefCell<Option<D3D11SizeDependentState>>,
 }
 
@@ -42,7 +39,7 @@ pub enum DirectXTextureError {
     Surfman(surfman::Error),
     #[error("No surface returned when the surface was unbound from the context")]
     NoSurface,
-    #[error("Wgpu is not using the dx12 backend")]
+    #[error("WGPU is not using the DX12 backend")]
     WgpuNotDx12,
     #[error("d3d11_share_handle() returned null — surface not D3D11-backed")]
     NullShareHandle,
@@ -163,72 +160,72 @@ impl super::GPURenderingContext {
         size: PhysicalSize<u32>,
         wgpu_device: &Device,
     ) -> Result<D3D11SizeDependentState, DirectXTextureError> {
-        let (d3d11_shared_texture, wgpu_texture) =
-            unsafe {
-                let mut dx12_texture_ptr: Option<ID3D11Texture2D> = None;
+        let (d3d11_shared_texture, wgpu_texture) = unsafe {
+            let mut dx12_texture_ptr: Option<ID3D11Texture2D> = None;
 
-                d3d11_device.CreateTexture2D(
-                    &Direct3D11::D3D11_TEXTURE2D_DESC {
-                        Width: size.width,
-                        Height: size.height,
-                        MipLevels: 1,
-                        ArraySize: 1,
-                        CPUAccessFlags: 0,
-                        Format: Common::DXGI_FORMAT_R8G8B8A8_UNORM,
-                        SampleDesc: Common::DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
-                        Usage: Direct3D11::D3D11_USAGE_DEFAULT,
-                        BindFlags: (Direct3D11::D3D11_BIND_RENDER_TARGET.0
-                            | Direct3D11::D3D11_BIND_SHADER_RESOURCE.0)
-                            as u32,
-                        MiscFlags: (Direct3D11::D3D11_RESOURCE_MISC_SHARED.0
-                            | Direct3D11::D3D11_RESOURCE_MISC_SHARED_NTHANDLE.0)
-                            as u32,
-                    },
-                    None,
-                    Some(&mut dx12_texture_ptr),
-                )?;
+            d3d11_device.CreateTexture2D(
+                &Direct3D11::D3D11_TEXTURE2D_DESC {
+                    Width: size.width,
+                    Height: size.height,
+                    MipLevels: 1,
+                    ArraySize: 1,
+                    CPUAccessFlags: 0,
+                    Format: Common::DXGI_FORMAT_R8G8B8A8_UNORM,
+                    SampleDesc: Common::DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+                    Usage: Direct3D11::D3D11_USAGE_DEFAULT,
+                    BindFlags: (Direct3D11::D3D11_BIND_RENDER_TARGET.0
+                        | Direct3D11::D3D11_BIND_SHADER_RESOURCE.0)
+                        as u32,
+                    MiscFlags: (Direct3D11::D3D11_RESOURCE_MISC_SHARED.0
+                        | Direct3D11::D3D11_RESOURCE_MISC_SHARED_NTHANDLE.0)
+                        as u32,
+                },
+                None,
+                Some(&mut dx12_texture_ptr),
+            )?;
 
-                let d3d11_dx12_texture = dx12_texture_ptr.unwrap();
+            let d3d11_dx12_texture = dx12_texture_ptr.unwrap();
 
-                let nt_handle = d3d11_dx12_texture
-                    .cast::<Dxgi::IDXGIResource1>()?
-                    .CreateSharedHandle(None, Dxgi::DXGI_SHARED_RESOURCE_READ.0, None)?;
+            let hal_device =
+                wgpu_device.as_hal::<Dx12>().ok_or(DirectXTextureError::WgpuNotDx12)?;
+            let dx12_device = hal_device.raw_device();
 
-                let hal_device =
-                    wgpu_device.as_hal::<Dx12>().ok_or(DirectXTextureError::WgpuNotDx12)?;
-                let dx12_device = hal_device.raw_device().clone();
+            let dxgi_resource = d3d11_dx12_texture.cast::<Dxgi::IDXGIResource1>()?;
+            let nt_handle =
+                dxgi_resource.CreateSharedHandle(None, Foundation::GENERIC_ALL.0, None)?;
 
-                let mut dx12_resource_ptr: Option<Direct3D12::ID3D12Resource> = None;
-                dx12_device.OpenSharedHandle(nt_handle, &mut dx12_resource_ptr)?;
-                let dx12_resource = dx12_resource_ptr.unwrap();
-                Foundation::CloseHandle(nt_handle)?;
+            let mut dx12_resource_ptr: Option<Direct3D12::ID3D12Resource> = None;
+            dx12_device.OpenSharedHandle(nt_handle, &mut dx12_resource_ptr)?;
+            let dx12_resource = dx12_resource_ptr.unwrap();
 
-                let extent =
-                    Extent3d { width: size.width, height: size.height, depth_or_array_layers: 1 };
+            Foundation::CloseHandle(nt_handle)?;
 
-                let wgpu_texture = wgpu_device.create_texture_from_hal::<Dx12>(
-                    <Dx12 as wgpu_hal::Api>::Device::texture_from_raw(
-                        dx12_resource,
-                        TextureFormat::Rgba8Unorm,
-                        TextureDimension::D2,
-                        extent,
-                        1,
-                        1,
-                    ),
-                    &TextureDescriptor {
-                        label: Some("servo webview shared texture"),
-                        size: extent,
-                        format: TextureFormat::Rgba8Unorm,
-                        dimension: TextureDimension::D2,
-                        mip_level_count: 1,
-                        sample_count: 1,
-                        usage: TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
-                        view_formats: &[],
-                    },
-                );
+            let extent =
+                Extent3d { width: size.width, height: size.height, depth_or_array_layers: 1 };
 
-                (d3d11_dx12_texture, wgpu_texture)
-            };
+            let wgpu_texture = wgpu_device.create_texture_from_hal::<Dx12>(
+                <Dx12 as wgpu_hal::Api>::Device::texture_from_raw(
+                    dx12_resource,
+                    TextureFormat::Rgba8Unorm,
+                    TextureDimension::D2,
+                    extent,
+                    1,
+                    1,
+                ),
+                &TextureDescriptor {
+                    label: Some("servo webview shared texture"),
+                    size: extent,
+                    format: TextureFormat::Rgba8Unorm,
+                    dimension: TextureDimension::D2,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    usage: TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
+                    view_formats: &[],
+                },
+            );
+
+            (d3d11_dx12_texture, wgpu_texture)
+        };
 
         Ok(D3D11SizeDependentState { d3d11_shared_texture, wgpu_texture })
     }

--- a/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
+++ b/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
@@ -68,7 +68,10 @@ impl GPURenderingContext {
         })
     }
 
-    fn pick_adapter(connection: &Connection, wgpu_device: &wgpu::Device) -> surfman::Adapter {
+    fn pick_adapter(
+        connection: &Connection,
+        #[allow(unused_variables)] wgpu_device: &wgpu::Device,
+    ) -> surfman::Adapter {
         #[cfg(target_os = "windows")]
         {
             if let Some(target) = unsafe {
@@ -124,7 +127,7 @@ impl GPURenderingContext {
 
     fn print_wgpu_backend(wgpu_device: &wgpu::Device) {
         let backend = unsafe {
-            use slint::wgpu_28::wgpu::hal::api::{self, Gles};
+            use slint::wgpu_28::wgpu::hal::api;
 
             #[cfg(target_os = "windows")]
             {
@@ -153,13 +156,7 @@ impl GPURenderingContext {
             #[cfg(target_vendor = "apple")]
             {
                 use api::Metal;
-                if wgpu_device.as_hal::<Metal>().is_some() {
-                    "Metal"
-                } else if wgpu_device.as_hal::<Gles>().is_some() {
-                    "OpenGL"
-                } else {
-                    "Unknown"
-                }
+                if wgpu_device.as_hal::<Metal>().is_some() { "Metal" } else { "Unknown" }
             }
         };
         eprintln!("[GPU] Active WGPU backend: {}", backend);

--- a/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
+++ b/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
@@ -41,7 +41,11 @@ impl GPURenderingContext {
 
         let connection = Connection::new()?;
 
-        let adapter = Self::pick_adapter(&connection, wgpu_device);
+        #[cfg(not(target_os = "windows"))]
+        let adapter = connection.create_adapter()?;
+
+        #[cfg(target_os = "windows")]
+        let adapter = Self::pick_synchronized_adapter(&connection, wgpu_device);
 
         let surfman_rendering_info = SurfmanRenderingContext::new(&connection, &adapter)?;
 
@@ -68,61 +72,72 @@ impl GPURenderingContext {
         })
     }
 
-    fn pick_adapter(
+    #[cfg(target_os = "windows")]
+    fn pick_synchronized_adapter(
         connection: &Connection,
-        #[allow(unused_variables)] wgpu_device: &wgpu::Device,
+        wgpu_device: &wgpu::Device,
     ) -> surfman::Adapter {
-        #[cfg(target_os = "windows")]
-        {
-            if let Some(target) = unsafe {
-                use slint::wgpu_28::wgpu::hal::api::Dx12;
-                wgpu_device.as_hal::<Dx12>().and_then(|hal| Some(hal.raw_device().GetAdapterLuid()))
-            } {
-                use windows::{
-                    Win32::Graphics::{Direct3D11::ID3D11Device, Dxgi},
-                    core::{IUnknown, Interface},
+        #[derive(Debug, Clone, Copy)]
+        enum AdapterMode {
+            Hardware,
+            LowPower,
+            Default,
+        }
+
+        if let Some(wgpu_luid) = unsafe {
+            use slint::wgpu_28::wgpu::hal::api::Dx12;
+            wgpu_device.as_hal::<Dx12>().and_then(|hal| Some(hal.raw_device().GetAdapterLuid()))
+        } {
+            use windows::{
+                Win32::Graphics::{Direct3D11::ID3D11Device, Dxgi},
+                core::{IUnknown, Interface},
+            };
+
+            // On Windows, Slint and Surfman must use the exact same physical GPU (LUID)
+            // to enable zero-copy texture sharing via shared handles.
+            // We iterate through Surfman's adapter presets to find the one that matches WGPU's selection.
+            for mode in [AdapterMode::Hardware, AdapterMode::LowPower, AdapterMode::Default] {
+                let surfman_adapter_result = match mode {
+                    AdapterMode::LowPower => connection.create_low_power_adapter(),
+                    AdapterMode::Hardware => connection.create_hardware_adapter(),
+                    AdapterMode::Default => connection.create_adapter(),
                 };
 
-                // On Windows, we must find an EXACT LUID match in Surfman to ensure zero-copy texture sharing works.
-                // This handles systems with multiple GPUs (e.g., Integrated + Discrete) or
-                // multiple backends (Vulkan vs DX12) by finding the physical card WGPU actually picked.
-                for mode in ["hardware", "low_power", "default"] {
-                    let candidate = match mode {
-                        "low_power" => connection.create_low_power_adapter(),
-                        "hardware" => connection.create_hardware_adapter(),
-                        _ => connection.create_adapter(),
-                    };
+                if let Ok(surfman_adapter) = surfman_adapter_result {
+                    // To verify the match, we create a temporary device and extract its D3D11 LUID.
+                    if let Ok(temp_device) = connection.create_device(&surfman_adapter) {
+                        let d3d11_device_ptr = temp_device.native_device().d3d11_device;
+                        let d3d11_device: ID3D11Device = unsafe {
+                            IUnknown::from_raw(d3d11_device_ptr as *mut _).cast().unwrap()
+                        };
 
-                    if let Ok(cand) = candidate {
-                        // Verify this adapter matches WGPU's LUID by creating a temporary device
-                        if let Ok(device) = connection.create_device(&cand) {
-                            let raw_d3d11 = device.native_device().d3d11_device;
-                            let d3d11_device: ID3D11Device =
-                                unsafe { IUnknown::from_raw(raw_d3d11 as *mut _).cast().unwrap() };
+                        let surfman_luid = unsafe {
+                            d3d11_device
+                                .cast::<Dxgi::IDXGIDevice>()
+                                .unwrap()
+                                .GetAdapter()
+                                .unwrap()
+                                .GetDesc()
+                                .unwrap()
+                                .AdapterLuid
+                        };
 
-                            let luid = unsafe {
-                                d3d11_device
-                                    .cast::<Dxgi::IDXGIDevice>()
-                                    .unwrap()
-                                    .GetAdapter()
-                                    .unwrap()
-                                    .GetDesc()
-                                    .unwrap()
-                                    .AdapterLuid
-                            };
-
-                            if luid.HighPart == target.HighPart && luid.LowPart == target.LowPart {
-                                eprintln!("[GPU] Matched Windows GPU via {} mode", mode);
-                                return cand;
-                            }
+                        // Compare the Surfman LUID with the WGPU LUID (target).
+                        if surfman_luid.HighPart == wgpu_luid.HighPart
+                            && surfman_luid.LowPart == wgpu_luid.LowPart
+                        {
+                            eprintln!("[GPU] Synchronized with WGPU via {:?} mode", mode);
+                            return surfman_adapter;
                         }
                     }
                 }
-                eprintln!("[GPU] WARNING: No exact LUID match found. Texture sharing may fail.");
             }
+            eprintln!("[GPU] WARNING: No exact LUID match found; texture sharing may fail.");
         }
 
-        connection.create_hardware_adapter().expect("Failed to create any Surfman adapter")
+        connection
+            .create_hardware_adapter()
+            .expect("Failed to create a hardware-accelerated Surfman adapter")
     }
 
     fn print_wgpu_backend(wgpu_device: &wgpu::Device) {
@@ -131,7 +146,7 @@ impl GPURenderingContext {
 
             #[cfg(target_os = "windows")]
             {
-                use api::{Dx12, Vulkan};
+                use api::{Dx12, Gles, Vulkan};
                 if wgpu_device.as_hal::<Dx12>().is_some() {
                     "DirectX 12"
                 } else if wgpu_device.as_hal::<Vulkan>().is_some() {
@@ -144,7 +159,7 @@ impl GPURenderingContext {
             }
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
-                use api::Vulkan;
+                use api::{Gles, Vulkan};
                 if wgpu_device.as_hal::<Vulkan>().is_some() {
                     "Vulkan"
                 } else if wgpu_device.as_hal::<Gles>().is_some() {

--- a/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
+++ b/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
@@ -77,25 +77,6 @@ impl GPURenderingContext {
         connection: &Connection,
         wgpu_device: &wgpu::Device,
     ) -> Result<surfman::Adapter, surfman::Error> {
-        #[derive(Debug, Clone, Copy)]
-        enum AdapterMode {
-            Hardware,
-            LowPower,
-            Default,
-        }
-
-        impl AdapterMode {
-            const ALL: [Self; 3] = [Self::Hardware, Self::LowPower, Self::Default];
-
-            fn create(&self, connection: &Connection) -> Result<surfman::Adapter, surfman::Error> {
-                match self {
-                    Self::Hardware => connection.create_hardware_adapter(),
-                    Self::LowPower => connection.create_low_power_adapter(),
-                    Self::Default => connection.create_adapter(),
-                }
-            }
-        }
-
         // On Windows, Slint and Surfman must use the exact same physical GPU (LUID)
         // to enable zero-copy texture sharing via shared handles.
         // This requires WGPU to be running on the DX12 backend.
@@ -114,8 +95,13 @@ impl GPURenderingContext {
         };
 
         // We iterate through Surfman's adapter presets to find the one that matches WGPU's selection.
-        for mode in AdapterMode::ALL {
-            if let Ok(surfman_adapter) = mode.create(connection) {
+        for create_adapter_fn in &[
+            Connection::create_hardware_adapter
+                as fn(&Connection) -> Result<surfman::Adapter, surfman::Error>,
+            Connection::create_low_power_adapter,
+            Connection::create_adapter,
+        ] {
+            if let Ok(surfman_adapter) = create_adapter_fn(connection) {
                 // To verify the match, we create a temporary device and extract its D3D11 LUID.
                 if let Ok(temp_device) = connection.create_device(&surfman_adapter) {
                     let d3d11_device_ptr = temp_device.native_device().d3d11_device;
@@ -137,7 +123,6 @@ impl GPURenderingContext {
                     if surfman_luid.HighPart == wgpu_luid.HighPart
                         && surfman_luid.LowPart == wgpu_luid.LowPart
                     {
-                        eprintln!("[GPU] Synchronized with WGPU via {:?} mode", mode);
                         return Ok(surfman_adapter);
                     }
                 }

--- a/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
+++ b/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
@@ -35,24 +35,13 @@ impl Drop for GPURenderingContext {
 impl GPURenderingContext {
     pub fn new(
         size: PhysicalSize<u32>,
-        _wgpu_device: &wgpu::Device,
+        wgpu_device: &wgpu::Device,
     ) -> Result<Self, surfman::Error> {
+        Self::print_wgpu_backend(wgpu_device);
+
         let connection = Connection::new()?;
 
-        // On Windows, surfman's create_adapter() calls create_hardware_adapter() which uses
-        // VendorPreference::Avoid(INTEL_PCI_ID). On systems with only an Intel GPU, this
-        // causes surfman to skip Intel and select the WARP software renderer instead
-        // (Microsoft Basic Render Driver, VendorId 0x1414 != 0x8086).
-        //
-        // Using create_low_power_adapter() reverses this: it prefers Intel (VendorId 0x8086),
-        // ensuring we always pick hardware over WARP. On systems without Intel, it falls back
-        // to the first adapter (which is the discrete GPU).
-        #[cfg(target_os = "windows")]
-        let adapter =
-            connection.create_low_power_adapter().or_else(|_| connection.create_adapter())?;
-
-        #[cfg(not(target_os = "windows"))]
-        let adapter = connection.create_adapter()?;
+        let adapter = Self::pick_adapter(&connection, wgpu_device);
 
         let surfman_rendering_info = SurfmanRenderingContext::new(&connection, &adapter)?;
 
@@ -77,6 +66,103 @@ impl GPURenderingContext {
             #[cfg(target_os = "windows")]
             d3d11_state,
         })
+    }
+
+    fn pick_adapter(connection: &Connection, wgpu_device: &wgpu::Device) -> surfman::Adapter {
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(target) = unsafe {
+                use slint::wgpu_28::wgpu::hal::api::Dx12;
+                wgpu_device.as_hal::<Dx12>().and_then(|hal| Some(hal.raw_device().GetAdapterLuid()))
+            } {
+                use windows::{
+                    Win32::Graphics::{Direct3D11::ID3D11Device, Dxgi},
+                    core::{IUnknown, Interface},
+                };
+
+                // On Windows, we must find an EXACT LUID match in Surfman to ensure zero-copy texture sharing works.
+                // This handles systems with multiple GPUs (e.g., Integrated + Discrete) or
+                // multiple backends (Vulkan vs DX12) by finding the physical card WGPU actually picked.
+                for mode in ["hardware", "low_power", "default"] {
+                    let candidate = match mode {
+                        "low_power" => connection.create_low_power_adapter(),
+                        "hardware" => connection.create_hardware_adapter(),
+                        _ => connection.create_adapter(),
+                    };
+
+                    if let Ok(cand) = candidate {
+                        // Verify this adapter matches WGPU's LUID by creating a temporary device
+                        if let Ok(device) = connection.create_device(&cand) {
+                            let raw_d3d11 = device.native_device().d3d11_device;
+                            let d3d11_device: ID3D11Device =
+                                unsafe { IUnknown::from_raw(raw_d3d11 as *mut _).cast().unwrap() };
+
+                            let luid = unsafe {
+                                d3d11_device
+                                    .cast::<Dxgi::IDXGIDevice>()
+                                    .unwrap()
+                                    .GetAdapter()
+                                    .unwrap()
+                                    .GetDesc()
+                                    .unwrap()
+                                    .AdapterLuid
+                            };
+
+                            if luid.HighPart == target.HighPart && luid.LowPart == target.LowPart {
+                                eprintln!("[GPU] Matched Windows GPU via {} mode", mode);
+                                return cand;
+                            }
+                        }
+                    }
+                }
+                eprintln!("[GPU] WARNING: No exact LUID match found. Texture sharing may fail.");
+            }
+        }
+
+        connection.create_hardware_adapter().expect("Failed to create any Surfman adapter")
+    }
+
+    fn print_wgpu_backend(wgpu_device: &wgpu::Device) {
+        let backend = unsafe {
+            use slint::wgpu_28::wgpu::hal::api::{self, Gles};
+
+            #[cfg(target_os = "windows")]
+            {
+                use api::{Dx12, Vulkan};
+                if wgpu_device.as_hal::<Dx12>().is_some() {
+                    "DirectX 12"
+                } else if wgpu_device.as_hal::<Vulkan>().is_some() {
+                    "Vulkan"
+                } else if wgpu_device.as_hal::<Gles>().is_some() {
+                    "OpenGL"
+                } else {
+                    "Unknown"
+                }
+            }
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                use api::Vulkan;
+                if wgpu_device.as_hal::<Vulkan>().is_some() {
+                    "Vulkan"
+                } else if wgpu_device.as_hal::<Gles>().is_some() {
+                    "OpenGL"
+                } else {
+                    "Unknown"
+                }
+            }
+            #[cfg(target_vendor = "apple")]
+            {
+                use api::Metal;
+                if wgpu_device.as_hal::<Metal>().is_some() {
+                    "Metal"
+                } else if wgpu_device.as_hal::<Gles>().is_some() {
+                    "OpenGL"
+                } else {
+                    "Unknown"
+                }
+            }
+        };
+        eprintln!("[GPU] Active WGPU backend: {}", backend);
     }
 
     /// Imports Metal surface as a WGPU texture for rendering on macOS/iOS.

--- a/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
+++ b/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
@@ -45,7 +45,7 @@ impl GPURenderingContext {
         let adapter = connection.create_adapter()?;
 
         #[cfg(target_os = "windows")]
-        let adapter = Self::pick_synchronized_adapter(&connection, wgpu_device);
+        let adapter = Self::pick_synchronized_adapter(&connection, wgpu_device)?;
 
         let surfman_rendering_info = SurfmanRenderingContext::new(&connection, &adapter)?;
 
@@ -76,7 +76,7 @@ impl GPURenderingContext {
     fn pick_synchronized_adapter(
         connection: &Connection,
         wgpu_device: &wgpu::Device,
-    ) -> surfman::Adapter {
+    ) -> Result<surfman::Adapter, surfman::Error> {
         #[derive(Debug, Clone, Copy)]
         enum AdapterMode {
             Hardware,
@@ -96,54 +96,55 @@ impl GPURenderingContext {
             }
         }
 
-        if let Some(wgpu_luid) = unsafe {
+        // On Windows, Slint and Surfman must use the exact same physical GPU (LUID)
+        // to enable zero-copy texture sharing via shared handles.
+        // This requires WGPU to be running on the DX12 backend.
+        let wgpu_luid = unsafe {
             use slint::wgpu_28::wgpu::hal::api::Dx12;
-            wgpu_device.as_hal::<Dx12>().and_then(|hal| Some(hal.raw_device().GetAdapterLuid()))
-        } {
-            use windows::{
-                Win32::Graphics::{Direct3D11::ID3D11Device, Dxgi},
-                core::{IUnknown, Interface},
-            };
+            wgpu_device
+                .as_hal::<Dx12>()
+                .ok_or(surfman::Error::Failed)?
+                .raw_device()
+                .GetAdapterLuid()
+        };
 
-            // On Windows, Slint and Surfman must use the exact same physical GPU (LUID)
-            // to enable zero-copy texture sharing via shared handles.
-            // We iterate through Surfman's adapter presets to find the one that matches WGPU's selection.
-            for mode in AdapterMode::ALL {
-                if let Ok(surfman_adapter) = mode.create(connection) {
-                    // To verify the match, we create a temporary device and extract its D3D11 LUID.
-                    if let Ok(temp_device) = connection.create_device(&surfman_adapter) {
-                        let d3d11_device_ptr = temp_device.native_device().d3d11_device;
-                        let d3d11_device: ID3D11Device = unsafe {
-                            IUnknown::from_raw(d3d11_device_ptr as *mut _).cast().unwrap()
-                        };
+        use windows::{
+            Win32::Graphics::{Direct3D11::ID3D11Device, Dxgi},
+            core::{IUnknown, Interface},
+        };
 
-                        let surfman_luid = unsafe {
-                            d3d11_device
-                                .cast::<Dxgi::IDXGIDevice>()
-                                .unwrap()
-                                .GetAdapter()
-                                .unwrap()
-                                .GetDesc()
-                                .unwrap()
-                                .AdapterLuid
-                        };
+        // We iterate through Surfman's adapter presets to find the one that matches WGPU's selection.
+        for mode in AdapterMode::ALL {
+            if let Ok(surfman_adapter) = mode.create(connection) {
+                // To verify the match, we create a temporary device and extract its D3D11 LUID.
+                if let Ok(temp_device) = connection.create_device(&surfman_adapter) {
+                    let d3d11_device_ptr = temp_device.native_device().d3d11_device;
+                    let d3d11_device: ID3D11Device =
+                        unsafe { IUnknown::from_raw(d3d11_device_ptr as *mut _).cast().unwrap() };
 
-                        // Compare the Surfman LUID with the WGPU LUID (target).
-                        if surfman_luid.HighPart == wgpu_luid.HighPart
-                            && surfman_luid.LowPart == wgpu_luid.LowPart
-                        {
-                            eprintln!("[GPU] Synchronized with WGPU via {:?} mode", mode);
-                            return surfman_adapter;
-                        }
+                    let surfman_luid = unsafe {
+                        d3d11_device
+                            .cast::<Dxgi::IDXGIDevice>()
+                            .unwrap()
+                            .GetAdapter()
+                            .unwrap()
+                            .GetDesc()
+                            .unwrap()
+                            .AdapterLuid
+                    };
+
+                    // Compare the Surfman LUID with the WGPU LUID.
+                    if surfman_luid.HighPart == wgpu_luid.HighPart
+                        && surfman_luid.LowPart == wgpu_luid.LowPart
+                    {
+                        eprintln!("[GPU] Synchronized with WGPU via {:?} mode", mode);
+                        return Ok(surfman_adapter);
                     }
                 }
             }
-            eprintln!("[GPU] WARNING: No exact LUID match found; texture sharing may fail.");
         }
 
-        connection
-            .create_hardware_adapter()
-            .expect("Failed to create a hardware-accelerated Surfman adapter")
+        Err(surfman::Error::NoAdapterFound)
     }
 
     fn print_wgpu_backend(wgpu_device: &wgpu::Device) {

--- a/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
+++ b/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
@@ -84,6 +84,18 @@ impl GPURenderingContext {
             Default,
         }
 
+        impl AdapterMode {
+            const ALL: [Self; 3] = [Self::Hardware, Self::LowPower, Self::Default];
+
+            fn create(&self, connection: &Connection) -> Result<surfman::Adapter, surfman::Error> {
+                match self {
+                    Self::Hardware => connection.create_hardware_adapter(),
+                    Self::LowPower => connection.create_low_power_adapter(),
+                    Self::Default => connection.create_adapter(),
+                }
+            }
+        }
+
         if let Some(wgpu_luid) = unsafe {
             use slint::wgpu_28::wgpu::hal::api::Dx12;
             wgpu_device.as_hal::<Dx12>().and_then(|hal| Some(hal.raw_device().GetAdapterLuid()))
@@ -96,14 +108,8 @@ impl GPURenderingContext {
             // On Windows, Slint and Surfman must use the exact same physical GPU (LUID)
             // to enable zero-copy texture sharing via shared handles.
             // We iterate through Surfman's adapter presets to find the one that matches WGPU's selection.
-            for mode in [AdapterMode::Hardware, AdapterMode::LowPower, AdapterMode::Default] {
-                let surfman_adapter_result = match mode {
-                    AdapterMode::LowPower => connection.create_low_power_adapter(),
-                    AdapterMode::Hardware => connection.create_hardware_adapter(),
-                    AdapterMode::Default => connection.create_adapter(),
-                };
-
-                if let Ok(surfman_adapter) = surfman_adapter_result {
+            for mode in AdapterMode::ALL {
+                if let Ok(surfman_adapter) = mode.create(connection) {
                     // To verify the match, we create a temporary device and extract its D3D11 LUID.
                     if let Ok(temp_device) = connection.create_device(&surfman_adapter) {
                         let d3d11_device_ptr = temp_device.native_device().d3d11_device;


### PR DESCRIPTION
- Implement universal LUID matching on Windows to ensure WGPU and Surfman use the same physical GPU.
- Add robust discovery loop to correctly handle multi-GPU systems (e.g., Intel Integrated + Arc Discrete).
- Introduce `print_wgpu_backend` helper for improved observability of the active graphics API.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
