### PR TITLE
Revert "esp-idf: Work around bug in xtensa toolchain"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -422,8 +422,6 @@ jobs:
 #                  default: true
 #                  buildtargets: esp32
 #                  ldproxy: false
-#                  # version pinned until new version of esp-hal with https://github.com/esp-rs/esp-hal/pull/2615/
-#                  version: 1.82.0
 #            - uses: Swatinem/rust-cache@v2
 #            - name: S3Box
 #              run: cargo +esp check -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box  --config examples/mcu-board-support/esp32_s3_box/cargo-config.toml --release
@@ -625,8 +623,6 @@ jobs:
                   default: true
                   buildtargets: esp32
                   ldproxy: false
-                  # Pin due to https://github.com/esp-rs/rust/issues/276
-                  version: "1.94.0.0"
             - uses: Swatinem/rust-cache@v2
             - name: Build and Test Printer demo
               shell: bash


### PR DESCRIPTION
This reverts commit b8846acb0e02a55b5fe93381e6cbd429129bceef.

Rust 1.95.0 is now the default esp-rs toolchain and the build issue is fixed.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
