### PR TITLE
Fix dependency calculation for layer size

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1120,10 +1120,8 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         let cache_entry = self.graphics_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let origin = bounding_rect.origin * self.scale_factor;
-            let size = (bounding_rect.size * self.scale_factor)
-                .ceil()
-                .try_cast()
-                .unwrap_or(euclid::Size2D::splat(0));
+            let size =
+                (bounding_rect.size * self.scale_factor).ceil().try_cast().unwrap_or_default();
 
             let layer_image = existing_layer_texture
                 .and_then(|layer_texture| {
@@ -1150,7 +1148,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                 // dependencies between the layer size and the descendents' bounding boxes can be
                 // tracked. If the size is 0, the above `new_empty_on_gpu` call will fail, so we
                 // use a dummy texture here.
-                .unwrap_or_else(|| &self.dummy_texture)
+                .unwrap_or(&self.dummy_texture)
                 .as_render_target();
 
             self.save_state();

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1112,7 +1112,11 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         let cache_entry = self.graphics_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let origin = bounding_rect.origin * self.scale_factor;
-            let size = (bounding_rect.size * self.scale_factor).ceil().try_cast()?;
+            let size = (bounding_rect.size * self.scale_factor)
+                .ceil()
+                .max(euclid::Size2D::splat(1.))
+                .try_cast()
+                .unwrap_or(euclid::Size2D::splat(1));
 
             let layer_image = existing_layer_texture
                 .and_then(|layer_texture| {
@@ -1130,14 +1134,14 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                 .or_else(|| {
                     *self.metrics.layers_created.as_mut().unwrap() += 1;
                     Texture::new_empty_on_gpu(&self.canvas, size.width, size.height)
-                })?;
+                })
+                .expect("Could not create render target texture");
 
             let previous_render_target = self.current_render_target();
 
+            self.save_state();
             {
                 let mut canvas = self.canvas.borrow_mut();
-                canvas.save();
-
                 canvas.set_render_target(layer_image.as_render_target());
 
                 canvas.reset();
@@ -1162,12 +1166,8 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                 &window_adapter,
             );
 
-            {
-                let mut canvas = self.canvas.borrow_mut();
-                canvas.restore();
-
-                canvas.set_render_target(previous_render_target);
-            }
+            self.restore_state();
+            self.canvas.borrow_mut().set_render_target(previous_render_target);
 
             Some(ItemGraphicsCacheEntry::TextureWithOrigin { texture: layer_image, origin })
         });

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1112,6 +1112,9 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         let cache_entry = self.graphics_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let origin = bounding_rect.origin * self.scale_factor;
+            // We need `Texture::new_empty_on_gpu` to actually return something, so
+            // `render_item_children` can be called and any dependencies between the
+            // layer size and the descendents' bounding boxes can be tracked.
             let size = (bounding_rect.size * self.scale_factor)
                 .ceil()
                 .max(euclid::Size2D::splat(1.))
@@ -1135,6 +1138,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                     *self.metrics.layers_created.as_mut().unwrap() += 1;
                     Texture::new_empty_on_gpu(&self.canvas, size.width, size.height)
                 })
+                // Explicitly panic here to prevent silently causing dependencies to be untracked
                 .expect("Could not create render target texture");
 
             let previous_render_target = self.current_render_target();

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1045,6 +1045,10 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         height: u32,
     ) -> Self {
         let scale_factor = ScaleFactor::new(window.scale_factor());
+        // femtovg doesn't have a concept of a null renderer, so we need to create _something_ to
+        // render to. Textures can't be zero-sized, so we need to give it a size of 1px. When we use
+        // this texture in `render_layer`, we discard the result, so we can safely reuse it many
+        // times.
         let dummy_texture =
             Texture::new_empty_on_gpu(canvas, 1, 1).expect("Could not create dummy texture");
         Self {

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1179,6 +1179,10 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
             self.restore_state();
             self.canvas.borrow_mut().set_render_target(previous_render_target);
 
+            // We do the `?` short-circuiting right at the end - we don't want to store the dummy texture in
+            // the layer cache, but we still want to call `render_item_children` in order to set up
+            // dependencies. This means that we still handle dependencies but ultimately return `None` if
+            // `layer_image` is `None`.
             Some(ItemGraphicsCacheEntry::TextureWithOrigin { texture: layer_image?, origin })
         });
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::RefCell;
+use std::ops::Deref as _;
 use std::pin::Pin;
 use std::rc::Rc;
 
@@ -103,6 +104,7 @@ pub struct GLItemRenderer<'a, R: femtovg::Renderer + TextureImporter> {
     window: &'a i_slint_core::api::Window,
     scale_factor: ScaleFactor,
     text_layout_cache: &'a sharedparley::TextLayoutCache,
+    dummy_texture: Rc<super::images::Texture<R>>,
     /// track the state manually since femtovg don't have accessor for its state
     state: Vec<State>,
     metrics: RenderingMetrics,
@@ -1044,6 +1046,8 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         height: u32,
     ) -> Self {
         let scale_factor = ScaleFactor::new(window.scale_factor());
+        let dummy_texture =
+            Texture::new_empty_on_gpu(canvas, 1, 1).expect("Could not create dummy texture");
         Self {
             graphics_cache,
             texture_cache,
@@ -1053,6 +1057,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
             window,
             scale_factor,
             text_layout_cache,
+            dummy_texture,
             state: vec![State {
                 scissor: LogicalRect::new(
                     LogicalPoint::default(),
@@ -1112,23 +1117,20 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         let cache_entry = self.graphics_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let origin = bounding_rect.origin * self.scale_factor;
-            // We need `Texture::new_empty_on_gpu` to actually return something, so
-            // `render_item_children` can be called and any dependencies between the
-            // layer size and the descendents' bounding boxes can be tracked.
             let size = (bounding_rect.size * self.scale_factor)
                 .ceil()
-                .max(euclid::Size2D::splat(1.))
                 .try_cast()
-                .unwrap_or(euclid::Size2D::splat(1));
+                .unwrap_or(euclid::Size2D::splat(0));
 
             let layer_image = existing_layer_texture
                 .and_then(|layer_texture| {
-                    // If we have an existing layer texture, there must be only one reference from within
-                    // the existing cache entry and one through the `existing_layer_texture` variable.
-                    // Then it is safe to render new content into it in this callback and when we return
-                    // into `get_or_update_cache_entry` the first ref is dropped.
-                    debug_assert_eq!(Rc::strong_count(&layer_texture), 2);
-                    if layer_texture.size() == Some(size.to_untyped()) {
+                    if Rc::strong_count(&layer_texture) > 2 {
+                        // If we have an existing layer texture, there must be only one reference from within
+                        // the existing cache entry and one through the `existing_layer_texture` variable.
+                        // Then it is safe to render new content into it in this callback and when we return
+                        // into `get_or_update_cache_entry` the first ref is dropped.
+                        None
+                    } else if layer_texture.size() == Some(size.to_untyped()) {
                         Some(layer_texture)
                     } else {
                         None
@@ -1138,8 +1140,11 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                     *self.metrics.layers_created.as_mut().unwrap() += 1;
                     Texture::new_empty_on_gpu(&self.canvas, size.width, size.height)
                 })
-                // Explicitly panic here to prevent silently causing dependencies to be untracked
-                .expect("Could not create render target texture");
+                // We need something to render to, so `render_item_children` can be called and any
+                // dependencies between the layer size and the descendents' bounding boxes can be
+                // tracked. If the size is 0, the above `new_empty_on_gpu` call will fail, so we
+                // use a dummy texture here.
+                .unwrap_or_else(|| self.dummy_texture.clone());
 
             let previous_render_target = self.current_render_target();
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::RefCell;
-use std::ops::Deref as _;
 use std::pin::Pin;
 use std::rc::Rc;
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1123,13 +1123,12 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
 
             let layer_image = existing_layer_texture
                 .and_then(|layer_texture| {
-                    if Rc::strong_count(&layer_texture) > 2 {
-                        // If we have an existing layer texture, there must be only one reference from within
-                        // the existing cache entry and one through the `existing_layer_texture` variable.
-                        // Then it is safe to render new content into it in this callback and when we return
-                        // into `get_or_update_cache_entry` the first ref is dropped.
-                        None
-                    } else if layer_texture.size() == Some(size.to_untyped()) {
+                    // If we have an existing layer texture, there must be only one reference from within
+                    // the existing cache entry and one through the `existing_layer_texture` variable.
+                    // Then it is safe to render new content into it in this callback and when we return
+                    // into `get_or_update_cache_entry` the first ref is dropped.
+                    debug_assert_eq!(Rc::strong_count(&layer_texture), 2);
+                    if layer_texture.size() == Some(size.to_untyped()) {
                         Some(layer_texture)
                     } else {
                         None
@@ -1138,19 +1137,22 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                 .or_else(|| {
                     *self.metrics.layers_created.as_mut().unwrap() += 1;
                     Texture::new_empty_on_gpu(&self.canvas, size.width, size.height)
-                })
+                });
+
+            let previous_render_target = self.current_render_target();
+            let layer_render_target = layer_image
+                .as_ref()
                 // We need something to render to, so `render_item_children` can be called and any
                 // dependencies between the layer size and the descendents' bounding boxes can be
                 // tracked. If the size is 0, the above `new_empty_on_gpu` call will fail, so we
                 // use a dummy texture here.
-                .unwrap_or_else(|| self.dummy_texture.clone());
-
-            let previous_render_target = self.current_render_target();
+                .unwrap_or_else(|| &self.dummy_texture)
+                .as_render_target();
 
             self.save_state();
             {
                 let mut canvas = self.canvas.borrow_mut();
-                canvas.set_render_target(layer_image.as_render_target());
+                canvas.set_render_target(layer_render_target);
 
                 canvas.reset();
 
@@ -1162,7 +1164,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
             *self.state.last_mut().unwrap() = State {
                 scissor: bounding_rect,
                 global_alpha: 1.,
-                current_render_target: layer_image.as_render_target(),
+                current_render_target: layer_render_target,
             };
 
             let window_adapter = self.window().window_adapter();
@@ -1177,7 +1179,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
             self.restore_state();
             self.canvas.borrow_mut().set_render_target(previous_render_target);
 
-            Some(ItemGraphicsCacheEntry::TextureWithOrigin { texture: layer_image, origin })
+            Some(ItemGraphicsCacheEntry::TextureWithOrigin { texture: layer_image?, origin })
         });
 
         cache_entry.and_then(|item_cache_entry| match item_cache_entry {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -364,6 +364,9 @@ impl<'a> SkiaItemRenderer<'a> {
         self.layer_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let physical_origin = bounding_rect.origin * self.scale_factor;
+            // We need `new_surface` to actually return something, so `render_item_children`
+            // can be called and any dependencies between the layer size and the descendents'
+            // bounding boxes can be tracked.
             let layer_size =
                 (bounding_rect.size * self.scale_factor).max(euclid::Size2D::splat(1.));
 
@@ -373,6 +376,7 @@ impl<'a> SkiaItemRenderer<'a> {
                 skia_safe::AlphaType::Premul,
                 None,
             );
+            // Explicitly panic here to prevent silently causing dependencies to be untracked
             let mut surface =
                 self.canvas.new_surface(&image_info, None).expect("Could not create surface");
             let canvas = surface.canvas();

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -37,7 +37,7 @@ pub struct SkiaItemRenderer<'a> {
     pub window: &'a i_slint_core::api::Window,
     surface: Option<&'a dyn crate::Surface>,
     // Shared canvas for when we want to call rendering functions without actually doing anything.
-    dummy_canvas: skia_safe::OwnedCanvas<'static>,
+    dummy_canvas: skia_safe::OwnedCanvas<'a>,
     state_stack: Vec<RenderState>,
     current_state: RenderState,
     image_cache: &'a ItemCache<Option<skia_safe::Image>>,
@@ -403,7 +403,10 @@ impl<'a> SkiaItemRenderer<'a> {
                 &WindowInner::from_pub(self.window).window_adapter(),
             );
 
-            //
+            // We do the `?` short-circuiting right at the end - we don't want to store an empty surface in
+            // the layer cache, but we still want to call `render_item_children` in order to set up
+            // dependencies. This means that we still handle dependencies but ultimately return `None` if
+            // `layer_image` is `None`.
             Some((physical_origin.to_vector(), surface?.image_snapshot()))
         })
     }

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -367,8 +367,7 @@ impl<'a> SkiaItemRenderer<'a> {
         self.layer_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let physical_origin = bounding_rect.origin * self.scale_factor;
-            let layer_size =
-                (bounding_rect.size * self.scale_factor).max(euclid::Size2D::splat(1.));
+            let layer_size = bounding_rect.size * self.scale_factor;
 
             let image_info = skia_safe::ImageInfo::new(
                 to_skia_size(&layer_size).to_ceil(),
@@ -378,30 +377,32 @@ impl<'a> SkiaItemRenderer<'a> {
             );
             let mut surface = self.canvas.new_surface(&image_info, None);
 
-            let canvas = match &mut surface {
-                Some(surface) => surface.canvas(),
-                None => &self.dummy_canvas,
-            };
-            canvas.clear(skia_safe::Color::TRANSPARENT);
+            {
+                let canvas = match &mut surface {
+                    Some(surface) => surface.canvas(),
+                    None => &self.dummy_canvas,
+                };
+                canvas.clear(skia_safe::Color::TRANSPARENT);
 
-            let mut sub_renderer = SkiaItemRenderer::new(
-                canvas,
-                self.window,
-                self.surface,
-                self.image_cache,
-                self.layer_cache,
-                self.path_cache,
-                self.text_layout_cache,
-                self.box_shadow_cache,
-            );
-            sub_renderer.translate(-bounding_rect.origin.to_vector());
+                let mut sub_renderer = SkiaItemRenderer::new(
+                    canvas,
+                    self.window,
+                    self.surface,
+                    self.image_cache,
+                    self.layer_cache,
+                    self.path_cache,
+                    self.text_layout_cache,
+                    self.box_shadow_cache,
+                );
+                sub_renderer.translate(-bounding_rect.origin.to_vector());
 
-            i_slint_core::item_rendering::render_item_children(
-                &mut sub_renderer,
-                item_rc.item_tree(),
-                item_rc.index() as isize,
-                &WindowInner::from_pub(self.window).window_adapter(),
-            );
+                i_slint_core::item_rendering::render_item_children(
+                    &mut sub_renderer,
+                    item_rc.item_tree(),
+                    item_rc.index() as isize,
+                    &WindowInner::from_pub(self.window).window_adapter(),
+                );
+            }
 
             // We do the `?` short-circuiting right at the end - we don't want to store an empty surface in
             // the layer cache, but we still want to call `render_item_children` in order to set up

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -36,6 +36,7 @@ pub struct SkiaItemRenderer<'a> {
     pub scale_factor: ScaleFactor,
     pub window: &'a i_slint_core::api::Window,
     surface: Option<&'a dyn crate::Surface>,
+    dummy_surface: skia_safe::Surface,
     state_stack: Vec<RenderState>,
     current_state: RenderState,
     image_cache: &'a ItemCache<Option<skia_safe::Image>>,
@@ -56,11 +57,19 @@ impl<'a> SkiaItemRenderer<'a> {
         text_layout_cache: &'a sharedparley::TextLayoutCache,
         box_shadow_cache: &'a mut SkiaBoxShadowCache,
     ) -> Self {
+        let dummy_image_info = skia_safe::ImageInfo::new(
+            skia_safe::ISize::new(1, 1),
+            skia_safe::ColorType::RGBA8888,
+            skia_safe::AlphaType::Premul,
+            None,
+        );
+
         Self {
             canvas,
             scale_factor: ScaleFactor::new(window.scale_factor()),
             window,
             surface,
+            dummy_surface: canvas.new_surface(&dummy_image_info, None).unwrap(),
             state_stack: Vec::new(),
             current_state: RenderState {
                 alpha: 1.0,
@@ -364,9 +373,6 @@ impl<'a> SkiaItemRenderer<'a> {
         self.layer_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let physical_origin = bounding_rect.origin * self.scale_factor;
-            // We need `new_surface` to actually return something, so `render_item_children`
-            // can be called and any dependencies between the layer size and the descendents'
-            // bounding boxes can be tracked.
             let layer_size =
                 (bounding_rect.size * self.scale_factor).max(euclid::Size2D::splat(1.));
 
@@ -376,9 +382,14 @@ impl<'a> SkiaItemRenderer<'a> {
                 skia_safe::AlphaType::Premul,
                 None,
             );
-            // Explicitly panic here to prevent silently causing dependencies to be untracked
-            let mut surface =
-                self.canvas.new_surface(&image_info, None).expect("Could not create surface");
+            let mut surface = self
+                .canvas
+                .new_surface(&image_info, None)
+                // We need `new_surface` to actually return something, so `render_item_children`
+                // can be called and any dependencies between the layer size and the descendents'
+                // bounding boxes can be tracked.
+                .unwrap_or_else(|| self.dummy_surface.clone());
+
             let canvas = surface.canvas();
             canvas.clear(skia_safe::Color::TRANSPARENT);
 

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -36,7 +36,8 @@ pub struct SkiaItemRenderer<'a> {
     pub scale_factor: ScaleFactor,
     pub window: &'a i_slint_core::api::Window,
     surface: Option<&'a dyn crate::Surface>,
-    dummy_surface: skia_safe::Surface,
+    // Shared canvas for when we want to call rendering functions without actually doing anything.
+    dummy_canvas: skia_safe::OwnedCanvas<'static>,
     state_stack: Vec<RenderState>,
     current_state: RenderState,
     image_cache: &'a ItemCache<Option<skia_safe::Image>>,
@@ -57,19 +58,12 @@ impl<'a> SkiaItemRenderer<'a> {
         text_layout_cache: &'a sharedparley::TextLayoutCache,
         box_shadow_cache: &'a mut SkiaBoxShadowCache,
     ) -> Self {
-        let dummy_image_info = skia_safe::ImageInfo::new(
-            skia_safe::ISize::new(1, 1),
-            skia_safe::ColorType::RGBA8888,
-            skia_safe::AlphaType::Premul,
-            None,
-        );
-
         Self {
             canvas,
             scale_factor: ScaleFactor::new(window.scale_factor()),
             window,
             surface,
-            dummy_surface: canvas.new_surface(&dummy_image_info, None).unwrap(),
+            dummy_canvas: Default::default(),
             state_stack: Vec::new(),
             current_state: RenderState {
                 alpha: 1.0,
@@ -382,15 +376,12 @@ impl<'a> SkiaItemRenderer<'a> {
                 skia_safe::AlphaType::Premul,
                 None,
             );
-            let mut surface = self
-                .canvas
-                .new_surface(&image_info, None)
-                // We need `new_surface` to actually return something, so `render_item_children`
-                // can be called and any dependencies between the layer size and the descendents'
-                // bounding boxes can be tracked.
-                .unwrap_or_else(|| self.dummy_surface.clone());
+            let mut surface = self.canvas.new_surface(&image_info, None);
 
-            let canvas = surface.canvas();
+            let canvas = match &mut surface {
+                Some(surface) => surface.canvas(),
+                None => &self.dummy_canvas,
+            };
             canvas.clear(skia_safe::Color::TRANSPARENT);
 
             let mut sub_renderer = SkiaItemRenderer::new(
@@ -412,7 +403,8 @@ impl<'a> SkiaItemRenderer<'a> {
                 &WindowInner::from_pub(self.window).window_adapter(),
             );
 
-            Some((physical_origin.to_vector(), surface.image_snapshot()))
+            //
+            Some((physical_origin.to_vector(), surface?.image_snapshot()))
         })
     }
 

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -364,7 +364,8 @@ impl<'a> SkiaItemRenderer<'a> {
         self.layer_cache.get_or_update_cache_entry(item_rc, || {
             let bounding_rect = layer_bounding_rect_fn();
             let physical_origin = bounding_rect.origin * self.scale_factor;
-            let layer_size = bounding_rect.size * self.scale_factor;
+            let layer_size =
+                (bounding_rect.size * self.scale_factor).max(euclid::Size2D::splat(1.));
 
             let image_info = skia_safe::ImageInfo::new(
                 to_skia_size(&layer_size).to_ceil(),
@@ -372,7 +373,8 @@ impl<'a> SkiaItemRenderer<'a> {
                 skia_safe::AlphaType::Premul,
                 None,
             );
-            let mut surface = self.canvas.new_surface(&image_info, None)?;
+            let mut surface =
+                self.canvas.new_surface(&image_info, None).expect("Could not create surface");
             let canvas = surface.canvas();
             canvas.clear(skia_safe::Color::TRANSPARENT);
 


### PR DESCRIPTION
Closes #11431.

This causes us to unconditionally call `render_item_children` on Skia and FemtoVG when rendering a layer, as otherwise a layer that starts with width or height 0 will not have tracking set up for the dependency between the layer size and the bounding boxes of the descendents.