### PR TITLE
Mark KeyEvent&KeyboardModifiers #[non_exhaustive]

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -296,18 +296,31 @@ impl AndroidWindowAdapter {
             WindowEvent::KeyPressed { text } => WindowInner::from_pub(&self.window)
                 .process_key_input(InternalKeyEvent {
                     event_type: KeyEventType::KeyPressed,
-                    key_event: KeyEvent { text, ..Default::default() },
+                    key_event: {
+                        let mut key_event = KeyEvent::default();
+                        key_event.text = text;
+                        key_event
+                    },
                     ..Default::default()
                 }),
             WindowEvent::KeyPressRepeated { text } => WindowInner::from_pub(&self.window)
                 .process_key_input(InternalKeyEvent {
                     event_type: KeyEventType::KeyPressed,
-                    key_event: KeyEvent { text, repeat: true, ..Default::default() },
+                    key_event: {
+                        let mut key_event = KeyEvent::default();
+                        key_event.text = text;
+                        key_event.repeat = true;
+                        key_event
+                    },
                     ..Default::default()
                 }),
             WindowEvent::KeyReleased { text } => WindowInner::from_pub(&self.window)
                 .process_key_input(InternalKeyEvent {
-                    key_event: KeyEvent { text, ..Default::default() },
+                    key_event: {
+                        let mut key_event = KeyEvent::default();
+                        key_event.text = text;
+                        key_event
+                    },
                     event_type: KeyEventType::KeyReleased,
                     ..Default::default()
                 }),
@@ -469,6 +482,13 @@ impl AndroidWindowAdapter {
                     let event = if let Some(r) = state.compose_region {
                         let adjust =
                             |pos| if pos > r.start { pos - r.start + r.end } else { pos } as i32;
+                        let mut key_event = KeyEvent::default();
+                        key_event.text = i_slint_core::format!(
+                            "{}{}",
+                            &state.text[..r.start],
+                            &state.text[r.end..]
+                        );
+
                         InternalKeyEvent {
                             event_type: KeyEventType::UpdateComposition,
                             preedit_text: state.text[r.start..r.end].into(),
@@ -476,26 +496,18 @@ impl AndroidWindowAdapter {
                             replacement_range: Some(i32::MIN..i32::MAX),
                             cursor_position: Some(adjust(state.selection.end)),
                             anchor_position: Some(adjust(state.selection.start)),
-                            key_event: KeyEvent {
-                                text: i_slint_core::format!(
-                                    "{}{}",
-                                    &state.text[..r.start],
-                                    &state.text[r.end..]
-                                ),
-                                ..Default::default()
-                            },
+                            key_event,
                             ..Default::default()
                         }
                     } else {
+                        let mut key_event = KeyEvent::default();
+                        key_event.text = state.text.as_str().into();
                         InternalKeyEvent {
                             event_type: KeyEventType::CommitComposition,
                             replacement_range: Some(i32::MIN..i32::MAX),
                             cursor_position: Some(state.selection.end as _),
                             anchor_position: Some(state.selection.start as _),
-                            key_event: KeyEvent {
-                                text: state.text.as_str().into(),
-                                ..Default::default()
-                            },
+                            key_event,
                             ..Default::default()
                         }
                     };

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -502,6 +502,10 @@ fn callback_update_text<'local>(
                         preedit_start
                     }
                 } as i32;
+                let mut key_event = KeyEvent::default();
+                key_event.text =
+                    i_slint_core::format!("{}{}", &text[..preedit_start], &text[preedit_end..]);
+
                 InternalKeyEvent {
                     event_type: KeyEventType::UpdateComposition,
                     preedit_text: text[preedit_start..preedit_end].into(),
@@ -509,23 +513,19 @@ fn callback_update_text<'local>(
                     replacement_range: Some(i32::MIN..i32::MAX),
                     cursor_position: Some(adjust(cursor_position)),
                     anchor_position: Some(adjust(anchor_position)),
-                    key_event: KeyEvent {
-                        text: i_slint_core::format!(
-                            "{}{}",
-                            &text[..preedit_start],
-                            &text[preedit_end..]
-                        ),
-                        ..Default::default()
-                    },
+                    key_event,
                     ..Default::default()
                 }
             } else {
+                let mut key_event = KeyEvent::default();
+                key_event.text = text;
+
                 InternalKeyEvent {
                     event_type: KeyEventType::CommitComposition,
                     replacement_range: Some(i32::MIN..i32::MAX),
                     cursor_position: Some(cursor_position as _),
                     anchor_position: Some(anchor_position as _),
-                    key_event: KeyEvent { text: text, ..Default::default() },
+                    key_event,
                     ..Default::default()
                 }
             };

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -381,11 +381,10 @@ cpp! {{
                 preedit_string: qttypes::QString as "QString", replacement_start: i32 as "int", replacement_length: i32 as "int",
                 preedit_cursor: i32 as "int"] {
                     let runtime_window = WindowInner::from_pub(&rust_window.window);
+                    let mut key_event = KeyEvent::default();
+                    key_event.text = i_slint_core::format!("{}", commit_string);
                     let event = InternalKeyEvent {
-                        key_event: KeyEvent {
-                            text: i_slint_core::format!("{}", commit_string),
-                            ..Default::default()
-                        },
+                        key_event,
                         event_type: KeyEventType::UpdateComposition,
                         preedit_text: i_slint_core::format!("{}", preedit_string),
                         preedit_selection: (preedit_cursor >= 0).then_some(preedit_cursor..preedit_cursor),

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -337,9 +337,11 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                         corelib::input::KeyEventType::KeyReleased
                     }
                 };
+                let mut key_event = KeyEvent::default();
+                key_event.text = text;
 
                 let event = corelib::input::InternalKeyEvent {
-                    key_event: corelib::input::KeyEvent { text, ..Default::default() },
+                    key_event,
                     event_type,
                     #[cfg(target_os = "windows")]
                     text_without_modifiers,
@@ -358,9 +360,11 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 runtime_window.process_key_input(event);
             }
             WindowEvent::Ime(winit::event::Ime::Commit(string)) => {
+                let mut key_event = KeyEvent::default();
+                key_event.text = string.into();
                 let event = InternalKeyEvent {
                     event_type: KeyEventType::CommitComposition,
-                    key_event: KeyEvent { text: string.into(), ..Default::default() },
+                    key_event,
                     ..Default::default()
                 };
                 runtime_window.process_key_input(event);

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -221,8 +221,12 @@ impl WasmInputHelper {
         h.add_event_listener("compositionend", move |e: web_sys::CompositionEvent| {
             if let (Some(window_adapter), Some(data)) = (win.upgrade(), e.data()) {
                 let window_inner = WindowInner::from_pub(window_adapter.window());
+
+                let mut key_event = KeyEvent::default();
+                key_event.text = data.into();
+
                 window_inner.process_key_input(InternalKeyEvent {
-                    key_event: KeyEvent { text: data.into(), ..Default::default() },
+                    key_event,
                     event_type: KeyEventType::CommitComposition,
                     ..Default::default()
                 });

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -37,6 +37,7 @@ macro_rules! for_each_builtin_structs {
             /// Slint maps the Command key to the control modifier, and the Control key to the meta modifier.
             ///
             /// On Windows, the Windows key is mapped to the meta modifier.
+            #[non_exhaustive]
             #[derive(Copy, Eq)]
             struct KeyboardModifiers {
                 @name = BuiltinPublicStruct::KeyboardModifiers,
@@ -89,6 +90,7 @@ macro_rules! for_each_builtin_structs {
             }
 
             /// This structure is generated and passed to the key press and release callbacks of the `FocusScope` element.
+            #[non_exhaustive]
             struct KeyEvent {
                 @name = BuiltinPublicStruct::KeyEvent,
                 export {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2624,11 +2624,13 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 quote!(
                     sp::make_keys(
                         #key.into(),
-                        sp::KeyboardModifiers {
-                            alt: #alt,
-                            control: #control,
-                            shift: #shift,
-                            meta: #meta
+                        {
+                            let mut modifiers = sp::KeyboardModifiers::default();
+                            modifiers.alt = #alt;
+                            modifiers.control = #control;
+                            modifiers.shift = #shift;
+                            modifiers.meta = #meta;
+                            modifiers
                         },
                         #ignore_shift,
                         #ignore_alt))

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -466,17 +466,20 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         Expression::EnumerationValue(value) => {
             Value::EnumerationValue(value.enumeration.name.to_string(), value.to_string())
         }
-        Expression::Keys(ks) => Value::Keys(i_slint_core::input::make_keys(
-            SharedString::from(&*ks.key),
-            i_slint_core::input::KeyboardModifiers {
-                alt: ks.modifiers.alt,
-                control: ks.modifiers.control,
-                shift: ks.modifiers.shift,
-                meta: ks.modifiers.meta,
-            },
-            ks.ignore_shift,
-            ks.ignore_alt,
-        )),
+        Expression::Keys(ks) => {
+            let mut modifiers = i_slint_core::input::KeyboardModifiers::default();
+            modifiers.alt = ks.modifiers.alt;
+            modifiers.control = ks.modifiers.control;
+            modifiers.shift = ks.modifiers.shift;
+            modifiers.meta = ks.modifiers.meta;
+
+            Value::Keys(i_slint_core::input::make_keys(
+                SharedString::from(&*ks.key),
+                modifiers,
+                ks.ignore_shift,
+                ks.ignore_alt,
+            ))
+        }
         Expression::ReturnStatement(x) => {
             let val = x.as_ref().map_or(Value::Void, |x| eval_expression(x, local_context));
             if local_context.return_value.is_none() {

--- a/tests/cases/input/altgr.slint
+++ b/tests/cases/input/altgr.slint
@@ -93,13 +93,12 @@ Ideally we should only remove the Ctrl+Alt modifiers if they actually caused a d
     let inner = i_slint_core::window::WindowInner::from_pub(instance.window());
     // If the text_without_modifiers is "@", then we know that this layout doesn't
     // have AltGr behavior to produce an `@`, and we can trigger the Ctrl+Alt+@ shortcut
+    let mut key_event = KeyEvent::default();
+    key_event.text = "@".into();
     inner.process_key_input(
         InternalKeyEvent {
             event_type: KeyEventType::KeyPressed,
-            key_event: KeyEvent {
-                text: "@".into(),
-                ..Default::default()
-            },
+            key_event,
             text_without_modifiers: "@".into(),
             ..Default::default()
         }
@@ -108,13 +107,12 @@ Ideally we should only remove the Ctrl+Alt modifiers if they actually caused a d
 
     // But if the text_without_modifiers is "q", then we know that this layout produces
     // an `@` when AltGr is pressed, and Ctrl+Alt+@ should just be interpreted as `@`
+    let mut key_event = KeyEvent::default();
+    key_event.text = "@".into();
     inner.process_key_input(
         InternalKeyEvent {
             event_type: KeyEventType::KeyPressed,
-            key_event: KeyEvent {
-                text: "@".into(),
-                ..Default::default()
-            },
+            key_event,
             text_without_modifiers: "q".into(),
             ..Default::default()
         }


### PR DESCRIPTION
Note: This is a breaking change! We missed implementing this after our
API review of 1.16.

We hope to release this soon before anyone depends on it.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
