### PR TITLE
Fix: Fixed width/height not applied to winit window

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1670,18 +1670,14 @@ fn adjust_window_size_to_satisfy_constraints(
     max_size: Option<winit::dpi::LogicalSize<f64>>,
 ) {
     let sf = adapter.window().scale_factor() as f64;
-    let Some(current_size) = adapter
+    let current_size = adapter
         .pending_requested_size
         .get()
-        .or_else(|| {
+        .unwrap_or_else(|| {
             let existing_adapter_size = adapter.size.get();
-            (existing_adapter_size.width != 0 && existing_adapter_size.height != 0)
-                .then(|| physical_size_to_winit(existing_adapter_size).into())
+            physical_size_to_winit(existing_adapter_size).into()
         })
-        .map(|s| s.to_logical::<f64>(sf))
-    else {
-        return;
-    };
+        .to_logical::<f64>(sf);
 
     let mut window_size = current_size;
     if let Some(min_size) = min_size {


### PR DESCRIPTION
When a fixed window height and width is set from the start then
the winit backend did not apply the size correctly.

Basically, we early returned from the function that sets the window size
if we did not yet have an existing known size (indicated by width/height
== 0).

Note that even with this fix, the window size might end up incorrect if
we're using client side decorations on wayland.
e.g. with this patch I get this:
<img width="500" height="505" alt="image" src="https://github.com/user-attachments/assets/a09555a3-f324-443e-b021-63e5bb8a893a" />
(Note how the rounded corners are only visible at the top of the window)

But that seems to be a winit bug, not a bug on our end (I'll open a bug report and PR on winit about it).

Closes #11448

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
