### PR TITLE
flickable consider virtual keyboard

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -614,12 +614,6 @@ impl ItemRc {
         self.map_to_item_tree_impl(p, |_| false)
     }
 
-    /// Maps a position in window coordinates to the item coordinates
-    #[cfg(test)]
-    pub(crate) fn map_from_window(&self, p: LogicalPoint) -> LogicalPoint {
-        self.map_from_item_tree_impl(p, |_| false)
-    }
-
     /// Returns an absolute position of `p` in the `ItemTree`'s coordinate system
     /// (does not add this item's x and y)
     pub fn map_to_item_tree(
@@ -646,33 +640,6 @@ impl ItemRc {
             return p;
         }
         self.local_to_window_transform(stop_condition).transform_point(p.cast()).cast()
-    }
-
-    #[cfg(test)]
-    fn map_from_item_tree_impl(
-        &self,
-        p: LogicalPoint,
-        stop_condition: impl Fn(&Self) -> bool,
-    ) -> LogicalPoint {
-        if stop_condition(self) {
-            return p;
-        }
-
-        if let Some(transform) = self.local_to_window_transform(&stop_condition).inverse() {
-            return transform.transform_point(p.cast()).cast();
-        }
-
-        let mut current = self.clone();
-        let mut offset = euclid::Vector2D::zero();
-        while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
-            if stop_condition(&parent) {
-                break;
-            }
-            offset += parent.geometry().origin.to_vector();
-            current = parent;
-        }
-
-        p - offset
     }
 
     /// Return the index of the item within the ItemTree
@@ -2748,7 +2715,6 @@ mod tests {
         let local_point = Point2D::new(4., 5.);
         let window_point = leaf.map_to_window(local_point);
         assert_point_approx_eq(window_point, Point2D::new(28., 53.));
-        assert_point_approx_eq(leaf.map_from_window(window_point), local_point);
     }
 
     #[test]

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -614,6 +614,11 @@ impl ItemRc {
         self.map_to_item_tree_impl(p, |_| false)
     }
 
+    /// Maps a position in window coordinates to the item coordinates
+    pub(crate) fn map_from_window(&self, p: LogicalPoint) -> LogicalPoint {
+        self.map_from_item_tree_impl(p, |_| false)
+    }
+
     /// Returns an absolute position of `p` in the `ItemTree`'s coordinate system
     /// (does not add this item's x and y)
     pub fn map_to_item_tree(
@@ -640,6 +645,32 @@ impl ItemRc {
             return p;
         }
         self.local_to_window_transform(stop_condition).transform_point(p.cast()).cast()
+    }
+
+    fn map_from_item_tree_impl(
+        &self,
+        p: LogicalPoint,
+        stop_condition: impl Fn(&Self) -> bool,
+    ) -> LogicalPoint {
+        if stop_condition(self) {
+            return p;
+        }
+
+        if let Some(transform) = self.local_to_window_transform(&stop_condition).inverse() {
+            return transform.transform_point(p.cast()).cast();
+        }
+
+        let mut current = self.clone();
+        let mut offset = euclid::Vector2D::zero();
+        while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
+            if stop_condition(&parent) {
+                break;
+            }
+            offset += parent.geometry().origin.to_vector();
+            current = parent;
+        }
+
+        p - offset
     }
 
     /// Return the index of the item within the ItemTree

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -615,6 +615,7 @@ impl ItemRc {
     }
 
     /// Maps a position in window coordinates to the item coordinates
+    #[cfg(test)]
     pub(crate) fn map_from_window(&self, p: LogicalPoint) -> LogicalPoint {
         self.map_from_item_tree_impl(p, |_| false)
     }
@@ -647,6 +648,7 @@ impl ItemRc {
         self.local_to_window_transform(stop_condition).transform_point(p.cast()).cast()
     }
 
+    #[cfg(test)]
     fn map_from_item_tree_impl(
         &self,
         p: LogicalPoint,

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -614,11 +614,6 @@ impl ItemRc {
         self.map_to_item_tree_impl(p, |_| false)
     }
 
-    /// Maps a position in window coordinates to the item coordinates
-    pub(crate) fn map_from_window(&self, p: LogicalPoint) -> LogicalPoint {
-        self.map_from_item_tree_impl(p, |_| false)
-    }
-
     /// Returns an absolute position of `p` in the `ItemTree`'s coordinate system
     /// (does not add this item's x and y)
     pub fn map_to_item_tree(
@@ -645,32 +640,6 @@ impl ItemRc {
             return p;
         }
         self.local_to_window_transform(stop_condition).transform_point(p.cast()).cast()
-    }
-
-    fn map_from_item_tree_impl(
-        &self,
-        p: LogicalPoint,
-        stop_condition: impl Fn(&Self) -> bool,
-    ) -> LogicalPoint {
-        if stop_condition(self) {
-            return p;
-        }
-
-        if let Some(transform) = self.local_to_window_transform(&stop_condition).inverse() {
-            return transform.transform_point(p.cast()).cast();
-        }
-
-        let mut current = self.clone();
-        let mut offset = euclid::Vector2D::zero();
-        while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
-            if stop_condition(&parent) {
-                break;
-            }
-            offset += parent.geometry().origin.to_vector();
-            current = parent;
-        }
-
-        p - offset
     }
 
     /// Return the index of the item within the ItemTree

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -326,9 +326,12 @@ impl Flickable {
         if let Some(keyboard_rect) = self_rc.window_adapter().and_then(|window_adapter| {
             window_adapter.window().virtual_keyboard(crate::InternalToken)
         }) {
-            let keyboard_top_left = self_rc.map_from_window(keyboard_rect.0.to_euclid());
-            if keyboard_top_left.y > geometry.origin.y {
-                geometry.size.height = keyboard_top_left.y - geometry.origin.y;
+            let keyboard_pos = keyboard_rect.0;
+
+            let self_in_window_coordinates = self_rc.map_to_native_window(geometry.origin);
+            if keyboard_pos.y < (self_in_window_coordinates.y + geometry.height()) {
+                // Keyboard is below the flickable and overlapping
+                geometry.size.height = keyboard_pos.y - self_in_window_coordinates.y;
             }
         }
         geometry
@@ -432,8 +435,9 @@ impl FlickableDataInner {
         flick_rc: &ItemRc,
     ) -> bool {
         let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
-        !(delta.x == 0 as Coord && flick.viewport_height() <= geo.height_length())
-            && !(delta.y == 0 as Coord && flick.viewport_width() <= geo.width_length())
+
+        (delta.y != 0 as Coord && flick.viewport_height() > geo.height_length())
+            || (delta.x != 0 as Coord && flick.viewport_width() > geo.width_length())
     }
 
     fn process_wheel_event(

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -329,9 +329,9 @@ impl Flickable {
             let keyboard_pos = keyboard_rect.0;
 
             let self_in_window_coordinates = self_rc.map_to_native_window(geometry.origin);
-            if keyboard_pos.y < (self_in_window_coordinates.y + geometry.height()) {
+            if (keyboard_pos.y as Coord) < (self_in_window_coordinates.y + geometry.height()) {
                 // Keyboard is below the flickable and overlapping
-                geometry.size.height = keyboard_pos.y - self_in_window_coordinates.y;
+                geometry.size.height = keyboard_pos.y as Coord - self_in_window_coordinates.y;
             }
         }
         geometry

--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -1,31 +1,38 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+// We have two flickables in each other. The inner can only be flicked horizontally,
+// the outer only vertically. If we get a vertical scroll event and the inner cannot scroll
+// vertically, we ignore the event and the outer (parent) can handle it
+
+export component TestCase inherits Window {
     width: 500px;
     height: 500px;
     no-frame: false;
 
+    // Scrolling only vertical
     outer := Flickable {
         x: 10px;
         y: 10px;
         width: parent.width - 20px;
         height: parent.height - 20px;
-        viewport_width: width;
-        viewport_height: 980px;
+        viewport-width: self.width;
+        viewport-height: 980px;
 
+        // Scrolling only horizontal
         inner := Flickable {
-            viewport_width: 1500px;
+            viewport-width: 1500px;
+            viewport-height: parent.height;
             Rectangle {
                 background: @radial-gradient(circle, yellow, blue, red, green);
             }
         }
     }
 
-    property<length> outer_y: - outer.viewport-y;
-    property<length> inner_x: - inner.viewport-x;
+    out property<length> outer_y: - outer.viewport-y;
+    out property<length> inner_x: - inner.viewport-x;
 
-    property <bool> test: outer.viewport-x == 0 && inner.viewport-y == 0;
+    out property <bool> test: outer.viewport-x == 0 && inner.viewport-y == 0;
 
 }
 
@@ -127,15 +134,16 @@ use slint::{LogicalPosition, platform::WindowEvent };
 let instance = TestCase::new().unwrap();
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: -50.0 });
 assert_eq!(instance.get_inner_x(), 0.);
-assert_eq!(instance.get_outer_y(), 50.);
+assert_eq!(instance.get_outer_y(), 50.); // Scrolling the outer because the inner cannot scroll vertically
 
+println!("Scroll horizontal");
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: -30.0, delta_y: 0.0 });
-assert_eq!(instance.get_inner_x(), 30.);
+assert_eq!(instance.get_inner_x(), 30.); // Scrolling the inner horizontal because the outer cannot scroll horizontally
 assert_eq!(instance.get_outer_y(), 50.);
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: 10.0 });
 assert_eq!(instance.get_inner_x(), 30.);
-assert_eq!(instance.get_outer_y(), 40.);
+assert_eq!(instance.get_outer_y(), 40.); // Scrolling vertical on the outer because the 
 ```
 
 */

--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -143,7 +143,7 @@ assert_eq!(instance.get_outer_y(), 50.);
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: 10.0 });
 assert_eq!(instance.get_inner_x(), 30.);
-assert_eq!(instance.get_outer_y(), 40.); // Scrolling vertical on the outer because the 
+assert_eq!(instance.get_outer_y(), 40.); // Scrolling vertical on the outer because the
 ```
 
 */

--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -134,16 +134,16 @@ use slint::{LogicalPosition, platform::WindowEvent };
 let instance = TestCase::new().unwrap();
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: -50.0 });
 assert_eq!(instance.get_inner_x(), 0.);
-assert_eq!(instance.get_outer_y(), 50.); // Scrolling the outer because the inner cannot scroll vertically
+assert_eq!(instance.get_outer_y(), 50., "Scrolling the outer because the inner cannot scroll vertically");
 
 println!("Scroll horizontal");
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: -30.0, delta_y: 0.0 });
-assert_eq!(instance.get_inner_x(), 30.); // Scrolling the inner horizontal because the outer cannot scroll horizontally
+assert_eq!(instance.get_inner_x(), 30., "Scrolling the inner horizontal because the outer cannot scroll horizontally");
 assert_eq!(instance.get_outer_y(), 50.);
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: 10.0 });
 assert_eq!(instance.get_inner_x(), 30.);
-assert_eq!(instance.get_outer_y(), 40.); // Scrolling vertical on the outer because the
+assert_eq!(instance.get_outer_y(), 40., "Scrolling vertical on the outer was not done. Because the inner is only horizontal");
 ```
 
 */


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Follow up of https://github.com/slint-ui/slint/pull/11519

map the geometry origin to window instead of keyboard to item coordinates

Reason: Because geometry does not consider the flick position of the parent
