### PR TITLE
Fix Skia WGPU 28 feature forwarding

### DIFF
--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -35,7 +35,11 @@ renderer-femtovg-wgpu = [
   "i-slint-backend-winit?/renderer-femtovg-wgpu",
   "i-slint-backend-linuxkms?/renderer-femtovg-wgpu",
 ]
-renderer-skia = ["dep:i-slint-renderer-skia", "i-slint-backend-winit?/renderer-skia", "i-slint-backend-linuxkms?/renderer-skia"]
+renderer-skia = [
+  "dep:i-slint-renderer-skia",
+  "i-slint-backend-winit?/renderer-skia",
+  "i-slint-backend-linuxkms?/renderer-skia",
+]
 renderer-skia-opengl = [
   "i-slint-backend-winit?/renderer-skia-opengl",
   "i-slint-backend-linuxkms?/renderer-skia-opengl",

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -35,7 +35,7 @@ renderer-femtovg-wgpu = [
   "i-slint-backend-winit?/renderer-femtovg-wgpu",
   "i-slint-backend-linuxkms?/renderer-femtovg-wgpu",
 ]
-renderer-skia = ["i-slint-backend-winit?/renderer-skia", "i-slint-backend-linuxkms?/renderer-skia"]
+renderer-skia = ["dep:i-slint-renderer-skia", "i-slint-backend-winit?/renderer-skia", "i-slint-backend-linuxkms?/renderer-skia"]
 renderer-skia-opengl = [
   "i-slint-backend-winit?/renderer-skia-opengl",
   "i-slint-backend-linuxkms?/renderer-skia-opengl",


### PR DESCRIPTION
## Summary
- Add `dep:i-slint-renderer-skia` to the `renderer-skia` feature in `i-slint-backend-selector`.
- This mirrors how `renderer-femtovg` already activates `dep:i-slint-renderer-femtovg` directly in the selector. Without this, the selector's `unstable-wgpu-28 = [..., "i-slint-renderer-skia?/unstable-wgpu-28"]` was a no-op for custom-platform users who don't go through winit or linuxkms backends (the `?` only fires if the dep is already activated in the same crate).

## Verification
- `cargo check -p slint --no-default-features --features 'std compat-1-2 renderer-skia unstable-wgpu-28'`