### PR TITLE
Start MCP/system-testing servers when set_platform() is used from Rust

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -430,6 +430,20 @@ pub fn update_all_translations() {
 pub mod platform {
     pub use i_slint_core::platform::*;
 
+    /// Set the Slint platform abstraction.
+    ///
+    /// If the platform abstraction was already set this will return `Err`.
+    pub fn set_platform(
+        platform: alloc::boxed::Box<dyn Platform + 'static>,
+    ) -> Result<(), SetPlatformError> {
+        i_slint_core::platform::set_platform(platform)?;
+        // Custom platforms bypass the backend selector, so start the embedded testing/MCP
+        // backends here to match applications that go through it.
+        #[cfg(any(feature = "mcp", feature = "system-testing"))]
+        i_slint_backend_selector::init_testing_backends();
+        Ok(())
+    }
+
     /// This module contains the [`femtovg_renderer::FemtoVGRenderer`] and related types.
     ///
     /// It is only enabled when the `renderer-femtovg` Slint feature is enabled.


### PR DESCRIPTION
## Summary

Selector-backed apps already get the embedded MCP server for free (the selector calls `init_testing_backends()` after backend creation). This PR extends that to apps that install a custom platform via `set_platform()` directly.

- Add `add_platform_init_hook()` / `fire_platform_init_hooks()` to `i_slint_core::context` — a thread-local, drain-once queue of `FnOnce` callbacks, analogous to `set_window_shown_hook`. Hooks are drained by `set_platform` immediately after the `SlintContext` is installed, before `update_timers_and_animations()`.
- Migrate the selector's MCP and system-testing init to the hook mechanism, registered inside the backend factory closure so they only enqueue when backend creation succeeds (preserving the existing `is_ok()` guard).
- Add a public `slint::mcp` module (gated on the `mcp` feature) with a `register()` function that custom platform authors call before `set_platform()` to opt in.

## Notes

The MCP implementation stays in `i-slint-backend-testing` because it reuses the existing introspection infrastructure. A possible future cleanup would split that layer into its own crate with clearer boundaries (accessibility, introspection/devtools, MCP transport, testing backend proper), but that is orthogonal to this PR.

## Verification

- `cargo build -p slint --release --no-default-features --features std,compat-1-2,mcp`
- `cargo check -p i-slint-backend-testing --features internal`