### PR TITLE
testing: Extract introspection submodule and introduce shared dispatch

### DIFF
--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -473,8 +473,8 @@ pub(crate) fn handle_to_index(handle: proto::Handle) -> Result<ArenaIndex, Strin
 
 pub(crate) mod dispatch {
     use super::{
-        ArenaIndex, IntrospectionState, convert_pointer_event_button,
-        invoke_element_accessibility_action, index_to_handle, proto,
+        ArenaIndex, IntrospectionState, convert_pointer_event_button, index_to_handle,
+        invoke_element_accessibility_action, proto,
     };
 
     pub(crate) fn list_windows(state: &IntrospectionState) -> proto::WindowListResponse {

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -19,10 +19,7 @@ slotmap::new_key_type! {
 }
 
 #[allow(dead_code, non_snake_case, unused_imports, non_camel_case_types, clippy::all)]
-pub(crate) mod proto {
-    include!(concat!(env!("OUT_DIR"), "/proto.rs"));
-    include!(concat!(env!("OUT_DIR"), "/proto.serde.rs"));
-}
+pub(crate) mod proto;
 
 /// Maximum number of element handles kept in the arena before evicting the oldest.
 const ELEMENT_HANDLE_CAP: usize = 10_000;
@@ -446,7 +443,7 @@ pub(crate) fn convert_pointer_event_button(
 }
 
 // ============================================================================
-// Index ↔ parts conversion
+// Index ↔ handle conversion
 // ============================================================================
 
 pub(crate) fn index_to_handle(index: ArenaIndex) -> proto::Handle {
@@ -468,6 +465,158 @@ pub(crate) fn handle_to_index(handle: proto::Handle) -> Result<ArenaIndex, Strin
     }
 
     Ok(index)
+}
+
+// ============================================================================
+// Shared dispatch functions used by both transports
+// ============================================================================
+
+pub(crate) mod dispatch {
+    use super::{
+        ArenaIndex, IntrospectionState, convert_pointer_event_button,
+        invoke_element_accessibility_action, index_to_handle, proto,
+    };
+
+    pub(crate) fn list_windows(state: &IntrospectionState) -> proto::WindowListResponse {
+        proto::WindowListResponse {
+            window_handles: state.window_handles().into_iter().map(index_to_handle).collect(),
+        }
+    }
+
+    pub(crate) fn window_properties(
+        state: &IntrospectionState,
+        window: ArenaIndex,
+    ) -> Result<proto::WindowPropertiesResponse, String> {
+        state.window_properties(window)
+    }
+
+    pub(crate) fn find_elements_by_id(
+        state: &IntrospectionState,
+        window: ArenaIndex,
+        elements_id: &str,
+    ) -> Result<proto::ElementsResponse, String> {
+        let elements = state.find_elements_by_id(window, elements_id)?;
+        Ok(proto::ElementsResponse {
+            element_handles: elements
+                .into_iter()
+                .map(|e| index_to_handle(state.element_to_handle(e)))
+                .collect(),
+        })
+    }
+
+    pub(crate) fn element_properties(
+        state: &IntrospectionState,
+        element: ArenaIndex,
+    ) -> Result<proto::ElementPropertiesResponse, String> {
+        let element = state.element("element_properties", element)?;
+        Ok(super::element_properties(&element))
+    }
+
+    pub(crate) fn query_element_descendants(
+        state: &IntrospectionState,
+        element: ArenaIndex,
+        query_stack: Vec<proto::ElementQueryInstruction>,
+        find_all: bool,
+    ) -> Result<proto::ElementQueryResponse, String> {
+        let element = state.element("query_element_descendants", element)?;
+        let results = super::query_element_descendants(element, query_stack, find_all)?;
+        Ok(proto::ElementQueryResponse {
+            element_handles: results
+                .into_iter()
+                .map(|e| index_to_handle(state.element_to_handle(e)))
+                .collect(),
+        })
+    }
+
+    pub(crate) fn take_snapshot(
+        state: &IntrospectionState,
+        window: ArenaIndex,
+        image_mime_type: &str,
+    ) -> Result<proto::TakeSnapshotResponse, String> {
+        state.take_snapshot_response(window, image_mime_type)
+    }
+
+    pub(crate) fn invoke_accessibility_action(
+        state: &IntrospectionState,
+        element: ArenaIndex,
+        action: proto::ElementAccessibilityAction,
+    ) -> Result<(), String> {
+        let element = state.element("invoke_accessibility_action", element)?;
+        invoke_element_accessibility_action(&element, action);
+        Ok(())
+    }
+
+    pub(crate) fn set_accessible_value(
+        state: &IntrospectionState,
+        element: ArenaIndex,
+        value: String,
+    ) -> Result<(), String> {
+        let element = state.element("set_accessible_value", element)?;
+        element.set_accessible_value(value);
+        Ok(())
+    }
+
+    pub(crate) async fn click(
+        state: &IntrospectionState,
+        element: ArenaIndex,
+        action: proto::ClickAction,
+        button: proto::PointerEventButton,
+    ) -> Result<(), String> {
+        let element = state.element("click", element)?;
+        let button = convert_pointer_event_button(button);
+        match action {
+            proto::ClickAction::SingleClick => element.single_click(button).await,
+            proto::ClickAction::DoubleClick => element.double_click(button).await,
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn drag(
+        state: &IntrospectionState,
+        element: ArenaIndex,
+        target: proto::LogicalPosition,
+        button: proto::PointerEventButton,
+    ) -> Result<(), String> {
+        let element = state.element("drag", element)?;
+        let button = convert_pointer_event_button(button);
+        let target = i_slint_core::api::LogicalPosition::new(target.x, target.y);
+        element.drag(target, button).await;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn test_dispatch_element_properties_stale_handle() {
+    let state = IntrospectionState::new();
+    let err = dispatch::element_properties(&state, ArenaIndex::default()).unwrap_err();
+    assert!(err.contains("Invalid element handle"), "got: {err}");
+}
+
+#[test]
+fn test_dispatch_find_elements_by_id_stale_window() {
+    let state = IntrospectionState::new();
+    let err = dispatch::find_elements_by_id(&state, ArenaIndex::default(), "foo").unwrap_err();
+    assert!(err.contains("Invalid window handle"), "got: {err}");
+}
+
+#[test]
+fn test_dispatch_click_double_click_stale_handle() {
+    futures_lite::future::block_on(async {
+        let state = IntrospectionState::new();
+        let err = dispatch::click(
+            &state,
+            ArenaIndex::default(),
+            proto::ClickAction::DoubleClick,
+            proto::PointerEventButton::Left,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("Invalid element handle"), "got: {err}");
+    });
 }
 
 #[test]

--- a/internal/backends/testing/introspection/proto.rs
+++ b/internal/backends/testing/introspection/proto.rs
@@ -1,0 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+include!(concat!(env!("OUT_DIR"), "/proto.rs"));
+include!(concat!(env!("OUT_DIR"), "/proto.serde.rs"));

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -214,8 +214,12 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            let response =
-                dispatch::query_element_descendants(state, element_index, p.query_stack, p.find_all)?;
+            let response = dispatch::query_element_descendants(
+                state,
+                element_index,
+                p.query_stack,
+                p.find_all,
+            )?;
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -20,7 +20,7 @@ use i_slint_core::api::EventLoopError;
 use serde_json::Value;
 use std::rc::Rc;
 
-use crate::introspection::{self, IntrospectionState, proto};
+use crate::introspection::{self, IntrospectionState, dispatch, proto};
 use introspection::{handle_to_index, index_to_handle};
 
 // ============================================================================
@@ -174,9 +174,7 @@ async fn handle_tool_call(
 ) -> Result<ToolResult, String> {
     match name {
         "list_windows" => {
-            let response = proto::WindowListResponse {
-                window_handles: state.window_handles().into_iter().map(index_to_handle).collect(),
-            };
+            let response = dispatch::list_windows(state);
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
@@ -186,7 +184,7 @@ async fn handle_tool_call(
             let window_index = handle_to_index(
                 p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
             )?;
-            let response = state.window_properties(window_index)?;
+            let response = dispatch::window_properties(state, window_index)?;
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
@@ -196,13 +194,7 @@ async fn handle_tool_call(
             let window_index = handle_to_index(
                 p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
             )?;
-            let elements = state.find_elements_by_id(window_index, &p.elements_id)?;
-            let response = proto::ElementsResponse {
-                element_handles: elements
-                    .into_iter()
-                    .map(|e| index_to_handle(state.element_to_handle(e)))
-                    .collect(),
-            };
+            let response = dispatch::find_elements_by_id(state, window_index, &p.elements_id)?;
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
@@ -212,8 +204,7 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            let element = state.element("get_element_properties", element_index)?;
-            let response = introspection::element_properties(&element);
+            let response = dispatch::element_properties(state, element_index)?;
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
@@ -223,15 +214,8 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            let element = state.element("query_element_descendants", element_index)?;
-            let results =
-                introspection::query_element_descendants(element, p.query_stack, p.find_all)?;
-            let response = proto::ElementQueryResponse {
-                element_handles: results
-                    .into_iter()
-                    .map(|e| index_to_handle(state.element_to_handle(e)))
-                    .collect(),
-            };
+            let response =
+                dispatch::query_element_descendants(state, element_index, p.query_stack, p.find_all)?;
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
@@ -291,7 +275,7 @@ async fn handle_tool_call(
             let window_index = handle_to_index(
                 p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
             )?;
-            let response = state.take_snapshot_response(window_index, "image/png")?;
+            let response = dispatch::take_snapshot(state, window_index, "image/png")?;
             let png_data = response.window_contents_as_encoded_image;
             Ok(ToolResult::Image {
                 meta: serde_json::json!({ "sizeBytes": png_data.len() }),
@@ -303,16 +287,11 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            let element = state.element("click_element", element_index)?;
             let button = proto::PointerEventButton::try_from(p.button)
                 .map_err(|_| format!("invalid button value: {}", p.button))?;
-            let button = introspection::convert_pointer_event_button(button);
             let action = proto::ClickAction::try_from(p.action)
                 .map_err(|_| format!("invalid action value: {}", p.action))?;
-            match action {
-                proto::ClickAction::SingleClick => element.single_click(button).await,
-                proto::ClickAction::DoubleClick => element.double_click(button).await,
-            }
+            dispatch::click(state, element_index, action, button).await?;
             let response = proto::ElementClickResponse {};
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
@@ -323,13 +302,10 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            let element = state.element("drag_element", element_index)?;
-            let target_pos = p.target.ok_or_else(|| "missing target position".to_string())?;
-            let target = i_slint_core::api::LogicalPosition::new(target_pos.x, target_pos.y);
+            let target = p.target.ok_or_else(|| "missing target position".to_string())?;
             let button = proto::PointerEventButton::try_from(p.button)
                 .map_err(|_| format!("invalid button value: {}", p.button))?;
-            let button = introspection::convert_pointer_event_button(button);
-            element.drag(target, button).await;
+            dispatch::drag(state, element_index, target, button).await?;
             let response = proto::ElementDragResponse {};
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
@@ -340,10 +316,9 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            let element = state.element("invoke_accessibility_action", element_index)?;
             let action = proto::ElementAccessibilityAction::try_from(p.action)
                 .map_err(|_| format!("invalid action value: {}", p.action))?;
-            introspection::invoke_element_accessibility_action(&element, action);
+            dispatch::invoke_accessibility_action(state, element_index, action)?;
             let response = proto::InvokeElementAccessibilityActionResponse {};
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
@@ -354,8 +329,7 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            let element = state.element("set_element_value", element_index)?;
-            element.set_accessible_value(p.value);
+            dispatch::set_accessible_value(state, element_index, p.value)?;
             let response = proto::SetElementAccessibleValueResponse {};
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -115,9 +115,10 @@ impl TestingClient {
                 window_handle,
                 image_mime_type,
             }) => {
-                let window_index = handle_to_index(window_handle.ok_or_else(|| {
-                    "grab window request missing window handle".to_string()
-                })?)?;
+                let window_index = handle_to_index(
+                    window_handle
+                        .ok_or_else(|| "grab window request missing window handle".to_string())?,
+                )?;
                 Resp::TakeSnapshotResponse(dispatch::take_snapshot(
                     &self.state,
                     window_index,
@@ -129,9 +130,10 @@ impl TestingClient {
                 action,
                 button,
             }) => {
-                let element_index = handle_to_index(element_handle.ok_or_else(|| {
-                    "element click request missing element handle".to_string()
-                })?)?;
+                let element_index =
+                    handle_to_index(element_handle.ok_or_else(|| {
+                        "element click request missing element handle".to_string()
+                    })?)?;
                 let button = proto::PointerEventButton::try_from(button)
                     .map_err(|_| format!("invalid PointerEventButton value: {button}"))?;
                 let action = proto::ClickAction::try_from(action)
@@ -144,9 +146,10 @@ impl TestingClient {
                 target,
                 button,
             }) => {
-                let element_index = handle_to_index(element_handle.ok_or_else(|| {
-                    "element drag request missing element handle".to_string()
-                })?)?;
+                let element_index =
+                    handle_to_index(element_handle.ok_or_else(|| {
+                        "element drag request missing element handle".to_string()
+                    })?)?;
                 let button = proto::PointerEventButton::try_from(button)
                     .map_err(|_| format!("invalid PointerEventButton value: {button}"))?;
                 let target =

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -10,9 +10,8 @@ use prost::Message;
 use std::io::Cursor;
 use std::rc::Rc;
 
-use crate::ElementHandle;
-use crate::introspection::{self, IntrospectionState, proto};
-use introspection::{handle_to_index, index_to_handle};
+use crate::introspection::{self, IntrospectionState, dispatch, proto};
+use introspection::handle_to_index;
 
 struct TestingClient {
     state: Rc<IntrospectionState>,
@@ -61,41 +60,31 @@ impl TestingClient {
         let request = request.ok_or_else(|| "Empty request".to_string())?;
 
         Ok(match request {
-            Req::RequestWindowList(..) => Resp::WindowList(proto::WindowListResponse {
-                window_handles: self
-                    .state
-                    .window_handles()
-                    .into_iter()
-                    .map(index_to_handle)
-                    .collect(),
-            }),
+            Req::RequestWindowList(..) => Resp::WindowList(dispatch::list_windows(&self.state)),
             Req::RequestWindowProperties(proto::RequestWindowProperties { window_handle }) => {
-                Resp::WindowProperties(self.state.window_properties(handle_to_index(
-                    window_handle.ok_or_else(|| {
-                        "window properties request missing window handle".to_string()
-                    })?,
-                )?)?)
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
+                    "window properties request missing window handle".to_string()
+                })?)?;
+                Resp::WindowProperties(dispatch::window_properties(&self.state, window_index)?)
             }
             Req::RequestFindElementsById(proto::RequestFindElementsById {
                 window_handle,
                 elements_id,
             }) => {
-                let elements = self.state.find_elements_by_id(
-                    handle_to_index(window_handle.ok_or_else(|| {
-                        "find elements by id request missing window handle".to_string()
-                    })?)?,
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
+                    "find elements by id request missing window handle".to_string()
+                })?)?;
+                Resp::Elements(dispatch::find_elements_by_id(
+                    &self.state,
+                    window_index,
                     &elements_id,
-                )?;
-                Resp::Elements(proto::ElementsResponse {
-                    element_handles: elements
-                        .into_iter()
-                        .map(|elem| self.element_to_handle(elem))
-                        .collect(),
-                })
+                )?)
             }
             Req::RequestElementProperties(proto::RequestElementProperties { element_handle }) => {
-                let element = self.element("element properties request", element_handle)?;
-                Resp::ElementProperties(introspection::element_properties(&element))
+                let element_index = handle_to_index(element_handle.ok_or_else(|| {
+                    "element properties request missing element handle".to_string()
+                })?)?;
+                Resp::ElementProperties(dispatch::element_properties(&self.state, element_index)?)
             }
             Req::RequestInvokeElementAccessibilityAction(
                 msg @ proto::RequestInvokeElementAccessibilityAction { element_handle, .. },
@@ -104,9 +93,10 @@ impl TestingClient {
                     proto::ElementAccessibilityAction::try_from(msg.action).map_err(|_| {
                         format!("invalid ElementAccessibilityAction value: {}", msg.action)
                     })?;
-                let element =
-                    self.element("invoke element accessibility action request", element_handle)?;
-                introspection::invoke_element_accessibility_action(&element, action);
+                let element_index = handle_to_index(element_handle.ok_or_else(|| {
+                    "invoke element accessibility action request missing element handle".to_string()
+                })?)?;
+                dispatch::invoke_accessibility_action(&self.state, element_index, action)?;
                 Resp::InvokeElementAccessibilityActionResponse(
                     proto::InvokeElementAccessibilityActionResponse {},
                 )
@@ -115,21 +105,22 @@ impl TestingClient {
                 element_handle,
                 value,
             }) => {
-                let element =
-                    self.element("set element accessible value request", element_handle)?;
-                element.set_accessible_value(value);
+                let element_index = handle_to_index(element_handle.ok_or_else(|| {
+                    "set element accessible value request missing element handle".to_string()
+                })?)?;
+                dispatch::set_accessible_value(&self.state, element_index, value)?;
                 Resp::SetElementAccessibleValueResponse(proto::SetElementAccessibleValueResponse {})
             }
             Req::RequestTakeSnapshot(proto::RequestTakeSnapshot {
                 window_handle,
                 image_mime_type,
             }) => {
-                Resp::TakeSnapshotResponse(self.state.take_snapshot_response(
-                    handle_to_index(
-                        window_handle.ok_or_else(|| {
-                            "grab window request missing window handle".to_string()
-                        })?,
-                    )?,
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
+                    "grab window request missing window handle".to_string()
+                })?)?;
+                Resp::TakeSnapshotResponse(dispatch::take_snapshot(
+                    &self.state,
+                    window_index,
                     &image_mime_type,
                 )?)
             }
@@ -138,17 +129,14 @@ impl TestingClient {
                 action,
                 button,
             }) => {
-                let element = self.element("element click request", element_handle)?;
-                let button = introspection::convert_pointer_event_button(
-                    proto::PointerEventButton::try_from(button)
-                        .map_err(|_| format!("invalid PointerEventButton value: {button}"))?,
-                );
-                match proto::ClickAction::try_from(action)
-                    .map_err(|_| format!("invalid ClickAction value: {action}"))?
-                {
-                    proto::ClickAction::SingleClick => element.single_click(button).await,
-                    proto::ClickAction::DoubleClick => element.double_click(button).await,
-                }
+                let element_index = handle_to_index(element_handle.ok_or_else(|| {
+                    "element click request missing element handle".to_string()
+                })?)?;
+                let button = proto::PointerEventButton::try_from(button)
+                    .map_err(|_| format!("invalid PointerEventButton value: {button}"))?;
+                let action = proto::ClickAction::try_from(action)
+                    .map_err(|_| format!("invalid ClickAction value: {action}"))?;
+                dispatch::click(&self.state, element_index, action, button).await?;
                 Resp::ElementClickResponse(proto::ElementClickResponse {})
             }
             Req::RequestElementDrag(proto::RequestElementDrag {
@@ -156,25 +144,25 @@ impl TestingClient {
                 target,
                 button,
             }) => {
-                let element = self.element("element drag request", element_handle)?;
-                let button = introspection::convert_pointer_event_button(
-                    proto::PointerEventButton::try_from(button)
-                        .map_err(|_| format!("invalid PointerEventButton value: {button}"))?,
-                );
+                let element_index = handle_to_index(element_handle.ok_or_else(|| {
+                    "element drag request missing element handle".to_string()
+                })?)?;
+                let button = proto::PointerEventButton::try_from(button)
+                    .map_err(|_| format!("invalid PointerEventButton value: {button}"))?;
                 let target =
                     target.ok_or_else(|| "element drag request missing target".to_string())?;
-                let target = i_slint_core::api::LogicalPosition::new(target.x, target.y);
-                element.drag(target, button).await;
+                dispatch::drag(&self.state, element_index, target, button).await?;
                 Resp::ElementDragResponse(proto::ElementDragResponse {})
             }
             Req::RequestDispatchWindowEvent(proto::RequestDispatchWindowEvent {
                 window_handle,
                 event,
             }) => {
+                let window_index = handle_to_index(window_handle.ok_or_else(|| {
+                    "window event dispatch request missing window handle".to_string()
+                })?)?;
                 self.state.dispatch_window_event(
-                    handle_to_index(window_handle.ok_or_else(|| {
-                        "window event dispatch request missing window handle".to_string()
-                    })?)?,
+                    window_index,
                     convert_window_event(event.ok_or_else(|| {
                         "window event dispatch request missing event".to_string()
                     })?)?,
@@ -186,36 +174,21 @@ impl TestingClient {
                 query_stack,
                 find_all,
             }) => {
-                let element = self.element("run element query request", element_handle)?;
-                let elements =
-                    introspection::query_element_descendants(element, query_stack, find_all)?;
-                Resp::ElementQueryResponse(proto::ElementQueryResponse {
-                    element_handles: elements
-                        .into_iter()
-                        .map(|elem| self.element_to_handle(elem))
-                        .collect(),
-                })
+                let element_index = handle_to_index(element_handle.ok_or_else(|| {
+                    "run element query request missing element handle".to_string()
+                })?)?;
+                Resp::ElementQueryResponse(dispatch::query_element_descendants(
+                    &self.state,
+                    element_index,
+                    query_stack,
+                    find_all,
+                )?)
             }
             // MCP-only tools — not supported over the binary system-testing transport
             Req::RequestDispatchKeyEvent(..) | Req::RequestGetElementTree(..) => {
                 return Err("this request is only supported via the MCP transport".into());
             }
         })
-    }
-
-    fn element(
-        &self,
-        request: &'static str,
-        element_handle: Option<proto::Handle>,
-    ) -> Result<ElementHandle, String> {
-        let index = handle_to_index(
-            element_handle.ok_or_else(|| format!("{request} missing element handle"))?,
-        )?;
-        self.state.element(request, index)
-    }
-
-    fn element_to_handle(&self, element: ElementHandle) -> proto::Handle {
-        index_to_handle(self.state.element_to_handle(element))
     }
 }
 


### PR DESCRIPTION
## Summary

The MCP (`mcp_server.rs`) and system-testing (`systest.rs`) transports previously duplicated the same boilerplate for every operation: resolve a handle → look up an element or window in the arena → call an `IntrospectionState` method → map the result back to proto types. This PR moves that logic into a single place.

### Changes

- **`introspection.rs` → `introspection/mod.rs` + `introspection/proto.rs`**: Converts the flat module into a submodule so that the generated proto `include!` macros can live in their own file rather than inline in `mod.rs`.

- **`introspection::dispatch` submodule**: New `pub(crate)` module that contains one function per transport operation (`list_windows`, `window_properties`, `find_elements_by_id`, `element_properties`, `query_element_descendants`, `take_snapshot`, `invoke_accessibility_action`, `set_accessible_value`, `click`, `drag`). Each function takes `&IntrospectionState` and typed proto arguments, performs the handle resolution and arena lookup, and returns the proto response type. Both transports now call these instead of reimplementing the same steps.

- **`mcp_server.rs`**: Each `match` arm in `handle_tool_call` is reduced to handle-parsing + a single `dispatch::*` call. The per-tool element/window resolution blocks are gone.

- **`systest.rs`**: Same simplification. The private `TestingClient::element()` and `element_to_handle()` helpers are removed as they are no longer needed.

- **Tests**: Three new unit tests exercise `dispatch::element_properties`, `dispatch::find_elements_by_id`, and `dispatch::click` with stale/default handles to confirm error paths work correctly.

## Test plan

- [ ] `cargo test -p i-slint-backend-testing --features mcp,system-testing` passes (includes the three new dispatch tests and the existing handle round-trip test).
- [ ] Run the gallery in MCP mode and verify `list_windows`, `get_element_properties`, `click_element`, `drag_element`, `set_element_value`, and `take_screenshot` all work as before.
- [ ] Run the gallery in system-testing mode and verify the same operations work over the binary transport.