### PR TITLE
fix(textlayout): restore text horizontal alignment broken by parley 0.9 upgrade

### DIFF
--- a/api/rs/slint/tests/text_alignment.rs
+++ b/api/rs/slint/tests/text_alignment.rs
@@ -1,0 +1,185 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Regression test for text horizontal alignment with the software renderer.
+//! Alignment (center/right) was broken by the parley 0.9 upgrade: the new API removed the
+//! width parameter from `align()` and relies on `break_all_lines()` instead, but the call
+//! to `break_all_lines` was filtered to pass `None` for no-wrap text, leaving no container
+//! width for alignment to work against.
+
+use slint::PhysicalSize;
+use slint::platform::software_renderer::{
+    MinimalSoftwareWindow, PremultipliedRgbaColor, RepaintBufferType, TargetPixel,
+};
+use slint::platform::{PlatformError, WindowAdapter};
+use std::rc::Rc;
+
+const WIDTH: u32 = 300;
+const HEIGHT: u32 = 30;
+
+thread_local! {
+    static WINDOW: Rc<MinimalSoftwareWindow> =
+        MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
+}
+
+struct TestPlatform;
+
+impl slint::platform::Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        Ok(WINDOW.with(|x| x.clone()))
+    }
+}
+
+fn setup() -> Rc<MinimalSoftwareWindow> {
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    let window = WINDOW.with(|x| x.clone());
+    window.set_size(PhysicalSize::new(WIDTH, HEIGHT));
+    window
+}
+
+/// A pixel that blends RGBA colors so we can inspect the resulting color.
+#[derive(Clone, Copy)]
+struct RgbPixel {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+impl Default for RgbPixel {
+    fn default() -> Self {
+        RgbPixel { r: 0, g: 0, b: 0 }
+    }
+}
+
+impl TargetPixel for RgbPixel {
+    fn blend(&mut self, color: PremultipliedRgbaColor) {
+        let inv_alpha = 255u32 - color.alpha as u32;
+        self.r = (color.red as u32 + self.r as u32 * inv_alpha / 255).min(255) as u8;
+        self.g = (color.green as u32 + self.g as u32 * inv_alpha / 255).min(255) as u8;
+        self.b = (color.blue as u32 + self.b as u32 * inv_alpha / 255).min(255) as u8;
+    }
+
+    fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        RgbPixel { r, g, b }
+    }
+}
+
+fn render(window: &Rc<MinimalSoftwareWindow>) -> Vec<RgbPixel> {
+    let mut buf = vec![RgbPixel::default(); (WIDTH * HEIGHT) as usize];
+    window.request_redraw();
+    window.draw_if_needed(|renderer| {
+        renderer.render(buf.as_mut_slice(), WIDTH as usize);
+    });
+    buf
+}
+
+/// Returns the leftmost column that contains a pixel significantly darker than white.
+/// Text rendered in black on a white background shows up as dark pixels.
+fn leftmost_glyph_col(buf: &[RgbPixel]) -> Option<u32> {
+    let width = WIDTH as usize;
+    let height = HEIGHT as usize;
+    for col in 0..width {
+        for row in 0..height {
+            let p = buf[row * width + col];
+            if p.r < 200 || p.g < 200 || p.b < 200 {
+                return Some(col as u32);
+            }
+        }
+    }
+    None
+}
+
+/// Returns the rightmost column that contains a dark pixel.
+fn rightmost_glyph_col(buf: &[RgbPixel]) -> Option<u32> {
+    let width = WIDTH as usize;
+    let height = HEIGHT as usize;
+    for col in (0..width).rev() {
+        for row in 0..height {
+            let p = buf[row * width + col];
+            if p.r < 200 || p.g < 200 || p.b < 200 {
+                return Some(col as u32);
+            }
+        }
+    }
+    None
+}
+
+/// Regression test: horizontal-alignment must position text correctly.
+///
+/// Before the fix, center and right alignment produced the same pixel layout as
+/// left alignment because `break_all_lines` was called with `None` for no-wrap
+/// text, giving parley no container width to align against.
+#[test]
+fn text_horizontal_alignment() {
+    let window = setup();
+
+    slint::slint! {
+        export component TestCase inherits Window {
+            in property <int> align: 0;
+            background: white;
+            Text {
+                width: 100%;
+                height: 100%;
+                text: "XXXX";
+                color: black;
+                font-size: 14px;
+                horizontal-alignment: align == 1 ? TextHorizontalAlignment.center
+                                    : align == 2 ? TextHorizontalAlignment.right
+                                                 : TextHorizontalAlignment.left;
+            }
+        }
+    }
+
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+
+    // --- Left alignment ---
+    ui.set_align(0);
+    let left_buf = render(&window);
+    let left_start = leftmost_glyph_col(&left_buf).expect("left-aligned text must be rendered");
+    let left_end = rightmost_glyph_col(&left_buf).expect("left-aligned text must be rendered");
+    let text_width = left_end - left_start + 1;
+
+    assert!(
+        left_start < WIDTH / 4,
+        "Left-aligned text should start near the left edge, but started at column {left_start}"
+    );
+
+    // --- Right alignment ---
+    ui.set_align(2);
+    let right_buf = render(&window);
+    let right_start = leftmost_glyph_col(&right_buf).expect("right-aligned text must be rendered");
+    let right_end = rightmost_glyph_col(&right_buf).expect("right-aligned text must be rendered");
+
+    assert!(
+        right_end >= WIDTH - WIDTH / 4,
+        "Right-aligned text should end near the right edge, but ended at column {right_end}"
+    );
+    assert!(
+        right_start > left_start + text_width,
+        "Right-aligned text (starts at {right_start}) must start well to the right of \
+         left-aligned text (starts at {left_start}, width {text_width})"
+    );
+    assert_ne!(
+        left_buf.iter().map(|p| [p.r, p.g, p.b]).collect::<Vec<_>>(),
+        right_buf.iter().map(|p| [p.r, p.g, p.b]).collect::<Vec<_>>(),
+        "Left and right alignment produced identical renders — alignment is broken"
+    );
+
+    // --- Center alignment ---
+    ui.set_align(1);
+    let center_buf = render(&window);
+    let center_start =
+        leftmost_glyph_col(&center_buf).expect("center-aligned text must be rendered");
+
+    assert!(
+        center_start > left_start,
+        "Center-aligned text (starts at {center_start}) must start to the right of \
+         left-aligned text (starts at {left_start})"
+    );
+    assert!(
+        center_start < right_start,
+        "Center-aligned text (starts at {center_start}) must start to the left of \
+         right-aligned text (starts at {right_start})"
+    );
+}

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -242,6 +242,15 @@ impl LayoutWithoutLineBreaksBuilder {
             TextWrap::NoWrap => parley::style::OverflowWrap::Normal,
             TextWrap::WordWrap | TextWrap::CharWrap => parley::style::OverflowWrap::Anywhere,
         }));
+        if self.text_wrap == TextWrap::NoWrap {
+            // Parley 0.9 removed the width parameter from `Layout::align()` and instead
+            // uses the `max_advance` set by `break_all_lines()` as the alignment container
+            // width. To allow passing `max_physical_width` to `break_all_lines` for alignment
+            // purposes without triggering actual line wrapping, we must set `TextWrapMode::NoWrap`.
+            builder.push_default(parley::StyleProperty::TextWrapMode(
+                parley::style::TextWrapMode::NoWrap,
+            ));
+        }
 
         builder.push_default(parley::StyleProperty::Brush(Brush {
             override_fill_color: None,
@@ -420,8 +429,6 @@ fn create_text_paragraphs(
     paragraphs
 }
 
-/// `text_wrap` is passed separately from the shaped paragraphs because
-/// `text_layout_info()` calls `text_size()` with `NoWrap` for horizontal sizing.
 /// Note: parley currently uses `WordBreak` while shaping via `analyze_text()`,
 /// so shaped paragraphs aren't identical across wrap modes. This is why `text_size()`
 /// doesn't use the `TextLayoutCache` — it would be incorrect to share cached paragraphs
@@ -431,7 +438,6 @@ fn layout(
     font_context: &mut parley::FontContext,
     mut paragraphs: Vec<TextParagraph>,
     scale_factor: ScaleFactor,
-    text_wrap: TextWrap,
     options: LayoutOptions,
 ) -> Layout {
     let max_physical_width = options.max_width.map(|max_width| max_width * scale_factor);
@@ -464,9 +470,7 @@ fn layout(
 
     let mut para_y = 0.0;
     for para in paragraphs.iter_mut() {
-        para.layout.break_all_lines(
-            max_physical_width.filter(|_| text_wrap != TextWrap::NoWrap).map(|width| width.get()),
-        );
+        para.layout.break_all_lines(max_physical_width.map(|width| width.get()));
         para.layout.align(
             match options.horizontal_align {
                 TextHorizontalAlignment::Start | TextHorizontalAlignment::Left => {
@@ -1058,14 +1062,12 @@ pub fn draw_text(
 
     let (horizontal_align, vertical_align) = text.alignment();
     let text_overflow = text.overflow();
-    let text_wrap = text.wrap();
 
     let layout = layout(
         &layout_builder,
         &mut font_ctx,
         guard.paragraphs.take().unwrap_or_default(),
         scale_factor,
-        text_wrap,
         LayoutOptions {
             horizontal_align,
             vertical_align,
@@ -1151,7 +1153,6 @@ pub fn link_under_cursor(
         font_context,
         guard.paragraphs.take().unwrap_or_default(),
         scale_factor,
-        text.wrap(),
         LayoutOptions {
             horizontal_align,
             vertical_align,
@@ -1263,7 +1264,6 @@ pub fn draw_text_input(
         &mut font_ctx,
         paragraphs_without_linebreaks,
         scale_factor,
-        text_input.wrap(),
         LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
     );
 
@@ -1349,7 +1349,6 @@ pub fn text_size(
         &mut font_ctx,
         paragraphs_without_linebreaks,
         scale_factor,
-        text_wrap,
         LayoutOptions {
             max_width,
             max_height: None,
@@ -1469,7 +1468,6 @@ pub fn text_input_byte_offset_for_position(
         &mut font_ctx,
         paragraphs_without_linebreaks,
         scale_factor,
-        text_input.wrap(),
         LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
     );
     let byte_offset = layout.byte_offset_from_point(pos);
@@ -1524,7 +1522,6 @@ pub fn text_input_cursor_rect_for_byte_offset(
         &mut font_ctx,
         paragraphs_without_linebreaks,
         scale_factor,
-        text_input.wrap(),
         LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
     );
     let cursor_rect = layout


### PR DESCRIPTION
## Summary

Parley 0.9 removed the width parameter from `Layout::align()`; alignment now uses the `max_advance` set by `break_all_lines()` as the container width. The previous code filtered the width to `None` for `NoWrap` text (the default wrap mode), so parley had no container width and silently produced zero alignment offset — making center and right alignment indistinguishable from left alignment.

**Fix:**
- Push `StyleProperty::TextWrapMode(NoWrap)` when the Slint wrap mode is `NoWrap`, so parley suppresses soft-wrapping internally. This lets us always pass `max_physical_width` to `break_all_lines()` to set a valid `max_advance` for alignment, without actually wrapping lines.
- Remove the now-unused `text_wrap` parameter from the internal `layout()` helper and its six call sites.

**Regression test:** `api/rs/slint/tests/text_alignment.rs` uses the off-screen software renderer to verify that left, center, and right alignment each position glyphs in the correct pixel region. The test fails on the unfixed code (right-aligned text ends at column 36 instead of near the right edge of the 300 px window).

## Test plan

- [x] New test `text_horizontal_alignment` passes
- [x] Existing `text_layout_cache` tests (8) pass
- [x] Existing software renderer screenshot tests for text (8) pass