### PR TITLE
renderer/femtovg: implement take_snapshot for FemtoVGWGPURenderer

### DIFF
--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -74,6 +74,18 @@ pub trait GraphicsBackend {
         width: NonZeroU32,
         height: NonZeroU32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+    /// Optionally override screenshot capture. If `Some` is returned, it takes precedence
+    /// over the default `canvas.screenshot()` path. The `render` closure triggers a full
+    /// render pass, which the implementation may redirect to an offscreen texture.
+    fn take_snapshot_pixels(
+        &self,
+        _width: u32,
+        _height: u32,
+        _render: &dyn Fn() -> Result<(), PlatformError>,
+    ) -> Option<Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError>> {
+        None
+    }
 }
 
 /// Use the FemtoVG renderer when implementing a custom Slint platform where you deliver events to
@@ -440,6 +452,18 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
 
     /// Returns an image buffer of what was rendered last by reading the previous front buffer (using glReadPixels).
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
+        let size = self
+            .maybe_window_adapter
+            .borrow()
+            .as_ref()
+            .and_then(|w| w.upgrade())
+            .map(|a| a.size())
+            .unwrap_or_default();
+        if let Some(result) =
+            self.graphics_backend.take_snapshot_pixels(size.width, size.height, &|| self.render())
+        {
+            return result;
+        }
         self.graphics_backend.with_graphics_api(|_| {
             let Some(canvas) = self.canvas.borrow().as_ref().cloned() else {
                 return Err("FemtoVG renderer cannot take screenshot without a window".into());

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -75,11 +75,13 @@ pub trait GraphicsBackend {
         height: NonZeroU32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
-    /// Optionally override screenshot capture. If `Some` is returned, it takes precedence
-    /// over the default `canvas.screenshot()` path. The `render` closure triggers a full
-    /// render pass, which the implementation may redirect to an offscreen texture.
+    /// Implement screenshot capture for this backend. The `canvas` is the FemtoVG canvas
+    /// (available for GL backends to call `canvas.screenshot()`). The `render` closure triggers
+    /// a full render pass, which WGPU-style implementations may redirect to an offscreen texture.
+    /// Return `None` if this backend does not support `take_snapshot`.
     fn take_snapshot_pixels(
         &self,
+        _canvas: Option<CanvasRc<Self::Renderer>>,
         _width: u32,
         _height: u32,
         _render: &dyn Fn() -> Result<(), PlatformError>,
@@ -450,7 +452,7 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         Ok(())
     }
 
-    /// Returns an image buffer of what was rendered last by reading the previous front buffer (using glReadPixels).
+    /// Returns an image buffer of what was rendered last.
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         let size = self
             .maybe_window_adapter
@@ -459,27 +461,10 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
             .and_then(|w| w.upgrade())
             .map(|a| a.size())
             .unwrap_or_default();
-        if let Some(result) =
-            self.graphics_backend.take_snapshot_pixels(size.width, size.height, &|| self.render())
-        {
-            return result;
-        }
-        self.graphics_backend.with_graphics_api(|_| {
-            let Some(canvas) = self.canvas.borrow().as_ref().cloned() else {
-                return Err("FemtoVG renderer cannot take screenshot without a window".into());
-            };
-            let screenshot = canvas
-                .borrow_mut()
-                .screenshot()
-                .map_err(|e| format!("FemtoVG error reading current back buffer: {e}"))?;
-
-            use rgb::ComponentBytes;
-            Ok(SharedPixelBuffer::clone_from_slice(
-                screenshot.buf().as_bytes(),
-                screenshot.width() as u32,
-                screenshot.height() as u32,
-            ))
-        })?
+        let canvas = self.canvas.borrow().as_ref().cloned();
+        self.graphics_backend
+            .take_snapshot_pixels(canvas, size.width, size.height, &|| self.render())
+            .unwrap_or_else(|| Err("take_snapshot is not supported by this FemtoVG backend".into()))
     }
 
     fn supports_transformations(&self) -> bool {

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, num::NonZeroU32, rc::Rc};
 
 use i_slint_core::api::PlatformError;
 
-use crate::{FemtoVGRenderer, GraphicsBackend, WindowSurface};
+use crate::{FemtoVGRenderer, GraphicsBackend, WindowSurface, itemrenderer::CanvasRc};
 
 /// This trait describes the interface GPU accelerated renderers in Slint require to render with OpenGL.
 ///
@@ -236,6 +236,32 @@ impl GraphicsBackend for OpenGLBackend {
         height: NonZeroU32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.opengl_context.borrow().resize(width, height)
+    }
+
+    fn take_snapshot_pixels(
+        &self,
+        canvas: Option<CanvasRc<Self::Renderer>>,
+        _width: u32,
+        _height: u32,
+        _render: &dyn Fn() -> Result<(), PlatformError>,
+    ) -> Option<Result<i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>, PlatformError>> {
+        let canvas = canvas?;
+        Some((|| {
+            self.opengl_context
+                .borrow()
+                .ensure_current()
+                .map_err(|e| PlatformError::Other(e.to_string()))?;
+            let screenshot = canvas
+                .borrow_mut()
+                .screenshot()
+                .map_err(|e| format!("FemtoVG error reading current back buffer: {e}"))?;
+            use rgb::ComponentBytes;
+            Ok(i_slint_core::graphics::SharedPixelBuffer::clone_from_slice(
+                screenshot.buf().as_bytes(),
+                screenshot.width() as u32,
+                screenshot.height() as u32,
+            ))
+        })())
     }
 }
 

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -244,7 +244,12 @@ impl GraphicsBackend for OpenGLBackend {
         _width: u32,
         _height: u32,
         _render: &dyn Fn() -> Result<(), PlatformError>,
-    ) -> Option<Result<i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>, PlatformError>> {
+    ) -> Option<
+        Result<
+            i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+            PlatformError,
+        >,
+    > {
         let canvas = canvas?;
         Some((|| {
             self.opengl_context

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -593,7 +593,10 @@ impl RendererSealed for FemtoVGWGPURenderer {
 
     fn take_snapshot(
         &self,
-    ) -> Result<i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>, PlatformError> {
+    ) -> Result<
+        i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+        PlatformError,
+    > {
         self.0.take_snapshot()
     }
 

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -237,6 +237,7 @@ impl GraphicsBackend for WGPUBackend {
 
     fn take_snapshot_pixels(
         &self,
+        _canvas: Option<crate::itemrenderer::CanvasRc<Self::Renderer>>,
         width: u32,
         height: u32,
         render: &dyn Fn() -> Result<(), i_slint_core::platform::PlatformError>,
@@ -411,6 +412,7 @@ impl GraphicsBackend for WgpuTextureBackend {
 
     fn take_snapshot_pixels(
         &self,
+        _canvas: Option<crate::itemrenderer::CanvasRc<Self::Renderer>>,
         width: u32,
         height: u32,
         render: &dyn Fn() -> Result<(), i_slint_core::platform::PlatformError>,

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -589,6 +589,12 @@ impl RendererSealed for FemtoVGWGPURenderer {
         self.0.resize(size)
     }
 
+    fn take_snapshot(
+        &self,
+    ) -> Result<i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>, PlatformError> {
+        self.0.take_snapshot()
+    }
+
     fn supports_transformations(&self) -> bool {
         self.0.supports_transformations()
     }

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -17,15 +17,136 @@ pub struct WGPUBackend {
     queue: RefCell<Option<wgpu::Queue>>,
     surface_config: RefCell<Option<wgpu::SurfaceConfiguration>>,
     surface: RefCell<Option<wgpu::Surface<'static>>>,
+    snapshot_output: RefCell<Option<femtovg::renderer::WGPURenderOutput>>,
 }
 
-pub struct WGPUWindowSurface {
-    surface_texture: wgpu::SurfaceTexture,
+pub enum WGPUWindowSurface {
+    Surface(wgpu::SurfaceTexture),
+    Snapshot(femtovg::renderer::WGPURenderOutput),
+}
+
+enum WGPURenderSource<'a> {
+    Texture(&'a wgpu::Texture),
+    Output(femtovg::renderer::WGPURenderOutput),
+}
+
+impl<'a> From<WGPURenderSource<'a>> for femtovg::renderer::WGPURenderOutput {
+    fn from(src: WGPURenderSource<'a>) -> Self {
+        match src {
+            WGPURenderSource::Texture(t) => t.into(),
+            WGPURenderSource::Output(o) => o,
+        }
+    }
 }
 
 impl WindowSurface<femtovg::renderer::WGPURenderer> for WGPUWindowSurface {
     fn render_output(&self) -> impl Into<femtovg::renderer::WGPURenderOutput> {
-        &self.surface_texture.texture
+        match self {
+            WGPUWindowSurface::Surface(st) => WGPURenderSource::Texture(&st.texture),
+            WGPUWindowSurface::Snapshot(ro) => WGPURenderSource::Output(ro.clone()),
+        }
+    }
+}
+
+fn wgpu_take_snapshot_pixels(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    snapshot_slot: &RefCell<Option<femtovg::renderer::WGPURenderOutput>>,
+    width: u32,
+    height: u32,
+    render: &dyn Fn() -> Result<(), i_slint_core::platform::PlatformError>,
+) -> Result<
+    i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+    i_slint_core::platform::PlatformError,
+> {
+    use i_slint_core::graphics::{Rgba8Pixel, SharedPixelBuffer};
+
+    if width == 0 || height == 0 {
+        return Err("take_snapshot: window size is zero".into());
+    }
+
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("slint_take_snapshot_wgpu"),
+        size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+
+    *snapshot_slot.borrow_mut() = Some(femtovg::renderer::WGPURenderOutput {
+        view: texture.create_view(&wgpu::TextureViewDescriptor::default()),
+        width,
+        height,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+    });
+
+    let render_result = render();
+    snapshot_slot.borrow_mut().take();
+    render_result?;
+
+    let unpadded_bytes_per_row = width * 4;
+    let bytes_per_row = (unpadded_bytes_per_row + wgpu::COPY_BYTES_PER_ROW_ALIGNMENT - 1)
+        & !(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT - 1);
+    let readback_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("slint_take_snapshot_wgpu_readback"),
+        size: (bytes_per_row * height) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback_buffer,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bytes_per_row),
+                rows_per_image: None,
+            },
+        },
+        wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+    );
+    queue.submit(std::iter::once(encoder.finish()));
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        Err("take_snapshot is not supported by FemtoVG WGPU on wasm/WebGPU".into())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let slice = readback_buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .map_err(|e| format!("take_snapshot: device poll failed: {e}"))?;
+        rx.recv()
+            .map_err(|e| format!("take_snapshot: map_async callback was not delivered: {e}"))?
+            .map_err(|e| format!("take_snapshot: map_async failed: {e}"))?;
+
+        let mapped = slice.get_mapped_range();
+        let mut pixels = SharedPixelBuffer::<Rgba8Pixel>::new(width, height);
+        let dst = pixels.make_mut_bytes();
+        for (row_idx, src_row) in mapped.chunks(bytes_per_row as usize).enumerate() {
+            let row_bytes = unpadded_bytes_per_row as usize;
+            let dst_start = row_idx * row_bytes;
+            dst[dst_start..dst_start + row_bytes].copy_from_slice(&src_row[..row_bytes]);
+        }
+        drop(mapped);
+        readback_buffer.unmap();
+
+        Ok(pixels)
     }
 }
 
@@ -41,6 +162,7 @@ impl GraphicsBackend for WGPUBackend {
             queue: Default::default(),
             surface_config: Default::default(),
             surface: Default::default(),
+            snapshot_output: Default::default(),
         }
     }
 
@@ -54,6 +176,9 @@ impl GraphicsBackend for WGPUBackend {
     fn begin_surface_rendering(
         &self,
     ) -> Result<Self::WindowSurface, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(snapshot_output) = self.snapshot_output.borrow().clone() {
+            return Ok(WGPUWindowSurface::Snapshot(snapshot_output));
+        }
         let surface = self.surface.borrow();
         let surface = surface.as_ref().unwrap();
         let frame = match surface.get_current_texture() {
@@ -68,7 +193,7 @@ impl GraphicsBackend for WGPUBackend {
                 surface.get_current_texture()?
             }
         };
-        Ok(WGPUWindowSurface { surface_texture: frame })
+        Ok(WGPUWindowSurface::Surface(frame))
     }
 
     fn submit_commands(&self, commands: <Self::Renderer as femtovg::Renderer>::CommandBuffer) {
@@ -79,7 +204,9 @@ impl GraphicsBackend for WGPUBackend {
         &self,
         surface: Self::WindowSurface,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        surface.surface_texture.present();
+        if let WGPUWindowSurface::Surface(st) = surface {
+            st.present();
+        }
         Ok(())
     }
 
@@ -106,6 +233,29 @@ impl GraphicsBackend for WGPUBackend {
         callback: impl FnOnce(Option<i_slint_core::api::GraphicsAPI<'_>>) -> R,
     ) -> Result<R, i_slint_core::platform::PlatformError> {
         Ok(callback(None))
+    }
+
+    fn take_snapshot_pixels(
+        &self,
+        width: u32,
+        height: u32,
+        render: &dyn Fn() -> Result<(), i_slint_core::platform::PlatformError>,
+    ) -> Option<
+        Result<
+            i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+            i_slint_core::platform::PlatformError,
+        >,
+    > {
+        let device = self.device.borrow().clone()?;
+        let queue = self.queue.borrow().clone()?;
+        Some(wgpu_take_snapshot_pixels(
+            &device,
+            &queue,
+            &self.snapshot_output,
+            width,
+            height,
+            render,
+        ))
     }
 
     fn resize(
@@ -257,6 +407,27 @@ impl GraphicsBackend for WgpuTextureBackend {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // No resize needed - texture size is determined by the texture passed to render_to_texture
         Ok(())
+    }
+
+    fn take_snapshot_pixels(
+        &self,
+        width: u32,
+        height: u32,
+        render: &dyn Fn() -> Result<(), i_slint_core::platform::PlatformError>,
+    ) -> Option<
+        Result<
+            i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+            i_slint_core::platform::PlatformError,
+        >,
+    > {
+        Some(wgpu_take_snapshot_pixels(
+            &self.device,
+            &self.queue,
+            &self.render_output,
+            width,
+            height,
+            render,
+        ))
     }
 }
 
@@ -416,15 +587,6 @@ impl RendererSealed for FemtoVGWGPURenderer {
 
     fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {
         self.0.resize(size)
-    }
-
-    fn take_snapshot(
-        &self,
-    ) -> Result<
-        i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
-        PlatformError,
-    > {
-        self.0.take_snapshot()
     }
 
     fn supports_transformations(&self) -> bool {


### PR DESCRIPTION
## Summary

- Add WGPU-backed snapshot capture for the FemtoVG renderer instead of relying on `canvas.screenshot()`, which does not work reliably for WGPU render targets.
- Route `FemtoVGRenderer::take_snapshot()` through an optional `GraphicsBackend::take_snapshot_pixels()` hook so WGPU backends can render a fresh full frame into an offscreen `Rgba8Unorm` texture and read it back.
- Support both WGPU paths:
  - the normal surface-backed `WGPUBackend`
  - `FemtoVGWGPURenderer`, which renders into caller-provided WGPU textures
- Handle WGPU row padding during texture readback and return a clear unsupported error for wasm/WebGPU, where the synchronous `take_snapshot()` API cannot safely wait for `map_async()`.

This makes `Window::take_snapshot()` and the MCP `take_screenshot` tool work for applications using the FemtoVG WGPU renderer, including custom render-loop integrations.

## Verification

- `cargo fmt --check --package i-slint-renderer-femtovg`
- `cargo check -p i-slint-renderer-femtovg --features wgpu-28`
