### PR TITLE
docs(testing): Add curl examples for MCP server scripting

### DIFF
--- a/docs/skills/slint/SKILL.md
+++ b/docs/skills/slint/SKILL.md
@@ -121,6 +121,25 @@ Do not add `mcp` to the `[features]` section of your `Cargo.toml` — use the `-
 
 **Step 2**: Connect to the running application's MCP server at `http://localhost:9315/mcp` using Streamable HTTP transport and use the available tools to inspect and interact with the UI.
 
+When scripting or verifying the server from the command line, use `curl` — it is the most reliable approach for raw JSON-RPC. Prefer `curl` over built-in HTTP fetch tools, which agents sometimes reach for but which are less predictable for this use case:
+
+```sh
+# Initialize (confirms the server is up and prints available tools)
+curl -s -X POST http://127.0.0.1:9315/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+
+# List windows
+curl -s -X POST http://127.0.0.1:9315/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_windows","arguments":{}}}'
+
+# Take a screenshot (response contains a base64-encoded PNG in the "data" field)
+curl -s -X POST http://127.0.0.1:9315/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"take_screenshot","arguments":{"windowHandle":{"index":"1","generation":"1"}}}}'
+```
+
 ### Version Requirements
 
 | Slint Version | MCP Support |

--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -233,6 +233,27 @@ set and then interact with it. For example, in Claude Code:
 > app includes a built-in MCP server. Connect to it and toggle the dark mode switch."
 
 The agent will discover the MCP endpoint, connect, and use the tools to accomplish the task.
+
+When scripting or testing from the command line, use `curl` to call tools directly — it is
+the most reliable way to send JSON-RPC requests to the server:
+
+```sh
+# Initialize (confirms the server is up and prints available tools)
+curl -s -X POST http://127.0.0.1:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+
+# List windows
+curl -s -X POST http://127.0.0.1:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_windows","arguments":{}}}'
+
+# Take a screenshot (response contains a base64-encoded PNG in the "data" field)
+curl -s -X POST http://127.0.0.1:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"take_screenshot","arguments":{"windowHandle":{"index":"1","generation":"1"}}}}'
+```
+
 You can also register the server in your MCP client's configuration if you prefer:
 
 ```json


### PR DESCRIPTION
## Summary

- Adds `curl` command examples to the "Usage with AI Agents" section of the MCP testing README, covering `initialize`, `list_windows`, and `take_screenshot`.
- Motivated by observed agent behaviour: when given no concrete guidance, agents tend to reach for their built-in HTTP fetch tools (e.g. a `WebFetch` or similar MCP tool) rather than shelling out to `curl`. Those paths are less reliable for raw JSON-RPC and harder to reproduce manually. Steering agents toward `curl` explicitly gives them a working copy-paste template and keeps the examples directly usable from the command line too.

## Test plan

- [ ] Read through the rendered README and verify the code block is syntactically correct and the commands match the server's actual endpoints.
- [ ] Run the gallery in MCP mode (`SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=8080 cargo run -p gallery --features slint/mcp`) and paste each curl command to confirm they work as shown.