### PR TITLE
winit/windows: prefer DwmGetColorizationColor for system accent

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -135,7 +135,7 @@ objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["
 block2 = "0.6.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { workspace = true, features = ["Win32_UI_WindowsAndMessaging", "Win32_Graphics_Gdi"] }
+windows = { workspace = true, features = ["Win32_UI_WindowsAndMessaging", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -814,7 +814,21 @@ impl WinitWindowAdapter {
     fn query_system_accent_color() -> Color {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "windows")] {
-                use windows::Win32::Graphics::Gdi::{GetSysColor, COLOR_HIGHLIGHT};
+                use windows::Win32::Graphics::{
+                    Dwm::DwmGetColorizationColor,
+                    Gdi::{GetSysColor, COLOR_HIGHLIGHT},
+                };
+
+                let mut argb = 0u32;
+                let mut _opaque_blend = windows::core::BOOL::default();
+                if unsafe { DwmGetColorizationColor(&mut argb, &mut _opaque_blend) }.is_ok() {
+                    let a = ((argb >> 24) & 0xFF) as u8;
+                    let r = ((argb >> 16) & 0xFF) as u8;
+                    let g = ((argb >> 8) & 0xFF) as u8;
+                    let b = (argb & 0xFF) as u8;
+                    return Color::from_argb_u8(a, r, g, b);
+                }
+
                 let colorref = unsafe { GetSysColor(COLOR_HIGHLIGHT) };
                 let r = (colorref & 0xFF) as u8;
                 let g = ((colorref >> 8) & 0xFF) as u8;


### PR DESCRIPTION
<img width="1886" height="1141" alt="image" src="https://github.com/user-attachments/assets/8395cb2a-36a1-441b-a995-0531bcd83188" />

Root cause: Windows accent was sourced from COLOR_HIGHLIGHT, which doesn’t reliably match the system personalization accent.

Fix: Prefer DwmGetColorizationColor() in winit; keep GetSysColor(COLOR_HIGHLIGHT) as fallback.

Fixes #11432 