### PR TITLE
Allow running C++ tests under LLDB

### DIFF
--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -173,6 +173,14 @@ namespace slint_testing = slint::private_api::testing;
         cmd.arg("--error-exitcode=1");
         cmd.arg("--num-callers=50");
         cmd.arg(binary_path.deref());
+    } else if std::env::var("USE_LLDB").is_ok() {
+        cmd = std::process::Command::new("rust-lldb");
+        cmd.args(["--one-line-on-crash", "bt\nexit 1"]);
+        cmd.args(["--one-line", "run"]);
+        cmd.arg("-Q");
+        cmd.arg("-b");
+        cmd.arg("-f");
+        cmd.arg(binary_path.deref());
     } else {
         cmd = std::process::Command::new(binary_path.deref());
     }


### PR DESCRIPTION
Valgrind is useful to debug segfaults, but only works on standard Linux distributions. It does not work on macOS, Windows (without WSL), or Linux distributions like CachyOS which recompile glibc to use AVX512 instructions, which are unsupported in Valgrind.

This PR introduces a new flag, which allows using `rust-lldb` to run the tests instead. This also allows debugging segfaults, but is cross-platform.