### PR TITLE
Add SkiaWGPURenderer::render_to_texture

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -162,7 +162,7 @@ renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "dep:i-slint-re
 renderer-femtovg-wgpu = ["i-slint-backend-selector/renderer-femtovg-wgpu", "i-slint-renderer-femtovg/wgpu", "std"]
 
 ## Render using [Skia](https://skia.org/).
-renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
+renderer-skia = ["i-slint-backend-selector/renderer-skia", "dep:i-slint-renderer-skia", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use OpenGL.
 ## Note: This is not supported on iOS. Use `renderer-skia` on iOS to enable Meta based rendering.
@@ -230,6 +230,7 @@ unstable-wgpu-28 = [
   "i-slint-core/unstable-wgpu-28",
   "i-slint-backend-selector/unstable-wgpu-28",
   "i-slint-backend-android-activity?/unstable-wgpu-28",
+  "i-slint-renderer-skia?/unstable-wgpu-28",
   "dep:wgpu-28",
 ]
 
@@ -279,6 +280,7 @@ i-slint-backend-selector = { workspace = true }
 i-slint-core-macros = { workspace = true }
 i-slint-common = { workspace = true }
 i-slint-renderer-software = { workspace = true, optional = true }
+i-slint-renderer-skia = { workspace = true, optional = true }
 slint-interpreter = { workspace = true, optional = true, default-features = false, features = ["display-diagnostics", "compat-1-2", "internal-live-preview"] }
 
 const-field-offset = { version = "0.2.0", path = "../../../helper_crates/const-field-offset" }

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -422,6 +422,16 @@ pub mod platform {
         pub use i_slint_renderer_femtovg::opengl::OpenGLInterface;
     }
 
+    /// This module contains the [`skia_renderer::SkiaWGPURenderer`] type.
+    ///
+    /// It is only enabled when both the `renderer-skia` and `unstable-wgpu-28` Slint features
+    /// are enabled.
+    #[cfg(all(feature = "renderer-skia", feature = "unstable-wgpu-28"))]
+    pub mod skia_renderer {
+        /// Use this type to render to a WGPU texture using Skia.
+        pub use i_slint_renderer_skia::SkiaWGPURenderer;
+    }
+
     #[cfg(feature = "renderer-software")]
     /// This module contains the [`software_renderer::SoftwareRenderer`] and related types.
     ///

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -3870,10 +3870,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "ctor-lite"
-version = "0.1.2"
+name = "ctor"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
+checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
+dependencies = [
+ "dtor",
+]
 
 [[package]]
 name = "ctrlc"
@@ -4054,6 +4057,12 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.4",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
 
 [[package]]
 name = "either"
@@ -4881,9 +4890,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "guillotiere"
@@ -6987,9 +6996,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -7019,9 +7028,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -7031,9 +7040,9 @@ dependencies = [
 
 [[package]]
 name = "orbclient"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
 dependencies = [
  "libc",
  "libredox",
@@ -8233,6 +8242,7 @@ dependencies = [
  "i-slint-core",
  "i-slint-core-macros",
  "i-slint-renderer-femtovg",
+ "i-slint-renderer-skia",
  "i-slint-renderer-software",
  "num-traits",
  "once_cell",
@@ -8766,12 +8776,12 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor",
  "libloading",
  "pkg-config",
  "tracing",
@@ -9353,11 +9363,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -9366,7 +9376,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -10674,6 +10684,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/examples/bevy/bevy-hosts-slint-gpu/Cargo.toml
+++ b/examples/bevy/bevy-hosts-slint-gpu/Cargo.toml
@@ -15,7 +15,7 @@ name = "bevy_hosts_slint_gpu"
 path = "main.rs"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["renderer-femtovg-wgpu", "unstable-wgpu-28", "std", "compat-1-2"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["renderer-skia", "unstable-wgpu-28", "std", "compat-1-2"] }
 # Bevy 0.19.0-dev (pre-release) pinned to specific commit for wgpu 28 support.
 # Update to bevy 0.19 stable once released.
 bevy = { git = "https://github.com/bevyengine/bevy", rev = "cc172dfc" }

--- a/examples/bevy/bevy-hosts-slint-gpu/main.rs
+++ b/examples/bevy/bevy-hosts-slint-gpu/main.rs
@@ -46,6 +46,7 @@
 //!
 //! Use arrow keys to rotate the cube. Click the button and interact with the slider on the UI.
 
+use bevy::render::renderer::RenderAdapter;
 use bevy::{
     input::{ButtonState, mouse::MouseButtonInput},
     prelude::*,
@@ -62,7 +63,6 @@ use bevy::{
     },
 };
 use slint::platform::skia_renderer::SkiaWGPURenderer;
-use bevy::render::renderer::RenderAdapter;
 use slint::{LogicalPosition, PhysicalSize, platform::WindowEvent};
 use std::{
     cell::{Cell, RefCell},

--- a/examples/bevy/bevy-hosts-slint-gpu/main.rs
+++ b/examples/bevy/bevy-hosts-slint-gpu/main.rs
@@ -4,27 +4,27 @@
 //! # Slint + Bevy GPU Integration Example
 //!
 //! This example demonstrates how to embed Slint UI within a Bevy application using
-//! **GPU-accelerated rendering** via FemtoVG and WGPU. The Slint UI is rendered directly
+//! **GPU-accelerated rendering** via Skia and WGPU. The Slint UI is rendered directly
 //! to a GPU texture that can be displayed on 3D geometry in the scene.
 //!
 //! ## Architecture Overview
 //!
-//! The integration uses Slint's `FemtoVGWGPURenderer` to render UI directly to a WGPU texture:
+//! The integration uses Slint's `SkiaWGPURenderer` to render UI directly to a WGPU texture:
 //!
 //! 1. Bevy creates a texture in its asset system
 //! 2. The texture handle is extracted to Bevy's render world via `ExtractResourcePlugin`
 //! 3. A channel passes the underlying WGPU texture from render world back to main world
-//! 4. `FemtoVGWGPURenderer::render_to_texture()` renders the UI directly to the GPU texture
+//! 4. `SkiaWGPURenderer::render_to_texture()` renders the UI directly to the GPU texture
 //! 5. Mouse input is handled by raycasting against the 3D quad and converting to Slint coordinates
 //!
 //! ## Key Difference from bevy-hosts-slint
 //!
 //! - **bevy-hosts-slint**: Uses `SoftwareRenderer` to CPU-render UI to a pixel buffer, then uploads to GPU
-//! - **bevy-hosts-slint-gpu**: Uses `FemtoVGWGPURenderer` for direct GPU rendering (better performance)
+//! - **bevy-hosts-slint-gpu**: Uses `SkiaWGPURenderer` for direct GPU rendering (better performance)
 //!
 //! ## Key Components
 //!
-//! - [`BevyWindowAdapter`]: Implements `slint::platform::WindowAdapter` using `FemtoVGWGPURenderer`
+//! - [`BevyWindowAdapter`]: Implements `slint::platform::WindowAdapter` using `SkiaWGPURenderer`
 //! - [`SlintBevyPlatform`]: Implements `slint::platform::Platform` to create window adapters
 //! - [`SlintSharedTexture`]: Manages texture sharing between Bevy's main and render worlds
 //! - [`render_slint`]: Bevy system that renders the Slint UI to the shared texture each frame
@@ -33,7 +33,7 @@
 //! ## Usage Pattern
 //!
 //! This example can serve as a template for GPU-accelerated Slint integration:
-//! 1. Implement the `Platform` and `WindowAdapter` traits with `FemtoVGWGPURenderer`
+//! 1. Implement the `Platform` and `WindowAdapter` traits with `SkiaWGPURenderer`
 //! 2. Share the WGPU texture between Bevy's render world and your Slint renderer
 //! 3. Call `render_to_texture()` each frame to render the UI directly on the GPU
 //! 4. Handle input by converting your coordinate system to Slint's logical coordinates
@@ -61,7 +61,8 @@ use bevy::{
         texture::GpuImage,
     },
 };
-use slint::platform::femtovg_renderer::FemtoVGWGPURenderer;
+use slint::platform::skia_renderer::SkiaWGPURenderer;
+use bevy::render::renderer::RenderAdapter;
 use slint::{LogicalPosition, PhysicalSize, platform::WindowEvent};
 use std::{
     cell::{Cell, RefCell},
@@ -119,13 +120,13 @@ slint::slint! {
 
 /// Window adapter that bridges Slint to Bevy using GPU rendering.
 ///
-/// Instead of rendering to a native OS window, this adapter uses `FemtoVGWGPURenderer`
+/// Instead of rendering to a native OS window, this adapter uses `SkiaWGPURenderer`
 /// to render directly to a WGPU texture that Bevy displays on 3D geometry.
 struct BevyWindowAdapter {
     size: Cell<slint::PhysicalSize>,
     scale_factor: Cell<f32>,
     slint_window: slint::Window,
-    renderer: FemtoVGWGPURenderer,
+    renderer: SkiaWGPURenderer,
 }
 
 impl slint::platform::WindowAdapter for BevyWindowAdapter {
@@ -149,10 +150,14 @@ impl slint::platform::WindowAdapter for BevyWindowAdapter {
 }
 
 impl BevyWindowAdapter {
-    fn new(instance: wgpu::Instance, device: wgpu::Device, queue: wgpu::Queue) -> Rc<Self> {
-        // Create renderer using the new helper
-        let renderer =
-            FemtoVGWGPURenderer::new(instance, device, queue).expect("Failed to create renderer");
+    fn new(
+        instance: wgpu::Instance,
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+    ) -> Rc<Self> {
+        let renderer = SkiaWGPURenderer::new(None, instance, adapter, device, queue)
+            .expect("Failed to create renderer");
 
         Rc::new_cyclic(|self_weak: &Weak<Self>| Self {
             size: Cell::new(slint::PhysicalSize::new(UI_WIDTH, UI_HEIGHT)),
@@ -176,9 +181,10 @@ impl BevyWindowAdapter {
 /// Slint platform implementation that creates GPU-rendered window adapters.
 ///
 /// Registered via `slint::platform::set_platform()` before creating Slint components.
-/// Stores the WGPU device and queue needed to create `FemtoVGWGPURenderer` instances.
+/// Stores the WGPU device and queue needed to create `SkiaWGPURenderer` instances.
 struct SlintBevyPlatform {
     instance: wgpu::Instance,
+    adapter: wgpu::Adapter,
     device: wgpu::Device,
     queue: wgpu::Queue,
 }
@@ -187,8 +193,12 @@ impl slint::platform::Platform for SlintBevyPlatform {
     fn create_window_adapter(
         &self,
     ) -> Result<Rc<dyn slint::platform::WindowAdapter>, slint::PlatformError> {
-        let adapter =
-            BevyWindowAdapter::new(self.instance.clone(), self.device.clone(), self.queue.clone());
+        let adapter = BevyWindowAdapter::new(
+            self.instance.clone(),
+            self.adapter.clone(),
+            self.device.clone(),
+            self.queue.clone(),
+        );
         SLINT_WINDOWS.with(|windows| {
             windows.borrow_mut().push(Rc::downgrade(&adapter));
         });
@@ -453,15 +463,18 @@ fn render_slint(slint_context: Option<NonSend<SlintContext>>, shared: Res<SlintS
 /// This runs as a startup system after `setup` to ensure Bevy's render device is available.
 fn initialize_slint(
     render_instance: &RenderInstance,
+    render_adapter: &RenderAdapter,
     render_device: &RenderDevice,
     render_queue: &bevy::render::renderer::RenderQueue,
 ) -> impl Fn(&mut World) + use<> {
     let instance = (**render_instance.0).clone();
+    let wgpu_adapter = (**render_adapter.0).clone();
     let device = render_device.wgpu_device().clone();
     let queue = (**render_queue.0).clone();
     move |world: &mut World| {
         let platform = SlintBevyPlatform {
             instance: instance.clone(),
+            adapter: wgpu_adapter.clone(),
             device: device.clone(),
             queue: queue.clone(),
         };
@@ -534,7 +547,7 @@ fn main() {
         &bevy::render::settings::WgpuSettings::default(),
     ));
 
-    let slint_init = initialize_slint(&instance, &render_device, &render_queue);
+    let slint_init = initialize_slint(&instance, &adapter, &render_device, &render_queue);
 
     let mut app = App::new();
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -61,6 +61,10 @@ pub mod opengl_surface;
 pub mod wgpu_27_surface;
 #[cfg(feature = "wgpu-28")]
 pub mod wgpu_28_surface;
+#[cfg(feature = "wgpu-28")]
+mod wgpu_renderer;
+#[cfg(feature = "wgpu-28")]
+pub use wgpu_renderer::SkiaWGPURenderer;
 
 use i_slint_core::items::{ItemRc, TextWrap};
 use itemrenderer::to_skia_rect;
@@ -606,7 +610,7 @@ impl SkiaRenderer {
         )
     }
 
-    fn render_to_canvas(
+    pub(crate) fn render_to_canvas(
         &self,
         skia_canvas: &skia_safe::Canvas,
         rotation_angle_degrees: f32,

--- a/internal/renderers/skia/wgpu_28_surface.rs
+++ b/internal/renderers/skia/wgpu_28_surface.rs
@@ -324,23 +324,21 @@ impl Backend {
 
     pub(crate) fn make_surface_from_texture(
         &self,
-        width: i32,
-        height: i32,
         gr_context: &mut skia_safe::gpu::DirectContext,
         texture: &wgpu::Texture,
     ) -> Option<skia_safe::Surface> {
         match self {
             #[cfg(target_vendor = "apple")]
             Self::Metal => unsafe {
-                metal::make_metal_surface_from_texture(width, height, gr_context, texture)
+                metal::make_metal_surface_from_texture(gr_context, texture)
             },
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe {
-                dx12::make_dx12_surface_from_texture(width, height, gr_context, texture)
+                dx12::make_dx12_surface_from_texture(gr_context, texture)
             },
             #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
             Self::Vulkan => unsafe {
-                vulkan::make_vulkan_surface_from_texture(width, height, gr_context, texture)
+                vulkan::make_vulkan_surface_from_texture(gr_context, texture)
             },
         }
     }

--- a/internal/renderers/skia/wgpu_28_surface.rs
+++ b/internal/renderers/skia/wgpu_28_surface.rs
@@ -329,13 +329,9 @@ impl Backend {
     ) -> Option<skia_safe::Surface> {
         match self {
             #[cfg(target_vendor = "apple")]
-            Self::Metal => unsafe {
-                metal::make_metal_surface_from_texture(gr_context, texture)
-            },
+            Self::Metal => unsafe { metal::make_metal_surface_from_texture(gr_context, texture) },
             #[cfg(target_family = "windows")]
-            Self::Dx12 => unsafe {
-                dx12::make_dx12_surface_from_texture(gr_context, texture)
-            },
+            Self::Dx12 => unsafe { dx12::make_dx12_surface_from_texture(gr_context, texture) },
             #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
             Self::Vulkan => unsafe {
                 vulkan::make_vulkan_surface_from_texture(gr_context, texture)

--- a/internal/renderers/skia/wgpu_28_surface.rs
+++ b/internal/renderers/skia/wgpu_28_surface.rs
@@ -258,7 +258,7 @@ impl raw_window_handle::HasDisplayHandle for WindowAndDisplayHandle {
     }
 }
 
-enum Backend {
+pub(crate) enum Backend {
     #[cfg(target_vendor = "apple")]
     Metal,
     #[cfg(target_family = "windows")]
@@ -290,7 +290,7 @@ impl TryFrom<wgpu::Backend> for Backend {
 }
 
 impl Backend {
-    fn make_context(
+    pub(crate) fn make_context(
         &self,
         _adapter: &wgpu::Adapter,
         device: &wgpu::Device,
@@ -322,7 +322,30 @@ impl Backend {
         }
     }
 
-    fn import_texture(
+    pub(crate) fn make_surface_from_texture(
+        &self,
+        width: i32,
+        height: i32,
+        gr_context: &mut skia_safe::gpu::DirectContext,
+        texture: &wgpu::Texture,
+    ) -> Option<skia_safe::Surface> {
+        match self {
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => unsafe {
+                metal::make_metal_surface_from_texture(width, height, gr_context, texture)
+            },
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => unsafe {
+                dx12::make_dx12_surface_from_texture(width, height, gr_context, texture)
+            },
+            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            Self::Vulkan => unsafe {
+                vulkan::make_vulkan_surface_from_texture(width, height, gr_context, texture)
+            },
+        }
+    }
+
+    pub(crate) fn import_texture(
         &self,
         canvas: &skia_safe::Canvas,
         texture: wgpu::Texture,

--- a/internal/renderers/skia/wgpu_28_surface/dx12.rs
+++ b/internal/renderers/skia/wgpu_28_surface/dx12.rs
@@ -11,40 +11,87 @@ use windows::Win32::Graphics::Dxgi::Common::{
 
 use wgpu_28 as wgpu;
 
+/// # Safety
+/// `resource` must be a valid D3D12 resource for the lifetime of the returned Surface.
+unsafe fn wrap_dx12_texture(
+    width: i32,
+    height: i32,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    resource: ID3D12Resource,
+    dxgi_format: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT,
+    color_type: skia_safe::ColorType,
+) -> Option<skia_safe::Surface> {
+    let texture_info = skia_safe::gpu::d3d::TextureResourceInfo {
+        resource,
+        alloc: None,
+        resource_state: D3D12_RESOURCE_STATE_PRESENT,
+        format: dxgi_format,
+        sample_count: 1,
+        level_count: 1,
+        sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+        protected: skia_safe::gpu::Protected::No,
+    };
+    let backend_render_target =
+        skia_safe::gpu::BackendRenderTarget::new_d3d((width, height), &texture_info);
+    skia_safe::gpu::surfaces::wrap_backend_render_target(
+        gr_context,
+        &backend_render_target,
+        skia_safe::gpu::SurfaceOrigin::TopLeft,
+        color_type,
+        None,
+        None,
+    )
+}
+
 pub unsafe fn make_dx12_surface(
     size: PhysicalWindowSize,
     gr_context: &mut skia_safe::gpu::DirectContext,
     frame: &wgpu::SurfaceTexture,
 ) -> Option<skia_safe::Surface> {
+    // SAFETY: frame.texture is alive for the duration of this call; the D3D12 resource is
+    // ref-counted (COM) and cloned into Skia's internal BackendRenderTarget.
     unsafe {
         let dx12_texture = frame.texture.as_hal::<wgpu::wgc::api::Dx12>();
-
-        let texture_info = skia_safe::gpu::d3d::TextureResourceInfo {
-            resource: windows_core::Interface::from_raw(windows_core::Interface::into_raw(
-                dx12_texture.unwrap().raw_resource().clone(),
-            )),
-            alloc: None,
-            resource_state: D3D12_RESOURCE_STATE_PRESENT,
-            format: DXGI_FORMAT_R8G8B8A8_UNORM,
-            sample_count: 1,
-            level_count: 1,
-            sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
-            protected: skia_safe::gpu::Protected::No,
-        };
-
-        let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_d3d(
-            (size.width as i32, size.height as i32),
-            &texture_info,
-        );
-
-        skia_safe::gpu::surfaces::wrap_backend_render_target(
+        let resource = windows_core::Interface::from_raw(windows_core::Interface::into_raw(
+            dx12_texture.unwrap().raw_resource().clone(),
+        ));
+        wrap_dx12_texture(
+            size.width as i32,
+            size.height as i32,
             gr_context,
-            &backend_render_target,
-            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            resource,
+            DXGI_FORMAT_R8G8B8A8_UNORM,
             skia_safe::ColorType::RGBA8888,
-            None,
-            None,
         )
+    }
+}
+
+/// # Safety
+/// The caller must ensure `texture` was created by a DX12-backed wgpu device and remains
+/// valid for the lifetime of the returned `skia_safe::Surface`.
+pub unsafe fn make_dx12_surface_from_texture(
+    width: i32,
+    height: i32,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    texture: &wgpu::Texture,
+) -> Option<skia_safe::Surface> {
+    // SAFETY: texture is borrowed for the duration of this call; the D3D12 resource is
+    // ref-counted (COM) and cloned into Skia's internal BackendRenderTarget via wrap_dx12_texture.
+    unsafe {
+        let dx12_texture = texture.as_hal::<wgpu::wgc::api::Dx12>()?;
+        let resource = windows_core::Interface::from_raw(windows_core::Interface::into_raw(
+            dx12_texture.raw_resource().clone(),
+        ));
+        let (dxgi_format, color_type) = match texture.format() {
+            wgpu::TextureFormat::Rgba8Unorm => {
+                (DXGI_FORMAT_R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888)
+            }
+            wgpu::TextureFormat::Rgba8UnormSrgb => {
+                (DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, skia_safe::ColorType::SRGBA8888)
+            }
+            _ => return None,
+        };
+        wrap_dx12_texture(width, height, gr_context, resource, dxgi_format, color_type)
     }
 }
 

--- a/internal/renderers/skia/wgpu_28_surface/dx12.rs
+++ b/internal/renderers/skia/wgpu_28_surface/dx12.rs
@@ -72,8 +72,6 @@ pub unsafe fn make_dx12_surface(
 /// The caller must ensure `texture` was created by a DX12-backed wgpu device and remains
 /// valid for the lifetime of the returned `skia_safe::Surface`.
 pub unsafe fn make_dx12_surface_from_texture(
-    width: i32,
-    height: i32,
     gr_context: &mut skia_safe::gpu::DirectContext,
     texture: &wgpu::Texture,
 ) -> Option<skia_safe::Surface> {
@@ -84,6 +82,7 @@ pub unsafe fn make_dx12_surface_from_texture(
         let resource = windows_core::Interface::from_raw(windows_core::Interface::into_raw(
             dx12_texture.raw_resource().clone(),
         ));
+        let size = texture.size();
         let (dxgi_format, color_type) = match texture.format() {
             wgpu::TextureFormat::Rgba8Unorm => {
                 (DXGI_FORMAT_R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888)
@@ -93,7 +92,14 @@ pub unsafe fn make_dx12_surface_from_texture(
             }
             _ => return None,
         };
-        wrap_dx12_texture(width, height, gr_context, resource, dxgi_format, color_type)
+        wrap_dx12_texture(
+            size.width as i32,
+            size.height as i32,
+            gr_context,
+            resource,
+            dxgi_format,
+            color_type,
+        )
     }
 }
 

--- a/internal/renderers/skia/wgpu_28_surface/dx12.rs
+++ b/internal/renderers/skia/wgpu_28_surface/dx12.rs
@@ -21,26 +21,28 @@ unsafe fn wrap_dx12_texture(
     dxgi_format: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT,
     color_type: skia_safe::ColorType,
 ) -> Option<skia_safe::Surface> {
-    let texture_info = skia_safe::gpu::d3d::TextureResourceInfo {
-        resource,
-        alloc: None,
-        resource_state: D3D12_RESOURCE_STATE_PRESENT,
-        format: dxgi_format,
-        sample_count: 1,
-        level_count: 1,
-        sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
-        protected: skia_safe::gpu::Protected::No,
-    };
-    let backend_render_target =
-        skia_safe::gpu::BackendRenderTarget::new_d3d((width, height), &texture_info);
-    skia_safe::gpu::surfaces::wrap_backend_render_target(
-        gr_context,
-        &backend_render_target,
-        skia_safe::gpu::SurfaceOrigin::TopLeft,
-        color_type,
-        None,
-        None,
-    )
+    unsafe {
+        let texture_info = skia_safe::gpu::d3d::TextureResourceInfo {
+            resource,
+            alloc: None,
+            resource_state: D3D12_RESOURCE_STATE_PRESENT,
+            format: dxgi_format,
+            sample_count: 1,
+            level_count: 1,
+            sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+            protected: skia_safe::gpu::Protected::No,
+        };
+        let backend_render_target =
+            skia_safe::gpu::BackendRenderTarget::new_d3d((width, height), &texture_info);
+        skia_safe::gpu::surfaces::wrap_backend_render_target(
+            gr_context,
+            &backend_render_target,
+            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            color_type,
+            None,
+            None,
+        )
+    }
 }
 
 pub unsafe fn make_dx12_surface(

--- a/internal/renderers/skia/wgpu_28_surface/metal.rs
+++ b/internal/renderers/skia/wgpu_28_surface/metal.rs
@@ -8,30 +8,71 @@ use skia_safe::gpu::mtl;
 
 use wgpu_28 as wgpu;
 
+/// # Safety
+/// `metal_handle` must be a valid Metal texture handle for the lifetime of the returned Surface.
+unsafe fn wrap_metal_texture(
+    width: i32,
+    height: i32,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    metal_handle: mtl::Handle,
+    color_type: skia_safe::ColorType,
+) -> Option<skia_safe::Surface> {
+    unsafe {
+        let texture_info = mtl::TextureInfo::new(metal_handle);
+        let backend_render_target =
+            skia_safe::gpu::backend_render_targets::make_mtl((width, height), &texture_info);
+        skia_safe::gpu::surfaces::wrap_backend_render_target(
+            gr_context,
+            &backend_render_target,
+            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            color_type,
+            None,
+            None,
+        )
+    }
+}
+
 pub unsafe fn make_metal_surface(
     size: PhysicalWindowSize,
     gr_context: &mut skia_safe::gpu::DirectContext,
     frame: &wgpu::SurfaceTexture,
 ) -> Option<skia_safe::Surface> {
+    // SAFETY: frame.texture is alive for the duration of this call; the Metal handle is copied
+    // into Skia's internal BackendRenderTarget.
     unsafe {
         let metal_texture = frame.texture.as_hal::<wgpu::wgc::api::Metal>();
-
-        let texture_info =
-            mtl::TextureInfo::new(metal_texture.unwrap().raw_handle().as_ptr() as mtl::Handle);
-
-        let backend_render_target = skia_safe::gpu::backend_render_targets::make_mtl(
-            (size.width as i32, size.height as i32),
-            &texture_info,
-        );
-
-        skia_safe::gpu::surfaces::wrap_backend_render_target(
+        let handle = metal_texture.unwrap().raw_handle().as_ptr() as mtl::Handle;
+        wrap_metal_texture(
+            size.width as i32,
+            size.height as i32,
             gr_context,
-            &backend_render_target,
-            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            handle,
             skia_safe::ColorType::BGRA8888,
-            None,
-            None,
         )
+    }
+}
+
+/// # Safety
+/// The caller must ensure `texture` was created by a Metal-backed wgpu device and remains
+/// valid for the lifetime of the returned `skia_safe::Surface`.
+pub unsafe fn make_metal_surface_from_texture(
+    width: i32,
+    height: i32,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    texture: &wgpu::Texture,
+) -> Option<skia_safe::Surface> {
+    // SAFETY: texture is borrowed for the duration of this call; the Metal handle is copied
+    // into Skia's internal BackendRenderTarget via wrap_metal_texture.
+    unsafe {
+        let metal_texture = texture.as_hal::<wgpu::wgc::api::Metal>()?;
+        let handle = metal_texture.raw_handle().as_ptr() as mtl::Handle;
+        let color_type = match texture.format() {
+            wgpu::TextureFormat::Bgra8Unorm => skia_safe::ColorType::BGRA8888,
+            wgpu::TextureFormat::Rgba8Unorm => skia_safe::ColorType::RGBA8888,
+            wgpu::TextureFormat::Rgba8UnormSrgb => skia_safe::ColorType::SRGBA8888,
+            _ => return None,
+        };
+        wrap_metal_texture(width, height, gr_context, handle, color_type)
     }
 }
 

--- a/internal/renderers/skia/wgpu_28_surface/metal.rs
+++ b/internal/renderers/skia/wgpu_28_surface/metal.rs
@@ -56,8 +56,6 @@ pub unsafe fn make_metal_surface(
 /// The caller must ensure `texture` was created by a Metal-backed wgpu device and remains
 /// valid for the lifetime of the returned `skia_safe::Surface`.
 pub unsafe fn make_metal_surface_from_texture(
-    width: i32,
-    height: i32,
     gr_context: &mut skia_safe::gpu::DirectContext,
     texture: &wgpu::Texture,
 ) -> Option<skia_safe::Surface> {
@@ -66,13 +64,14 @@ pub unsafe fn make_metal_surface_from_texture(
     unsafe {
         let metal_texture = texture.as_hal::<wgpu::wgc::api::Metal>()?;
         let handle = metal_texture.raw_handle().as_ptr() as mtl::Handle;
+        let size = texture.size();
         let color_type = match texture.format() {
             wgpu::TextureFormat::Bgra8Unorm => skia_safe::ColorType::BGRA8888,
             wgpu::TextureFormat::Rgba8Unorm => skia_safe::ColorType::RGBA8888,
             wgpu::TextureFormat::Rgba8UnormSrgb => skia_safe::ColorType::SRGBA8888,
             _ => return None,
         };
-        wrap_metal_texture(width, height, gr_context, handle, color_type)
+        wrap_metal_texture(size.width as i32, size.height as i32, gr_context, handle, color_type)
     }
 }
 

--- a/internal/renderers/skia/wgpu_28_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_28_surface/vulkan.rs
@@ -87,8 +87,6 @@ pub unsafe fn make_vulkan_surface(
 /// The caller must ensure `texture` was created by a Vulkan-backed wgpu device and remains
 /// valid for the lifetime of the returned `skia_safe::Surface`.
 pub unsafe fn make_vulkan_surface_from_texture(
-    width: i32,
-    height: i32,
     gr_context: &mut skia_safe::gpu::DirectContext,
     texture: &wgpu::Texture,
 ) -> Option<skia_safe::Surface> {
@@ -97,8 +95,16 @@ pub unsafe fn make_vulkan_surface_from_texture(
     unsafe {
         let vulkan_texture = texture.as_hal::<wgpu::wgc::api::Vulkan>()?;
         let vk_image_raw = vulkan_texture.raw_handle().as_raw();
+        let size = texture.size();
         let (vk_format, color_type) = vk_format_and_color_type(texture.format())?;
-        wrap_vulkan_texture(width, height, gr_context, vk_image_raw, vk_format, color_type)
+        wrap_vulkan_texture(
+            size.width as i32,
+            size.height as i32,
+            gr_context,
+            vk_image_raw,
+            vk_format,
+            color_type,
+        )
     }
 }
 

--- a/internal/renderers/skia/wgpu_28_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_28_surface/vulkan.rs
@@ -8,55 +8,95 @@ use skia_safe::gpu::vk;
 
 use wgpu_28 as wgpu;
 
+fn vk_format_and_color_type(
+    format: wgpu::TextureFormat,
+) -> Option<(skia_safe::gpu::vk::Format, skia_safe::ColorType)> {
+    match format {
+        wgpu::TextureFormat::Rgba8Unorm => {
+            Some((skia_safe::gpu::vk::Format::R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888))
+        }
+        wgpu::TextureFormat::Rgba8UnormSrgb => {
+            Some((skia_safe::gpu::vk::Format::R8G8B8A8_SRGB, skia_safe::ColorType::SRGBA8888))
+        }
+        wgpu::TextureFormat::Bgra8Unorm => {
+            Some((skia_safe::gpu::vk::Format::B8G8R8A8_UNORM, skia_safe::ColorType::BGRA8888))
+        }
+        _ => None,
+    }
+}
+
+/// # Safety
+/// `vk_image_raw` must be a valid Vulkan image handle for the lifetime of the returned Surface.
+unsafe fn wrap_vulkan_texture(
+    width: i32,
+    height: i32,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    vk_image_raw: u64,
+    vk_format: skia_safe::gpu::vk::Format,
+    color_type: skia_safe::ColorType,
+) -> Option<skia_safe::Surface> {
+    let texture_info = &skia_safe::gpu::vk::ImageInfo::new(
+        vk_image_raw as _,
+        skia_safe::gpu::vk::Alloc::default(),
+        skia_safe::gpu::vk::ImageTiling::OPTIMAL,
+        skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        vk_format,
+        1,
+        None,
+        None,
+        None,
+        None,
+    );
+    let backend_render_target =
+        skia_safe::gpu::backend_render_targets::make_vk((width, height), texture_info);
+    skia_safe::gpu::surfaces::wrap_backend_render_target(
+        gr_context,
+        &backend_render_target,
+        skia_safe::gpu::SurfaceOrigin::TopLeft,
+        color_type,
+        None,
+        None,
+    )
+}
+
 pub unsafe fn make_vulkan_surface(
     size: PhysicalWindowSize,
     gr_context: &mut skia_safe::gpu::DirectContext,
     frame: &wgpu::SurfaceTexture,
 ) -> Option<skia_safe::Surface> {
+    // SAFETY: frame.texture is alive for the duration of this call; the Vulkan handle is copied
+    // into Skia's internal BackendRenderTarget.
     unsafe {
         let vulkan_texture = frame.texture.as_hal::<wgpu::wgc::api::Vulkan>();
-
-        let alloc = skia_safe::gpu::vk::Alloc::default();
-
-        let (vk_format, color_type) = match frame.texture.format() {
-            wgpu::TextureFormat::Rgba8Unorm => {
-                (skia_safe::gpu::vk::Format::R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888)
-            }
-            wgpu::TextureFormat::Rgba8UnormSrgb => {
-                (skia_safe::gpu::vk::Format::R8G8B8A8_SRGB, skia_safe::ColorType::SRGBA8888)
-            }
-            wgpu::TextureFormat::Bgra8Unorm => {
-                (skia_safe::gpu::vk::Format::B8G8R8A8_UNORM, skia_safe::ColorType::BGRA8888)
-            }
-            _ => return None,
-        };
-
-        let texture_info = &skia_safe::gpu::vk::ImageInfo::new(
-            vulkan_texture.unwrap().raw_handle().as_raw() as _,
-            alloc,
-            skia_safe::gpu::vk::ImageTiling::OPTIMAL,
-            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
-            vk_format,
-            1,
-            None,
-            None,
-            None,
-            None,
-        );
-
-        let backend_render_target = skia_safe::gpu::backend_render_targets::make_vk(
-            (size.width as i32, size.height as i32),
-            texture_info,
-        );
-
-        skia_safe::gpu::surfaces::wrap_backend_render_target(
+        let vk_image_raw = vulkan_texture.unwrap().raw_handle().as_raw();
+        let (vk_format, color_type) = vk_format_and_color_type(frame.texture.format())?;
+        wrap_vulkan_texture(
+            size.width as i32,
+            size.height as i32,
             gr_context,
-            &backend_render_target,
-            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            vk_image_raw,
+            vk_format,
             color_type,
-            None,
-            None,
         )
+    }
+}
+
+/// # Safety
+/// The caller must ensure `texture` was created by a Vulkan-backed wgpu device and remains
+/// valid for the lifetime of the returned `skia_safe::Surface`.
+pub unsafe fn make_vulkan_surface_from_texture(
+    width: i32,
+    height: i32,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    texture: &wgpu::Texture,
+) -> Option<skia_safe::Surface> {
+    // SAFETY: texture is borrowed for the duration of this call; the Vulkan handle is copied
+    // into Skia's internal BackendRenderTarget via wrap_vulkan_texture.
+    unsafe {
+        let vulkan_texture = texture.as_hal::<wgpu::wgc::api::Vulkan>()?;
+        let vk_image_raw = vulkan_texture.raw_handle().as_raw();
+        let (vk_format, color_type) = vk_format_and_color_type(texture.format())?;
+        wrap_vulkan_texture(width, height, gr_context, vk_image_raw, vk_format, color_type)
     }
 }
 

--- a/internal/renderers/skia/wgpu_28_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_28_surface/vulkan.rs
@@ -35,28 +35,30 @@ unsafe fn wrap_vulkan_texture(
     vk_format: skia_safe::gpu::vk::Format,
     color_type: skia_safe::ColorType,
 ) -> Option<skia_safe::Surface> {
-    let texture_info = &skia_safe::gpu::vk::ImageInfo::new(
-        vk_image_raw as _,
-        skia_safe::gpu::vk::Alloc::default(),
-        skia_safe::gpu::vk::ImageTiling::OPTIMAL,
-        skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
-        vk_format,
-        1,
-        None,
-        None,
-        None,
-        None,
-    );
-    let backend_render_target =
-        skia_safe::gpu::backend_render_targets::make_vk((width, height), texture_info);
-    skia_safe::gpu::surfaces::wrap_backend_render_target(
-        gr_context,
-        &backend_render_target,
-        skia_safe::gpu::SurfaceOrigin::TopLeft,
-        color_type,
-        None,
-        None,
-    )
+    unsafe {
+        let texture_info = &skia_safe::gpu::vk::ImageInfo::new(
+            vk_image_raw as _,
+            skia_safe::gpu::vk::Alloc::default(),
+            skia_safe::gpu::vk::ImageTiling::OPTIMAL,
+            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            vk_format,
+            1,
+            None,
+            None,
+            None,
+            None,
+        );
+        let backend_render_target =
+            skia_safe::gpu::backend_render_targets::make_vk((width, height), texture_info);
+        skia_safe::gpu::surfaces::wrap_backend_render_target(
+            gr_context,
+            &backend_render_target,
+            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            color_type,
+            None,
+            None,
+        )
+    }
 }
 
 pub unsafe fn make_vulkan_surface(

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -1,0 +1,366 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::cell::RefCell;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use i_slint_core::api::{GraphicsAPI, PhysicalSize as PhysicalWindowSize};
+use i_slint_core::graphics::RequestedGraphicsAPI;
+use i_slint_core::partial_renderer::DirtyRegion;
+use i_slint_core::platform::PlatformError;
+use i_slint_core::renderer::RendererSealed;
+use i_slint_core::window::WindowAdapter;
+
+use wgpu_28 as wgpu;
+
+use crate::wgpu_28_surface::Backend;
+use crate::{SkiaRenderer, SkiaSharedContext};
+
+/// Use the Skia renderer with WGPU when implementing a custom Slint platform where you want the
+/// scene to be rendered into a WGPU texture. The rendering is done using the
+/// [Skia](https://skia.org/) library with platform-native GPU acceleration.
+///
+/// This is the Skia equivalent of `FemtoVGWGPURenderer`, offering superior font rendering
+/// quality through platform-native text rasterizers.
+///
+/// Rendering notifier callbacks registered via
+/// [`Window::set_rendering_notifier()`](i_slint_core::api::Window::set_rendering_notifier)
+/// will receive [`GraphicsAPI::WGPU28`](i_slint_core::api::GraphicsAPI::WGPU28) with the
+/// renderer's instance, device, and queue.
+pub struct SkiaWGPURenderer {
+    renderer: SkiaRenderer,
+    gr_context: RefCell<skia_safe::gpu::DirectContext>,
+    instance: wgpu::Instance,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    backend: Backend,
+    textures_to_transition_for_sampling: RefCell<Vec<wgpu::Texture>>,
+}
+
+impl SkiaWGPURenderer {
+    /// Creates a new SkiaWGPURenderer.
+    ///
+    /// The `instance`, `adapter`, `device` and `queue` are the WGPU resources used for rendering.
+    /// The `adapter` is needed to determine the GPU backend and create the Skia graphics context.
+    ///
+    /// An optional `shared_context` can be provided to share resources (e.g., a Vulkan instance)
+    /// across multiple renderers. If `None`, a new default context is created.
+    ///
+    /// The wgpu resources are also provided to rendering notifier callbacks via
+    /// [`GraphicsAPI::WGPU28`](i_slint_core::api::GraphicsAPI::WGPU28).
+    pub fn new(
+        shared_context: Option<&SkiaSharedContext>,
+        instance: wgpu::Instance,
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+    ) -> Result<Self, PlatformError> {
+        let backend: Backend = adapter.get_info().backend.try_into()?;
+
+        let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
+            PlatformError::from("Failed to create Skia graphics context from WGPU")
+        })?;
+
+        let default_context;
+        let shared_context = match shared_context {
+            Some(ctx) => ctx,
+            None => {
+                default_context = SkiaSharedContext::default();
+                &default_context
+            }
+        };
+        // Use SkiaRenderer::default() to stay resilient to field additions, then disable
+        // partial rendering — there is no buffer age tracking for external texture targets.
+        let mut renderer = SkiaRenderer::default(shared_context);
+        renderer.partial_rendering_state = None;
+
+        Ok(Self {
+            renderer,
+            gr_context: RefCell::new(gr_context),
+            instance,
+            device,
+            queue,
+            backend,
+            textures_to_transition_for_sampling: Default::default(),
+        })
+    }
+
+    /// Render the scene to the given texture.
+    ///
+    /// The texture must have been created with `RENDER_ATTACHMENT` usage and have a supported
+    /// format (`Rgba8Unorm`, `Bgra8Unorm`, or sRGB variants on Vulkan).
+    pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
+        let size = texture.size();
+        self.render_to_texture_impl(texture, size.width as i32, size.height as i32)
+    }
+
+    /// Render the scene to a sub-region of the given texture, specified by width and height.
+    ///
+    /// `width` and `height` must not exceed the texture's dimensions.
+    pub fn render_to_texture_view(
+        &self,
+        texture: &wgpu::Texture,
+        width: u32,
+        height: u32,
+    ) -> Result<(), PlatformError> {
+        let size = texture.size();
+        if width > size.width || height > size.height {
+            return Err(format!(
+                "render_to_texture_view: requested size {}x{} exceeds texture size {}x{}",
+                width, height, size.width, size.height
+            )
+            .into());
+        }
+        self.render_to_texture_impl(texture, width as i32, height as i32)
+    }
+
+    fn render_to_texture_impl(
+        &self,
+        texture: &wgpu::Texture,
+        width: i32,
+        height: i32,
+    ) -> Result<(), PlatformError> {
+        let gr_context = &mut self.gr_context.borrow_mut();
+
+        let mut skia_surface = self
+            .backend
+            .make_surface_from_texture(width, height, gr_context, texture)
+            .ok_or_else(|| {
+                PlatformError::from("Failed to wrap WGPU texture as Skia render target")
+            })?;
+
+        let window_adapter = self.renderer.window_adapter()?;
+        let window = window_adapter.window();
+
+        let surface_adapter = TextureSurface {
+            instance: &self.instance,
+            device: &self.device,
+            queue: &self.queue,
+            backend: &self.backend,
+            textures_to_transition: &self.textures_to_transition_for_sampling,
+        };
+
+        self.renderer.render_to_canvas(
+            skia_surface.canvas(),
+            0.,
+            (0., 0.),
+            Some(gr_context),
+            0,
+            Some(&surface_adapter),
+            window,
+            None,
+        );
+
+        // Transition any imported wgpu textures to sampling state before submitting.
+        let textures_to_transition = self.textures_to_transition_for_sampling.take();
+        if !textures_to_transition.is_empty() {
+            let mut encoder =
+                self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("Skia texture transition encoder"),
+                });
+            encoder.transition_resources(
+                std::iter::empty(),
+                textures_to_transition.iter().map(|texture| wgpu::TextureTransition {
+                    texture,
+                    selector: None,
+                    state: wgpu::TextureUses::RESOURCE,
+                }),
+            );
+            self.queue.submit(Some(encoder.finish()));
+        }
+
+        gr_context.submit(None);
+
+        Ok(())
+    }
+
+    /// Returns a reference to the inner [`SkiaRenderer`].
+    ///
+    /// Use this to return from [`WindowAdapter::renderer()`](i_slint_core::window::WindowAdapter::renderer)
+    /// in your platform implementation. The `SkiaRenderer` implements the `Renderer` trait.
+    pub fn renderer(&self) -> &SkiaRenderer {
+        &self.renderer
+    }
+}
+
+/// Lightweight adapter that implements the [`Surface`](crate::Surface) trait for
+/// render-to-texture, providing `with_graphics_api` and `import_wgpu_texture` support
+/// without requiring a window or swapchain.
+struct TextureSurface<'a> {
+    instance: &'a wgpu::Instance,
+    device: &'a wgpu::Device,
+    queue: &'a wgpu::Queue,
+    backend: &'a Backend,
+    textures_to_transition: &'a RefCell<Vec<wgpu::Texture>>,
+}
+
+impl crate::Surface for TextureSurface<'_> {
+    fn new(
+        _: &SkiaSharedContext,
+        _: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+        _: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
+        _: PhysicalWindowSize,
+        _: Option<RequestedGraphicsAPI>,
+    ) -> Result<Self, PlatformError>
+    where
+        Self: Sized,
+    {
+        Err("TextureSurface cannot be created from a window handle".into())
+    }
+
+    fn name(&self) -> &'static str {
+        "wgpu-texture"
+    }
+
+    #[cfg(feature = "unstable-wgpu-28")]
+    fn with_graphics_api(&self, callback: &mut dyn FnMut(GraphicsAPI<'_>)) {
+        let api = i_slint_core::graphics::create_graphics_api_wgpu_28(
+            self.instance.clone(),
+            self.device.clone(),
+            self.queue.clone(),
+        );
+        callback(api)
+    }
+
+    fn render(
+        &self,
+        _: &i_slint_core::api::Window,
+        _: PhysicalWindowSize,
+        _: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>, u8) -> Option<DirtyRegion>,
+        _: &RefCell<Option<Box<dyn FnMut()>>>,
+    ) -> Result<(), PlatformError> {
+        Err("TextureSurface does not support render() — use render_to_texture() instead".into())
+    }
+
+    fn resize_event(&self, _: PhysicalWindowSize) -> Result<(), PlatformError> {
+        Ok(())
+    }
+
+    fn bits_per_pixel(&self) -> Result<u8, PlatformError> {
+        Ok(32)
+    }
+
+    #[cfg(any(feature = "unstable-wgpu-27", feature = "unstable-wgpu-28"))]
+    fn import_wgpu_texture(
+        &self,
+        canvas: &skia_safe::Canvas,
+        any_wgpu_texture: &i_slint_core::graphics::WGPUTexture,
+    ) -> Option<skia_safe::Image> {
+        let texture = match any_wgpu_texture {
+            #[cfg(feature = "unstable-wgpu-27")]
+            i_slint_core::graphics::WGPUTexture::WGPU27Texture(..) => return None,
+            #[cfg(feature = "unstable-wgpu-28")]
+            i_slint_core::graphics::WGPUTexture::WGPU28Texture(texture) => texture.clone(),
+        };
+
+        self.textures_to_transition.borrow_mut().push(texture.clone());
+        self.backend.import_texture(canvas, texture)
+    }
+}
+
+#[doc(hidden)]
+impl RendererSealed for SkiaWGPURenderer {
+    fn text_size(
+        &self,
+        text_item: Pin<&dyn i_slint_core::item_rendering::RenderString>,
+        item_rc: &i_slint_core::items::ItemRc,
+        max_width: Option<i_slint_core::lengths::LogicalLength>,
+        text_wrap: i_slint_core::items::TextWrap,
+    ) -> i_slint_core::lengths::LogicalSize {
+        self.renderer.text_size(text_item, item_rc, max_width, text_wrap)
+    }
+
+    fn char_size(
+        &self,
+        text_item: Pin<&dyn i_slint_core::item_rendering::HasFont>,
+        item_rc: &i_slint_core::items::ItemRc,
+        ch: char,
+    ) -> i_slint_core::lengths::LogicalSize {
+        self.renderer.char_size(text_item, item_rc, ch)
+    }
+
+    fn font_metrics(
+        &self,
+        font_request: i_slint_core::graphics::FontRequest,
+    ) -> i_slint_core::items::FontMetrics {
+        self.renderer.font_metrics(font_request)
+    }
+
+    fn text_input_byte_offset_for_position(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::items::ItemRc,
+        pos: i_slint_core::lengths::LogicalPoint,
+    ) -> usize {
+        self.renderer.text_input_byte_offset_for_position(text_input, item_rc, pos)
+    }
+
+    fn text_input_cursor_rect_for_byte_offset(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::items::ItemRc,
+        byte_offset: usize,
+    ) -> i_slint_core::lengths::LogicalRect {
+        self.renderer.text_input_cursor_rect_for_byte_offset(text_input, item_rc, byte_offset)
+    }
+
+    fn register_font_from_memory(
+        &self,
+        data: &'static [u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.renderer.register_font_from_memory(data)
+    }
+
+    fn register_font_from_path(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.renderer.register_font_from_path(path)
+    }
+
+    fn default_font_size(&self) -> i_slint_core::lengths::LogicalLength {
+        self.renderer.default_font_size()
+    }
+
+    fn set_rendering_notifier(
+        &self,
+        callback: Box<dyn i_slint_core::api::RenderingNotifier>,
+    ) -> Result<(), i_slint_core::api::SetRenderingNotifierError> {
+        self.renderer.set_rendering_notifier(callback)
+    }
+
+    fn free_graphics_resources(
+        &self,
+        component: i_slint_core::item_tree::ItemTreeRef,
+        items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
+    ) -> Result<(), PlatformError> {
+        self.renderer.free_graphics_resources(component, items)
+    }
+
+    fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
+        self.renderer.set_window_adapter(window_adapter)
+    }
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        RendererSealed::window_adapter(&self.renderer)
+    }
+
+    fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {
+        self.renderer.resize(size)
+    }
+
+    fn take_snapshot(
+        &self,
+    ) -> Result<
+        i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+        PlatformError,
+    > {
+        self.renderer.take_snapshot()
+    }
+
+    fn supports_transformations(&self) -> bool {
+        self.renderer.supports_transformations()
+    }
+}

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -92,42 +92,14 @@ impl SkiaWGPURenderer {
     /// The texture must have been created with `RENDER_ATTACHMENT` usage and have a supported
     /// format (`Rgba8Unorm`, `Bgra8Unorm`, or sRGB variants on Vulkan).
     pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
-        let size = texture.size();
-        self.render_to_texture_impl(texture, size.width as i32, size.height as i32)
-    }
-
-    /// Render the scene to a sub-region of the given texture, specified by width and height.
-    ///
-    /// `width` and `height` must not exceed the texture's dimensions.
-    pub fn render_to_texture_view(
-        &self,
-        texture: &wgpu::Texture,
-        width: u32,
-        height: u32,
-    ) -> Result<(), PlatformError> {
-        let size = texture.size();
-        if width > size.width || height > size.height {
-            return Err(format!(
-                "render_to_texture_view: requested size {}x{} exceeds texture size {}x{}",
-                width, height, size.width, size.height
-            )
-            .into());
-        }
-        self.render_to_texture_impl(texture, width as i32, height as i32)
-    }
-
-    fn render_to_texture_impl(
-        &self,
-        texture: &wgpu::Texture,
-        width: i32,
-        height: i32,
-    ) -> Result<(), PlatformError> {
         let gr_context = &mut self.gr_context.borrow_mut();
 
-        let mut skia_surface =
-            self.backend.make_surface_from_texture(width, height, gr_context, texture).ok_or_else(
-                || PlatformError::from("Failed to wrap WGPU texture as Skia render target"),
-            )?;
+        let mut skia_surface = self
+            .backend
+            .make_surface_from_texture(gr_context, texture)
+            .ok_or_else(|| {
+                PlatformError::from("Failed to wrap WGPU texture as Skia render target")
+            })?;
 
         let window_adapter = self.renderer.window_adapter()?;
         let window = window_adapter.window();

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -124,12 +124,10 @@ impl SkiaWGPURenderer {
     ) -> Result<(), PlatformError> {
         let gr_context = &mut self.gr_context.borrow_mut();
 
-        let mut skia_surface = self
-            .backend
-            .make_surface_from_texture(width, height, gr_context, texture)
-            .ok_or_else(|| {
-                PlatformError::from("Failed to wrap WGPU texture as Skia render target")
-            })?;
+        let mut skia_surface =
+            self.backend.make_surface_from_texture(width, height, gr_context, texture).ok_or_else(
+                || PlatformError::from("Failed to wrap WGPU texture as Skia render target"),
+            )?;
 
         let window_adapter = self.renderer.window_adapter()?;
         let window = window_adapter.window();
@@ -156,10 +154,9 @@ impl SkiaWGPURenderer {
         // Transition any imported wgpu textures to sampling state before submitting.
         let textures_to_transition = self.textures_to_transition_for_sampling.take();
         if !textures_to_transition.is_empty() {
-            let mut encoder =
-                self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("Skia texture transition encoder"),
-                });
+            let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Skia texture transition encoder"),
+            });
             encoder.transition_resources(
                 std::iter::empty(),
                 textures_to_transition.iter().map(|texture| wgpu::TextureTransition {
@@ -228,7 +225,11 @@ impl crate::Surface for TextureSurface<'_> {
         &self,
         _: &i_slint_core::api::Window,
         _: PhysicalWindowSize,
-        _: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>, u8) -> Option<DirtyRegion>,
+        _: &dyn Fn(
+            &skia_safe::Canvas,
+            Option<&mut skia_safe::gpu::DirectContext>,
+            u8,
+        ) -> Option<DirtyRegion>,
         _: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<(), PlatformError> {
         Err("TextureSurface does not support render() — use render_to_texture() instead".into())

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -94,10 +94,8 @@ impl SkiaWGPURenderer {
     pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
         let gr_context = &mut self.gr_context.borrow_mut();
 
-        let mut skia_surface = self
-            .backend
-            .make_surface_from_texture(gr_context, texture)
-            .ok_or_else(|| {
+        let mut skia_surface =
+            self.backend.make_surface_from_texture(gr_context, texture).ok_or_else(|| {
                 PlatformError::from("Failed to wrap WGPU texture as Skia render target")
             })?;
 


### PR DESCRIPTION
## Summary

- Adds `SkiaWGPURenderer`, a new public type that renders Slint UI via Skia directly into a caller-supplied `wgpu::Texture` — the Skia counterpart to `FemtoVGWGPURenderer`
- Per-platform HAL bridge functions (Metal, Vulkan, DX12) wrap a `wgpu::Texture` as a Skia render target, sharing helpers with the existing swapchain surface functions to avoid duplication
- `TextureSurface` adapter provides rendering notifier callbacks (`GraphicsAPI::WGPU28`) and wgpu texture import support during render-to-texture
- Public API at `slint::platform::skia_renderer::SkiaWGPURenderer`, gated on `renderer-skia` + `unstable-wgpu-28`
- Ports `examples/bevy/bevy-hosts-slint-gpu` from `FemtoVGWGPURenderer` to `SkiaWGPURenderer`

## Motivation

`FemtoVGWGPURenderer` already supports this pattern for the FemtoVG renderer (used by `examples/bevy/bevy-hosts-slint-gpu`). The Skia renderer has superior font rendering through platform-native rasterizers but lacked this API — it could only render to a `wgpu::Surface` (swapchain). This enables sharing a wgpu device between Bevy and Slint with zero-copy GPU texture handoff.

## Test plan

- [x] `cargo build -p slint --features renderer-skia,unstable-wgpu-28` — compiles
- [x] `cargo build -p slint --features renderer-skia` — compiles (no wgpu module exposed)
- [x] `cargo build -p i-slint-renderer-skia --features wgpu-28` — compiles without `unstable-wgpu-28`
- [x] `cargo clippy -p i-slint-renderer-skia --features wgpu-28,unstable-wgpu-28 -- -D warnings` — no warnings
- [x] Ported `examples/bevy/bevy-hosts-slint-gpu` from FemtoVG to Skia — runs correctly with UI rendering, input, and transparency on macOS Metal