### PR TITLE
Improve data URI image embedding from #9414

### DIFF
--- a/internal/compiler/data_uri.rs
+++ b/internal/compiler/data_uri.rs
@@ -1,25 +1,22 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-fn extract_extension_from_media_type(media_type: &str) -> String {
-    let subtype = media_type.strip_prefix("image/").unwrap_or(media_type);
-    let subtype = subtype.split(';').next().unwrap_or(subtype);
-    if subtype.starts_with("svg") { "svg".to_string() } else { subtype.to_string() }
-}
-
 pub fn decode_data_uri(data_uri: &str) -> Result<(Vec<u8>, String), String> {
     let data_url =
         data_url::DataUrl::process(data_uri).map_err(|e| format!("Invalid data URI: {e}"))?;
 
     let media_type = data_url.mime_type();
-    if !media_type.matches("image", &media_type.subtype) {
+    if media_type.type_ != "image" {
         return Err(format!(
-            "Unsupported media type: {}. Only image/* data URLs are supported",
-            media_type
+            "Unsupported media type: {media_type}. Only image/* data URLs are supported",
         ));
     }
 
-    let extension = extract_extension_from_media_type(&media_type.to_string());
+    let extension = if media_type.subtype.starts_with("svg") {
+        "svg".to_string()
+    } else {
+        media_type.subtype.clone()
+    };
 
     let (decoded_data, _) =
         data_url.decode_to_vec().map_err(|e| format!("Invalid data URI payload: {e}"))?;

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -96,15 +96,23 @@ fn embed_images_from_expression(
         && let ImageReference::AbsolutePath(path) = resource_ref
     {
         if path.starts_with("data:") {
-            let image_ref = embed_data_uri(
-                global_embedded_resources,
-                path,
+            // Data URIs have no external file to track, so skip for
+            // Nothing (interpreter) and ListAllResources (dependency tracking).
+            if !matches!(
                 embed_files,
-                scale_factor,
-                diag,
-                source_location,
-            );
-            *resource_ref = image_ref;
+                EmbedResourcesKind::Nothing | EmbedResourcesKind::ListAllResources
+            ) {
+                let image_ref = embed_data_uri(
+                    global_embedded_resources,
+                    path_to_id,
+                    path,
+                    embed_files,
+                    scale_factor,
+                    diag,
+                    source_location,
+                );
+                *resource_ref = image_ref;
+            }
             return;
         }
 
@@ -467,23 +475,29 @@ fn load_image(
     load_image_from_bytes(&data, extension, scale_factor)
 }
 
-#[cfg(feature = "software-renderer")]
-fn load_image_from_data_uri(
-    decoded_data: &[u8],
-    extension: &str,
-    scale_factor: f32,
-) -> image::ImageResult<(image::RgbaImage, SourceFormat, Size)> {
-    load_image_from_bytes(decoded_data, Some(extension), scale_factor)
-}
-
 fn embed_data_uri(
     global_embedded_resources: &RefCell<TiVec<EmbeddedResourcesIdx, EmbeddedResources>>,
+    path_to_id: &mut HashMap<SmolStr, EmbeddedResourcesIdx>,
     data_uri: &str,
     _embed_files: EmbedResourcesKind,
     _scale_factor: f32,
     diag: &mut BuildDiagnostics,
     source_location: &Option<crate::diagnostics::SourceLocation>,
 ) -> ImageReference {
+    if let Some(&resource_id) = path_to_id.get(data_uri) {
+        let resources = global_embedded_resources.borrow();
+        return match &resources[resource_id].kind {
+            #[cfg(feature = "software-renderer")]
+            EmbeddedResourcesKind::TextureData { .. } => {
+                ImageReference::EmbeddedTexture { resource_id }
+            }
+            EmbeddedResourcesKind::DataUriPayload(_, ext) => {
+                ImageReference::EmbeddedData { resource_id, extension: ext.clone() }
+            }
+            _ => ImageReference::None,
+        };
+    }
+
     let (decoded_data, extension) = match crate::data_uri::decode_data_uri(data_uri) {
         Ok(result) => result,
         Err(e) => {
@@ -493,22 +507,23 @@ fn embed_data_uri(
     };
 
     let mut resources = global_embedded_resources.borrow_mut();
+    let mut push = |kind| {
+        let id = resources.push_and_get_key(EmbeddedResources { path: None, kind });
+        path_to_id.insert(data_uri.into(), id);
+        id
+    };
 
     #[cfg(feature = "software-renderer")]
     if _embed_files == EmbedResourcesKind::EmbedTextures {
-        let data_buffer = decoded_data.clone();
-        match load_image_from_data_uri(&data_buffer, &extension, _scale_factor)
+        match load_image_from_bytes(&decoded_data, Some(&extension), _scale_factor)
             .map_err(|e| e.to_string())
         {
             Ok((img, source_format, original_size)) => {
-                let resource_id = resources.push_and_get_key(EmbeddedResources {
-                    path: None,
-                    kind: EmbeddedResourcesKind::TextureData(generate_texture(
-                        img,
-                        source_format,
-                        original_size,
-                    )),
-                });
+                let resource_id = push(EmbeddedResourcesKind::TextureData(generate_texture(
+                    img,
+                    source_format,
+                    original_size,
+                )));
                 return ImageReference::EmbeddedTexture { resource_id };
             }
             Err(err) => {
@@ -518,10 +533,7 @@ fn embed_data_uri(
         }
     }
 
-    let resource_id = resources.push_and_get_key(EmbeddedResources {
-        path: None,
-        kind: EmbeddedResourcesKind::DataUriPayload(decoded_data, extension.clone()),
-    });
+    let resource_id = push(EmbeddedResourcesKind::DataUriPayload(decoded_data, extension.clone()));
 
     ImageReference::EmbeddedData { resource_id, extension }
 }

--- a/internal/compiler/tests/syntax/basic/image.slint
+++ b/internal/compiler/tests/syntax/basic/image.slint
@@ -16,6 +16,21 @@ export SubElements := Rectangle {
 //              >                                              <error{Cannot find image file builtin:/common/does-not-exist.svg}
     }
 
+    Image {
+        source: @image-url("data:text/plain;base64,SGVsbG8=");
+//              >                                           <error{Unsupported media type: text/plain. Only image/* data URLs are supported}
+    }
+
+    Image {
+        source: @image-url("data:not-valid");
+//              >                          <error{Invalid data URI: data url is missing comma delimiting attributes and body}
+    }
+
+    Image {
+        source: @image-url("data:image/png;base64,!!!invalid-base64!!!");
+//              >                                                      <error{Invalid data URI payload: symbol with codepoint 33 not expected}
+    }
+
     Rectangle {
         background: red;
     }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -359,13 +359,12 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 i_slint_compiler::expression_tree::ImageReference::None => Ok(Default::default()),
                 i_slint_compiler::expression_tree::ImageReference::AbsolutePath(path) => {
                     if path.starts_with("data:") {
-                        match i_slint_compiler::data_uri::decode_data_uri(path) {
-                            Ok((data, extension)) => {
+                        i_slint_compiler::data_uri::decode_data_uri(path)
+                            .ok()
+                            .and_then(|(data, extension)| {
                                 corelib::graphics::decode_image_data(&data, &extension)
-                                    .ok_or_else(Default::default)
-                            }
-                            Err(_) => Err(Default::default()),
-                        }
+                            })
+                            .ok_or_else(Default::default)
                     } else {
                         let path = std::path::Path::new(path);
                         if path.starts_with("builtin:/") {

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -25,6 +25,15 @@ TestCase := Rectangle {
         source: @image-url("data:image/svg+xml,%3Csvg%20width%3D%22100%22%20height%3D%2295%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpolygon%20fill%3D%22%23231815%22%20points%3D%2250%2C0%2065.451%2C31.271%20100%2C36.287%2075%2C60.729%2081.902%2C95%2050%2C78.361%2018.098%2C95%2025%2C60.729%200%2C36.287%2034.549%2C31.271%22%2F%3E%3C%2Fsvg%3E");
     }
 
+    img6 := Image {
+        source: @image-url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAiIGhlaWdodD0iNDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iMjUiIGN5PSIyMCIgcj0iMTUiIGZpbGw9InJlZCIvPjwvc3ZnPg==");
+    }
+
+    // same data URI as img4, tests deduplication
+    img7 := Image {
+        source: @image-url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
+    }
+
     out property <image> with-border: @image-url("dog.jpg", nine-slice(12 13 14 15));
 
     property <length> img_width: img.width;
@@ -33,7 +42,9 @@ TestCase := Rectangle {
     property <bool> test: img2.source-clip-height * 1px == img2.height && img2.source-clip-width * 1px == img2.width &&
          img2.width/1px == img2.source.width - 20 && img3.source.width == 0 && img3.source.height == 0 && test_no_overflow == -149.5 &&
          img4.source.width == 1 && img4.source.height == 1 &&
-         img5.source.width > 0 && img5.source.height > 0;
+         img5.source.width > 0 && img5.source.height > 0 &&
+         img6.source.width == 50 && img6.source.height == 40 &&
+         img7.source.width == 1 && img7.source.height == 1;
 }
 
 /*


### PR DESCRIPTION
Previous commits already fixed the memory leak (Box::leak) and dependency tracking. This addresses remaining issues:

- Deduplicate data URIs: the same data URI used twice no longer produces two separate embedded resources. Use path_to_id cache like we already do for file-path images.

- Skip embedding for Nothing and ListAllResources modes. Data URIs are inline content with no file to track, so there is nothing to do in these modes.

- Fix the MIME type check which compared the subtype against itself (always true). Check media_type.type_ != "image" directly.

- Simplify extension extraction: use media_type.subtype directly instead of serializing and re-parsing the MIME type string.

- Remove trivial load_image_from_data_uri wrapper and unnecessary decoded_data.clone().

- Add tests for invalid MIME type, malformed data URI, corrupt base64 payload, base64-encoded SVG, and duplicate data URI.

