### PR TITLE
winit/macOS: Fix crash on macOS 13 when creating a window

### DIFF
--- a/internal/backends/winit/frame_throttle/macos_display_link.rs
+++ b/internal/backends/winit/frame_throttle/macos_display_link.rs
@@ -78,8 +78,12 @@ pub(super) fn try_create(
     window_adapter: Weak<WinitWindowAdapter>,
     winit_window: &winit::window::Window,
 ) -> Option<Box<dyn super::FrameThrottle>> {
-    // CADisplayLink on macOS requires 14.0+; check at runtime.
-    AnyClass::get(c"CADisplayLink")?;
+    // -[NSView displayLinkWithTarget:selector:] is only available on macOS
+    // 14.0+. The CADisplayLink class itself is reachable on older macOS via
+    // QuartzCore, so check for the selector instead of the class.
+    if !AnyClass::get(c"NSView")?.responds_to(sel!(displayLinkWithTarget:selector:)) {
+        return None;
+    }
 
     let mtm = MainThreadMarker::new().expect("frame throttle must be created on main thread");
 


### PR DESCRIPTION
The CADisplayLink-based frame throttle path was gated on the presence of the CADisplayLink class, but that class is reachable on macOS 13 via QuartzCore bridging. The API that actually requires macOS 14.0 is the NSView displayLink(target:selector:) instance method, so check for the selector instead. On macOS 13 we now fall back to the timer-based throttle instead of panicking.

Fixes #11499

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
