### PR TITLE
C++: Fix C++26 extension warning for = delete with message

### DIFF
--- a/api/cpp/include/private/slint_config.h
+++ b/api/cpp/include/private/slint_config.h
@@ -25,7 +25,7 @@
 #    endif
 #endif // !defined(DOXYGEN)
 
-#if defined(__cpp_deleted_function) && __cpp_deleted_function >= 202403L
+#if defined(__cpp_deleted_function) && __cpp_deleted_function >= 202403L && __cplusplus > 202302L
 #    define SLINT_DELETED_FUNCTION(reason) delete (reason)
 #else
 #    define SLINT_DELETED_FUNCTION(reason) delete


### PR DESCRIPTION
Only use `= delete("reason")` when the compiler is actually in C++26 mode, not just when it advertises the feature as an extension.

Fixes: #11581
