### PR TITLE
Add SkiaWGPURenderer for rendering into external WGPU textures

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -166,18 +166,10 @@ renderer-skia = ["i-slint-backend-selector/renderer-skia", "dep:i-slint-renderer
 
 ## Same as `renderer-skia`, but Skia will always use OpenGL.
 ## Note: This is not supported on iOS. Use `renderer-skia` on iOS to enable Meta based rendering.
-renderer-skia-opengl = [
-  "i-slint-backend-selector/renderer-skia-opengl",
-  "dep:i-slint-renderer-skia",
-  "std",
-]
+renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "dep:i-slint-renderer-skia", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use Vulkan.
-renderer-skia-vulkan = [
-  "i-slint-backend-selector/renderer-skia-vulkan",
-  "dep:i-slint-renderer-skia",
-  "std",
-]
+renderer-skia-vulkan = ["i-slint-backend-selector/renderer-skia-vulkan", "dep:i-slint-renderer-skia", "std"]
 
 ## Render using the software renderer.
 renderer-software = ["i-slint-backend-selector/renderer-software", "dep:i-slint-renderer-software"]

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -162,14 +162,22 @@ renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "dep:i-slint-re
 renderer-femtovg-wgpu = ["i-slint-backend-selector/renderer-femtovg-wgpu", "i-slint-renderer-femtovg/wgpu", "std"]
 
 ## Render using [Skia](https://skia.org/).
-renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
+renderer-skia = ["i-slint-backend-selector/renderer-skia", "dep:i-slint-renderer-skia", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use OpenGL.
 ## Note: This is not supported on iOS. Use `renderer-skia` on iOS to enable Meta based rendering.
-renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "std"]
+renderer-skia-opengl = [
+  "i-slint-backend-selector/renderer-skia-opengl",
+  "dep:i-slint-renderer-skia",
+  "std",
+]
 
 ## Same as `renderer-skia`, but Skia will always use Vulkan.
-renderer-skia-vulkan = ["i-slint-backend-selector/renderer-skia-vulkan", "std"]
+renderer-skia-vulkan = [
+  "i-slint-backend-selector/renderer-skia-vulkan",
+  "dep:i-slint-renderer-skia",
+  "std",
+]
 
 ## Render using the software renderer.
 renderer-software = ["i-slint-backend-selector/renderer-software", "dep:i-slint-renderer-software"]
@@ -304,6 +312,7 @@ i-slint-backend-winit = { workspace = true, optional = true }
 # FemtoVG is disabled on android because it doesn't compile without setting RUST_FONTCONFIG_DLOPEN=on
 # end even then wouldn't work because it can't load fonts
 i-slint-renderer-femtovg = { workspace = true, optional = true }
+i-slint-renderer-skia = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-backend-android-activity = { workspace = true, optional = true }

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -422,6 +422,21 @@ pub mod platform {
         pub use i_slint_renderer_femtovg::opengl::OpenGLInterface;
     }
 
+    /// This module contains the [`skia_renderer::SkiaWGPURenderer`] and related types.
+    ///
+    /// It is only enabled when the `renderer-skia` Slint feature is enabled.
+    #[cfg(all(
+        feature = "unstable-wgpu-28",
+        any(
+            feature = "renderer-skia",
+            feature = "renderer-skia-opengl",
+            feature = "renderer-skia-vulkan"
+        )
+    ))]
+    pub mod skia_renderer {
+        pub use i_slint_renderer_skia::SkiaWGPURenderer;
+    }
+
     #[cfg(feature = "renderer-software")]
     /// This module contains the [`software_renderer::SoftwareRenderer`] and related types.
     ///

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -3870,10 +3870,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "ctor-lite"
-version = "0.1.2"
+name = "ctor"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "dtor",
+]
 
 [[package]]
 name = "ctrlc"
@@ -4054,6 +4057,12 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.4",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 
 [[package]]
 name = "either"
@@ -4881,9 +4890,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "guillotiere"
@@ -6987,9 +6996,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -7019,9 +7028,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -7031,9 +7040,9 @@ dependencies = [
 
 [[package]]
 name = "orbclient"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
 dependencies = [
  "libc",
  "libredox",
@@ -7861,9 +7870,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -7883,9 +7892,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8233,6 +8242,7 @@ dependencies = [
  "i-slint-core",
  "i-slint-core-macros",
  "i-slint-renderer-femtovg",
+ "i-slint-renderer-skia",
  "i-slint-renderer-software",
  "num-traits",
  "once_cell",
@@ -8766,12 +8776,12 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor",
  "libloading",
  "pkg-config",
  "tracing",
@@ -8916,7 +8926,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -8925,7 +8935,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -9353,11 +9363,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -9366,7 +9376,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -10659,9 +10669,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -10674,6 +10684,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -61,6 +61,10 @@ pub mod opengl_surface;
 pub mod wgpu_27_surface;
 #[cfg(feature = "wgpu-28")]
 pub mod wgpu_28_surface;
+#[cfg(feature = "wgpu-28")]
+mod wgpu_renderer;
+#[cfg(feature = "wgpu-28")]
+pub use wgpu_renderer::SkiaWGPURenderer;
 
 use i_slint_core::items::{ItemRc, TextWrap};
 use itemrenderer::to_skia_rect;
@@ -560,15 +564,10 @@ impl SkiaRenderer {
         self.internal_render_with_post_callback(0., (0., 0.), size, None)
     }
 
-    fn internal_render_with_post_callback(
+    fn invoke_rendering_notifier_setup(
         &self,
-        rotation_angle_degrees: f32,
-        translation: (f32, f32),
-        surface_size: PhysicalWindowSize,
-        post_render_cb: Option<&dyn Fn(&mut dyn ItemRenderer)>,
+        surface: &dyn Surface,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
-        let surface = self.surface.borrow();
-        let Some(surface) = surface.as_ref() else { return Ok(()) };
         if self.rendering_first_time.take() {
             *self.rendering_metrics_collector.borrow_mut() =
                 RenderingMetricsCollector::new(&format!(
@@ -583,6 +582,19 @@ impl SkiaRenderer {
                 })
             }
         }
+        Ok(())
+    }
+
+    fn internal_render_with_post_callback(
+        &self,
+        rotation_angle_degrees: f32,
+        translation: (f32, f32),
+        surface_size: PhysicalWindowSize,
+        post_render_cb: Option<&dyn Fn(&mut dyn ItemRenderer)>,
+    ) -> Result<(), i_slint_core::platform::PlatformError> {
+        let surface = self.surface.borrow();
+        let Some(surface) = surface.as_ref() else { return Ok(()) };
+        self.invoke_rendering_notifier_setup(surface.as_ref())?;
 
         let window_adapter = self.window_adapter()?;
         let window = window_adapter.window();

--- a/internal/renderers/skia/wgpu_28_surface.rs
+++ b/internal/renderers/skia/wgpu_28_surface.rs
@@ -1,7 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use i_slint_core::api::{GraphicsAPI, PhysicalSize as PhysicalWindowSize, Window};
+#[cfg(feature = "unstable-wgpu-28")]
+use i_slint_core::api::GraphicsAPI;
+use i_slint_core::api::{PhysicalSize as PhysicalWindowSize, Window};
 use i_slint_core::graphics::RequestedGraphicsAPI;
 use i_slint_core::partial_renderer::DirtyRegion;
 use i_slint_core::platform::PlatformError;
@@ -20,17 +22,17 @@ mod metal;
 #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
 mod vulkan;
 
-/// This surface renders into the given window using Metal. The provided display argument
-/// is ignored, as it has no meaning on macOS.
+/// Skia rendering surface backed by WGPU. Supports both on-screen rendering (with a
+/// window surface) and offscreen rendering into caller-provided textures.
 pub struct WGPUSurface {
-    gr_context: RefCell<skia_safe::gpu::DirectContext>,
+    pub(crate) gr_context: RefCell<skia_safe::gpu::DirectContext>,
     instance: wgpu::Instance,
     device: wgpu::Device,
     queue: wgpu::Queue,
-    surface_config: RefCell<wgpu::SurfaceConfiguration>,
-    surface: wgpu::Surface<'static>,
+    surface_config: RefCell<Option<wgpu::SurfaceConfiguration>>,
+    surface: Option<wgpu::Surface<'static>>,
     textures_to_transition_for_sampling: RefCell<Vec<wgpu::Texture>>,
-    backend: Backend,
+    pub(crate) backend: Backend,
 }
 
 impl WGPUSurface {
@@ -79,15 +81,57 @@ impl WGPUSurface {
             instance,
             device,
             queue,
-            surface_config: surface_config.into(),
-            surface,
+            surface_config: Some(surface_config).into(),
+            surface: Some(surface),
             textures_to_transition_for_sampling: RefCell::new(Vec::new()),
             backend,
         })
     }
+
+    pub(crate) fn new_offscreen(
+        instance: wgpu::Instance,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        backend: Backend,
+        gr_context: skia_safe::gpu::DirectContext,
+    ) -> Self {
+        Self {
+            gr_context: RefCell::new(gr_context),
+            instance,
+            device,
+            queue,
+            surface_config: None.into(),
+            surface: None,
+            textures_to_transition_for_sampling: RefCell::new(Vec::new()),
+            backend,
+        }
+    }
+
+    /// Transitions any imported wgpu textures to sampling state and flushes
+    /// the Skia graphics context. Must be called after rendering to ensure
+    /// Skia's GPU work is submitted.
+    pub(crate) fn flush_and_submit(&self, gr_context: &mut skia_safe::gpu::DirectContext) {
+        let textures_to_transition = self.textures_to_transition_for_sampling.take();
+        if !textures_to_transition.is_empty() {
+            let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Skia texture transition encoder"),
+            });
+            encoder.transition_resources(
+                std::iter::empty(),
+                textures_to_transition.iter().map(|texture| wgpu::TextureTransition {
+                    texture,
+                    selector: None,
+                    state: wgpu::TextureUses::RESOURCE,
+                }),
+            );
+            self.queue.submit(Some(encoder.finish()));
+        }
+
+        gr_context.submit(None);
+    }
 }
 
-impl super::Surface for WGPUSurface {
+impl crate::Surface for WGPUSurface {
     fn new(
         _shared_context: &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
@@ -104,11 +148,15 @@ impl super::Surface for WGPUSurface {
     }
 
     fn name(&self) -> &'static str {
-        "wgpu"
+        if self.surface.is_some() { "wgpu" } else { "wgpu-texture" }
     }
 
     fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        let mut surface_config = self.surface_config.borrow_mut();
+        let mut surface_config_opt = self.surface_config.borrow_mut();
+        let (Some(surface_config), Some(surface)) = (surface_config_opt.as_mut(), &self.surface)
+        else {
+            return Ok(());
+        };
 
         // Skip reconfigure if size hasn't changed — DRM/KMS surfaces don't
         // support being reconfigured.
@@ -128,14 +176,14 @@ impl super::Surface for WGPUSurface {
         surface_config.width = size.width;
         surface_config.height = size.height;
 
-        self.surface.configure(&self.device, &surface_config);
+        surface.configure(&self.device, surface_config);
         Ok(())
     }
 
     fn render(
         &self,
         _window: &Window,
-        size: PhysicalWindowSize,
+        _size: PhysicalWindowSize,
         callback: &dyn Fn(
             &skia_safe::Canvas,
             Option<&mut skia_safe::gpu::DirectContext>,
@@ -143,19 +191,22 @@ impl super::Surface for WGPUSurface {
         ) -> Option<DirtyRegion>,
         pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<(), PlatformError> {
+        let (Some(surface), Some(surface_config)) = (&self.surface, &*self.surface_config.borrow())
+        else {
+            return Err("WGPUSurface::render() called on offscreen surface".into());
+        };
+
         let gr_context = &mut self.gr_context.borrow_mut();
 
-        let frame = match self.surface.get_current_texture() {
+        let frame = match surface.get_current_texture() {
             Ok(texture) => texture,
-            Err(wgpu::SurfaceError::Timeout) => {
-                self.surface.get_current_texture().map_err(|e| {
-                    format!("Error obtaining current surface texture after timeout: {e}")
-                })?
-            }
+            Err(wgpu::SurfaceError::Timeout) => surface.get_current_texture().map_err(|e| {
+                format!("Error obtaining current surface texture after timeout: {e}")
+            })?,
             // Outdated or lost: re-configure and try again
             Err(_) => {
-                self.surface.configure(&self.device, &self.surface_config.borrow());
-                self.surface.get_current_texture().map_err(|e| {
+                surface.configure(&self.device, surface_config);
+                surface.get_current_texture().map_err(|e| {
                     format!("Error obtaining current surface texture after initial error: {e}")
                 })?
             }
@@ -168,24 +219,7 @@ impl super::Surface for WGPUSurface {
 
         callback(skia_surface.canvas(), Some(gr_context), 0);
 
-        let textures_to_transition = self.textures_to_transition_for_sampling.take();
-        if !textures_to_transition.is_empty() {
-            let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("Skia texture transition encoder"),
-            });
-            encoder.transition_resources(
-                std::iter::empty(),
-                textures_to_transition.iter().map(|texture| wgpu::TextureTransition {
-                    texture,
-                    selector: None,
-                    state: wgpu::TextureUses::RESOURCE,
-                }),
-            );
-
-            self.queue.submit(Some(encoder.finish()));
-        }
-
-        gr_context.submit(None);
+        self.flush_and_submit(gr_context);
 
         if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
             pre_present_callback();
@@ -197,13 +231,18 @@ impl super::Surface for WGPUSurface {
     }
 
     fn bits_per_pixel(&self) -> Result<u8, PlatformError> {
-        Ok(match self.surface_config.borrow().format {
-            wgpu_28::TextureFormat::Rgba8Unorm
-            | wgpu_28::TextureFormat::Rgba8UnormSrgb
-            | wgpu_28::TextureFormat::Bgra8Unorm
-            | wgpu_28::TextureFormat::Bgra8UnormSrgb => 32,
-            fmt => return Err(format!("Unsupported surface format {:#?}", fmt).into()),
-        })
+        if let Some(surface_config) = &*self.surface_config.borrow() {
+            Ok(match surface_config.format {
+                wgpu_28::TextureFormat::Rgba8Unorm
+                | wgpu_28::TextureFormat::Rgba8UnormSrgb
+                | wgpu_28::TextureFormat::Bgra8Unorm
+                | wgpu_28::TextureFormat::Bgra8UnormSrgb => 32,
+                fmt => return Err(format!("Unsupported surface format {:#?}", fmt).into()),
+            })
+        } else {
+            // All supported render-target formats (Rgba8Unorm, Bgra8Unorm, and sRGB variants) are 32bpp.
+            Ok(32)
+        }
     }
 
     #[cfg(feature = "unstable-wgpu-28")]
@@ -258,7 +297,7 @@ impl raw_window_handle::HasDisplayHandle for WindowAndDisplayHandle {
     }
 }
 
-enum Backend {
+pub(crate) enum Backend {
     #[cfg(target_vendor = "apple")]
     Metal,
     #[cfg(target_family = "windows")]
@@ -290,7 +329,7 @@ impl TryFrom<wgpu::Backend> for Backend {
 }
 
 impl Backend {
-    fn make_context(
+    pub(crate) fn make_context(
         &self,
         _adapter: &wgpu::Adapter,
         device: &wgpu::Device,
@@ -306,23 +345,22 @@ impl Backend {
         }
     }
 
-    fn make_surface(
+    pub(crate) fn make_surface(
         &self,
-        size: PhysicalWindowSize,
         gr_context: &mut skia_safe::gpu::DirectContext,
-        frame: &wgpu::SurfaceTexture,
+        texture: &wgpu::Texture,
     ) -> Option<skia_safe::Surface> {
         match self {
             #[cfg(target_vendor = "apple")]
-            Self::Metal => unsafe { metal::make_metal_surface(size, gr_context, frame) },
+            Self::Metal => unsafe { metal::make_metal_surface(gr_context, texture) },
             #[cfg(target_family = "windows")]
-            Self::Dx12 => unsafe { dx12::make_dx12_surface(size, gr_context, frame) },
+            Self::Dx12 => unsafe { dx12::make_dx12_surface(gr_context, texture) },
             #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
-            Self::Vulkan => unsafe { vulkan::make_vulkan_surface(size, gr_context, frame) },
+            Self::Vulkan => unsafe { vulkan::make_vulkan_surface(gr_context, texture) },
         }
     }
 
-    fn import_texture(
+    pub(crate) fn import_texture(
         &self,
         canvas: &skia_safe::Canvas,
         texture: wgpu::Texture,

--- a/internal/renderers/skia/wgpu_28_surface.rs
+++ b/internal/renderers/skia/wgpu_28_surface.rs
@@ -161,7 +161,7 @@ impl super::Surface for WGPUSurface {
             }
         };
 
-        let skia_surface = self.backend.make_surface(size, gr_context, &frame);
+        let skia_surface = self.backend.make_surface(gr_context, &frame.texture);
 
         let mut skia_surface = skia_surface
             .ok_or_else(|| PlatformError::from("Failed to create Skia surface from WGPU"))?;

--- a/internal/renderers/skia/wgpu_28_surface/dx12.rs
+++ b/internal/renderers/skia/wgpu_28_surface/dx12.rs
@@ -1,8 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
-
 use windows::Win32::Graphics::Direct3D12::{D3D12_RESOURCE_STATE_PRESENT, ID3D12Resource};
 use windows::Win32::Graphics::Dxgi::Common::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN;
 use windows::Win32::Graphics::Dxgi::Common::{
@@ -11,39 +9,71 @@ use windows::Win32::Graphics::Dxgi::Common::{
 
 use wgpu_28 as wgpu;
 
-pub unsafe fn make_dx12_surface(
-    size: PhysicalWindowSize,
+/// # Safety
+/// `resource` must be a valid D3D12 resource for the lifetime of the returned Surface.
+unsafe fn wrap_dx12_texture(
+    width: i32,
+    height: i32,
     gr_context: &mut skia_safe::gpu::DirectContext,
-    frame: &wgpu::SurfaceTexture,
+    resource: ID3D12Resource,
+    dxgi_format: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT,
+    color_type: skia_safe::ColorType,
 ) -> Option<skia_safe::Surface> {
     unsafe {
-        let dx12_texture = frame.texture.as_hal::<wgpu::wgc::api::Dx12>();
-
         let texture_info = skia_safe::gpu::d3d::TextureResourceInfo {
-            resource: windows_core::Interface::from_raw(windows_core::Interface::into_raw(
-                dx12_texture.unwrap().raw_resource().clone(),
-            )),
+            resource,
             alloc: None,
             resource_state: D3D12_RESOURCE_STATE_PRESENT,
-            format: DXGI_FORMAT_R8G8B8A8_UNORM,
+            format: dxgi_format,
             sample_count: 1,
             level_count: 1,
             sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
             protected: skia_safe::gpu::Protected::No,
         };
-
-        let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_d3d(
-            (size.width as i32, size.height as i32),
-            &texture_info,
-        );
-
+        let backend_render_target =
+            skia_safe::gpu::BackendRenderTarget::new_d3d((width, height), &texture_info);
         skia_safe::gpu::surfaces::wrap_backend_render_target(
             gr_context,
             &backend_render_target,
             skia_safe::gpu::SurfaceOrigin::TopLeft,
-            skia_safe::ColorType::RGBA8888,
+            color_type,
             None,
             None,
+        )
+    }
+}
+
+/// # Safety
+/// The caller must ensure `texture` was created by a DX12-backed wgpu device and remains
+/// valid for the lifetime of the returned `skia_safe::Surface`.
+pub unsafe fn make_dx12_surface(
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    texture: &wgpu::Texture,
+) -> Option<skia_safe::Surface> {
+    // SAFETY: texture is borrowed for the duration of this call; the D3D12 resource is
+    // ref-counted (COM) and cloned into Skia's internal BackendRenderTarget via wrap_dx12_texture.
+    unsafe {
+        let dx12_texture = texture.as_hal::<wgpu::wgc::api::Dx12>()?;
+        let resource = windows_core::Interface::from_raw(windows_core::Interface::into_raw(
+            dx12_texture.raw_resource().clone(),
+        ));
+        let size = texture.size();
+        let (dxgi_format, color_type) = match texture.format() {
+            wgpu::TextureFormat::Rgba8Unorm => {
+                (DXGI_FORMAT_R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888)
+            }
+            wgpu::TextureFormat::Rgba8UnormSrgb => {
+                (DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, skia_safe::ColorType::SRGBA8888)
+            }
+            _ => return None,
+        };
+        wrap_dx12_texture(
+            size.width as i32,
+            size.height as i32,
+            gr_context,
+            resource,
+            dxgi_format,
+            color_type,
         )
     }
 }

--- a/internal/renderers/skia/wgpu_28_surface/metal.rs
+++ b/internal/renderers/skia/wgpu_28_surface/metal.rs
@@ -2,36 +2,55 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use foreign_types::ForeignType;
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 
 use skia_safe::gpu::mtl;
 
 use wgpu_28 as wgpu;
 
-pub unsafe fn make_metal_surface(
-    size: PhysicalWindowSize,
+/// # Safety
+/// `metal_handle` must be a valid Metal texture handle for the lifetime of the returned Surface.
+unsafe fn wrap_metal_texture(
+    width: i32,
+    height: i32,
     gr_context: &mut skia_safe::gpu::DirectContext,
-    frame: &wgpu::SurfaceTexture,
+    metal_handle: mtl::Handle,
+    color_type: skia_safe::ColorType,
 ) -> Option<skia_safe::Surface> {
     unsafe {
-        let metal_texture = frame.texture.as_hal::<wgpu::wgc::api::Metal>();
-
-        let texture_info =
-            mtl::TextureInfo::new(metal_texture.unwrap().raw_handle().as_ptr() as mtl::Handle);
-
-        let backend_render_target = skia_safe::gpu::backend_render_targets::make_mtl(
-            (size.width as i32, size.height as i32),
-            &texture_info,
-        );
-
+        let texture_info = mtl::TextureInfo::new(metal_handle);
+        let backend_render_target =
+            skia_safe::gpu::backend_render_targets::make_mtl((width, height), &texture_info);
         skia_safe::gpu::surfaces::wrap_backend_render_target(
             gr_context,
             &backend_render_target,
             skia_safe::gpu::SurfaceOrigin::TopLeft,
-            skia_safe::ColorType::BGRA8888,
+            color_type,
             None,
             None,
         )
+    }
+}
+
+/// # Safety
+/// The caller must ensure `texture` was created by a Metal-backed wgpu device and remains
+/// valid for the lifetime of the returned `skia_safe::Surface`.
+pub unsafe fn make_metal_surface(
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    texture: &wgpu::Texture,
+) -> Option<skia_safe::Surface> {
+    // SAFETY: texture is borrowed for the duration of this call; the Metal handle is copied
+    // into Skia's internal BackendRenderTarget via wrap_metal_texture.
+    unsafe {
+        let metal_texture = texture.as_hal::<wgpu::wgc::api::Metal>()?;
+        let handle = metal_texture.raw_handle().as_ptr() as mtl::Handle;
+        let size = texture.size();
+        let color_type = match texture.format() {
+            wgpu::TextureFormat::Bgra8Unorm => skia_safe::ColorType::BGRA8888,
+            wgpu::TextureFormat::Rgba8Unorm => skia_safe::ColorType::RGBA8888,
+            wgpu::TextureFormat::Rgba8UnormSrgb => skia_safe::ColorType::SRGBA8888,
+            _ => return None,
+        };
+        wrap_metal_texture(size.width as i32, size.height as i32, gr_context, handle, color_type)
     }
 }
 

--- a/internal/renderers/skia/wgpu_28_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_28_surface/vulkan.rs
@@ -1,39 +1,42 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
-
 use ash::vk::Handle;
 use skia_safe::gpu::vk;
 
 use wgpu_28 as wgpu;
 
-pub unsafe fn make_vulkan_surface(
-    size: PhysicalWindowSize,
+fn vk_format_and_color_type(
+    format: wgpu::TextureFormat,
+) -> Option<(skia_safe::gpu::vk::Format, skia_safe::ColorType)> {
+    match format {
+        wgpu::TextureFormat::Rgba8Unorm => {
+            Some((skia_safe::gpu::vk::Format::R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888))
+        }
+        wgpu::TextureFormat::Rgba8UnormSrgb => {
+            Some((skia_safe::gpu::vk::Format::R8G8B8A8_SRGB, skia_safe::ColorType::SRGBA8888))
+        }
+        wgpu::TextureFormat::Bgra8Unorm => {
+            Some((skia_safe::gpu::vk::Format::B8G8R8A8_UNORM, skia_safe::ColorType::BGRA8888))
+        }
+        _ => None,
+    }
+}
+
+/// # Safety
+/// `vk_image_raw` must be a valid Vulkan image handle for the lifetime of the returned Surface.
+unsafe fn wrap_vulkan_texture(
+    width: i32,
+    height: i32,
     gr_context: &mut skia_safe::gpu::DirectContext,
-    frame: &wgpu::SurfaceTexture,
+    vk_image_raw: u64,
+    vk_format: skia_safe::gpu::vk::Format,
+    color_type: skia_safe::ColorType,
 ) -> Option<skia_safe::Surface> {
     unsafe {
-        let vulkan_texture = frame.texture.as_hal::<wgpu::wgc::api::Vulkan>();
-
-        let alloc = skia_safe::gpu::vk::Alloc::default();
-
-        let (vk_format, color_type) = match frame.texture.format() {
-            wgpu::TextureFormat::Rgba8Unorm => {
-                (skia_safe::gpu::vk::Format::R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888)
-            }
-            wgpu::TextureFormat::Rgba8UnormSrgb => {
-                (skia_safe::gpu::vk::Format::R8G8B8A8_SRGB, skia_safe::ColorType::SRGBA8888)
-            }
-            wgpu::TextureFormat::Bgra8Unorm => {
-                (skia_safe::gpu::vk::Format::B8G8R8A8_UNORM, skia_safe::ColorType::BGRA8888)
-            }
-            _ => return None,
-        };
-
         let texture_info = &skia_safe::gpu::vk::ImageInfo::new(
-            vulkan_texture.unwrap().raw_handle().as_raw() as _,
-            alloc,
+            vk_image_raw as _,
+            skia_safe::gpu::vk::Alloc::default(),
             skia_safe::gpu::vk::ImageTiling::OPTIMAL,
             skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
             vk_format,
@@ -43,12 +46,8 @@ pub unsafe fn make_vulkan_surface(
             None,
             None,
         );
-
-        let backend_render_target = skia_safe::gpu::backend_render_targets::make_vk(
-            (size.width as i32, size.height as i32),
-            texture_info,
-        );
-
+        let backend_render_target =
+            skia_safe::gpu::backend_render_targets::make_vk((width, height), texture_info);
         skia_safe::gpu::surfaces::wrap_backend_render_target(
             gr_context,
             &backend_render_target,
@@ -56,6 +55,31 @@ pub unsafe fn make_vulkan_surface(
             color_type,
             None,
             None,
+        )
+    }
+}
+
+/// # Safety
+/// The caller must ensure `texture` was created by a Vulkan-backed wgpu device and remains
+/// valid for the lifetime of the returned `skia_safe::Surface`.
+pub unsafe fn make_vulkan_surface(
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    texture: &wgpu::Texture,
+) -> Option<skia_safe::Surface> {
+    // SAFETY: texture is borrowed for the duration of this call; the Vulkan handle is copied
+    // into Skia's internal BackendRenderTarget via wrap_vulkan_texture.
+    unsafe {
+        let vulkan_texture = texture.as_hal::<wgpu::wgc::api::Vulkan>()?;
+        let vk_image_raw = vulkan_texture.raw_handle().as_raw();
+        let size = texture.size();
+        let (vk_format, color_type) = vk_format_and_color_type(texture.format())?;
+        wrap_vulkan_texture(
+            size.width as i32,
+            size.height as i32,
+            gr_context,
+            vk_image_raw,
+            vk_format,
+            color_type,
         )
     }
 }

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -1,0 +1,201 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::pin::Pin;
+use std::rc::Rc;
+
+use i_slint_core::platform::PlatformError;
+use i_slint_core::renderer::RendererSealed;
+use i_slint_core::window::WindowAdapter;
+
+use wgpu_28 as wgpu;
+
+use crate::wgpu_28_surface::{Backend, WGPUSurface};
+use crate::{SkiaRenderer, SkiaSharedContext};
+
+/// Use the Skia renderer with WGPU when implementing a custom Slint platform where you want the
+/// scene to be rendered into a WGPU texture. The rendering is done using the
+/// [Skia](https://skia.org/) library with platform-native GPU acceleration.
+///
+/// This is the Skia equivalent of `FemtoVGWGPURenderer`, offering superior font rendering
+/// quality through platform-native text rasterizers.
+///
+/// Rendering notifier callbacks registered via
+/// [`Window::set_rendering_notifier()`](i_slint_core::api::Window::set_rendering_notifier)
+/// will receive [`GraphicsAPI::WGPU28`](i_slint_core::api::GraphicsAPI::WGPU28) with the
+/// renderer's instance, device, and queue.
+pub struct SkiaWGPURenderer {
+    renderer: SkiaRenderer,
+    surface: WGPUSurface,
+}
+
+impl SkiaWGPURenderer {
+    /// Creates a new SkiaWGPURenderer.
+    ///
+    /// The `instance`, `adapter`, `device` and `queue` are the WGPU resources used for rendering.
+    /// The `adapter` is needed to determine the GPU backend and create the Skia graphics context.
+    ///
+    /// The wgpu resources are also provided to rendering notifier callbacks via
+    /// [`GraphicsAPI::WGPU28`](i_slint_core::api::GraphicsAPI::WGPU28).
+    pub fn new(
+        instance: wgpu::Instance,
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+    ) -> Result<Self, PlatformError> {
+        let backend: Backend = adapter.get_info().backend.try_into()?;
+
+        let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
+            PlatformError::from("Failed to create Skia graphics context from WGPU")
+        })?;
+
+        let surface = WGPUSurface::new_offscreen(instance, device, queue, backend, gr_context);
+
+        let shared_context = SkiaSharedContext::default();
+        // Use SkiaRenderer::default() to stay resilient to field additions, then disable
+        // partial rendering — there is no buffer age tracking for external texture targets.
+        let mut renderer = SkiaRenderer::default(&shared_context);
+        renderer.partial_rendering_state = None;
+
+        Ok(Self { renderer, surface })
+    }
+
+    /// Render the scene to the given texture.
+    ///
+    /// The texture must have been created with `RENDER_ATTACHMENT` usage and have a supported
+    /// format. Supported formats depend on the GPU backend: `Rgba8Unorm` and `Rgba8UnormSrgb`
+    /// are supported on all backends; `Bgra8Unorm` is additionally supported on Metal and Vulkan.
+    pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
+        self.renderer.invoke_rendering_notifier_setup(&self.surface)?;
+
+        let gr_context = &mut self.surface.gr_context.borrow_mut();
+
+        let mut skia_surface =
+            self.surface.backend.make_surface(gr_context, texture).ok_or_else(|| {
+                PlatformError::from("Failed to wrap WGPU texture as Skia render target")
+            })?;
+
+        let window_adapter = self.renderer.window_adapter()?;
+        let window = window_adapter.window();
+
+        self.renderer.render_to_canvas(
+            skia_surface.canvas(),
+            0.,
+            (0., 0.),
+            Some(gr_context),
+            0,
+            Some(&self.surface),
+            window,
+            None,
+        );
+
+        self.surface.flush_and_submit(gr_context);
+
+        Ok(())
+    }
+}
+
+#[doc(hidden)]
+impl RendererSealed for SkiaWGPURenderer {
+    fn text_size(
+        &self,
+        text_item: Pin<&dyn i_slint_core::item_rendering::RenderString>,
+        item_rc: &i_slint_core::items::ItemRc,
+        max_width: Option<i_slint_core::lengths::LogicalLength>,
+        text_wrap: i_slint_core::items::TextWrap,
+    ) -> i_slint_core::lengths::LogicalSize {
+        self.renderer.text_size(text_item, item_rc, max_width, text_wrap)
+    }
+
+    fn char_size(
+        &self,
+        text_item: Pin<&dyn i_slint_core::item_rendering::HasFont>,
+        item_rc: &i_slint_core::items::ItemRc,
+        ch: char,
+    ) -> i_slint_core::lengths::LogicalSize {
+        self.renderer.char_size(text_item, item_rc, ch)
+    }
+
+    fn font_metrics(
+        &self,
+        font_request: i_slint_core::graphics::FontRequest,
+    ) -> i_slint_core::items::FontMetrics {
+        self.renderer.font_metrics(font_request)
+    }
+
+    fn text_input_byte_offset_for_position(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::items::ItemRc,
+        pos: i_slint_core::lengths::LogicalPoint,
+    ) -> usize {
+        self.renderer.text_input_byte_offset_for_position(text_input, item_rc, pos)
+    }
+
+    fn text_input_cursor_rect_for_byte_offset(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::items::ItemRc,
+        byte_offset: usize,
+    ) -> i_slint_core::lengths::LogicalRect {
+        self.renderer.text_input_cursor_rect_for_byte_offset(text_input, item_rc, byte_offset)
+    }
+
+    fn register_font_from_memory(
+        &self,
+        data: &'static [u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.renderer.register_font_from_memory(data)
+    }
+
+    fn register_font_from_path(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.renderer.register_font_from_path(path)
+    }
+
+    fn default_font_size(&self) -> i_slint_core::lengths::LogicalLength {
+        self.renderer.default_font_size()
+    }
+
+    fn set_rendering_notifier(
+        &self,
+        callback: Box<dyn i_slint_core::api::RenderingNotifier>,
+    ) -> Result<(), i_slint_core::api::SetRenderingNotifierError> {
+        self.renderer.set_rendering_notifier(callback)
+    }
+
+    fn free_graphics_resources(
+        &self,
+        component: i_slint_core::item_tree::ItemTreeRef,
+        items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
+    ) -> Result<(), PlatformError> {
+        self.renderer.free_graphics_resources(component, items)
+    }
+
+    fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
+        self.renderer.set_window_adapter(window_adapter)
+    }
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        RendererSealed::window_adapter(&self.renderer)
+    }
+
+    fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {
+        self.renderer.resize(size)
+    }
+
+    fn take_snapshot(
+        &self,
+    ) -> Result<
+        i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+        PlatformError,
+    > {
+        self.renderer.take_snapshot()
+    }
+
+    fn supports_transformations(&self) -> bool {
+        self.renderer.supports_transformations()
+    }
+}


### PR DESCRIPTION
## Summary

- Refactors the Skia WGPU backend surface functions to accept `&wgpu::Texture` instead of `&SurfaceTexture`, enabling reuse for both on-screen and offscreen rendering
- Makes `WGPUSurface` support offscreen (texture-only) mode with `Option` surface/config fields
- Adds `SkiaWGPURenderer` — the Skia equivalent of `FemtoVGWGPURenderer` — for rendering Slint scenes into caller-provided WGPU textures
- Exposes `SkiaWGPURenderer` in the public API at `slint::platform::skia_renderer` (behind `unstable-wgpu-28` feature gate)
- Wires up `dep:i-slint-renderer-skia` in Cargo feature flags for the selector and slint crates

Obsoletes #11456, which took a different approach (monolithic, no refactoring of the backend surface layer).

## Test plan

- [ ] Verify existing Skia WGPU on-screen rendering is unaffected (gallery example with `renderer-skia`)
- [ ] Verify `SkiaWGPURenderer::render_to_texture()` works with the bevy-hosts-slint-gpu example (see companion PR)
- [ ] Verify rendering notifier callbacks (`RenderingSetup`, `BeforeRendering`, `AfterRendering`) fire correctly in the offscreen path