### PR TITLE
Upgrade parley and fontique to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,11 +3585,11 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23358480a54a886d51b306718d5ca743fdfe238e5df38ef650f4e72f29c5d9e9"
+checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.4",
@@ -3597,7 +3597,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts",
+ "read-fonts 0.39.1",
  "roxmltree",
  "smallvec",
  "windows 0.62.2",
@@ -4628,14 +4628,14 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9"
+checksum = "a9ce5e848d21ba97a324266e41c70e0eb5e2577a610c1fbd546e15096f2e8e37"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
  "core_maths",
- "read-fonts",
+ "read-fonts 0.39.1",
  "smallvec",
 ]
 
@@ -4679,6 +4679,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -5080,7 +5083,7 @@ dependencies = [
  "fontique",
  "htmlparser",
  "pulldown-cmark",
- "skrifa",
+ "skrifa 0.42.0",
 ]
 
 [[package]]
@@ -5116,7 +5119,7 @@ dependencies = [
  "rspolib",
  "serde",
  "serde_json",
- "skrifa",
+ "skrifa 0.42.0",
  "smol_str 0.3.2",
  "spin_on",
  "strum 0.28.0",
@@ -5164,7 +5167,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "skrifa",
+ "skrifa 0.42.0",
  "slab",
  "slint",
  "static_assertions",
@@ -5262,7 +5265,7 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "raw-window-metal",
- "read-fonts",
+ "read-fonts 0.39.1",
  "scoped-tls-hkt",
  "skia-safe",
  "softbuffer",
@@ -5292,7 +5295,7 @@ dependencies = [
  "integer-sqrt",
  "lyon_path",
  "num-traits",
- "skrifa",
+ "skrifa 0.42.0",
  "swash",
  "zeno",
 ]
@@ -7853,27 +7856,27 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c00ec192e1a402861526eff91a4b4690a2e5a17a4ae2deb772d72b49daf868"
+checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
 dependencies = [
  "fontique",
  "harfrust",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "icu_normalizer",
  "icu_properties",
  "icu_segmenter",
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa",
+ "skrifa 0.42.0",
 ]
 
 [[package]]
 name = "parley_data"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232313eddc02ac27f015e8f8eeb7facce8a896116df7e3eda1bfd9f600a9a39d"
+checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
 dependencies = [
  "icu_properties",
 ]
@@ -8877,6 +8880,17 @@ name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "core_maths",
+ "font-types",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d7821ebf634094f5e5ae9d43c3109407f420f03a7a2e021d3a5d955a4f09fc"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -10012,7 +10026,17 @@ checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "core_maths",
- "read-fonts",
+ "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c844316c7318cf6ae9034ee45edd2c432076ef910fdc4bc598183b31f88d03c3"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.1",
 ]
 
 [[package]]
@@ -10749,7 +10773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
 dependencies = [
  "core_maths",
- "skrifa",
+ "skrifa 0.40.0",
  "yazi",
  "zeno",
 ]
@@ -13613,15 +13637,15 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12725b0845073e20b04e79b500dbfb465904d7cbd84883a1f1bbd084debc515"
+checksum = "ce8b548f3c4467727d74d4237f48cbc08b8ebee551f7d7f17ac63b853cd9c481"
 dependencies = [
  "font-types",
  "indexmap",
  "kurbo",
  "log",
- "read-fonts",
+ "read-fonts 0.39.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,11 +191,11 @@ wgpu-27 = { package = "wgpu", version = "27", default-features = false }
 wgpu-28 = { package = "wgpu", version = "28", default-features = false }
 input = { version = "0.9.0", default-features = false }
 tr = { version = "0.1", default-features = false }
-fontique = { version = "0.8.0" }
+fontique = { version = "0.9.0" }
 # Pinned to match parley's version
-read-fonts = { version = "0.37" }
+read-fonts = { version = "0.39" }
 # Pinned to match parley's version
-skrifa = { version = "0.40" }
+skrifa = { version = "0.42" }
 windows = { version = "0.62" }
 windows-core = { version = "0.62.0" }
 lyon_path = { version = "1.0", default-features = false }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -259,7 +259,7 @@ unstable-winit-030 = ["backend-winit", "dep:i-slint-backend-winit", "i-slint-bac
 ## ```
 unstable-libinput-09 = ["i-slint-backend-selector/unstable-libinput-09"]
 
-## Enable support for exposing [fontique](https://docs.rs/fontique/0.8.0/fontique/) related APIs.
+## Enable support for exposing [fontique](https://docs.rs/fontique/0.9.0/fontique/) related APIs.
 ##
 ## APIs guarded with this feature are *NOT* subject to the usual Slint API stability guarantees. This feature as well as the APIs changed or removed
 ## in future minor releases of Slint, likely to be replaced by a feature with a similar name but the fontique version suffix being bumped.
@@ -268,9 +268,9 @@ unstable-libinput-09 = ["i-slint-backend-selector/unstable-libinput-09"]
 ## in your `Cargo.toml` when enabling this feature:
 ##
 ## ```toml
-## slint = { version = "~1.17", features = ["unstable-fontique-08"] }
+## slint = { version = "~1.17", features = ["unstable-fontique-09"] }
 ## ```
-unstable-fontique-08 = ["i-slint-common/shared-fontique"]
+unstable-fontique-09 = ["i-slint-common/shared-fontique"]
 
 [dependencies]
 i-slint-core = { workspace = true }
@@ -335,6 +335,6 @@ features = [
   "unstable-wgpu-28",
   "unstable-winit-030",
   "unstable-libinput-09",
-  "unstable-fontique-08",
+  "unstable-fontique-09",
 ]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -747,9 +747,9 @@ pub mod winit_030 {
     pub type WinitWindowEventResult = EventResult;
 }
 
-#[cfg(feature = "unstable-fontique-08")]
-pub mod fontique_08 {
-    //! Fontique 0.8 specific types and re-exports.
+#[cfg(feature = "unstable-fontique-09")]
+pub mod fontique_09 {
+    //! Fontique 0.9 specific types and re-exports.
     //!
     //! *Note*: This module is behind a feature flag and may be removed or changed in future minor releases,
     //!         as new major Fontique releases become available.
@@ -772,18 +772,18 @@ pub mod fontique_08 {
     ///
     /// `Cargo.toml`:
     /// ```toml
-    /// slint = { version = "~1.17", features = ["unstable-fontique-08"] }
+    /// slint = { version = "~1.17", features = ["unstable-fontique-09"] }
     /// ```
     ///
     /// `main.rs`:
     /// ```rust,no_run
-    /// use slint::fontique_08::fontique;
+    /// use slint::fontique_09::fontique;
     ///
     /// fn main() {
     ///     // ...
     ///     let downloaded_font: Vec<u8> = todo!("Download https://somewebsite.com/font.ttf");
     ///     let blob = fontique::Blob::new(std::sync::Arc::new(downloaded_font));
-    ///     let mut collection = slint::fontique_08::shared_collection();
+    ///     let mut collection = slint::fontique_09::shared_collection();
     ///     let fonts = collection.register_fonts(blob, None);
     ///     collection
     ///         .append_fallbacks(fontique::FallbackKey::new(fontique::Script::from_str_unchecked("Hira"), None), fonts.iter().map(|x| x.0));

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -4352,11 +4352,11 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23358480a54a886d51b306718d5ca743fdfe238e5df38ef650f4e72f29c5d9e9"
+checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.4",
@@ -4364,7 +4364,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.37.0",
+ "read-fonts 0.39.1",
  "roxmltree 0.21.1",
  "smallvec",
  "windows 0.62.2",
@@ -4955,14 +4955,14 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9"
+checksum = "a9ce5e848d21ba97a324266e41c70e0eb5e2577a610c1fbd546e15096f2e8e37"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
  "core_maths",
- "read-fonts 0.37.0",
+ "read-fonts 0.39.1",
  "smallvec",
 ]
 
@@ -5008,6 +5008,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -5291,10 +5294,10 @@ name = "i-slint-common"
 version = "1.17.0"
 dependencies = [
  "derive_more",
- "fontique 0.8.0",
+ "fontique 0.9.0",
  "htmlparser",
  "pulldown-cmark",
- "skrifa 0.40.0",
+ "skrifa 0.42.0",
 ]
 
 [[package]]
@@ -5344,7 +5347,7 @@ dependencies = [
  "lyon_path",
  "num-traits",
  "once_cell",
- "parley 0.8.0",
+ "parley 0.9.0",
  "pin-project",
  "pin-weak",
  "portable-atomic",
@@ -5353,7 +5356,7 @@ dependencies = [
  "rgb",
  "scoped-tls-hkt",
  "scopeguard",
- "skrifa 0.40.0",
+ "skrifa 0.42.0",
  "slab",
  "strum",
  "swash",
@@ -5428,7 +5431,7 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "raw-window-metal",
- "read-fonts 0.37.0",
+ "read-fonts 0.39.1",
  "scoped-tls-hkt",
  "skia-safe",
  "softbuffer",
@@ -5457,7 +5460,7 @@ dependencies = [
  "integer-sqrt",
  "lyon_path",
  "num-traits",
- "skrifa 0.40.0",
+ "skrifa 0.42.0",
  "swash",
  "zeno",
 ]
@@ -7118,27 +7121,27 @@ dependencies = [
 
 [[package]]
 name = "parley"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c00ec192e1a402861526eff91a4b4690a2e5a17a4ae2deb772d72b49daf868"
+checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
 dependencies = [
- "fontique 0.8.0",
- "harfrust 0.5.2",
- "hashbrown 0.16.1",
+ "fontique 0.9.0",
+ "harfrust 0.6.0",
+ "hashbrown 0.17.0",
  "icu_normalizer",
  "icu_properties",
  "icu_segmenter",
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa 0.40.0",
+ "skrifa 0.42.0",
 ]
 
 [[package]]
 name = "parley_data"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232313eddc02ac27f015e8f8eeb7facce8a896116df7e3eda1bfd9f600a9a39d"
+checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
 dependencies = [
  "icu_properties",
 ]
@@ -7604,6 +7607,16 @@ name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d7821ebf634094f5e5ae9d43c3109407f420f03a7a2e021d3a5d955a4f09fc"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -8214,6 +8227,16 @@ checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c844316c7318cf6ae9034ee45edd2c432076ef910fdc4bc598183b31f88d03c3"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.1",
 ]
 
 [[package]]
@@ -10756,15 +10779,15 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12725b0845073e20b04e79b500dbfb465904d7cbd84883a1f1bbd084debc515"
+checksum = "ce8b548f3c4467727d74d4237f48cbc08b8ebee551f7d7f17ac63b853cd9c481"
 dependencies = [
  "font-types 0.11.3",
  "indexmap",
  "kurbo",
  "log",
- "read-fonts 0.37.0",
+ "read-fonts 0.39.1",
 ]
 
 [[package]]

--- a/examples/gallery/Cargo.toml
+++ b/examples/gallery/Cargo.toml
@@ -34,7 +34,7 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# web-sys = { version = "0.3", features = ["console", "Window", "Navigator"] }
 #wasm# js-sys = { version = "0.3.57" }
 #wasm# console_error_panic_hook = "0.1.5"
-#wasm# slint = { path = "../../api/rs/slint", features = ["unstable-fontique-08"] }
+#wasm# slint = { path = "../../api/rs/slint", features = ["unstable-fontique-09"] }
 #wasm# icu_locale_core = { version = "2.1.1" }
 
 [package.metadata.bundle]

--- a/examples/gallery/main.rs
+++ b/examples/gallery/main.rs
@@ -11,11 +11,11 @@ slint::include_modules!();
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn load_font_from_bytes(font_data: js_sys::Uint8Array, locale: &str) -> Result<(), JsValue> {
-    use slint::fontique_08::fontique;
+    use slint::fontique_09::fontique;
 
     let font_data = font_data.to_vec();
     let blob = fontique::Blob::new(std::sync::Arc::new(font_data));
-    let mut collection = slint::fontique_08::shared_collection();
+    let mut collection = slint::fontique_09::shared_collection();
     let fonts = collection.register_fonts(blob, None);
 
     scripts_for_locale(locale, |script| {
@@ -29,9 +29,9 @@ pub fn load_font_from_bytes(font_data: js_sys::Uint8Array, locale: &str) -> Resu
 #[cfg(target_arch = "wasm32")]
 fn scripts_for_locale(
     locale: &str,
-    mut callback: impl FnMut(&slint::fontique_08::fontique::Script),
+    mut callback: impl FnMut(&slint::fontique_09::fontique::Script),
 ) {
-    use slint::fontique_08::fontique;
+    use slint::fontique_09::fontique;
 
     let Ok(locale) = icu_locale_core::Locale::try_from_str(locale) else {
         return;

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -119,7 +119,7 @@ unicode-linebreak = { version = "0.1.5", optional = true }
 unicode-script = { version = "0.5.7", optional = true }
 icu_normalizer = { workspace = true, optional = true }
 sys-locale = { version = "0.3.2", optional = true, features = ["js"] }
-parley = { version = "0.8.0", optional = true }
+parley = { version = "0.9.0", optional = true }
 
 image = { workspace = true, optional = true, default-features = false }
 clru = { workspace = true, optional = true }

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -468,7 +468,6 @@ fn layout(
             max_physical_width.filter(|_| text_wrap != TextWrap::NoWrap).map(|width| width.get()),
         );
         para.layout.align(
-            max_physical_width.map(|width| width.get()),
             match options.horizontal_align {
                 TextHorizontalAlignment::Start | TextHorizontalAlignment::Left => {
                     parley::Alignment::Left
@@ -605,7 +604,7 @@ impl TextParagraph {
                     // we want to place an elipsis on the last line and not draw any lines beyond the
                     // given max height.
                     Some(max_physical_height) if layout.elision_info.is_some() => {
-                        max_physical_height.get().ceil() >= metrics.max_coord
+                        max_physical_height.get().ceil() >= metrics.block_max_coord
                     }
                     _ => true,
                 }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -112,8 +112,8 @@ wgpu-27 = { workspace = true, optional = true, features = ["metal"] }
 wgpu-28 = { workspace = true, optional = true, features = ["metal"] }
 
 read-fonts = { workspace = true }
-# Pinned to 0.45 to align with read-fonts from parley and avoid duplicated dependencies
-write-fonts = { version = "0.45" }
+# Pinned to 0.48 to align with read-fonts from parley and avoid duplicated dependencies
+write-fonts = { version = "0.48" }
 
 [target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]
 skia-safe = { version = "0.90", features = ["gl", "vulkan"] }


### PR DESCRIPTION
Bump parley, fontique, read-fonts, skrifa, and write-fonts to the versions released alongside parley 0.9. The `Layout::align` width parameter is gone (alignment now uses `max_advance` from `break_all_lines`) and `LineMetrics::max_coord` was renamed to `block_max_coord`.

Following the per-version-suffix convention, rename the `unstable-fontique-08` Cargo feature and `slint::fontique_08` module to `unstable-fontique-09` / `slint::fontique_09`.

Fixes #10900
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
