### PR TITLE
core: Add generic ChannelEventLoopProxy for custom platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,9 +680,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
 
 [[package]]
 name = "atspi"
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1455,11 +1455,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -1846,31 +1847,35 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
 ]
 
 [[package]]
-name = "ctor-lite"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
-
-[[package]]
 name = "ctor-proc-macro"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
+checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "custom_event_loop"
+version = "1.17.0"
+dependencies = [
+ "slint",
+ "slint-build",
+ "softbuffer",
+ "winit",
+]
 
 [[package]]
 name = "darling"
@@ -2303,18 +2308,18 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 dependencies = [
  "dtor-proc-macro",
 ]
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131"
+checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "dwrote"
@@ -3152,7 +3157,7 @@ dependencies = [
  "cfg-if",
  "document-features",
  "esp-metadata-generated 0.4.0",
- "esp32s3 0.35.0",
+ "esp32s3 0.35.2",
 ]
 
 [[package]]
@@ -3240,11 +3245,10 @@ dependencies = [
 
 [[package]]
 name = "esp32s3"
-version = "0.35.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4519c25f8442f92d51feccc7bb87981b2a2a3c4b0ff512845b39fbdddd95d9bc"
+checksum = "8b4b8c4e4d9f187553ecdb7173edec7b2deb2beea106eedefecdb1654b8ee25a"
 dependencies = [
- "critical-section",
  "vcell",
 ]
 
@@ -3597,7 +3601,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.39.1",
+ "read-fonts 0.39.2",
  "roxmltree",
  "smallvec",
  "windows 0.62.2",
@@ -3873,9 +3877,9 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generativity"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5881e4c3c2433fe4905bb19cfd2b5d49d4248274862b68c27c33d9ba4e13f9ec"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
 
 [[package]]
 name = "generic-array"
@@ -4334,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "gstreamer"
@@ -4635,7 +4639,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
  "core_maths",
- "read-fonts 0.39.1",
+ "read-fonts 0.39.2",
  "smallvec",
 ]
 
@@ -5083,7 +5087,7 @@ dependencies = [
  "fontique",
  "htmlparser",
  "pulldown-cmark",
- "skrifa 0.42.0",
+ "skrifa 0.42.1",
 ]
 
 [[package]]
@@ -5119,7 +5123,7 @@ dependencies = [
  "rspolib",
  "serde",
  "serde_json",
- "skrifa 0.42.0",
+ "skrifa 0.42.1",
  "smol_str 0.3.2",
  "spin_on",
  "strum 0.28.0",
@@ -5167,7 +5171,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "skrifa 0.42.0",
+ "skrifa 0.42.1",
  "slab",
  "slint",
  "static_assertions",
@@ -5265,7 +5269,7 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "raw-window-metal",
- "read-fonts 0.39.1",
+ "read-fonts 0.39.2",
  "scoped-tls-hkt",
  "skia-safe",
  "softbuffer",
@@ -5295,7 +5299,7 @@ dependencies = [
  "integer-sqrt",
  "lyon_path",
  "num-traits",
- "skrifa 0.42.0",
+ "skrifa 0.42.1",
  "swash",
  "zeno",
 ]
@@ -5749,9 +5753,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -5762,9 +5766,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5905,6 +5909,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6002,9 +6021,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -6125,18 +6144,18 @@ checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
 
 [[package]]
 name = "linkme"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7763,9 +7782,9 @@ dependencies = [
 
 [[package]]
 name = "orbclient"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
 dependencies = [
  "libc",
  "libredox",
@@ -7869,7 +7888,7 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa 0.42.0",
+ "skrifa 0.42.1",
 ]
 
 [[package]]
@@ -7911,9 +7930,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version 0.4.1",
 ]
@@ -8266,9 +8285,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -8412,7 +8431,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8527,9 +8546,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
@@ -8653,21 +8672,12 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -8888,9 +8898,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.39.1"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d7821ebf634094f5e5ae9d43c3109407f420f03a7a2e021d3a5d955a4f09fc"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -9445,9 +9455,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "log",
  "once_cell",
@@ -9469,18 +9479,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -9867,9 +9877,9 @@ checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",
@@ -10031,12 +10041,12 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c844316c7318cf6ae9034ee45edd2c432076ef910fdc4bc598183b31f88d03c3"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
- "read-fonts 0.39.1",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -10500,7 +10510,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11220,12 +11230,12 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor",
  "libloading 0.8.9",
  "pkg-config",
  "tracing",
@@ -11295,9 +11305,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -11381,7 +11391,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -11412,7 +11422,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -11421,7 +11431,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -11582,9 +11592,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucs2"
@@ -12115,11 +12125,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -12393,7 +12403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -12454,9 +12464,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni 0.22.4",
@@ -13415,15 +13425,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -13465,6 +13472,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro 0.51.0",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -13637,15 +13650,15 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8b548f3c4467727d74d4237f48cbc08b8ebee551f7d7f17ac63b853cd9c481"
+checksum = "cb731d4c4d93eacc69a1ad2f270f905788a98e4a3438267bcafbe08d3431c8d8"
 dependencies = [
  "font-types",
  "indexmap",
  "kurbo",
  "log",
- "read-fonts 0.39.1",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -13866,9 +13879,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -13893,7 +13906,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -13925,9 +13938,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -13940,22 +13953,22 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
+checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
 dependencies = [
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "zbus_names",
  "zvariant",
@@ -14102,23 +14115,23 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -14129,13 +14142,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   'examples/opengl_underlay',
   'examples/opengl_texture',
   'examples/wgpu_texture',
+  'examples/custom_event_loop',
   'examples/ffmpeg',
   'examples/gstreamer-player',
   'examples/plotter',

--- a/examples/custom_event_loop/Cargo.toml
+++ b/examples/custom_event_loop/Cargo.toml
@@ -1,0 +1,19 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "custom_event_loop"
+version = "1.17.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+build = "build.rs"
+license = "MIT"
+publish = false
+
+[dependencies]
+slint = { path = "../../api/rs/slint", default-features = false, features = ["renderer-software", "std", "compat-1-2"] }
+softbuffer = { workspace = true, features = ["x11", "x11-dlopen", "wayland", "wayland-dlopen"] }
+winit = { version = "0.30.2", default-features = false, features = ["rwh_06"] }
+
+[build-dependencies]
+slint-build = { path = "../../api/rs/build" }

--- a/examples/custom_event_loop/Cargo.toml
+++ b/examples/custom_event_loop/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 [dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["renderer-software", "std", "compat-1-2"] }
 softbuffer = { workspace = true, features = ["x11", "x11-dlopen", "wayland", "wayland-dlopen"] }
-winit = { version = "0.30.2", default-features = false, features = ["rwh_06"] }
+winit = { version = "0.30.2", default-features = false, features = ["rwh_06", "x11", "wayland"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }

--- a/examples/custom_event_loop/build.rs
+++ b/examples/custom_event_loop/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    slint_build::compile("ui/app.slint").unwrap();
+}

--- a/examples/custom_event_loop/src/main.rs
+++ b/examples/custom_event_loop/src/main.rs
@@ -25,9 +25,9 @@
 //! - In `about_to_wait`, call `receiver.drain()` to run pending Slint work.
 
 use slint::platform::{
-    software_renderer::{MinimalSoftwareWindow, RepaintBufferType, SoftwareRenderer},
     ChannelEventLoopProxy, ChannelEventLoopReceiver, EventLoopProxy, Platform, WindowAdapter,
     WindowEvent,
+    software_renderer::{MinimalSoftwareWindow, RepaintBufferType, SoftwareRenderer},
 };
 use slint::{LogicalPosition, PhysicalSize, WindowSize};
 use softbuffer::Surface;
@@ -126,7 +126,8 @@ impl ApplicationHandler<()> for App {
         let size = window.inner_size();
         let scale_factor = window.scale_factor() as f32;
         self.dispatch(WindowEvent::ScaleFactorChanged { scale_factor });
-        self.slint_window.set_size(WindowSize::Physical(PhysicalSize::new(size.width, size.height)));
+        self.slint_window
+            .set_size(WindowSize::Physical(PhysicalSize::new(size.width, size.height)));
         self.dispatch(WindowEvent::WindowActiveChanged(true));
 
         self.surface = Some(surface);
@@ -150,10 +151,8 @@ impl ApplicationHandler<()> for App {
 
         // duration_until_next_timer_update() does not account for active animations;
         // check has_active_animations() separately and keep the loop ticking if needed.
-        let has_animations = self
-            .slint_app
-            .as_ref()
-            .is_some_and(|app| app.window().has_active_animations());
+        let has_animations =
+            self.slint_app.as_ref().is_some_and(|app| app.window().has_active_animations());
         let next_timer = slint::platform::duration_until_next_timer_update();
         event_loop.set_control_flow(match (has_animations, next_timer) {
             (_, Some(d)) => winit::event_loop::ControlFlow::WaitUntil(
@@ -189,12 +188,9 @@ impl ApplicationHandler<()> for App {
                 self.render();
             }
             WinitWindowEvent::CursorMoved { position, .. } => {
-                let scale =
-                    self.window.as_ref().map(|w| w.scale_factor()).unwrap_or(1.0) as f32;
-                let pos = LogicalPosition::new(
-                    position.x as f32 / scale,
-                    position.y as f32 / scale,
-                );
+                let scale = self.window.as_ref().map(|w| w.scale_factor()).unwrap_or(1.0) as f32;
+                let pos =
+                    LogicalPosition::new(position.x as f32 / scale, position.y as f32 / scale);
                 self.cursor_pos = Some(pos);
                 self.dispatch(WindowEvent::PointerMoved { position: pos });
             }

--- a/examples/custom_event_loop/src/main.rs
+++ b/examples/custom_event_loop/src/main.rs
@@ -9,8 +9,9 @@
 //! ## The problem
 //!
 //! When you drive the event loop yourself (instead of calling `slint::run_event_loop()`),
-//! Slint has no way to wake your loop when timers or animations fire. Without a wakeup
-//! mechanism, animations freeze and callbacks are delayed until the next user input.
+//! Slint needs a way to wake your loop when work is queued through
+//! [`slint::invoke_from_event_loop()`] or [`slint::quit_event_loop()`]. Without a wakeup
+//! mechanism, callbacks from worker threads are delayed until the next user input.
 //!
 //! ## The solution: ChannelEventLoopProxy
 //!
@@ -21,7 +22,7 @@
 //! - Pass the **proxy** to your custom platform's `new_event_loop_proxy()`.
 //!   Slint uses it to post events that need to be processed.
 //! - The **wakeup_fn** is called whenever Slint wants to unblock your loop
-//!   (e.g. when a timer fires). Here we send a winit user event.
+//!   after queueing work. Here we send a winit user event.
 //! - In `about_to_wait`, call `receiver.drain()` to run pending Slint work.
 
 use slint::platform::{
@@ -29,9 +30,9 @@ use slint::platform::{
     WindowEvent,
     software_renderer::{MinimalSoftwareWindow, RepaintBufferType, SoftwareRenderer},
 };
-use slint::{LogicalPosition, PhysicalSize, WindowSize};
+use slint::{ComponentHandle, LogicalPosition, PhysicalSize, SharedString, WindowSize};
 use softbuffer::Surface;
-use std::{ops::ControlFlow, rc::Rc, sync::Arc};
+use std::{ops::ControlFlow, rc::Rc, sync::Arc, time::Duration};
 use winit::{
     application::ApplicationHandler,
     event::{ElementState, MouseButton, WindowEvent as WinitWindowEvent},
@@ -85,6 +86,7 @@ impl App {
         .expect("platform already set");
 
         let slint_app = AppUi::new().expect("failed to create UI");
+        configure_callbacks(&slint_app);
         slint_app.window().show().expect("failed to show window");
 
         Self {
@@ -109,6 +111,51 @@ impl App {
             blit(renderer, surface, window);
         });
     }
+}
+
+fn configure_callbacks(app: &AppUi) {
+    app.on_start_worker({
+        let app_weak = app.as_weak();
+        move || {
+            let Some(app) = app_weak.upgrade() else { return };
+            app.set_worker_running(true);
+            app.set_worker_progress(0);
+            app.set_worker_status(SharedString::from("Worker started"));
+
+            std::thread::spawn({
+                let app_weak = app_weak.clone();
+                move || {
+                    for step in 1..=5 {
+                        std::thread::sleep(Duration::from_millis(300));
+                        let progress = step * 20;
+                        let app_weak = app_weak.clone();
+                        slint::invoke_from_event_loop(move || {
+                            if let Some(app) = app_weak.upgrade() {
+                                app.set_worker_progress(progress);
+                                app.set_worker_status(SharedString::from(format!(
+                                    "Worker progress: {progress}%"
+                                )));
+                                if progress == 100 {
+                                    app.set_worker_running(false);
+                                    app.set_worker_status(SharedString::from(
+                                        "Worker finished on the UI thread",
+                                    ));
+                                }
+                            }
+                        })
+                        .ok();
+                    }
+                }
+            });
+        }
+    });
+
+    app.on_quit_from_worker(move || {
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            slint::quit_event_loop().ok();
+        });
+    });
 }
 
 // --- winit ApplicationHandler ------------------------------------------------
@@ -146,23 +193,8 @@ impl ApplicationHandler<()> for App {
             event_loop.exit();
             return;
         }
-        slint::platform::update_timers_and_animations();
         self.render();
-
-        // duration_until_next_timer_update() does not account for active animations;
-        // check has_active_animations() separately and keep the loop ticking if needed.
-        let has_animations =
-            self.slint_app.as_ref().is_some_and(|app| app.window().has_active_animations());
-        let next_timer = slint::platform::duration_until_next_timer_update();
-        event_loop.set_control_flow(match (has_animations, next_timer) {
-            (_, Some(d)) => winit::event_loop::ControlFlow::WaitUntil(
-                std::time::Instant::now() + d.min(std::time::Duration::from_millis(16)),
-            ),
-            (true, None) => winit::event_loop::ControlFlow::WaitUntil(
-                std::time::Instant::now() + std::time::Duration::from_millis(16),
-            ),
-            (false, None) => winit::event_loop::ControlFlow::Wait,
-        });
+        event_loop.set_control_flow(winit::event_loop::ControlFlow::Wait);
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WinitWindowEvent) {
@@ -184,7 +216,6 @@ impl ApplicationHandler<()> for App {
                 });
             }
             WinitWindowEvent::RedrawRequested => {
-                slint::platform::update_timers_and_animations();
                 self.render();
             }
             WinitWindowEvent::CursorMoved { position, .. } => {

--- a/examples/custom_event_loop/src/main.rs
+++ b/examples/custom_event_loop/src/main.rs
@@ -1,0 +1,270 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+//! # Custom Event Loop with ChannelEventLoopProxy
+//!
+//! Demonstrates how to integrate a Slint UI into a custom winit event loop
+//! using [`slint::platform::channel_event_loop_proxy`].
+//!
+//! ## The problem
+//!
+//! When you drive the event loop yourself (instead of calling `slint::run_event_loop()`),
+//! Slint has no way to wake your loop when timers or animations fire. Without a wakeup
+//! mechanism, animations freeze and callbacks are delayed until the next user input.
+//!
+//! ## The solution: ChannelEventLoopProxy
+//!
+//! ```text
+//! channel_event_loop_proxy(wakeup_fn) -> (ChannelEventLoopProxy, ChannelEventLoopReceiver)
+//! ```
+//!
+//! - Pass the **proxy** to your custom platform's `new_event_loop_proxy()`.
+//!   Slint uses it to post events that need to be processed.
+//! - The **wakeup_fn** is called whenever Slint wants to unblock your loop
+//!   (e.g. when a timer fires). Here we send a winit user event.
+//! - In `about_to_wait`, call `receiver.drain()` to run pending Slint work.
+
+use slint::platform::{
+    software_renderer::{MinimalSoftwareWindow, RepaintBufferType, SoftwareRenderer},
+    ChannelEventLoopProxy, ChannelEventLoopReceiver, EventLoopProxy, Platform, WindowAdapter,
+    WindowEvent,
+};
+use slint::{LogicalPosition, PhysicalSize, WindowSize};
+use softbuffer::Surface;
+use std::{ops::ControlFlow, rc::Rc, sync::Arc};
+use winit::{
+    application::ApplicationHandler,
+    event::{ElementState, MouseButton, WindowEvent as WinitWindowEvent},
+    event_loop::{ActiveEventLoop, EventLoop},
+    window::{Window as WinitWindow, WindowId},
+};
+
+slint::include_modules!();
+
+// --- Custom platform ---------------------------------------------------------
+
+struct CustomPlatform {
+    proxy: ChannelEventLoopProxy,
+    window: Rc<MinimalSoftwareWindow>,
+}
+
+impl Platform for CustomPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, slint::PlatformError> {
+        Ok(self.window.clone())
+    }
+
+    fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
+        Some(Box::new(self.proxy.clone()))
+    }
+
+    fn duration_since_start(&self) -> core::time::Duration {
+        static START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+        START.get_or_init(std::time::Instant::now).elapsed()
+    }
+}
+
+// --- Application state -------------------------------------------------------
+
+struct App {
+    window: Option<Arc<WinitWindow>>,
+    surface: Option<Surface<Arc<WinitWindow>, Arc<WinitWindow>>>,
+    slint_window: Rc<MinimalSoftwareWindow>,
+    slint_app: Option<AppUi>,
+    cursor_pos: Option<LogicalPosition>,
+    slint_receiver: ChannelEventLoopReceiver,
+}
+
+impl App {
+    fn new(proxy: ChannelEventLoopProxy, receiver: ChannelEventLoopReceiver) -> Self {
+        let slint_window = MinimalSoftwareWindow::new(RepaintBufferType::NewBuffer);
+
+        slint::platform::set_platform(Box::new(CustomPlatform {
+            proxy,
+            window: slint_window.clone(),
+        }))
+        .expect("platform already set");
+
+        let slint_app = AppUi::new().expect("failed to create UI");
+        slint_app.window().show().expect("failed to show window");
+
+        Self {
+            window: None,
+            surface: None,
+            slint_window,
+            slint_app: Some(slint_app),
+            cursor_pos: None,
+            slint_receiver: receiver,
+        }
+    }
+
+    fn dispatch(&self, event: WindowEvent) {
+        if let Some(app) = &self.slint_app {
+            app.window().dispatch_event(event);
+        }
+    }
+
+    fn render(&mut self) {
+        let (Some(window), Some(surface)) = (&self.window, &mut self.surface) else { return };
+        self.slint_window.draw_if_needed(|renderer| {
+            blit(renderer, surface, window);
+        });
+    }
+}
+
+// --- winit ApplicationHandler ------------------------------------------------
+
+impl ApplicationHandler<()> for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let attrs = winit::window::WindowAttributes::default()
+            .with_title("Custom Event Loop — ChannelEventLoopProxy")
+            .with_inner_size(winit::dpi::LogicalSize::new(640.0, 480.0));
+        let window = Arc::new(event_loop.create_window(attrs).expect("failed to create window"));
+
+        let ctx = softbuffer::Context::new(window.clone()).expect("softbuffer context");
+        let surface = softbuffer::Surface::new(&ctx, window.clone()).expect("softbuffer surface");
+
+        let size = window.inner_size();
+        let scale_factor = window.scale_factor() as f32;
+        self.dispatch(WindowEvent::ScaleFactorChanged { scale_factor });
+        self.slint_window.set_size(WindowSize::Physical(PhysicalSize::new(size.width, size.height)));
+        self.dispatch(WindowEvent::WindowActiveChanged(true));
+
+        self.surface = Some(surface);
+        self.window = Some(window);
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, _event: ()) {
+        // Slint sent a wakeup via the proxy; request a redraw so about_to_wait runs promptly.
+        if let Some(w) = &self.window {
+            w.request_redraw();
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if self.slint_receiver.drain() == ControlFlow::Break(()) {
+            event_loop.exit();
+            return;
+        }
+        slint::platform::update_timers_and_animations();
+        self.render();
+
+        // duration_until_next_timer_update() does not account for active animations;
+        // check has_active_animations() separately and keep the loop ticking if needed.
+        let has_animations = self
+            .slint_app
+            .as_ref()
+            .is_some_and(|app| app.window().has_active_animations());
+        let next_timer = slint::platform::duration_until_next_timer_update();
+        event_loop.set_control_flow(match (has_animations, next_timer) {
+            (_, Some(d)) => winit::event_loop::ControlFlow::WaitUntil(
+                std::time::Instant::now() + d.min(std::time::Duration::from_millis(16)),
+            ),
+            (true, None) => winit::event_loop::ControlFlow::WaitUntil(
+                std::time::Instant::now() + std::time::Duration::from_millis(16),
+            ),
+            (false, None) => winit::event_loop::ControlFlow::Wait,
+        });
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WinitWindowEvent) {
+        match event {
+            WinitWindowEvent::CloseRequested => event_loop.exit(),
+            WinitWindowEvent::Resized(size) => {
+                self.slint_window
+                    .set_size(WindowSize::Physical(PhysicalSize::new(size.width, size.height)));
+                if let Some(w) = &self.window {
+                    w.request_redraw();
+                }
+            }
+            WinitWindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                let size = self.window.as_ref().map(|w| w.inner_size()).unwrap_or_default();
+                self.slint_window
+                    .set_size(WindowSize::Physical(PhysicalSize::new(size.width, size.height)));
+                self.dispatch(WindowEvent::ScaleFactorChanged {
+                    scale_factor: scale_factor as f32,
+                });
+            }
+            WinitWindowEvent::RedrawRequested => {
+                slint::platform::update_timers_and_animations();
+                self.render();
+            }
+            WinitWindowEvent::CursorMoved { position, .. } => {
+                let scale =
+                    self.window.as_ref().map(|w| w.scale_factor()).unwrap_or(1.0) as f32;
+                let pos = LogicalPosition::new(
+                    position.x as f32 / scale,
+                    position.y as f32 / scale,
+                );
+                self.cursor_pos = Some(pos);
+                self.dispatch(WindowEvent::PointerMoved { position: pos });
+            }
+            WinitWindowEvent::CursorLeft { .. } => {
+                self.cursor_pos = None;
+                self.dispatch(WindowEvent::PointerExited);
+            }
+            WinitWindowEvent::MouseInput { state, button, .. } => {
+                if let Some(pos) = self.cursor_pos {
+                    let btn = match button {
+                        MouseButton::Left => slint::platform::PointerEventButton::Left,
+                        MouseButton::Right => slint::platform::PointerEventButton::Right,
+                        _ => slint::platform::PointerEventButton::Other,
+                    };
+                    self.dispatch(match state {
+                        ElementState::Pressed => {
+                            WindowEvent::PointerPressed { button: btn, position: pos }
+                        }
+                        ElementState::Released => {
+                            WindowEvent::PointerReleased { button: btn, position: pos }
+                        }
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- Rendering ---------------------------------------------------------------
+
+fn blit(
+    renderer: &SoftwareRenderer,
+    surface: &mut Surface<Arc<WinitWindow>, Arc<WinitWindow>>,
+    window: &Arc<WinitWindow>,
+) {
+    let size = window.inner_size();
+    let (width, height) = (size.width, size.height);
+    if width == 0 || height == 0 {
+        return;
+    }
+    surface
+        .resize(width.try_into().unwrap(), height.try_into().unwrap())
+        .expect("softbuffer resize");
+
+    let mut sb_buffer = surface.buffer_mut().expect("softbuffer buffer_mut");
+    let mut pixels = vec![slint::Rgb8Pixel::default(); (width * height) as usize];
+    renderer.render(&mut pixels, width as usize);
+
+    for (dst, src) in sb_buffer.iter_mut().zip(pixels.iter()) {
+        *dst = (src.r as u32) << 16 | (src.g as u32) << 8 | src.b as u32;
+    }
+    sb_buffer.present().expect("softbuffer present");
+}
+
+// --- Entry point -------------------------------------------------------------
+
+fn main() {
+    let event_loop =
+        EventLoop::<()>::with_user_event().build().expect("failed to build event loop");
+    event_loop.set_control_flow(winit::event_loop::ControlFlow::Wait);
+
+    let winit_proxy = event_loop.create_proxy();
+    let (slint_proxy, slint_receiver) = slint::platform::channel_event_loop_proxy(Some(
+        // Wakeup callback: unblock the winit event loop when Slint has pending work.
+        Box::new(move || {
+            let _ = winit_proxy.send_event(());
+        }),
+    ));
+
+    let mut app = App::new(slint_proxy, slint_receiver);
+    event_loop.run_app(&mut app).expect("event loop failed");
+}

--- a/examples/custom_event_loop/ui/app.slint
+++ b/examples/custom_event_loop/ui/app.slint
@@ -1,0 +1,53 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Button, VerticalBox } from "std-widgets.slint";
+
+export component AppUi inherits Window {
+    title: "Custom Event Loop — ChannelEventLoopProxy";
+    preferred-width: 640px;
+    preferred-height: 480px;
+
+    in-out property <int> count: 0;
+
+    // Continuously animating property driven by animation-tick().
+    // Requires update_timers_and_animations() to be called each frame.
+    property <float> hue: mod(animation-tick() / 3000ms, 1.0);
+
+    VerticalBox {
+        alignment: center;
+        spacing: 16px;
+        padding: 32px;
+
+        Text {
+            text: "ChannelEventLoopProxy Demo";
+            font-size: 22px;
+            font-weight: 700;
+            horizontal-alignment: center;
+        }
+
+        Text {
+            text: "The colour below animates via timer wakeups delivered\nthrough the proxy to the custom winit event loop.";
+            horizontal-alignment: center;
+            wrap: word-wrap;
+        }
+
+        Rectangle {
+            width: 120px;
+            height: 120px;
+            border-radius: 12px;
+            background: Colors.blue.mix(Colors.red, hue);
+        }
+
+        Text {
+            text: "Button clicks: " + count;
+            font-size: 16px;
+            horizontal-alignment: center;
+        }
+
+        Button {
+            text: "Click me";
+            clicked => { count += 1; }
+        }
+    }
+}

--- a/examples/custom_event_loop/ui/app.slint
+++ b/examples/custom_event_loop/ui/app.slint
@@ -8,11 +8,11 @@ export component AppUi inherits Window {
     preferred-width: 640px;
     preferred-height: 480px;
 
-    in-out property <int> count: 0;
-
-    // Continuously animating property driven by animation-tick().
-    // Requires update_timers_and_animations() to be called each frame.
-    property <float> hue: mod(animation-tick() / 3000ms, 1.0);
+    in-out property <int> worker-progress: 0;
+    in-out property <string> worker-status: "Worker idle";
+    in-out property <bool> worker-running: false;
+    callback start-worker();
+    callback quit-from-worker();
 
     VerticalBox {
         alignment: center;
@@ -27,27 +27,40 @@ export component AppUi inherits Window {
         }
 
         Text {
-            text: "The colour below animates via timer wakeups delivered\nthrough the proxy to the custom winit event loop.";
+            text: "Worker thread updates are queued with invoke_from_event_loop()\nand delivered through the custom winit event loop.";
             horizontal-alignment: center;
             wrap: word-wrap;
         }
 
-        Rectangle {
-            width: 120px;
-            height: 120px;
-            border-radius: 12px;
-            background: Colors.blue.mix(Colors.red, hue);
-        }
-
         Text {
-            text: "Button clicks: " + count;
+            text: worker-status;
             font-size: 16px;
             horizontal-alignment: center;
         }
 
+        Rectangle {
+            width: 220px;
+            height: 12px;
+            border-radius: 6px;
+            background: #d0d0d0;
+
+            Rectangle {
+                width: parent.width * worker-progress / 100;
+                height: parent.height;
+                border-radius: parent.border-radius;
+                background: #2f8f5b;
+            }
+        }
+
         Button {
-            text: "Click me";
-            clicked => { count += 1; }
+            text: worker-running ? "Worker running" : "Start worker thread";
+            enabled: !worker-running;
+            clicked => { start-worker(); }
+        }
+
+        Button {
+            text: "Quit from worker thread";
+            clicked => { quit-from-worker(); }
         }
     }
 }

--- a/internal/core/event_loop_proxy_channel.rs
+++ b/internal/core/event_loop_proxy_channel.rs
@@ -1,0 +1,199 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use crate::api::EventLoopError;
+use crate::platform::EventLoopProxy;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, Sender};
+
+enum Message {
+    Invoke(Box<dyn FnOnce() + Send>),
+    Quit,
+}
+
+/// A generic implementation of [`EventLoopProxy`] that uses a [`std::sync::mpsc`] channel.
+///
+/// This can be used by custom platforms to implement [`crate::platform::Platform::new_event_loop_proxy`]
+/// without having to implement the callback queueing and wake-up plumbing manually.
+#[derive(Clone)]
+pub struct ChannelEventLoopProxy {
+    sender: Sender<Message>,
+    wakeup: Option<Arc<dyn Fn() + Send + Sync>>,
+    quit_requested: Arc<AtomicBool>,
+}
+
+impl EventLoopProxy for ChannelEventLoopProxy {
+    fn quit_event_loop(&self) -> Result<(), EventLoopError> {
+        self.quit_requested.store(true, Ordering::SeqCst);
+        self.sender.send(Message::Quit).map_err(|_| EventLoopError::EventLoopTerminated)?;
+        if let Some(wakeup) = &self.wakeup {
+            wakeup();
+        }
+        Ok(())
+    }
+
+    fn invoke_from_event_loop(
+        &self,
+        event: Box<dyn FnOnce() + Send>,
+    ) -> Result<(), EventLoopError> {
+        self.sender
+            .send(Message::Invoke(event))
+            .map_err(|_| EventLoopError::EventLoopTerminated)?;
+        if let Some(wakeup) = &self.wakeup {
+            wakeup();
+        }
+        Ok(())
+    }
+}
+
+/// The receiver side of the channel created by [`channel_event_loop_proxy`].
+///
+/// This should be owned by the host event loop and drained regularly.
+pub struct ChannelEventLoopReceiver {
+    receiver: Mutex<Receiver<Message>>,
+    quit_requested: Arc<AtomicBool>,
+}
+
+impl ChannelEventLoopReceiver {
+    /// Runs all pending callbacks.
+    ///
+    /// Returns `core::ops::ControlFlow::Break(())` if `quit_event_loop()` was requested
+    /// through a proxy, otherwise `core::ops::ControlFlow::Continue(())`.
+    pub fn drain(&self) -> core::ops::ControlFlow<()> {
+        let mut quit_seen = false;
+        loop {
+            let msg = {
+                let receiver = self.receiver.lock().unwrap();
+                receiver.try_recv()
+            };
+
+            let Ok(msg) = msg else { break };
+            match msg {
+                Message::Invoke(f) => f(),
+                Message::Quit => {
+                    quit_seen = true;
+                }
+            }
+        }
+        if quit_seen {
+            self.quit_requested.store(false, Ordering::SeqCst);
+            core::ops::ControlFlow::Break(())
+        } else {
+            core::ops::ControlFlow::Continue(())
+        }
+    }
+
+    /// Returns `true` if `quit_event_loop()` was requested through a proxy.
+    pub fn quit_requested(&self) -> bool {
+        self.quit_requested.load(Ordering::SeqCst)
+    }
+}
+
+/// Creates a pair of [`ChannelEventLoopProxy`] and [`ChannelEventLoopReceiver`].
+///
+/// The `wakeup` closure is called every time a message is sent to the proxy. It can be used
+/// to wake up the host event loop if it's sleeping.
+pub fn channel_event_loop_proxy(
+    wakeup: Option<Box<dyn Fn() + Send + Sync>>,
+) -> (ChannelEventLoopProxy, ChannelEventLoopReceiver) {
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let quit_requested = Arc::new(AtomicBool::new(false));
+    (
+        ChannelEventLoopProxy {
+            sender,
+            wakeup: wakeup.map(Arc::from),
+            quit_requested: quit_requested.clone(),
+        },
+        ChannelEventLoopReceiver { receiver: Mutex::new(receiver), quit_requested },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn test_channel_proxy() {
+        let wakeup_called = Arc::new(AtomicBool::new(false));
+        let wakeup_called_clone = wakeup_called.clone();
+        let (proxy, receiver) = channel_event_loop_proxy(Some(Box::new(move || {
+            wakeup_called_clone.store(true, Ordering::SeqCst);
+        })));
+
+        let invoked = Arc::new(AtomicBool::new(false));
+        let invoked_clone = invoked.clone();
+        proxy
+            .invoke_from_event_loop(Box::new(move || {
+                invoked_clone.store(true, Ordering::SeqCst);
+            }))
+            .unwrap();
+
+        assert!(wakeup_called.load(Ordering::SeqCst));
+        assert!(!invoked.load(Ordering::SeqCst));
+
+        assert_eq!(receiver.drain(), core::ops::ControlFlow::Continue(()));
+        assert!(invoked.load(Ordering::SeqCst));
+        assert!(!receiver.quit_requested());
+
+        wakeup_called.store(false, Ordering::SeqCst);
+        proxy.quit_event_loop().unwrap();
+        assert!(wakeup_called.load(Ordering::SeqCst));
+        assert!(receiver.quit_requested());
+        assert_eq!(receiver.drain(), core::ops::ControlFlow::Break(()));
+        assert!(!receiver.quit_requested());
+
+        let invoked_again = Arc::new(AtomicBool::new(false));
+        let invoked_again_clone = invoked_again.clone();
+        proxy
+            .invoke_from_event_loop(Box::new(move || {
+                invoked_again_clone.store(true, Ordering::SeqCst);
+            }))
+            .unwrap();
+        assert_eq!(receiver.drain(), core::ops::ControlFlow::Continue(()));
+        assert!(invoked_again.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_drain_does_not_hold_lock_while_invoking() {
+        let (proxy, receiver) = channel_event_loop_proxy(None);
+        let receiver = Arc::new(receiver);
+        let invoked = Arc::new(AtomicBool::new(false));
+        let receiver_clone = receiver.clone();
+        let invoked_clone = invoked.clone();
+
+        proxy
+            .invoke_from_event_loop(Box::new(move || {
+                assert_eq!(receiver_clone.drain(), core::ops::ControlFlow::Continue(()));
+                invoked_clone.store(true, Ordering::SeqCst);
+            }))
+            .unwrap();
+
+        assert_eq!(receiver.drain(), core::ops::ControlFlow::Continue(()));
+        assert!(invoked.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_channel_proxy_without_wakeup() {
+        let (proxy, receiver) = channel_event_loop_proxy(None);
+
+        let invoked = Arc::new(AtomicBool::new(false));
+        let invoked_clone = invoked.clone();
+        proxy
+            .invoke_from_event_loop(Box::new(move || {
+                invoked_clone.store(true, Ordering::SeqCst);
+            }))
+            .unwrap();
+
+        assert_eq!(receiver.drain(), core::ops::ControlFlow::Continue(()));
+        assert!(invoked.load(Ordering::SeqCst));
+
+        proxy.quit_event_loop().unwrap();
+        assert!(receiver.quit_requested());
+        assert_eq!(receiver.drain(), core::ops::ControlFlow::Break(()));
+        assert!(!receiver.quit_requested());
+    }
+}

--- a/internal/core/event_loop_proxy_channel.rs
+++ b/internal/core/event_loop_proxy_channel.rs
@@ -5,7 +5,6 @@ use crate::api::EventLoopError;
 use crate::platform::EventLoopProxy;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
-use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::sync::mpsc::{Receiver, Sender};
 
@@ -22,12 +21,10 @@ enum Message {
 pub struct ChannelEventLoopProxy {
     sender: Sender<Message>,
     wakeup: Option<Arc<dyn Fn() + Send + Sync>>,
-    quit_requested: Arc<AtomicBool>,
 }
 
 impl EventLoopProxy for ChannelEventLoopProxy {
     fn quit_event_loop(&self) -> Result<(), EventLoopError> {
-        self.quit_requested.store(true, Ordering::SeqCst);
         self.sender.send(Message::Quit).map_err(|_| EventLoopError::EventLoopTerminated)?;
         if let Some(wakeup) = &self.wakeup {
             wakeup();
@@ -51,10 +48,10 @@ impl EventLoopProxy for ChannelEventLoopProxy {
 
 /// The receiver side of the channel created by [`channel_event_loop_proxy`].
 ///
-/// This should be owned by the host event loop and drained regularly.
+/// This should be owned by the host event loop and drained on the event loop thread.
+/// Queued callbacks run synchronously on the thread that calls [`Self::drain`].
 pub struct ChannelEventLoopReceiver {
     receiver: Mutex<Receiver<Message>>,
-    quit_requested: Arc<AtomicBool>,
 }
 
 impl ChannelEventLoopReceiver {
@@ -79,35 +76,26 @@ impl ChannelEventLoopReceiver {
             }
         }
         if quit_seen {
-            self.quit_requested.store(false, Ordering::SeqCst);
             core::ops::ControlFlow::Break(())
         } else {
             core::ops::ControlFlow::Continue(())
         }
-    }
-
-    /// Returns `true` if `quit_event_loop()` was requested through a proxy.
-    pub fn quit_requested(&self) -> bool {
-        self.quit_requested.load(Ordering::SeqCst)
     }
 }
 
 /// Creates a pair of [`ChannelEventLoopProxy`] and [`ChannelEventLoopReceiver`].
 ///
 /// The `wakeup` closure is called every time a message is sent to the proxy. It can be used
-/// to wake up the host event loop if it's sleeping.
+/// to wake up the host event loop if it's sleeping. It may be called from any thread and should
+/// only signal the host event loop to wake up; queued callbacks are executed later by
+/// [`ChannelEventLoopReceiver::drain`].
 pub fn channel_event_loop_proxy(
     wakeup: Option<Box<dyn Fn() + Send + Sync>>,
 ) -> (ChannelEventLoopProxy, ChannelEventLoopReceiver) {
     let (sender, receiver) = std::sync::mpsc::channel();
-    let quit_requested = Arc::new(AtomicBool::new(false));
     (
-        ChannelEventLoopProxy {
-            sender,
-            wakeup: wakeup.map(Arc::from),
-            quit_requested: quit_requested.clone(),
-        },
-        ChannelEventLoopReceiver { receiver: Mutex::new(receiver), quit_requested },
+        ChannelEventLoopProxy { sender, wakeup: wakeup.map(Arc::from) },
+        ChannelEventLoopReceiver { receiver: Mutex::new(receiver) },
     )
 }
 
@@ -137,14 +125,11 @@ mod tests {
 
         assert_eq!(receiver.drain(), core::ops::ControlFlow::Continue(()));
         assert!(invoked.load(Ordering::SeqCst));
-        assert!(!receiver.quit_requested());
 
         wakeup_called.store(false, Ordering::SeqCst);
         proxy.quit_event_loop().unwrap();
         assert!(wakeup_called.load(Ordering::SeqCst));
-        assert!(receiver.quit_requested());
         assert_eq!(receiver.drain(), core::ops::ControlFlow::Break(()));
-        assert!(!receiver.quit_requested());
 
         let invoked_again = Arc::new(AtomicBool::new(false));
         let invoked_again_clone = invoked_again.clone();
@@ -192,8 +177,6 @@ mod tests {
         assert!(invoked.load(Ordering::SeqCst));
 
         proxy.quit_event_loop().unwrap();
-        assert!(receiver.quit_requested());
         assert_eq!(receiver.drain(), core::ops::ControlFlow::Break(()));
-        assert!(!receiver.quit_requested());
     }
 }

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -37,6 +37,8 @@ pub mod component_factory;
 pub mod context;
 pub mod date_time;
 pub mod debug_log;
+#[cfg(feature = "std")]
+pub mod event_loop_proxy_channel;
 pub mod future;
 pub mod graphics;
 pub mod input;

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -201,6 +201,11 @@ impl std::convert::From<crate::animations::Instant> for time::Instant {
     }
 }
 
+#[cfg(feature = "std")]
+pub use crate::event_loop_proxy_channel::{
+    ChannelEventLoopProxy, ChannelEventLoopReceiver, channel_event_loop_proxy,
+};
+
 #[cfg(not(target_os = "android"))]
 static EVENTLOOP_PROXY: OnceCell<Box<dyn EventLoopProxy + 'static>> = OnceCell::new();
 


### PR DESCRIPTION
This adds a small std-backed EventLoopProxy helper for custom platforms. It provides a cloneable proxy plus a receiver that host event loops can drain on their event-loop thread, so custom platforms can support slint::invoke_from_event_loop() and slint::quit_event_loop() without reimplementing the queueing and wakeup plumbing.

The PR also adds a focused custom_event_loop example using winit and the software renderer. The example demonstrates a worker thread posting UI updates through slint::invoke_from_event_loop(), waking the winit event loop through the proxy wakeup closure, and executing queued work via ChannelEventLoopReceiver::drain().

Checks run locally:
- cargo test -p i-slint-core event_loop_proxy_channel
- cargo check -p custom_event_loop