### PR TITLE
Fix build with nightly Rust

### DIFF
--- a/internal/common/key_codes.rs
+++ b/internal/common/key_codes.rs
@@ -29,7 +29,7 @@
 #[macro_export]
 macro_rules! for_each_keys {
     ($macro:ident) => {
-        $macro![
+        $macro! {
 '\u{0008}'  # Backspace   # => Backspace   # Qt_Key_Key_Backspace    # Backspace    # BackSpace  ;
 '\u{0009}'  # Tab         # => Tab         # Qt_Key_Key_Tab          # Tab          # Tab        ;
 '\u{000a}'  # Return      # => Enter       # Qt_Key_Key_Enter|Qt_Key_Key_Return # Enter # Return;
@@ -202,6 +202,6 @@ macro_rules! for_each_keys {
 ']' # CloseBracket      # CloseCurlyBracket ;
 '\''# Quote             # DoubleQuote       ;
 
-];
+}
     };
 }


### PR DESCRIPTION
Switch the inner invocation in `for_each_keys!` from `$macro![...];` to `$macro! { ... }`. Newer nightly rustc rejects the old form: the trailing `;` is invalid in expression-context callers (e.g. `for_each_keys!(generate_key_map).into_iter().collect()` in `internal/compiler/passes/resolving.rs`), but removing it breaks item-context callers because `[...]`-delimited macros at item position must be followed by `;` or use `{}` delimiters. Brace delimiters work in both positions.