### PR TITLE
Fix warnings about unused functions in testing/build.rs

### DIFF
--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -31,7 +31,7 @@ fn main() {
 
 /// Generate JSON schemas for proto Request* messages, used by the MCP server
 /// to build tool definitions from the proto source of truth.
-#[cfg(any(feature = "system-testing", feature = "mcp"))]
+#[cfg(feature = "mcp")]
 fn generate_mcp_schemas(fds: &prost_types::FileDescriptorSet, out_dir: &std::path::Path) {
     use std::fmt::Write;
 
@@ -109,7 +109,7 @@ fn generate_mcp_schemas(fds: &prost_types::FileDescriptorSet, out_dir: &std::pat
     std::fs::write(out_dir.join("mcp_schemas.rs"), code).expect("failed to write mcp_schemas.rs");
 }
 
-#[cfg(any(feature = "system-testing", feature = "mcp"))]
+#[cfg(feature = "mcp")]
 fn message_to_json_schema(
     msg: &prost_types::DescriptorProto,
     messages: &std::collections::HashMap<String, &prost_types::DescriptorProto>,
@@ -188,7 +188,7 @@ fn message_to_json_schema(
     format!(r#"{{"type": "object", "properties": {{{props}}}}}"#)
 }
 
-#[cfg(any(feature = "system-testing", feature = "mcp"))]
+#[cfg(feature = "mcp")]
 fn snake_to_camel(s: &str) -> String {
     let mut result = String::new();
     let mut capitalize_next = false;


### PR DESCRIPTION
When compiling with feature `system-testing` enabled, but without `mcp`, compiling Slint emitted the following warnings:

```bash
warning: function `generate_mcp_schemas` is never used
  --> internal/backends/testing/build.rs:35:4
   |
35 | fn generate_mcp_schemas(fds: &prost_types::FileDescriptorSet, out_dir: &std::path::Path) {
   |    ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: function `message_to_json_schema` is never used
   --> internal/backends/testing/build.rs:113:4
    |
113 | fn message_to_json_schema(
    |    ^^^^^^^^^^^^^^^^^^^^^^

warning: function `snake_to_camel` is never used
   --> internal/backends/testing/build.rs:192:4
    |
192 | fn snake_to_camel(s: &str) -> String {
    |    ^^^^^^^^^^^^^^

warning: `i-slint-backend-testing` (build script) generated 3 warnings
```

Fixed by correcting the corresponding `#[cfg]`.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
