### PR TITLE
live preview: make PopupWindow inspectable

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -479,6 +479,7 @@ pub struct WindowInner {
 
     /// Stack of currently active popups
     active_popups: RefCell<Vec<PopupWindow>>,
+    enable_native_popups: Cell<bool>,
     next_popup_id: Cell<NonZeroU32>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
@@ -541,6 +542,7 @@ impl WindowInner {
             last_ime_text: Default::default(),
             cursor_blinker: Default::default(),
             active_popups: Default::default(),
+            enable_native_popups: Cell::new(true),
             next_popup_id: Cell::new(NonZeroU32::MIN),
             had_popup_on_press: Default::default(),
             close_requested: Default::default(),
@@ -1346,9 +1348,19 @@ impl WindowInner {
     /// Create a new popup window adapter
     /// This window adapter can be used on a popup component and shown with show_popup()
     pub fn create_popup_window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        if !self.enable_native_popups.get() {
+            return None;
+        }
         self.window_adapter()
             .internal(crate::InternalToken)
             .and_then(|s| s.create_popup_window_adapter())
+    }
+
+    /// Enable or disable native popups for this window.
+    ///
+    /// Live preview turns this off so popups stay inside the window.
+    pub fn set_enable_native_popups(&self, enable: bool) {
+        self.enable_native_popups.set(enable);
     }
 
     /// Show a popup at the given position relative to the `parent_item` and returns its ID.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -680,18 +680,16 @@ impl WindowInner {
             match popup.close_policy {
                 PopupClosePolicy::CloseOnClick => {
                     let mouse_inside_popup = mouse_inside_popup();
-                    let close_outside_click = !self
-                        .ignore_close_on_outside_click_for_non_menu_popups
-                        .get()
-                        || popup.is_menu;
+                    let close_outside_click =
+                        !self.ignore_close_on_outside_click_for_non_menu_popups.get()
+                            || popup.is_menu;
                     (mouse_inside_popup && released_event && self.had_popup_on_press.get())
                         || (close_outside_click && !mouse_inside_popup && pressed_event)
                 }
                 PopupClosePolicy::CloseOnClickOutside => {
-                    let close_outside_click = !self
-                        .ignore_close_on_outside_click_for_non_menu_popups
-                        .get()
-                        || popup.is_menu;
+                    let close_outside_click =
+                        !self.ignore_close_on_outside_click_for_non_menu_popups.get()
+                            || popup.is_menu;
                     close_outside_click && !mouse_inside_popup() && pressed_event
                 }
                 PopupClosePolicy::NoAutoClose => false,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -480,7 +480,7 @@ pub struct WindowInner {
     /// Stack of currently active popups
     active_popups: RefCell<Vec<PopupWindow>>,
     enable_native_popups: Cell<bool>,
-    ignore_close_on_outside_click_for_non_menu_popups: Cell<bool>,
+    allow_interaction_outside_non_menu_popups: Cell<bool>,
     next_popup_id: Cell<NonZeroU32>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
@@ -544,7 +544,7 @@ impl WindowInner {
             cursor_blinker: Default::default(),
             active_popups: Default::default(),
             enable_native_popups: Cell::new(true),
-            ignore_close_on_outside_click_for_non_menu_popups: Cell::new(false),
+            allow_interaction_outside_non_menu_popups: Cell::new(false),
             next_popup_id: Cell::new(NonZeroU32::MIN),
             had_popup_on_press: Default::default(),
             close_requested: Default::default(),
@@ -681,15 +681,13 @@ impl WindowInner {
                 PopupClosePolicy::CloseOnClick => {
                     let mouse_inside_popup = mouse_inside_popup();
                     let close_outside_click =
-                        !self.ignore_close_on_outside_click_for_non_menu_popups.get()
-                            || popup.is_menu;
+                        !self.allow_interaction_outside_non_menu_popups.get() || popup.is_menu;
                     (mouse_inside_popup && released_event && self.had_popup_on_press.get())
                         || (close_outside_click && !mouse_inside_popup && pressed_event)
                 }
                 PopupClosePolicy::CloseOnClickOutside => {
                     let close_outside_click =
-                        !self.ignore_close_on_outside_click_for_non_menu_popups.get()
-                            || popup.is_menu;
+                        !self.allow_interaction_outside_non_menu_popups.get() || popup.is_menu;
                     close_outside_click && !mouse_inside_popup() && pressed_event
                 }
                 PopupClosePolicy::NoAutoClose => false,
@@ -704,30 +702,42 @@ impl WindowInner {
             let mut offset = LogicalPoint::default();
             let mut menubar_item = None;
             for (idx, popup) in active_popups.borrow().iter().enumerate().rev() {
-                item_tree = None;
-                menubar_item = None;
                 if let PopupWindowLocation::ChildWindow(coordinates) = &popup.location {
                     let geom = ItemTreeRc::borrow_pin(&popup.component).as_ref().item_geometry(0);
                     let mouse_inside_popup = event
                         .position()
                         .is_none_or(|pos| geom.contains(pos - coordinates.to_vector()));
                     if mouse_inside_popup {
+                        if self.allow_interaction_outside_non_menu_popups.get() && !popup.is_menu {
+                            continue;
+                        }
                         item_tree = Some(popup.component.clone());
+                        menubar_item = None;
                         offset = *coordinates;
                         break;
                     }
                 } else if native_popup_index.is_some_and(|i| i == idx) {
+                    if self.allow_interaction_outside_non_menu_popups.get() && !popup.is_menu {
+                        continue;
+                    }
                     item_tree = self.component.borrow().upgrade();
+                    menubar_item = None;
                     break;
                 }
 
                 if !popup.is_menu {
+                    if self.allow_interaction_outside_non_menu_popups.get() {
+                        continue;
+                    }
+                    item_tree = None;
+                    menubar_item = None;
                     break;
                 } else if popup_to_close.is_some() {
                     // clicking outside of a popup menu should close all the menus
                     popup_to_close = Some(popup.popup_id);
                 }
 
+                item_tree = None;
                 menubar_item = popup.parent_item.upgrade();
             }
 
@@ -1374,8 +1384,8 @@ impl WindowInner {
     }
 
     /// Live preview helper.
-    pub fn set_ignore_close_on_outside_click_for_non_menu_popups(&self, enable: bool) {
-        self.ignore_close_on_outside_click_for_non_menu_popups.set(enable);
+    pub fn set_allow_interaction_outside_non_menu_popups(&self, enable: bool) {
+        self.allow_interaction_outside_non_menu_popups.set(enable);
     }
 
     /// Show a popup at the given position relative to the `parent_item` and returns its ID.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -480,6 +480,7 @@ pub struct WindowInner {
     /// Stack of currently active popups
     active_popups: RefCell<Vec<PopupWindow>>,
     enable_native_popups: Cell<bool>,
+    ignore_close_on_outside_click_for_non_menu_popups: Cell<bool>,
     next_popup_id: Cell<NonZeroU32>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
@@ -543,6 +544,7 @@ impl WindowInner {
             cursor_blinker: Default::default(),
             active_popups: Default::default(),
             enable_native_popups: Cell::new(true),
+            ignore_close_on_outside_click_for_non_menu_popups: Cell::new(false),
             next_popup_id: Cell::new(NonZeroU32::MIN),
             had_popup_on_press: Default::default(),
             close_requested: Default::default(),
@@ -678,10 +680,20 @@ impl WindowInner {
             match popup.close_policy {
                 PopupClosePolicy::CloseOnClick => {
                     let mouse_inside_popup = mouse_inside_popup();
+                    let close_outside_click = !self
+                        .ignore_close_on_outside_click_for_non_menu_popups
+                        .get()
+                        || popup.is_menu;
                     (mouse_inside_popup && released_event && self.had_popup_on_press.get())
-                        || (!mouse_inside_popup && pressed_event)
+                        || (close_outside_click && !mouse_inside_popup && pressed_event)
                 }
-                PopupClosePolicy::CloseOnClickOutside => !mouse_inside_popup() && pressed_event,
+                PopupClosePolicy::CloseOnClickOutside => {
+                    let close_outside_click = !self
+                        .ignore_close_on_outside_click_for_non_menu_popups
+                        .get()
+                        || popup.is_menu;
+                    close_outside_click && !mouse_inside_popup() && pressed_event
+                }
                 PopupClosePolicy::NoAutoClose => false,
             }
             .then_some(popup.popup_id)
@@ -1361,6 +1373,11 @@ impl WindowInner {
     /// Live preview turns this off so popups stay inside the window.
     pub fn set_enable_native_popups(&self, enable: bool) {
         self.enable_native_popups.set(enable);
+    }
+
+    /// Live preview helper.
+    pub fn set_ignore_close_on_outside_click_for_non_menu_popups(&self, enable: bool) {
+        self.ignore_close_on_outside_click_for_non_menu_popups.set(enable);
     }
 
     /// Show a popup at the given position relative to the `parent_item` and returns its ID.

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -55,9 +55,7 @@ fn root_origin_in_native_coordinates(root_component_instance: &ItemTreeBox) -> L
 
 fn try_cast_item_tree_to_dynamic_component(item_tree: &ItemTreeRc) -> Option<DynamicComponentVRc> {
     let comp_ref_pin = vtable::VRc::borrow_pin(item_tree);
-    if vtable::VRef::downcast_pin::<ErasedItemTreeBox>(comp_ref_pin).is_none() {
-        return None;
-    }
+    vtable::VRef::downcast_pin::<ErasedItemTreeBox>(comp_ref_pin)?;
 
     // Safety We just checked that the vtable matches `ErasedItemTreeBox`.
     Some(unsafe { core::mem::transmute::<ItemTreeRc, DynamicComponentVRc>(item_tree.clone()) })

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -68,7 +68,10 @@ fn active_popup_instances(root_component_instance: &ItemTreeBox) -> Vec<DynamicC
         return Vec::new();
     };
     let active_popups = WindowInner::from_pub(window_adapter.window()).active_popups();
-    active_popups.iter().filter_map(|popup| try_cast_item_tree_to_dynamic_component(&popup.component)).collect()
+    active_popups
+        .iter()
+        .filter_map(|popup| try_cast_item_tree_to_dynamic_component(&popup.component))
+        .collect()
 }
 
 fn collect_highlight_data(
@@ -243,9 +246,9 @@ fn fill_highlight_data(
             }
             let origin =
                 item_rc.map_to_native_window(geometry.origin) - root_origin_in_native.to_vector();
-            let top_right = item_rc.map_to_native_window(
-                geometry.origin + euclid::vec2(geometry.size.width, 0.),
-            ) - root_origin_in_native.to_vector();
+            let top_right = item_rc
+                .map_to_native_window(geometry.origin + euclid::vec2(geometry.size.width, 0.))
+                - root_origin_in_native.to_vector();
             let delta = top_right - origin;
             let width = delta.length();
             let height = geometry.size.height * width / geometry.size.width;

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -3,11 +3,13 @@
 
 //! This module contains the code for the highlight of some elements
 
-use crate::dynamic_item_tree::{DynamicComponentVRc, ItemTreeBox};
+use crate::dynamic_item_tree::{DynamicComponentVRc, ErasedItemTreeBox, ItemTreeBox};
 use i_slint_compiler::object_tree::{Component, Element, ElementRc};
 use i_slint_core::graphics::euclid;
+use i_slint_core::item_tree::ItemTreeRc;
 use i_slint_core::items::ItemRc;
 use i_slint_core::lengths::{LogicalPoint, LogicalRect};
+use i_slint_core::window::WindowInner;
 use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::path::Path;
@@ -44,6 +46,31 @@ impl HighlightedRect {
     }
 }
 
+fn root_origin_in_native_coordinates(root_component_instance: &ItemTreeBox) -> LogicalPoint {
+    let vrc = VRc::into_dyn(
+        root_component_instance.borrow_instance().self_weak().get().unwrap().upgrade().unwrap(),
+    );
+    ItemRc::new_root(vrc).map_to_native_window(LogicalPoint::default())
+}
+
+fn try_cast_item_tree_to_dynamic_component(item_tree: &ItemTreeRc) -> Option<DynamicComponentVRc> {
+    let comp_ref_pin = vtable::VRc::borrow_pin(item_tree);
+    if vtable::VRef::downcast_pin::<ErasedItemTreeBox>(comp_ref_pin).is_none() {
+        return None;
+    }
+
+    // Safety We just checked that the vtable matches `ErasedItemTreeBox`.
+    Some(unsafe { core::mem::transmute::<ItemTreeRc, DynamicComponentVRc>(item_tree.clone()) })
+}
+
+fn active_popup_instances(root_component_instance: &ItemTreeBox) -> Vec<DynamicComponentVRc> {
+    let Ok(window_adapter) = root_component_instance.window_adapter_ref() else {
+        return Vec::new();
+    };
+    let active_popups = WindowInner::from_pub(window_adapter.window()).active_popups();
+    active_popups.iter().filter_map(|popup| try_cast_item_tree_to_dynamic_component(&popup.component)).collect()
+}
+
 fn collect_highlight_data(
     component: &DynamicComponentVRc,
     elements: &[std::rc::Weak<RefCell<Element>>],
@@ -52,19 +79,39 @@ fn collect_highlight_data(
     let component_instance = component_instance.upgrade().unwrap();
     generativity::make_guard!(guard);
     let c = component_instance.unerase(guard);
+    let root_origin_in_native = root_origin_in_native_coordinates(&c);
+    let popup_instances = active_popup_instances(&c);
     let mut values = Vec::new();
     for element in elements.iter().filter_map(|e| e.upgrade()) {
         let element = normalize_repeated_element(element);
-        if let Some(repeater_path) = repeater_path(&element) {
+        let Some(repeater_path) = repeater_path(&element) else { continue };
+
+        let enclosing_component = element.borrow().enclosing_component.upgrade().unwrap();
+        if Rc::ptr_eq(&enclosing_component, &c.description().original) {
             fill_highlight_data(
                 &repeater_path,
                 &element,
                 &c,
-                &c,
                 ElementPositionFilter::IncludeClipped,
+                root_origin_in_native,
                 &mut values,
             );
-        }
+        } else {
+            for popup_instance in &popup_instances {
+                generativity::make_guard!(guard);
+                let popup = popup_instance.unerase(guard);
+                if Rc::ptr_eq(&popup.description().original, &enclosing_component) {
+                    fill_highlight_data(
+                        &repeater_path,
+                        &element,
+                        &popup,
+                        ElementPositionFilter::IncludeClipped,
+                        root_origin_in_native,
+                        &mut values,
+                    );
+                }
+            }
+        };
     }
     values
 }
@@ -102,12 +149,39 @@ pub fn element_positions(
 ) -> Vec<HighlightedRect> {
     generativity::make_guard!(guard);
     let c = component_instance.unerase(guard);
+    let root_origin_in_native = root_origin_in_native_coordinates(&c);
+    let popup_instances = active_popup_instances(&c);
 
     let mut values = Vec::new();
 
     let element = normalize_repeated_element(element.clone());
     if let Some(repeater_path) = repeater_path(&element) {
-        fill_highlight_data(&repeater_path, &element, &c, &c, filter_clipped, &mut values);
+        let enclosing_component = element.borrow().enclosing_component.upgrade().unwrap();
+        if Rc::ptr_eq(&enclosing_component, &c.description().original) {
+            fill_highlight_data(
+                &repeater_path,
+                &element,
+                &c,
+                filter_clipped,
+                root_origin_in_native,
+                &mut values,
+            );
+        } else {
+            for popup_instance in &popup_instances {
+                generativity::make_guard!(guard);
+                let popup = popup_instance.unerase(guard);
+                if Rc::ptr_eq(&popup.description().original, &enclosing_component) {
+                    fill_highlight_data(
+                        &repeater_path,
+                        &element,
+                        &popup,
+                        filter_clipped,
+                        root_origin_in_native,
+                        &mut values,
+                    );
+                }
+            }
+        }
     }
     values
 }
@@ -127,8 +201,8 @@ fn fill_highlight_data(
     repeater_path: &[SmolStr],
     element: &ElementRc,
     component_instance: &ItemTreeBox,
-    root_component_instance: &ItemTreeBox,
     filter_clipped: ElementPositionFilter,
+    root_origin_in_native: LogicalPoint,
     values: &mut Vec<HighlightedRect>,
 ) {
     if element.borrow().repeated.is_some() {
@@ -150,8 +224,8 @@ fn fill_highlight_data(
                     rest,
                     element,
                     &c.unerase(guard),
-                    root_component_instance,
                     filter_clipped,
+                    root_origin_in_native,
                     values,
                 );
             }
@@ -160,9 +234,6 @@ fn fill_highlight_data(
         let vrc = VRc::into_dyn(
             component_instance.borrow_instance().self_weak().get().unwrap().upgrade().unwrap(),
         );
-        let root_vrc = VRc::into_dyn(
-            root_component_instance.borrow_instance().self_weak().get().unwrap().upgrade().unwrap(),
-        );
         let index = element.borrow().item_index.get().copied().unwrap();
         let item_rc = ItemRc::new(vrc.clone(), index);
         if filter_clipped == ElementPositionFilter::IncludeClipped || item_rc.is_visible() {
@@ -170,11 +241,11 @@ fn fill_highlight_data(
             if geometry.size.is_empty() {
                 return;
             }
-            let origin = item_rc.map_to_item_tree(geometry.origin, &root_vrc);
-            let top_right = item_rc.map_to_item_tree(
+            let origin =
+                item_rc.map_to_native_window(geometry.origin) - root_origin_in_native.to_vector();
+            let top_right = item_rc.map_to_native_window(
                 geometry.origin + euclid::vec2(geometry.size.width, 0.),
-                &root_vrc,
-            );
+            ) - root_origin_in_native.to_vector();
             let delta = top_right - origin;
             let width = delta.length();
             let height = geometry.size.height * width / geometry.size.width;
@@ -238,8 +309,11 @@ fn find_element_node_at_source_code_position(
 fn repeater_path(elem: &ElementRc) -> Option<Vec<SmolStr>> {
     let enclosing = elem.borrow().enclosing_component.upgrade().unwrap();
     if let Some(parent) = enclosing.parent_element() {
-        // This is not a repeater, it might be a popup menu which is not supported ATM
-        parent.borrow().repeated.as_ref()?;
+        // This is a component coming from a repeated element. When this isn't the case (for example
+        // PopupWindow), stop at the current component.
+        if parent.borrow().repeated.is_none() {
+            return Some(Vec::new());
+        }
 
         let mut r = repeater_path(&parent)?;
         r.push(parent.borrow().id.clone());

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -72,6 +72,19 @@ fn active_popup_instances(root_component_instance: &ItemTreeBox) -> Vec<DynamicC
         .collect()
 }
 
+/// Return the root elements of currently active popups for this component instance.
+pub fn active_popup_roots(component_instance: &DynamicComponentVRc) -> Vec<ElementRc> {
+    generativity::make_guard!(guard);
+    let c = component_instance.unerase(guard);
+    active_popup_instances(&c)
+        .into_iter()
+        .map(|popup_instance| {
+            generativity::make_guard!(guard);
+            popup_instance.unerase(guard).description().original.root_element.clone()
+        })
+        .collect()
+}
+
 fn collect_highlight_data(
     component: &DynamicComponentVRc,
     elements: &[std::rc::Weak<RefCell<Element>>],
@@ -87,7 +100,7 @@ fn collect_highlight_data(
         let element = normalize_repeated_element(element);
         let Some(repeater_path) = repeater_path(&element) else { continue };
 
-        let enclosing_component = element.borrow().enclosing_component.upgrade().unwrap();
+        let enclosing_component = top_enclosing_component(&element);
         if Rc::ptr_eq(&enclosing_component, &c.description().original) {
             fill_highlight_data(
                 &repeater_path,
@@ -157,7 +170,7 @@ pub fn element_positions(
 
     let element = normalize_repeated_element(element.clone());
     if let Some(repeater_path) = repeater_path(&element) {
-        let enclosing_component = element.borrow().enclosing_component.upgrade().unwrap();
+        let enclosing_component = top_enclosing_component(&element);
         if Rc::ptr_eq(&enclosing_component, &c.description().original) {
             fill_highlight_data(
                 &repeater_path,
@@ -305,6 +318,17 @@ fn find_element_node_at_source_code_position(
         },
     );
     result
+}
+
+fn top_enclosing_component(element: &ElementRc) -> Rc<Component> {
+    let mut component = element.borrow().enclosing_component.upgrade().unwrap();
+    while let Some(parent) = component.parent_element() {
+        if parent.borrow().repeated.is_none() {
+            break;
+        }
+        component = parent.borrow().enclosing_component.upgrade().unwrap();
+    }
+    component
 }
 
 fn repeater_path(elem: &ElementRc) -> Option<Vec<SmolStr>> {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1525,8 +1525,12 @@ fn set_preview_factory(
     callback: Box<dyn Fn(ComponentInstance)>,
     behavior: LoadBehavior,
 ) {
-    // Ensure that any popups are closed as they are related to the old factory
-    i_slint_core::window::WindowInner::from_pub(app_window.window()).close_all_popups();
+    let preview_window = i_slint_core::window::WindowInner::from_pub(app_window.window());
+
+    // Close popups from the old preview instance
+    preview_window.close_all_popups();
+    // Keep popups embedded so the inspector still works
+    preview_window.set_enable_native_popups(false);
 
     compiled.set_debug_handler(
         |location, text| {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1525,14 +1525,8 @@ fn set_preview_factory(
     callback: Box<dyn Fn(ComponentInstance)>,
     behavior: LoadBehavior,
 ) {
-    let preview_window = i_slint_core::window::WindowInner::from_pub(app_window.window());
-
     // Close popups from the old preview instance
-    preview_window.close_all_popups();
-    // Keep popups embedded so the inspector still works
-    preview_window.set_enable_native_popups(false);
-    // Don't auto-close user popups when clicking the preview UI (inspector, side panels, etc).
-    preview_window.set_ignore_close_on_outside_click_for_non_menu_popups(true);
+    i_slint_core::window::WindowInner::from_pub(app_window.window()).close_all_popups();
 
     compiled.set_debug_handler(
         |location, text| {
@@ -1574,6 +1568,9 @@ fn set_preview_factory(
 
     let factory = slint::ComponentFactory::new(move |ctx: FactoryContext| {
         let instance = compiled.create_embedded(ctx).unwrap();
+        let previewed_window = i_slint_core::window::WindowInner::from_pub(instance.window());
+        previewed_window.set_enable_native_popups(false);
+        previewed_window.set_allow_interaction_outside_non_menu_popups(true);
 
         callback(instance.clone_strong());
 
@@ -1714,6 +1711,7 @@ fn set_selected_element(
     set_drop_mark(&None);
 
     let element_node = selection.as_ref().and_then(|s| s.as_element_node());
+    let element_node_for_editor = element_node.clone();
     let notify_editor_about_selection_after_update =
         editor_notification == SelectionNotification::AfterUpdate;
 
@@ -1733,6 +1731,9 @@ fn set_selected_element(
         };
 
         if let Some(api) = preview_state.api.upgrade() {
+            api.set_popup_selection_overlay(selection.as_ref().is_some_and(|selection| {
+                selection.path.to_string_lossy().starts_with("builtin:/")
+            }));
             api.set_selection(ui::Selection {
                 highlight_index: selection.as_ref().map(|s| s.instance_index as i32).unwrap_or(-1),
                 layout_data: layout_kind,
@@ -1740,6 +1741,8 @@ fn set_selected_element(
                 is_moveable: true,
                 is_resizable: !is_in_layout && !is_layout,
             });
+
+            let mut properties_set = false;
 
             if let Some(document_cache) = document_cache_from(preview_state)
                 && let Some((uri, version, selection)) = selection
@@ -1792,6 +1795,41 @@ fn set_selected_element(
                         &document_cache,
                         properties::query_properties(&uri, version, &selection, in_layout).ok(),
                     ));
+                    properties_set = true;
+                }
+            }
+
+            if !properties_set {
+                preview_state.property_range_declarations = None;
+
+                if let Some(element_node) = element_node.as_ref() {
+                    let (component_name, type_name): (String, String) = element_node
+                        .with_element_node(|node| {
+                            let component_name = node
+                                .parent()
+                                .and_then(syntax_nodes::Component::new)
+                                .map(|component| component.DeclaredIdentifier().text().to_string())
+                                .unwrap_or_default();
+                            let type_name = node
+                                .QualifiedName()
+                                .map(|name| name.text().to_string().trim().to_string())
+                                .unwrap_or_default();
+                            (component_name, type_name)
+                        });
+
+                    let selection = selection.as_ref().unwrap();
+                    api.set_properties(Default::default());
+                    api.set_current_element(ui::ElementInformation {
+                        id: element_node.element.borrow().id.to_string().into(),
+                        component_name: component_name.into(),
+                        type_name: type_name.into(),
+                        source_uri: selection.path.to_string_lossy().to_string().into(),
+                        source_version: i32::MIN,
+                        offset: u32::from(selection.offset) as i32,
+                    });
+                } else {
+                    api.set_properties(Default::default());
+                    api.set_current_element(ui::ElementInformation::default());
                 }
             }
         }
@@ -1804,7 +1842,7 @@ fn set_selected_element(
     });
 
     if editor_notification == SelectionNotification::Now
-        && let Some(element_node) = element_node
+        && let Some(element_node) = element_node_for_editor
     {
         let (path, pos) = element_node.with_element_node(|node| {
             let sf = &node.source_file;

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1531,6 +1531,8 @@ fn set_preview_factory(
     preview_window.close_all_popups();
     // Keep popups embedded so the inspector still works
     preview_window.set_enable_native_popups(false);
+    // Don't auto-close user popups when clicking the preview UI (inspector, side panels, etc).
+    preview_window.set_ignore_close_on_outside_click_for_non_menu_popups(true);
 
     compiled.set_debug_handler(
         |location, text| {

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -183,6 +183,10 @@ fn select_element_node(
 // Return the real root element, skipping the WindowElement that might got added
 pub fn root_element(component_instance: &ComponentInstance) -> ElementRc {
     let root_element = component_instance.definition().root_component().root_element.clone();
+    real_root_element(root_element)
+}
+
+fn real_root_element(root_element: ElementRc) -> ElementRc {
     if root_element.borrow().debug.is_empty() {
         // The root element has no debug set if it is a window inserted by the compiler.
         // That window will have one child -- the "real root", but it might
@@ -272,14 +276,21 @@ pub fn collect_all_element_nodes_covering(
     position: LogicalPoint,
     component_instance: &ComponentInstance,
 ) -> Vec<SelectionCandidate> {
-    let root_element = root_element(component_instance);
     let mut elements = Vec::new();
-    collect_all_element_nodes_covering_impl(
-        position,
-        component_instance,
-        &root_element,
-        &mut elements,
-    );
+    let root_component = component_instance.definition().root_component();
+
+    // Check popups first
+    for popup in root_component.popup_windows.borrow().iter().rev() {
+        collect_all_element_nodes_covering_impl(
+            position,
+            component_instance,
+            &real_root_element(popup.component.root_element.clone()),
+            &mut elements,
+        );
+    }
+
+    let root_element = root_element(component_instance);
+    collect_all_element_nodes_covering_impl(position, component_instance, &root_element, &mut elements);
 
     assign_is_in_root_component(&mut elements);
 
@@ -875,6 +886,248 @@ export component Entry inherits Main { /* @lsp:ignore-node */ } // 401
     }
 
     #[test]
+    fn test_popup_window_element_positions() {
+        let source = r#"
+export component Main inherits Window {
+    width: 200px;
+    height: 200px;
+
+    popup := PopupWindow {
+        x: 20px;
+        y: 30px;
+        width: 100px;
+        height: 80px;
+
+        popup_rect := Rectangle {
+            x: 10px;
+            y: 5px;
+            width: 40px;
+            height: 20px;
+        }
+    }
+
+    init => {
+        popup.show();
+    }
+}
+"#;
+
+        let component_instance = crate::preview::test::interpret_test("fluent", source);
+
+        let test_file = test::main_test_file_name();
+        let rect_offset =
+            source.find("popup_rect := Rectangle").unwrap() + "popup_rect := ".len();
+
+        let popup_rect_element = component_instance
+            .element_node_at_source_code_position(&test_file, rect_offset as u32)
+            .into_iter()
+            .next()
+            .map(|(e, _)| e)
+            .expect("popup_rect element not found");
+
+        let rect = component_instance
+            .element_positions(&popup_rect_element)
+            .first()
+            .copied()
+            .expect("popup_rect element has no geometry");
+
+        const EPS: f32 = 0.01;
+        assert!((rect.rect.origin.x - 30.0).abs() <= EPS, "{rect:?}");
+        assert!((rect.rect.origin.y - 35.0).abs() <= EPS, "{rect:?}");
+        assert!((rect.rect.size.width - 40.0).abs() <= EPS, "{rect:?}");
+        assert!((rect.rect.size.height - 20.0).abs() <= EPS, "{rect:?}");
+        assert!((rect.angle - 0.0).abs() <= EPS, "{rect:?}");
+    }
+
+    #[test]
+    fn test_popup_window_hit_testing() {
+        let source = r#"
+export component Main inherits Window {
+    width: 200px;
+    height: 200px;
+
+    popup := PopupWindow {
+        x: 20px;
+        y: 30px;
+        width: 100px;
+        height: 80px;
+
+        popup_rect := Rectangle {
+            x: 10px;
+            y: 5px;
+            width: 40px;
+            height: 20px;
+        }
+    }
+
+    init => {
+        popup.show();
+    }
+}
+"#;
+
+        let component_instance = crate::preview::test::interpret_test("fluent", source);
+
+        let test_file = test::main_test_file_name();
+        let rect_offset =
+            source.find("popup_rect := Rectangle").unwrap() + "popup_rect := ".len();
+
+        let (popup_rect_element, popup_rect_debug_index) = component_instance
+            .element_node_at_source_code_position(&test_file, rect_offset as u32)
+            .into_iter()
+            .next()
+            .expect("popup_rect element not found");
+
+        let popup_rect_node =
+            crate::common::ElementRcNode::new(popup_rect_element, popup_rect_debug_index)
+                .expect("popup_rect debug node not found");
+
+        let rect = component_instance
+            .element_positions(&popup_rect_node.element)
+            .first()
+            .copied()
+            .expect("popup_rect element has no geometry");
+
+        let center = rect.rect.center();
+        let candidates = super::collect_all_element_nodes_covering(center, &component_instance);
+
+        assert!(
+            candidates.iter().any(|sc| sc.as_element_node().as_ref() == Some(&popup_rect_node)),
+            "popup_rect not found at {center:?}: {candidates:?}",
+        );
+    }
+
+    #[test]
+    fn test_popup_window_select_at() {
+        let source = r#"
+export component Main inherits Window {
+    width: 200px;
+    height: 200px;
+
+    popup := PopupWindow {
+        x: 20px;
+        y: 30px;
+        width: 100px;
+        height: 80px;
+
+        popup_rect := Rectangle {
+            x: 10px;
+            y: 5px;
+            width: 40px;
+            height: 20px;
+        }
+    }
+
+    init => {
+        popup.show();
+    }
+}
+"#;
+
+        let component_instance = crate::preview::test::interpret_test("fluent", source);
+
+        let test_file = test::main_test_file_name();
+        let rect_offset = source.find("popup_rect := Rectangle").unwrap() + "popup_rect := ".len();
+
+        let (popup_rect_element, popup_rect_debug_index) = component_instance
+            .element_node_at_source_code_position(&test_file, rect_offset as u32)
+            .into_iter()
+            .next()
+            .expect("popup_rect element not found");
+
+        let popup_rect_node =
+            crate::common::ElementRcNode::new(popup_rect_element, popup_rect_debug_index)
+                .expect("popup_rect debug node not found");
+
+        let rect = component_instance
+            .element_positions(&popup_rect_node.element)
+            .first()
+            .copied()
+            .expect("popup_rect element has no geometry");
+
+        let selected =
+            super::select_element_at_impl(&component_instance, rect.rect.center(), false)
+                .expect("no selection at popup center");
+
+        assert_eq!(selected, popup_rect_node);
+    }
+
+    #[test]
+    fn test_combobox_popup_select_at() {
+        use i_slint_core::api::LogicalPosition;
+        use i_slint_core::items::PointerEventButton;
+        use i_slint_core::platform::WindowEvent;
+        use i_slint_core::window::WindowInner;
+
+        let source = r#"
+import { ComboBox } from "std-widgets.slint";
+
+export component Main inherits Window {
+    width: 400px;
+    height: 300px;
+
+    background := Rectangle {
+        width: parent.width;
+        height: parent.height;
+    }
+
+    VerticalLayout {
+        alignment: center;
+
+        box := ComboBox {
+            model: ["First", "Second", "Third", "Fourth"];
+        }
+    }
+}
+"#;
+
+        let component_instance = crate::preview::test::interpret_test("fluent", source);
+        let window = WindowInner::from_pub(component_instance.window());
+        window.set_enable_native_popups(false);
+        window.set_allow_interaction_outside_non_menu_popups(true);
+        let click_pos = LogicalPosition::new(200.0, 150.0);
+        component_instance
+            .window()
+            .dispatch_event(WindowEvent::PointerMoved { position: click_pos });
+        component_instance.window().dispatch_event(WindowEvent::PointerPressed {
+            position: click_pos,
+            button: PointerEventButton::Left,
+        });
+        component_instance.window().dispatch_event(WindowEvent::PointerReleased {
+            position: click_pos,
+            button: PointerEventButton::Left,
+        });
+
+        let popup_roots = slint_interpreter::highlight::active_popup_roots(
+            &component_instance.clone_strong().into(),
+        );
+        assert!(!popup_roots.is_empty(), "combobox popup did not open");
+
+        let popup_click = LogicalPoint::new(200.0, 190.0);
+        let selected = super::select_element_at_impl(&component_instance, popup_click, false)
+            .expect("no selection in combobox popup");
+
+        let selected_path_and_offset = selected.path_and_offset();
+
+        assert_eq!(
+            selected_path_and_offset.0,
+            PathBuf::from("builtin:/fluent/combobox.slint"),
+            "background got selected instead: {selected:?}",
+        );
+
+        let item_positions = component_instance
+            .component_positions(&selected_path_and_offset.0, selected_path_and_offset.1.into());
+        assert!(
+            !item_positions.is_empty(),
+            "selected popup item has no geometry: {selected:?}",
+        );
+        assert!(
+            item_positions.iter().any(|position| position.contains(popup_click)),
+            "selected popup item does not cover the click: {item_positions:?}",
+        );
+    }
+
+    #[test]
     fn test_select_imported_component_at_use_site() {
         use crate::common::test::{main_test_file_name, test_file_name};
         use crate::preview::test::interpret_test_with_sources;
@@ -926,15 +1179,14 @@ export component MyInput {
         let selected = super::select_element_at_impl(
             &component_instance,
             LogicalPoint::new(100.0, 100.0),
-            /* enter_component */ false,
+            false,
         )
         .expect("a click on MyInput should select something");
 
         let (path, _offset) = selected.path_and_offset();
         assert_eq!(
             path, main_path,
-            "selection without `enter_component` should land on the MyInput use site \
-             in the main file, not on a node inside the imported component"
+            "selection without `enter_component` should land on the MyInput use site in the main file, not on a node inside the imported component",
         );
     }
 }

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -290,7 +290,12 @@ pub fn collect_all_element_nodes_covering(
     }
 
     let root_element = root_element(component_instance);
-    collect_all_element_nodes_covering_impl(position, component_instance, &root_element, &mut elements);
+    collect_all_element_nodes_covering_impl(
+        position,
+        component_instance,
+        &root_element,
+        &mut elements,
+    );
 
     assign_is_in_root_component(&mut elements);
 
@@ -915,8 +920,7 @@ export component Main inherits Window {
         let component_instance = crate::preview::test::interpret_test("fluent", source);
 
         let test_file = test::main_test_file_name();
-        let rect_offset =
-            source.find("popup_rect := Rectangle").unwrap() + "popup_rect := ".len();
+        let rect_offset = source.find("popup_rect := Rectangle").unwrap() + "popup_rect := ".len();
 
         let popup_rect_element = component_instance
             .element_node_at_source_code_position(&test_file, rect_offset as u32)
@@ -969,8 +973,7 @@ export component Main inherits Window {
         let component_instance = crate::preview::test::interpret_test("fluent", source);
 
         let test_file = test::main_test_file_name();
-        let rect_offset =
-            source.find("popup_rect := Rectangle").unwrap() + "popup_rect := ".len();
+        let rect_offset = source.find("popup_rect := Rectangle").unwrap() + "popup_rect := ".len();
 
         let (popup_rect_element, popup_rect_debug_index) = component_instance
             .element_node_at_source_code_position(&test_file, rect_offset as u32)

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -1148,10 +1148,7 @@ export component Main inherits Window {
         );
         let item_positions = component_instance
             .component_positions(&selected_path_and_offset.0, selected_path_and_offset.1.into());
-        assert!(
-            !item_positions.is_empty(),
-            "selected popup item has no geometry: {selected:?}",
-        );
+        assert!(!item_positions.is_empty(), "selected popup item has no geometry: {selected:?}",);
         assert!(
             item_positions.iter().any(|position| position.contains(popup_click)),
             "selected popup item does not cover the click: {item_positions:?}",

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -68,6 +68,10 @@ fn lsp_element_node_position(
             )
     });
 
+    if f.starts_with("builtin:/") {
+        return None;
+    }
+
     use lsp_types::{Position, Range};
     let start = Position::new((sl as u32).saturating_sub(1), (sc as u32).saturating_sub(1));
     let end = Position::new((el as u32).saturating_sub(1), (ec as u32).saturating_sub(1));
@@ -138,13 +142,28 @@ pub fn highlight_positions(
         return Default::default();
     };
 
-    let Some(path) =
-        crate::Url::parse(source_uri.as_str()).ok().and_then(|u| crate::common::uri_to_file(&u))
-    else {
-        return Default::default();
-    };
-    let offset = TextSize::new(offset as u32);
-    let positions = component_instance.component_positions(&path, offset.into());
+    let is_builtin = source_uri.starts_with("builtin:/");
+    let positions = (!is_builtin)
+        .then(|| crate::Url::parse(source_uri.as_str()).ok())
+        .flatten()
+        .and_then(|u| crate::common::uri_to_file(&u))
+        .map(|path| component_instance.component_positions(&path, offset as u32))
+        .filter(|positions| !positions.is_empty())
+        .or_else(|| {
+            super::selected_element().and_then(|selection| {
+                let instance_index = selection.instance_index;
+                selection.as_element().map(|element| {
+                    let positions = component_instance.element_positions(&element);
+                    positions
+                        .get(instance_index)
+                        .copied()
+                        .map(|position| vec![position])
+                        .unwrap_or(positions)
+                })
+            })
+        })
+        .unwrap_or_default();
+
     let model = slint::VecModel::from_iter(positions.iter().map(|g| ui::SelectionRectangle {
         width: g.rect.size.width,
         height: g.rect.size.height,
@@ -205,6 +224,7 @@ pub struct SelectionCandidate {
     pub debug_index: usize,
     pub geometry: HighlightedRect,
     pub is_in_root_component: bool,
+    pub is_popup: bool,
 }
 
 impl SelectionCandidate {
@@ -229,24 +249,26 @@ fn collect_all_element_nodes_covering_impl(
     position: LogicalPoint,
     component_instance: &ComponentInstance,
     current_element: &ElementRc,
+    is_popup: bool,
     result: &mut Vec<SelectionCandidate>,
 ) {
     let ce = self_or_embedded_component_root(current_element);
 
     for c in ce.borrow().children.iter().rev() {
-        collect_all_element_nodes_covering_impl(position, component_instance, c, result);
+        collect_all_element_nodes_covering_impl(position, component_instance, c, is_popup, result);
     }
 
-    if let Some(geometry) = element_covers_point(position, component_instance, current_element) {
+    if let Some(geometry) = element_covers_point(position, component_instance, &ce) {
         for (i, d) in ce.borrow().debug.iter().enumerate().rev() {
             if !common::is_element_node_ignored(&d.node)
-                && !d.node.source_file.path().starts_with("builtin:/")
+                && (is_popup || !d.node.source_file.path().starts_with("builtin:/"))
             {
                 // All nodes have the same geometry
                 result.push(SelectionCandidate {
                     element: ce.clone(),
                     debug_index: i,
                     is_in_root_component: false,
+                    is_popup,
                     geometry,
                 });
             }
@@ -277,14 +299,16 @@ pub fn collect_all_element_nodes_covering(
     component_instance: &ComponentInstance,
 ) -> Vec<SelectionCandidate> {
     let mut elements = Vec::new();
-    let root_component = component_instance.definition().root_component();
+    let popup_roots =
+        slint_interpreter::highlight::active_popup_roots(&component_instance.clone_strong().into());
 
-    // Check popups first
-    for popup in root_component.popup_windows.borrow().iter().rev() {
+    // Check active popups first
+    for popup_root in popup_roots.into_iter().rev() {
         collect_all_element_nodes_covering_impl(
             position,
             component_instance,
-            &real_root_element(popup.component.root_element.clone()),
+            &real_root_element(popup_root),
+            true,
             &mut elements,
         );
     }
@@ -294,6 +318,7 @@ pub fn collect_all_element_nodes_covering(
         position,
         component_instance,
         &root_element,
+        false,
         &mut elements,
     );
 
@@ -531,7 +556,10 @@ fn filter_nodes_for_selection(
     selection_candidate: &SelectionCandidate,
     enter_component: bool,
 ) -> Option<common::ElementRcNode> {
-    if !selection_candidate.is_in_root_component && !enter_component {
+    if !selection_candidate.is_in_root_component
+        && !selection_candidate.is_popup
+        && !enter_component
+    {
         return None;
     }
 
@@ -612,6 +640,7 @@ mod tests {
     use std::path::PathBuf;
 
     use i_slint_core::lengths::LogicalPoint;
+    use slint::ComponentHandle;
     use slint_interpreter::ComponentInstance;
 
     fn demo_app() -> ComponentInstance {
@@ -1117,7 +1146,6 @@ export component Main inherits Window {
             PathBuf::from("builtin:/fluent/combobox.slint"),
             "background got selected instead: {selected:?}",
         );
-
         let item_positions = component_instance
             .component_positions(&selected_path_and_offset.0, selected_path_and_offset.1.into());
         assert!(

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -298,6 +298,7 @@ export global Api {
     // Borders around things
     pure callback highlight-positions(source-uri: string, offset: int) -> [SelectionRectangle];
     in-out property <Selection> selection;
+    in-out property <bool> popup-selection-overlay;
     in-out property <DropMark> drop-mark;
     // The actual preview
     in-out property <component-factory> preview-area;

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -183,6 +183,52 @@ component SelectionFrame {
     }
 }
 
+component SelectionOverlay inherits Rectangle {
+    in property <[SelectionRectangle]> selections;
+    in property <Selection> selection;
+    in property <bool> enabled: false;
+    in property <length> overlay-width: 0px;
+    in property <length> overlay-height: 0px;
+
+    x: 0px;
+    y: 0px;
+    width: 0px;
+    height: 0px;
+    background: Colors.transparent;
+
+    public function refresh() {
+        if root.enabled && root.selections.length > 0 {
+            popup.close();
+            popup.show();
+        } else {
+            popup.close();
+        }
+    }
+
+    popup := PopupWindow {
+        x: 0px;
+        y: 0px;
+        width: root.overlay-width;
+        height: root.overlay-height;
+        close-policy: PopupClosePolicy.no-auto-close;
+
+        Rectangle {
+            background: Colors.transparent;
+
+            for s[idx] in root.selections: SelectionFrame {
+                x: s.x;
+                y: s.y;
+                width: s.width;
+                height: s.height;
+                transform-rotation: s.angle;
+                interactive: false;
+                selection: root.selection;
+                is-primary: root.selection.highlight-index == idx;
+            }
+        }
+    }
+}
+
 export component PreviewView inherits Rectangle {
     property <[SelectionRectangle]> selections: Api.highlight-positions(Api.current-element.source-uri, Api.current-element.offset);
     in property <ComponentItem> visible-component;
@@ -208,6 +254,14 @@ export component PreviewView inherits Rectangle {
         if self.diagnostic-summary == DiagnosticSummary.Errors {
             StatusLineApi.help-text = @tr("Check your text editor for errors");
         }
+    }
+
+    changed selections => {
+        selection-overlay.refresh();
+    }
+
+    changed mode => {
+        selection-overlay.refresh();
     }
 
     Rectangle {
@@ -413,6 +467,14 @@ export component PreviewView inherits Rectangle {
                         x: 0px;
                         y: 0px;
                         max-popup-height: root.height * 0.9;
+                    }
+
+                    selection-overlay := SelectionOverlay {
+                        selections <=> root.selections;
+                        selection: Api.selection;
+                        enabled: root.mode == DrawAreaMode.selecting && Api.popup-selection-overlay;
+                        overlay-width: preview-area-container.width;
+                        overlay-height: preview-area-container.height;
                     }
 
                     selection-display-area := Rectangle {


### PR DESCRIPTION
Live preview now keeps PopupWindow inspectable by disabling top level popups in the preview window so the inspector doesn’t lose input when a popup is shown extending selection to include popup item trees and fixing element highlight lookup for elements inside active popups
Fixes #11567