### PR TITLE
Components should not declare any properties/callbacks in an interface that it implements

### DIFF
--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -255,7 +255,36 @@ fn apply_interface_property_declaration(
 ) {
     let lookup_result = e.lookup_property(unresolved_prop_name);
 
+    fn find_conflicting_node(
+        e: &mut Element,
+        unresolved_prop_name: &SmolStr,
+    ) -> Option<parser::SyntaxNode> {
+        e.property_declarations.get(unresolved_prop_name).and_then(|decl| decl.node.clone())
+    }
+
     if lookup_result.property_type != Type::Invalid {
+        if lookup_result.is_local_to_component {
+            let property_type_name = match prop_decl.property_type {
+                Type::Invalid => Err(()),
+                Type::Callback { .. } => Ok("callback"),
+                Type::Function { .. } => Ok("function"),
+                _ => Ok("property"),
+            }
+            .expect("Expected valid property type");
+
+            let local_property_node = find_conflicting_node(e, unresolved_prop_name)
+                .expect("Expected local property to have a syntax node");
+
+            diag.push_error(
+                format!(
+                    "Conflict with '{}' which declares a {} with the same name",
+                    interface_name, property_type_name
+                ),
+                &local_property_node,
+            );
+            return;
+        }
+
         match property_matches_interface(&lookup_result, prop_decl) {
             Ok(()) => {
                 // The property already exists and matches the interface declaration, so we don't need to do anything.
@@ -264,11 +293,7 @@ fn apply_interface_property_declaration(
             Err(error) => {
                 // Attempt to find a node for the existing property for better diagnostics. If the property is not local
                 // to the component, we fall back to pointing at the implements specifier below.
-                if let Some(local_property_node) = e
-                    .property_declarations
-                    .get(unresolved_prop_name)
-                    .and_then(|decl| decl.node.clone())
-                {
+                if let Some(local_property_node) = find_conflicting_node(e, unresolved_prop_name) {
                     diag.push_error(
                         format!("Conflict with '{}' which {}", interface_name, error),
                         &local_property_node,

--- a/internal/compiler/tests/syntax/interfaces/callbacks.slint
+++ b/internal/compiler/tests/syntax/interfaces/callbacks.slint
@@ -7,7 +7,7 @@ interface Inverter {
 
 export component InverterDuplicate implements Inverter {
     callback invert(bool) -> bool;
-//  >                            <error{Conflict with 'Inverter' which expected purity declaration: 'true'}
+//  >                            <error{Conflict with 'Inverter' which declares a callback with the same name}
 }
 
 export component InverterAliases implements Inverter {

--- a/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
+++ b/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
@@ -17,7 +17,7 @@ export component Impl {
     @children
 }
 
-export component DerivedImplementsInterfaceImplicitly implements ValidInterface inherits Impl { }
+export component ComponentImplementsInterface implements ValidInterface inherits Impl { }
 
 export component IncorrectImpl {
     in-out property <float> value;
@@ -34,28 +34,32 @@ export component DerivedImplementsInterfaceIncorrectly implements ValidInterface
 //                                                                >             <^error{Cannot implement interface 'ValidInterface' because 'speak' conflicts with an existing callback in 'IncorrectImpl'}
 //                                                                >             <^^error{Incorrect arguments for implementation of 'reset' from interface 'ValidInterface'. Expected () but got (float)}
 
-export component ComponentImplementsInterfaceImplicitly implements ValidInterface {
+export component ComponentDeclaresInterfaceAPI implements ValidInterface {
     in-out property <int> value: 24;
+//  >                              <error{Conflict with 'ValidInterface' which declares a property with the same name}
     callback speak();
+//  >               <error{Conflict with 'ValidInterface' which declares a callback with the same name}
     public function reset() {
         self.value = 0;
     }
 }
 
-export component ComponentImplementsInterfaceImplicitlyWithTwoWayBinding implements ValidInterface {
+export component ComponentDeclaresInterfaceAPIWithTwoWayBinding implements ValidInterface {
     in-out property <int> other: 32;
     in-out property <int> value <=> self.other;
+//  >                                         <error{Conflict with 'ValidInterface' which declares a property with the same name}
     callback speak();
+//  >               <error{Conflict with 'ValidInterface' which declares a callback with the same name}
     public function reset() {
         self.value = 0;
     }
 }
 
-export component ComponentImplementsInterfaceIncorrectly implements ValidInterface {
+export component ComponentDeclaresInterfaceAPIIncorrectly implements ValidInterface {
     in-out property <float> value;
-//  >                            <error{Conflict with 'ValidInterface' which expected type: 'int'}
+//  >                            <error{Conflict with 'ValidInterface' which declares a property with the same name}
     callback speak(string);
-//  >                     <error{Conflict with 'ValidInterface' which expected type: 'callback-> void'}
+//  >                     <error{Conflict with 'ValidInterface' which declares a callback with the same name}
     public function reset(to: float) {
 //  >error{Incorrect arguments for implementation of 'reset' from interface 'ValidInterface'. Expected () but got (float)}
         self.value = to;

--- a/internal/compiler/tests/syntax/interfaces/interface_properties.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_properties.slint
@@ -14,6 +14,11 @@ export interface ValidInterfacePropertyDeclarations {
     in_out property <angle> in-out-underscore-property;
 }
 
+export component ComponentWithDuplicateProperty implements ValidInterfacePropertyDeclarations {
+    out property <string> out-property;
+//  >                                 <error{Conflict with 'ValidInterfacePropertyDeclarations' which declares a property with the same name}
+}
+
 export interface Background {
     in-out property <color> background;
     callback clip();

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -10,7 +10,6 @@ export component LineEditBase implements LineEditInterface inherits Rectangle {
     text <=> text-input.text;
     enabled <=> text-input.enabled;
     has-focus: text-input.has-focus;
-    in property <InputType> input-type;
     // When true, the password input shows as plain text.
     // Cleared automatically on focus loss.
     in-out property <bool> password-revealed: false;

--- a/tests/cases/interfaces/component_overrides_defaults.slint
+++ b/tests/cases/interfaces/component_overrides_defaults.slint
@@ -19,12 +19,7 @@ export component TestCase implements InterfaceWithDefaults {
         text.character-count
     }
 
-    in-out property <string> text: "Hello";
-    out property <bool> enabled: true;
-    in property <int> precision: 2;
-    in property <float> confidence: 0.5;
-
-    callback checked();
+    confidence: 0.5;
 }
 
 /*


### PR DESCRIPTION
Previously we allowed a component to explicitly declare any properties/callbacks in an interface that it implemented. This is no longer supported and the compiler emits an error.

This decision was made because:

1) having duplicate property/callback declarations make reading a
   component definition confusing (e.g. why is this property declared
in the component and the interface?);

2) if the interface changes, the explicit property/callback
   declaration in the component will not be changed. If the name
remains the same we would now get a compiler error because there are duplicate property/declarations with the same name. The worse case would be if the name changes, the explicit implementation would be left behind, potentially leading to unexpected errors.

It is still possible for a component to override interface property defaults.
