### PR TITLE
CI: Skip Cloudflare preview upload for PRs from forks

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -229,6 +229,8 @@ jobs:
                 echo "site_prefix=${prefix}/slint" >> "${GITHUB_OUTPUT}"
             - name: Deploy preview to slint-docs-staging (Workers)
               id: preview
+              # Forks don't have access to repository secrets; only run for PRs from the same repo.
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
               working-directory: docs/astro
               run: |
                 OUTPUT=$(pnpm dlx wrangler@3 versions upload 2>&1)

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -237,9 +237,21 @@ jobs:
                 echo "${OUTPUT}"
                 PREVIEW_URL=$(echo "${OUTPUT}" | grep -oE 'https://[^[:space:]]+\.workers\.dev' | head -1)
                 echo "url=${PREVIEW_URL}" >> "${GITHUB_OUTPUT}"
+                if [ -n "${PREVIEW_URL}" ]; then
+                  BASE="${PREVIEW_URL%/}"
+                  PREFIX="${PREVIEW_SITE_PREFIX#/}"
+                  PREFIX="${PREFIX%/}"
+                  FULL="${BASE}/${PREFIX}/"
+                  {
+                    echo "### Preview"
+                    echo ""
+                    echo "[$FULL]($FULL)"
+                  } >> "$GITHUB_STEP_SUMMARY"
+                fi
               env:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_2 }}
                 CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_2 }}
+                PREVIEW_SITE_PREFIX: ${{ steps.repack.outputs.site_prefix }}
             - name: Create GitHub deployment for PR
               if: steps.preview.outputs.url != ''
               uses: actions/github-script@v9

--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -155,6 +155,13 @@ jobs:
           echo "$OUTPUT"
           PREVIEW_URL=$(echo "$OUTPUT" | grep -oE 'https://[^[:space:]]+\.workers\.dev' | head -1)
           echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+          if [ -n "$PREVIEW_URL" ]; then
+            {
+              echo "### Preview"
+              echo ""
+              echo "[$PREVIEW_URL]($PREVIEW_URL)"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
         working-directory: ui-libraries/material/docs
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_2 }}

--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -148,7 +148,8 @@ jobs:
 
       - name: Deploy preview to material-staging (Workers)
         id: preview
-        if: (github.event_name != 'workflow_dispatch' || github.event.inputs.deploy_production != 'true') && github.ref != 'refs/heads/master'
+        # Forks don't have access to repository secrets; only run for PRs from the same repo.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           OUTPUT=$(pnpm dlx wrangler@3 versions upload 2>&1)
           echo "$OUTPUT"

--- a/.github/workflows/safety_docs.yaml
+++ b/.github/workflows/safety_docs.yaml
@@ -32,6 +32,8 @@ jobs:
               run: pnpm build
             - name: Deploy preview to safety-docs-staging (Workers)
               id: preview
+              # Forks don't have access to repository secrets; only run for PRs from the same repo.
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
               working-directory: docs/safety
               run: |
                 OUTPUT=$(pnpm dlx wrangler@3 versions upload 2>&1)

--- a/.github/workflows/safety_docs.yaml
+++ b/.github/workflows/safety_docs.yaml
@@ -40,6 +40,13 @@ jobs:
                 echo "$OUTPUT"
                 PREVIEW_URL=$(echo "$OUTPUT" | grep -oE 'https://[^[:space:]]+\.workers\.dev' | head -1)
                 echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+                if [ -n "$PREVIEW_URL" ]; then
+                  {
+                    echo "### Preview"
+                    echo ""
+                    echo "[$PREVIEW_URL]($PREVIEW_URL)"
+                  } >> "$GITHUB_STEP_SUMMARY"
+                fi
               env:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_2 }}
                 CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_2 }}

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -99,6 +99,8 @@ jobs:
                   path: tools/slintpad/dist/
             - name: Deploy slintpad to slintpad-staging (Workers)
               id: preview
+              # Forks don't have access to repository secrets; only run for PRs from the same repo.
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
               working-directory: tools/slintpad
               run: |
                 OUTPUT=$(pnpm dlx wrangler@3 versions upload 2>&1)

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -107,6 +107,13 @@ jobs:
                 echo "$OUTPUT"
                 PREVIEW_URL=$(echo "$OUTPUT" | grep -oE 'https://[^[:space:]]+\.workers\.dev' | head -1)
                 echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+                if [ -n "$PREVIEW_URL" ]; then
+                  {
+                    echo "### Preview"
+                    echo ""
+                    echo "[$PREVIEW_URL]($PREVIEW_URL)"
+                  } >> "$GITHUB_STEP_SUMMARY"
+                fi
               env:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_2 }}
                 CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_2 }}


### PR DESCRIPTION
Fork PRs don't have access to repository secrets, so the wrangler versions upload step fails. Guard each preview deploy step so it only runs for non-fork PRs (and for non-PR events like workflow_dispatch).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
