### PR TITLE
input: add @physical-keys for physical shortcuts

### DIFF
--- a/api/cpp/include/private/slint_keys.h
+++ b/api/cpp/include/private/slint_keys.h
@@ -12,7 +12,7 @@ class Keys;
 namespace private_api {
 
 void make_keys(Keys &out, const slint::SharedString &key, bool alt, bool control, bool shift,
-               bool meta, bool ignoreShift, bool ignoreAlt);
+               bool meta, bool ignoreShift, bool ignoreAlt, bool isPhysical);
 
 } // namespace private_api
 
@@ -67,7 +67,7 @@ private:
     Keys(cbindgen_private::types::Keys &&data) : data(std::move(data)) { }
     friend void private_api::make_keys(Keys &out, const slint::SharedString &key, bool alt,
                                        bool control, bool shift, bool meta, bool ignoreShift,
-                                       bool ignoreAlt);
+                                       bool ignoreAlt, bool isPhysical);
 };
 
 namespace private_api {
@@ -75,10 +75,10 @@ namespace private_api {
 // We need to use Keys& out so that we can forward-declare this and then use it as a friend
 // Otherwise the size of `Keys` is not yet known.
 inline void make_keys(Keys &out, const slint::SharedString &key, bool alt, bool control, bool shift,
-                      bool meta, bool ignoreShift, bool ignoreAlt)
+                      bool meta, bool ignoreShift, bool ignoreAlt, bool isPhysical)
 {
     ::slint::cbindgen_private::types::slint_keys(&key, alt, control, shift, meta, ignoreShift,
-                                                 ignoreAlt, &out.data);
+                                                 ignoreAlt, isPhysical, &out.data);
 }
 
 } // namespace private_api

--- a/docs/astro/src/content/docs/reference/keyboard-input/overview.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/overview.mdx
@@ -21,6 +21,7 @@ Slint's <Link type="KeyBinding" label="KeyBinding"/> elements and the built-in <
  This structure is generated and passed to the key press and release callbacks of the `FocusScope` element.
 
 - **`text`** (_string_):  The unicode representation of the key pressed.
+- **`physical-key`** (_string_): The physical key that was pressed, if the backend reports it. This uses the same names as `@physical-keys(...)`, for example `A`, `Digit1`, or `LeftArrow`.
 - **`modifiers`** (_KeyboardModifiers_):  The keyboard modifiers active at the time of the key press event.
 - **`repeat`** (_bool_):  This field is set to true for key press events that are repeated, i.e. the key is held down. It's always false for key release events.
 
@@ -29,7 +30,7 @@ Slint's <Link type="KeyBinding" label="KeyBinding"/> elements and the built-in <
 Use the <Link type="KeyBinding" label="KeyBinding element"/> inside a `FocusScope` to declare key bindings (or keyboard shortcuts).
 The `KeyBinding`'s `keys` property takes an instance of the <Link label="keys type" type="keys"/> and invokes the `activated` callback when the key combination is detected.
 
-The `keys` type represents a key, combined with modifiers and is constructed with the `@keys` macro.
+The `keys` type represents a key, combined with modifiers and is constructed with either the `@keys` macro for logical keys or the `@physical-keys` macro for physical key positions.
 
 Key bindings in Slint are based on **logical keys** — the character a keypress produces on the current keyboard layout — not the physical position of a key.
 This means, for example, that `@keys(Control + Z)` activates when the user presses the key that produces `z` on their layout, regardless of where that key sits on the keyboard.
@@ -100,6 +101,26 @@ For example, to support key bindings that produce a Euro-Sign (€), add both `S
 This will allow your users to reach the binding on almost all keyboard layouts that have a key with this label.
 
 As another example, `@keys(Control + Plus)` is equivalent to `@keys(Control + Shift? + "+")`.
+
+### Physical Key Bindings
+
+If you want to match a physical key position instead of the character produced on the current keyboard layout, use `@physical-keys(..)`.
+
+```slint
+export component Example inherits Window {
+    forward-focus: scope;
+
+    scope := FocusScope {
+        KeyBinding {
+            keys: @physical-keys(Control + A);
+            activated => { debug("The physical A key was pressed"); }
+        }
+    }
+}
+```
+
+Physical key names reuse familiar `Key` names such as `A`, `Digit1`, `BackQuote`, or `LeftArrow`, but they refer to a physical key location instead of logical text.
+Unlike `@keys(..)`, `@physical-keys(..)` does not accept string literals.
 
 ## Key Namespace
 

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -172,7 +172,7 @@ RGB color with an alpha channel, with 8 bit precision for each channel. CSS colo
 A keys represents a key combined with a list of modifiers.
 This is the primitive type used to detect if a KeyEvent should trigger a given key binding.
 
-Key bindings in Slint are based on **logical keys** — the character a key produces on the current keyboard layout — not the physical position of a key on the keyboard.
+Key bindings in Slint can use **logical keys** via `@keys(...)` or **physical keys** via `@physical-keys(...)`.
 See <Link type="KeyBindingOverview" label="Key Bindings" /> for details.
 
 Use the `to-string` function to convert a `keys` instance to `string`.

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -290,8 +290,25 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     }
                     i_slint_common::for_each_keys!(winit_key_to_char)
                 }
+
+                fn to_slint_physical_key(
+                    physical_key: &winit::keyboard::PhysicalKey,
+                ) -> SharedString {
+                    macro_rules! winit_physical_key_to_name {
+                        ($($name:ident # $code:ident;)*) => {
+                            match physical_key {
+                                $(winit::keyboard::PhysicalKey::Code(winit::keyboard::KeyCode::$code) => stringify!($name).into(),)*
+                                _ => Default::default(),
+                            }
+                        };
+                    }
+
+                    i_slint_common::for_each_physical_keys!(winit_physical_key_to_name)
+                }
+
                 #[allow(unused_mut)]
                 let mut text = to_slint_key(&event, &key_code);
+                let physical_key = to_slint_physical_key(&event.physical_key);
 
                 #[cfg(target_os = "windows")]
                 let text_without_modifiers = {
@@ -339,7 +356,11 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 };
 
                 let event = corelib::input::InternalKeyEvent {
-                    key_event: corelib::input::KeyEvent { text, ..Default::default() },
+                    key_event: corelib::input::KeyEvent {
+                        text,
+                        physical_key,
+                        ..Default::default()
+                    },
                     event_type,
                     #[cfg(target_os = "windows")]
                     text_without_modifiers,

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -335,6 +335,21 @@ fn key_string_to_key(string: &str) -> muda::accelerator::Key {
     i_slint_common::for_each_keys!(key_string_to_code_impl)
 }
 
+fn physical_key_string_to_code(string: &str) -> Option<muda::accelerator::Code> {
+    use muda::accelerator::Code;
+
+    macro_rules! key_string_to_code_impl {
+        ($($name:ident # $code:ident;)*) => {
+            match string {
+                $(stringify!($name) => Some(Code::$code),)*
+                _ => None,
+            }
+        };
+    }
+
+    i_slint_common::for_each_physical_keys!(key_string_to_code_impl)
+}
+
 fn keys_to_accelerator(
     keys: &i_slint_core::input::Keys,
 ) -> Option<muda::accelerator::KeyAccelerator> {
@@ -367,9 +382,12 @@ fn keys_to_accelerator(
             modifiers |= Modifiers::SUPER;
         }
     }
-    let key = key_string_to_key(&shortcut.key);
-
-    Some(KeyAccelerator::new(Some(modifiers), key))
+    if shortcut.is_physical {
+        Some(Accelerator::new(Some(modifiers), physical_key_string_to_code(&shortcut.key)?).into())
+    } else {
+        let key = key_string_to_key(&shortcut.key);
+        Some(KeyAccelerator::new(Some(modifiers), key))
+    }
 }
 
 fn install_event_handler_if_necessary(proxy: EventLoopProxy<SlintEvent>) {

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -94,6 +94,12 @@ macro_rules! for_each_builtin_structs {
                 export {
                     /// The unicode representation of the key pressed.
                     text: SharedString,
+                    /// The physical key that was pressed, if the backend can report it.
+                    ///
+                    /// This uses the same names as `@physical-keys(...)`, for example `A`,
+                    /// `Digit1`, or `LeftArrow`. It is empty when the backend doesn't provide
+                    /// physical key information.
+                    physical_key: SharedString,
                     /// The keyboard modifiers active at the time of the key press event.
                     modifiers: KeyboardModifiers,
                     /// This field is set to true for key press events that are repeated,

--- a/internal/common/lib.rs
+++ b/internal/common/lib.rs
@@ -12,6 +12,7 @@ pub mod builtin_structs;
 pub mod color_parsing;
 pub mod enums;
 pub mod key_codes;
+pub mod physical_key_codes;
 
 #[cfg(feature = "shared-fontique")]
 pub mod sharedfontique;

--- a/internal/common/physical_key_codes.rs
+++ b/internal/common/physical_key_codes.rs
@@ -1,0 +1,106 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Shared physical key names used by `@physical-keys(...)`.
+
+#[macro_export]
+macro_rules! for_each_physical_keys {
+    ($macro:ident) => {
+        $macro![
+            A # KeyA;
+            B # KeyB;
+            C # KeyC;
+            D # KeyD;
+            E # KeyE;
+            F # KeyF;
+            G # KeyG;
+            H # KeyH;
+            I # KeyI;
+            J # KeyJ;
+            K # KeyK;
+            L # KeyL;
+            M # KeyM;
+            N # KeyN;
+            O # KeyO;
+            P # KeyP;
+            Q # KeyQ;
+            R # KeyR;
+            S # KeyS;
+            T # KeyT;
+            U # KeyU;
+            V # KeyV;
+            W # KeyW;
+            X # KeyX;
+            Y # KeyY;
+            Z # KeyZ;
+
+            Digit0 # Digit0;
+            Digit1 # Digit1;
+            Digit2 # Digit2;
+            Digit3 # Digit3;
+            Digit4 # Digit4;
+            Digit5 # Digit5;
+            Digit6 # Digit6;
+            Digit7 # Digit7;
+            Digit8 # Digit8;
+            Digit9 # Digit9;
+
+            BackQuote # Backquote;
+            HyphenMinus # Minus;
+            Equals # Equal;
+            OpenBracket # BracketLeft;
+            CloseBracket # BracketRight;
+            BackSlash # Backslash;
+            Semicolon # Semicolon;
+            Quote # Quote;
+            Comma # Comma;
+            Period # Period;
+            Slash # Slash;
+            Space # Space;
+
+            Escape # Escape;
+            Tab # Tab;
+            Return # Enter;
+            Backspace # Backspace;
+            Delete # Delete;
+            Insert # Insert;
+            Home # Home;
+            End # End;
+            PageUp # PageUp;
+            PageDown # PageDown;
+            UpArrow # ArrowUp;
+            DownArrow # ArrowDown;
+            LeftArrow # ArrowLeft;
+            RightArrow # ArrowRight;
+            Menu # ContextMenu;
+            CapsLock # CapsLock;
+            ScrollLock # ScrollLock;
+            Pause # Pause;
+
+            F1 # F1;
+            F2 # F2;
+            F3 # F3;
+            F4 # F4;
+            F5 # F5;
+            F6 # F6;
+            F7 # F7;
+            F8 # F8;
+            F9 # F9;
+            F10 # F10;
+            F11 # F11;
+            F12 # F12;
+            F13 # F13;
+            F14 # F14;
+            F15 # F15;
+            F16 # F16;
+            F17 # F17;
+            F18 # F18;
+            F19 # F19;
+            F20 # F20;
+            F21 # F21;
+            F22 # F22;
+            F23 # F23;
+            F24 # F24;
+        ];
+    };
+}

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1983,7 +1983,11 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
             None => write!(f, "{}.{}", e.enumeration.name, e.value),
         },
         Expression::Keys(keys) => {
-            write!(f, "@keys({keys})")
+            if keys.is_physical {
+                write!(f, "@physical-keys({keys})")
+            } else {
+                write!(f, "@keys({keys})")
+            }
         }
         Expression::ReturnStatement(e) => {
             write!(f, "return ")?;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3503,11 +3503,11 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         Expression::BoolLiteral(b) => b.to_string(),
         Expression::KeysLiteral(ks) => {
             format!(
-                "[&](const slint::SharedString &key, bool alt, bool control, bool shift, bool meta, bool ignoreShift, bool ignoreAlt) {{
+                "[&](const slint::SharedString &key, bool alt, bool control, bool shift, bool meta, bool ignoreShift, bool ignoreAlt, bool isPhysical) {{
                     slint::Keys out;
-                    slint::private_api::make_keys(out, key, alt, control, shift, meta, ignoreShift, ignoreAlt);
+                    slint::private_api::make_keys(out, key, alt, control, shift, meta, ignoreShift, ignoreAlt, isPhysical);
                     return out;
-                }}({}, {}, {}, {}, {}, {}, {})",
+                }}({}, {}, {}, {}, {}, {}, {}, {})",
                 shared_string_literal(&ks.key),
                 ks.modifiers.alt,
                 ks.modifiers.control,
@@ -3515,6 +3515,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 ks.modifiers.meta,
                 ks.ignore_shift,
                 ks.ignore_alt,
+                ks.is_physical,
             )
         }
         Expression::PropertyReference(nr) => access_member(nr, ctx).get_property(),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2620,6 +2620,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 let meta = keys.modifiers.meta;
                 let ignore_shift = keys.ignore_shift;
                 let ignore_alt = keys.ignore_alt;
+                let is_physical = keys.is_physical;
 
                 quote!(
                     sp::make_keys(
@@ -2631,7 +2632,8 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                             meta: #meta
                         },
                         #ignore_shift,
-                        #ignore_alt))
+                        #ignore_alt,
+                        #is_physical))
         },
         Expression::NumberLiteral(n) if n.is_finite() => quote!(#n),
         Expression::NumberLiteral(_) => quote!(0.),

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -1036,6 +1036,7 @@ pub struct Keys {
     pub modifiers: KeyboardModifiers,
     pub ignore_shift: bool,
     pub ignore_alt: bool,
+    pub is_physical: bool,
 }
 
 impl std::fmt::Display for Keys {
@@ -1056,20 +1057,24 @@ impl std::fmt::Display for Keys {
                 .then_some("Shift?+")
                 .or(self.modifiers.shift.then_some("Shift+"))
                 .unwrap_or_default();
-            let keycode: String = self
-                .key
-                .chars()
-                .flat_map(|character| {
-                    let mut escaped = vec![];
-                    if character.is_control() {
-                        escaped.extend(character.escape_unicode());
-                    } else {
-                        escaped.push(character);
-                    }
-                    escaped
-                })
-                .collect();
-            write!(f, "{meta}{ctrl}{alt}{shift}\"{keycode}\"")
+            if self.is_physical {
+                write!(f, "{meta}{ctrl}{alt}{shift}{}", self.key)
+            } else {
+                let keycode: String = self
+                    .key
+                    .chars()
+                    .flat_map(|character| {
+                        let mut escaped = vec![];
+                        if character.is_control() {
+                            escaped.extend(character.escape_unicode());
+                        } else {
+                            escaped.push(character);
+                        }
+                        escaped
+                    })
+                    .collect();
+                write!(f, "{meta}{ctrl}{alt}{shift}\"{keycode}\"")
+            }
         }
     }
 }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -306,7 +306,11 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             Expression::NumberLiteral(x) => write!(f, "{x:?}"),
             Expression::BoolLiteral(x) => write!(f, "{x:?}"),
             Expression::KeysLiteral(keys) => {
-                write!(f, "@keys({keys})",)
+                if keys.is_physical {
+                    write!(f, "@physical-keys({keys})",)
+                } else {
+                    write!(f, "@keys({keys})",)
+                }
             }
             Expression::PropertyReference(x) => write!(f, "{}", DisplayPropertyRef(x, ctx)),
             Expression::FunctionParameterReference { index } => write!(f, "arg_{index}"),

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -375,7 +375,7 @@ declare_syntax! {
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
-                       ?MemberAccess, ?AtKeys ],
+                       ?MemberAccess, ?AtKeys, ?AtPhysicalKeys ],
         /// Concatenate the children Expressions and StringLiteral to make a string
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
@@ -391,6 +391,8 @@ declare_syntax! {
         TrPlural -> [Expression],
         /// `@keys(...)`
         AtKeys -> [],
+        /// `@physical-keys(...)`
+        AtPhysicalKeys -> [],
         /// expression()
         FunctionCallExpression -> [*Expression],
         /// `expression[index]`

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -261,10 +261,13 @@ fn parse_at_keyword(p: &mut impl Parser) {
         "keys" => {
             parse_keys(p);
         }
+        "physical-keys" | "physical_keys" => {
+            parse_physical_keys(p);
+        }
         _ => {
             p.consume();
             p.test(SyntaxKind::Identifier); // consume the identifier, so that autocomplete works
-            p.error("Expected 'image-url', 'tr', 'keys', 'conic-gradient', 'linear-gradient', or 'radial-gradient' after '@'");
+            p.error("Expected 'image-url', 'tr', 'keys', 'physical-keys', 'conic-gradient', 'linear-gradient', or 'radial-gradient' after '@'");
         }
     }
 }
@@ -487,10 +490,26 @@ fn parse_markdown(p: &mut impl Parser) {
 /// @keys(Control +Shift + Alt?+Meta+Return)
 /// ```
 fn parse_keys(p: &mut impl Parser) {
-    let mut p = p.start_node(SyntaxKind::AtKeys);
+    parse_key_like_macro(p, SyntaxKind::AtKeys, "keys");
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,AtPhysicalKeys
+/// @physical-keys(A)
+/// @physical-keys(Control + Shift + Digit1)
+/// @physical-keys(Meta + LeftArrow)
+/// @physical-keys(Alt? + BackQuote)
+/// @physical-keys(Control + PageDown)
+/// ```
+fn parse_physical_keys(p: &mut impl Parser) {
+    parse_key_like_macro(p, SyntaxKind::AtPhysicalKeys, "physical-keys");
+}
+
+fn parse_key_like_macro(p: &mut impl Parser, syntax_kind: SyntaxKind, macro_name: &str) {
+    let mut p = p.start_node(syntax_kind);
     p.expect(SyntaxKind::At);
-    debug_assert_eq!(p.peek().as_str(), "keys");
-    p.expect(SyntaxKind::Identifier); //"keys"
+    debug_assert_eq!(p.peek().as_str(), macro_name);
+    p.expect(SyntaxKind::Identifier);
     p.expect(SyntaxKind::LParent);
 
     // Parse custom syntax here...

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -17,7 +17,7 @@ use crate::object_tree::*;
 use crate::parser::{NodeOrToken, SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
 use crate::typeregister::TypeRegister;
 use core::num::IntErrorKind;
-use i_slint_common::for_each_keys;
+use i_slint_common::{for_each_keys, for_each_physical_keys};
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -90,6 +90,9 @@ fn resolve_expression(
             }
             SyntaxKind::AtKeys => {
                 Expression::from_at_keys_node(node.clone().into(), &mut lookup_ctx)
+            }
+            SyntaxKind::AtPhysicalKeys => {
+                Expression::from_at_physical_keys_node(node.clone().into(), &mut lookup_ctx)
             }
             _ => {
                 debug_assert!(diag.has_errors());
@@ -371,6 +374,9 @@ impl Expression {
                     SyntaxKind::AtTr => Some(Self::from_at_tr(node.into(), ctx)),
                     SyntaxKind::AtMarkdown => Some(Self::from_at_markdown(node.into(), ctx)),
                     SyntaxKind::AtKeys => Some(Self::from_at_keys_node(node.into(), ctx)),
+                    SyntaxKind::AtPhysicalKeys => {
+                        Some(Self::from_at_physical_keys_node(node.into(), ctx))
+                    }
                     SyntaxKind::QualifiedName => Some(Self::from_qualified_name_node(
                         node.clone().into(),
                         ctx,
@@ -1135,6 +1141,77 @@ impl Expression {
         Expression::Keys(keys)
     }
 
+    pub fn from_at_physical_keys_node(
+        node: syntax_nodes::AtPhysicalKeys,
+        ctx: &mut LookupCtx,
+    ) -> Self {
+        let mut keys = langtype::Keys { is_physical: true, ..Default::default() };
+
+        let idents_and_questions: Vec<_> = node
+            .children_with_tokens()
+            .filter(|n| matches!(n.kind(), SyntaxKind::Identifier | SyntaxKind::Question))
+            .skip(1)
+            .collect();
+
+        for (index, ident_or_question) in idents_and_questions.iter().enumerate() {
+            if ident_or_question.kind() == SyntaxKind::Question {
+                continue;
+            }
+            let identifier = ident_or_question;
+
+            let is_question = || -> bool {
+                matches!(
+                    idents_and_questions.get(index + 1).map(NodeOrToken::kind),
+                    Some(SyntaxKind::Question)
+                )
+            };
+
+            match identifier.as_token().unwrap().text() {
+                "Alt" => {
+                    if is_question() {
+                        keys.ignore_alt = true;
+                    } else {
+                        keys.modifiers.alt = true;
+                    }
+                }
+                "Control" => keys.modifiers.control = true,
+                "Meta" => keys.modifiers.meta = true,
+                "Shift" => {
+                    if is_question() {
+                        keys.ignore_shift = true;
+                    } else {
+                        keys.modifiers.shift = true;
+                    }
+                }
+                key_name => {
+                    if let Some(key) = lookup_physical_key(key_name) {
+                        keys.key = key.into();
+                    } else {
+                        ctx.diag.push_error(
+                            format!(
+                                "{key_name} is not supported by @physical-keys\n\
+                                Use a physical key name such as A, Digit1, BackQuote, or LeftArrow"
+                            ),
+                            identifier,
+                        );
+                        keys.modifiers = KeyboardModifiers::default();
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some(token) = node.child_token(SyntaxKind::StringLiteral) {
+            ctx.diag.push_error(
+                "String literals are not supported in @physical-keys (use a key name such as A or LeftArrow)"
+                    .into(),
+                &token,
+            );
+        }
+
+        Expression::Keys(keys)
+    }
+
     /// Perform the lookup
     fn from_qualified_name_node(
         node: syntax_nodes::QualifiedName,
@@ -1722,6 +1799,27 @@ fn with_key_map<R>(fun: impl FnOnce(&HashMap<&'static str, (char, ShiftBehavior)
 /// Look up the given key in the Keys namespace, including its shift behavior
 fn lookup_key(keycode: &str) -> Option<(char, ShiftBehavior)> {
     with_key_map(|map| map.get(keycode).cloned())
+}
+
+fn with_physical_key_map<R>(fun: impl FnOnce(&HashMap<&'static str, &'static str>) -> R) -> R {
+    macro_rules! generate_physical_key_map {
+        [ $($name:ident # $code:ident;)* ] => {
+            {
+                [$( (stringify!($name), stringify!($name)) ),*]
+            }
+        };
+    }
+
+    thread_local! {
+        pub static PHYSICAL_KEY_MAP: HashMap<&'static str, &'static str> =
+            for_each_physical_keys!(generate_physical_key_map).into_iter().collect();
+    }
+
+    PHYSICAL_KEY_MAP.with(fun)
+}
+
+fn lookup_physical_key(keycode: &str) -> Option<&'static str> {
+    with_physical_key_map(|map| map.get(keycode).copied())
 }
 
 /// Return the type that merge two times when they are used in two branch of a condition

--- a/internal/compiler/tests/syntax/expressions/at_physical_keys_valid.slint
+++ b/internal/compiler/tests/syntax/expressions/at_physical_keys_valid.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SuperSimple {
+    property <[keys]> shortcuts: [
+        @physical-keys(A),
+        @physical-keys(Control + Shift + Digit1),
+        @physical-keys(Meta + LeftArrow),
+        @physical-keys(Alt? + BackQuote),
+        @physical-keys(Control + PageDown),
+    ];
+}

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -442,9 +442,16 @@ pub fn make_keys(
     modifiers: KeyboardModifiers,
     ignore_shift: bool,
     ignore_alt: bool,
+    is_physical: bool,
 ) -> Keys {
     Keys {
-        inner: KeysInner { key: key.to_lowercase().into(), modifiers, ignore_shift, ignore_alt },
+        inner: KeysInner {
+            key: if is_physical { key } else { key.to_lowercase().into() },
+            modifiers,
+            ignore_shift,
+            ignore_alt,
+            is_physical,
+        },
     }
 }
 
@@ -464,6 +471,7 @@ pub(crate) mod ffi {
         meta: bool,
         ignore_shift: bool,
         ignore_alt: bool,
+        is_physical: bool,
         out: &mut Keys,
     ) {
         *out = make_keys(
@@ -471,6 +479,7 @@ pub(crate) mod ffi {
             KeyboardModifiers { alt, control, shift, meta },
             ignore_shift,
             ignore_alt,
+            is_physical,
         );
     }
 
@@ -491,8 +500,6 @@ pub(crate) mod ffi {
 #[repr(C)]
 pub struct KeysInner {
     /// The `key` used to trigger the shortcut
-    ///
-    /// Note: This is currently converted to lowercase when the shortcut is created!
     pub key: SharedString,
     /// `KeyboardModifier`s that need to be pressed for the shortcut to fire
     pub modifiers: KeyboardModifiers,
@@ -500,6 +507,8 @@ pub struct KeysInner {
     pub ignore_shift: bool,
     /// Whether to ignore alt state when matching the shortcut
     pub ignore_alt: bool,
+    /// Whether this shortcut matches the physical key code instead of the logical key text.
+    pub is_physical: bool,
 }
 
 impl KeysInner {
@@ -526,20 +535,30 @@ impl Keys {
         if inner.ignore_alt {
             expected_modifiers.alt = key_event.modifiers.alt;
         }
-        // Note: The shortcut's key is already in lowercase and NFC-normalized
-        // (by the compiler and backends respectively), so we only need to
-        // lowercase the event text. Backends are expected to NFC-normalize
-        // key event text before dispatching.
-        //
-        // This improves our handling of CapsLock and Shift, as the event text will be in uppercase
-        // if caps lock is active, even if shift is not pressed.
-        let event_text = key_event.text.chars().flat_map(|character| character.to_lowercase());
+        let key_matches = if inner.is_physical {
+            key_event.physical_key == inner.key
+        } else {
+            // Note: The shortcut's key is already in lowercase and NFC-normalized
+            // (by the compiler and backends respectively), so we only need to
+            // lowercase the event text. Backends are expected to NFC-normalize
+            // key event text before dispatching.
+            //
+            // This improves our handling of CapsLock and Shift, as the event text will be in uppercase
+            // if caps lock is active, even if shift is not pressed.
+            let event_text = key_event.text.chars().flat_map(|character| character.to_lowercase());
+            event_text.eq(inner.key.chars())
+        };
 
-        event_text.eq(inner.key.chars()) && key_event.modifiers == expected_modifiers
+        key_matches && key_event.modifiers == expected_modifiers
     }
 
     fn format_key_for_display(&self) -> crate::SharedString {
         let key_str = self.inner.key.as_str();
+
+        if self.inner.is_physical {
+            return key_str.into();
+        }
+
         let first_char = key_str.chars().next();
 
         if let Some(first_char) = first_char {
@@ -662,20 +681,24 @@ impl core::fmt::Debug for Keys {
                 .then_some("Shift?+")
                 .or(inner.modifiers.shift.then_some("Shift+"))
                 .unwrap_or_default();
-            let keycode: SharedString = inner
-                .key
-                .chars()
-                .flat_map(|character| {
-                    let mut escaped = alloc::vec![];
-                    if character.is_control() {
-                        escaped.extend(character.escape_unicode());
-                    } else {
-                        escaped.push(character);
-                    }
-                    escaped
-                })
-                .collect();
-            write!(f, "{meta}{ctrl}{alt}{shift}\"{keycode}\"")
+            if inner.is_physical {
+                write!(f, "{meta}{ctrl}{alt}{shift}{}", inner.key)
+            } else {
+                let keycode: SharedString = inner
+                    .key
+                    .chars()
+                    .flat_map(|character| {
+                        let mut escaped = alloc::vec![];
+                        if character.is_control() {
+                            escaped.extend(character.escape_unicode());
+                        } else {
+                            escaped.push(character);
+                        }
+                        escaped
+                    })
+                    .collect();
+                write!(f, "{meta}{ctrl}{alt}{shift}\"{keycode}\"")
+            }
         }
     }
 }
@@ -2417,7 +2440,7 @@ mod tests {
             _expected_linux,
         ) in test_cases
         {
-            let shortcut = make_keys(key.into(), modifiers, ignore_shift, ignore_alt);
+            let shortcut = make_keys(key.into(), modifiers, ignore_shift, ignore_alt, false);
 
             use crate::alloc::string::ToString;
             let result = shortcut.to_string();

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -476,6 +476,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             },
             ks.ignore_shift,
             ks.ignore_alt,
+            ks.is_physical,
         )),
         Expression::ReturnStatement(x) => {
             let val = x.as_ref().map_or(Value::Void, |x| eval_expression(x, local_context));

--- a/tests/cases/input/physical_keys.slint
+++ b/tests/cases/input/physical_keys.slint
@@ -1,0 +1,61 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    in-out property <string> matched: "";
+    forward-focus: scope;
+
+    init => {
+        scope.focus();
+    }
+
+    scope := FocusScope {
+        KeyBinding {
+            keys: @physical-keys(Control + A);
+            activated => {
+                matched = "physical-a";
+            }
+        }
+
+        KeyBinding {
+            keys: @keys(Control + A);
+            activated => {
+                matched = "logical-a";
+            }
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+let inner = i_slint_core::window::WindowInner::from_pub(instance.window());
+
+use i_slint_core::input::{InternalKeyEvent, KeyEventType};
+use i_slint_core::items::{KeyEvent, KeyboardModifiers};
+
+let send = |text: &str, physical_key: &str| {
+    inner.process_key_input(InternalKeyEvent {
+        event_type: KeyEventType::KeyPressed,
+        key_event: KeyEvent {
+            text: text.into(),
+            physical_key: physical_key.into(),
+            modifiers: KeyboardModifiers { control: true, alt: false, shift: false, meta: false },
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+};
+
+send("z", "A");
+assert_eq!(instance.get_matched(), "physical-a");
+instance.set_matched("".into());
+
+send("a", "Q");
+assert_eq!(instance.get_matched(), "logical-a");
+instance.set_matched("".into());
+
+send("a", "");
+assert_eq!(instance.get_matched(), "logical-a");
+```
+*/


### PR DESCRIPTION
## Summary
based on #11247 I add first-pass support for physical keyboard shortcuts via `@physical-keys(...)`
This keeps existing `@keys(...)` behavior unchanged and introduces an explicit API for matching physical key positions instead of logical key text and the `keys` type now carries whether it is logical or physical`KeyEvent` exposes `physical-key`and the winit backend populates it from the platform event
