### PR TITLE
System Tray: Add activation support on Windows

### DIFF
--- a/docs/astro/src/content/docs/reference/window/systemtray.mdx
+++ b/docs/astro/src/content/docs/reference/window/systemtray.mdx
@@ -56,10 +56,15 @@ the accessible label of the icon. Typically the application name.
 
 ## Callbacks
 
-### clicked()
+### activated()
 
-Invoked when the user activates the tray icon itself (as opposed to picking an entry from its
-menu) — typically a left-click on the icon.
+Invoked when the user activates the tray icon itself, as opposed to picking an entry from its menu.
+What counts as activation, and whether it's invoked at all, depends on the platform:
+
+| Platform      | Activation behavior                                                                   |
+| ------------- | ------------------------------------------------------------------------------------- |
+| Linux, \*BSD  | Invoked on a left-click of the icon. The exact gesture is decided by the desktop environment or shell extension hosting the tray. |
+| macOS         | Not invoked. Clicking the icon always opens the menu; AppKit's status item has no separate activation gesture. |
 
 ## Menu
 

--- a/docs/astro/src/content/docs/reference/window/systemtray.mdx
+++ b/docs/astro/src/content/docs/reference/window/systemtray.mdx
@@ -65,6 +65,7 @@ What counts as activation, and whether it's invoked at all, depends on the platf
 | ------------- | ------------------------------------------------------------------------------------- |
 | Linux, \*BSD  | Invoked on a left-click of the icon. The exact gesture is decided by the desktop environment or shell extension hosting the tray. |
 | macOS         | Not invoked. Clicking the icon always opens the menu; AppKit's status item has no separate activation gesture. |
+| Windows       | Invoked on a left-click of the icon. Right-click opens the menu.                      |
 
 ## Menu
 

--- a/examples/system_tray/main.rs
+++ b/examples/system_tray/main.rs
@@ -10,7 +10,7 @@ slint::slint! {
         // rebuilds to reflect the new state on every toggle.
         in-out property <bool> more-enabled: true;
 
-        clicked => {
+        activated => {
             more-enabled = !more-enabled;
         }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -840,7 +840,7 @@ export global NativePalette {
 export component SystemTray {
     in property <image> icon;
     in property <string> title;
-    callback clicked();
+    callback activated();
     Menu { }
     //-disallow_global_types_as_child_elements
 }

--- a/internal/core/items/system_tray.rs
+++ b/internal/core/items/system_tray.rs
@@ -143,7 +143,7 @@ impl crate::properties::PropertyDirtyHandler for MenuDirtyHandler {
 pub struct SystemTray {
     pub icon: Property<Image>,
     pub title: Property<SharedString>,
-    pub clicked: Callback<VoidArg>,
+    pub activated: Callback<VoidArg>,
     pub cached_rendering_data: CachedRenderingData,
     data: SystemTrayDataBox,
 }

--- a/internal/core/items/system_tray/ksni.rs
+++ b/internal/core/items/system_tray/ksni.rs
@@ -159,7 +159,7 @@ async fn dispatch_loop(rx: async_channel::Receiver<Event>, self_weak: crate::ite
                 }
             }
             Event::Activate(_x, _y) => {
-                tray.clicked.call(&());
+                tray.activated.call(&());
             }
         }
     }

--- a/internal/core/items/system_tray/windows.rs
+++ b/internal/core/items/system_tray/windows.rs
@@ -33,7 +33,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     HWND_MESSAGE, ICONINFO, MF_DISABLED, MF_GRAYED, MF_POPUP, MF_SEPARATOR, MF_STRING,
     PostMessageW, RegisterClassW, RegisterWindowMessageW, SetForegroundWindow, SetWindowLongPtrW,
     TPM_BOTTOMALIGN, TPM_LEFTALIGN, TPM_RETURNCMD, TPM_RIGHTBUTTON, TrackPopupMenu,
-    WINDOW_EX_STYLE, WINDOW_STYLE, WM_APP, WM_CONTEXTMENU, WM_NULL, WM_RBUTTONUP, WNDCLASSW,
+    WINDOW_EX_STYLE, WINDOW_STYLE, WM_APP, WM_CONTEXTMENU, WM_LBUTTONUP, WM_NULL, WM_RBUTTONUP,
+    WNDCLASSW,
 };
 use windows::core::{HSTRING, PCWSTR, w};
 
@@ -72,6 +73,12 @@ impl Inner {
         if let Some(entry) = state.entries.get(entry_index) {
             vtable::VRc::borrow(&state.menu_vrc).activate(entry);
         }
+    }
+
+    fn activated(&self) {
+        let Some(item_rc) = self.self_weak.upgrade() else { return };
+        let Some(tray) = item_rc.downcast::<super::SystemTray>() else { return };
+        tray.as_pin_ref().activated.call(&());
     }
 }
 
@@ -227,6 +234,11 @@ unsafe extern "system" fn wnd_proc(
             let inner_ptr = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) } as *const Inner;
             if !inner_ptr.is_null() {
                 show_popup_menu(hwnd, unsafe { &*inner_ptr });
+            }
+        } else if event == WM_LBUTTONUP {
+            let inner_ptr = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) } as *const Inner;
+            if !inner_ptr.is_null() {
+                unsafe { &*inner_ptr }.activated();
             }
         }
         return LRESULT(0);


### PR DESCRIPTION
This renames the callback and adds support for Windows.