### PR TITLE
remote-viewer: Revert resource_preloader from compiler/interpreter public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,6 +5438,7 @@ dependencies = [
 name = "i-slint-preview-protocol"
 version = "1.17.0"
 dependencies = [
+ "derive_more",
  "lsp-types",
  "serde",
  "serde_json",

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -568,12 +568,8 @@ pub fn compile_with_output_path(
     let syntax_node = syntax_node.expect("diags contained no compilation errors");
 
     // 'spin_on' is ok here because the compiler in single threaded and does not block if there is no blocking future
-    let (doc, diag, loader) = spin_on::spin_on(i_slint_compiler::compile_syntax_node(
-        syntax_node,
-        diag,
-        compiler_config,
-        (),
-    ));
+    let (doc, diag, loader) =
+        spin_on::spin_on(i_slint_compiler::compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_errors()
         || (!diag.is_empty() && std::env::var("SLINT_COMPILER_DENY_WARNINGS").is_ok())

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -372,7 +372,7 @@ pub fn slint(stream: TokenStream) -> TokenStream {
     //println!("{syntax_node:#?}");
     compiler_config.translation_domain = std::env::var("CARGO_PKG_NAME").ok();
     let (root_component, diag, loader) =
-        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config, ()));
+        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
     //println!("{tree:#?}");
     if diag.has_errors() {
         return diag.report_macro_diagnostic(&tokens);

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -70,29 +70,35 @@ export type RemoteViewerInfo = {
 };
 export const remote_viewers = new Map<string, RemoteViewerInfo>();
 
-export let remoteViewerStatusBarItem: vscode.StatusBarItem | undefined;
+let remoteViewerStatusBarItem: vscode.StatusBarItem | undefined;
 export function updateRemoteViewerStatusBarItem(newItem: vscode.StatusBarItem) {
     remoteViewerStatusBarItem = newItem;
 }
 export enum RemoteViewerStatusBarItemState {
-    disconnected,
-    connecting,
-    connected,
+    disconnected = 0,
+    connecting = 1,
+    connected = 2,
 }
-export function setRemoteViewerStatusBarItemState(state: RemoteViewerStatusBarItemState) {
+export function setRemoteViewerStatusBarItemState(
+    state: RemoteViewerStatusBarItemState,
+) {
     if (remoteViewerStatusBarItem) {
         switch (state) {
             case RemoteViewerStatusBarItemState.disconnected:
-                remoteViewerStatusBarItem.text = `$(vm) Slint Remote Preview`;
-                remoteViewerStatusBarItem.command = 'slint.selectRemotePreview';
+                remoteViewerStatusBarItem.text = "$(vm) Slint Remote Preview";
+                remoteViewerStatusBarItem.command = "slint.selectRemotePreview";
                 break;
             case RemoteViewerStatusBarItemState.connecting:
-                remoteViewerStatusBarItem.text = `$(vm-connect) Slint Remote Preview`;
-                remoteViewerStatusBarItem.command = 'slint.disconnectRemotePreview';
+                remoteViewerStatusBarItem.text =
+                    "$(vm-connect) Slint Remote Preview";
+                remoteViewerStatusBarItem.command =
+                    "slint.disconnectRemotePreview";
                 break;
             case RemoteViewerStatusBarItemState.connected:
-                remoteViewerStatusBarItem.text = `$(vm-active) Slint Remote Preview`;
-                remoteViewerStatusBarItem.command = 'slint.disconnectRemotePreview';
+                remoteViewerStatusBarItem.text =
+                    "$(vm-active) Slint Remote Preview";
+                remoteViewerStatusBarItem.command =
+                    "slint.disconnectRemotePreview";
                 break;
         }
     }
@@ -192,9 +198,13 @@ export function activate(
 
     client.add_updater((cl) => {
         wasm_preview.initClientForPreview(context, cl);
-        cl?.onNotification("slint/remote_viewer_discovered", async (params) => {
-            vscode.window.showInformationMessage(`Received update for remote viewers: ${JSON.stringify(params)}`);
-            cl.outputChannel.appendLine(`Received update for remote viewers: ${JSON.stringify(params)}`);
+        cl?.onNotification("slint/remote_viewer_discovered", (params) => {
+            vscode.window.showInformationMessage(
+                `Received update for remote viewers: ${JSON.stringify(params)}`,
+            );
+            cl.outputChannel.appendLine(
+                `Received update for remote viewers: ${JSON.stringify(params)}`,
+            );
             const old_entry = remote_viewers.get(params.host);
             if (old_entry) {
                 clearTimeout(old_entry.timer);
@@ -203,7 +213,7 @@ export function activate(
                 id: params.host,
 
                 label: params.host,
-                detail: params.addresses.join(', '),
+                detail: params.addresses.join(", "),
 
                 value: params,
                 timer: setTimeout(() => {
@@ -212,17 +222,29 @@ export function activate(
             };
             remote_viewers.set(params.host, remote_viewer_entry);
         });
-        cl?.onNotification("slint/remote_viewer_connection_state", async (params) => {
+        cl?.onNotification("slint/remote_viewer_connection_state", (params) => {
             switch (params.state) {
                 case "connected":
-                    vscode.window.showInformationMessage(`Remote viewer connected: ${params.address}:${params.port}, remoteViewerStatusBarItem ${remoteViewerStatusBarItem ? 'available' : 'undefined'}`);
-                    cl.outputChannel.appendLine(`Remote viewer connected: ${params.address}:${params.port}`);
-                    setRemoteViewerStatusBarItemState(RemoteViewerStatusBarItemState.connected);
+                    vscode.window.showInformationMessage(
+                        `Remote viewer connected: ${params.address}:${params.port}, remoteViewerStatusBarItem ${remoteViewerStatusBarItem ? "available" : "undefined"}`,
+                    );
+                    cl.outputChannel.appendLine(
+                        `Remote viewer connected: ${params.address}:${params.port}`,
+                    );
+                    setRemoteViewerStatusBarItemState(
+                        RemoteViewerStatusBarItemState.connected,
+                    );
                     break;
                 case "disconnected":
-                    vscode.window.showInformationMessage(`Remote viewer disconnected: ${params.address}:${params.port}`);
-                    cl.outputChannel.appendLine(`Remote viewer disconnected: ${params.address}:${params.port}`);
-                    setRemoteViewerStatusBarItemState(RemoteViewerStatusBarItemState.disconnected);
+                    vscode.window.showInformationMessage(
+                        `Remote viewer disconnected: ${params.address}:${params.port}`,
+                    );
+                    cl.outputChannel.appendLine(
+                        `Remote viewer disconnected: ${params.address}:${params.port}`,
+                    );
+                    setRemoteViewerStatusBarItemState(
+                        RemoteViewerStatusBarItemState.disconnected,
+                    );
                     break;
             }
             // TODO

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -237,7 +237,9 @@ function startClient(
             },
         );
 
-        common.setRemoteViewerStatusBarItemState(common.RemoteViewerStatusBarItemState.disconnected);
+        common.setRemoteViewerStatusBarItemState(
+            common.RemoteViewerStatusBarItemState.disconnected,
+        );
     });
 
     const cl = new LanguageClient(
@@ -413,43 +415,56 @@ function startTelemetryTimer(
     }
 }
 
-const remotePreviewConnectionStringMatcher = /^(?:\[(?<ipv6>[0-9A-Fa-f:.]+)\]|(?<host>[^:\s\[\]]+)):(?<port>\d{1,5})$/;
+const remotePreviewConnectionStringMatcher =
+    /^(?:\[(?<ipv6>[0-9A-Fa-f:.]+)\]|(?<host>[^:\s\[\]]+)):(?<port>\d{1,5})$/;
 
 function setupRemotePreview(context: vscode.ExtensionContext) {
     const remoteViewerStatusBarItem = vscode.window.createStatusBarItem(
-        vscode.StatusBarAlignment.Right, 100
+        vscode.StatusBarAlignment.Right,
+        100,
     );
 
     common.updateRemoteViewerStatusBarItem(remoteViewerStatusBarItem);
-    common.setRemoteViewerStatusBarItemState(common.RemoteViewerStatusBarItemState.disconnected);
+    common.setRemoteViewerStatusBarItemState(
+        common.RemoteViewerStatusBarItemState.disconnected,
+    );
     remoteViewerStatusBarItem.show();
 
     context.subscriptions.push(
         vscode.commands.registerCommand("slint.selectRemotePreview", () => {
-            const picker = vscode.window.createQuickPick<vscode.QuickPickItem & Partial<common.RemoteViewerInfo>>();
+            const picker = vscode.window.createQuickPick<
+                vscode.QuickPickItem & Partial<common.RemoteViewerInfo>
+            >();
             picker.title = "Select a remote preview";
             picker.placeholder = "Manual entry (e.g. 127.0.1:1234)";
             picker.ignoreFocusOut = true;
 
             const updateItems = () => {
                 const typed = picker.value.trim();
-                const items: (vscode.QuickPickItem & Partial<common.RemoteViewerInfo>)[] = [];
+                const items: (vscode.QuickPickItem &
+                    Partial<common.RemoteViewerInfo>)[] = [];
 
                 remotePreviewConnectionStringMatcher.lastIndex = 0;
                 const match = remotePreviewConnectionStringMatcher.exec(typed);
 
                 if (match) {
                     items.push({
-                        id: 'ENTER',
+                        id: "ENTER",
                         label: `Use typed value: ${typed}`,
                         detail: "",
                         alwaysShow: true,
                         value: {
-                            addresses: [match.groups?.ipv6 ?? match.groups?.host ?? ""],
-                            port: parseInt(match.groups?.port ?? "1234"),
+                            addresses: [
+                                match.groups?.ipv6 ?? match.groups?.host ?? "",
+                            ],
+                            port: Number.parseInt(match.groups?.port ?? "1234"),
                         },
                     });
-                    items.push({ id: "sep", label: "", kind: vscode.QuickPickItemKind.Separator });
+                    items.push({
+                        id: "sep",
+                        label: "",
+                        kind: vscode.QuickPickItemKind.Separator,
+                    });
                 }
 
                 items.push(...common.remote_viewers.values());
@@ -457,9 +472,14 @@ function setupRemotePreview(context: vscode.ExtensionContext) {
                 picker.items = items;
             };
 
-            const connect = async (item: common.RemoteViewerInfo) => {
-                lsp_commands.connectRemotePreview(item.value.addresses, item.value.port);
-                common.setRemoteViewerStatusBarItemState(common.RemoteViewerStatusBarItemState.connecting);
+            const connect = (item: common.RemoteViewerInfo) => {
+                lsp_commands.connectRemotePreview(
+                    item.value.addresses,
+                    item.value.port,
+                );
+                common.setRemoteViewerStatusBarItemState(
+                    common.RemoteViewerStatusBarItemState.connecting,
+                );
 
                 picker.hide();
             };

--- a/editors/vscode/src/lsp_commands.ts
+++ b/editors/vscode/src/lsp_commands.ts
@@ -22,8 +22,15 @@ export function showPreview(url: LspURI, component: string): Thenable<unknown> {
     return vscode.commands.executeCommand("slint/showPreview", url, component);
 }
 
-export function connectRemotePreview(addresses: string[], port: number): Thenable<unknown> {
-    return vscode.commands.executeCommand("slint/connectRemotePreview", addresses, port);
+export function connectRemotePreview(
+    addresses: string[],
+    port: number,
+): Thenable<unknown> {
+    return vscode.commands.executeCommand(
+        "slint/connectRemotePreview",
+        addresses,
+        port,
+    );
 }
 
 export function disconnectRemotePreview(): Thenable<unknown> {

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -25,7 +25,10 @@ export function update_configuration() {
     if (language_client) {
         send_to_lsp({
             PreviewTypeChanged: {
-                target: (previewPanel !== null || use_wasm_preview()) ? 'embedded-wasm' : 'child-process',
+                target:
+                    previewPanel !== null || use_wasm_preview()
+                        ? "embedded-wasm"
+                        : "child-process",
             },
         });
     }

--- a/internal/compiler/benches/semantic_analysis.rs
+++ b/internal/compiler/benches/semantic_analysis.rs
@@ -209,7 +209,7 @@ fn compile_full(source: &str) -> (Document, BuildDiagnostics) {
     let config = CompilerConfiguration::new(i_slint_compiler::generator::OutputFormat::Interpreter);
 
     let (doc, diag, _loader) =
-        spin_on::spin_on(i_slint_compiler::compile_syntax_node(node, diagnostics, config, ()));
+        spin_on::spin_on(i_slint_compiler::compile_syntax_node(node, diagnostics, config));
     (doc, diag)
 }
 
@@ -363,7 +363,7 @@ mod proc_macro_simulation {
         let config = CompilerConfiguration::new(i_slint_compiler::generator::OutputFormat::Rust);
 
         let (doc, diag, loader) =
-            spin_on::spin_on(i_slint_compiler::compile_syntax_node(node, diagnostics, config, ()));
+            spin_on::spin_on(i_slint_compiler::compile_syntax_node(node, diagnostics, config));
 
         let rust_code = i_slint_compiler::generator::rust::generate(&doc, &loader.compiler_config)
             .expect("Rust code generation failed");
@@ -427,7 +427,6 @@ mod phase_breakdown {
             node,
             diagnostics,
             config,
-            (),
         )));
     }
 
@@ -439,7 +438,7 @@ mod phase_breakdown {
         let node = parse_source(EMPTY_COMPONENT);
         let config = CompilerConfiguration::new(i_slint_compiler::generator::OutputFormat::Rust);
         let (doc, _diag, loader) =
-            spin_on::spin_on(i_slint_compiler::compile_syntax_node(node, diagnostics, config, ()));
+            spin_on::spin_on(i_slint_compiler::compile_syntax_node(node, diagnostics, config));
 
         // Now benchmark just the code generation
         divan::black_box(
@@ -504,7 +503,6 @@ mod phase_breakdown {
             &mut loader,
             false,
             &mut diag,
-            (),
         )));
     }
 

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -297,7 +297,6 @@ pub async fn compile_syntax_node(
     doc_node: parser::SyntaxNode,
     mut diagnostics: diagnostics::BuildDiagnostics,
     #[allow(unused_mut)] mut compiler_config: CompilerConfiguration,
-    resource_preloader: impl crate::passes::ResourcePreloader,
 ) -> (object_tree::Document, diagnostics::BuildDiagnostics, typeloader::TypeLoader) {
     let mut loader = prepare_for_compile(&mut diagnostics, compiler_config);
 
@@ -317,8 +316,7 @@ pub async fn compile_syntax_node(
     );
 
     if !diagnostics.has_errors() {
-        passes::run_passes(&mut doc, &mut loader, false, &mut diagnostics, resource_preloader)
-            .await;
+        passes::run_passes(&mut doc, &mut loader, false, &mut diagnostics).await;
     } else {
         // Don't run all the passes in case of errors because because some invariants are not met.
         passes::run_import_passes(&doc, &loader, &mut diagnostics);
@@ -337,13 +335,11 @@ pub async fn load_root_file(
     source_code: String,
     mut diagnostics: diagnostics::BuildDiagnostics,
     #[allow(unused_mut)] mut compiler_config: CompilerConfiguration,
-    resource_preloader: impl passes::ResourcePreloader,
 ) -> (std::path::PathBuf, diagnostics::BuildDiagnostics, typeloader::TypeLoader) {
     let mut loader = prepare_for_compile(&mut diagnostics, compiler_config);
 
-    let (path, _) = loader
-        .load_root_file(path, source_path, source_code, false, &mut diagnostics, resource_preloader)
-        .await;
+    let (path, _) =
+        loader.load_root_file(path, source_path, source_code, false, &mut diagnostics).await;
 
     (path, diagnostics, loader)
 }
@@ -360,7 +356,6 @@ pub async fn load_root_file_with_raw_type_loader(
     source_code: String,
     mut diagnostics: diagnostics::BuildDiagnostics,
     #[allow(unused_mut)] mut compiler_config: CompilerConfiguration,
-    resource_preloader: impl passes::ResourcePreloader,
 ) -> (
     std::path::PathBuf,
     diagnostics::BuildDiagnostics,
@@ -369,9 +364,8 @@ pub async fn load_root_file_with_raw_type_loader(
 ) {
     let mut loader = prepare_for_compile(&mut diagnostics, compiler_config);
 
-    let (path, raw_type_loader) = loader
-        .load_root_file(path, source_path, source_code, true, &mut diagnostics, resource_preloader)
-        .await;
+    let (path, raw_type_loader) =
+        loader.load_root_file(path, source_path, source_code, true, &mut diagnostics).await;
 
     (path, diagnostics, loader, raw_type_loader)
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -61,7 +61,6 @@ use crate::expression_tree::Expression;
 use smol_str::SmolStr;
 
 pub use binding_analysis::GlobalAnalysis;
-pub use embed_images::ResourcePreloader;
 
 pub fn ignore_debug_hooks(expr: &Expression) -> &Expression {
     let mut expr = expr;
@@ -78,7 +77,6 @@ pub async fn run_passes(
     type_loader: &mut crate::typeloader::TypeLoader,
     keep_raw: bool,
     diag: &mut crate::diagnostics::BuildDiagnostics,
-    resource_preloader: impl ResourcePreloader,
 ) -> Option<crate::typeloader::TypeLoader> {
     let style_metrics = {
         // Ignore import errors
@@ -243,7 +241,6 @@ pub async fn run_passes(
         }
     });
 
-    embed_images::preload_images(doc, resource_preloader).await;
     embed_images::embed_images(
         doc,
         type_loader.compiler_config.embed_resources,

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -356,7 +356,7 @@ export component Foo {
         &mut test_diags,
     );
     let (doc, diag, _) =
-        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config, ()));
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
     assert!(!diag.has_errors(), "slint compile error {:#?}", diag.to_string_vec());
 
     let expected_p = 3.0 * 2.0 + 15.0;
@@ -487,7 +487,7 @@ export component Foo inherits Window {{
             crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
         compiler_config.style = Some("fluent".into());
         let (doc, diag, _) =
-            spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config, ()));
+            spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
         assert!(!diag.has_errors(), "slint compile error {:#?}", diag.to_string_vec());
 
         let bindings = &doc.inner_components.last().unwrap().root_element.borrow().bindings;
@@ -514,7 +514,7 @@ export component Foo inherits Window {
     compiler_config.style = Some("fluent".into());
     compiler_config.const_scale_factor = Some(2.);
     let (doc, diag, _) =
-        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config, ()));
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
     assert!(!diag.has_errors(), "slint compile error {:#?}", diag.to_string_vec());
 
     let bindings = &doc.inner_components.last().unwrap().root_element.borrow().bindings;

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -565,7 +565,7 @@ fn test_no_property_for_100pc() {
         &mut test_diags,
     );
     let (doc, diag, _) =
-        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config, ()));
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
     assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
 
     let root_elem = doc.inner_components.last().unwrap().root_element.borrow();

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -10,57 +10,11 @@ use crate::object_tree::*;
 use image::GenericImageView;
 use smol_str::SmolStr;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use typed_index_collections::TiVec;
-
-pub trait ResourcePreloader {
-    fn load<'a>(
-        &self,
-        paths: impl Iterator<Item = &'a str>,
-        push: Rc<impl Fn(/* path */ &'a str, /* extension */ String, /* data */ Vec<u8>)>,
-    ) -> impl Future<Output = ()>;
-}
-
-impl ResourcePreloader for () {
-    fn load<'a>(
-        &self,
-        _paths: impl Iterator<Item = &'a str>,
-        _push: Rc<impl Fn(&'a str, String, Vec<u8>)>,
-    ) -> impl Future<Output = ()> {
-        std::future::ready(())
-    }
-}
-
-pub async fn preload_images(doc: &Document, resource_preloader: impl ResourcePreloader) {
-    let mut all_components = Vec::new();
-    doc.visit_all_used_components(|c| all_components.push(c.clone()));
-
-    let mut paths = HashSet::<SmolStr>::new();
-    for component in &all_components {
-        visit_all_expressions(component, |e, _| {
-            foreach_image_url_from_expression(e, &mut |path| {
-                paths.insert(path.clone());
-            })
-        });
-    }
-
-    let global_embedded_resources = &doc.embedded_file_resources;
-    resource_preloader
-        .load(
-            paths.iter().map(SmolStr::as_str),
-            Rc::new(|path: &str, extension, data: Vec<u8>| {
-                // let mut resources = global_embedded_resources.borrow_mut();
-                // resources.push(EmbeddedResources {
-                //     path: Some(path.into()),
-                //     kind: EmbeddedResourcesKind::DataUriPayload(data, extension),
-                // });
-            }),
-        )
-        .await;
-}
 
 pub async fn embed_images(
     doc: &Document,
@@ -75,11 +29,6 @@ pub async fn embed_images(
 
     let global_embedded_resources = &doc.embedded_file_resources;
     let mut path_to_id = HashMap::<SmolStr, EmbeddedResourcesIdx>::new();
-    for (id, resource) in global_embedded_resources.borrow().iter_enumerated() {
-        if let Some(path) = &resource.path {
-            path_to_id.insert(path.clone(), id);
-        }
-    }
 
     let mut all_components = Vec::new();
     doc.visit_all_used_components(|c| all_components.push(c.clone()));
@@ -92,9 +41,7 @@ pub async fn embed_images(
             // Collect URLs (sync!):
             for component in &all_components {
                 visit_all_expressions(component, |e, _| {
-                    foreach_image_url_from_expression(e, &mut |path| {
-                        urls.insert(path.clone(), None);
-                    })
+                    collect_image_urls_from_expression(e, &mut urls)
                 });
             }
 
@@ -123,14 +70,17 @@ pub async fn embed_images(
     }
 }
 
-fn foreach_image_url_from_expression(e: &Expression, f: &mut impl FnMut(&SmolStr)) {
+fn collect_image_urls_from_expression(
+    e: &Expression,
+    urls: &mut HashMap<SmolStr, Option<SmolStr>>,
+) {
     if let Expression::ImageReference { resource_ref, .. } = e
         && let ImageReference::AbsolutePath(path) = resource_ref
     {
-        f(path);
+        urls.insert(path.clone(), None);
     };
 
-    e.visit(|e| foreach_image_url_from_expression(e, f));
+    e.visit(|e| collect_image_urls_from_expression(e, urls));
 }
 
 fn embed_images_from_expression(
@@ -145,16 +95,6 @@ fn embed_images_from_expression(
     if let Expression::ImageReference { resource_ref, source_location, nine_slice: _ } = e
         && let ImageReference::AbsolutePath(path) = resource_ref
     {
-        if let Some(id) = path_to_id.get(path) {
-            if let Some(resource) = global_embedded_resources.borrow().get(*id)
-                && let EmbeddedResourcesKind::DataUriPayload(_, extension) = &resource.kind
-            {
-                *resource_ref =
-                    ImageReference::EmbeddedData { resource_id: *id, extension: extension.clone() };
-            }
-            return;
-        }
-
         if path.starts_with("data:") {
             // Data URIs have no external file to track, so skip for
             // Nothing (interpreter) and ListAllResources (dependency tracking).

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -447,7 +447,6 @@ fn process_file_source(
             syntax_node.clone(),
             parse_diagnostics,
             compiler_config.clone(),
-            (),
         ));
         build_diags
     } else {
@@ -473,7 +472,6 @@ fn process_file_source(
             syntax_node,
             compile_diagnostics,
             compiler_config,
-            (),
         ));
     }
 

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1479,7 +1479,6 @@ impl TypeLoader {
         source_code: String,
         keep_raw: bool,
         diag: &mut BuildDiagnostics,
-        resource_preloader: impl crate::passes::ResourcePreloader,
     ) -> (PathBuf, Option<TypeLoader>) {
         let path = crate::pathutils::clean_path(path);
         let doc_node: syntax_nodes::Document =
@@ -1492,8 +1491,7 @@ impl TypeLoader {
         let mut state = state.borrow_mut();
         let state = &mut *state;
         let raw_type_loader = if !state.diag.has_errors() {
-            crate::passes::run_passes(&mut doc, state.tl, keep_raw, state.diag, resource_preloader)
-                .await
+            crate::passes::run_passes(&mut doc, state.tl, keep_raw, state.diag).await
         } else {
             None
         };

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -781,7 +781,6 @@ impl ComponentCompiler {
     pub async fn build_from_path<P: AsRef<Path>>(
         &mut self,
         path: P,
-        resource_preloader: impl i_slint_compiler::passes::ResourcePreloader,
     ) -> Option<ComponentDefinition> {
         let path = path.as_ref();
         let source = match i_slint_compiler::diagnostics::load_from_path(path) {
@@ -792,13 +791,7 @@ impl ComponentCompiler {
             }
         };
 
-        let r = crate::dynamic_item_tree::load(
-            source,
-            path.into(),
-            self.config.clone(),
-            resource_preloader,
-        )
-        .await;
+        let r = crate::dynamic_item_tree::load(source, path.into(), self.config.clone()).await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -823,15 +816,8 @@ impl ComponentCompiler {
         &mut self,
         source_code: String,
         path: PathBuf,
-        resource_preloader: impl i_slint_compiler::passes::ResourcePreloader,
     ) -> Option<ComponentDefinition> {
-        let r = crate::dynamic_item_tree::load(
-            source_code,
-            path,
-            self.config.clone(),
-            resource_preloader,
-        )
-        .await;
+        let r = crate::dynamic_item_tree::load(source_code, path, self.config.clone()).await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -963,11 +949,7 @@ impl Compiler {
     /// [`Self::set_file_loader`] was called and its future is actually asynchronous.
     /// If that is not used, then it is fine to use a very simple executor, such as the one
     /// provided by the `spin_on` crate
-    pub async fn build_from_path<P: AsRef<Path>>(
-        &self,
-        path: P,
-        resource_preloader: impl i_slint_compiler::passes::ResourcePreloader,
-    ) -> CompilationResult {
+    pub async fn build_from_path<P: AsRef<Path>>(&self, path: P) -> CompilationResult {
         let path = path.as_ref();
         let source = match i_slint_compiler::diagnostics::load_from_path(path) {
             Ok(s) => s,
@@ -985,8 +967,7 @@ impl Compiler {
             }
         };
 
-        crate::dynamic_item_tree::load(source, path.into(), self.config.clone(), resource_preloader)
-            .await
+        crate::dynamic_item_tree::load(source, path.into(), self.config.clone()).await
     }
 
     /// Compile some .slint code
@@ -1001,14 +982,8 @@ impl Compiler {
     /// [`Self::set_file_loader`] is set and its future is actually asynchronous.
     /// If that is not used, then it is fine to use a very simple executor, such as the one
     /// provided by the `spin_on` crate
-    pub async fn build_from_source(
-        &self,
-        source_code: String,
-        path: PathBuf,
-        resource_preloader: impl i_slint_compiler::passes::ResourcePreloader,
-    ) -> CompilationResult {
-        crate::dynamic_item_tree::load(source_code, path, self.config.clone(), resource_preloader)
-            .await
+    pub async fn build_from_source(&self, source_code: String, path: PathBuf) -> CompilationResult {
+        crate::dynamic_item_tree::load(source_code, path, self.config.clone()).await
     }
 }
 
@@ -1823,7 +1798,6 @@ fn component_definition_properties() {
     }"#
             .into(),
             "".into(),
-            (),
         ),
     )
     .component("Dummy")
@@ -1875,7 +1849,6 @@ fn component_definition_properties2() {
     }"#
             .into(),
             "".into(),
-            (),
         ),
     )
     .component("Dummy")
@@ -1929,7 +1902,6 @@ fn globals() {
     }"#
             .into(),
             "".into(),
-            (),
         ),
     )
     .component("Dummy")
@@ -2059,7 +2031,6 @@ fn call_functions() {
     }"#
             .into(),
             "".into(),
-            (),
         ),
     )
     .component("Test")
@@ -2104,7 +2075,6 @@ fn component_definition_struct_properties() {
     }"#
             .into(),
             "".into(),
-            (),
         ),
     )
     .component("Dummy")
@@ -2149,7 +2119,6 @@ fn component_definition_model_properties() {
     let comp_def = spin_on::spin_on(compiler.build_from_source(
         "export component Dummy { in-out property <[int]> prop: [42, 12]; }".into(),
         "".into(),
-        (),
     ))
     .component("Dummy")
     .unwrap();
@@ -2254,7 +2223,6 @@ fn test_multi_components() {
         "#
             .into(),
             PathBuf::from("hello.slint"),
-            (),
         ),
     );
 
@@ -2299,7 +2267,7 @@ fn compile(code: &str) -> (ComponentInstance, PathBuf) {
     let path = PathBuf::from("/tmp/test.slint");
 
     let compile_result =
-        spin_on::spin_on(compiler.build_from_source(code.to_string(), path.clone(), ()));
+        spin_on::spin_on(compiler.build_from_source(code.to_string(), path.clone()));
 
     for d in &compile_result.diagnostics {
         eprintln!("{d}");

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -911,7 +911,6 @@ pub async fn load(
     source: String,
     path: std::path::PathBuf,
     mut compiler_config: CompilerConfiguration,
-    resource_preloader: impl i_slint_compiler::passes::ResourcePreloader,
 ) -> CompilationResult {
     // If the native style should be Qt, resolve it here as we know that we have it
     let is_native = compiler_config.style.as_deref() == Some("native");
@@ -954,19 +953,11 @@ pub async fn load(
             source,
             diag,
             compiler_config,
-            resource_preloader,
         )
         .await;
     #[cfg(not(feature = "internal-highlight"))]
-    let (path, mut diag, loader) = i_slint_compiler::load_root_file(
-        &path,
-        &path,
-        source,
-        diag,
-        compiler_config,
-        resource_preloader,
-    )
-    .await;
+    let (path, mut diag, loader) =
+        i_slint_compiler::load_root_file(&path, &path, source, diag, compiler_config).await;
     if diag.has_errors() {
         return CompilationResult {
             components: HashMap::new(),

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -18,8 +18,7 @@ fn reuse_window() {
     let handle = {
         let mut compiler = Compiler::default();
         compiler.set_style("fluent".into());
-        let result =
-            spin_on::spin_on(compiler.build_from_source(code.into(), Default::default(), ()));
+        let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
         assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
         let definition = result.component("MainWindow").unwrap();
         let instance = definition.create().unwrap();
@@ -33,8 +32,7 @@ fn reuse_window() {
     let _handle2 = {
         let mut compiler = Compiler::default();
         compiler.set_style("fluent".into());
-        let result =
-            spin_on::spin_on(compiler.build_from_source(code.into(), Default::default(), ()));
+        let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
         assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
         let definition = result.component("MainWindow").unwrap();
         let instance = definition.create_with_existing_window(handle.window()).unwrap();
@@ -70,7 +68,7 @@ export component Clock {
 }
     "#;
     let compiler = Compiler::default();
-    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default(), ()));
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
     assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
     let definition = result.component("Clock").unwrap();
     let instance = definition.create().unwrap();

--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -41,7 +41,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
             i_slint_compiler::DefaultTranslationContext::None;
     }
     let (root_component, diag, loader) =
-        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config, ()));
+        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_errors() {
         let vec = diag.to_string_vec();

--- a/tests/driver/python/python.rs
+++ b/tests/driver/python/python.rs
@@ -32,7 +32,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
             Some(testcase.absolute_path.file_stem().unwrap().to_str().unwrap().to_string());
     }
     let (root_component, diag, loader) =
-        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config, ()));
+        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_errors() {
         let vec = diag.to_string_vec();

--- a/tests/screenshots/build.rs
+++ b/tests/screenshots/build.rs
@@ -155,7 +155,7 @@ fn generate_source(
     compiler_config.style = Some("fluent".to_string());
     compiler_config.const_scale_factor = scale_factor.into();
     let (root_component, diag, loader) =
-        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config, ()));
+        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_errors() {
         diag.print_warnings_and_exit_on_error();

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -209,7 +209,7 @@ fn main() -> std::io::Result<()> {
     }
     let syntax_node = syntax_node.expect("diags contained no compilation errors");
     let (doc, diag, loader) =
-        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config, ()));
+        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     let diag = diag.check_and_exit_on_error();
 

--- a/tools/figma_import/src/figmatypes.rs
+++ b/tools/figma_import/src/figmatypes.rs
@@ -7,7 +7,7 @@ use float_cmp::ApproxEq;
 
 use std::collections::HashMap;
 
-use derive_more::*;
+use derive_more::{Add, AddAssign, Neg, Sub, SubAssign};
 use serde::Deserialize;
 use smart_default::SmartDefault;
 

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -19,6 +19,8 @@ pub use document_cache::DocumentCache;
 pub use i_slint_compiler::diagnostics::ByteFormat;
 pub mod rename_component;
 pub mod rename_element_id;
+mod switchable;
+pub use switchable::SwitchableLspToPreview;
 #[cfg(test)]
 pub mod test;
 #[cfg(any(test, feature = "preview-engine"))]

--- a/tools/lsp/common/switchable.rs
+++ b/tools/lsp/common/switchable.rs
@@ -1,13 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 use i_slint_preview_protocol::PreviewTarget;
 use std::{any::Any, cell::RefCell, collections::HashMap};
 
-use crate::common::{LspToPreview, Result};
+use super::{LspToPreview, Result};
 
+#[allow(dead_code)]
 pub struct SwitchableLspToPreview {
     lsp_to_previews: HashMap<PreviewTarget, Box<dyn LspToPreview>>,
     current_target: RefCell<PreviewTarget>,
 }
 
+#[allow(dead_code)]
 impl SwitchableLspToPreview {
     pub fn new(
         lsp_to_previews: HashMap<PreviewTarget, Box<dyn LspToPreview>>,

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -247,9 +247,7 @@ async fn lsp_main(
                 }
                 Some(
                     contents
-                        .and_then(|c| {
-                            String::from_utf8(c).map_err(|err| std::io::Error::other(err))
-                        })
+                        .and_then(|c| String::from_utf8(c).map_err(std::io::Error::other))
                         .map(|c| (None, c)),
                 )
             })

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -12,8 +12,8 @@ mod signature_help;
 #[cfg(test)]
 pub mod test;
 
+use crate::common::SwitchableLspToPreview;
 use crate::common::uri_to_file;
-use crate::preview::connector::SwitchableLspToPreview;
 use crate::{common, util};
 
 #[cfg(target_arch = "wasm32")]
@@ -48,7 +48,9 @@ use std::rc::Rc;
 
 const POPULATE_COMMAND: &str = "slint/populate";
 pub const SHOW_PREVIEW_COMMAND: &str = "slint/showPreview";
+#[cfg(feature = "preview-remote")]
 pub const CONNECT_REMOTE_PREVIEW_COMMAND: &str = "slint/connectRemotePreview";
+#[cfg(feature = "preview-remote")]
 pub const DISCONNECT_REMOTE_PREVIEW_COMMAND: &str = "slint/disconnectRemotePreview";
 
 fn command_list() -> Vec<String> {
@@ -174,6 +176,7 @@ pub struct Context {
     /// Files to recompile after all other operations are done
     /// (i.e. recompilations triggered by updates to unopened files)
     pub pending_recompile: HashSet<lsp_types::Url>,
+    #[cfg_attr(not(feature = "preview-remote"), allow(dead_code))]
     pub preview_to_lsp_sender: tokio::sync::mpsc::UnboundedSender<PreviewToLspMessage>,
 }
 

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -199,7 +199,7 @@ fn test_goto_definition_multi_files() {
         init_param: Default::default(),
         to_show: None,
         open_urls: Default::default(),
-        to_preview: std::rc::Rc::new(crate::preview::connector::SwitchableLspToPreview::with_one(
+        to_preview: std::rc::Rc::new(crate::common::SwitchableLspToPreview::with_one(
             common::DummyLspToPreview::default(),
         )),
         pending_recompile: Default::default(),

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -11,8 +11,8 @@ use std::rc::Rc;
 
 use crate::{
     common,
+    common::SwitchableLspToPreview,
     language::{convert_diagnostics, load_document_impl},
-    preview::connector::SwitchableLspToPreview,
 };
 
 use super::Context;

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -40,11 +40,9 @@ use std::sync::{Arc, atomic};
 use std::task::{Poll, Waker};
 use std::time::Duration;
 
+use crate::common::{SwitchableLspToPreview, document_cache::CompilerConfiguration};
 #[cfg(feature = "preview-remote")]
 use crate::preview::connector::RemoteLspToPreview;
-use crate::{
-    common::document_cache::CompilerConfiguration, preview::connector::SwitchableLspToPreview,
-};
 
 #[cfg(not(any(
     target_os = "openbsd",

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1436,7 +1436,7 @@ async fn parse_source(
             common::document_cache::SourceFileVersionMap::from([(path.clone(), version)]),
         );
 
-    let result = builder.build_from_source(source_code, path, ()).await;
+    let result = builder.build_from_source(source_code, path).await;
 
     let compiled = result.components().next();
     (result.diagnostics().collect(), compiled, open_file_fallback, source_file_versions)

--- a/tools/lsp/preview/connector.rs
+++ b/tools/lsp/preview/connector.rs
@@ -11,8 +11,7 @@ pub mod native;
 #[cfg(all(not(target_arch = "wasm32"), feature = "preview-builtin"))]
 pub use native::*;
 
-mod switchable;
-pub use switchable::SwitchableLspToPreview;
+pub use crate::common::SwitchableLspToPreview;
 #[cfg(feature = "preview-remote")]
 pub mod remote;
 #[cfg(feature = "preview-remote")]

--- a/tools/lsp/preview/connector/remote.rs
+++ b/tools/lsp/preview/connector/remote.rs
@@ -1,3 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 use std::sync::Arc;
 
 use futures_util::{

--- a/tools/lsp/preview/connector/remote/remote_notifications.rs
+++ b/tools/lsp/preview/connector/remote/remote_notifications.rs
@@ -1,3 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 use lsp_types::notification::Notification;
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -7,8 +7,6 @@
 use crate::common;
 use crate::preview::{self, connector, ui};
 
-use slint_interpreter::ComponentHandle;
-
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -610,7 +610,7 @@ export component Main { }
                 init_param: Default::default(),
                 to_show: None,
                 open_urls: Default::default(),
-                to_preview: Rc::new(crate::preview::connector::SwitchableLspToPreview::with_one(
+                to_preview: Rc::new(crate::common::SwitchableLspToPreview::with_one(
                     crate::common::DummyLspToPreview::default(),
                 )),
                 pending_recompile: Default::default(),

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -272,7 +272,7 @@ pub fn create(
             if let Ok(contents) = &contents {
                 to_preview.send(&LspToPreviewMessage::SetContents {
                     url: VersionedUrl::new(url, None),
-                    contents: contents.clone(),
+                    contents: contents.clone().into(),
                 });
             }
             Some(contents.map(|c| (None, c)))

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -11,12 +11,12 @@ mod language;
 mod preview;
 pub mod util;
 
+use common::SwitchableLspToPreview;
 use common::{DocumentCache, Result};
 use i_slint_preview_protocol::{LspToPreviewMessage, VersionedUrl};
 use js_sys::Function;
 pub use language::{Context, RequestHandler};
 use lsp_types::Url;
-use preview::connector::SwitchableLspToPreview;
 
 use std::cell::RefCell;
 use std::future::Future;
@@ -283,6 +283,8 @@ pub fn create(
     let mut rh = RequestHandler::default();
     language::register_request_handlers(&mut rh);
 
+    let (preview_to_lsp_sender, _preview_to_lsp_receiver) = tokio::sync::mpsc::unbounded_channel();
+
     Ok(SlintServer {
         ctx: ReentryGuard::new(Context {
             document_cache,
@@ -293,6 +295,7 @@ pub fn create(
             open_urls: Default::default(),
             to_preview,
             pending_recompile: Default::default(),
+            preview_to_lsp_sender,
         }),
         rh: Rc::new(rh),
     })

--- a/tools/remote-viewer/Cargo.toml
+++ b/tools/remote-viewer/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 [package]
 name = "remote-viewer"
 description = "The remote viewer binary for Slint"
@@ -18,7 +21,7 @@ i-slint-core = { workspace = true }
 i-slint-backend-selector = { workspace = true }
 i-slint-preview-protocol = { workspace = true }
 slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility", "image-default-formats", "internal-json"] }
-slint = { path = "../../api/rs/slint", features = ["serde", "backend-android-activity-06"] }
+slint = { workspace = true, features = ["default", "serde", "backend-android-activity-06"] }
 lsp-types = { version = "0.95.0" }
 serde = { version = "1.0", features = ["derive"] }
 dashmap = { version = "6.1.0" }

--- a/tools/remote-viewer/LICENSES/GPL-3.0-only.txt
+++ b/tools/remote-viewer/LICENSES/GPL-3.0-only.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/GPL-3.0-only.txt

--- a/tools/remote-viewer/LICENSES/LicenseRef-Slint-Royalty-free-2.0.md
+++ b/tools/remote-viewer/LICENSES/LicenseRef-Slint-Royalty-free-2.0.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-2.0.md

--- a/tools/remote-viewer/LICENSES/LicenseRef-Slint-Software-3.0.md
+++ b/tools/remote-viewer/LICENSES/LicenseRef-Slint-Software-3.0.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Software-3.0.md

--- a/tools/remote-viewer/src/connection.rs
+++ b/tools/remote-viewer/src/connection.rs
@@ -24,6 +24,7 @@ use mdns_sd::ServiceInfo;
 
 #[derive(Clone, Debug)]
 pub struct VersionedFileContent {
+    #[allow(dead_code)]
     pub version: SourceFileVersion,
     pub contents: Arc<[u8]>,
 }
@@ -49,6 +50,7 @@ pub enum ConnectionMessage {
         preview_component: PreviewComponent,
         file_cache: Arc<DashMap<String, CacheEntry>>,
     },
+    #[allow(dead_code)]
     HighlightFromEditor {
         url: Option<Url>,
         offset: u32,

--- a/tools/remote-viewer/src/resources.rs
+++ b/tools/remote-viewer/src/resources.rs
@@ -1,8 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 use std::collections::HashSet;
 
 use i_slint_compiler::typeloader::TypeLoader;
 use lsp_types::Url;
 
+#[allow(dead_code)]
 fn extract_resources(dependencies: &HashSet<Url>, type_loader: &TypeLoader) -> HashSet<Url> {
     let mut result: HashSet<Url> = Default::default();
 

--- a/tools/remote-viewer/src/ui.rs
+++ b/tools/remote-viewer/src/ui.rs
@@ -1,19 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{net::SocketAddr, path::Path, rc::Rc, sync::Arc};
+use std::{net::SocketAddr, rc::Rc};
 
-use futures_util::FutureExt;
-use i_slint_compiler::{diagnostics::BuildDiagnostics, passes::ResourcePreloader};
+use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_core::InternalToken;
 use i_slint_preview_protocol::PreviewToLspMessage;
 use slint::{ComponentHandle as _, SharedString};
-use slint_interpreter::ComponentInstance;
 use tokio::sync;
 
 use crate::{
     compilation,
-    connection::{self, CacheEntry, Connection},
+    connection::{self, CacheEntry},
     util,
 };
 
@@ -32,7 +30,7 @@ pub async fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Resu
     let mut compiler = compilation::init_compiler(Rc::downgrade(&connection));
     let current_exe = std::env::current_exe().unwrap();
     let compilation_result = compiler
-        .build_from_source(MAIN_SLINT.to_owned(), current_exe.parent().unwrap().to_owned(), ())
+        .build_from_source(MAIN_SLINT.to_owned(), current_exe.parent().unwrap().to_owned())
         .await;
     if compilation_result.has_errors() {
         let mut build_diagnostics = BuildDiagnostics::default();
@@ -110,8 +108,8 @@ pub async fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Resu
                         "Cached files: {:#?}",
                         file_cache.iter().map(|entry| entry.key().to_string()).collect::<Vec<_>>()
                     );
-                    let file_cache_preloader =
-                        FileCachePreloader { connection: &connection, window: &inner_window };
+                    // TODO: pass resources from the file cache to the compiler via
+                    // a resource preloader in CompilerConfiguration
                     let compilation_result = if let Some(entry) = file_cache.get(
                         preview_component.url.to_file_path().unwrap().as_os_str().to_str().unwrap(),
                     ) && let CacheEntry::Ready(file) = &*entry
@@ -121,7 +119,6 @@ pub async fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Resu
                             .build_from_source(
                                 str::from_utf8(&file.contents).unwrap().to_owned(),
                                 preview_component.url.path().into(),
-                                file_cache_preloader,
                             )
                             .await
                     } else {
@@ -129,9 +126,7 @@ pub async fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Resu
                             "Failed fetching file {} from cache.",
                             preview_component.url
                         );
-                        compiler
-                            .build_from_path(preview_component.url.path(), file_cache_preloader)
-                            .await
+                        compiler.build_from_path(preview_component.url.path()).await
                     };
                     if compilation_result.has_errors() {
                         let mut build_diagnostics = BuildDiagnostics::default();
@@ -265,50 +260,4 @@ pub async fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Resu
         mdns.shutdown().await?;
     }
     Ok(())
-}
-
-struct FileCachePreloader<'a> {
-    connection: &'a Connection,
-    window: &'a ComponentInstance,
-}
-
-impl<'p> ResourcePreloader for FileCachePreloader<'p> {
-    fn load<'a>(
-        &self,
-        paths: impl Iterator<Item = &'a str>,
-        push: Rc<impl Fn(/* url */ &'a str, /* extension */ String, /* data */ Vec<u8>)>,
-    ) -> impl Future<Output = ()> {
-        if let Err(err) =
-            self.window.set_property("message", SharedString::from("Loading resources...").into())
-        {
-            tracing::error!("Failed setting property: {err}");
-        }
-
-        futures_util::future::join_all(paths.map(|path| {
-            let push = push.clone();
-            async move {
-                if path.starts_with("builtin:/") {
-                    tracing::debug!("Skipping builtin resource {path}");
-                    return;
-                }
-                tracing::debug!("Preloading file {path}");
-                match self.connection.request_file(path.to_owned()).await {
-                    Ok(file) => {
-                        tracing::debug!("Got file {path} with {} bytes", file.contents.len());
-                        let extension = Path::new(&path)
-                            .extension()
-                            .and_then(std::ffi::OsStr::to_str)
-                            .map(std::string::ToString::to_string)
-                            .unwrap_or_default();
-
-                        push(path, extension, file.contents.to_vec());
-                    }
-                    Err(err) => {
-                        tracing::error!("Failed requesting file {path}: {err}");
-                    }
-                }
-            }
-        }))
-        .map(|_| ())
-    }
 }

--- a/tools/remote-viewer/src/util.rs
+++ b/tools/remote-viewer/src/util.rs
@@ -1,3 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 use i_slint_compiler::diagnostics::ByteFormat;
 use slint_interpreter::{Diagnostic, DiagnosticLevel};
 


### PR DESCRIPTION
The WIP merge of the remote-viewer added this. Revert to the state before.

The ResourcePreloader trait and its plumbing through compile_syntax_node, load_root_file, run_passes, build_from_path, and build_from_source broke all downstream callers. Resource preloading should be part of CompilerConfiguration instead, and merged with the URL mapper.

For now, revert the compiler and interpreter API changes and leave TODO comments in the remote-viewer where the preloader was used.
