### PR TITLE
Node.js tutorial: spread model into array before using array methods

### DIFF
--- a/docs/astro/src/content/code/main_game_logic.js
+++ b/docs/astro/src/content/code/main_game_logic.js
@@ -7,7 +7,7 @@ import * as slint from "slint-ui";
 const ui = slint.loadFile(new URL("./memory.slint", import.meta.url));
 const mainWindow = new ui.MainWindow();
 
-const initial_tiles = mainWindow.memory_tiles;
+const initial_tiles = [...mainWindow.memory_tiles];
 const tiles = initial_tiles.concat(
     initial_tiles.map((tile) => Object.assign({}, tile)),
 );

--- a/docs/astro/src/content/code/main_tiles_from_js.js
+++ b/docs/astro/src/content/code/main_tiles_from_js.js
@@ -7,7 +7,7 @@ import * as slint from "slint-ui";
 const ui = slint.loadFile(new URL("./ui/app-window.slint", import.meta.url));
 const mainWindow = new ui.MainWindow();
 
-const initial_tiles = mainWindow.memory_tiles;
+const initial_tiles = [...mainWindow.memory_tiles];
 const tiles = initial_tiles.concat(
     initial_tiles.map((tile) => Object.assign({}, tile)),
 );


### PR DESCRIPTION
`mainWindow.memory_tiles` returns a Slint model object which is iterable but doesn't have `.concat()` or `.map()` methods. Spread it into an array first, matching what `examples/memory/main.js` already does.

Fixes: #11593
