### PR TITLE
CI: Attempt to improve deployment handling for docs preview

### DIFF
--- a/.github/actions/cloudflare-preview-deploy/action.yaml
+++ b/.github/actions/cloudflare-preview-deploy/action.yaml
@@ -69,7 +69,7 @@ runs:
           env:
             PREVIEW_URL: ${{ steps.preview.outputs.url }}
             PREVIEW_PATH_SUFFIX: ${{ inputs.path-suffix }}
-            DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+            DEPLOY_ENVIRONMENT: ${{ inputs.environment }}-${{ github.event.number }}
           with:
             script: |
               const raw = (process.env.PREVIEW_URL || '').trim();
@@ -83,7 +83,8 @@ runs:
                 ref,
                 environment: process.env.DEPLOY_ENVIRONMENT,
                 auto_merge: false,
-                required_contexts: []
+                required_contexts: [],
+                transient_environment: true
               });
               if (deployment.data.id) {
                 await github.rest.repos.createDeploymentStatus({


### PR DESCRIPTION
Avoid that subsequent PRs invalidate earlier deployments by giving each deployment a unique environment, and let github mark it as inactivate once the PR is closed.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
