### PR TITLE
Fix macOS display link not firing callbacks on some setups

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -117,7 +117,7 @@ futures = { version = "0.3.31" }
 # To disable macOS automatic shortcut translation
 objc2 = { workspace = true }
 # For GL rendering
-objc2-app-kit = { version = "0.3.2", features = ["NSColor", "objc2-core-foundation"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSColor", "NSView", "objc2-core-foundation"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "block2", "NSString", "NSNotification", "NSRunLoop", "NSObjCRuntime"] }
 objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["CADisplayLink"] }
 block2 = "0.6.2"

--- a/internal/backends/winit/frame_throttle.rs
+++ b/internal/backends/winit/frame_throttle.rs
@@ -12,13 +12,16 @@ use crate::winitwindowadapter::WinitWindowAdapter;
 
 pub fn create_frame_throttle(
     window_adapter: Weak<WinitWindowAdapter>,
+    _winit_window: &winit::window::Window,
     _is_wayland: bool,
 ) -> Box<dyn FrameThrottle> {
     if _is_wayland {
-        WinitBasedFrameThrottle::create(window_adapter)
+        WinitBasedFrameThrottle::create()
     } else {
         #[cfg(target_os = "macos")]
-        if let Some(throttle) = macos_display_link::try_create(window_adapter.clone()) {
+        if let Some(throttle) =
+            macos_display_link::try_create(window_adapter.clone(), _winit_window)
+        {
             return throttle;
         }
         TimerBasedFrameThrottle::create(window_adapter)
@@ -26,7 +29,7 @@ pub fn create_frame_throttle(
 }
 
 pub trait FrameThrottle {
-    fn request_throttled_redraw(&self);
+    fn request_throttled_redraw(&self, winit_window: &winit::window::Window);
 }
 
 struct TimerBasedFrameThrottle {
@@ -41,15 +44,12 @@ impl TimerBasedFrameThrottle {
 }
 
 impl FrameThrottle for TimerBasedFrameThrottle {
-    fn request_throttled_redraw(&self) {
+    fn request_throttled_redraw(&self, winit_window: &winit::window::Window) {
         if self.timer.running() {
             return;
         }
-        let refresh_interval_millihertz = self
-            .window_adapter
-            .upgrade()
-            .and_then(|adapter| adapter.winit_window())
-            .and_then(|winit_window| winit_window.current_monitor())
+        let refresh_interval_millihertz = winit_window
+            .current_monitor()
             .and_then(|monitor| monitor.refresh_rate_millihertz())
             .unwrap_or(60000) as u64;
         let window_adapter = self.window_adapter.clone();
@@ -83,18 +83,16 @@ fn redraw_now(window_adapter: &Weak<WinitWindowAdapter>) {
     winit_window.request_redraw();
 }
 
-struct WinitBasedFrameThrottle {
-    window_adapter: Weak<WinitWindowAdapter>,
-}
+struct WinitBasedFrameThrottle;
 
 impl WinitBasedFrameThrottle {
-    fn create(window_adapter: Weak<WinitWindowAdapter>) -> Box<dyn FrameThrottle> {
-        Box::new(Self { window_adapter })
+    fn create() -> Box<dyn FrameThrottle> {
+        Box::new(Self)
     }
 }
 
 impl FrameThrottle for WinitBasedFrameThrottle {
-    fn request_throttled_redraw(&self) {
-        redraw_now(&self.window_adapter)
+    fn request_throttled_redraw(&self, winit_window: &winit::window::Window) {
+        winit_window.request_redraw();
     }
 }

--- a/internal/backends/winit/frame_throttle/macos_display_link.rs
+++ b/internal/backends/winit/frame_throttle/macos_display_link.rs
@@ -7,11 +7,11 @@ use i_slint_core as corelib;
 use i_slint_core::platform::WindowAdapter as _;
 use objc2::rc::Retained;
 use objc2::runtime::AnyClass;
-use objc2::{
-    ClassType, DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel,
-};
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+use objc2_app_kit::NSView;
 use objc2_foundation::{NSObject, NSObjectProtocol, NSRunLoop, NSRunLoopCommonModes};
 use objc2_quartz_core::CADisplayLink;
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use crate::winitwindowadapter::WinitWindowAdapter;
 
@@ -69,26 +69,27 @@ impl Drop for CADisplayLinkFrameThrottle {
 }
 
 impl super::FrameThrottle for CADisplayLinkFrameThrottle {
-    fn request_throttled_redraw(&self) {
+    fn request_throttled_redraw(&self, _winit_window: &winit::window::Window) {
         self.display_link.setPaused(false);
     }
 }
 
 pub(super) fn try_create(
     window_adapter: Weak<WinitWindowAdapter>,
+    winit_window: &winit::window::Window,
 ) -> Option<Box<dyn super::FrameThrottle>> {
     // CADisplayLink on macOS requires 14.0+; check at runtime.
     AnyClass::get(c"CADisplayLink")?;
 
     let mtm = MainThreadMarker::new().expect("frame throttle must be created on main thread");
 
-    let target = DisplayLinkTarget::new(mtm, window_adapter);
-    // Use msg_send! instead of the typed wrapper because the wrapper panics
-    // on NULL, which happens in headless CI environments without a display.
-    let display_link: Option<Retained<CADisplayLink>> = unsafe {
-        msg_send![CADisplayLink::class(), displayLinkWithTarget: &*target, selector: sel!(tick:)]
+    let RawWindowHandle::AppKit(handle) = winit_window.window_handle().ok()?.as_raw() else {
+        return None;
     };
-    let display_link = display_link?;
+    let ns_view: &NSView = unsafe { handle.ns_view.cast().as_ref() };
+
+    let target = DisplayLinkTarget::new(mtm, window_adapter);
+    let display_link = unsafe { ns_view.displayLinkWithTarget_selector(&target, sel!(tick:)) };
 
     // Use NSRunLoopCommonModes so the callback fires during modal tracking loops
     // (context menus, window resize, etc.)

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -164,6 +164,7 @@ fn window_is_resizable(
 enum WinitWindowOrNone {
     HasWindow {
         window: Arc<winit::window::Window>,
+        frame_throttle: Box<dyn crate::frame_throttle::FrameThrottle>,
         #[cfg(enable_accesskit)]
         accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
         #[cfg(muda)]
@@ -371,8 +372,6 @@ pub struct WinitWindowAdapter {
     /// Winit's window_icon API has no way of checking if the window icon is
     /// the same as a previously set one, so keep track of that here.
     window_icon_cache_key: RefCell<Option<ImageCacheKey>>,
-
-    frame_throttle: Box<dyn crate::frame_throttle::FrameThrottle>,
 }
 
 impl WinitWindowAdapter {
@@ -420,10 +419,6 @@ impl WinitWindowAdapter {
             #[cfg(all(muda, target_os = "macos"))]
             muda_enable_default_menu_bar,
             window_icon_cache_key: Default::default(),
-            frame_throttle: crate::frame_throttle::create_frame_throttle(
-                self_weak.clone(),
-                shared_backend_data.is_wayland,
-            ),
         });
 
         self_rc.shared_backend_data.register_inactive_window((self_rc.clone()) as _);
@@ -503,8 +498,15 @@ impl WinitWindowAdapter {
             (view, self.self_weak.clone())
         };
 
+        let frame_throttle = crate::frame_throttle::create_frame_throttle(
+            self.self_weak.clone(),
+            &winit_window,
+            self.shared_backend_data.is_wayland,
+        );
+
         *self.winit_window_or_none.borrow_mut() = WinitWindowOrNone::HasWindow {
             window: winit_window.clone(),
+            frame_throttle,
             #[cfg(enable_accesskit)]
             accesskit_adapter: crate::accesskit::AccessKitAdapter::new(
                 self.self_weak.clone(),
@@ -1232,8 +1234,11 @@ impl WindowAdapter for WinitWindowAdapter {
     }
 
     fn request_redraw(&self) {
-        if !self.pending_redraw.replace(true) {
-            self.frame_throttle.request_throttled_redraw();
+        if !self.pending_redraw.replace(true)
+            && let WinitWindowOrNone::HasWindow { window, frame_throttle, .. } =
+                &*self.winit_window_or_none.borrow()
+        {
+            frame_throttle.request_throttled_redraw(window);
         }
     }
 


### PR DESCRIPTION
+[CADisplayLink displayLinkWithTarget:selector:] is an iOS-only class method; on macOS the display link must be obtained from an NSView, NSWindow, or NSScreen instance. Using the class method worked on some setups but on others the link stayed active without ever invoking its callback, so property changes after the first paint never produced a redraw.

Defer display link creation until the first redraw request (the winit window isn't available at throttle-construction time), then obtain it via -[NSView displayLinkWithTarget:selector:] from the window's NSView. Fall back to winit's request_redraw if the view isn't ready yet so a pre-show property change isn't lost.

cc #11472

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
