### PR TITLE
Fix tab focus skipping Flickable items inside a clip container

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -398,35 +398,26 @@ impl ItemRc {
             return true;
         }
 
-        let (_, geometry) = self.absolute_clip_rect_and_geometry();
-        let geometry = geometry.to_box2d();
-
-        let mut clip = LogicalRect::from_size((crate::Coord::MAX, crate::Coord::MAX).into());
-        let mut ancestors = Vec::new();
+        // The item is not visible. Walk toward the root and find the first
+        // clipping ancestor that actually hides the item: if it is a
+        // Flickable, scrolling can bring the item back into view.
+        let geometry = self.absolute_clip_rect_and_geometry().1.to_box2d();
         let mut parent = self.parent_item(ParentItemTraversalMode::StopAtPopups);
-        while let Some(item_rc) = parent {
-            parent = item_rc.parent_item(ParentItemTraversalMode::StopAtPopups);
-            ancestors.push(item_rc);
-        }
-
-        for ancestor in ancestors.into_iter().rev() {
-            let clips_children = ancestor.borrow().as_ref().clips_children();
-            if !clips_children {
-                continue;
+        while let Some(ancestor) = parent {
+            if ancestor.borrow().as_ref().clips_children() {
+                let (clip, ancestor_geo) = ancestor.absolute_clip_rect_and_geometry();
+                let clip = ancestor_geo.intersection(&clip).unwrap_or_default().to_box2d();
+                let item_in_clip = !clip.is_empty()
+                    && clip.max.x >= geometry.min.x
+                    && clip.max.y >= geometry.min.y
+                    && clip.min.x <= geometry.max.x
+                    && clip.min.y <= geometry.max.y;
+                if !item_in_clip {
+                    return ancestor.downcast::<crate::items::Flickable>().is_some()
+                        && ancestor.is_visible_or_clipped_by_flickable();
+                }
             }
-
-            let ancestor_geometry = ancestor.absolute_clip_rect_and_geometry().1;
-            clip = ancestor_geometry.intersection(&clip).unwrap_or_default();
-            let clip = clip.to_box2d();
-
-            let is_visible = !clip.is_empty()
-                && clip.max.x >= geometry.min.x
-                && clip.max.y >= geometry.min.y
-                && clip.min.x <= geometry.max.x
-                && clip.min.y <= geometry.max.y;
-            if !is_visible {
-                return ancestor.downcast::<crate::items::Flickable>().is_some();
-            }
+            parent = ancestor.parent_item(ParentItemTraversalMode::StopAtPopups);
         }
 
         false
@@ -1052,7 +1043,6 @@ impl ItemRc {
                         ),
                     ],
                 );
-                break;
             }
 
             parent = item_rc.parent_item(ParentItemTraversalMode::StopAtPopups);

--- a/tests/cases/issues/issue_10321_tab_focus_flickable_clip.slint
+++ b/tests/cases/issues/issue_10321_tab_focus_flickable_clip.slint
@@ -3,37 +3,57 @@
 
 // cSpell: ignore backtab
 
+// Same as issue_10321_tab_focus_flickable but with the Flickable
+// inside a clip:true container. Also tests that a visible:false
+// Flickable's items are skipped during tab navigation.
+
 export component TestCase inherits Window {
     width: 120px;
     height: 110px;
 
     out property <int> focused-index: -1;
 
-    flick := Flickable {
+    Rectangle {
+        clip: true;
         width: 100%;
         height: 100%;
-        viewport-height: 420px;
 
-        VerticalLayout {
-            width: parent.width;
-            spacing: 10px;
+        flick := Flickable {
+            width: 100%;
+            height: 100%;
+            viewport-height: 420px;
 
-            for _[index] in [0, 1, 2, 3, 4, 5] : FocusScope {
-                width: 100%;
-                height: 60px;
-                focus-gained(_) => { root.focused-index = index; }
+            VerticalLayout {
+                width: parent.width;
+                spacing: 10px;
 
-                Rectangle {
+                for _[index] in [0, 1, 2, 3, 4, 5] : FocusScope {
                     width: 100%;
-                    height: 100%;
-                    background: index == 0 ? red
-                        : index == 1 ? orange
-                        : index == 2 ? yellow
-                        : index == 3 ? green
-                        : index == 4 ? blue
-                        : purple;
+                    height: 60px;
+                    focus-gained(_) => { root.focused-index = index; }
+
+                    Rectangle {
+                        width: 100%;
+                        height: 100%;
+                        background: index == 0 ? red
+                            : index == 1 ? orange
+                            : index == 2 ? yellow
+                            : index == 3 ? green
+                            : index == 4 ? blue
+                            : purple;
+                    }
                 }
             }
+        }
+    }
+
+    // Items inside a visible:false Flickable must not receive tab focus.
+    Flickable {
+        visible: false;
+        viewport-height: 200px;
+        FocusScope {
+            height: 60px;
+            focus-gained(_) => { root.focused-index = 100; }
         }
     }
 }

--- a/tests/cases/issues/issue_10321_tab_focus_nested_flickable.slint
+++ b/tests/cases/issues/issue_10321_tab_focus_nested_flickable.slint
@@ -3,35 +3,47 @@
 
 // cSpell: ignore backtab
 
+// Test tab/shift-tab with nested Flickables: the inner Flickable is
+// scrolled out of the outer Flickable's viewport.
+
 export component TestCase inherits Window {
     width: 120px;
-    height: 110px;
+    height: 200px;
 
     out property <int> focused-index: -1;
 
-    flick := Flickable {
+    outer := Flickable {
         width: 100%;
         height: 100%;
-        viewport-height: 420px;
+        viewport-height: 500px;
 
-        VerticalLayout {
-            width: parent.width;
-            spacing: 10px;
+        FocusScope {
+            y: 0;
+            width: 100%;
+            height: 60px;
+            focus-gained(_) => { root.focused-index = 0; }
+            Rectangle { width: 100%; height: 100%; background: red; }
+        }
 
-            for _[index] in [0, 1, 2, 3, 4, 5] : FocusScope {
-                width: 100%;
-                height: 60px;
-                focus-gained(_) => { root.focused-index = index; }
+        inner := Flickable {
+            y: 300px;
+            width: 100%;
+            height: 200px;
+            viewport-height: 400px;
 
-                Rectangle {
+            VerticalLayout {
+                width: parent.width;
+                spacing: 10px;
+
+                for val[_] in [1, 2, 3] : FocusScope {
                     width: 100%;
-                    height: 100%;
-                    background: index == 0 ? red
-                        : index == 1 ? orange
-                        : index == 2 ? yellow
-                        : index == 3 ? green
-                        : index == 4 ? blue
-                        : purple;
+                    height: 60px;
+                    focus-gained(_) => { root.focused-index = val; }
+                    Rectangle {
+                        width: 100%;
+                        height: 100%;
+                        background: val == 1 ? green : val == 2 ? blue : purple;
+                    }
                 }
             }
         }
@@ -43,19 +55,19 @@ export component TestCase inherits Window {
 let instance = TestCase::new().unwrap();
 assert_eq!(instance.get_focused_index(), -1);
 
-for i in 0..=5 {
+for i in 0..=3 {
     slint_testing::send_keyboard_string_sequence(&instance, "\t");
     assert_eq!(instance.get_focused_index(), i, "tab to item {i}");
 }
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert_eq!(instance.get_focused_index(), 0, "tab wraps to item 0");
 
-for i in (0..=5).rev() {
+for i in (0..=3).rev() {
     slint_testing::send_keyboard_string_sequence(&instance, "\u{19}");
     assert_eq!(instance.get_focused_index(), i, "backtab to item {i}");
 }
 slint_testing::send_keyboard_string_sequence(&instance, "\u{19}");
-assert_eq!(instance.get_focused_index(), 5, "backtab wraps to item 5");
+assert_eq!(instance.get_focused_index(), 3, "backtab wraps to item 3");
 ```
 
 ```cpp
@@ -63,18 +75,18 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 assert_eq(instance.get_focused_index(), -1);
 
-for (int i = 0; i <= 5; i++) {
+for (int i = 0; i <= 3; i++) {
     slint_testing::send_keyboard_string_sequence(&instance, "\t");
     assert_eq(instance.get_focused_index(), i);
 }
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert_eq(instance.get_focused_index(), 0);
 
-for (int i = 5; i >= 0; i--) {
+for (int i = 3; i >= 0; i--) {
     slint_testing::send_keyboard_string_sequence(&instance, "\u0019");
     assert_eq(instance.get_focused_index(), i);
 }
 slint_testing::send_keyboard_string_sequence(&instance, "\u0019");
-assert_eq(instance.get_focused_index(), 5);
+assert_eq(instance.get_focused_index(), 3);
 ```
 */


### PR DESCRIPTION
When a non-Flickable clipping ancestor (e.g. clip:true) sits above a Flickable, is_visible_or_clipped_by_flickable returned false because it only checked whether the immediate clipping ancestor was a Flickable. Now it also checks whether a Flickable closer to the item could scroll it into view.

Fixes: #10321