### PR TITLE
output error of wrangler upload

### DIFF
--- a/.github/actions/cloudflare-preview-deploy/action.yaml
+++ b/.github/actions/cloudflare-preview-deploy/action.yaml
@@ -40,8 +40,16 @@ runs:
           working-directory: ${{ inputs.working-directory }}
           shell: bash
           run: |
-            OUTPUT=$(pnpm dlx wrangler@3 versions upload 2>&1)
+            set +e
+            OUTPUT=$(pnpm dlx wrangler@4 versions upload 2>&1)
+            STATUS=$?
+            set -e
+
             echo "$OUTPUT"
+            if [ "$STATUS" -ne 0 ]; then
+              echo "Wrangler upload failed with exit code $STATUS" >&2
+              exit "$STATUS"
+            fi
             PREVIEW_URL=$(echo "$OUTPUT" | grep -oE 'https://[^[:space:]]+\.workers\.dev' | head -1)
             echo "url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
             if [ -n "$PREVIEW_URL" ]; then

--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -126,7 +126,7 @@ jobs:
             rm -rf material-${MATERIAL_ZIP_VERSION}
       - name: Deploy to materialui (Pages)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_production == 'true'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Deploy to material-staging (Workers production)
         if: (github.event_name != 'workflow_dispatch' || github.event.inputs.deploy_production != 'true') && github.ref == 'refs/heads/master'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN_2 }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_2 }}


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

```bash
Run OUTPUT=$(pnpm dlx wrangler@3 versions upload 2>&1)
  OUTPUT=$(pnpm dlx wrangler@3 versions upload 2>&1)
  echo "$OUTPUT"
  PREVIEW_URL=$(echo "$OUTPUT" | grep -oE 'https://[^[:space:]]+\.workers\.dev' | head -1)
  echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
  env:
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
    CLOUDFLARE_API_TOKEN: 
    CLOUDFLARE_ACCOUNT_ID: 
Error: Process completed with exit code 1.
```
