### PR TITLE
Software renderer: avoid recursive font_context borrow in TextInput cursor queries

### DIFF
--- a/api/rs/slint/tests/common/mod.rs
+++ b/api/rs/slint/tests/common/mod.rs
@@ -1,0 +1,36 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Shared scaffolding for integration tests that drive a `MinimalSoftwareWindow`.
+//!
+//! Each test file that uses this declares `mod common;` and calls
+//! `common::setup(width, height)` to obtain the platform-installed window.
+
+#![allow(dead_code)]
+
+use slint::PhysicalSize;
+use slint::platform::software_renderer::{MinimalSoftwareWindow, RepaintBufferType};
+use slint::platform::{PlatformError, WindowAdapter};
+use std::rc::Rc;
+
+thread_local! {
+    static WINDOW: Rc<MinimalSoftwareWindow> =
+        MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
+}
+
+struct TestPlatform;
+
+impl slint::platform::Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        Ok(WINDOW.with(|x| x.clone()))
+    }
+}
+
+/// Install `TestPlatform` (idempotent across tests in the same binary) and resize
+/// the shared window to `width` x `height` physical pixels.
+pub fn setup(width: u32, height: u32) -> Rc<MinimalSoftwareWindow> {
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    let window = WINDOW.with(|x| x.clone());
+    window.set_size(PhysicalSize::new(width, height));
+    window
+}

--- a/api/rs/slint/tests/issue_11629_text_input_cursor_borrow.rs
+++ b/api/rs/slint/tests/issue_11629_text_input_cursor_borrow.rs
@@ -1,0 +1,119 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Regression test for https://github.com/slint-ui/slint/issues/11629
+//!
+//! `SoftwareRenderer::text_input_cursor_rect_for_byte_offset` used to hold a
+//! `borrow_mut()` on the slint context's font_context across a call to
+//! `text_input.width()`. When the layout had been dirtied (e.g. because the
+//! text just changed), evaluating that property recurses into the renderer's
+//! `text_size`, which tries to borrow the same `RefCell` again and panics.
+
+use slint::PhysicalSize;
+use slint::platform::software_renderer::{
+    MinimalSoftwareWindow, PremultipliedRgbaColor, RepaintBufferType, SoftwareRenderer, TargetPixel,
+};
+use slint::platform::{PlatformError, WindowAdapter};
+use std::rc::Rc;
+
+thread_local! {
+    static WINDOW: Rc<MinimalSoftwareWindow> =
+        MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
+}
+
+struct TestPlatform;
+impl slint::platform::Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        Ok(WINDOW.with(|x| x.clone()))
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Default)]
+struct TestPixel(bool);
+
+impl TargetPixel for TestPixel {
+    fn blend(&mut self, _color: PremultipliedRgbaColor) {
+        *self = Self(true);
+    }
+    fn from_rgb(_red: u8, _green: u8, _blue: u8) -> Self {
+        Self(true)
+    }
+}
+
+const WIDTH: usize = 200;
+const HEIGHT: usize = 32;
+
+fn render(renderer: &SoftwareRenderer) {
+    let mut buf = vec![TestPixel(false); WIDTH * HEIGHT];
+    renderer.render(buf.as_mut_slice(), WIDTH);
+}
+
+#[test]
+fn text_input_cursor_rect_does_not_recurse_into_font_context() {
+    // Force the buggy code path. The default (VectorFont, parley enabled) branch
+    // correctly drops the borrow before recursing; the (PixelFont, _) and
+    // (VectorFont, parley disabled) branches share the same hold-across-width()
+    // bug. The env var is the simplest way to drive the latter from a test that
+    // doesn't ship its own bitmap font. See `parley_disabled()` in the software
+    // renderer.
+    //
+    // SAFETY: this is the only test in this binary, so no other thread reads
+    // env vars concurrently.
+    unsafe {
+        std::env::set_var("SLINT_SOFTWARE_RENDERER_PARLEY_DISABLED", "1");
+    }
+
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    let window = WINDOW.with(|x| x.clone());
+    window.set_size(PhysicalSize::new(WIDTH as u32, HEIGHT as u32));
+
+    slint::slint! {
+        export component TestCase inherits Window {
+            width: 200px;
+            height: 32px;
+            forward-focus: ti;
+            HorizontalLayout {
+                ti := TextInput {
+                    text: "Hello";
+                    font-size: 12px;
+                }
+                // This element's layout-info depends on `ti.text`, so changing
+                // the text dirties the parent layout's solution and therefore
+                // `ti.width()`. Re-evaluating that binding from inside the
+                // renderer is what triggers the recursive borrow.
+                Text {
+                    text: ti.text + "!";
+                    font-size: 12px;
+                }
+            }
+        }
+    }
+
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+
+    // Initial render so the layout settles.
+    window.draw_if_needed(render);
+
+    // Click inside the TextInput to give it focus.
+    ui.window().dispatch_event(slint::platform::WindowEvent::PointerPressed {
+        position: slint::LogicalPosition { x: 10.0, y: 16.0 },
+        button: slint::platform::PointerEventButton::Left,
+    });
+    ui.window().dispatch_event(slint::platform::WindowEvent::PointerReleased {
+        position: slint::LogicalPosition { x: 10.0, y: 16.0 },
+        button: slint::platform::PointerEventButton::Left,
+    });
+    window.draw_if_needed(render);
+
+    // Type a character. The KeyPressed handler runs `TextInput::set_cursor_position`,
+    // which calls `Renderer::text_input_cursor_rect_for_byte_offset`. With the bug,
+    // that function holds a `borrow_mut()` on font_context across `text_input.width()`,
+    // and the dirty layout binding recurses into `text_size` → `borrow_mut` → panic.
+    ui.window().dispatch_event(slint::platform::WindowEvent::KeyPressed { text: "X".into() });
+    ui.window().dispatch_event(slint::platform::WindowEvent::KeyReleased { text: "X".into() });
+
+    // One more render to flush any deferred work.
+    window.draw_if_needed(render);
+}

--- a/api/rs/slint/tests/issue_11629_text_input_cursor_borrow.rs
+++ b/api/rs/slint/tests/issue_11629_text_input_cursor_borrow.rs
@@ -9,24 +9,9 @@
 //! text just changed), evaluating that property recurses into the renderer's
 //! `text_size`, which tries to borrow the same `RefCell` again and panics.
 
-use slint::PhysicalSize;
-use slint::platform::software_renderer::{
-    MinimalSoftwareWindow, PremultipliedRgbaColor, RepaintBufferType, SoftwareRenderer, TargetPixel,
-};
-use slint::platform::{PlatformError, WindowAdapter};
-use std::rc::Rc;
+mod common;
 
-thread_local! {
-    static WINDOW: Rc<MinimalSoftwareWindow> =
-        MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
-}
-
-struct TestPlatform;
-impl slint::platform::Platform for TestPlatform {
-    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
-        Ok(WINDOW.with(|x| x.clone()))
-    }
-}
+use slint::platform::software_renderer::{PremultipliedRgbaColor, SoftwareRenderer, TargetPixel};
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Default)]
@@ -64,9 +49,7 @@ fn text_input_cursor_rect_does_not_recurse_into_font_context() {
         std::env::set_var("SLINT_SOFTWARE_RENDERER_PARLEY_DISABLED", "1");
     }
 
-    slint::platform::set_platform(Box::new(TestPlatform)).ok();
-    let window = WINDOW.with(|x| x.clone());
-    window.set_size(PhysicalSize::new(WIDTH as u32, HEIGHT as u32));
+    let window = common::setup(WIDTH as u32, HEIGHT as u32);
 
     slint::slint! {
         export component TestCase inherits Window {

--- a/api/rs/slint/tests/text_alignment.rs
+++ b/api/rs/slint/tests/text_alignment.rs
@@ -7,34 +7,18 @@
 //! to `break_all_lines` was filtered to pass `None` for no-wrap text, leaving no container
 //! width for alignment to work against.
 
-use slint::PhysicalSize;
+mod common;
+
 use slint::platform::software_renderer::{
-    MinimalSoftwareWindow, PremultipliedRgbaColor, RepaintBufferType, TargetPixel,
+    MinimalSoftwareWindow, PremultipliedRgbaColor, TargetPixel,
 };
-use slint::platform::{PlatformError, WindowAdapter};
 use std::rc::Rc;
 
 const WIDTH: u32 = 300;
 const HEIGHT: u32 = 30;
 
-thread_local! {
-    static WINDOW: Rc<MinimalSoftwareWindow> =
-        MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
-}
-
-struct TestPlatform;
-
-impl slint::platform::Platform for TestPlatform {
-    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
-        Ok(WINDOW.with(|x| x.clone()))
-    }
-}
-
 fn setup() -> Rc<MinimalSoftwareWindow> {
-    slint::platform::set_platform(Box::new(TestPlatform)).ok();
-    let window = WINDOW.with(|x| x.clone());
-    window.set_size(PhysicalSize::new(WIDTH, HEIGHT));
-    window
+    common::setup(WIDTH, HEIGHT)
 }
 
 /// A pixel that blends RGBA colors so we can inspect the resulting color.

--- a/api/rs/slint/tests/text_layout_cache.rs
+++ b/api/rs/slint/tests/text_layout_cache.rs
@@ -1,24 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use slint::PhysicalSize;
+mod common;
+
 use slint::platform::software_renderer::{
-    MinimalSoftwareWindow, PremultipliedRgbaColor, RepaintBufferType, SoftwareRenderer, TargetPixel,
+    MinimalSoftwareWindow, PremultipliedRgbaColor, SoftwareRenderer, TargetPixel,
 };
-use slint::platform::{PlatformError, WindowAdapter};
 use std::rc::Rc;
-
-thread_local! {
-    static WINDOW: Rc<MinimalSoftwareWindow> =
-        MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
-}
-
-struct TestPlatform;
-impl slint::platform::Platform for TestPlatform {
-    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
-        Ok(WINDOW.with(|x| x.clone()))
-    }
-}
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Default)]
@@ -38,10 +26,7 @@ const WIDTH: usize = 200;
 const HEIGHT: usize = 100;
 
 fn setup() -> Rc<MinimalSoftwareWindow> {
-    slint::platform::set_platform(Box::new(TestPlatform)).ok();
-    let window = WINDOW.with(|x| x.clone());
-    window.set_size(PhysicalSize::new(WIDTH as u32, HEIGHT as u32));
-    window
+    common::setup(WIDTH as u32, HEIGHT as u32)
 }
 
 fn render_and_get_miss_count(renderer: &SoftwareRenderer) -> u64 {

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -959,19 +959,20 @@ impl RendererSealed for SoftwareRenderer {
         let Some(slint_ctx) = self.slint_context() else {
             return Default::default();
         };
-        #[cfg(feature = "systemfonts")]
-        let mut font_ctx = slint_ctx.font_context().borrow_mut();
-        let font = fonts::match_font(
-            &font_request,
-            scale_factor,
+        let font = {
             #[cfg(feature = "systemfonts")]
-            &mut font_ctx,
-        );
+            let mut font_ctx = slint_ctx.font_context().borrow_mut();
+            fonts::match_font(
+                &font_request,
+                scale_factor,
+                #[cfg(feature = "systemfonts")]
+                &mut font_ctx,
+            )
+        };
 
         match (font, parley_disabled()) {
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
-                drop(font_ctx);
                 sharedparley::text_input_byte_offset_for_position(self, text_input, item_rc, pos)
             }
             #[cfg(feature = "systemfonts")]
@@ -1048,19 +1049,20 @@ impl RendererSealed for SoftwareRenderer {
         let Some(slint_ctx) = self.slint_context() else {
             return Default::default();
         };
-        #[cfg(feature = "systemfonts")]
-        let mut font_ctx = slint_ctx.font_context().borrow_mut();
-        let font = fonts::match_font(
-            &font_request,
-            scale_factor,
+        let font = {
             #[cfg(feature = "systemfonts")]
-            &mut font_ctx,
-        );
+            let mut font_ctx = slint_ctx.font_context().borrow_mut();
+            fonts::match_font(
+                &font_request,
+                scale_factor,
+                #[cfg(feature = "systemfonts")]
+                &mut font_ctx,
+            )
+        };
 
         match (font, parley_disabled()) {
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
-                drop(font_ctx);
                 sharedparley::text_input_cursor_rect_for_byte_offset(
                     self,
                     text_input,


### PR DESCRIPTION
Holding the borrow across `text_input.width()` / `height()` lets a dirty
layout binding recurse back into `text_size`, which panics when it tries
to re-borrow the same `RefCell`. Closes #11629.