### PR TITLE
system tray: split up code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2929,7 +2929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5134,6 +5134,7 @@ dependencies = [
  "auto_enums",
  "bitflags 2.11.1",
  "cfg-if",
+ "cfg_aliases",
  "chrono",
  "clru",
  "const-field-offset",
@@ -6114,25 +6115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libxdo"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
-dependencies = [
- "libxdo-sys",
-]
-
-[[package]]
-name = "libxdo-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
-dependencies = [
- "libc",
- "x11",
-]
-
-[[package]]
 name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6700,7 +6682,6 @@ dependencies = [
  "crossbeam-channel",
  "dpi",
  "keyboard-types",
- "libxdo",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -7087,7 +7068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9491,7 +9472,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10938,7 +10919,6 @@ dependencies = [
 name = "system_tray"
 version = "1.16.0"
 dependencies = [
- "i-slint-core",
  "slint",
  "slint-build",
 ]
@@ -10994,7 +10974,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11003,7 +10983,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11022,7 +11002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11602,7 +11582,7 @@ dependencies = [
 [[package]]
 name = "tray-icon"
 version = "0.22.0"
-source = "git+https://github.com/expenses/tray-icon?branch=optional-gtk#05f2f022e07ff162db36b1f29c7a35ebe53c7ddb"
+source = "git+https://github.com/expenses/tray-icon?branch=optional-gtk#223835e3306226cbf33c3065a3da22690877317a"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -12900,7 +12880,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -13722,16 +13702,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "x11"
-version = "2.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
-dependencies = [
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "x11-clipboard"

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -2262,7 +2262,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3870,10 +3870,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "ctor-lite"
-version = "0.1.2"
+name = "ctor"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
+checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
+dependencies = [
+ "dtor",
+]
 
 [[package]]
 name = "ctrlc"
@@ -3942,6 +3945,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4056,6 +4080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,7 +4182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4881,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "guillotiere"
@@ -5264,7 +5294,7 @@ dependencies = [
  "i-slint-renderer-software",
  "imgref",
  "lyon_path",
- "muda",
+ "muda 0.18.0",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -5329,6 +5359,7 @@ dependencies = [
  "auto_enums",
  "bitflags 2.11.1",
  "cfg-if",
+ "cfg_aliases",
  "chrono",
  "clru",
  "const-field-offset",
@@ -5338,6 +5369,7 @@ dependencies = [
  "i-slint-core-macros",
  "icu_normalizer",
  "image",
+ "ksni",
  "lyon_algorithms",
  "lyon_extra",
  "lyon_geom",
@@ -5359,6 +5391,7 @@ dependencies = [
  "swash",
  "sys-locale",
  "taffy",
+ "tray-icon",
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
@@ -5928,6 +5961,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "ksni"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ca513d0be42df5edb485af9f44a12b2cb85af773d91c27dc796d1c58b78edc"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "futures-channel",
+ "futures-lite",
+ "futures-util",
+ "once_cell",
+ "pastey",
+ "serde",
+ "zbus",
+]
+
+[[package]]
 name = "ktx2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6262,6 +6313,25 @@ dependencies = [
 
 [[package]]
 name = "muda"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "keyboard-types",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "png 0.17.16",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "muda"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20e2339ef964849496bd6dab1bcd8ceb7a3a5a268dc64c8b84c833e75d66dab"
@@ -6492,7 +6562,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6987,9 +7057,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -7019,9 +7089,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -7030,10 +7100,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "orbclient"
-version = "0.3.51"
+name = "option-ext"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "orbclient"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
 dependencies = [
  "libc",
  "libredox",
@@ -7148,6 +7224,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "percent-encoding"
@@ -7644,6 +7726,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7856,7 +7949,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7883,9 +7976,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8646,7 +8739,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8766,12 +8859,12 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor",
  "libloading",
  "pkg-config",
  "tracing",
@@ -8916,7 +9009,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -8925,7 +9018,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -9062,6 +9155,25 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tray-icon"
+version = "0.22.0"
+source = "git+https://github.com/expenses/tray-icon?branch=optional-gtk#223835e3306226cbf33c3065a3da22690877317a"
+dependencies = [
+ "crossbeam-channel",
+ "dirs",
+ "muda 0.17.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "png 0.18.1",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9353,11 +9465,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -9366,7 +9478,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -9987,7 +10099,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10659,9 +10771,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -10674,6 +10786,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/examples/system_tray/Cargo.toml
+++ b/examples/system_tray/Cargo.toml
@@ -15,7 +15,6 @@ name = "system_tray"
 
 [dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["renderer-femtovg", "backend-winit-x11", "compat-1-2"] }
-i-slint-core = { workspace = true, features = ["system-tray"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -43,7 +43,6 @@ std = [
   "i-slint-common/markdown",
   "taffy/std",
 ]
-system-tray = ["dep:ksni", "dep:tray-icon"]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
@@ -146,16 +145,19 @@ taffy = { version = "0.9", default-features = false, features = ["flexbox", "taf
 gettext-rs = { version = "0.7.1", optional = true, features = ["gettext-system"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
-tray-icon = { git = "https://github.com/expenses/tray-icon", branch = "optional-gtk", optional = true }
+tray-icon = { git = "https://github.com/expenses/tray-icon", branch = "optional-gtk", default-features = false }
 
-[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
-ksni = { version = "0.3.3", optional = true, default-features = false, features = ["async-io"] }
+[target.'cfg(all(target_family = "unix", not(target_vendor = "apple"), not(target_os = "android")))'.dependencies]
+ksni = { version = "0.3.3", default-features = false, features = ["async-io"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2" }
 web-sys = { workspace = true, features = ["HtmlImageElement", "Navigator"] }
 
+
+[build-dependencies]
+cfg_aliases = { workspace = true }
 
 [dev-dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "renderer-software"] }

--- a/internal/core/build.rs
+++ b/internal/core/build.rs
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    cfg_aliases! {
+       // Targets where a system tray icon backend is available:
+       // - macOS and Windows use the `tray-icon` crate (muda-based).
+       // - Linux/BSD (unix minus Apple and Android) use `ksni`.
+       // Other targets (iOS, Android, wasm, bare-metal) have no backend, so the
+       // `system_tray` module is not compiled there.
+       system_tray: {
+           any(
+               target_os = "macos",
+               target_os = "windows",
+               all(
+                   target_family = "unix",
+                   not(target_vendor = "apple"),
+                   not(target_os = "android")
+               )
+           )
+       },
+    }
+    println!("cargo:rustc-check-cfg=cfg(system_tray)");
+}

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -37,6 +37,7 @@ use crate::lengths::{
 pub use crate::menus::MenuItem;
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
+#[cfg(system_tray)]
 pub use crate::system_tray::SystemTray;
 use crate::window::{WindowAdapter, WindowAdapterRc, WindowInner};
 use crate::{Callback, Coord, Property, SharedString};
@@ -1851,6 +1852,7 @@ declare_item_vtable! {
     fn slint_get_MenuItemVTable() -> MenuItemVTable for MenuItem
 }
 
+#[cfg(system_tray)]
 declare_item_vtable! {
     fn slint_get_SystemTrayVTable() -> SystemTrayVTable for SystemTray
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -37,9 +37,9 @@ use crate::lengths::{
 pub use crate::menus::MenuItem;
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
+pub use crate::system_tray::SystemTray;
 use crate::window::{WindowAdapter, WindowAdapterRc, WindowInner};
 use crate::{Callback, Coord, Property, SharedString};
-use alloc::boxed::Box;
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
@@ -1814,173 +1814,6 @@ declare_item_vtable! {
     fn slint_get_BoxShadowVTable() -> BoxShadowVTable for BoxShadow
 }
 
-#[repr(C)]
-/// Wraps the internal data structure for the SystemTray
-pub struct SystemTrayDataBox(core::ptr::NonNull<SystemTrayData>);
-
-impl Default for SystemTrayDataBox {
-    fn default() -> Self {
-        SystemTrayDataBox(Box::leak(Box::<SystemTrayData>::default()).into())
-    }
-}
-impl Drop for SystemTrayDataBox {
-    fn drop(&mut self) {
-        // Safety: the self.0 was constructed from a Box::leak in SystemTrayDataBox::default
-        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
-    }
-}
-
-impl core::ops::Deref for SystemTrayDataBox {
-    type Target = SystemTrayData;
-    fn deref(&self) -> &Self::Target {
-        // Safety: initialized in SystemTrayDataBox::default
-        unsafe { self.0.as_ref() }
-    }
-}
-
-#[derive(Default)]
-pub struct SystemTrayData {
-    #[cfg(feature = "system-tray")]
-    inner: std::cell::OnceCell<crate::system_tray::SystemTray>,
-    #[cfg_attr(not(feature = "system-tray"), allow(unused))]
-    change_tracker: crate::properties::ChangeTracker,
-}
-
-#[repr(C)]
-#[derive(FieldOffsets, Default, SlintElement)]
-#[pin]
-pub struct SystemTray {
-    pub icon: Property<crate::graphics::Image>,
-    pub title: Property<SharedString>,
-    //pub menu: Property<crate::model::ModelRc<SystemTrayListItem>>,
-    pub cached_rendering_data: CachedRenderingData,
-    data: SystemTrayDataBox,
-}
-
-impl Item for SystemTray {
-    #[cfg_attr(not(feature = "system-tray"), allow(unused))]
-    fn init(self: Pin<&Self>, self_rc: &ItemRc) {
-        #[cfg(feature = "system-tray")]
-        self.data.change_tracker.init_delayed(
-            self_rc.downgrade(),
-            |_| true,
-            |self_weak, has_icon| {
-                let Some(tray_rc) = self_weak.upgrade() else {
-                    return;
-                };
-                let Some(tray) = tray_rc.downcast::<SystemTray>() else {
-                    return;
-                };
-                if !*has_icon {
-                    return;
-                }
-                let tray = tray.as_pin_ref();
-                let system_tray =
-                    match crate::system_tray::SystemTray::new(crate::system_tray::Params {
-                        icon: &tray.icon(),
-                        title: &tray.title(),
-                        //menu: tray.menu(),
-                    }) {
-                        Ok(system_tray) => system_tray,
-                        Err(err) => panic!("{}", err),
-                    };
-
-                let _ = tray.data.inner.set(system_tray);
-            },
-        );
-    }
-
-    fn deinit(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
-
-    fn layout_info(
-        self: Pin<&Self>,
-        _orientation: Orientation,
-        _cross_axis_constraint: Coord,
-        _window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
-    ) -> LayoutInfo {
-        LayoutInfo::default()
-    }
-
-    fn input_event_filter_before_children(
-        self: Pin<&Self>,
-        _: &MouseEvent,
-        _window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
-        _: &mut MouseCursor,
-    ) -> InputEventFilterResult {
-        InputEventFilterResult::ForwardAndIgnore
-    }
-
-    fn input_event(
-        self: Pin<&Self>,
-        _: &MouseEvent,
-        _window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
-        _: &mut MouseCursor,
-    ) -> InputEventResult {
-        InputEventResult::EventIgnored
-    }
-
-    fn capture_key_event(
-        self: Pin<&Self>,
-        _: &InternalKeyEvent,
-        _window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
-    ) -> KeyEventResult {
-        KeyEventResult::EventIgnored
-    }
-
-    fn key_event(
-        self: Pin<&Self>,
-        _: &InternalKeyEvent,
-        _window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
-    ) -> KeyEventResult {
-        KeyEventResult::EventIgnored
-    }
-
-    fn focus_event(
-        self: Pin<&Self>,
-        _: &FocusEvent,
-        _window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
-    ) -> FocusEventResult {
-        FocusEventResult::FocusIgnored
-    }
-
-    fn render(
-        self: Pin<&Self>,
-        _backend: &mut ItemRendererRef,
-        _self_rc: &ItemRc,
-        _size: LogicalSize,
-    ) -> RenderingResult {
-        RenderingResult::ContinueRenderingChildren
-    }
-
-    fn bounding_rect(
-        self: core::pin::Pin<&Self>,
-        _window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
-        geometry: LogicalRect,
-    ) -> LogicalRect {
-        geometry
-    }
-
-    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
-        false
-    }
-}
-
-impl ItemConsts for SystemTray {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
-}
-
-declare_item_vtable! {
-    fn slint_get_SystemTrayVTable() -> SystemTrayVTable for SystemTray
-}
-
 declare_item_vtable! {
     fn slint_get_ComponentContainerVTable() -> ComponentContainerVTable for ComponentContainer
 }
@@ -2016,6 +1849,10 @@ declare_item_vtable! {
 
 declare_item_vtable! {
     fn slint_get_MenuItemVTable() -> MenuItemVTable for MenuItem
+}
+
+declare_item_vtable! {
+    fn slint_get_SystemTrayVTable() -> SystemTrayVTable for SystemTray
 }
 
 macro_rules! declare_enums {

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -57,7 +57,6 @@ pub mod sharedvector;
 pub mod slice;
 pub mod string;
 pub mod styled_text;
-#[cfg(feature = "system-tray")]
 pub mod system_tray;
 pub mod tests;
 pub mod textlayout;

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -57,6 +57,7 @@ pub mod sharedvector;
 pub mod slice;
 pub mod string;
 pub mod styled_text;
+#[cfg(system_tray)]
 pub mod system_tray;
 pub mod tests;
 pub mod textlayout;

--- a/internal/core/system_tray.rs
+++ b/internal/core/system_tray.rs
@@ -1,147 +1,238 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use crate::{
-    graphics::Image,
-    items::SystemTrayListItem,
-    model::{Model, ModelRc},
+// for `declare_item_vtable!`
+#![allow(unsafe_code)]
+
+//! System tray integration.
+//!
+//! This module hosts the `SystemTray` native item (the element exposed to `.slint`) and
+//! wraps the platform-specific tray icon backends: [`ksni`](ksni) on Linux/BSD and
+//! [`tray-icon`](tray_icon) (muda-based) on macOS and Windows.
+
+use crate::graphics::Image;
+use crate::input::{
+    FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, InternalKeyEvent,
+    KeyEventResult, MouseEvent,
 };
-use std::string::ToString;
+use crate::item_rendering::CachedRenderingData;
+use crate::items::{Item, ItemConsts, ItemRc, MouseCursor, Orientation, RenderingResult};
+use crate::layout::LayoutInfo;
+use crate::lengths::{LogicalRect, LogicalSize};
+#[cfg(feature = "rtti")]
+use crate::rtti::*;
+use crate::window::WindowAdapter;
+use crate::{Coord, Property, SharedString};
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use const_field_offset::FieldOffsets;
+use core::pin::Pin;
+use i_slint_core_macros::*;
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-use ksni::TrayMethods;
+#[cfg(all(feature = "system-tray", not(any(target_os = "macos", target_os = "windows"))))]
+mod ksni;
+#[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
+mod tray_icon;
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-struct KsniTray {
-    icon: ksni::Icon,
-    title: std::string::String,
-    //menu: std::vec::Vec<SystemTrayListItem>,
-}
+#[cfg(all(feature = "system-tray", not(any(target_os = "macos", target_os = "windows"))))]
+use self::ksni::PlatformTray;
+#[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
+use self::tray_icon::PlatformTray;
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-impl ksni::Tray for KsniTray {
-    fn id(&self) -> std::string::String {
-        // This cannot be empty.
-        "slint-tray".into()
-    }
-
-    fn title(&self) -> std::string::String {
-        self.title.clone()
-    }
-
-    fn icon_pixmap(&self) -> std::vec::Vec<ksni::Icon> {
-        std::vec![self.icon.clone()]
-    }
-
-    fn menu(&self) -> std::vec::Vec<ksni::MenuItem<KsniTray>> {
-        /*
-        self.menu
-            .iter()
-            .map(|item| {
-                ksni::menu::StandardItem {
-                    label: item.label.to_string(),
-                    enabled: item.enabled,
-                    ..Default::default()
-                }
-                .into()
-            })
-            .collect()
-            */
-        std::vec::Vec::new()
-    }
-}
-
+/// Parameters passed to the platform-specific tray backend when building a tray icon.
 pub struct Params<'a> {
     pub icon: &'a Image,
     pub title: &'a str,
-    //pub menu: ModelRc<SystemTrayListItem>,
 }
 
-pub struct SystemTray {
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    _tray_icon: tray_icon::TrayIcon,
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    _tray: crate::future::JoinHandle<ksni::Handle<KsniTray>>,
-}
-
-impl SystemTray {
-    pub fn new(params: Params) -> Result<Self, Error> {
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        {
-            let pixel_buffer = params.icon.to_rgba8().ok_or(Error::Rgba8)?;
-
-            let mut data = pixel_buffer.as_bytes().to_vec();
-            let width = pixel_buffer.width() as i32;
-            let height = pixel_buffer.height() as i32;
-
-            for pixel in data.chunks_exact_mut(4) {
-                pixel.rotate_right(1) // rgba to argb
-            }
-
-            let tray = KsniTray {
-                icon: ksni::Icon { width, height, data },
-                title: params.title.into(),
-                menu: params.menu.iter().collect(),
-            };
-
-            let tray = crate::context::with_global_context(
-                || panic!(""),
-                |ctx| {
-                    ctx.spawn_local(async move {
-                        match tray.spawn().await {
-                            Ok(handle) => handle,
-                            Err(error) => {
-                                panic!("{}", error);
-                            }
-                        }
-                    })
-                },
-            )
-            .map_err(Error::PlatformError)?
-            .map_err(Error::EventLoopError)?;
-            Ok(Self { _tray: tray })
-        }
-
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
-        {
-            fn icon_to_tray_icon(icon: &Image) -> Result<tray_icon::Icon, Error> {
-                let pixel_buffer = icon.to_rgba8().ok_or(Error::Rgba8)?;
-
-                let rgba = pixel_buffer.as_bytes();
-                let width = pixel_buffer.width() as u32;
-                let height = pixel_buffer.height() as u32;
-
-                let tray_icon = tray_icon::Icon::from_rgba(rgba.to_vec(), width, height)
-                    .map_err(Error::BadIcon)?;
-
-                Ok(tray_icon)
-            }
-
-            let icon = icon_to_tray_icon(params.icon)?;
-
-            let tray_icon = tray_icon::TrayIconBuilder::new()
-                .with_icon(icon)
-                .with_title(params.title)
-                .build()
-                .map_err(Error::BuildError)?;
-
-            Ok(Self { _tray_icon: tray_icon })
-        }
-    }
-}
-
+/// Errors raised while constructing a platform tray icon.
 #[derive(Debug, derive_more::Error, derive_more::Display)]
 pub enum Error {
     #[display("Failed to create a rgba8 buffer from an icon image")]
     Rgba8,
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
     #[display("Bad icon: {}", 0)]
-    BadIcon(tray_icon::BadIcon),
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    BadIcon(::tray_icon::BadIcon),
+    #[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
     #[display("Build error: {}", 0)]
-    BuildError(tray_icon::Error),
+    BuildError(::tray_icon::Error),
     #[display("{}", 0)]
     PlatformError(crate::platform::PlatformError),
     #[display("{}", 0)]
     EventLoopError(crate::api::EventLoopError),
+}
+
+/// Owning handle to a live platform tray icon. Dropping it removes the icon.
+#[cfg(feature = "system-tray")]
+pub struct SystemTrayHandle(#[allow(dead_code)] PlatformTray);
+
+#[cfg(feature = "system-tray")]
+impl SystemTrayHandle {
+    pub fn new(params: Params) -> Result<Self, Error> {
+        PlatformTray::new(params).map(Self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native `SystemTray` item, exposed to `.slint`.
+// ---------------------------------------------------------------------------
+
+#[repr(C)]
+/// Wraps the internal data structure for the SystemTray
+pub struct SystemTrayDataBox(core::ptr::NonNull<SystemTrayData>);
+
+impl Default for SystemTrayDataBox {
+    fn default() -> Self {
+        SystemTrayDataBox(Box::leak(Box::<SystemTrayData>::default()).into())
+    }
+}
+impl Drop for SystemTrayDataBox {
+    fn drop(&mut self) {
+        // Safety: the self.0 was constructed from a Box::leak in SystemTrayDataBox::default
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+    }
+}
+
+impl core::ops::Deref for SystemTrayDataBox {
+    type Target = SystemTrayData;
+    fn deref(&self) -> &Self::Target {
+        // Safety: initialized in SystemTrayDataBox::default
+        unsafe { self.0.as_ref() }
+    }
+}
+
+#[derive(Default)]
+pub struct SystemTrayData {
+    #[cfg(feature = "system-tray")]
+    inner: std::cell::OnceCell<SystemTrayHandle>,
+    #[cfg_attr(not(feature = "system-tray"), allow(unused))]
+    change_tracker: crate::properties::ChangeTracker,
+}
+
+#[repr(C)]
+#[derive(FieldOffsets, Default, SlintElement)]
+#[pin]
+pub struct SystemTray {
+    pub icon: Property<Image>,
+    pub title: Property<SharedString>,
+    pub cached_rendering_data: CachedRenderingData,
+    data: SystemTrayDataBox,
+}
+
+impl Item for SystemTray {
+    #[cfg_attr(not(feature = "system-tray"), allow(unused))]
+    fn init(self: Pin<&Self>, self_rc: &ItemRc) {
+        #[cfg(feature = "system-tray")]
+        self.data.change_tracker.init_delayed(
+            self_rc.downgrade(),
+            |_| true,
+            |self_weak, has_icon| {
+                let Some(tray_rc) = self_weak.upgrade() else {
+                    return;
+                };
+                let Some(tray) = tray_rc.downcast::<SystemTray>() else {
+                    return;
+                };
+                if !*has_icon {
+                    return;
+                }
+                let tray = tray.as_pin_ref();
+                let handle = match SystemTrayHandle::new(Params {
+                    icon: &tray.icon(),
+                    title: &tray.title(),
+                }) {
+                    Ok(handle) => handle,
+                    Err(err) => panic!("{}", err),
+                };
+
+                let _ = tray.data.inner.set(handle);
+            },
+        );
+    }
+
+    fn deinit(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
+
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _cross_axis_constraint: Coord,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> LayoutInfo {
+        LayoutInfo::default()
+    }
+
+    fn input_event_filter_before_children(
+        self: Pin<&Self>,
+        _: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        _: &mut MouseCursor,
+    ) -> InputEventFilterResult {
+        InputEventFilterResult::ForwardAndIgnore
+    }
+
+    fn input_event(
+        self: Pin<&Self>,
+        _: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        _: &mut MouseCursor,
+    ) -> InputEventResult {
+        InputEventResult::EventIgnored
+    }
+
+    fn capture_key_event(
+        self: Pin<&Self>,
+        _: &InternalKeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn key_event(
+        self: Pin<&Self>,
+        _: &InternalKeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> FocusEventResult {
+        FocusEventResult::FocusIgnored
+    }
+
+    fn render(
+        self: Pin<&Self>,
+        _backend: &mut &mut dyn crate::item_rendering::ItemRenderer,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+    ) -> RenderingResult {
+        RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect(
+        self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
+}
+
+impl ItemConsts for SystemTray {
+    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
+        Self::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
 }

--- a/internal/core/system_tray.rs
+++ b/internal/core/system_tray.rs
@@ -29,14 +29,14 @@ use const_field_offset::FieldOffsets;
 use core::pin::Pin;
 use i_slint_core_macros::*;
 
-#[cfg(all(feature = "system-tray", not(any(target_os = "macos", target_os = "windows"))))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 mod ksni;
-#[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 mod tray_icon;
 
-#[cfg(all(feature = "system-tray", not(any(target_os = "macos", target_os = "windows"))))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use self::ksni::PlatformTray;
-#[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use self::tray_icon::PlatformTray;
 
 /// Parameters passed to the platform-specific tray backend when building a tray icon.
@@ -50,10 +50,10 @@ pub struct Params<'a> {
 pub enum Error {
     #[display("Failed to create a rgba8 buffer from an icon image")]
     Rgba8,
-    #[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     #[display("Bad icon: {}", 0)]
     BadIcon(::tray_icon::BadIcon),
-    #[cfg(all(feature = "system-tray", any(target_os = "macos", target_os = "windows")))]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     #[display("Build error: {}", 0)]
     BuildError(::tray_icon::Error),
     #[display("{}", 0)]
@@ -63,10 +63,8 @@ pub enum Error {
 }
 
 /// Owning handle to a live platform tray icon. Dropping it removes the icon.
-#[cfg(feature = "system-tray")]
 pub struct SystemTrayHandle(#[allow(dead_code)] PlatformTray);
 
-#[cfg(feature = "system-tray")]
 impl SystemTrayHandle {
     pub fn new(params: Params) -> Result<Self, Error> {
         PlatformTray::new(params).map(Self)
@@ -103,9 +101,7 @@ impl core::ops::Deref for SystemTrayDataBox {
 
 #[derive(Default)]
 pub struct SystemTrayData {
-    #[cfg(feature = "system-tray")]
     inner: std::cell::OnceCell<SystemTrayHandle>,
-    #[cfg_attr(not(feature = "system-tray"), allow(unused))]
     change_tracker: crate::properties::ChangeTracker,
 }
 
@@ -120,9 +116,7 @@ pub struct SystemTray {
 }
 
 impl Item for SystemTray {
-    #[cfg_attr(not(feature = "system-tray"), allow(unused))]
     fn init(self: Pin<&Self>, self_rc: &ItemRc) {
-        #[cfg(feature = "system-tray")]
         self.data.change_tracker.init_delayed(
             self_rc.downgrade(),
             |_| true,

--- a/internal/core/system_tray/ksni.rs
+++ b/internal/core/system_tray/ksni.rs
@@ -1,0 +1,69 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Linux system tray backend using the `ksni` crate (StatusNotifierItem/AppIndicator).
+
+use super::{Error, Params};
+use ::ksni::TrayMethods;
+
+struct KsniTray {
+    icon: ::ksni::Icon,
+    title: std::string::String,
+}
+
+impl ::ksni::Tray for KsniTray {
+    fn id(&self) -> std::string::String {
+        // This cannot be empty.
+        "slint-tray".into()
+    }
+
+    fn title(&self) -> std::string::String {
+        self.title.clone()
+    }
+
+    fn icon_pixmap(&self) -> std::vec::Vec<::ksni::Icon> {
+        std::vec![self.icon.clone()]
+    }
+
+    fn menu(&self) -> std::vec::Vec<::ksni::MenuItem<KsniTray>> {
+        std::vec::Vec::new()
+    }
+}
+
+pub struct PlatformTray {
+    _tray: crate::future::JoinHandle<::ksni::Handle<KsniTray>>,
+}
+
+impl PlatformTray {
+    pub fn new(params: Params) -> Result<Self, Error> {
+        let pixel_buffer = params.icon.to_rgba8().ok_or(Error::Rgba8)?;
+
+        let mut data = pixel_buffer.as_bytes().to_vec();
+        let width = pixel_buffer.width() as i32;
+        let height = pixel_buffer.height() as i32;
+
+        for pixel in data.chunks_exact_mut(4) {
+            pixel.rotate_right(1) // rgba to argb
+        }
+
+        let tray =
+            KsniTray { icon: ::ksni::Icon { width, height, data }, title: params.title.into() };
+
+        let tray = crate::context::with_global_context(
+            || panic!(""),
+            |ctx| {
+                ctx.spawn_local(async move {
+                    match tray.spawn().await {
+                        Ok(handle) => handle,
+                        Err(error) => {
+                            panic!("{}", error);
+                        }
+                    }
+                })
+            },
+        )
+        .map_err(Error::PlatformError)?
+        .map_err(Error::EventLoopError)?;
+        Ok(Self { _tray: tray })
+    }
+}

--- a/internal/core/system_tray/tray_icon.rs
+++ b/internal/core/system_tray/tray_icon.rs
@@ -1,0 +1,38 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! macOS and Windows system tray backend using the `tray-icon` crate (muda-based).
+
+use super::{Error, Params};
+use crate::graphics::Image;
+
+fn icon_to_tray_icon(icon: &Image) -> Result<::tray_icon::Icon, Error> {
+    let pixel_buffer = icon.to_rgba8().ok_or(Error::Rgba8)?;
+
+    let rgba = pixel_buffer.as_bytes();
+    let width = pixel_buffer.width() as u32;
+    let height = pixel_buffer.height() as u32;
+
+    let tray_icon =
+        ::tray_icon::Icon::from_rgba(rgba.to_vec(), width, height).map_err(Error::BadIcon)?;
+
+    Ok(tray_icon)
+}
+
+pub struct PlatformTray {
+    _tray_icon: ::tray_icon::TrayIcon,
+}
+
+impl PlatformTray {
+    pub fn new(params: Params) -> Result<Self, Error> {
+        let icon = icon_to_tray_icon(params.icon)?;
+
+        let tray_icon = ::tray_icon::TrayIconBuilder::new()
+            .with_icon(icon)
+            .with_title(params.title)
+            .build()
+            .map_err(Error::BuildError)?;
+
+        Ok(Self { _tray_icon: tray_icon })
+    }
+}

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1087,11 +1087,16 @@ fn generate_rtti() -> HashMap<&'static str, Rc<ItemRTTI>> {
             rtti_for::<DropArea>(),
             rtti_for::<ContextMenu>(),
             rtti_for::<MenuItem>(),
-            rtti_for::<SystemTray>(),
         ]
         .iter()
         .cloned(),
     );
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "windows",
+        all(target_family = "unix", not(target_vendor = "apple"), not(target_os = "android"))
+    ))]
+    rtti.extend([rtti_for::<SystemTray>()].iter().cloned());
 
     trait NativeHelper {
         fn push(rtti: &mut HashMap<&str, Rc<ItemRTTI>>);


### PR DESCRIPTION
Move the system tray item and data box into the system_tray module and move the platform specific code into ksni.rs and tray_icon.rs as those are going to grow.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
