### PR TITLE
Add accessible-orientation property

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -32,6 +32,10 @@ fn enums(path: &Path) -> anyhow::Result<()> {
             writeln!(enums_priv, "using slint::testing::AccessibleRole;")?;
             &mut enums_pub
         }};
+        (Orientation) => {{
+            writeln!(enums_priv, "using slint::Orientation;")?;
+            &mut enums_pub
+        }};
         ($_:ident) => {
             &mut enums_priv
         };

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -378,6 +378,19 @@ public:
         return get_accessible_bool_property(cbindgen_private::AccessibleStringProperty::ReadOnly);
     }
 
+    /// Returns the accessible-orientation of that element, if any.
+    std::optional<Orientation> accessible_orientation() const
+    {
+        if (auto str = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Orientation)) {
+            if (*str == "horizontal")
+                return Orientation::Horizontal;
+            if (*str == "vertical")
+                return Orientation::Vertical;
+        }
+        return std::nullopt;
+    }
+
     /// Invokes the expand accessibility action of that element
     /// (`accessible-action-expand`).
     void invoke_accessible_expand_action() const

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -433,6 +433,12 @@ for i in 5: Rectangle {
 The label for an interactive element. (default value: empty for most elements, or the value of the `text` property for Text elements)
 </SlintProperty>
 
+### accessible-orientation
+<SlintProperty typeName="enum" enumName="Orientation">
+The orientation of the element when it makes sense, such as a `Slider` or a `ScrollBar`. Assistive
+technologies can use this to inform the user whether the widget is laid out horizontally or vertically.
+</SlintProperty>
+
 ### accessible-value-maximum
 <SlintProperty typeName="float" propName="accessible-value-maximum" default="0">
 The maximum value of the item. This is used for example by spin boxes.

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -84,6 +84,7 @@ export component SideBar inherits Rectangle {
             alignment: start;
             vertical-stretch: 0;
             accessible-role: tab-list;
+            accessible-orientation: Orientation.vertical;
             accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current-item;
             accessible-label: root.title;
             accessible-item-count: root.model.length;

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -214,6 +214,7 @@ impl SlintAccessibleItemData {
                 item_rc.accessible_string_property(AccessibleStringProperty::Expandable);
                 item_rc.accessible_string_property(AccessibleStringProperty::Expanded);
                 item_rc.accessible_string_property(AccessibleStringProperty::ReadOnly);
+                item_rc.accessible_string_property(AccessibleStringProperty::Orientation);
             }
         });
     }
@@ -357,6 +358,23 @@ cpp! {{
                 -> *mut c_void as "void*" {
             let root_item = Box::new(ItemRc::new_root(WindowInner::from_pub(&rustWindow.window).component()).downgrade());
             Box::into_raw(root_item) as _
+        });
+    }
+
+    // Returns the orientation of the item as a Qt::Orientation value
+    // (Qt::Horizontal=1, Qt::Vertical=2), or 0 if the property is not set.
+    int item_qt_orientation(void *data) {
+        return rust!(item_qt_orientation_
+            [data: &SlintAccessibleItemData as "void*"]
+                -> i32 as "int" {
+            data.item.upgrade()
+                .and_then(|i| i.accessible_string_property(AccessibleStringProperty::Orientation))
+                .and_then(|s| s.parse::<i_slint_core::items::Orientation>().ok())
+                .map(|o| match o {
+                    i_slint_core::items::Orientation::Horizontal => 1,
+                    i_slint_core::items::Orientation::Vertical => 2,
+                })
+                .unwrap_or(0)
         });
     }
 
@@ -562,7 +580,11 @@ cpp! {{
     // Slint_accessible_item:
     // ------------------------------------------------------------------------------
 
-    class Slint_accessible_item : public Slint_accessible, public QAccessibleValueInterface, public QAccessibleActionInterface {
+    class Slint_accessible_item : public Slint_accessible, public QAccessibleValueInterface, public QAccessibleActionInterface
+#if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
+        , public QAccessibleAttributesInterface
+#endif
+    {
     public:
         Slint_accessible_item(void *item, QObject *obj, QAccessible::Role role, QAccessibleInterface *parent) :
             Slint_accessible(role, parent), m_object(obj)
@@ -655,8 +677,34 @@ cpp! {{
             } else if (t == QAccessible::ActionInterface) {
                 return static_cast<QAccessibleActionInterface*>(this);
             }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
+            else if (t == QAccessible::AttributesInterface) {
+                return static_cast<QAccessibleAttributesInterface*>(this);
+            }
+#endif
             return QAccessibleInterface::interface_cast(t);
         }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
+        // QAccessibleAttributesInterface
+        QList<QAccessible::Attribute> attributeKeys() const override {
+            QList<QAccessible::Attribute> keys;
+            if (item_qt_orientation(m_data) != 0) {
+                keys << QAccessible::Attribute::Orientation;
+            }
+            return keys;
+        }
+
+        QVariant attributeValue(QAccessible::Attribute key) const override {
+            if (key == QAccessible::Attribute::Orientation) {
+                int o = item_qt_orientation(m_data);
+                if (o != 0) {
+                    return QVariant::fromValue(static_cast<Qt::Orientation>(o));
+                }
+            }
+            return QVariant();
+        }
+#endif
 
         // AccessibleValueInterface:
         QVariant currentValue() const override {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -109,4 +109,4 @@ pub fn configure_test_fonts() {
     .unwrap();
 }
 
-pub use i_slint_core::items::AccessibleRole;
+pub use i_slint_core::items::{AccessibleRole, Orientation};

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -783,6 +783,17 @@ impl ElementHandle {
             .and_then(|item| item.parse().ok())
     }
 
+    /// Returns the value of the `accessible-orientation` property, if present.
+    pub fn accessible_orientation(&self) -> Option<crate::Orientation> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item
+            .upgrade()
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Orientation))
+            .and_then(|s| s.parse().ok())
+    }
+
     /// Returns the size of the element in logical pixels. This corresponds to the value of the `width` and
     /// `height` properties in Slint code. Returns a zero size if the element is not valid.
     pub fn size(&self) -> i_slint_core::api::LogicalSize {

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -6,7 +6,9 @@ use std::pin::Pin;
 use std::ptr::NonNull;
 use std::rc::Weak;
 
-use accesskit::{Action, ActionRequest, Node, NodeId, Role, Toggled, Tree, TreeId, TreeUpdate};
+use accesskit::{
+    Action, ActionRequest, Node, NodeId, Orientation, Role, Toggled, Tree, TreeId, TreeUpdate,
+};
 use i_slint_core::SharedString;
 use i_slint_core::accessibility::{
     AccessibilityAction, AccessibleStringProperty, SupportedAccessibilityAction,
@@ -662,6 +664,16 @@ impl NodeCollection {
             .is_some_and(|x| x == "true")
         {
             node.set_read_only();
+        }
+
+        if let Some(orientation) = item
+            .accessible_string_property(AccessibleStringProperty::Orientation)
+            .and_then(|s| s.parse::<i_slint_core::items::Orientation>().ok())
+        {
+            node.set_orientation(match orientation {
+                i_slint_core::items::Orientation::Horizontal => Orientation::Horizontal,
+                i_slint_core::items::Orientation::Vertical => Orientation::Vertical,
+            });
         }
 
         if item

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -696,9 +696,13 @@ fn lower_sub_component(
                     to: Type::String,
                 },
                 Type::String => super::Expression::PropertyReference(prop),
-                Type::Enumeration(e) if e.name == "AccessibleRole" => {
+                Type::Enumeration(ref e) if e.name == "AccessibleRole" => {
                     super::Expression::PropertyReference(prop)
                 }
+                Type::Enumeration(_) => super::Expression::Cast {
+                    from: super::Expression::PropertyReference(prop).into(),
+                    to: Type::String,
+                },
                 Type::Callback(callback) => super::Expression::CallBackCall {
                     callback: prop,
                     arguments: (0..callback.args.len())

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -44,7 +44,7 @@ pub fn lower_accessibility_properties(component: &Rc<Component>, diag: &mut Buil
 
             for prop_name in crate::typeregister::reserved_accessibility_properties()
                 .map(|x| x.0)
-                .chain(std::iter::once("accessible-role"))
+                .chain(["accessible-role", "accessible-orientation"])
             {
                 if accessible_role_set {
                     if elem.borrow().is_binding_set(prop_name, false) {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -273,10 +273,6 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-read-only", Type::Bool),
     ]
     .into_iter()
-    .chain(std::iter::once((
-        "accessible-orientation",
-        Type::Enumeration(BUILTIN.with(|e| e.enums.Orientation.clone())),
-    )))
 }
 
 /// list of reserved property injected in every item
@@ -333,6 +329,11 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
                 "accessible-role",
                 Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleRole.clone())),
                 PropertyVisibility::Constexpr,
+            ),
+            (
+                "accessible-orientation",
+                Type::Enumeration(BUILTIN.with(|e| e.enums.Orientation.clone())),
+                PropertyVisibility::Input,
             ),
         ]))
         .chain(std::iter::once(("init", noarg_callback_type(), PropertyVisibility::Private)))

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -273,6 +273,10 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-read-only", Type::Bool),
     ]
     .into_iter()
+    .chain(std::iter::once((
+        "accessible-orientation",
+        Type::Enumeration(BUILTIN.with(|e| e.enums.Orientation.clone())),
+    )))
 }
 
 /// list of reserved property injected in every item

--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -6,6 +6,7 @@ import { ListItem, ScrollView } from "std-widgets-impl.slint";
 export component ListView inherits ScrollView {
     @children
     accessible-role: list;
+    accessible-orientation: Orientation.vertical;
 }
 
 component StandardListViewBase inherits ListView {

--- a/internal/compiler/widgets/cosmic/slider.slint
+++ b/internal/compiler/widgets/cosmic/slider.slint
@@ -23,6 +23,7 @@ export component Slider {
     horizontal-stretch: base.vertical ? 0 : 1;
     accessible-role: slider;
     accessible-enabled: root.enabled;
+    accessible-orientation: root.orientation;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -188,6 +188,7 @@ component CosmicTabBarBase inherits TabBarBase {
 }
 
 export component TabBarHorizontalImpl inherits CosmicTabBarBase {
+    accessible-orientation: Orientation.horizontal;
     Flickable {
         HorizontalLayout {
             @children
@@ -196,6 +197,7 @@ export component TabBarHorizontalImpl inherits CosmicTabBarBase {
 }
 
 export component TabBarVerticalImpl inherits CosmicTabBarBase {
+    accessible-orientation: Orientation.vertical;
     Flickable {
         VerticalLayout {
             @children

--- a/internal/compiler/widgets/cupertino/slider.slint
+++ b/internal/compiler/widgets/cupertino/slider.slint
@@ -22,6 +22,7 @@ export component Slider {
     horizontal-stretch: base.vertical ? 0 : 1;
     accessible-role: slider;
     accessible-enabled: root.enabled;
+    accessible-orientation: root.orientation;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -164,6 +164,7 @@ component CupertinoTabBarBase inherits TabBarBase {
 }
 
 export component TabBarHorizontalImpl inherits CupertinoTabBarBase {
+    accessible-orientation: Orientation.horizontal;
     Flickable {
         HorizontalLayout {
             min-height: 22px;
@@ -175,6 +176,7 @@ export component TabBarHorizontalImpl inherits CupertinoTabBarBase {
 }
 
 export component TabBarVerticalImpl inherits CupertinoTabBarBase {
+    accessible-orientation: Orientation.vertical;
     Flickable {
         VerticalLayout {
             // TODO min-height: 22px;

--- a/internal/compiler/widgets/fluent/slider.slint
+++ b/internal/compiler/widgets/fluent/slider.slint
@@ -22,6 +22,7 @@ export component Slider {
     horizontal-stretch: base.vertical ? 0 : 1;
     accessible-role: slider;
     accessible-enabled: root.enabled;
+    accessible-orientation: root.orientation;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -146,6 +146,7 @@ component FluentTabBarBase inherits TabBarBase {
 }
 
 export component TabBarHorizontalImpl inherits FluentTabBarBase {
+    accessible-orientation: Orientation.horizontal;
     Flickable {
         HorizontalLayout {
             @children
@@ -154,6 +155,7 @@ export component TabBarHorizontalImpl inherits FluentTabBarBase {
 }
 
 export component TabBarVerticalImpl inherits FluentTabBarBase {
+    accessible-orientation: Orientation.vertical;
     Flickable {
         VerticalLayout {
             @children

--- a/internal/compiler/widgets/material/slider.slint
+++ b/internal/compiler/widgets/material/slider.slint
@@ -22,6 +22,7 @@ export component Slider {
     min-height: base.vertical ? 0px : 20px;
     accessible-role: slider;
     accessible-enabled: root.enabled;
+    accessible-orientation: root.orientation;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -158,6 +158,7 @@ component MaterialTabBarBase inherits TabBarBase {
 }
 
 export component TabBarHorizontalImpl inherits MaterialTabBarBase {
+    accessible-orientation: Orientation.horizontal;
     Flickable {
         HorizontalLayout {
             @children
@@ -166,6 +167,7 @@ export component TabBarHorizontalImpl inherits MaterialTabBarBase {
 }
 
 export component TabBarVerticalImpl inherits MaterialTabBarBase {
+    accessible-orientation: Orientation.vertical;
     Flickable {
         VerticalLayout {
             @children

--- a/internal/compiler/widgets/qt/slider.slint
+++ b/internal/compiler/widgets/qt/slider.slint
@@ -5,6 +5,7 @@ export component Slider inherits NativeSlider {
     value: root.minimum;
     accessible-role: slider;
     accessible-enabled: root.enabled;
+    accessible-orientation: root.orientation;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;

--- a/internal/compiler/widgets/qt/tabwidget.slint
+++ b/internal/compiler/widgets/qt/tabwidget.slint
@@ -47,6 +47,7 @@ component QtTabBarBase inherits TabBarBase {
 }
 
 export component TabBarHorizontalImpl inherits QtTabBarBase{
+    accessible-orientation: Orientation.horizontal;
     Rectangle {
         // The breeze style draws outside of the tab bar, which is clip by default with Qt
         clip: true;
@@ -61,6 +62,7 @@ export component TabBarHorizontalImpl inherits QtTabBarBase{
 }
 
 export component TabBarVerticalImpl inherits QtTabBarBase{
+    accessible-orientation: Orientation.vertical;
     Rectangle {
         // The breeze style draws outside of the tab bar, which is clip by default with Qt
         clip: true;

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -30,6 +30,7 @@ pub enum AccessibleStringProperty {
     ItemSelectable,
     ItemSelected,
     Label,
+    Orientation,
     PlaceholderText,
     ReadOnly,
     Value,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2453,6 +2453,7 @@ extern "C" fn accessible_string_property(
             Value::String(s) => *result = s,
             Value::Bool(b) => *result = if b { "true" } else { "false" }.into(),
             Value::Number(x) => *result = x.to_string().into(),
+            Value::EnumerationValue(_, v) => *result = v.into(),
             _ => unimplemented!("invalid type for accessible_string_property"),
         };
         true

--- a/tests/cases/accessibility/orientation.slint
+++ b/tests/cases/accessibility/orientation.slint
@@ -1,0 +1,84 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test the accessible-orientation property.
+
+export component TestCase inherits Window {
+    width: 300phx;
+    height: 300phx;
+
+    in-out property <Orientation> slider-orientation: Orientation.horizontal;
+
+    VerticalLayout {
+        Rectangle {
+            accessible-role: slider;
+            accessible-label: "horizontal-slider";
+            accessible-orientation: Orientation.horizontal;
+        }
+        Rectangle {
+            accessible-role: slider;
+            accessible-label: "vertical-slider";
+            accessible-orientation: Orientation.vertical;
+        }
+        Rectangle {
+            accessible-role: slider;
+            accessible-label: "dynamic-slider";
+            accessible-orientation: root.slider-orientation;
+        }
+        Rectangle {
+            accessible-role: button;
+            accessible-label: "no-orientation";
+        }
+    }
+}
+
+
+/*
+
+```rust
+use slint_testing::Orientation;
+
+let instance = TestCase::new().unwrap();
+
+let h = slint_testing::ElementHandle::find_by_accessible_label(&instance, "horizontal-slider").next().unwrap();
+assert_eq!(h.accessible_orientation(), Some(Orientation::Horizontal));
+
+let v = slint_testing::ElementHandle::find_by_accessible_label(&instance, "vertical-slider").next().unwrap();
+assert_eq!(v.accessible_orientation(), Some(Orientation::Vertical));
+
+let d = slint_testing::ElementHandle::find_by_accessible_label(&instance, "dynamic-slider").next().unwrap();
+assert_eq!(d.accessible_orientation(), Some(Orientation::Horizontal));
+instance.set_slider_orientation(Orientation::Vertical);
+assert_eq!(d.accessible_orientation(), Some(Orientation::Vertical));
+
+let b = slint_testing::ElementHandle::find_by_accessible_label(&instance, "no-orientation").next().unwrap();
+// Element has no accessible-orientation binding, so the property is not exposed.
+assert!(b.accessible_orientation().is_none());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+auto h = slint::testing::ElementHandle::find_by_accessible_label(handle, "horizontal-slider");
+assert_eq(h.size(), 1);
+assert(h[0].accessible_orientation().has_value());
+assert(*h[0].accessible_orientation() == slint::Orientation::Horizontal);
+
+auto v = slint::testing::ElementHandle::find_by_accessible_label(handle, "vertical-slider");
+assert_eq(v.size(), 1);
+assert(v[0].accessible_orientation().has_value());
+assert(*v[0].accessible_orientation() == slint::Orientation::Vertical);
+
+auto d = slint::testing::ElementHandle::find_by_accessible_label(handle, "dynamic-slider");
+assert_eq(d.size(), 1);
+assert(*d[0].accessible_orientation() == slint::Orientation::Horizontal);
+instance.set_slider_orientation(slint::Orientation::Vertical);
+assert(*d[0].accessible_orientation() == slint::Orientation::Vertical);
+
+auto b = slint::testing::ElementHandle::find_by_accessible_label(handle, "no-orientation");
+assert_eq(b.size(), 1);
+assert(!b[0].accessible_orientation().has_value());
+```
+
+*/


### PR DESCRIPTION
<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
