### PR TITLE
Use relative links for language API doc URLs

### DIFF
--- a/docs/common/src/utils/site-config.ts
+++ b/docs/common/src/utils/site-config.ts
@@ -4,10 +4,10 @@
 export const BASE_URL = "https://localhost";
 export const BASE_PATH = "/docs/";
 export const SLINT_DOWNLOAD_VERSION = "nightly";
-export const CPP_BASE_URL = `${BASE_URL}${BASE_PATH}../cpp/`;
-export const RUST_BASE_URL = `${BASE_URL}${BASE_PATH}../rust/`;
+export const CPP_BASE_URL = `${BASE_PATH}../cpp/`;
+export const RUST_BASE_URL = `${BASE_PATH}../rust/`;
 export const RUST_SLINT_CRATE_URL = `${RUST_BASE_URL}slint/`;
 export const RUST_SLINT_INTERPRETER_CRATE_URL = `${RUST_BASE_URL}slint_interpreter/`;
 export const RUST_SLINT_BUILD_CRATE_URL = `${RUST_BASE_URL}slint_build/`;
-export const NODEJS_BASE_URL = `${BASE_URL}${BASE_PATH}../node/`;
-export const PYTHON_BASE_URL = `${BASE_URL}${BASE_PATH}../python/`;
+export const NODEJS_BASE_URL = `${BASE_PATH}../node/`;
+export const PYTHON_BASE_URL = `${BASE_PATH}../python/`;


### PR DESCRIPTION
The language integration links (C++, Rust, Node, Python) were using absolute URLs with BASE_URL, which broke preview deployments since those links pointed to snapshots.slint.dev instead of the preview domain. Use root-relative paths from BASE_PATH instead.

