### PR TITLE
qt: Do not attempt to render zero-sized layers

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1684,6 +1684,12 @@ impl QtItemRenderer<'_> {
                 height: (layer_size.height * dpr) as _,
             };
 
+            // Skip rendering if the size is zero since QPainter fails to draw
+            // on an empty QImage (and also to avoid wasting CPU cycles).
+            if layer_size.width == 0 || layer_size.height == 0 {
+                return qttypes::QPixmap::default();
+            }
+
             let mut layer_image = qttypes::QImage::new(layer_size, qttypes::ImageFormat::ARGB32_Premultiplied);
             layer_image.fill(qttypes::QColor::from_rgba_f(0., 0., 0., 0.));
 


### PR DESCRIPTION
QPainter fails to draw on a zero-sized QImage, which leads to very noisy warnings on the console, thus now skipping zero-size layers.

The emitted warnings were:

```
QPainter::begin: Paint device returned engine == 0, type: 3
QPainter::setClipRect: Painter not active
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::save: Painter not active
QPainter::clipBoundingRect: Painter not active
QPainter::translate: Painter not active
```

One unresolved question: A few lines after the new early return, there is the following line:

```rs
*self.metrics.layers_created.as_mut().unwrap() += 1;
```

Should this be executed *before* the early return or not?

EDIT: Clarification why this is needed: Zero-sized layers can easily happen by having elements with opacity<1, for example elements which can be collapsed/expanded and therefore sometimes have height=0 (possibly with an animation).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
