### PR TITLE
Python: support asyncio signal handlers in the event loop

### DIFF
--- a/api/python/slint/slint/loop.py
+++ b/api/python/slint/slint/loop.py
@@ -240,5 +240,10 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
         native.invoke_from_event_loop(run_handle_cb)
         return handle
 
-    def _write_to_self(self) -> None:
-        raise NotImplementedError
+    def _add_callback_signalsafe(self, handle: asyncio.Handle) -> None:
+        # Signal handlers are dispatched by asyncio via this method after the
+        # self-pipe wakeup byte is read. The base implementation appends to
+        # `_ready`, which only the default asyncio run loop drains; slint's
+        # native loop does not, so route through our own scheduler instead.
+        if not handle._cancelled:
+            self.call_soon(handle._run)

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -235,68 +235,66 @@ def test_exception_thrown() -> None:
         slint.run_event_loop(throws())
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="add_signal_handler is Unix-only in asyncio"
-)
-def test_add_signal_handler() -> None:
-    import os
-    import signal
+# Guarded with `sys.platform != "win32"` (in addition to the pytest skipif) so
+# that `ty` narrows the branch away on Windows, where `signal.SIGUSR1` is not
+# defined in the stdlib stubs.
+if sys.platform != "win32":
 
-    handler_called = [False]
+    def test_add_signal_handler() -> None:
+        import os
+        import signal
 
-    async def setup_and_signal() -> None:
-        loop = asyncio.get_running_loop()
+        handler_called = [False]
 
-        def handler() -> None:
-            handler_called[0] = True
+        async def setup_and_signal() -> None:
+            loop = asyncio.get_running_loop()
+
+            def handler() -> None:
+                handler_called[0] = True
+                slint.quit_event_loop()
+
+            loop.add_signal_handler(signal.SIGUSR1, handler)
+            os.kill(os.getpid(), signal.SIGUSR1)
+
+            await asyncio.sleep(5)
             slint.quit_event_loop()
 
-        loop.add_signal_handler(signal.SIGUSR1, handler)
-        os.kill(os.getpid(), signal.SIGUSR1)
+        slint.run_event_loop(setup_and_signal())
+        assert handler_called[0]
 
-        await asyncio.sleep(5)
-        slint.quit_event_loop()
+    def test_signal_wakes_idle_loop() -> None:
+        # Signal delivered from a background thread while the loop has no pending
+        # Python work — it must be parked in the native wait and woken by the
+        # signal wakeup byte.
+        import os
+        import signal
+        import threading
+        import time
 
-    slint.run_event_loop(setup_and_signal())
-    assert handler_called[0]
+        handler_called = [False]
 
+        def deliver_signal_later() -> None:
+            time.sleep(0.2)
+            os.kill(os.getpid(), signal.SIGUSR1)
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="add_signal_handler is Unix-only in asyncio"
-)
-def test_signal_wakes_idle_loop() -> None:
-    # Signal delivered from a background thread while the loop has no pending
-    # Python work — it must be parked in the native wait and woken by the
-    # signal wakeup byte.
-    import os
-    import signal
-    import threading
-    import time
+        def watchdog() -> None:
+            time.sleep(5)
+            if not handler_called[0]:
+                native.invoke_from_event_loop(slint.quit_event_loop)
 
-    handler_called = [False]
+        async def run() -> None:
+            loop = asyncio.get_running_loop()
 
-    def deliver_signal_later() -> None:
-        time.sleep(0.2)
-        os.kill(os.getpid(), signal.SIGUSR1)
+            def handler() -> None:
+                handler_called[0] = True
+                slint.quit_event_loop()
 
-    def watchdog() -> None:
-        time.sleep(5)
-        if not handler_called[0]:
-            native.invoke_from_event_loop(slint.quit_event_loop)
+            loop.add_signal_handler(signal.SIGUSR1, handler)
 
-    async def run() -> None:
-        loop = asyncio.get_running_loop()
+            threading.Thread(target=deliver_signal_later, daemon=True).start()
+            threading.Thread(target=watchdog, daemon=True).start()
 
-        def handler() -> None:
-            handler_called[0] = True
-            slint.quit_event_loop()
+            await asyncio.Event().wait()
 
-        loop.add_signal_handler(signal.SIGUSR1, handler)
-
-        threading.Thread(target=deliver_signal_later, daemon=True).start()
-        threading.Thread(target=watchdog, daemon=True).start()
-
-        await asyncio.Event().wait()
-
-    slint.run_event_loop(run())
-    assert handler_called[0]
+        slint.run_event_loop(run())
+        assert handler_called[0]

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -233,3 +233,70 @@ def test_exception_thrown() -> None:
 
     with pytest.raises(RuntimeError, match="Boo"):
         slint.run_event_loop(throws())
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="add_signal_handler is Unix-only in asyncio"
+)
+def test_add_signal_handler() -> None:
+    import os
+    import signal
+
+    handler_called = [False]
+
+    async def setup_and_signal() -> None:
+        loop = asyncio.get_running_loop()
+
+        def handler() -> None:
+            handler_called[0] = True
+            slint.quit_event_loop()
+
+        loop.add_signal_handler(signal.SIGUSR1, handler)
+        os.kill(os.getpid(), signal.SIGUSR1)
+
+        await asyncio.sleep(5)
+        slint.quit_event_loop()
+
+    slint.run_event_loop(setup_and_signal())
+    assert handler_called[0]
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="add_signal_handler is Unix-only in asyncio"
+)
+def test_signal_wakes_idle_loop() -> None:
+    # Signal delivered from a background thread while the loop has no pending
+    # Python work — it must be parked in the native wait and woken by the
+    # signal wakeup byte.
+    import os
+    import signal
+    import threading
+    import time
+
+    handler_called = [False]
+
+    def deliver_signal_later() -> None:
+        time.sleep(0.2)
+        os.kill(os.getpid(), signal.SIGUSR1)
+
+    def watchdog() -> None:
+        time.sleep(5)
+        if not handler_called[0]:
+            native.invoke_from_event_loop(slint.quit_event_loop)
+
+    async def run() -> None:
+        loop = asyncio.get_running_loop()
+
+        def handler() -> None:
+            handler_called[0] = True
+            slint.quit_event_loop()
+
+        loop.add_signal_handler(signal.SIGUSR1, handler)
+
+        threading.Thread(target=deliver_signal_later, daemon=True).start()
+        threading.Thread(target=watchdog, daemon=True).start()
+
+        await asyncio.Event().wait()
+
+    slint.run_event_loop(run())
+    assert handler_called[0]


### PR DESCRIPTION
Route signal handler dispatch through `call_soon` instead of asyncio's `_ready` queue, which slint's native loop doesn't drain.

Fixes #11507

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
