### PR TITLE
core: fix absolute_clip_rect_and_geometry for items under Transform

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -423,25 +423,51 @@ impl ItemRc {
         false
     }
 
+    /// Returns the accumulated transform from this item's local coordinate space to window
+    /// coordinates, walking up the ancestor chain until `stop_condition` returns true.
+    ///
+    /// At each ancestor the ancestor's `children_transform` (scale/rotate) is composed first,
+    /// then its translation. This matches the traversal order used by
+    /// [`map_to_item_tree_impl`](Self::map_to_item_tree_impl) and the partial renderer's
+    /// `current_transform()`.
+    fn local_to_window_transform(&self, stop_condition: impl Fn(&Self) -> bool) -> ItemTransform {
+        let supports_transformations = self
+            .window_adapter()
+            .is_none_or(|adapter| adapter.renderer().supports_transformations());
+        let mut transform = ItemTransform::identity();
+        let mut current = self.clone();
+        while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
+            if stop_condition(&parent) {
+                break;
+            }
+            if supports_transformations {
+                if let Some(children_transform) = parent.children_transform() {
+                    transform = transform.then(&children_transform);
+                }
+            }
+            transform = transform.then_translate(parent.geometry().origin.to_vector().cast());
+            current = parent;
+        }
+        transform
+    }
+
     /// Returns the clip rect that applies to this item (in window coordinates) as well as the
     /// item's (unclipped) geometry (also in window coordinates).
     fn absolute_clip_rect_and_geometry(&self) -> (LogicalRect, LogicalRect) {
-        let (mut clip, parent_geometry) =
-            self.parent_item(ParentItemTraversalMode::StopAtPopups).map_or_else(
-                || {
-                    (
-                        LogicalRect::from_size((crate::Coord::MAX, crate::Coord::MAX).into()),
-                        Default::default(),
-                    )
-                },
-                |parent| parent.absolute_clip_rect_and_geometry(),
-            );
+        let geometry = self
+            .local_to_window_transform(|_| false)
+            .outer_transformed_rect(&self.geometry().cast())
+            .cast();
 
-        let geometry = self.geometry().translate(parent_geometry.origin.to_vector());
-
-        let item = self.borrow();
-        if item.as_ref().clips_children() {
-            clip = geometry.intersection(&clip).unwrap_or_default();
+        // Intersect the clip rects contributed by all clipping ancestors.
+        let mut clip = LogicalRect::from_size((crate::Coord::MAX, crate::Coord::MAX).into());
+        let mut cur = self.parent_item(ParentItemTraversalMode::StopAtPopups);
+        while let Some(ref ancestor) = cur {
+            if ancestor.borrow().as_ref().clips_children() {
+                let (_, ancestor_geom) = ancestor.absolute_clip_rect_and_geometry();
+                clip = ancestor_geom.intersection(&clip).unwrap_or_default();
+            }
+            cur = ancestor.parent_item(ParentItemTraversalMode::StopAtPopups);
         }
 
         (clip, geometry)
@@ -615,26 +641,10 @@ impl ItemRc {
         p: LogicalPoint,
         stop_condition: impl Fn(&Self) -> bool,
     ) -> LogicalPoint {
-        let mut current = self.clone();
-        let mut result = p;
-        if stop_condition(&current) {
-            return result;
+        if stop_condition(self) {
+            return p;
         }
-        let supports_transformations = self
-            .window_adapter()
-            .is_none_or(|adapter| adapter.renderer().supports_transformations());
-        while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
-            if stop_condition(&parent) {
-                break;
-            }
-            let geometry = parent.geometry();
-            if supports_transformations && let Some(transform) = parent.children_transform() {
-                result = transform.transform_point(result.cast()).cast();
-            }
-            result += geometry.origin.to_vector();
-            current = parent;
-        }
-        result
+        self.local_to_window_transform(stop_condition).transform_point(p.cast()).cast()
     }
 
     fn map_from_item_tree_impl(
@@ -642,41 +652,25 @@ impl ItemRc {
         p: LogicalPoint,
         stop_condition: impl Fn(&Self) -> bool,
     ) -> LogicalPoint {
-        let mut current = self.clone();
-        let mut result = p;
-        if stop_condition(&current) {
-            return result;
+        if stop_condition(self) {
+            return p;
         }
-        let supports_transformations = self
-            .window_adapter()
-            .is_none_or(|adapter| adapter.renderer().supports_transformations());
 
-        let mut full_transform = supports_transformations.then(ItemTransform::identity);
+        if let Some(transform) = self.local_to_window_transform(&stop_condition).inverse() {
+            return transform.transform_point(p.cast()).cast();
+        }
+
+        let mut current = self.clone();
         let mut offset = euclid::Vector2D::zero();
         while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
             if stop_condition(&parent) {
                 break;
             }
-            let geometry = parent.geometry();
-            if let (Some(transform), Some(children_transform)) =
-                (full_transform, parent.children_transform())
-            {
-                full_transform = Some(
-                    transform
-                        .then_translate(geometry.origin.to_vector().cast())
-                        .then(&children_transform),
-                );
-            }
-            offset += geometry.origin.to_vector();
+            offset += parent.geometry().origin.to_vector();
             current = parent;
         }
-        full_transform = full_transform.and_then(|ft| ft.inverse());
-        if let Some(transform) = full_transform {
-            result = transform.transform_point(result.cast()).cast();
-        } else {
-            result -= offset;
-        }
-        result
+
+        p - offset
     }
 
     /// Return the index of the item within the ItemTree

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -440,10 +440,8 @@ impl ItemRc {
             if stop_condition(&parent) {
                 break;
             }
-            if supports_transformations {
-                if let Some(children_transform) = parent.children_transform() {
-                    transform = transform.then(&children_transform);
-                }
+            if supports_transformations && let Some(children_transform) = parent.children_transform() {
+                transform = transform.then(&children_transform);
             }
             transform = transform.then_translate(parent.geometry().origin.to_vector().cast());
             current = parent;

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -440,7 +440,9 @@ impl ItemRc {
             if stop_condition(&parent) {
                 break;
             }
-            if supports_transformations && let Some(children_transform) = parent.children_transform() {
+            if supports_transformations
+                && let Some(children_transform) = parent.children_transform()
+            {
                 transform = transform.then(&children_transform);
             }
             transform = transform.then_translate(parent.geometry().origin.to_vector().cast());

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1470,7 +1470,7 @@ mod tests {
     use crate::Property;
     use crate::api::LogicalPosition;
     use crate::api::Window;
-    use crate::items::WindowItem;
+    use crate::items::{Clip, Transform, WindowItem};
     use crate::lengths::LogicalLength;
     use crate::lengths::LogicalSize;
     use euclid::Point2D;
@@ -1482,7 +1482,9 @@ mod tests {
     const GEOMETRY_HEIGHT: f32 = 42.;
 
     #[derive(Default)]
-    struct Renderer {}
+    struct Renderer {
+        supports_transformations: bool,
+    }
 
     struct WindowAdapter {
         renderer: Renderer,
@@ -1491,9 +1493,13 @@ mod tests {
 
     impl WindowAdapter {
         fn new() -> Rc<Self> {
+            Self::new_with_transformations(false)
+        }
+
+        fn new_with_transformations(supports_transformations: bool) -> Rc<Self> {
             Rc::<Self>::new_cyclic(|w| Self {
                 window: Window::new(w.clone()),
-                renderer: Default::default(),
+                renderer: Renderer { supports_transformations },
             })
         }
     }
@@ -2505,6 +2511,188 @@ mod tests {
         )
     }
 
+    struct TransformTestItemTree {
+        item_tree: Vec<ItemTreeNode>,
+        geometries: Vec<LogicalRect>,
+        window_adapter: WindowAdapterRc,
+        root: WindowItem,
+        transform: Transform,
+        clip: Clip,
+        leaf: WindowItem,
+    }
+
+    impl ItemTree for TransformTestItemTree {
+        fn visit_children_item(
+            self: Pin<&Self>,
+            _index: isize,
+            _order: TraversalOrder,
+            _visitor: vtable::VRefMut<ItemVisitorVTable>,
+        ) -> VisitChildrenResult {
+            unimplemented!("Not needed for this test")
+        }
+
+        fn get_item_ref(self: Pin<&Self>, index: u32) -> Pin<VRef<'_, ItemVTable>> {
+            let this = self.get_ref();
+            match index {
+                0 => Pin::new(VRef::new(&this.root)),
+                1 => Pin::new(VRef::new(&this.transform)),
+                2 => Pin::new(VRef::new(&this.clip)),
+                3 => Pin::new(VRef::new(&this.leaf)),
+                _ => unimplemented!("Not needed for this test"),
+            }
+        }
+
+        fn get_item_tree(self: Pin<&Self>) -> Slice<'_, ItemTreeNode> {
+            Slice::from_slice(&self.get_ref().item_tree)
+        }
+
+        fn parent_node(self: Pin<&Self>, _result: &mut ItemWeak) {}
+
+        fn embed_component(
+            self: Pin<&Self>,
+            _parent_component: &ItemTreeWeak,
+            _item_tree_index: u32,
+        ) -> bool {
+            false
+        }
+
+        fn layout_info(self: Pin<&Self>, _orientation: Orientation) -> LayoutInfo {
+            unimplemented!("Not needed for this test")
+        }
+
+        fn subtree_index(self: Pin<&Self>) -> usize {
+            usize::MAX
+        }
+
+        fn get_subtree_range(self: Pin<&Self>, _subtree_index: u32) -> IndexRange {
+            (0..0).into()
+        }
+
+        fn get_subtree(
+            self: Pin<&Self>,
+            _subtree_index: u32,
+            _component_index: usize,
+            _result: &mut ItemTreeWeak,
+        ) {
+            unimplemented!("Not needed for this test")
+        }
+
+        fn accessible_role(self: Pin<&Self>, _index: u32) -> AccessibleRole {
+            unimplemented!("Not needed for this test")
+        }
+
+        fn accessible_string_property(
+            self: Pin<&Self>,
+            _index: u32,
+            _what: AccessibleStringProperty,
+            _result: &mut SharedString,
+        ) -> bool {
+            false
+        }
+
+        fn item_element_infos(self: Pin<&Self>, _index: u32, _result: &mut SharedString) -> bool {
+            false
+        }
+
+        fn window_adapter(
+            self: Pin<&Self>,
+            _do_create: bool,
+            result: &mut Option<WindowAdapterRc>,
+        ) {
+            *result = Some(self.window_adapter.clone())
+        }
+
+        fn item_geometry(self: Pin<&Self>, index: u32) -> LogicalRect {
+            self.geometries[index as usize]
+        }
+
+        fn accessibility_action(self: Pin<&Self>, _index: u32, _action: &AccessibilityAction) {
+            unimplemented!("Not needed for this test")
+        }
+
+        fn supported_accessibility_actions(
+            self: Pin<&Self>,
+            _index: u32,
+        ) -> SupportedAccessibilityAction {
+            unimplemented!("Not needed for this test")
+        }
+    }
+
+    crate::item_tree::ItemTreeVTable_static!(static TRANSFORM_TEST_COMPONENT_VT for TransformTestItemTree);
+
+    fn create_transform_test_items() -> VRc<ItemTreeVTable> {
+        let window_adapter = WindowAdapter::new_with_transformations(true);
+
+        let mut transform = Transform::default();
+        transform.transform_scale_x = Property::new(2.);
+        transform.transform_scale_y = Property::new(3.);
+        transform.transform_rotation = Property::new(0.);
+        transform.transform_origin = Property::new(LogicalPosition::new(0., 0.));
+
+        let mut clip = Clip::default();
+        clip.clip = Property::new(true);
+
+        VRc::into_dyn(VRc::new(TransformTestItemTree {
+            item_tree: vec![
+                ItemTreeNode::Item {
+                    is_accessible: false,
+                    children_count: 1,
+                    children_index: 1,
+                    parent_index: 0,
+                    item_array_index: 0,
+                },
+                ItemTreeNode::Item {
+                    is_accessible: false,
+                    children_count: 1,
+                    children_index: 2,
+                    parent_index: 0,
+                    item_array_index: 1,
+                },
+                ItemTreeNode::Item {
+                    is_accessible: false,
+                    children_count: 1,
+                    children_index: 3,
+                    parent_index: 1,
+                    item_array_index: 2,
+                },
+                ItemTreeNode::Item {
+                    is_accessible: false,
+                    children_count: 0,
+                    children_index: 4,
+                    parent_index: 2,
+                    item_array_index: 3,
+                },
+            ],
+            geometries: vec![
+                LogicalRect::new(Point2D::new(0., 0.), LogicalSize::new(100., 100.)),
+                LogicalRect::new(Point2D::new(10., 20.), LogicalSize::new(40., 40.)),
+                LogicalRect::new(Point2D::new(5., 6.), LogicalSize::new(20., 20.)),
+                LogicalRect::new(Point2D::new(8., 4.), LogicalSize::new(10., 10.)),
+            ],
+            window_adapter,
+            root: WindowItem::default(),
+            transform,
+            clip,
+            leaf: WindowItem::default(),
+        }))
+    }
+
+    fn assert_point_approx_eq(actual: LogicalPoint, expected: LogicalPoint) {
+        const EPSILON: f32 = 0.0001;
+        assert!(
+            (actual.x - expected.x).abs() < EPSILON,
+            "actual x {}, expected x {}",
+            actual.x,
+            expected.x
+        );
+        assert!(
+            (actual.y - expected.y).abs() < EPSILON,
+            "actual y {}, expected y {}",
+            actual.y,
+            expected.y
+        );
+    }
+
     #[test]
     fn test_map_to_anchestor() {
         let item_tree = create_subsubtree_items().1;
@@ -2545,6 +2733,36 @@ mod tests {
         // Position of position of first_child  + first_child_of_first_child
         assert_eq!(point.x, GEOMETRY_POSITION_X + GEOMETRY_POSITION_X - 5.);
         assert_eq!(point.y, GEOMETRY_POSITION_Y + GEOMETRY_POSITION_Y + 7.);
+    }
+
+    #[test]
+    fn test_map_to_window_through_transform_roundtrip() {
+        let item_tree = create_transform_test_items();
+        let root = ItemRc::new_root(item_tree);
+        let transform = root.first_child().unwrap();
+        let clip = transform.first_child().unwrap();
+        let leaf = clip.first_child().unwrap();
+
+        let local_point = Point2D::new(4., 5.);
+        let window_point = leaf.map_to_window(local_point);
+        assert_point_approx_eq(window_point, Point2D::new(28., 53.));
+        assert_point_approx_eq(leaf.map_from_window(window_point), local_point);
+    }
+
+    #[test]
+    fn test_visibility_with_clip_under_transform() {
+        let item_tree = create_transform_test_items();
+        let root = ItemRc::new_root(item_tree);
+        let transform = root.first_child().unwrap();
+        let clip = transform.first_child().unwrap();
+        let leaf = clip.first_child().unwrap();
+
+        assert!(leaf.is_visible());
+
+        let hidden_point = leaf.map_to_window(Point2D::new(25., 25.));
+        let (clip_rect, leaf_geometry) = leaf.absolute_clip_rect_and_geometry();
+        assert!(clip_rect.intersection(&leaf_geometry).is_some());
+        assert!(!clip_rect.contains(hidden_point));
     }
 
     #[test]
@@ -2802,7 +3020,7 @@ mod tests {
         }
 
         fn supports_transformations(&self) -> bool {
-            false
+            self.supports_transformations
         }
 
         fn take_snapshot(

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -24,7 +24,7 @@ use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, SizeLengths};
 use crate::menus::MenuVTable;
 use crate::properties::{Property, PropertyTracker};
 use crate::renderer::Renderer;
-use crate::{Callback, SharedString, SharedVector};
+use crate::{Callback, Coord, SharedString, SharedVector};
 use alloc::boxed::Box;
 use alloc::rc::{Rc, Weak};
 use alloc::vec::Vec;
@@ -1685,7 +1685,7 @@ impl WindowInner {
         let root_item = component.as_ref().get_item_ref(0);
         let window_item = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)?;
         let keyboard_size = window_item.virtual_keyboard_size();
-        if keyboard_size.width == 0. || keyboard_size.height == 0. {
+        if keyboard_size.width == 0. as Coord || keyboard_size.height == 0. as Coord {
             None
         } else {
             Some((window_item.virtual_keyboard_position(), keyboard_size))

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1676,6 +1676,7 @@ impl WindowInner {
         }
     }
 
+    // Get geometry of the virtual keyboard if available
     pub(crate) fn window_item_virtual_keyboard(
         &self,
     ) -> Option<(crate::lengths::LogicalPoint, crate::lengths::LogicalSize)> {
@@ -1683,7 +1684,12 @@ impl WindowInner {
         let component = ItemTreeRc::borrow_pin(&component_rc);
         let root_item = component.as_ref().get_item_ref(0);
         let window_item = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)?;
-        Some((window_item.virtual_keyboard_position(), window_item.virtual_keyboard_size()))
+        let keyboard_size = window_item.virtual_keyboard_size();
+        if keyboard_size.width == 0. || keyboard_size.height == 0. {
+            None
+        } else {
+            Some((window_item.virtual_keyboard_position(), keyboard_size))
+        }
     }
 
     /// Sets the close_requested callback. The callback will be run when the user tries to close a window.


### PR DESCRIPTION
## Summary

- `absolute_clip_rect_and_geometry` accumulated window-space geometry by recursively adding parent origins, with no awareness of `Transform` scale or rotation — the same class of bug fixed for the partial renderer in #11441
- Items inside a scaled or rotated `Transform` element would report wrong window-space geometry and clip rects, causing incorrect hit-testing and element inspection results (including the MCP server's element bounds)
- Extract a shared `local_to_window_transform(stop_condition)` helper that walks the ancestor chain composing each ancestor's `children_transform` (scale/rotate) + translation into a single `ItemTransform`, mirroring the approach used by the partial renderer's `current_transform()`
- Apply `outer_transformed_rect` to map the local rect to its axis-aligned bounding box in window space — correctly handles both scale and rotation
- Simplify `map_to_item_tree_impl` to use the same helper, eliminating the duplicate ancestor walk

## Test plan
- [x] All 66 `i-slint-core` tests pass
- [ ] Manual test: item inside `Transform { scale: 2; }` should report geometry at 2× the local size in window coordinates (hit-testing, MCP element inspection)