### PR TITLE
Fix interface defaults overriding two-way bindings

### DIFF
--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -321,7 +321,9 @@ pub(super) fn apply_default_property_values(
         })
         .filter(|(property_name, _)| {
             // Only apply the default binding if there isn't already a binding set on the element.
-            !e.borrow().is_binding_set(property_name, true)
+            // `need_explicit: false` includes two-way bindings from a `uses { ... }` alias on
+            // a base component — overriding those with an interface default would sever the alias.
+            !e.borrow().is_binding_set(property_name, false)
         })
         .collect();
 

--- a/tests/cases/interfaces/implements_inherits_aliased_property.slint
+++ b/tests/cases/interfaces/implements_inherits_aliased_property.slint
@@ -1,0 +1,49 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// When a component `implements` an interface whose property has a default
+// value AND inherits a base that exposes the same property via a `uses { ... }`
+// alias, the interface's default value must not override the alias.
+//
+// `sink.value` defaults to `true`, so if the alias is intact, `value` reads
+// as `true`. If the interface's `false` default clobbered the alias, it reads
+// as `false`.
+
+interface I {
+    in-out property <bool> value: false;
+}
+
+component Sink implements I {
+    value: true;
+}
+
+component Base uses { I from sink } {
+    sink := Sink { }
+
+    @children
+}
+
+component Derived implements I inherits Base { }
+
+export component TestCase {
+    out property <bool> test: derived.value;
+    derived := Derived { }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
When a component `implements` an interface whose property has a default value AND inherits a base that exposes the same property via a `uses { ... }` alias, the interface's default value must not override the alias.

This issue was caused by `apply_default_property_values` applying interface defaults for properties that had bindings because `Element::is_binding_set` was called with `need_explicit: true` - causing it to exclude two-way bindings.

This issue was discovered whilst implementing interface inheritance, which is why the test case might appear a bit contrived. It is a minimal case that reproduces the issue. It could be modified by adding an inherited interface:

```slint
interface J inherits I { }
```

and having `Derived` implement `J` instead of `I`:

```slint
component Derived implements J inherits Base { }
```