### PR TITLE
ListView: Prospective fix for panic reported in vs code crash reports

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1812,7 +1812,9 @@ impl Element {
             diag,
             tr,
         );
-        let is_listview = if parent.borrow().base_type.to_string() == "ListView" {
+        let is_listview = if parent.borrow().base_type.to_string() == "ListView"
+            && let Some(geometry_props) = e.borrow().geometry_props.as_ref()
+        {
             let lvi = ListViewInfo {
                 viewport_y: NamedReference::new(parent, SmolStr::new_static("viewport-y")),
                 viewport_height: NamedReference::new(
@@ -1826,7 +1828,7 @@ impl Element {
             // these properties are set by the ListView layouting code
             lvi.viewport_height.mark_as_set();
             lvi.viewport_width.mark_as_set();
-            e.borrow().geometry_props.as_ref().unwrap().y.mark_as_set();
+            geometry_props.y.mark_as_set();
             Some(lvi)
         } else {
             None


### PR DESCRIPTION
Replace the unwrap() with a graceful fallback.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
