### PR TITLE
widgets: preserve accent chroma and hue in accentify palettes

### DIFF
--- a/internal/compiler/widgets/cosmic/styling.slint
+++ b/internal/compiler/widgets/cosmic/styling.slint
@@ -9,18 +9,9 @@ export struct TextStyle {
 }
 
 export global CosmicFontSettings {
-    out property <TextStyle> body: {
-        font-size: 14 * 0.0769rem,
-        font-weight: FontWeight.normal
-    };
-    out property <TextStyle> body-strong: {
-        font-size: 14 * 0.0769rem,
-        font-weight: FontWeight.semi-bold
-    };
-    out property <TextStyle> title: {
-        font-size: 24 * 0.0769rem,
-        font-weight: FontWeight.light
-    };
+    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: FontWeight.normal };
+    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> title: { font-size: 24 * 0.0769rem, font-weight: FontWeight.light };
 }
 
 export global CosmicPalette {
@@ -35,8 +26,9 @@ export global CosmicPalette {
     pure function accentify(default-color: color) -> color {
         let accent-color = SlintInternal.accent-color;
         if (accent-color.alpha > 0) {
-            let lch = default-color.to-oklch();
-            return oklch(lch.lightness, lch.chroma, accent-color.to-oklch().hue);
+            let default-lch = default-color.to-oklch();
+            let accent-lch = accent-color.to-oklch();
+            return oklch(default-lch.lightness, accent-lch.chroma, accent-lch.hue);
         }
         return default-color;
     }
@@ -65,10 +57,10 @@ export global CosmicPalette {
     out property <brush> accent-text: accent-background;
     out property <brush> placeholder-foreground: dark-color-scheme ? #959595 : #585858;
     out property <brush> neutral-5-background: #636363;
-    out property <brush> neutral-6-background: dark-color-scheme ? #808080 :#484848;
+    out property <brush> neutral-6-background: dark-color-scheme ? #808080 : #484848;
 
-    out property <brush> control-disabled: dark-color-scheme ? #212121 :#cfcfcf;
-    out property <brush> text-disabled: dark-color-scheme ? #707070 :#808080;
+    out property <brush> control-disabled: dark-color-scheme ? #212121 : #cfcfcf;
+    out property <brush> text-disabled: dark-color-scheme ? #707070 : #808080;
     out property <brush> secondary-accent-background: dark-color-scheme ? accentify(#51a3ae) : accentify(#367378);
 
     out property <brush> state: dark-color-scheme ? #ffffff : #000000;

--- a/internal/compiler/widgets/cupertino/styling.slint
+++ b/internal/compiler/widgets/cupertino/styling.slint
@@ -9,23 +9,14 @@ export struct TextStyle {
 }
 
 export global CupertinoFontSettings {
-    out property <TextStyle> body: {
-        font-size: 13 * 0.0769rem,
-        font-weight: FontWeight.normal
-    };
+    out property <TextStyle> body: { font-size: 13 * 0.0769rem, font-weight: FontWeight.normal };
 
-
-    out property <TextStyle> title: {
-        font-size: 28 * 0.0769rem,
-        font-weight: FontWeight.light
-    };
+    out property <TextStyle> title: { font-size: 28 * 0.0769rem, font-weight: FontWeight.light };
 
     // needed?
-    out property <TextStyle> body-strong: {
-        font-size: 14 * 0.0769rem,
-        font-weight: FontWeight.semi-bold
-    };
+    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
 }
+
 export global CupertinoColors {
     out property <color> systemGray: #8E8E93;
     out property <color> systemGray2: #AEAEB2;
@@ -59,6 +50,7 @@ export global CupertinoColors {
 
     out property <brush> selection-color: self.blue;
 }
+
 export global CupertinoPalette {
     in-out property <ColorScheme> color-scheme: ColorSchemeSelector.color-scheme;
     property <bool> dark-color-scheme: {
@@ -71,14 +63,15 @@ export global CupertinoPalette {
     pure function accentify(default-color: color) -> color {
         let accent-color = SlintInternal.accent-color;
         if (accent-color.alpha > 0) {
-            let lch = default-color.to-oklch();
-            return oklch(lch.lightness, lch.chroma, accent-color.to-oklch().hue);
+            let default-lch = default-color.to-oklch();
+            let accent-lch = accent-color.to-oklch();
+            return oklch(default-lch.lightness, accent-lch.chroma, accent-lch.hue);
         }
         return default-color;
     }
 
     // base palette
-    out property <brush> background: dark-color-scheme ? CupertinoColors.systemGray55-dark: CupertinoColors.systemGray55;
+    out property <brush> background: dark-color-scheme ? CupertinoColors.systemGray55-dark : CupertinoColors.systemGray55;
     out property <brush> foreground: dark-color-scheme ? CupertinoColors.systemGray6 : CupertinoColors.systemGray6-dark;
     out property <brush> alternate-background: dark-color-scheme ? CupertinoColors.systemGray5-dark : CupertinoColors.systemGray5;
     out property <brush> alternate-foreground: dark-color-scheme ? CupertinoColors.systemGray5 : CupertinoColors.systemGray5-dark;
@@ -109,7 +102,7 @@ export global CupertinoPalette {
     out property <brush> separator: dark-color-scheme ? CupertinoColors.systemGray6-dark : CupertinoColors.systemGray4;
     out property <brush> bar-background: dark-color-scheme ? CupertinoColors.systemGray4-dark : CupertinoColors.systemGray4;
     out property <brush> bar-border: dark-color-scheme ? @linear-gradient(180deg, CupertinoColors.systemGray4-dark 0%, CupertinoColors.systemGray3-dark 80%, CupertinoColors.systemGray2-dark 100%) : CupertinoColors.systemGray5;
-    out property <brush> inner-border: dark-color-scheme ? CupertinoColors.systemGray5-dark: CupertinoColors.systemGray4;
+    out property <brush> inner-border: dark-color-scheme ? CupertinoColors.systemGray5-dark : CupertinoColors.systemGray4;
     out property <brush> inner-shadow: dark-color-scheme ? CupertinoColors.systemGray5-dark : CupertinoColors.systemGray6;
 
     out property <brush> state: dark-color-scheme ? CupertinoColors.systemGray6 : CupertinoColors.systemGray6-dark;

--- a/internal/compiler/widgets/fluent/styling.slint
+++ b/internal/compiler/widgets/fluent/styling.slint
@@ -9,18 +9,9 @@ export struct TextStyle {
 }
 
 export global FluentFontSettings {
-    out property <TextStyle> body: {
-        font-size: 14 * 0.0769rem,
-        font-weight: FontWeight.normal
-    };
-    out property <TextStyle> body-strong: {
-        font-size: 14 * 0.0769rem,
-        font-weight: FontWeight.semi-bold
-    };
-    out property <TextStyle> title: {
-        font-size: 28 * 0.0769rem,
-        font-weight: FontWeight.semi-bold
-    };
+    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: FontWeight.normal };
+    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> title: { font-size: 28 * 0.0769rem, font-weight: FontWeight.semi-bold };
 }
 
 export global FluentPalette {
@@ -35,8 +26,9 @@ export global FluentPalette {
     pure function accentify(default-color: color) -> color {
         let accent-color = SlintInternal.accent-color;
         if (accent-color.alpha > 0) {
-            let lch = default-color.to-oklch();
-            return oklch(lch.lightness, lch.chroma, accent-color.to-oklch().hue);
+            let default-lch = default-color.to-oklch();
+            let accent-lch = accent-color.to-oklch();
+            return oklch(default-lch.lightness, accent-lch.chroma, accent-lch.hue);
         }
         return default-color;
     }
@@ -58,17 +50,14 @@ export global FluentPalette {
     out property <brush> secondary-accent-background: accent-background.with-alpha(0.9);
     out property <brush> tertiary-accent-background: accent-background.with-alpha(0.8);
     out property <brush> accent-disabled: dark-color-scheme ? #FFFFFF29 : #00000038;
-    out property <brush> accent-control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF14 90.67%, #00000024 100%)
-        : @linear-gradient(180deg, #FFFFFF14 90.67%, #00000066 100%);
-    out property <brush> control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF17 0%, #00000012 8.33%)
-        : @linear-gradient(180deg, #0000000F 90.58%, #00000029 100%);
+    out property <brush> accent-control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF14 90.67%, #00000024 100%) : @linear-gradient(180deg, #FFFFFF14 90.67%, #00000066 100%);
+    out property <brush> control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF17 0%, #00000012 8.33%) : @linear-gradient(180deg, #0000000F 90.58%, #00000029 100%);
     out property <brush> text-accent-foreground-secondary: dark-color-scheme ? #00000080 : #FFFFFFB3;
     out property <brush> text-accent-foreground-disabled: dark-color-scheme ? #FFFFFF87 : #FFFFFF;
     out property <brush> text-secondary: dark-color-scheme ? #FFFFFFC9 : #00000099;
     out property <brush> text-tertiary: dark-color-scheme ? #FFFFFF8A : #00000073;
     out property <brush> text-disabled: dark-color-scheme ? #FFFFFF5E : #0000005E;
-    out property <brush> text-control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF14 99.98%, #FFFFFF8A 100%, #FFFFFF8A 100%)
-        : @linear-gradient(180deg, #0000000F 99.99%, #00000073 100%, #00000073 100%);
+    out property <brush> text-control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF14 99.98%, #FFFFFF8A 100%, #FFFFFF8A 100%) : @linear-gradient(180deg, #0000000F 99.99%, #00000073 100%, #00000073 100%);
     out property <brush> control-secondary: dark-color-scheme ? #FFFFFF14 : #F9F9F980;
     out property <brush> control-tertiary: dark-color-scheme ? #FFFFFF08 : #F9F9F94D;
     out property <brush> control-disabled: dark-color-scheme ? #FFFFFF0A : #F9F9F94D;
@@ -78,9 +67,8 @@ export global FluentPalette {
     out property <brush> control-alt-disabled: transparent;
     out property <brush> control-strong-stroke: dark-color-scheme ? #FFFFFF99 : #00000099;
     out property <brush> control-strong-stroke-disabled: dark-color-scheme ? #FFFFFF29 : #00000038;
-    out property <brush> control-solid: dark-color-scheme ? #454545: #FFFFFF;
-    out property <brush> circle-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF17 0%, #FFFFFF12 100%)
-    : @linear-gradient(180deg, #0000000F 0%, #00000029 100%);
+    out property <brush> control-solid: dark-color-scheme ? #454545 : #FFFFFF;
+    out property <brush> circle-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF17 0%, #FFFFFF12 100%) : @linear-gradient(180deg, #0000000F 0%, #00000029 100%);
     out property <brush> control-input-active: dark-color-scheme ? #1E1E1EB3 : #FFFFFF;
     out property <brush> focus-stroke-inner: dark-color-scheme ? #000000B3 : #FFFFFF;
     out property <brush> focus-stroke-outer: dark-color-scheme ? #FFFFFF : #000000E6;

--- a/internal/compiler/widgets/material/styling.slint
+++ b/internal/compiler/widgets/material/styling.slint
@@ -5,9 +5,7 @@
 import { ColorSchemeSelector } from "color-scheme.slint";
 
 // typo settings
-struct TextStyle  {
-    font-size: relative-font-size,
-    font-weight: int}
+struct TextStyle { font-size: relative-font-size, font-weight: int}
 
 export global MaterialFontSettings {
     out property <TextStyle> label-large: { font-size: 14 * 0.0625rem, font-weight: FontWeight.medium };
@@ -15,10 +13,7 @@ export global MaterialFontSettings {
     out property <TextStyle> body-large: { font-size: 16 * 0.0625rem, font-weight: FontWeight.normal };
     out property <TextStyle> body-small: { font-size: 12 * 0.0625rem, font-weight: FontWeight.normal };
     out property <TextStyle> title-small: { font-size: 14 * 0.0625rem, font-weight: FontWeight.medium };
-    out property <TextStyle> headline-large: {
-        font-size: 32 * 0.0625rem,
-        font-weight: FontWeight.medium
-    };
+    out property <TextStyle> headline-large: { font-size: 32 * 0.0625rem, font-weight: FontWeight.medium };
 }
 
 export global Elevation {
@@ -39,8 +34,9 @@ export global MaterialPalette {
     pure function accentify(default-color: color) -> color {
         let accent-color = SlintInternal.accent-color;
         if (accent-color.alpha > 0) {
-            let lch = default-color.to-oklch();
-            return oklch(lch.lightness, lch.chroma, accent-color.to-oklch().hue);
+            let default-lch = default-color.to-oklch();
+            let accent-lch = accent-color.to-oklch();
+            return oklch(default-lch.lightness, accent-lch.chroma, accent-lch.hue);
         }
         return default-color;
     }


### PR DESCRIPTION
Before: 
<img width="1768" height="1180" alt="image" src="https://github.com/user-attachments/assets/1f42a38a-d114-416e-8611-82506c59849b" />


After: 
<img width="1829" height="1171" alt="image" src="https://github.com/user-attachments/assets/4f2d69ed-aeef-4f3f-9635-6e4b0cb11b12" />

Fixes #11440 