### PR TITLE
Flickable: Fix multiple click inside a Flickable

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1220,6 +1220,10 @@ pub(crate) fn process_delayed_event(
         None => return MouseInputState::default(),
     };
 
+    // Recover the real previous click target so click_count is preserved across delayed events
+    let prev_target = mouse_input_state.delayed_exit_items.last().and_then(|x| x.upgrade());
+    let last_top_item = prev_target.as_ref().unwrap_or(&top_item);
+
     let mut actual_visitor =
         |component: &ItemTreeRc, index: u32, _: Pin<ItemRef>| -> VisitChildrenResult {
             send_mouse_event_to_item(
@@ -1227,7 +1231,7 @@ pub(crate) fn process_delayed_event(
                 ItemRc::new(component.clone(), index),
                 window_adapter,
                 &mut mouse_input_state,
-                Some(&top_item),
+                Some(last_top_item),
                 true,
             )
         };

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1012,6 +1012,11 @@ impl MouseInputState {
     pub fn top_item_including_delayed(&self) -> Option<ItemRc> {
         self.delayed_exit_items.last().and_then(|x| x.upgrade()).or_else(|| self.top_item())
     }
+
+    /// Returns true if there is a pending delayed event (e.g. from a Flickable)
+    pub fn has_delayed_event(&self) -> bool {
+        self.delayed.is_some()
+    }
 }
 
 /// Try to handle the mouse grabber. Return None if the event has been handled, otherwise
@@ -1165,7 +1170,7 @@ pub fn process_mouse_input(
     root: ItemRc,
     mouse_event: &MouseEvent,
     window_adapter: &Rc<dyn WindowAdapter>,
-    mouse_input_state: MouseInputState,
+    mut mouse_input_state: MouseInputState,
 ) -> MouseInputState {
     let mut result = MouseInputState {
         drag_data: mouse_input_state.drag_data.clone(),
@@ -1185,7 +1190,8 @@ pub fn process_mouse_input(
             || Option::zip(result.item_stack.last(), mouse_input_state.item_stack.last())
                 .is_none_or(|(a, b)| a.0 != b.0))
     {
-        // Keep the delayed event
+        // Keep the delayed event, but preserve the cursor from the new result
+        mouse_input_state.cursor = result.cursor;
         return mouse_input_state;
     }
     send_exit_events(&mouse_input_state, &mut result, mouse_event.position(), window_adapter);

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -630,6 +630,7 @@ impl WindowInner {
 
         let pressed_event = matches!(event, MouseEvent::Pressed { .. });
         let released_event = matches!(event, MouseEvent::Released { .. });
+        let had_delay = mouse_input_state.has_delayed_event();
 
         let last_top_item = mouse_input_state.top_item_including_delayed();
         if released_event {
@@ -761,7 +762,10 @@ impl WindowInner {
             self.click_state.check_repeat(event, self.context().platform().click_interval());
         }
 
-        if old_cursor != mouse_input_state.cursor
+        if !had_delay && mouse_input_state.has_delayed_event() {
+            // A delay was just set up, preserve the old cursor
+            mouse_input_state.cursor = old_cursor;
+        } else if old_cursor != mouse_input_state.cursor
             && let Some(window_adapter) = window_adapter.internal(crate::InternalToken)
         {
             window_adapter.set_mouse_cursor(mouse_input_state.cursor);

--- a/tests/cases/elements/flickable_text_double_click.slint
+++ b/tests/cases/elements/flickable_text_double_click.slint
@@ -1,7 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Double-clicking on a TextInput inside a Flickable should select a word
+// Test TextInput inside a Flickable: double-click selects a word
+// and the mouse cursor stays as "text" during the Flickable press delay
 
 export component TestCase inherits Window {
     width: 500phx;
@@ -33,12 +34,19 @@ export component TestCase inherits Window {
 
 /*
 ```rust
+use slint::{platform::WindowEvent, LogicalPosition, platform::PointerEventButton};
+use slint::private_unstable_api::re_exports::MouseCursor;
+
 let instance = TestCase::new().unwrap();
+let cursor = || slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor());
+
+assert_eq!(cursor(), MouseCursor::Default);
 
 // Focus the TextInput with a click
 slint_testing::send_mouse_click(&instance, 50.0, 15.0);
 slint_testing::mock_elapsed_time(200);
 assert!(instance.get_input_focused(), "TextInput should be focused");
+assert_eq!(cursor(), MouseCursor::Text, "Cursor should be text after clicking on TextInput");
 
 // Type text
 slint_testing::send_keyboard_string_sequence(&instance, "Hello World");
@@ -48,7 +56,20 @@ assert!(!instance.get_has_selection(), "No selection after typing");
 // Wait to reset click count
 slint_testing::mock_elapsed_time(1000);
 
-// Double-click on "Hello" (FixedTestFont at 10phx = 10phx per character, x=25 → column 2)
+// Verify cursor stays "text" during a press while Flickable delays the event
+let position = LogicalPosition::new(25.0, 5.0);
+let button = PointerEventButton::Left;
+instance.window().dispatch_event(WindowEvent::PointerMoved { position });
+assert_eq!(cursor(), MouseCursor::Text, "Cursor should be text after moving over TextInput");
+instance.window().dispatch_event(WindowEvent::PointerPressed { position, button });
+assert_eq!(cursor(), MouseCursor::Text, "Cursor must stay text during Flickable press delay");
+slint_testing::mock_elapsed_time(50);
+assert_eq!(cursor(), MouseCursor::Text, "Cursor must stay text while delay is pending");
+instance.window().dispatch_event(WindowEvent::PointerReleased { position, button });
+assert_eq!(cursor(), MouseCursor::Text, "Cursor should be text after release");
+
+// Wait to reset click count, then double-click on "Hello"
+slint_testing::mock_elapsed_time(1000);
 slint_testing::send_mouse_click(&instance, 25.0, 5.0);
 slint_testing::mock_elapsed_time(50);
 slint_testing::send_mouse_click(&instance, 25.0, 5.0);
@@ -57,5 +78,6 @@ slint_testing::send_mouse_click(&instance, 25.0, 5.0);
 assert!(instance.get_has_selection(), "Double-click in Flickable should select a word");
 assert_eq!(instance.get_test_anchor_pos(), 0, "Selection anchor should be at start of 'Hello'");
 assert_eq!(instance.get_test_cursor_pos(), 5, "Selection cursor should be at end of 'Hello'");
+assert_eq!(cursor(), MouseCursor::Text, "Cursor should be text after double-click");
 ```
 */

--- a/tests/cases/elements/flickable_text_double_click.slint
+++ b/tests/cases/elements/flickable_text_double_click.slint
@@ -1,0 +1,61 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Double-clicking on a TextInput inside a Flickable should select a word
+
+export component TestCase inherits Window {
+    width: 500phx;
+    height: 500phx;
+
+    flick := Flickable {
+        x: 0phx;
+        y: 0phx;
+        width: 500phx;
+        height: 500phx;
+        viewport-height: 2000phx;
+
+        ti := TextInput {
+            x: 0phx;
+            y: 0phx;
+            width: 200phx;
+            height: 30phx;
+            font-family: "FixedTestFont";
+            font-size: 10phx;
+        }
+    }
+
+    out property <string> test_text <=> ti.text;
+    out property <int> test_cursor_pos: ti.cursor-position-byte-offset;
+    out property <int> test_anchor_pos: ti.anchor-position-byte-offset;
+    out property <bool> has_selection: test_cursor_pos != test_anchor_pos;
+    out property <bool> input_focused: ti.has-focus;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+// Focus the TextInput with a click
+slint_testing::send_mouse_click(&instance, 50.0, 15.0);
+slint_testing::mock_elapsed_time(200);
+assert!(instance.get_input_focused(), "TextInput should be focused");
+
+// Type text
+slint_testing::send_keyboard_string_sequence(&instance, "Hello World");
+assert_eq!(instance.get_test_text(), "Hello World");
+assert!(!instance.get_has_selection(), "No selection after typing");
+
+// Wait to reset click count
+slint_testing::mock_elapsed_time(1000);
+
+// Double-click on "Hello" (FixedTestFont at 10phx = 10phx per character, x=25 → column 2)
+slint_testing::send_mouse_click(&instance, 25.0, 5.0);
+slint_testing::mock_elapsed_time(50);
+slint_testing::send_mouse_click(&instance, 25.0, 5.0);
+
+// "Hello" should be selected (offsets 0 to 5)
+assert!(instance.get_has_selection(), "Double-click in Flickable should select a word");
+assert_eq!(instance.get_test_anchor_pos(), 0, "Selection anchor should be at start of 'Hello'");
+assert_eq!(instance.get_test_cursor_pos(), 5, "Selection cursor should be at end of 'Hello'");
+```
+*/


### PR DESCRIPTION
Fix double-click text selection inside Flickable

When a Flickable delays a press event, process_delayed_event() was using the Flickable as last_top_item, causing click_count to reset to 0 for the actual child target. Use delayed_exit_items to recover the real previous click target instead.
