### PR TITLE
Simplify docs preview deployment to include all docs

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -60,12 +60,6 @@ safety_docs:
  - *js_config
  - *ci_config
 
-docs_astro:
- - 'docs/astro/**'
- - 'docs/common/**'
- - *js_config
- - *ci_config
-
 internal: &internal
  # The API specific tests don't depends on renderer or backend, but they do depend on the Qt widgets and the testing backend
  - 'internal/!({renderers,backends}/**)'

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -27,11 +27,6 @@ on:
         app-id:
           type: string
           required: true
-        docs_astro:
-          type: boolean
-          default: false
-          required: false
-          description: "True when path filter docs_astro matched (e.g. docs/astro or docs/common); use to gate deploy after astro-docs-tests."
 
 jobs:
     # Job 1: Build Rust and C++ documentation
@@ -96,6 +91,8 @@ jobs:
     # Job 2: Build Astro docs and run tests
     astro-docs-tests:
         runs-on: ubuntu-24.04
+        outputs:
+            version: ${{ steps.version.outputs.VERSION }}
         env:
             RUSTFLAGS: -D warnings -W deprecated
             RUSTDOCFLAGS: --html-in-header=/home/runner/work/slint/slint/docs/astro/src/utils/slint-docs-highlight.html -D warnings -W deprecated --cfg docsrs -Zunstable-options --generate-link-to-definition
@@ -194,9 +191,9 @@ jobs:
                 name: docs-astro
                 path: artifact
 
-    docs-astro-preview:
-        needs: astro-docs-tests
-        if: inputs.docs_astro && github.event_name == 'pull_request'
+    docs-preview:
+        needs: [rust-cpp-docs, astro-docs-tests, node-python-docs]
+        if: github.event_name == 'pull_request'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -210,30 +207,26 @@ jobs:
               with:
                 node-version: 24
                 package-manager-cache: false
-            - name: Download Astro docs artifact
+            - name: Download all docs artifacts
               uses: actions/download-artifact@v8
               with:
-                name: docs-astro
+                pattern: docs-*
                 path: restored-docs
-            - name: Lay out Astro dist under cf-assets for Worker URL paths
+                merge-multiple: true
+            - name: Lay out docs under cf-assets
               id: repack
               working-directory: docs/astro
-              env:
-                RELEASE_INPUT: ${{ inputs.release }}
               run: |
                 set -euo pipefail
-                root="${GITHUB_WORKSPACE}"
-                version=$(awk '/^\[workspace.package\]/ {found=1} found && /^version = / {gsub(/version = |"/, "", $0); print $0; exit}' "${root}/Cargo.toml")
-                if [ -z "${version}" ]; then echo "Version not found"; exit 1; fi
                 rm -rf cf-assets
-                if [ "${RELEASE_INPUT}" != "true" ]; then
-                  prefix="master/docs/slint"
+                if [ "${{ inputs.release }}" != "true" ]; then
+                  prefix="master/docs"
                 else
-                  prefix="${version}/docs/slint"
+                  prefix="${{ needs.astro-docs-tests.outputs.version }}/docs"
                 fi
                 mkdir -p "cf-assets/${prefix}"
-                cp -R "${root}/restored-docs/docs/slint/." "cf-assets/${prefix}/"
-                echo "site_prefix=${prefix}" >> "${GITHUB_OUTPUT}"
+                cp -R "${GITHUB_WORKSPACE}/restored-docs/docs/." "cf-assets/${prefix}/"
+                echo "site_prefix=${prefix}/slint" >> "${GITHUB_OUTPUT}"
             - name: Deploy preview to slint-docs-staging (Workers)
               id: preview
               working-directory: docs/astro
@@ -246,7 +239,7 @@ jobs:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_2 }}
                 CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_2 }}
             - name: Create GitHub deployment for PR
-              if: steps.preview.outputs.url != '' && github.event_name == 'pull_request'
+              if: steps.preview.outputs.url != ''
               uses: actions/github-script@v8
               env:
                 PREVIEW_URL: ${{ steps.preview.outputs.url }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
         figma_inspector : ${{ steps.filter.outputs.figma_inspector }}
         material_components : ${{ steps.filter.outputs.material_components }}
         safety_docs : ${{ steps.filter.outputs.safety_docs }}
-        docs_astro : ${{ steps.filter.outputs.docs_astro }}
         internal : ${{ steps.filter.outputs.internal }}
         api_cpp : ${{ steps.filter.outputs.api_cpp }}
         api_python : ${{ steps.filter.outputs.api_python }}
@@ -437,7 +436,6 @@ jobs:
         with:
           release: false
           app-id: ${{ vars.READ_WRITE_APP_ID }}
-          docs_astro: ${{ needs.files-changed.outputs.docs_astro == 'true' }}
 
     slintpad:
         needs: files-changed

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -48,7 +48,6 @@ jobs:
         with:
           release: ${{ github.event.inputs.release }}
           app-id: ${{ vars.READ_WRITE_APP_ID }}
-          docs_astro: false
 
     wasm_demo:
         uses: ./.github/workflows/wasm_demos.yaml


### PR DESCRIPTION
The preview was only deploying astro docs, missing C++, Rust, Node, and Python docs. Deploy the full docs folder like the final website does by downloading all doc artifacts and merging them. Remove the unnecessary docs_astro path filter plumbing.
