### PR TITLE
Implement operator `+=` for arrays/models

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4347,6 +4347,13 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 format!(
                     "(std::abs(float({lhs_str} - {rhs_str})) {op} std::numeric_limits<float>::epsilon())"
                 )
+            } else if let Type::Array(element_ty) = &lhs_ty
+                && **element_ty == rhs.ty(ctx)
+                && *op == '+'
+            {
+                format!(
+                    "[&](auto model, const auto &value) {{ slint::private_api::model_push(model, value); return model; }}({lhs_str}, {rhs_str})"
+                )
             } else {
                 let mut buffer = [0; 3];
                 format!(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3840,7 +3840,8 @@ fn compile_binary_expression(expr: &Expression, ctx: &EvaluationContext) -> Toke
     let mut result = compile_expression_to_value_no_parenthesis(node, ctx);
     let mut result_ty = node.ty(ctx);
     for (rhs, op) in spine.into_iter().rev() {
-        result = compile_binary_operator(result, &result_ty, rhs, op, ctx);
+        let rsh_ty = rhs.ty(ctx);
+        result = compile_binary_operator(result, &result_ty, rhs, &rsh_ty, op, ctx);
         result_ty = llr::binary_expression_ty(op, || result_ty);
     }
     result
@@ -3850,6 +3851,7 @@ fn compile_binary_operator(
     lhs: TokenStream,
     lhs_ty: &Type,
     rhs: &Expression,
+    rhs_ty: &Type,
     op: char,
     ctx: &EvaluationContext,
 ) -> TokenStream {
@@ -3858,6 +3860,15 @@ fn compile_binary_operator(
     if lhs_ty.as_unit_product().is_some() && (op == '=' || op == '!') {
         let maybe_negate = if op == '!' { quote!(!) } else { quote!() };
         quote!(#maybe_negate sp::ApproxEq::<f64>::approx_eq(&(#lhs as f64), &(#rhs as f64)))
+    } else if let Type::Array(element_ty) = &lhs_ty
+        && **element_ty == *rhs_ty
+        && (op == '+')
+    {
+        quote!({
+            let model = #lhs;
+            model.push_row(#rhs);
+            model
+        })
     } else {
         let (conv1, conv2) = match crate::expression_tree::operator_class(op) {
             OperatorClass::ArithmeticOp => match lhs_ty {

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1721,6 +1721,10 @@ impl Expression {
         let expected_ty = match op {
             '=' => ty,
             '+' if ty == Type::String || ty.as_unit_product().is_some() => ty,
+            '+' if matches!(ty, Type::Array(_)) => {
+                let Type::Array(item_type) = ty else { unreachable!() };
+                (*item_type).clone()
+            }
             '-' if ty.as_unit_product().is_some() => ty,
             '/' | '*' if ty.as_unit_product().is_some() => Type::Float32,
             _ => {

--- a/internal/compiler/tests/syntax/expressions/array.slint
+++ b/internal/compiler/tests/syntax/expressions/array.slint
@@ -38,4 +38,19 @@ export component Test {
         a.insert("string", 1);
 //               >      <error{Cannot convert string to int}
     }
+
+    public function test_plus_operator_with_array() {
+        a += [1];
+//           > <error{Cannot convert [float] to int}
+    }
+
+    public function append-wrong-type() {
+        a += "string";
+//           >      <error{Cannot convert string to int}
+    }
+
+    public function append-out-module() {
+        a += 10;
+    }
+
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -2015,6 +2015,10 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
         (Value::Number(a), Value::Number(b), '-') => Value::Number(a - b),
         (Value::Number(a), Value::Number(b), '/') => Value::Number(a / b),
         (Value::Number(a), Value::Number(b), '*') => Value::Number(a * b),
+        (Value::Model(ref mut a), b, '+') => {
+            a.push_row(b.clone());
+            Value::Model(a.clone())
+        }
         (lhs, rhs, op) => panic!("unsupported {lhs:?} {op} {rhs:?}"),
     };
     match lhs {

--- a/tests/cases/models/array.slint
+++ b/tests/cases/models/array.slint
@@ -24,6 +24,7 @@ export component TestCase {
     public function push_one(val: int) { ints.push(val) }
     public function remove_one(index: int) { ints.remove(index) }
     public function insert_one(index: int, value: int) { ints.insert(index, value) }
+    public function self_append_one(val: int) { ints += val }
 
     public function push_one_empty(val: int) { empty_ints.push(val) }
     public function remove_one_empty() { empty_ints.remove(0) }
@@ -92,6 +93,10 @@ instance.invoke_insert_one(0, 30);
 assert_eq(model->row_count(), 4);
 assert_eq(model->row_data(0).value(), 30);
 assert_eq(model->row_data(1).value(), 20);
+
+instance.invoke_self_append_one(42);
+assert_eq(model->row_count(), 5);
+assert_eq(model->row_data(4).value(), 42);
 
 // `empty_ints` is an uninitialized `out` model property: in C++ it defaults to a
 // null model, so the modifying operations are no-ops and the model stays empty.
@@ -169,6 +174,11 @@ assert_eq!(model.row_count(), 4);
 assert_eq!(model.row_data(0).unwrap(), 30);
 assert_eq!(model.row_data(1).unwrap(), 20);
 
+assert_eq!(model.row_count(), 4);
+instance.invoke_self_append_one(42);
+assert_eq!(model.row_count(), 5);
+assert_eq!(model.row_data(4).unwrap(), 42);
+
 let model = instance.get_empty_ints();
 assert_eq!(model.row_count(), 0);
 instance.invoke_push_one_empty(1);
@@ -238,6 +248,10 @@ instance.insert_one(0, 30);
 assert.equal(model.rowCount(), 4);
 assert.equal(model.rowData(0), 30);
 assert.equal(model.rowData(1), 20);
+
+instance.self_append_one(42);
+assert.equal(model.rowCount(), 5);
+assert.equal(model.rowData(4), 42);
 
 model = instance.empty_ints;
 assert.equal(model.rowCount(), 0);


### PR DESCRIPTION
compiler: support += on array models

Allow array models to append an element through self-assignment and cover
the behavior in the C++, Rust, JavaScript, and interpreter paths.

Fixes #9412 