### PR TITLE
Fixes two way binding misbehavior

### DIFF
--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -159,16 +159,26 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
             }
             common_property
         };
-        Self::link_two_way_with_map_to_common_property(common_property, prop2, map_to, map_from);
+        Self::link_two_way_with_map_to_common_property(
+            common_property,
+            prop2,
+            map_to,
+            map_from,
+            false,
+        );
     }
 
     /// Make a two way binding between the common property and the binding prop2.
-    /// if prop2 has a binding, it will be preserved
+    /// Two-way bindings on prop2 are always forwarded through the chain.
+    /// Regular closure bindings on prop2 are preserved when
+    /// `preserve_prop2_binding` is true, or dropped (so the common
+    /// property's value wins) when false.
     pub(crate) fn link_two_way_with_map_to_common_property<T2: PartialEq + Clone + 'static>(
         common_property: Pin<Rc<Self>>,
         prop2: Pin<&Property<T2>>,
         map_to: impl Fn(&T) -> T2 + Clone + 'static,
         map_from: impl Fn(&mut T, &T2) + Clone + 'static,
+        preserve_prop2_binding: bool,
     ) {
         struct TwoWayBindingWithMap<T, T2, M1, M2> {
             common_property: Pin<Rc<Property<T>>>,
@@ -271,9 +281,14 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                 if ((*old).vtable.intercept_set_binding)(old, new_binding) {
                     prop2.handle.set_binding_impl(old);
                 } else {
-                    // Regular closure — wrap it as a BindingMapper.
                     prop2.handle.set_binding_impl(new_binding);
-                    prop2.handle.set_binding_impl(old);
+                    if preserve_prop2_binding {
+                        // Re-attach so TwoWayBindingWithMap wraps it
+                        // as a BindingMapper for reactivity.
+                        prop2.handle.set_binding_impl(old);
+                    } else {
+                        ((*old).vtable.drop)(old);
+                    }
                 }
             } else {
                 prop2.handle.set_binding(
@@ -610,8 +625,7 @@ fn test_two_way_with_map() {
 /// When a property already has a binding with dependants and is then linked
 /// via `link_two_way_with_map`, the old binding's dependency list must be
 /// transferred to the new `TwoWayBindingWithMap` binding. Without this
-/// transfer, the old binding is later freed (via `BindingMapper::drop`) while
-/// dependency nodes still point into its `dependencies` field, causing
+/// transfer, dependency nodes would point into freed memory, causing
 /// panics in `DependencyNode::debug_assert_valid` on drop.
 ///
 /// The drop order is arranged so that the tracker (which owns the
@@ -648,8 +662,9 @@ fn test_two_way_with_map_dependency_list_transfer() {
     assert!(!tracker.as_ref().is_dirty());
 
     // link_two_way_with_map replaces p_field's binding with a
-    // TwoWayBindingWithMap and wraps the old binding in a BindingMapper
-    // on the common property. The dependency list must be transferred.
+    // TwoWayBindingWithMap. The old closure binding is dropped
+    // (prop1's value wins), so p_field now reads from the common
+    // property initialized from p_struct.
     let p_struct = Rc::pin(Property::new(Wrapper { value: 0 }));
     Property::link_two_way_with_map(
         p_struct.as_ref(),
@@ -658,16 +673,16 @@ fn test_two_way_with_map_dependency_list_transfer() {
         |s, v| s.value = *v,
     );
 
-    assert_eq!(p_field.as_ref().get(), 20);
-    assert_eq!(p_struct.as_ref().get(), Wrapper { value: 20 });
+    assert_eq!(p_field.as_ref().get(), 0);
+    assert_eq!(p_struct.as_ref().get(), Wrapper { value: 0 });
 
-    // The tracker's dependency should still fire when the source changes.
-    source.as_ref().set(5);
+    // The binding replacement dirtied the tracker via the transferred
+    // dependency list.
     assert!(tracker.as_ref().is_dirty());
 
     // Implicit drop order: p_struct, p_field, tracker, source.
-    // p_field's drop frees the common property chain (including the old
-    // binding via BindingMapper::drop). tracker is dropped afterwards —
-    // its DependencyNode::remove would panic in debug_assert_valid if
-    // the dependency list was not properly transferred.
+    // p_field's drop frees the TwoWayBindingWithMap binding.
+    // tracker is dropped afterwards — its DependencyNode::remove
+    // would panic in debug_assert_valid if the dependency list was
+    // not properly transferred.
 }

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -258,25 +258,31 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
             prop2.debug_name.borrow()
         );
 
-        // Detach the old binding (if any) from prop2, transferring its
-        // dependency list back to the handle so that set_binding() will
-        // properly move it into the new TwoWayBindingWithMap binding.
-        // Without this, the old binding's dependency list would be orphaned
-        // when it is later freed via BindingMapper::drop, leaving
-        // DependencyNodes with dangling prev pointers.
         let old_binding = prop2.handle.detach_binding();
 
         unsafe {
-            prop2.handle.set_binding(
-                TwoWayBindingWithMap { common_property, map_to, map_from, marker: PhantomData },
-                #[cfg(slint_debug_property)]
-                debug_name.as_str(),
-            );
-
-            if let Some(binding) = old_binding {
-                prop2.handle.set_binding_impl(binding);
+            if let Some(old) = old_binding {
+                let new_binding = alloc_binding_holder(TwoWayBindingWithMap {
+                    common_property,
+                    map_to,
+                    map_from,
+                    marker: PhantomData,
+                });
+                if ((*old).vtable.intercept_set_binding)(old, new_binding) {
+                    prop2.handle.set_binding_impl(old);
+                } else {
+                    // Regular closure — wrap it as a BindingMapper.
+                    prop2.handle.set_binding_impl(new_binding);
+                    prop2.handle.set_binding_impl(old);
+                }
+            } else {
+                prop2.handle.set_binding(
+                    TwoWayBindingWithMap { common_property, map_to, map_from, marker: PhantomData },
+                    #[cfg(slint_debug_property)]
+                    debug_name.as_str(),
+                );
             }
-        };
+        }
     }
 }
 
@@ -302,7 +308,7 @@ where
     }
 
     unsafe fn intercept_set_binding(self: Pin<&Self>, _new_binding: *mut BindingHolder) -> bool {
-        panic!("Cannot assign a binding to a property bound two-way to a model");
+        false
     }
 
     fn intercept_set(self: Pin<&Self>, value: &T) -> bool {

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -247,6 +247,7 @@ where
             p1,
             |v| v.clone().try_into().unwrap_or_default(),
             |v, v2| *v = v2.clone().try_into().unwrap_or_default(),
+            true,
         );
         shared_property
     }
@@ -267,6 +268,7 @@ where
                     prop1.as_ref(),
                     move |value| m1.map_to(value),
                     move |value, value2| m2.map_from(value, value2),
+                    true,
                 );
             }
             None => {
@@ -275,6 +277,7 @@ where
                     prop1.as_ref(),
                     |value| value.clone(),
                     |value, value2| *value = value2.clone(),
+                    true,
                 );
             }
         }

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -223,9 +223,20 @@ where
     fn prepare_for_two_way_binding(&self, item: Pin<&Item>) -> Pin<Rc<Property<Value>>> {
         if let Some(self_) =
             (self as &dyn core::any::Any).downcast_ref::<FieldOffset<Item, Property<Value>>>()
-            && let Some(p) = Property::check_common_property(self_.apply_pin(item))
         {
-            return p;
+            let p = self_.apply_pin(item);
+            if let Some(cp) = Property::check_common_property(p) {
+                return cp;
+            }
+            // link_two_way sets a TwoWayBinding on p, which
+            // check_common_property can find on subsequent calls.
+            // Only safe when p has no binding yet (a pre-existing
+            // binding's intercept_set_binding may not accept this).
+            if !p.has_binding() {
+                let anchor = Rc::pin(Property::<Value>::default());
+                Property::link_two_way(anchor.as_ref(), p);
+                return Property::check_common_property(p).unwrap();
+            }
         }
 
         let p1 = self.apply_pin(item);

--- a/tests/cases/bindings/two_way_binding_chain_override.slint
+++ b/tests/cases/bindings/two_way_binding_chain_override.slint
@@ -1,0 +1,67 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// When a two-way struct-field binding (str <=> pair.a) is overridden at
+// the instance level (str <=> source.val.name), the RHS value wins.
+
+export struct Pair {
+    a: string,
+    b: string,
+}
+
+export struct Data {
+    name: string,
+    value: int,
+}
+
+component Link {
+    in-out property <Pair> pair: { a: "link-default", b: "bb" };
+    in-out property <string> str <=> pair.a;
+}
+
+component Source {
+    in-out property <Data> val: { name: "from-source", value: 42 };
+}
+
+export component TestCase inherits Window {
+    source := Source {}
+    link := Link {
+        str <=> source.val.name;
+    }
+
+    out property <string> source_name: source.val.name;
+    out property <string> link_str: link.str;
+
+    out property <bool> test:
+        source.val.name == "from-source"
+        && link.str == "from-source";
+}
+
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_source_name(), "from-source");
+assert_eq!(instance.get_link_str(), "from-source");
+assert!(instance.get_test());
+```
+
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_source_name(), "from-source");
+assert_eq(instance.get_link_str(), "from-source");
+assert(instance.get_test());
+```
+
+
+```js
+let instance = new slint.TestCase({});
+assert.equal(instance.source_name, "from-source");
+assert.equal(instance.link_str, "from-source");
+assert(instance.test);
+```
+
+*/

--- a/tests/cases/bindings/two_way_binding_chain_override_with_default.slint
+++ b/tests/cases/bindings/two_way_binding_chain_override_with_default.slint
@@ -1,0 +1,66 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// When prop2 already carries a regular closure binding (the TextInput
+// default "inner-default"), the RHS struct value should win.
+// The Source sub-component's default is set during its init (before the
+// two-way chain), so there is no late .set() to mask the bug.
+
+export struct Data {
+    name: string,
+    value: int,
+}
+
+component Inner {
+    in-out property <string> text <=> tx.text;
+    tx := TextInput {
+        text: "inner-default";
+    }
+}
+
+component Source {
+    in-out property <Data> val: { name: "correct", value: 42 };
+}
+
+export component TestCase inherits Window {
+    source := Source {}
+    inner := Inner {
+        text <=> source.val.name;
+    }
+
+    out property <string> check_name: source.val.name;
+    out property <string> check_text: inner.text;
+
+    out property <bool> test:
+        source.val.name == "correct"
+        && inner.text == "correct";
+}
+
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_check_name(), "correct");
+assert_eq!(instance.get_check_text(), "correct");
+assert!(instance.get_test());
+```
+
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_check_name(), "correct");
+assert_eq(instance.get_check_text(), "correct");
+assert(instance.get_test());
+```
+
+
+```js
+let instance = new slint.TestCase({});
+assert.equal(instance.check_name, "correct");
+assert.equal(instance.check_text, "correct");
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
This should unify the behavior between Rust, C++, Interpreter and make sure we always keep the right side value of a `<=>` binding