### PR TITLE
Fix: Add missing default expression for StyledText

### DIFF
--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -149,27 +149,33 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
 
                 if let Some(arg) = args.get(arg_index) {
                     let arg_paragraphs = arg.as_ref();
-                    if arg_paragraphs.len() != 1 {
-                        return Err(StyledTextError::MultiParagraphInterpolation);
-                    }
-                    let arg_paragraph = &arg_paragraphs[0];
 
-                    let offset = paragraph.text.len();
-                    paragraph.text.push_str(&arg_paragraph.text);
-                    paragraph.formatting.extend(arg_paragraph.formatting.iter().cloned().map(
-                        |mut f| {
-                            f.range.start += offset;
-                            f.range.end += offset;
-                            f
-                        },
-                    ));
-                    paragraph.links.extend(arg_paragraph.links.iter().cloned().map(
-                        |(mut range, link)| {
-                            range.start += offset;
-                            range.end += offset;
-                            (range, link)
-                        },
-                    ));
+                    match arg_paragraphs {
+                        [arg_paragraph] => {
+                            let offset = paragraph.text.len();
+                            paragraph.text.push_str(&arg_paragraph.text);
+                            paragraph.formatting.extend(
+                                arg_paragraph.formatting.iter().cloned().map(|mut f| {
+                                    f.range.start += offset;
+                                    f.range.end += offset;
+                                    f
+                                }),
+                            );
+                            paragraph.links.extend(arg_paragraph.links.iter().cloned().map(
+                                |(mut range, link)| {
+                                    range.start += offset;
+                                    range.end += offset;
+                                    (range, link)
+                                },
+                            ));
+                        }
+                        [] => {
+                            // No paragraphs in the argument, so nothing to add
+                        }
+                        _ => {
+                            return Err(StyledTextError::MultiParagraphInterpolation);
+                        }
+                    }
                 } else {
                     return Err(StyledTextError::ArgumentOutOfRange(arg_index, args.len()));
                 }
@@ -736,4 +742,11 @@ fn markdown_parsing_interpolated() {
             links: alloc::vec![]
         }]
     );
+    // Empty paragraph list might be caused by a StyledText::default()
+    assert_eq!(
+        parse_interpolated(&format!("{MARKDOWN_INTERPOLATION_PLACEHOLDER}"), &[[]])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap(),
+        [StyledTextParagraph { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }]
+    )
 }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1562,7 +1562,11 @@ impl Expression {
             }
             Type::Keys => Expression::Keys(Keys::default()),
             Type::ComponentFactory => Expression::EmptyComponentFactory,
-            Type::StyledText => Expression::Invalid,
+            Type::StyledText => Expression::FunctionCall {
+                function: Callable::Builtin(BuiltinFunction::StringToStyledText),
+                arguments: vec![Self::default_value_for_type(&Type::String)],
+                source_location: None,
+            },
         }
     }
 

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -96,10 +96,23 @@ pub fn parse_markdown<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph
 pub fn string_to_styled_text(_string: alloc::string::String) -> StyledText {
     #[cfg(feature = "std")]
     {
+        if _string.is_empty() {
+            return Default::default();
+        }
         StyledText {
             paragraphs: [i_slint_common::styled_text::paragraph_from_plain_text(_string)].into(),
         }
     }
     #[cfg(not(feature = "std"))]
     Default::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_to_styled_text() {
+        assert_eq!(super::string_to_styled_text(Default::default()), StyledText::default());
+    }
 }

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -3,6 +3,11 @@
 
 //ignore: pyi
 
+export struct TestStruct {
+    label: string,
+    text: styled-text,
+}
+
 export component TestCase inherits Window {
     property <string> world: "World";
     VerticalLayout {
@@ -36,6 +41,11 @@ export component TestCase inherits Window {
     out property<styled-text> t1: s1.text;
     out property<styled-text> t2: s2.text;
     out property<styled-text> t3: s3.text;
+    // Regression test for #11471 - StyledText type must have a default,
+    // otherwise it crashes when left out of a struct declaration!
+    out property<TestStruct> default-struct : {
+        label: "test",
+    };
 
     out property<length> w1: s1.preferred-width;
     out property<length> w2: s2.preferred-width;
@@ -61,6 +71,8 @@ assert_eq!(instance.get_w3(), 64.0);
 assert_eq!(instance.get_w4(), 64.0);
 assert_eq!(instance.get_w5(), 65.0);
 assert!(instance.get_test());
+
+assert_eq!(instance.get_default_struct().text, StyledText::default());
 ```
 ```cpp
 auto handle = TestCase::create();


### PR DESCRIPTION
To avoid adding another expression variant this just calls
string_to_styled_text.
In order for this to work correctly though, we need the
string_to_styled_text function to return a default StyledText if the string
is empty.

This also surfaced an issue where string interpolation did not work
correctly if one argument is a default constructed styled text.

Closes #11471

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
