### PR TITLE
testing: ship LICENSES symlinks like every other backend

### DIFF
--- a/internal/backends/testing/LICENSES/GPL-3.0-only.txt
+++ b/internal/backends/testing/LICENSES/GPL-3.0-only.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/GPL-3.0-only.txt

--- a/internal/backends/testing/LICENSES/LicenseRef-Slint-Royalty-free-2.0.md
+++ b/internal/backends/testing/LICENSES/LicenseRef-Slint-Royalty-free-2.0.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-2.0.md

--- a/internal/backends/testing/LICENSES/LicenseRef-Slint-Software-3.0.md
+++ b/internal/backends/testing/LICENSES/LicenseRef-Slint-Software-3.0.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Software-3.0.md


### PR DESCRIPTION
Every other backend under `internal/backends/` (qt, selector, winit, linuxkms, android-activity) ships a `LICENSES/` directory with three symlinks to the workspace-root LICENSES/:

    GPL-3.0-only.txt                     -> ../../../../LICENSES/GPL-3.0-only.txt
    LicenseRef-Slint-Royalty-free-2.0.md -> ../../../../LICENSES/LicenseRef-Slint-Royalty-free-2.0.md
    LicenseRef-Slint-Software-3.0.md     -> ../../../../LICENSES/LicenseRef-Slint-Software-3.0.md

`cargo publish` resolves the symlinks at packaging time, so each backend's published `.crate` carries actual copies of the three license files.

`internal/backends/testing/` has been missing this set since the backend's directory was created (commit a3b86690f, "[reorg]: Move the rendering backends into internal" — `git log --diff-filter=A` on `internal/backends/testing/LICENSES*` returns empty). The testing backend's published `i-slint-backend-testing-*.crate` therefore ships no license-text files at all, even though the crate carries the same triple-license expression as every other Slint crate.

Concrete downstream impact: tools like cargo-about, used to generate per-crate third-party-attribution bundles, scan crate sources for license text. With the LICENSES/ contents present they can be clarified to point at the actual file (as they can for every sibling Slint crate); without them the only recourse is to fetch the file from the source repo over git, awkward for offline / sandboxed builds.

Adds the three symlinks to match the sibling backends. No code change; `cargo publish` picks them up automatically on the next release.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
