### PR TITLE
vscode: TextMate grammar fixes (callback-setup, @rust-attr)

### DIFF
--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -880,7 +880,7 @@
                     }
                 },
                 {
-                    "begin": "(?<!-)([a-zA-Z_][a-zA-Z0-9_-]*)\\s*\\(",
+                    "begin": "(?<!-)([a-zA-Z_][a-zA-Z0-9_-]*)(?=\\s*\\([^()]*\\)\\s*=>)\\s*\\(",
                     "beginCaptures": {
                         "1": {
                             "name": "entity.name.function.slint"

--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -8,6 +8,9 @@
             "include": "#comment"
         },
         {
+            "include": "#rust-attr"
+        },
+        {
             "include": "#import-list"
         },
         {
@@ -33,7 +36,6 @@
             "comment": "Element contents should in principle not be supported here, but we still want to highlight partial snippets",
             "include": "#element-contents"
         }
-
     ],
     "repository": {
         "block-comment": {
@@ -895,6 +897,80 @@
                             "match": "\\s*,\\s*"
                         }
                     ]
+                }
+            ]
+        },
+        "rust-attr": {
+            "patterns": [
+                {
+                    "name": "meta.attribute.rust-attr.slint",
+                    "begin": "(@rust-attr)\\s*(\\()",
+                    "end": "(\\))",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.macro.slint"
+                        },
+                        "2": {
+                            "name": "punctuation.brackets.round.slint"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.brackets.round.slint"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#rust-attr-body"
+                        }
+                    ]
+                }
+            ]
+        },
+        "rust-attr-body": {
+            "patterns": [
+                {
+                    "begin": "\\(",
+                    "end": "\\)",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.round.slint"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.round.slint"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#rust-attr-body"
+                        }
+                    ]
+                },
+                {
+                    "match": "\"[^\"]*\"",
+                    "name": "string.quoted.double.slint"
+                },
+                {
+                    "match": "\\b([A-Z][a-zA-Z0-9_]*)\\b",
+                    "name": "entity.name.type.slint"
+                },
+                {
+                    "match": "::",
+                    "name": "punctuation.separator.namespace.slint"
+                },
+                {
+                    "match": ",",
+                    "name": "punctuation.separator.comma.slint"
+                },
+                {
+                    "match": "=",
+                    "name": "keyword.operator.assignment.slint"
+                },
+                {
+                    "match": "\\b[a-z_][a-zA-Z0-9_]*\\b",
+                    "name": "variable.other.rust-attr.slint"
                 }
             ]
         }


### PR DESCRIPTION
Two TextMate grammar fixes for `docs/common/src/utils/slint.tmLanguage.json` (the canonical source; `editors/vscode/slint.tmLanguage.json` is a symlink to it).

---

## 1. `callback-setup` no longer swallows bare function calls (closes #11568)

`callback-setup`'s parenthesised pattern was opening on any `identifier(` and only closing at `)\s*=>`. Plain function calls written with an unqualified name (e.g. `max(...)`, `min(...)`, `mod(...)`, `debug(...)` at top level of a property body) entered the scope and never exited, swallowing every following token to EOF. Dotted names (`Math.foo(...)`, `TimeUtil.foo(...)`) were unaffected because the rule's identifier class `[a-zA-Z_][a-zA-Z0-9_-]*` disallows `.`, so they fell through to `function-call`.

Fix: add a positive lookahead requiring `(...)\s*=>` after the identifier, so the rule only fires on actual callback bindings. Slint callback bindings have flat parameter lists, so a no-nested-paren single-line lookahead is sufficient.

```diff
- "begin": "(?<!-)([a-zA-Z_][a-zA-Z0-9_-]*)\\s*\\("
+ "begin": "(?<!-)([a-zA-Z_][a-zA-Z0-9_-]*)(?=\\s*\\([^()]*\\)\\s*=>)\\s*\\("
```

### Repro

```slint
component Foo inherits Rectangle {
    property <float> a:
        max(1, 2);
    property <length> next: 5px;       // before: not highlighted
    VerticalLayout { ... }              // before: not highlighted
}
```

Before the patch the rule stack pushed by `max(` is never popped. After the patch the file tokenises with the stack returning to depth 1 at EOF.

---

## 2. Highlight `@rust-attr(...)` annotations

Slint allows `@rust-attr(...)` on `struct` and `enum` declarations to forward Rust attributes (`#[...]`) to the generated type, with multiple `@rust-attr` allowed per item. The grammar had no rule for this, so the whole annotation rendered as plain text.

Fix: add a `rust-attr` entry rule that opens on `@rust-attr(`, and a recursive `rust-attr-body` rule that handles nested parens, strings, paths with `::`, identifiers, type names, `=`, and `,`. Include `#rust-attr` near the top of the root pattern list so it fires before `#struct`/`#enum`.

### Example

```slint
@rust-attr(derive(Debug, Clone))
@rust-attr(cfg_attr(feature="serde", derive(Serialize, Deserialize)))
export struct WinData { number: int, text: string }
```

After the patch the whole annotation is scoped under `meta.attribute.rust-attr.slint` with sensible sub-scopes (`@rust-attr` as `support.function.macro`, `Debug`/`Serialize` as `entity.name.type`, `"serde"` as `string.quoted.double`, etc.), the rule stack closes cleanly, and the following `struct` declaration highlights as before.

---

## Test plan

Both changes verified with a `vscode-textmate` + `vscode-oniguruma` tokenisation harness:

- [x] `max(...)`, `min(...)`, `mod(...)`, `debug(...)` calls — rule stack closes correctly, `property` and elements after the call regain their scopes.
- [x] Callback bindings still highlight: `clicked => { ... }` and `moved(x, y) => { ... }` parse identically to before, with `entity.name.function.slint` on the callback name.
- [x] `@rust-attr(...)` annotations (single, stacked, with nested parens, with strings) — every token gets a sensible scope, rule stack returns to depth 1 after the closing paren.
- [x] Verified on real-world `.slint` files in a downstream project; bare `max`/`min` calls and surrounding code now highlight as intended.

---

> Disclosure: this PR was authored by [Claude Opus 4.7](https://www.anthropic.com/news/claude-opus-4-7) (Anthropic) running inside Cursor, on behalf of @1Mr-Newton. The diagnosis, fix, tokenizer-based verification, and PR write-up were all produced by the model; @1Mr-Newton reviewed the changes against their own working local extension (which already carried the same fixes) before opening the PR. Flagging up-front so reviewers can apply whatever extra scrutiny they prefer for AI-assisted contributions.