### PR TITLE
FemtoVG: Fix rounded clip rendering when children don't fill the clip

### DIFF
--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -120,6 +120,10 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
         )
     }
 
+    pub fn id(&self) -> femtovg::ImageId {
+        self.id
+    }
+
     // Upload the image to the GPU. This function could take just a canvas as parameter,
     // but since an upload requires a current context, this is "enforced" by taking
     // a renderer instead (which implies a current context).

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -677,8 +677,19 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         if !radius.is_zero() {
             if let Some((layer_origin, layer_image)) =
                 i_slint_core::item_rendering::render_layer(self, item_rc)
+                && let Some(layer_image_size) = layer_image.size()
             {
-                let layer_image_paint = layer_image.as_paint();
+                let layer_image_width = layer_image_size.width as f32;
+                let layer_image_height = layer_image_size.height as f32;
+                let layer_image_paint = femtovg::Paint::image(
+                    layer_image.id(),
+                    layer_origin.x,
+                    layer_origin.y,
+                    layer_image_width,
+                    layer_image_height,
+                    0.0,
+                    1.0,
+                );
 
                 let layer_path = clip_path_for_rect_alike_item(
                     geometry,
@@ -688,7 +699,15 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
                 );
 
                 self.canvas.borrow_mut().save_with(|canvas| {
-                    canvas.translate(layer_origin.x, layer_origin.y);
+                    // The layer_path can be bigger than the layer image (e.g. when the children occupy
+                    // a smaller region than the clip), so clip to avoid the image paint extending past
+                    // the image bounds.
+                    canvas.intersect_scissor(
+                        layer_origin.x,
+                        layer_origin.y,
+                        layer_image_width,
+                        layer_image_height,
+                    );
                     canvas.fill_path(&layer_path, &layer_image_paint);
                 });
             }


### PR DESCRIPTION
The previous code translated the canvas by layer_origin and filled the
clip's full rounded path, which only rendered correctly when the layer
spanned the full clip area. But when the children's bounding box is
smaller than the clip path, we ended up with a non-zero layer origin and
two bugs:

- The clip path ended up being translated, which is wrong. it's the
  layer image that needs to be translated only, and that's now done with
  the Paint::image constructor.
- As the layer image can be smaller than the clip path, we'd end up
  repeating/filling the remaining area of the clip path with the same
  texture, which we don't want. So we also need to apply a scissor clip.

Fixes #11608