### PR TITLE
CI: Skip cpp_package_test when ubuntu-22.04 isn't in the cmake matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,7 +288,8 @@ jobs:
                   path: ${{ runner.workspace }}/cppbuild/Slint-cpp-*
 
     cpp_package_test:
-        needs: [cpp_cmake]
+        needs: [cpp_cmake_matrix, cpp_cmake]
+        if: ${{ always() && !cancelled() && needs.cpp_cmake.result == 'success' && contains(fromJSON(needs.cpp_cmake_matrix.outputs.matrix).include.*.os, 'ubuntu-22.04') }}
         runs-on: ubuntu-22.04
         env:
             QT_QPA_PLATFORM: offscreen


### PR DESCRIPTION
The Ubuntu artifact only exists when api_cpp changed (or full mode), so gate the job on the matrix actually including ubuntu-22.04.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
