### PR TITLE
SlintPad: Show a progress bar when loading

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -26,6 +26,7 @@
         "path-browserify",
         "vscode-uri",
         "@lsp/slint_lsp_wasm.js",
+        "@lsp/slint_lsp_wasm_bg.wasm",
         "@interpreter/slint_wasm_interpreter.js"
       ]
     },

--- a/tools/slintpad/index.html
+++ b/tools/slintpad/index.html
@@ -16,8 +16,12 @@
 </head>
 
 <body>
-  <div class="loader" style="z-index: 1000; position: absolute">
-    <img class="loader-image" src="static/loader.svg" />
+  <div class="loader" id="loader" style="z-index: 1000; position: absolute">
+    <div class="loader-content">
+      <img class="loader-logo" src="static/loader.svg" alt="Slint" />
+      <label class="loader-message" id="loader-message" for="loader-progress">Loading…</label>
+      <progress class="loader-progress" id="loader-progress"></progress>
+    </div>
   </div>
 </body>
 

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -4,7 +4,7 @@
 // cSpell: ignore cupertino lumino permalink
 
 import { EditorWidget, initialize as initializeEditor } from "./editor_widget";
-import { LspWaiter, type Lsp } from "./lsp";
+import { LspWaiter, type Lsp, type LoadPhase } from "./lsp";
 import { PreviewWidget } from "./preview_widget";
 
 import {
@@ -26,7 +26,35 @@ import { Menu, MenuBar, SplitPanel, Widget } from "@lumino/widgets";
 
 import { type InvokeSlintpadCallback, SlintPadCallbackFunction } from "./lsp";
 
-const lsp_waiter = new LspWaiter();
+const loader = document.getElementById("loader");
+const loader_message = document.getElementById("loader-message");
+const loader_progress = document.getElementById(
+    "loader-progress",
+) as HTMLProgressElement | null;
+
+function update_loader(phase: LoadPhase) {
+    if (loader_message === null || loader_progress === null) return;
+    if (phase.kind === "downloading") {
+        if (phase.total) {
+            const percent = Math.round((phase.received / phase.total) * 100);
+            loader_message.textContent = `Downloading Slint runtime… ${percent}%`;
+            loader_progress.max = phase.total;
+            loader_progress.value = phase.received;
+        } else {
+            const kb = Math.round(phase.received / 1024);
+            loader_message.textContent = `Downloading Slint runtime… ${kb} KB`;
+            loader_progress.removeAttribute("value");
+        }
+    } else if (phase.kind === "compiling") {
+        loader_message.textContent = "Compiling…";
+        loader_progress.removeAttribute("value");
+    } else if (phase.kind === "initializing") {
+        loader_message.textContent = "Initializing…";
+        loader_progress.removeAttribute("value");
+    }
+}
+
+const lsp_waiter = new LspWaiter(update_loader);
 
 const commands = new CommandRegistry();
 
@@ -72,11 +100,14 @@ function setup(lsp: Lsp) {
 function main() {
     initializeEditor()
         .then((_) => {
+            if (loader_message !== null) {
+                loader_message.textContent = "Starting language server…";
+            }
             lsp_waiter
                 .wait_for_lsp()
                 .then((lsp) => {
                     setup(lsp);
-                    document.body.getElementsByClassName("loader")[0].remove();
+                    loader?.remove();
                 })
                 .catch((e) => {
                     console.info("LSP fail:", e);
@@ -84,7 +115,7 @@ function main() {
                     div.className = "browser-error";
                     div.innerHTML =
                         "<p>Failed to start the slint language server</p>";
-                    document.body.getElementsByClassName("loader")[0].remove();
+                    loader?.remove();
                     document.body.appendChild(div);
                 });
         })

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -102,11 +102,18 @@ function createLanguageClient(
 
 export type FileReader = (_url: string) => Promise<string>;
 
+export type LoadPhase =
+    | { kind: "downloading"; received: number; total: number }
+    | { kind: "compiling" }
+    | { kind: "initializing" };
+
+export type LoadProgressCallback = (phase: LoadPhase) => void;
+
 export class LspWaiter {
     #previewer_promise: Promise<slint_preview.InitOutput> | null;
     #lsp_promise: Promise<Worker> | null;
 
-    constructor() {
+    constructor(on_progress?: LoadProgressCallback) {
         const worker = new Worker(
             new URL("worker/lsp_worker.ts", import.meta.url),
             { type: "module" },
@@ -136,14 +143,41 @@ export class LspWaiter {
 
         // Fetch and compile the LSP wasm once on the main thread and share the
         // compiled module with the worker, so the browser does not have to
-        // download the same wasm twice.
+        // download the same wasm twice. A cloned response is read in parallel
+        // so we can report byte-level download progress while compileStreaming
+        // consumes the original.
         this.#previewer_promise = (async () => {
             const response = await fetch(slint_lsp_wasm_url);
-            const wasm_module = await WebAssembly.compileStreaming(response);
+            const compile_promise = WebAssembly.compileStreaming(response);
+            const progress_stream = response.clone();
+            const total =
+                Number(progress_stream.headers.get("Content-Length")) || 0;
+            on_progress?.({ kind: "downloading", received: 0, total });
+
+            const reader = progress_stream.body?.getReader();
+            if (reader) {
+                let received = 0;
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    if (value) {
+                        received += value.length;
+                        on_progress?.({
+                            kind: "downloading",
+                            received,
+                            total,
+                        });
+                    }
+                }
+            }
+
+            on_progress?.({ kind: "compiling" });
+            const wasm_module = await compile_promise;
             worker.postMessage({
                 type: "slintpad/init_wasm",
                 module: wasm_module,
             });
+            on_progress?.({ kind: "initializing" });
             return await slint_init({ module_or_path: wasm_module });
         })();
     }

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -23,6 +23,7 @@ export { Position as LspPosition } from "vscode-languageserver-types";
 import type { Position as LspPosition } from "vscode-languageserver-types";
 
 import slint_init, * as slint_preview from "@lsp/slint_lsp_wasm.js";
+import slint_lsp_wasm_url from "@lsp/slint_lsp_wasm_bg.wasm?url";
 
 import { report_panic_dialog } from "./dialogs";
 
@@ -133,7 +134,18 @@ export class LspWaiter {
             );
         });
 
-        this.#previewer_promise = slint_init({});
+        // Fetch and compile the LSP wasm once on the main thread and share the
+        // compiled module with the worker, so the browser does not have to
+        // download the same wasm twice.
+        this.#previewer_promise = (async () => {
+            const response = await fetch(slint_lsp_wasm_url);
+            const wasm_module = await WebAssembly.compileStreaming(response);
+            worker.postMessage({
+                type: "slintpad/init_wasm",
+                module: wasm_module,
+            });
+            return await slint_init({ module_or_path: wasm_module });
+        })();
     }
 
     async wait_for_lsp(): Promise<Lsp> {

--- a/tools/slintpad/src/tsconfig.json
+++ b/tools/slintpad/src/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../tsconfig.default.json",
     "compilerOptions": {
         "lib": ["dom", "es2021"],
-        "types": ["vscode"]
+        "types": ["vscode", "vite/client"]
     },
     "include": ["./*.ts", "../package.json", "./welcome/*.ts"],
     "references": [

--- a/tools/slintpad/src/worker/lsp_worker.ts
+++ b/tools/slintpad/src/worker/lsp_worker.ts
@@ -22,92 +22,114 @@ self.addEventListener("unhandledrejection", (e) =>
     post_panic(String(e.reason ?? "Unhandled rejection in LSP worker")),
 );
 
-slint_init({}).then(() => {
-    slint_lsp.set_panic_hook(post_panic);
-
-    const reader = new BrowserMessageReader(self);
-    const writer = new BrowserMessageWriter(self);
-
-    let the_lsp: slint_lsp.SlintServer;
-
-    const connection = createConnection(reader, writer);
-
-    function send_notification(method: string, params: unknown): boolean {
-        connection.sendNotification(method, params);
-        return true;
-    }
-
-    async function send_request(
-        method: string,
-        params: unknown,
-    ): Promise<unknown> {
-        return await connection.sendRequest(method, params);
-    }
-
-    async function load_file(path: string): Promise<string> {
-        return await connection.sendRequest("slint/load_file", path);
-    }
-
-    connection.onInitialize((params: InitializeParams): InitializeResult => {
-        the_lsp = slint_lsp.create(
-            params,
-            send_notification,
-            send_request,
-            load_file,
-        );
-
-        setTimeout(() => {
-            the_lsp.startup_lsp();
-        }, 0);
-
-        return the_lsp.server_initialize_result(params.capabilities);
-    });
-
-    connection.onRequest(async (method, params, token) => {
-        return await the_lsp.handle_request(token, method, params);
-    });
-
-    connection.onNotification(
-        "slint/preview_to_lsp",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (params: any) => {
-            await the_lsp.process_preview_to_lsp_message(params);
-        },
-    );
-
-    connection.onDidChangeWatchedFiles(async (param) => {
-        for (const event of param.changes) {
-            await the_lsp.trigger_file_watcher(event.uri, event.type);
+// Wait for the main thread to share the compiled wasm module instead of
+// fetching and compiling it a second time here.
+const wasm_module_promise = new Promise<WebAssembly.Module>((resolve) => {
+    function handler(m: MessageEvent) {
+        const data = m.data;
+        if (
+            data &&
+            typeof data === "object" &&
+            data.type === "slintpad/init_wasm"
+        ) {
+            self.removeEventListener("message", handler);
+            resolve(data.module as WebAssembly.Module);
         }
-    });
-
-    connection.onDidOpenTextDocument(async (param) => {
-        await the_lsp.open_document(
-            param.textDocument.text,
-            param.textDocument.uri,
-            param.textDocument.version,
-        );
-    });
-
-    connection.onDidChangeTextDocument(async (param) => {
-        await the_lsp.load_document(
-            param.contentChanges[param.contentChanges.length - 1].text,
-            param.textDocument.uri,
-            param.textDocument.version,
-        );
-    });
-
-    connection.onDidCloseTextDocument(async (param) => {
-        await the_lsp.close_document(param.textDocument.uri);
-    });
-
-    connection.onDidChangeConfiguration(async (_param) => {
-        await the_lsp.reload_config();
-    });
-
-    // Listen on the connection
-    connection.listen();
-
-    // Now that we listen, the client is ready to send the init message
-    self.postMessage("OK");
+    }
+    self.addEventListener("message", handler);
 });
+
+wasm_module_promise
+    .then((wasm_module) => slint_init({ module_or_path: wasm_module }))
+    .then(() => {
+        slint_lsp.set_panic_hook(post_panic);
+
+        const reader = new BrowserMessageReader(self);
+        const writer = new BrowserMessageWriter(self);
+
+        let the_lsp: slint_lsp.SlintServer;
+
+        const connection = createConnection(reader, writer);
+
+        function send_notification(method: string, params: unknown): boolean {
+            connection.sendNotification(method, params);
+            return true;
+        }
+
+        async function send_request(
+            method: string,
+            params: unknown,
+        ): Promise<unknown> {
+            return await connection.sendRequest(method, params);
+        }
+
+        async function load_file(path: string): Promise<string> {
+            return await connection.sendRequest("slint/load_file", path);
+        }
+
+        connection.onInitialize(
+            (params: InitializeParams): InitializeResult => {
+                the_lsp = slint_lsp.create(
+                    params,
+                    send_notification,
+                    send_request,
+                    load_file,
+                );
+
+                setTimeout(() => {
+                    the_lsp.startup_lsp();
+                }, 0);
+
+                return the_lsp.server_initialize_result(params.capabilities);
+            },
+        );
+
+        connection.onRequest(async (method, params, token) => {
+            return await the_lsp.handle_request(token, method, params);
+        });
+
+        connection.onNotification(
+            "slint/preview_to_lsp",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (params: any) => {
+                await the_lsp.process_preview_to_lsp_message(params);
+            },
+        );
+
+        connection.onDidChangeWatchedFiles(async (param) => {
+            for (const event of param.changes) {
+                await the_lsp.trigger_file_watcher(event.uri, event.type);
+            }
+        });
+
+        connection.onDidOpenTextDocument(async (param) => {
+            await the_lsp.open_document(
+                param.textDocument.text,
+                param.textDocument.uri,
+                param.textDocument.version,
+            );
+        });
+
+        connection.onDidChangeTextDocument(async (param) => {
+            await the_lsp.load_document(
+                param.contentChanges[param.contentChanges.length - 1].text,
+                param.textDocument.uri,
+                param.textDocument.version,
+            );
+        });
+
+        connection.onDidCloseTextDocument(async (param) => {
+            await the_lsp.close_document(param.textDocument.uri);
+        });
+
+        connection.onDidChangeConfiguration(async (_param) => {
+            await the_lsp.reload_config();
+        });
+
+        // Listen on the connection
+        connection.listen();
+
+        // Now that we listen, the client is ready to send the init message
+        self.postMessage("OK");
+    })
+    .catch((e) => post_panic(String(e)));

--- a/tools/slintpad/styles/index.css
+++ b/tools/slintpad/styles/index.css
@@ -44,21 +44,32 @@ body {
     justify-content: center;
     align-items: center;
     background: var(--color_blue);
+    color: var(--color_white);
+    font-family: system-ui, -apple-system, Helvetica, Arial, sans-serif;
 }
 
-.loader-image {
-    width: 100px;
-    animation: pulse 1s linear infinite;
+.loader-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: min(360px, 60vw);
 }
 
-@keyframes pulse {
-    0% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(0.8);
-    }
-    100% {
-        transform: scale(1);
-    }
+.loader-logo {
+    width: 96px;
+    height: 96px;
+    margin-bottom: 8px;
+}
+
+.loader-message {
+    font-size: 13px;
+    opacity: 0.85;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+
+.loader-progress {
+    width: 100%;
+    height: 6px;
 }


### PR DESCRIPTION
On a slower connection when the wasm code isn't cached, loading can take a while. This PR replaces the bouncing Slint logo with a progress bar.