### PR TITLE
markdown: fix link and color interpolation, refactor error reporting

### DIFF
--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -124,8 +124,8 @@ pub struct TestingBackend {
     clipboard: Mutex<Option<String>>,
     queue: Option<Queue>,
     mock_time: bool,
-    #[allow(dead_code)]
     pub open_url: Rc<RefCell<Option<SharedString>>>,
+    pub debug_logs: Rc<RefCell<Vec<String>>>,
 }
 
 impl TestingBackend {
@@ -135,6 +135,7 @@ impl TestingBackend {
             queue: options.threading.then(|| Queue(Default::default(), std::thread::current())),
             mock_time: options.mock_time,
             open_url: Default::default(),
+            debug_logs: Default::default(),
         }
     }
 }
@@ -150,6 +151,7 @@ impl i_slint_core::platform::Platform for TestingBackend {
             mouse_cursor: Default::default(),
             all_item_trees: Default::default(),
             open_url: self.open_url.clone(),
+            debug_logs: self.debug_logs.clone(),
         }))
     }
 
@@ -211,6 +213,11 @@ impl i_slint_core::platform::Platform for TestingBackend {
         *self.open_url.borrow_mut() = Some(url.into());
         Ok(())
     }
+
+    fn debug_log(&self, arguments: core::fmt::Arguments) {
+        self.debug_logs.borrow_mut().push(arguments.to_string());
+        i_slint_core::debug_log::default_debug_log(arguments);
+    }
 }
 
 #[derive(Default)]
@@ -235,6 +242,7 @@ pub struct TestingWindow {
     mouse_cursor: Cell<i_slint_core::items::MouseCursor>,
     all_item_trees: CheckAllItemTreesUnregistered,
     pub open_url: Rc<RefCell<Option<SharedString>>>,
+    pub debug_logs: Rc<RefCell<Vec<String>>>,
 }
 
 impl TestingWindow {
@@ -246,6 +254,11 @@ impl TestingWindow {
     #[allow(dead_code)]
     pub fn open_url(&self) -> Option<SharedString> {
         self.open_url.borrow().clone()
+    }
+
+    /// Drain and return all debug_log messages captured since the last call.
+    pub fn take_debug_log(&self) -> Vec<String> {
+        self.debug_logs.borrow_mut().drain(..).collect()
     }
 }
 

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -42,11 +42,50 @@ pub struct StyledTextParagraph {
     pub links: alloc::vec::Vec<(core::ops::Range<usize>, alloc::string::String)>,
 }
 
-/// Error type returned by `StyledText::parse`
+/// Error returned by markdown styled text parsing
 #[cfg(feature = "markdown")]
-#[derive(Debug, derive_more::Error, derive_more::Display, PartialEq)]
-#[non_exhaustive]
-pub enum StyledTextError<'a> {
+#[derive(Debug, derive_more::Error, derive_more::Display)]
+#[display("{kind}")]
+pub struct StyledTextParseError {
+    kind: StyledTextParseErrorKind,
+    /// Byte range in the format string where the error occurred
+    range: Option<core::ops::Range<usize>>,
+}
+
+#[cfg(feature = "markdown")]
+impl StyledTextParseError {
+    /// Byte range in the markdown format string where the error occurred
+    pub fn range(&self) -> Option<core::ops::Range<usize>> {
+        self.range.clone()
+    }
+
+    fn new(kind: StyledTextParseErrorKind, range: core::ops::Range<usize>) -> Self {
+        Self { kind, range: Some(range) }
+    }
+
+    fn without_range(kind: StyledTextParseErrorKind) -> Self {
+        Self { kind, range: None }
+    }
+
+    /// Returns true if this is an invalid color error.
+    /// Useful for the compiler to skip this during compile-time validation
+    /// when color values may come from dynamic interpolation.
+    pub fn is_invalid_color(&self) -> bool {
+        matches!(self.kind, StyledTextParseErrorKind::InvalidColor(_))
+    }
+}
+
+#[cfg(feature = "markdown")]
+impl PartialEq for StyledTextParseError {
+    /// Compares only the error kind, ignoring the byte range.
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+#[cfg(feature = "markdown")]
+#[derive(Debug, derive_more::Display, PartialEq)]
+enum StyledTextParseErrorKind {
     /// Spans are unbalanced: stack already empty when popped
     #[display("Spans are unbalanced: stack already empty when popped")]
     Pop,
@@ -56,27 +95,21 @@ pub enum StyledTextError<'a> {
     /// Paragraph not started
     #[display("Paragraph not started")]
     ParagraphNotStarted,
-    /// Unimplemented markdown tag
-    #[display("Unimplemented tag: {:?}", _0.to_end())]
-    UnimplementedTag(#[error(not(source))] pulldown_cmark::Tag<'a>),
-    /// Unimplemented markdown event
-    #[display("Unimplemented event: {_0:?}")]
-    UnimplementedEvent(#[error(not(source))] pulldown_cmark::Event<'a>),
-    /// Unimplemented html event
-    #[display("Unimplemented html: {_0}")]
-    UnimplementedHtmlEvent(#[error(not(source))] alloc::string::String),
-    /// Unimplemented html tag
-    #[display("Unimplemented html tag: {_0}")]
-    UnimplementedHtmlTag(#[error(not(source))] alloc::string::String),
+    /// Unsupported markdown syntax
+    #[display("Markdown {_0} are not supported")]
+    UnsupportedMarkdown(alloc::string::String),
+    /// Unsupported html tag
+    #[display("HTML tag <{_0}> is not supported")]
+    UnsupportedHtmlTag(alloc::string::String),
     /// Unimplemented html attribute
     #[display("Unexpected {_0} attribute in html {_1}")]
-    UnexpectedAttribute(#[error(not(source))] alloc::string::String, alloc::string::String),
+    UnexpectedAttribute(alloc::string::String, alloc::string::String),
     /// Missing color attribute in html
     #[display("Missing color attribute in html {_0}")]
-    MissingColor(#[error(not(source))] alloc::string::String),
+    MissingColor(alloc::string::String),
     /// Closing html tag doesn't match the opening tag
     #[display("Closing html tag doesn't match the opening tag. Expected {_0}, got {_1}")]
-    ClosingTagMismatch(#[error(not(source))] &'a str, alloc::string::String),
+    ClosingTagMismatch(alloc::string::String, alloc::string::String),
     /// Argument index out of range
     #[display("Argument index {_0} out of range: {_1} arguments provided")]
     ArgumentOutOfRange(usize, usize),
@@ -87,7 +120,7 @@ pub enum StyledTextError<'a> {
     MultiParagraphInterpolation,
     /// Invalid color value
     #[display("Invalid color value '{_0}'")]
-    InvalidColor(#[error(not(source))] alloc::string::String),
+    InvalidColor(alloc::string::String),
 }
 
 #[cfg(feature = "markdown")]
@@ -103,16 +136,24 @@ pub const MARKDOWN_INTERPOLATION_PLACEHOLDER: char = '\u{e541}';
 pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
     format_string: &str,
     args: &[S],
-) -> impl Iterator<Item = Result<StyledTextParagraph, StyledTextError<'static>>> {
-    let mut parser = pulldown_cmark::Parser::new_ext(
+) -> (alloc::vec::Vec<StyledTextParagraph>, alloc::vec::Vec<StyledTextParseError>) {
+    use StyledTextParseErrorKind as E;
+
+    let parser = pulldown_cmark::Parser::new_ext(
         format_string,
         pulldown_cmark::Options::ENABLE_STRIKETHROUGH,
     );
 
     let mut list_state_stack: alloc::vec::Vec<Option<u64>> = alloc::vec::Vec::new();
-    let mut style_stack = alloc::vec::Vec::new();
+    let mut style_stack: alloc::vec::Vec<(Style, usize)> = alloc::vec::Vec::new();
     let mut current_url = None;
     let mut arg_index = 0;
+    let mut paragraphs = alloc::vec::Vec::new();
+    let mut errors = alloc::vec::Vec::new();
+    // Tracks skipped Start tags whose End events haven't been seen yet.
+    // When an End event fails to pop the style stack and this is > 0,
+    // we silently consume it instead of reporting a cascading Pop error.
+    let mut skip_end_count: usize = 0;
 
     let begin_paragraph = |indentation: u32, list_item_type: Option<ListItemType>| {
         let mut text = alloc::string::String::with_capacity(indentation as usize * 4);
@@ -136,50 +177,53 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
         StyledTextParagraph { text, formatting: Default::default(), links: Default::default() }
     };
 
-    let mut current_paragraph = None;
+    let mut current_paragraph: Option<StyledTextParagraph> = None;
+
+    fn append_paragraph(target: &mut StyledTextParagraph, source: &StyledTextParagraph) {
+        let offset = target.text.len();
+        target.text.push_str(&source.text);
+        target.formatting.extend(source.formatting.iter().cloned().map(|mut f| {
+            f.range.start += offset;
+            f.range.end += offset;
+            f
+        }));
+        target.links.extend(source.links.iter().cloned().map(|(mut range, link)| {
+            range.start += offset;
+            range.end += offset;
+            (range, link)
+        }));
+    }
 
     fn substitute<S: AsRef<[StyledTextParagraph]>>(
         paragraph: &mut StyledTextParagraph,
         string: &str,
         args: &[S],
         arg_index: &mut usize,
-    ) -> Result<(), StyledTextError<'static>> {
+        errors: &mut alloc::vec::Vec<StyledTextParseError>,
+        event_range: &core::ops::Range<usize>,
+    ) {
         let mut pos = 0;
         while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
             p += pos;
             paragraph.text.push_str(&string[pos..p]);
 
             if let Some(arg) = args.get(*arg_index) {
-                let arg_paragraphs = arg.as_ref();
-
-                match arg_paragraphs {
-                    [arg_paragraph] => {
-                        let offset = paragraph.text.len();
-                        paragraph.text.push_str(&arg_paragraph.text);
-                        paragraph.formatting.extend(
-                            arg_paragraph.formatting.iter().cloned().map(|mut f| {
-                                f.range.start += offset;
-                                f.range.end += offset;
-                                f
-                            }),
-                        );
-                        paragraph.links.extend(arg_paragraph.links.iter().cloned().map(
-                            |(mut range, link)| {
-                                range.start += offset;
-                                range.end += offset;
-                                (range, link)
-                            },
+                match arg.as_ref() {
+                    [source] => append_paragraph(paragraph, source),
+                    [] => {}
+                    [first, ..] => {
+                        errors.push(StyledTextParseError::new(
+                            E::MultiParagraphInterpolation,
+                            event_range.clone(),
                         ));
-                    }
-                    [] => {
-                        // No paragraphs in the argument, so nothing to add
-                    }
-                    _ => {
-                        return Err(StyledTextError::MultiParagraphInterpolation);
+                        append_paragraph(paragraph, first);
                     }
                 }
             } else {
-                return Err(StyledTextError::ArgumentOutOfRange(*arg_index, args.len()));
+                errors.push(StyledTextParseError::new(
+                    E::ArgumentOutOfRange(*arg_index, args.len()),
+                    event_range.clone(),
+                ));
             }
 
             *arg_index += 1;
@@ -188,15 +232,15 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
             pos = p;
         }
         paragraph.text.push_str(&string[pos..]);
-
-        Ok(())
     }
 
     fn substitute_in_string<S: AsRef<[StyledTextParagraph]>>(
         string: &str,
         args: &[S],
         arg_index: &mut usize,
-    ) -> Result<alloc::string::String, StyledTextError<'static>> {
+        errors: &mut alloc::vec::Vec<StyledTextParseError>,
+        event_range: &core::ops::Range<usize>,
+    ) -> alloc::string::String {
         let mut result = alloc::string::String::with_capacity(string.len());
         let mut pos = 0;
         while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
@@ -206,312 +250,413 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                 match arg.as_ref() {
                     [arg_paragraph] => result.push_str(&arg_paragraph.text),
                     [] => {}
-                    _ => return Err(StyledTextError::MultiParagraphInterpolation),
+                    [first, ..] => {
+                        errors.push(StyledTextParseError::new(
+                            E::MultiParagraphInterpolation,
+                            event_range.clone(),
+                        ));
+                        result.push_str(&first.text);
+                    }
                 }
             } else {
-                return Err(StyledTextError::ArgumentOutOfRange(*arg_index, args.len()));
+                errors.push(StyledTextParseError::new(
+                    E::ArgumentOutOfRange(*arg_index, args.len()),
+                    event_range.clone(),
+                ));
             }
             *arg_index += 1;
             p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
             pos = p;
         }
         result.push_str(&string[pos..]);
-        Ok(result)
+        result
     }
 
-    std::iter::from_fn(move || {
-        for event in &mut parser {
-            let indentation = list_state_stack.len().saturating_sub(1) as _;
+    fn get_or_create_paragraph<'a>(
+        current_paragraph: &'a mut Option<StyledTextParagraph>,
+        errors: &mut alloc::vec::Vec<StyledTextParseError>,
+        event_range: &core::ops::Range<usize>,
+    ) -> &'a mut StyledTextParagraph {
+        if current_paragraph.is_none() {
+            errors.push(StyledTextParseError::new(E::ParagraphNotStarted, event_range.clone()));
+            *current_paragraph = Some(StyledTextParagraph {
+                text: Default::default(),
+                formatting: Default::default(),
+                links: Default::default(),
+            });
+        }
+        current_paragraph.as_mut().unwrap()
+    }
 
-            match event {
-                pulldown_cmark::Event::SoftBreak | pulldown_cmark::Event::HardBreak => {
-                    if let Some(paragraph) =
-                        current_paragraph.replace(begin_paragraph(indentation, None))
-                    {
-                        return Some(Ok(paragraph));
-                    }
-                }
-                pulldown_cmark::Event::End(pulldown_cmark::TagEnd::List(_)) => {
-                    if list_state_stack.pop().is_none() {
-                        return Some(Err(StyledTextError::Pop));
-                    }
-                }
-                pulldown_cmark::Event::End(
-                    pulldown_cmark::TagEnd::Paragraph | pulldown_cmark::TagEnd::Item,
-                ) => {}
-                pulldown_cmark::Event::Start(tag) => {
-                    let style = match tag {
-                        pulldown_cmark::Tag::Paragraph => {
-                            if let Some(paragraph) =
-                                current_paragraph.replace(begin_paragraph(indentation, None))
-                            {
-                                return Some(Ok(paragraph));
-                            }
-                            continue;
-                        }
-                        pulldown_cmark::Tag::Item => {
-                            let old_paragraph = current_paragraph.replace(begin_paragraph(
-                                indentation,
-                                Some(match list_state_stack.last().copied() {
-                                    Some(Some(index)) => ListItemType::Ordered(index),
-                                    _ => ListItemType::Unordered,
-                                }),
-                            ));
-                            if let Some(state) = list_state_stack.last_mut() {
-                                *state = state.map(|state| state + 1);
-                            }
-                            if let Some(paragraph) = old_paragraph {
-                                return Some(Ok(paragraph));
-                            }
-                            continue;
-                        }
-                        pulldown_cmark::Tag::List(index) => {
-                            list_state_stack.push(index);
-                            continue;
-                        }
-                        pulldown_cmark::Tag::Strong => Style::Strong,
-                        pulldown_cmark::Tag::Emphasis => Style::Emphasis,
-                        pulldown_cmark::Tag::Strikethrough => Style::Strikethrough,
-                        pulldown_cmark::Tag::Link { dest_url, .. } => {
-                            current_url = Some(dest_url);
-                            Style::Link
-                        }
+    fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String {
+        match tag {
+            pulldown_cmark::Tag::Heading { .. } => "headings",
+            pulldown_cmark::Tag::Image { .. } => "images",
+            pulldown_cmark::Tag::BlockQuote(_) => "block quotes",
+            pulldown_cmark::Tag::CodeBlock(_) => "code blocks",
+            pulldown_cmark::Tag::Table(_) => "tables",
+            pulldown_cmark::Tag::HtmlBlock => "HTML blocks",
+            pulldown_cmark::Tag::FootnoteDefinition(_) => "footnotes",
+            pulldown_cmark::Tag::DefinitionList
+            | pulldown_cmark::Tag::DefinitionListTitle
+            | pulldown_cmark::Tag::DefinitionListDefinition => "definition lists",
+            pulldown_cmark::Tag::TableHead
+            | pulldown_cmark::Tag::TableRow
+            | pulldown_cmark::Tag::TableCell => "tables",
+            pulldown_cmark::Tag::MetadataBlock(_) => "metadata blocks",
+            pulldown_cmark::Tag::Superscript => "superscript",
+            pulldown_cmark::Tag::Subscript => "subscript",
+            other => return alloc::format!("{:?}", other.to_end()),
+        }
+        .into()
+    }
 
-                        pulldown_cmark::Tag::Heading { .. }
-                        | pulldown_cmark::Tag::Image { .. }
-                        | pulldown_cmark::Tag::DefinitionList
-                        | pulldown_cmark::Tag::DefinitionListTitle
-                        | pulldown_cmark::Tag::DefinitionListDefinition
-                        | pulldown_cmark::Tag::TableHead
-                        | pulldown_cmark::Tag::TableRow
-                        | pulldown_cmark::Tag::TableCell
-                        | pulldown_cmark::Tag::HtmlBlock
-                        | pulldown_cmark::Tag::Superscript
-                        | pulldown_cmark::Tag::Subscript
-                        | pulldown_cmark::Tag::Table(_)
-                        | pulldown_cmark::Tag::MetadataBlock(_)
-                        | pulldown_cmark::Tag::BlockQuote(_)
-                        | pulldown_cmark::Tag::CodeBlock(_)
-                        | pulldown_cmark::Tag::FootnoteDefinition(_) => {
-                            return Some(Err(StyledTextError::UnimplementedTag(tag.into_static())));
-                        }
-                    };
+    fn unsupported_event_name(event: &pulldown_cmark::Event<'_>) -> alloc::string::String {
+        match event {
+            pulldown_cmark::Event::Rule => "horizontal rules".into(),
+            pulldown_cmark::Event::TaskListMarker(_) => "task lists".into(),
+            pulldown_cmark::Event::FootnoteReference(_) => "footnote references".into(),
+            pulldown_cmark::Event::InlineMath(_) | pulldown_cmark::Event::DisplayMath(_) => {
+                "math".into()
+            }
+            pulldown_cmark::Event::Html(text) => {
+                alloc::format!("HTML blocks ({})", text.trim())
+            }
+            _ => alloc::format!("{event:?}"),
+        }
+    }
 
-                    let paragraph = match current_paragraph.as_mut() {
-                        Some(paragraph) => paragraph,
-                        None => return Some(Err(StyledTextError::ParagraphNotStarted)),
-                    };
+    for (event, event_range) in parser.into_offset_iter() {
+        let indentation = list_state_stack.len().saturating_sub(1) as _;
 
-                    style_stack.push((style, paragraph.text.len()));
-                }
-                pulldown_cmark::Event::Text(text) => {
-                    let paragraph = match current_paragraph.as_mut() {
-                        Some(paragraph) => paragraph,
-                        None => return Some(Err(StyledTextError::ParagraphNotStarted)),
-                    };
-
-                    if let Err(err) = substitute(paragraph, &text, &args, &mut arg_index) {
-                        return Some(Err(err));
-                    };
-                }
-                pulldown_cmark::Event::End(_) => {
-                    let (style, start) = if let Some(value) = style_stack.pop() {
-                        value
-                    } else {
-                        return Some(Err(StyledTextError::Pop));
-                    };
-
-                    let paragraph = match current_paragraph.as_mut() {
-                        Some(paragraph) => paragraph,
-                        None => return Some(Err(StyledTextError::ParagraphNotStarted)),
-                    };
-                    let end = paragraph.text.len();
-
-                    if let Some(url) = current_url.take() {
-                        let url = if url.contains(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
-                            match substitute_in_string(&url, &args, &mut arg_index) {
-                                Ok(url) => url,
-                                Err(err) => return Some(Err(err)),
-                            }
-                        } else {
-                            url.into()
-                        };
-                        paragraph.links.push((start..end, url));
-                    }
-
-                    paragraph.formatting.push(FormattedSpan { range: start..end, style });
-                }
-                pulldown_cmark::Event::Code(text) => {
-                    let paragraph = match current_paragraph.as_mut() {
-                        Some(paragraph) => paragraph,
-                        None => return Some(Err(StyledTextError::ParagraphNotStarted)),
-                    };
-                    let start = paragraph.text.len();
-
-                    if let Err(err) = substitute(paragraph, &text, &args, &mut arg_index) {
-                        return Some(Err(err));
-                    }
-                    paragraph.formatting.push(FormattedSpan {
-                        range: start..paragraph.text.len(),
-                        style: Style::Code,
-                    });
-                }
-                pulldown_cmark::Event::InlineHtml(html) => {
-                    if html.starts_with("</") {
-                        let (style, start) = if let Some(value) = style_stack.pop() {
-                            value
-                        } else {
-                            return Some(Err(StyledTextError::Pop));
-                        };
-
-                        let expected_tag = match &style {
-                            Style::Color(_) => "</font>",
-                            Style::Underline => "</u>",
-                            other => std::unreachable!(
-                                "Got unexpected closing style {:?} with html {}. This error should have been caught earlier.",
-                                other,
-                                html
-                            ),
-                        };
-
-                        if (&*html) != expected_tag {
-                            return Some(Err(StyledTextError::ClosingTagMismatch(
-                                expected_tag,
-                                (&*html).into(),
-                            )));
-                        }
-
-                        let paragraph = match current_paragraph.as_mut() {
-                            Some(paragraph) => paragraph,
-                            None => return Some(Err(StyledTextError::ParagraphNotStarted)),
-                        };
-
-                        let end = paragraph.text.len();
-                        paragraph.formatting.push(FormattedSpan { range: start..end, style });
-                    } else {
-                        let mut expecting_color_attribute = false;
-
-                        for token in htmlparser::Tokenizer::from(&*html) {
-                            match token {
-                                Ok(htmlparser::Token::ElementStart { local: tag_type, .. }) => {
-                                    match &*tag_type {
-                                        "u" => {
-                                            let paragraph = match current_paragraph.as_mut() {
-                                                Some(paragraph) => paragraph,
-                                                None => {
-                                                    return Some(Err(
-                                                        StyledTextError::ParagraphNotStarted,
-                                                    ));
-                                                }
-                                            };
-                                            style_stack
-                                                .push((Style::Underline, paragraph.text.len()));
-                                        }
-                                        "font" => {
-                                            expecting_color_attribute = true;
-                                        }
-                                        _ => {
-                                            return Some(Err(
-                                                StyledTextError::UnimplementedHtmlTag(
-                                                    (&*tag_type).into(),
-                                                ),
-                                            ));
-                                        }
-                                    }
-                                }
-                                Ok(htmlparser::Token::Attribute {
-                                    local: key,
-                                    value: Some(value),
-                                    ..
-                                }) => match &*key {
-                                    "color" => {
-                                        if !expecting_color_attribute {
-                                            return Some(Err(
-                                                StyledTextError::UnexpectedAttribute(
-                                                    (&*key).into(),
-                                                    (&*html).into(),
-                                                ),
-                                            ));
-                                        }
-                                        expecting_color_attribute = false;
-
-                                        let value =
-                                            match crate::color_parsing::parse_color_literal(&value)
-                                                .or_else(|| {
-                                                    crate::color_parsing::named_colors()
-                                                        .get(&*value)
-                                                        .copied()
-                                                }) {
-                                                Some(value) => value,
-                                                None => {
-                                                    return Some(Err(
-                                                        StyledTextError::InvalidColor(
-                                                            value.to_string(),
-                                                        ),
-                                                    ));
-                                                }
-                                            };
-
-                                        let paragraph = match current_paragraph.as_mut() {
-                                            Some(paragraph) => paragraph,
-                                            None => {
-                                                return Some(Err(
-                                                    StyledTextError::ParagraphNotStarted,
-                                                ));
-                                            }
-                                        };
-                                        style_stack
-                                            .push((Style::Color(value), paragraph.text.len()));
-                                    }
-                                    _ => {
-                                        return Some(Err(StyledTextError::UnexpectedAttribute(
-                                            (&*key).into(),
-                                            (&*html).into(),
-                                        )));
-                                    }
-                                },
-                                Ok(htmlparser::Token::ElementEnd { .. }) => {}
-                                _ => {
-                                    return Some(Err(StyledTextError::UnimplementedHtmlEvent(
-                                        alloc::format!("{:?}", token),
-                                    )));
-                                }
-                            }
-                        }
-
-                        if expecting_color_attribute {
-                            return Some(Err(StyledTextError::MissingColor((&*html).into())));
-                        }
-                    }
-                }
-                pulldown_cmark::Event::Rule
-                | pulldown_cmark::Event::TaskListMarker(_)
-                | pulldown_cmark::Event::FootnoteReference(_)
-                | pulldown_cmark::Event::InlineMath(_)
-                | pulldown_cmark::Event::DisplayMath(_)
-                | pulldown_cmark::Event::Html(_) => {
-                    return Some(Err(StyledTextError::UnimplementedEvent(event.into_static())));
+        match event {
+            pulldown_cmark::Event::SoftBreak | pulldown_cmark::Event::HardBreak => {
+                if let Some(paragraph) =
+                    current_paragraph.replace(begin_paragraph(indentation, None))
+                {
+                    paragraphs.push(paragraph);
                 }
             }
-        }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::List(_)) => {
+                if list_state_stack.pop().is_none() {
+                    errors.push(StyledTextParseError::new(E::Pop, event_range.clone()));
+                }
+            }
+            pulldown_cmark::Event::End(
+                pulldown_cmark::TagEnd::Paragraph | pulldown_cmark::TagEnd::Item,
+            ) => {}
+            pulldown_cmark::Event::Start(tag) => {
+                let style = match tag {
+                    pulldown_cmark::Tag::Paragraph => {
+                        if let Some(paragraph) =
+                            current_paragraph.replace(begin_paragraph(indentation, None))
+                        {
+                            paragraphs.push(paragraph);
+                        }
+                        continue;
+                    }
+                    pulldown_cmark::Tag::Item => {
+                        let old_paragraph = current_paragraph.replace(begin_paragraph(
+                            indentation,
+                            Some(match list_state_stack.last().copied() {
+                                Some(Some(index)) => ListItemType::Ordered(index),
+                                _ => ListItemType::Unordered,
+                            }),
+                        ));
+                        if let Some(state) = list_state_stack.last_mut() {
+                            *state = state.map(|state| state + 1);
+                        }
+                        if let Some(paragraph) = old_paragraph {
+                            paragraphs.push(paragraph);
+                        }
+                        continue;
+                    }
+                    pulldown_cmark::Tag::List(index) => {
+                        list_state_stack.push(index);
+                        continue;
+                    }
+                    pulldown_cmark::Tag::Strong => Style::Strong,
+                    pulldown_cmark::Tag::Emphasis => Style::Emphasis,
+                    pulldown_cmark::Tag::Strikethrough => Style::Strikethrough,
+                    pulldown_cmark::Tag::Link { dest_url, .. } => {
+                        current_url = Some(dest_url);
+                        Style::Link
+                    }
 
-        if arg_index != args.len() {
-            return Some(Err(StyledTextError::PlaceholderCountMismatch(arg_index, args.len())));
-        }
+                    ref unsupported => {
+                        errors.push(StyledTextParseError::new(
+                            E::UnsupportedMarkdown(unsupported_tag_name(unsupported)),
+                            event_range.clone(),
+                        ));
+                        skip_end_count += 1;
+                        continue;
+                    }
+                };
 
-        if !style_stack.is_empty() {
-            return Some(Err(StyledTextError::NotEmpty));
-        }
+                let paragraph =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
 
-        current_paragraph.take().map(Ok)
-    })
+                style_stack.push((style, paragraph.text.len()));
+            }
+            pulldown_cmark::Event::Text(text) => {
+                let paragraph =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+
+                substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
+            }
+            pulldown_cmark::Event::End(_) => {
+                let (style, start) = if let Some(value) = style_stack.pop() {
+                    value
+                } else if skip_end_count > 0 {
+                    skip_end_count -= 1;
+                    continue;
+                } else {
+                    errors.push(StyledTextParseError::new(E::Pop, event_range.clone()));
+                    continue;
+                };
+
+                let paragraph =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+                let end = paragraph.text.len();
+
+                if let Some(url) = current_url.take() {
+                    let url = if url.contains(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
+                        substitute_in_string(&url, args, &mut arg_index, &mut errors, &event_range)
+                    } else {
+                        url.into()
+                    };
+                    paragraph.links.push((start..end, url));
+                }
+
+                paragraph.formatting.push(FormattedSpan { range: start..end, style });
+            }
+            pulldown_cmark::Event::Code(text) => {
+                let paragraph =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+                let start = paragraph.text.len();
+
+                substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
+                paragraph
+                    .formatting
+                    .push(FormattedSpan { range: start..paragraph.text.len(), style: Style::Code });
+            }
+            pulldown_cmark::Event::InlineHtml(html) => {
+                if html.starts_with("</") {
+                    let (style, start) = if let Some(value) = style_stack.pop() {
+                        value
+                    } else if skip_end_count > 0 {
+                        skip_end_count -= 1;
+                        continue;
+                    } else {
+                        errors.push(StyledTextParseError::new(E::Pop, event_range.clone()));
+                        continue;
+                    };
+
+                    let expected_tag = match &style {
+                        Style::Color(_) => "</font>",
+                        Style::Underline => "</u>",
+                        _ => {
+                            errors.push(StyledTextParseError::new(
+                                E::ClosingTagMismatch(
+                                    alloc::format!("{:?}", style),
+                                    (&*html).into(),
+                                ),
+                                event_range.clone(),
+                            ));
+                            continue;
+                        }
+                    };
+
+                    if (&*html) != expected_tag {
+                        errors.push(StyledTextParseError::new(
+                            E::ClosingTagMismatch(expected_tag.into(), (&*html).into()),
+                            event_range.clone(),
+                        ));
+                        // Still apply the style as best-effort
+                    }
+
+                    let paragraph =
+                        get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+
+                    let end = paragraph.text.len();
+                    paragraph.formatting.push(FormattedSpan { range: start..end, style });
+                } else {
+                    let mut expecting_color_attribute = false;
+                    let mut push_skip = false;
+
+                    // htmlparser offsets are relative to `html`; add event_range.start
+                    // to get absolute format-string offsets
+                    let base = event_range.start;
+
+                    for token in htmlparser::Tokenizer::from(&*html) {
+                        match token {
+                            Ok(htmlparser::Token::ElementStart {
+                                local: tag_type, span, ..
+                            }) => match &*tag_type {
+                                "u" => {
+                                    let paragraph = get_or_create_paragraph(
+                                        &mut current_paragraph,
+                                        &mut errors,
+                                        &event_range,
+                                    );
+                                    style_stack.push((Style::Underline, paragraph.text.len()));
+                                }
+                                "font" => {
+                                    expecting_color_attribute = true;
+                                }
+                                _ => {
+                                    let r = base + span.start()..base + span.end();
+                                    errors.push(StyledTextParseError::new(
+                                        E::UnsupportedHtmlTag((&*tag_type).into()),
+                                        r,
+                                    ));
+                                    push_skip = true;
+                                }
+                            },
+                            Ok(htmlparser::Token::Attribute {
+                                local: key,
+                                value: Some(value),
+                                span,
+                                ..
+                            }) => match &*key {
+                                "color" => {
+                                    if !expecting_color_attribute {
+                                        let r = base + span.start()..base + span.end();
+                                        errors.push(StyledTextParseError::new(
+                                            E::UnexpectedAttribute((&*key).into(), (&*html).into()),
+                                            r,
+                                        ));
+                                        continue;
+                                    }
+                                    expecting_color_attribute = false;
+
+                                    let color_str =
+                                        if value.contains(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
+                                            Some(substitute_in_string(
+                                                &value,
+                                                args,
+                                                &mut arg_index,
+                                                &mut errors,
+                                                &event_range,
+                                            ))
+                                        } else {
+                                            None
+                                        };
+                                    let color_str = color_str.as_deref().unwrap_or(&*value);
+
+                                    let color_value =
+                                        crate::color_parsing::parse_color_literal(color_str)
+                                            .or_else(|| {
+                                                crate::color_parsing::named_colors()
+                                                    .get(color_str)
+                                                    .copied()
+                                            });
+
+                                    match color_value {
+                                        Some(value) => {
+                                            let paragraph = get_or_create_paragraph(
+                                                &mut current_paragraph,
+                                                &mut errors,
+                                                &event_range,
+                                            );
+                                            style_stack
+                                                .push((Style::Color(value), paragraph.text.len()));
+                                        }
+                                        None => {
+                                            let r = base + span.start()..base + span.end();
+                                            errors.push(StyledTextParseError::new(
+                                                E::InvalidColor(color_str.into()),
+                                                r,
+                                            ));
+                                            // Push a dummy style so the closing </font> tag
+                                            // can pop it without error
+                                            let paragraph = get_or_create_paragraph(
+                                                &mut current_paragraph,
+                                                &mut errors,
+                                                &event_range,
+                                            );
+                                            style_stack
+                                                .push((Style::Color(0), paragraph.text.len()));
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    let r = base + span.start()..base + span.end();
+                                    errors.push(StyledTextParseError::new(
+                                        E::UnexpectedAttribute((&*key).into(), (&*html).into()),
+                                        r,
+                                    ));
+                                }
+                            },
+                            Ok(htmlparser::Token::ElementEnd { .. }) => {}
+                            _ => {
+                                errors.push(StyledTextParseError::new(
+                                    E::UnsupportedMarkdown(alloc::format!("{:?}", token)),
+                                    event_range.clone(),
+                                ));
+                            }
+                        }
+                    }
+
+                    if expecting_color_attribute {
+                        errors.push(StyledTextParseError::new(
+                            E::MissingColor((&*html).into()),
+                            event_range.clone(),
+                        ));
+                        push_skip = true;
+                    }
+
+                    if push_skip {
+                        skip_end_count += 1;
+                    }
+                }
+            }
+            pulldown_cmark::Event::Rule
+            | pulldown_cmark::Event::TaskListMarker(_)
+            | pulldown_cmark::Event::FootnoteReference(_)
+            | pulldown_cmark::Event::InlineMath(_)
+            | pulldown_cmark::Event::DisplayMath(_)
+            | pulldown_cmark::Event::Html(_) => {
+                errors.push(StyledTextParseError::new(
+                    E::UnsupportedMarkdown(unsupported_event_name(&event)),
+                    event_range,
+                ));
+            }
+        }
+    }
+
+    if arg_index != args.len() {
+        errors.push(StyledTextParseError::without_range(E::PlaceholderCountMismatch(
+            arg_index,
+            args.len(),
+        )));
+    }
+
+    if !style_stack.is_empty() {
+        errors.push(StyledTextParseError::without_range(E::NotEmpty));
+    }
+
+    if let Some(paragraph) = current_paragraph.take() {
+        paragraphs.push(paragraph);
+    }
+
+    (paragraphs, errors)
+}
+
+#[cfg(all(feature = "markdown", test))]
+fn assert_no_errors(
+    result: (alloc::vec::Vec<StyledTextParagraph>, alloc::vec::Vec<StyledTextParseError>),
+) -> alloc::vec::Vec<StyledTextParagraph> {
+    let (paragraphs, errors) = result;
+    assert!(errors.is_empty(), "Unexpected errors: {errors:?}");
+    paragraphs
 }
 
 #[cfg(feature = "markdown")]
 #[test]
 fn markdown_parsing() {
     assert_eq!(
-        parse_interpolated::<&[_]>("hello *world*", &[]).collect::<Result<Vec<_>, _>>().unwrap(),
+        assert_no_errors(parse_interpolated::<&[_]>("hello *world*", &[])),
         [StyledTextParagraph {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan { range: 6..11, style: Style::Emphasis }],
@@ -520,15 +665,13 @@ fn markdown_parsing() {
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>(
+        assert_no_errors(parse_interpolated::<&[_]>(
             "
 - line 1
 - line 2
             ",
             &[]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [
             StyledTextParagraph {
                 text: "• line 1".into(),
@@ -544,16 +687,14 @@ fn markdown_parsing() {
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>(
+        assert_no_errors(parse_interpolated::<&[_]>(
             "
 1. a
 2. b
 4. c
         ",
             &[]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [
             StyledTextParagraph {
                 text: "1. a".into(),
@@ -574,15 +715,13 @@ fn markdown_parsing() {
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>(
+        assert_no_errors(parse_interpolated::<&[_]>(
             "
 Normal _italic_ **strong** ~~strikethrough~~ `code`
 new *line*
 ",
             &[]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [
             StyledTextParagraph {
                 text: "Normal italic strong strikethrough code".into(),
@@ -603,7 +742,7 @@ new *line*
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>(
+        assert_no_errors(parse_interpolated::<&[_]>(
             "
 - root
   - child
@@ -611,9 +750,7 @@ new *line*
       - great grandchild
 ",
             &[]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [
             StyledTextParagraph {
                 text: "• root".into(),
@@ -639,9 +776,7 @@ new *line*
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>("hello [*world*](https://example.com)", &[])
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap(),
+        assert_no_errors(parse_interpolated::<&[_]>("hello [*world*](https://example.com)", &[])),
         [StyledTextParagraph {
             text: "hello world".into(),
             formatting: alloc::vec![
@@ -653,9 +788,7 @@ new *line*
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>("<u>hello world</u>", &[])
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap(),
+        assert_no_errors(parse_interpolated::<&[_]>("<u>hello world</u>", &[])),
         [StyledTextParagraph {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan { range: 0..11, style: Style::Underline },],
@@ -664,9 +797,10 @@ new *line*
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>(r#"<font color="blue">hello world</font>"#, &[])
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap(),
+        assert_no_errors(parse_interpolated::<&[_]>(
+            r#"<font color="blue">hello world</font>"#,
+            &[]
+        )),
         [StyledTextParagraph {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan {
@@ -678,9 +812,10 @@ new *line*
     );
 
     assert_eq!(
-        parse_interpolated::<&[_]>(r#"<u><font color="red">hello world</font></u>"#, &[])
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap(),
+        assert_no_errors(parse_interpolated::<&[_]>(
+            r#"<u><font color="red">hello world</font></u>"#,
+            &[]
+        )),
         [StyledTextParagraph {
             text: "hello world".into(),
             formatting: alloc::vec![
@@ -691,24 +826,35 @@ new *line*
         }]
     );
 
-    assert_eq!(
-        parse_interpolated::<&[_]>(r#"<u><font color="\#a">hello world</font></u>"#, &[])
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap_err(),
-        StyledTextError::InvalidColor(r"\#a".into())
-    );
+    // Invalid color: text still renders, error is reported
+    {
+        let (paragraphs, errors) =
+            parse_interpolated::<&[_]>(r#"<u><font color="\#a">hello world</font></u>"#, &[]);
+        assert_eq!(
+            paragraphs,
+            [StyledTextParagraph {
+                text: "hello world".into(),
+                formatting: alloc::vec![
+                    FormattedSpan { range: 0..11, style: Style::Color(0) },
+                    FormattedSpan { range: 0..11, style: Style::Underline },
+                ],
+                links: alloc::vec::Vec::new()
+            }]
+        );
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].to_string(), r"Invalid color value '\#a'");
+        assert!(errors[0].range().is_some());
+    }
 }
 
 #[cfg(feature = "markdown")]
 #[test]
 fn markdown_parsing_interpolated() {
     assert_eq!(
-        parse_interpolated(
+        assert_no_errors(parse_interpolated(
             &format!("Text: *{MARKDOWN_INTERPOLATION_PLACEHOLDER}*"),
             &[&[paragraph_from_plain_text("italic".into())]]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [StyledTextParagraph {
             text: "Text: italic".into(),
             formatting: alloc::vec![FormattedSpan { range: 6..12, style: Style::Emphasis }],
@@ -716,12 +862,10 @@ fn markdown_parsing_interpolated() {
         }]
     );
     assert_eq!(
-        parse_interpolated(
+        assert_no_errors(parse_interpolated(
             &format!("Escaped text: {MARKDOWN_INTERPOLATION_PLACEHOLDER}"),
             &[&[paragraph_from_plain_text("*bold*".into())]]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [StyledTextParagraph {
             text: "Escaped text: *bold*".into(),
             formatting: alloc::vec![],
@@ -729,12 +873,10 @@ fn markdown_parsing_interpolated() {
         }]
     );
     assert_eq!(
-        parse_interpolated(
+        assert_no_errors(parse_interpolated(
             &format!("Code block text: `{MARKDOWN_INTERPOLATION_PLACEHOLDER}`"),
             &[&[paragraph_from_plain_text("*bold*".into())]]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [StyledTextParagraph {
             text: "Code block text: *bold*".into(),
             formatting: alloc::vec![FormattedSpan { range: 17..23, style: Style::Code }],
@@ -742,17 +884,15 @@ fn markdown_parsing_interpolated() {
         }]
     );
     assert_eq!(
-        parse_interpolated(
+        assert_no_errors(parse_interpolated(
             &format!(
                 "**{MARKDOWN_INTERPOLATION_PLACEHOLDER}** {MARKDOWN_INTERPOLATION_PLACEHOLDER}"
             ),
             &[
                 alloc::vec![paragraph_from_plain_text("Hello".into())],
-                parse_interpolated::<&[_]>("*World*", &[]).collect::<Result<_, _>>().unwrap()
+                parse_interpolated::<&[_]>("*World*", &[]).0
             ]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [StyledTextParagraph {
             text: "Hello World".into(),
             formatting: alloc::vec![
@@ -763,14 +903,10 @@ fn markdown_parsing_interpolated() {
         }]
     );
     assert_eq!(
-        parse_interpolated(
+        assert_no_errors(parse_interpolated(
             &format!("<u>{MARKDOWN_INTERPOLATION_PLACEHOLDER}</u>"),
-            &[parse_interpolated::<&[_]>("*underline_and_italic*", &[])
-                .collect::<Result<Vec<_>, _>>()
-                .unwrap()]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+            &[parse_interpolated::<&[_]>("*underline_and_italic*", &[]).0]
+        )),
         [StyledTextParagraph {
             text: "underline_and_italic".into(),
             formatting: alloc::vec![
@@ -782,19 +918,18 @@ fn markdown_parsing_interpolated() {
     );
     // Empty paragraph list might be caused by a StyledText::default()
     assert_eq!(
-        parse_interpolated(&format!("{MARKDOWN_INTERPOLATION_PLACEHOLDER}"), &[[]])
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap(),
+        assert_no_errors(parse_interpolated(
+            &format!("{MARKDOWN_INTERPOLATION_PLACEHOLDER}"),
+            &[[]]
+        )),
         [StyledTextParagraph { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }]
     );
     // Interpolation in link URL
     assert_eq!(
-        parse_interpolated(
+        assert_no_errors(parse_interpolated(
             &format!("[Click here]({MARKDOWN_INTERPOLATION_PLACEHOLDER})"),
             &[&[paragraph_from_plain_text("https://example.com".into())]]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [StyledTextParagraph {
             text: "Click here".into(),
             formatting: alloc::vec![FormattedSpan { range: 0..10, style: Style::Link }],
@@ -803,14 +938,10 @@ fn markdown_parsing_interpolated() {
     );
     // Interpolation in link URL with surrounding text
     assert_eq!(
-        parse_interpolated(
-            &format!(
-                "[link](https://{MARKDOWN_INTERPOLATION_PLACEHOLDER}/path) after"
-            ),
+        assert_no_errors(parse_interpolated(
+            &format!("[link](https://{MARKDOWN_INTERPOLATION_PLACEHOLDER}/path) after"),
             &[&[paragraph_from_plain_text("example.com".into())]]
-        )
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap(),
+        )),
         [StyledTextParagraph {
             text: "link after".into(),
             formatting: alloc::vec![FormattedSpan { range: 0..4, style: Style::Link }],

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -66,13 +66,6 @@ impl StyledTextParseError {
     fn without_range(kind: StyledTextParseErrorKind) -> Self {
         Self { kind, range: None }
     }
-
-    /// Returns true if this is an invalid color error.
-    /// Useful for the compiler to skip this during compile-time validation
-    /// when color values may come from dynamic interpolation.
-    pub fn is_invalid_color(&self) -> bool {
-        matches!(self.kind, StyledTextParseErrorKind::InvalidColor(_))
-    }
 }
 
 #[cfg(feature = "markdown")]
@@ -81,6 +74,14 @@ impl PartialEq for StyledTextParseError {
     fn eq(&self, other: &Self) -> bool {
         self.kind == other.kind
     }
+}
+
+/// Returns true if this is an invalid color error.
+/// Useful for the compiler to skip this during compile-time validation
+/// when color values may come from dynamic interpolation.
+#[cfg(feature = "markdown")]
+pub fn is_invalid_color(error: &StyledTextParseError) -> bool {
+    matches!(error.kind, StyledTextParseErrorKind::InvalidColor(_))
 }
 
 #[cfg(feature = "markdown")]
@@ -133,6 +134,179 @@ pub fn paragraph_from_plain_text(text: alloc::string::String) -> StyledTextParag
 pub const MARKDOWN_INTERPOLATION_PLACEHOLDER: char = '\u{e541}';
 
 #[cfg(feature = "markdown")]
+fn begin_paragraph(indentation: u32, list_item_type: Option<ListItemType>) -> StyledTextParagraph {
+    let mut text = alloc::string::String::with_capacity(indentation as usize * 4);
+    for _ in 0..indentation {
+        text.push_str("    ");
+    }
+    match list_item_type {
+        Some(ListItemType::Unordered) => {
+            let remainder = indentation % 3;
+            if remainder == 0 {
+                text.push_str("• ")
+            } else if remainder == 1 {
+                text.push_str("◦ ")
+            } else {
+                text.push_str("▪ ")
+            }
+        }
+        Some(ListItemType::Ordered(num)) => text.push_str(&alloc::format!("{}. ", num)),
+        None => {}
+    };
+    StyledTextParagraph { text, formatting: Default::default(), links: Default::default() }
+}
+
+#[cfg(feature = "markdown")]
+fn append_paragraph(target: &mut StyledTextParagraph, source: &StyledTextParagraph) {
+    let offset = target.text.len();
+    target.text.push_str(&source.text);
+    target.formatting.extend(source.formatting.iter().cloned().map(|mut f| {
+        f.range.start += offset;
+        f.range.end += offset;
+        f
+    }));
+    target.links.extend(source.links.iter().cloned().map(|(mut range, link)| {
+        range.start += offset;
+        range.end += offset;
+        (range, link)
+    }));
+}
+
+#[cfg(feature = "markdown")]
+fn substitute<S: AsRef<[StyledTextParagraph]>>(
+    paragraph: &mut StyledTextParagraph,
+    string: &str,
+    args: &[S],
+    arg_index: &mut usize,
+    errors: &mut alloc::vec::Vec<StyledTextParseError>,
+    event_range: &core::ops::Range<usize>,
+) {
+    use StyledTextParseErrorKind as E;
+    let mut pos = 0;
+    while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
+        p += pos;
+        paragraph.text.push_str(&string[pos..p]);
+
+        if let Some(arg) = args.get(*arg_index) {
+            match arg.as_ref() {
+                [source] => append_paragraph(paragraph, source),
+                [] => {}
+                [first, ..] => {
+                    errors.push(StyledTextParseError::new(
+                        E::MultiParagraphInterpolation,
+                        event_range.clone(),
+                    ));
+                    append_paragraph(paragraph, first);
+                }
+            }
+        } else {
+            errors.push(StyledTextParseError::new(
+                E::ArgumentOutOfRange(*arg_index, args.len()),
+                event_range.clone(),
+            ));
+        }
+
+        *arg_index += 1;
+
+        p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
+        pos = p;
+    }
+    paragraph.text.push_str(&string[pos..]);
+}
+
+#[cfg(feature = "markdown")]
+fn substitute_in_string<S: AsRef<[StyledTextParagraph]>>(
+    string: &str,
+    args: &[S],
+    arg_index: &mut usize,
+    errors: &mut alloc::vec::Vec<StyledTextParseError>,
+    event_range: &core::ops::Range<usize>,
+) -> alloc::string::String {
+    use StyledTextParseErrorKind as E;
+    let mut result = alloc::string::String::with_capacity(string.len());
+    let mut pos = 0;
+    while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
+        p += pos;
+        result.push_str(&string[pos..p]);
+        if let Some(arg) = args.get(*arg_index) {
+            match arg.as_ref() {
+                [arg_paragraph] => result.push_str(&arg_paragraph.text),
+                [] => {}
+                [first, ..] => {
+                    errors.push(StyledTextParseError::new(
+                        E::MultiParagraphInterpolation,
+                        event_range.clone(),
+                    ));
+                    result.push_str(&first.text);
+                }
+            }
+        } else {
+            errors.push(StyledTextParseError::new(
+                E::ArgumentOutOfRange(*arg_index, args.len()),
+                event_range.clone(),
+            ));
+        }
+        *arg_index += 1;
+        p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
+        pos = p;
+    }
+    result.push_str(&string[pos..]);
+    result
+}
+
+#[cfg(feature = "markdown")]
+fn get_or_create_paragraph<'a>(
+    current_paragraph: &'a mut Option<StyledTextParagraph>,
+    errors: &mut alloc::vec::Vec<StyledTextParseError>,
+    event_range: &core::ops::Range<usize>,
+) -> &'a mut StyledTextParagraph {
+    use StyledTextParseErrorKind as E;
+    if current_paragraph.is_none() {
+        errors.push(StyledTextParseError::new(E::ParagraphNotStarted, event_range.clone()));
+        *current_paragraph = Some(StyledTextParagraph {
+            text: Default::default(),
+            formatting: Default::default(),
+            links: Default::default(),
+        });
+    }
+    current_paragraph.as_mut().unwrap()
+}
+
+#[cfg(feature = "markdown")]
+fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String {
+    use pulldown_cmark::Tag::*;
+    match tag {
+        Heading { .. } => "headings",
+        Image { .. } => "images",
+        BlockQuote(_) => "block quotes",
+        CodeBlock(_) => "code blocks",
+        Table(_) => "tables",
+        HtmlBlock => "HTML blocks",
+        FootnoteDefinition(_) => "footnotes",
+        DefinitionList | DefinitionListTitle | DefinitionListDefinition => "definition lists",
+        TableHead | TableRow | TableCell => "tables",
+        MetadataBlock(_) => "metadata blocks",
+        Superscript => "superscript",
+        Subscript => "subscript",
+        other => return alloc::format!("{:?}", other.to_end()),
+    }
+    .into()
+}
+
+#[cfg(feature = "markdown")]
+fn unsupported_event_name(event: &pulldown_cmark::Event<'_>) -> alloc::string::String {
+    use pulldown_cmark::Event::*;
+    match event {
+        Rule => "horizontal rules".into(),
+        TaskListMarker(_) => "task lists".into(),
+        FootnoteReference(_) => "footnote references".into(),
+        InlineMath(_) | DisplayMath(_) => "math".into(),
+        Html(text) => alloc::format!("HTML blocks ({})", text.trim()),
+        _ => alloc::format!("{event:?}"),
+    }
+}
+
+#[cfg(feature = "markdown")]
 pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
     format_string: &str,
     args: &[S],
@@ -155,176 +329,7 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
     // we silently consume it instead of reporting a cascading Pop error.
     let mut skip_end_count: usize = 0;
 
-    let begin_paragraph = |indentation: u32, list_item_type: Option<ListItemType>| {
-        let mut text = alloc::string::String::with_capacity(indentation as usize * 4);
-        for _ in 0..indentation {
-            text.push_str("    ");
-        }
-        match list_item_type {
-            Some(ListItemType::Unordered) => {
-                let remainder = indentation % 3;
-                if remainder == 0 {
-                    text.push_str("• ")
-                } else if remainder == 1 {
-                    text.push_str("◦ ")
-                } else {
-                    text.push_str("▪ ")
-                }
-            }
-            Some(ListItemType::Ordered(num)) => text.push_str(&alloc::format!("{}. ", num)),
-            None => {}
-        };
-        StyledTextParagraph { text, formatting: Default::default(), links: Default::default() }
-    };
-
     let mut current_paragraph: Option<StyledTextParagraph> = None;
-
-    fn append_paragraph(target: &mut StyledTextParagraph, source: &StyledTextParagraph) {
-        let offset = target.text.len();
-        target.text.push_str(&source.text);
-        target.formatting.extend(source.formatting.iter().cloned().map(|mut f| {
-            f.range.start += offset;
-            f.range.end += offset;
-            f
-        }));
-        target.links.extend(source.links.iter().cloned().map(|(mut range, link)| {
-            range.start += offset;
-            range.end += offset;
-            (range, link)
-        }));
-    }
-
-    fn substitute<S: AsRef<[StyledTextParagraph]>>(
-        paragraph: &mut StyledTextParagraph,
-        string: &str,
-        args: &[S],
-        arg_index: &mut usize,
-        errors: &mut alloc::vec::Vec<StyledTextParseError>,
-        event_range: &core::ops::Range<usize>,
-    ) {
-        let mut pos = 0;
-        while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
-            p += pos;
-            paragraph.text.push_str(&string[pos..p]);
-
-            if let Some(arg) = args.get(*arg_index) {
-                match arg.as_ref() {
-                    [source] => append_paragraph(paragraph, source),
-                    [] => {}
-                    [first, ..] => {
-                        errors.push(StyledTextParseError::new(
-                            E::MultiParagraphInterpolation,
-                            event_range.clone(),
-                        ));
-                        append_paragraph(paragraph, first);
-                    }
-                }
-            } else {
-                errors.push(StyledTextParseError::new(
-                    E::ArgumentOutOfRange(*arg_index, args.len()),
-                    event_range.clone(),
-                ));
-            }
-
-            *arg_index += 1;
-
-            p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
-            pos = p;
-        }
-        paragraph.text.push_str(&string[pos..]);
-    }
-
-    fn substitute_in_string<S: AsRef<[StyledTextParagraph]>>(
-        string: &str,
-        args: &[S],
-        arg_index: &mut usize,
-        errors: &mut alloc::vec::Vec<StyledTextParseError>,
-        event_range: &core::ops::Range<usize>,
-    ) -> alloc::string::String {
-        let mut result = alloc::string::String::with_capacity(string.len());
-        let mut pos = 0;
-        while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
-            p += pos;
-            result.push_str(&string[pos..p]);
-            if let Some(arg) = args.get(*arg_index) {
-                match arg.as_ref() {
-                    [arg_paragraph] => result.push_str(&arg_paragraph.text),
-                    [] => {}
-                    [first, ..] => {
-                        errors.push(StyledTextParseError::new(
-                            E::MultiParagraphInterpolation,
-                            event_range.clone(),
-                        ));
-                        result.push_str(&first.text);
-                    }
-                }
-            } else {
-                errors.push(StyledTextParseError::new(
-                    E::ArgumentOutOfRange(*arg_index, args.len()),
-                    event_range.clone(),
-                ));
-            }
-            *arg_index += 1;
-            p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
-            pos = p;
-        }
-        result.push_str(&string[pos..]);
-        result
-    }
-
-    fn get_or_create_paragraph<'a>(
-        current_paragraph: &'a mut Option<StyledTextParagraph>,
-        errors: &mut alloc::vec::Vec<StyledTextParseError>,
-        event_range: &core::ops::Range<usize>,
-    ) -> &'a mut StyledTextParagraph {
-        if current_paragraph.is_none() {
-            errors.push(StyledTextParseError::new(E::ParagraphNotStarted, event_range.clone()));
-            *current_paragraph = Some(StyledTextParagraph {
-                text: Default::default(),
-                formatting: Default::default(),
-                links: Default::default(),
-            });
-        }
-        current_paragraph.as_mut().unwrap()
-    }
-
-    fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String {
-        match tag {
-            pulldown_cmark::Tag::Heading { .. } => "headings",
-            pulldown_cmark::Tag::Image { .. } => "images",
-            pulldown_cmark::Tag::BlockQuote(_) => "block quotes",
-            pulldown_cmark::Tag::CodeBlock(_) => "code blocks",
-            pulldown_cmark::Tag::Table(_) => "tables",
-            pulldown_cmark::Tag::HtmlBlock => "HTML blocks",
-            pulldown_cmark::Tag::FootnoteDefinition(_) => "footnotes",
-            pulldown_cmark::Tag::DefinitionList
-            | pulldown_cmark::Tag::DefinitionListTitle
-            | pulldown_cmark::Tag::DefinitionListDefinition => "definition lists",
-            pulldown_cmark::Tag::TableHead
-            | pulldown_cmark::Tag::TableRow
-            | pulldown_cmark::Tag::TableCell => "tables",
-            pulldown_cmark::Tag::MetadataBlock(_) => "metadata blocks",
-            pulldown_cmark::Tag::Superscript => "superscript",
-            pulldown_cmark::Tag::Subscript => "subscript",
-            other => return alloc::format!("{:?}", other.to_end()),
-        }
-        .into()
-    }
-
-    fn unsupported_event_name(event: &pulldown_cmark::Event<'_>) -> alloc::string::String {
-        match event {
-            pulldown_cmark::Event::Rule => "horizontal rules".into(),
-            pulldown_cmark::Event::TaskListMarker(_) => "task lists".into(),
-            pulldown_cmark::Event::FootnoteReference(_) => "footnote references".into(),
-            pulldown_cmark::Event::InlineMath(_) | pulldown_cmark::Event::DisplayMath(_) => {
-                "math".into()
-            }
-            pulldown_cmark::Event::Html(text) => {
-                alloc::format!("HTML blocks ({})", text.trim())
-            }
-            _ => alloc::format!("{event:?}"),
-        }
-    }
 
     for (event, event_range) in parser.into_offset_iter() {
         let indentation = list_state_stack.len().saturating_sub(1) as _;
@@ -381,6 +386,25 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     pulldown_cmark::Tag::Link { dest_url, .. } => {
                         current_url = Some(dest_url);
                         Style::Link
+                    }
+
+                    pulldown_cmark::Tag::BlockQuote(_) => {
+                        let mut r = event_range.clone();
+                        if let Some(pos) = format_string[r.clone()].find('>') {
+                            r.start += pos;
+                        }
+                        errors.push(StyledTextParseError::new(
+                            E::UnsupportedMarkdown(unsupported_tag_name(&tag)),
+                            r,
+                        ));
+                        skip_end_count += 1;
+                        continue;
+                    }
+                    pulldown_cmark::Tag::HtmlBlock => {
+                        // Don't report an error here; the accompanying Html event
+                        // provides a more descriptive message with the actual content
+                        skip_end_count += 1;
+                        continue;
                     }
 
                     ref unsupported => {
@@ -487,6 +511,8 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     // htmlparser offsets are relative to `html`; add event_range.start
                     // to get absolute format-string offsets
                     let base = event_range.start;
+
+                    let errors_before = errors.len();
 
                     for token in htmlparser::Tokenizer::from(&*html) {
                         match token {
@@ -599,10 +625,14 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     }
 
                     if expecting_color_attribute {
-                        errors.push(StyledTextParseError::new(
-                            E::MissingColor((&*html).into()),
-                            event_range.clone(),
-                        ));
+                        // Only report MissingColor when no other errors were
+                        // reported for this HTML fragment (avoids cascading diagnostics)
+                        if errors.len() == errors_before {
+                            errors.push(StyledTextParseError::new(
+                                E::MissingColor((&*html).into()),
+                                event_range.clone(),
+                            ));
+                        }
                         push_skip = true;
                     }
 

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -138,58 +138,88 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
 
     let mut current_paragraph = None;
 
-    std::iter::from_fn(move || {
-        let mut substitute = |paragraph: &mut StyledTextParagraph,
-                              string: &str|
-         -> Result<(), StyledTextError<'static>> {
-            let mut pos = 0;
-            while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
-                p += pos;
-                paragraph.text.push_str(&string[pos..p]);
+    fn substitute<S: AsRef<[StyledTextParagraph]>>(
+        paragraph: &mut StyledTextParagraph,
+        string: &str,
+        args: &[S],
+        arg_index: &mut usize,
+    ) -> Result<(), StyledTextError<'static>> {
+        let mut pos = 0;
+        while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
+            p += pos;
+            paragraph.text.push_str(&string[pos..p]);
 
-                if let Some(arg) = args.get(arg_index) {
-                    let arg_paragraphs = arg.as_ref();
+            if let Some(arg) = args.get(*arg_index) {
+                let arg_paragraphs = arg.as_ref();
 
-                    match arg_paragraphs {
-                        [arg_paragraph] => {
-                            let offset = paragraph.text.len();
-                            paragraph.text.push_str(&arg_paragraph.text);
-                            paragraph.formatting.extend(
-                                arg_paragraph.formatting.iter().cloned().map(|mut f| {
-                                    f.range.start += offset;
-                                    f.range.end += offset;
-                                    f
-                                }),
-                            );
-                            paragraph.links.extend(arg_paragraph.links.iter().cloned().map(
-                                |(mut range, link)| {
-                                    range.start += offset;
-                                    range.end += offset;
-                                    (range, link)
-                                },
-                            ));
-                        }
-                        [] => {
-                            // No paragraphs in the argument, so nothing to add
-                        }
-                        _ => {
-                            return Err(StyledTextError::MultiParagraphInterpolation);
-                        }
+                match arg_paragraphs {
+                    [arg_paragraph] => {
+                        let offset = paragraph.text.len();
+                        paragraph.text.push_str(&arg_paragraph.text);
+                        paragraph.formatting.extend(
+                            arg_paragraph.formatting.iter().cloned().map(|mut f| {
+                                f.range.start += offset;
+                                f.range.end += offset;
+                                f
+                            }),
+                        );
+                        paragraph.links.extend(arg_paragraph.links.iter().cloned().map(
+                            |(mut range, link)| {
+                                range.start += offset;
+                                range.end += offset;
+                                (range, link)
+                            },
+                        ));
                     }
-                } else {
-                    return Err(StyledTextError::ArgumentOutOfRange(arg_index, args.len()));
+                    [] => {
+                        // No paragraphs in the argument, so nothing to add
+                    }
+                    _ => {
+                        return Err(StyledTextError::MultiParagraphInterpolation);
+                    }
                 }
-
-                arg_index += 1;
-
-                p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
-                pos = p;
+            } else {
+                return Err(StyledTextError::ArgumentOutOfRange(*arg_index, args.len()));
             }
-            paragraph.text.push_str(&string[pos..]);
 
-            Ok(())
-        };
+            *arg_index += 1;
 
+            p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
+            pos = p;
+        }
+        paragraph.text.push_str(&string[pos..]);
+
+        Ok(())
+    }
+
+    fn substitute_in_string<S: AsRef<[StyledTextParagraph]>>(
+        string: &str,
+        args: &[S],
+        arg_index: &mut usize,
+    ) -> Result<alloc::string::String, StyledTextError<'static>> {
+        let mut result = alloc::string::String::with_capacity(string.len());
+        let mut pos = 0;
+        while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
+            p += pos;
+            result.push_str(&string[pos..p]);
+            if let Some(arg) = args.get(*arg_index) {
+                match arg.as_ref() {
+                    [arg_paragraph] => result.push_str(&arg_paragraph.text),
+                    [] => {}
+                    _ => return Err(StyledTextError::MultiParagraphInterpolation),
+                }
+            } else {
+                return Err(StyledTextError::ArgumentOutOfRange(*arg_index, args.len()));
+            }
+            *arg_index += 1;
+            p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
+            pos = p;
+        }
+        result.push_str(&string[pos..]);
+        Ok(result)
+    }
+
+    std::iter::from_fn(move || {
         for event in &mut parser {
             let indentation = list_state_stack.len().saturating_sub(1) as _;
 
@@ -280,7 +310,7 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                         None => return Some(Err(StyledTextError::ParagraphNotStarted)),
                     };
 
-                    if let Err(err) = substitute(paragraph, &text) {
+                    if let Err(err) = substitute(paragraph, &text, &args, &mut arg_index) {
                         return Some(Err(err));
                     };
                 }
@@ -298,7 +328,15 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     let end = paragraph.text.len();
 
                     if let Some(url) = current_url.take() {
-                        paragraph.links.push((start..end, url.into()));
+                        let url = if url.contains(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
+                            match substitute_in_string(&url, &args, &mut arg_index) {
+                                Ok(url) => url,
+                                Err(err) => return Some(Err(err)),
+                            }
+                        } else {
+                            url.into()
+                        };
+                        paragraph.links.push((start..end, url));
                     }
 
                     paragraph.formatting.push(FormattedSpan { range: start..end, style });
@@ -310,7 +348,7 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     };
                     let start = paragraph.text.len();
 
-                    if let Err(err) = substitute(paragraph, &text) {
+                    if let Err(err) = substitute(paragraph, &text, &args, &mut arg_index) {
                         return Some(Err(err));
                     }
                     paragraph.formatting.push(FormattedSpan {
@@ -748,5 +786,35 @@ fn markdown_parsing_interpolated() {
             .collect::<Result<Vec<_>, _>>()
             .unwrap(),
         [StyledTextParagraph { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }]
-    )
+    );
+    // Interpolation in link URL
+    assert_eq!(
+        parse_interpolated(
+            &format!("[Click here]({MARKDOWN_INTERPOLATION_PLACEHOLDER})"),
+            &[&[paragraph_from_plain_text("https://example.com".into())]]
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap(),
+        [StyledTextParagraph {
+            text: "Click here".into(),
+            formatting: alloc::vec![FormattedSpan { range: 0..10, style: Style::Link }],
+            links: alloc::vec![(0..10, "https://example.com".into())]
+        }]
+    );
+    // Interpolation in link URL with surrounding text
+    assert_eq!(
+        parse_interpolated(
+            &format!(
+                "[link](https://{MARKDOWN_INTERPOLATION_PLACEHOLDER}/path) after"
+            ),
+            &[&[paragraph_from_plain_text("example.com".into())]]
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap(),
+        [StyledTextParagraph {
+            text: "link after".into(),
+            formatting: alloc::vec![FormattedSpan { range: 0..4, style: Style::Link }],
+            links: alloc::vec![(0..4, "https://example.com/path".into())]
+        }]
+    );
 }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -768,11 +768,35 @@ impl Expression {
     fn from_at_markdown(node: syntax_nodes::AtMarkdown, ctx: &mut LookupCtx) -> Expression {
         let mut markdown = String::new();
         let mut values = Vec::new();
+        // Maps byte ranges in the markdown format string to source locations,
+        // sorted by range start. Used to report parse errors at the correct
+        // position in the .slint source.
+        let mut source_map: Vec<(std::ops::Range<usize>, crate::diagnostics::SourceLocation)> =
+            Vec::new();
+
+        fn record_string_literal(
+            markdown: &mut String,
+            source_map: &mut Vec<(std::ops::Range<usize>, crate::diagnostics::SourceLocation)>,
+            s: &str,
+            loc: crate::diagnostics::SourceLocation,
+        ) {
+            let start = markdown.len();
+            markdown.push_str(s);
+            let end = markdown.len();
+            if end > start {
+                source_map.push((start..end, loc));
+            }
+        }
 
         for n in node.children_with_tokens() {
             if n.kind() == SyntaxKind::StringLiteral {
                 if let Some(s) = crate::literals::unescape_string(n.as_token().unwrap().text()) {
-                    markdown.push_str(&s);
+                    record_string_literal(
+                        &mut markdown,
+                        &mut source_map,
+                        &s,
+                        n.to_source_location(),
+                    );
                 } else {
                     ctx.diag.push_error("Cannot parse string literal".into(), &n);
                 }
@@ -782,7 +806,12 @@ impl Expression {
                         if let Some(s) =
                             crate::literals::unescape_string(n.as_token().unwrap().text())
                         {
-                            markdown.push_str(&s);
+                            record_string_literal(
+                                &mut markdown,
+                                &mut source_map,
+                                &s,
+                                n.to_source_location(),
+                            );
                         } else {
                             ctx.diag.push_error("Cannot parse string literal".into(), &n);
                         }
@@ -803,8 +832,10 @@ impl Expression {
                             }
                         };
                         values.push(expr);
+                        let start = markdown.len();
                         markdown
                             .push(i_slint_common::styled_text::MARKDOWN_INTERPOLATION_PLACEHOLDER);
+                        source_map.push((start..markdown.len(), node.to_source_location()));
                     }
                 }
             }
@@ -813,13 +844,50 @@ impl Expression {
         let dummy_paragraph = i_slint_common::styled_text::paragraph_from_plain_text("".into());
 
         // Validate the markdown format string with dummy values
-        if let Err(e) = i_slint_common::styled_text::parse_interpolated(
+        let (_, parse_errors) = i_slint_common::styled_text::parse_interpolated(
             &markdown,
             &vec![&[dummy_paragraph]; values.len()],
-        )
-        .collect::<Result<Vec<_>, _>>()
-        {
-            ctx.diag.push_error(e.to_string(), &node);
+        );
+        for e in &parse_errors {
+            // Skip InvalidColor when the color value came from interpolation
+            // (dummy values resolve to empty strings during compile-time validation)
+            if e.is_invalid_color()
+                && e.range().is_some_and(|r| {
+                    r.end <= markdown.len()
+                        && markdown[r.start..r.end].contains(
+                            i_slint_common::styled_text::MARKDOWN_INTERPOLATION_PLACEHOLDER,
+                        )
+                })
+            {
+                continue;
+            }
+            // Look up the source location from the error's byte range.
+            // Compute sub-literal precision: adjust the source span to point
+            // at the specific position within the string literal.
+            let loc = e.range().and_then(|r| {
+                let idx = source_map.partition_point(|(range, _)| range.start <= r.start);
+                if idx > 0 {
+                    let (fmt_range, loc) = &source_map[idx - 1];
+                    if fmt_range.contains(&r.start) {
+                        let delta = r.start - fmt_range.start;
+                        let err_len = (r.end - r.start).min(loc.span.length.saturating_sub(delta));
+                        // +1 to skip the opening quote of the string literal
+                        return Some(crate::diagnostics::SourceLocation {
+                            source_file: loc.source_file.clone(),
+                            span: crate::diagnostics::Span::new(
+                                loc.span.offset + 1 + delta,
+                                err_len,
+                            ),
+                        });
+                    }
+                }
+                None
+            });
+            if let Some(loc) = loc {
+                ctx.diag.push_error_with_span(e.to_string(), loc);
+            } else {
+                ctx.diag.push_error(e.to_string(), &node);
+            }
         }
 
         Expression::FunctionCall {

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -851,7 +851,7 @@ impl Expression {
         for e in &parse_errors {
             // Skip InvalidColor when the color value came from interpolation
             // (dummy values resolve to empty strings during compile-time validation)
-            if e.is_invalid_color()
+            if i_slint_common::styled_text::is_invalid_color(e)
                 && e.range().is_some_and(|r| {
                     r.end <= markdown.len()
                         && markdown[r.start..r.end].contains(
@@ -865,12 +865,14 @@ impl Expression {
             // Compute sub-literal precision: adjust the source span to point
             // at the specific position within the string literal.
             let loc = e.range().and_then(|r| {
+                // partition_point returns the first index where range.start > r.start,
+                // so idx - 1 is the last entry whose range could contain r.start.
                 let idx = source_map.partition_point(|(range, _)| range.start <= r.start);
                 if idx > 0 {
                     let (fmt_range, loc) = &source_map[idx - 1];
                     if fmt_range.contains(&r.start) {
                         let delta = r.start - fmt_range.start;
-                        let err_len = (r.end - r.start).min(loc.span.length.saturating_sub(delta));
+                        let err_len = r.len().min(loc.span.length.saturating_sub(delta));
                         // +1 to skip the opening quote of the string literal
                         return Some(crate::diagnostics::SourceLocation {
                             source_file: loc.source_file.clone(),

--- a/internal/compiler/tests/syntax/basic/markdown_syntax.slint
+++ b/internal/compiler/tests/syntax/basic/markdown_syntax.slint
@@ -5,7 +5,8 @@ export component X {
     property <styled-text> t1: @markdown("Foo\invalid");
 //                                       >           <error{Cannot parse string literal}
     property <styled-text> t2: @markdown("Foo\u{e541}Bar");  // Using the MARKDOWN_INTERPOLATION_PLACEHOLDER cause strange errors
-//                             >                         <error{Argument index 0 out of range: 0 arguments provided}
+//                                        >       <error{Argument index 0 out of range: 0 arguments provided}
+//                             >                         <^error{Format string contains 1 placeholders, but 0 arguments were provided}
     property <styled-text> t3: @markdown("XXX"  "TTT \{12px} ZZZ");
 //                                                     >  <error{Cannot convert length to string. Divide by 1px to convert to a plain number}
     property <styled-text> t9: @markdown("{");
@@ -13,27 +14,103 @@ export component X {
     property <styled-text> t11: @markdown("{abc}");
     property <styled-text> t12: @markdown("{0");
     property <styled-text> t13: @markdown("> quote");
-//                              >                  <error{Unimplemented tag: BlockQuote(None)}
+//                                         >     <error{Markdown block quotes are not supported}
     property <styled-text> t14: @markdown("![alt](image.png)");
-//                              >                            <error{Unimplemented tag: Image}
+//                                         >               <error{Markdown images are not supported}
     property <styled-text> t15: @markdown("---");
-//                              >              <error{Unimplemented event: Rule}
+//                                         > <error{Markdown horizontal rules are not supported}
     property <styled-text> t16: @markdown("<span>text</span>");
-//                              >                            <error{Unimplemented html tag: span}
+//                                         >   <error{HTML tag <span> is not supported}
     property <styled-text> t17: @markdown("<div>text</div>");
-//                              >                          <error{Unimplemented tag: HtmlBlock}
+//                                         >             <error{Markdown HTML blocks are not supported}
+//                                         >             <^error{Markdown HTML blocks (<div>text</div>) are not supported}
     property <styled-text> t18: @markdown("<u>unclosed");
 //                              >                      <error{Spans are unbalanced: stack contained items at end of function}
     property <styled-text> t19: @markdown("<font color='red'>unclosed");
 //                              >                                     <error{Spans are unbalanced: stack contained items at end of function}
     property <styled-text> t20: @markdown("<u>text</font>");
-//                              >                         <error{Closing html tag doesn't match the opening tag. Expected </u>, got </font>}
+//                                                >     <error{Closing html tag doesn't match the opening tag. Expected </u>, got </font>}
     property <styled-text> t21: @markdown("<font>text</font>");
-//                              >                            <error{Missing color attribute in html <font>}
+//                                         >    <error{Missing color attribute in html <font>}
     property <styled-text> t22: @markdown("<font size='12'>text</font>");
-//                              >                                      <error{Unexpected size attribute in html <font size='12'>}
+//                                               >       <error{Unexpected size attribute in html <font size='12'>}
+//                                         >              <^error{Missing color attribute in html <font size='12'>}
     property <styled-text> t23: @markdown("<u class='test'>text</u>");
-//                              >                                   <error{Unexpected class attribute in html <u class='test'>}
+//                                            >          <error{Unexpected class attribute in html <u class='test'>}
     property <styled-text> t24: @markdown("<font color='#q'>text</font>");
-//                              >                                       <error{Invalid color value '#q'}
+//                                               >        <error{Invalid color value '#q'}
+
+    // --- Comprehensive error location tests ---
+
+    property <string> some-prop: "hello";
+
+    // Multiple unrelated errors in one expression: each should point to its own tag
+    property <styled-text> m1: @markdown("<xyz>text</xyz> *ok* <abc>text</abc>");
+//                                        >  <error{HTML tag <xyz> is not supported}
+//                                                             >  <^error{HTML tag <abc> is not supported}
+
+    // Error in second string literal: should point to that literal
+    property <styled-text> m2: @markdown("*hello* " "<xyz>world</xyz>");
+//                                                   >  <error{HTML tag <xyz> is not supported}
+
+    // Error with interpolation before it
+    property <styled-text> m3: @markdown("hello \{some-prop} " "<xyz>oops</xyz>");
+//                                                              >  <error{HTML tag <xyz> is not supported}
+
+    // Multiple string literals, error in middle one
+    property <styled-text> m4: @markdown("aaa" "<xyz>ccc</xyz>" " ddd");
+//                                              >  <error{HTML tag <xyz> is not supported}
+
+    // Valid markdown mixed with errors in different literals
+    property <styled-text> m5: @markdown("**bold** " "<xyz>bad</xyz>" " *italic*");
+//                                                    >  <error{HTML tag <xyz> is not supported}
+
+    // Block quote error in a multi-line expression
+    property <styled-text> m6: @markdown("text"
+                                         "\n> block quote");
+//                                         >           <error{Markdown block quotes are not supported}
+
+    // Multiple errors on different lines
+    property <styled-text> m7: @markdown("--- "
+                                         "<span>text</span>");
+//                                        >   <error{HTML tag <span> is not supported}
+
+    // Error after interpolation in multi-line
+    property <styled-text> m8: @markdown("hello \{some-prop}"
+                                         " <xyz>bad</xyz>");
+//                                         >  <error{HTML tag <xyz> is not supported}
+
+    // Invalid color in second literal
+    property <styled-text> m9: @markdown("hello "
+                                         "<font color='invalid'>colored</font>");
+//                                              >             <error{Invalid color value 'invalid'}
+
+    // Two errors in two different literals
+    property <styled-text> m10: @markdown("<xyz>aa</xyz>"
+//                                         >  <error{HTML tag <xyz> is not supported}
+                                          " <abc>bb</abc>");
+//                                          >  <error{HTML tag <abc> is not supported}
+
+    // Longer markdown with error in the middle
+    property <styled-text> m11: @markdown("*bold* normal **strong** <xyz>bad</xyz> _italic_");
+//                                                                  >  <error{HTML tag <xyz> is not supported}
+
+    // Literal invalid color alongside an interpolation (should still report the error)
+    property <styled-text> m12: @markdown("<font color='badcolor'>\{some-prop}</font>");
+//                                               >              <error{Invalid color value 'badcolor'}
+
+    // Valid interpolated color (should not report error)
+    property <styled-text> m13: @markdown("<font color='\{some-prop}'>text</font>");
+
+    // Multiple attributes and tags in longer content
+    property <styled-text> m14: @markdown("hello *world* "
+                                          "<font color='invalid'>colored</font>"
+//                                               >             <error{Invalid color value 'invalid'}
+                                          " **more** text");
+
+    // Error in tag after valid content and interpolation
+    property <styled-text> m15: @markdown("prefix \{some-prop} middle "
+                                          "<abc>bad</abc>"
+//                                         >  <error{HTML tag <abc> is not supported}
+                                          " suffix");
 }

--- a/internal/compiler/tests/syntax/basic/markdown_syntax.slint
+++ b/internal/compiler/tests/syntax/basic/markdown_syntax.slint
@@ -22,8 +22,7 @@ export component X {
     property <styled-text> t16: @markdown("<span>text</span>");
 //                                         >   <error{HTML tag <span> is not supported}
     property <styled-text> t17: @markdown("<div>text</div>");
-//                                         >             <error{Markdown HTML blocks are not supported}
-//                                         >             <^error{Markdown HTML blocks (<div>text</div>) are not supported}
+//                                         >             <error{Markdown HTML blocks (<div>text</div>) are not supported}
     property <styled-text> t18: @markdown("<u>unclosed");
 //                              >                      <error{Spans are unbalanced: stack contained items at end of function}
     property <styled-text> t19: @markdown("<font color='red'>unclosed");
@@ -34,7 +33,6 @@ export component X {
 //                                         >    <error{Missing color attribute in html <font>}
     property <styled-text> t22: @markdown("<font size='12'>text</font>");
 //                                               >       <error{Unexpected size attribute in html <font size='12'>}
-//                                         >              <^error{Missing color attribute in html <font size='12'>}
     property <styled-text> t23: @markdown("<u class='test'>text</u>");
 //                                            >          <error{Unexpected class attribute in html <u class='test'>}
     property <styled-text> t24: @markdown("<font color='#q'>text</font>");
@@ -113,4 +111,10 @@ export component X {
                                           "<abc>bad</abc>"
 //                                         >  <error{HTML tag <abc> is not supported}
                                           " suffix");
+
+    // Combined errors from different markdown features in a single string with escape sequences
+    property <styled-text> t25: @markdown("---\n\n> quote\n\n<span>text</span>");
+//                                         >  <error{Markdown horizontal rules are not supported}
+//                                              >      <^error{Markdown block quotes are not supported}
+//                                                       >   <^^error{HTML tag <span> is not supported}
 }

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -86,10 +86,10 @@ pub fn parse_markdown<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph
     _args: &[S],
 ) -> StyledText {
     #[cfg(feature = "std")]
-    {
-        StyledText::parse_interpolated(_format_string, _args).unwrap()
+    match StyledText::parse_interpolated(_format_string, _args) {
+        Ok(styled_text) => return styled_text,
+        Err(e) => crate::debug_log!("@markdown parse error: {e}"),
     }
-    #[cfg(not(feature = "std"))]
     Default::default()
 }
 

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -14,11 +14,10 @@ impl StyledText {
     pub fn parse_interpolated<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph]>>(
         format_string: &str,
         args: &[S],
-    ) -> Result<Self, i_slint_common::styled_text::StyledTextError<'static>> {
-        Ok(Self {
-            paragraphs: i_slint_common::styled_text::parse_interpolated(format_string, args)
-                .collect::<Result<crate::SharedVector<_>, _>>()?,
-        })
+    ) -> (Self, alloc::vec::Vec<i_slint_common::styled_text::StyledTextParseError>) {
+        let (paragraphs, errors) =
+            i_slint_common::styled_text::parse_interpolated(format_string, args);
+        (Self { paragraphs: paragraphs.as_slice().into() }, errors)
     }
 }
 
@@ -86,10 +85,14 @@ pub fn parse_markdown<S: AsRef<[i_slint_common::styled_text::StyledTextParagraph
     _args: &[S],
 ) -> StyledText {
     #[cfg(feature = "std")]
-    match StyledText::parse_interpolated(_format_string, _args) {
-        Ok(styled_text) => return styled_text,
-        Err(e) => crate::debug_log!("@markdown parse error: {e}"),
+    {
+        let (styled_text, errors) = StyledText::parse_interpolated(_format_string, _args);
+        for e in &errors {
+            crate::debug_log!("@markdown: {e}");
+        }
+        styled_text
     }
+    #[cfg(not(feature = "std"))]
     Default::default()
 }
 

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -97,6 +97,11 @@ assert_eq!(instance.get_w5(), 65.0);
 assert!(instance.get_test());
 
 assert_eq!(instance.get_default_struct().text, StyledText::default());
+
+// s11 uses an invalid interpolated color — check that it logged a debug_log error
+let logs = slint_testing::access_testing_window(instance.window(), |w| w.take_debug_log());
+let has_color_error = logs.iter().any(|l| l.contains("Invalid color value") && l.contains("not-a-color"));
+assert!(has_color_error, "Expected debug_log about invalid color, got: {logs:?}");
 ```
 ```cpp
 auto handle = TestCase::create();

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -40,9 +40,23 @@ export component TestCase inherits Window {
         s8 := StyledText {
             text: @markdown("[Click](\{my-url})");
         }
+        // Color with a literal value
+        s9 := StyledText {
+            text: @markdown("<font color=\"red\">colored</font>");
+        }
+        // Color with an interpolated value
+        s10 := StyledText {
+            text: @markdown("<font color=\"\{my-color}\">colored</font>");
+        }
+        // Invalid color at runtime (should still render text, just without color)
+        s11 := StyledText {
+            text: @markdown("<font color=\"\{bad-color}\">still visible</font>");
+        }
     }
 
     property <string> my-url: "https://slint.dev";
+    property <string> my-color: "blue";
+    property <string> bad-color: "not-a-color";
 
     out property<styled-text> t1: s1.text;
     out property<styled-text> t2: s2.text;
@@ -61,17 +75,20 @@ export component TestCase inherits Window {
     out property<length> w6: s6.preferred-width;
     out property<length> w7: s7.preferred-width;
     out property<length> w8: s8.preferred-width;
+    out property<length> w9: s9.preferred-width;
+    out property<length> w10: s10.preferred-width;
+    out property<length> w11: s11.preferred-width;
 
-    out property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px && w6 > 0px && w7 > w1 && w8 > 0px;
+    out property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px && w6 > 0px && w7 > w1 && w8 > 0px && w9 > 0px && w10 > 0px && w11 > 0px;
 }
 
 /*
 ```rust
 use slint::private_unstable_api::re_exports::StyledText;
 let instance = TestCase::new().unwrap();
-assert_eq!(instance.get_t1(), StyledText::parse_interpolated::<StyledText>("Hello World", &[]).unwrap());
-assert_eq!(instance.get_t2(), StyledText::parse_interpolated::<StyledText>("Hello \\*World\\*", &[]).unwrap());
-assert_eq!(instance.get_t3(), StyledText::parse_interpolated::<StyledText>("Hello *World*", &[]).unwrap());
+assert_eq!(instance.get_t1(), StyledText::parse_interpolated::<StyledText>("Hello World", &[]).0);
+assert_eq!(instance.get_t2(), StyledText::parse_interpolated::<StyledText>("Hello \\*World\\*", &[]).0);
+assert_eq!(instance.get_t3(), StyledText::parse_interpolated::<StyledText>("Hello *World*", &[]).0);
 assert_eq!(instance.get_w1(), 66.0);
 assert_eq!(instance.get_w2(), 80.0);
 assert_eq!(instance.get_w3(), 64.0);

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -36,7 +36,13 @@ export component TestCase inherits Window {
             text: @markdown("Hello \{world}");
             default-font-size: 24px;
         }
+        // Regression test for #11527 - interpolation in link URL
+        s8 := StyledText {
+            text: @markdown("[Click](\{my-url})");
+        }
     }
+
+    property <string> my-url: "https://slint.dev";
 
     out property<styled-text> t1: s1.text;
     out property<styled-text> t2: s2.text;
@@ -54,8 +60,9 @@ export component TestCase inherits Window {
     out property<length> w5: s5.preferred-width;
     out property<length> w6: s6.preferred-width;
     out property<length> w7: s7.preferred-width;
+    out property<length> w8: s8.preferred-width;
 
-    out property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px && w6 > 0px && w7 > w1;
+    out property<bool> test: w1 == 66px && w2 == 80px && w3 == 64px && w4 == 64px && w5 == 65px && w6 > 0px && w7 > w1 && w8 > 0px;
 }
 
 /*


### PR DESCRIPTION
The first commit fixes #11527: interpolated values in markdown link URLs were not substituted. (This one can be backported to the release branch if we need to)
  
The second commit adds support for color interpolation (`<font color="\{expr}">`). This requires parse_interpolated to always produce output instead of stopping at the first error, so invalid colors at runtime still render text and log the error. The refactor also adds byte ranges to errors for precise source locations in diagnostics, suppresses cascading errors, and cleans up error messages. 

(The third commit is just a test for the debug_log output)   