### PR TITLE
docs: Store builtin element docs in the TypeRegister

### DIFF
--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -1,137 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Extract documentation from builtins.slint and generate mdx files.
+// Generate mdx documentation files for builtin elements using data from
+// the compiler's TypeRegister.
 
-use i_slint_compiler::parser::{self, SyntaxKind, identifier_text, syntax_nodes};
+use i_slint_compiler::langtype::{
+    BuiltinElement, BuiltinElementDocEntry, BuiltinPropertyDefault, BuiltinPropertyInfo,
+    ElementType, Type,
+};
+use i_slint_compiler::object_tree::PropertyVisibility;
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::Write as FmtWrite;
 use std::fs::create_dir_all;
 use std::io::{BufWriter, Write};
 
 use crate::mdx;
-
-#[derive(Clone, Debug, PartialEq)]
-enum MemberKind {
-    Property,
-    Callback,
-    Function,
-    /// Raw text from `//!` comments, inserted between members.
-    SectionHeader,
-}
-
-#[derive(Clone, Debug)]
-struct MemberDoc {
-    name: String,
-    kind: MemberKind,
-    /// For properties: the type name. For callbacks/functions: the signature.
-    type_name: String,
-    description: String,
-    /// "in", "out", "in-out", or "" (only for properties).
-    direction: String,
-    default_value: String,
-    /// True when the member had a `///` doc comment. Members without
-    /// doc comments are internal and should not appear in the output.
-    has_doc_comment: bool,
-}
-
-struct ElementDoc {
-    name: String,
-    is_global: bool,
-    description: String,
-    footer: String,
-    skip_inherited: bool,
-    /// When true, sub-elements are not documented on this page (they
-    /// belong to another element's page instead).
-    skip_children: bool,
-    /// Marks experimental elements. The Astro content config excludes
-    /// draft pages when experimental features are disabled.
-    /// Extracted from `\draft` annotation.
-    draft: bool,
-    /// Subdirectory within the generated output folder, e.g. "elements".
-    /// Extracted from `\group` annotation. `None` means no page is generated.
-    group: Option<String>,
-    members: Vec<MemberDoc>,
-    /// Direct child component names (sub-elements).
-    children: Vec<String>,
-}
-
-// -- Doc comment helpers --
-
-/// Walk backwards through sibling tokens collecting consecutive `///` lines.
-fn collect_doc_comments_before(node: &parser::SyntaxNode) -> Option<String> {
-    let mut lines = Vec::new();
-    let mut iter = node.node.prev_sibling_or_token();
-
-    while let Some(ref cur) = iter {
-        match cur.kind() {
-            SyntaxKind::Whitespace => {}
-            SyntaxKind::Comment => {
-                let text = cur.as_token().unwrap().text().to_string();
-                if text.starts_with("///") {
-                    lines.push(text);
-                } else if text.starts_with("//") {
-                    // Skip regular comments and //-annotations.
-                } else {
-                    break;
-                }
-            }
-            SyntaxKind::ExportsList => {
-                // Doc comments may sit inside a preceding ExportsList.
-                if let Some(node) = cur.as_node() {
-                    let mut last = node.last_child_or_token();
-                    while let Some(ref child) = last {
-                        match child.kind() {
-                            SyntaxKind::Whitespace => {}
-                            SyntaxKind::Comment => {
-                                let t = child.as_token().unwrap().text().to_string();
-                                if t.starts_with("///") {
-                                    lines.push(t);
-                                } else if t.starts_with("//") {
-                                    // skip
-                                } else {
-                                    break;
-                                }
-                            }
-                            _ => break,
-                        }
-                        last = child.prev_sibling_or_token();
-                    }
-                }
-                break;
-            }
-            _ => break,
-        }
-        iter = cur.prev_sibling_or_token();
-    }
-
-    if lines.is_empty() {
-        return None;
-    }
-    lines.reverse();
-    Some(
-        lines
-            .iter()
-            .map(|t| t.strip_prefix("/// ").or_else(|| t.strip_prefix("///")).unwrap_or(""))
-            .collect::<Vec<_>>()
-            .join("\n"),
-    )
-}
-
-/// Extract `///` doc comment before a syntax node.
-/// Also checks before an ExportsList parent if the node is inside one.
-fn extract_doc_comment(node: &parser::SyntaxNode) -> Option<String> {
-    if let Some(doc) = collect_doc_comments_before(node) {
-        return Some(doc);
-    }
-    if let Some(parent) = node.parent()
-        && parent.kind() == SyntaxKind::ExportsList
-    {
-        return collect_doc_comments_before(&parent);
-    }
-    None
-}
 
 // -- Annotation helpers --
 
@@ -158,18 +42,14 @@ fn extract_default(doc: &str) -> (String, Option<String>) {
     (doc.to_string(), None)
 }
 
-/// Extract and remove `\group` or `\group:name` annotation.
-/// Returns `Some(name)` when a group was specified (name may be empty
-/// for bare `\group`), or `None` when the annotation is absent.
+/// Extract and remove `\group:name` annotation.
+/// Returns `Some(name)` when a group was specified, or `None` when absent.
 fn extract_group(doc: &mut String) -> Option<String> {
     let mut result = None;
     let mut lines: Vec<&str> = doc.lines().collect();
     for i in (0..lines.len()).rev() {
         if let Some(val) = lines[i].strip_prefix("\\group:") {
             result = Some(val.trim().to_string());
-            lines.remove(i);
-        } else if lines[i].trim() == "\\group" {
-            result = Some(String::new());
             lines.remove(i);
         }
     }
@@ -359,547 +239,349 @@ fn transform_code_fences(text: &str, counter: &mut ScreenshotCounter) -> String 
     result
 }
 
-// -- AST helpers --
+// -- Type formatting helpers --
 
-fn type_text(type_node: &syntax_nodes::Type) -> String {
-    if let Some(qn) = type_node.QualifiedName() {
-        return identifier_text(&qn).unwrap_or_default().to_string();
+/// Format a type name for documentation output. Same as `Type::Display`
+/// except enumerations omit the `enum` prefix.
+fn format_type_name(ty: &Type) -> String {
+    match ty {
+        Type::Enumeration(e) => e.name.to_string(),
+        _ => ty.to_string(),
     }
-    let node: &parser::SyntaxNode = type_node;
-    node.text().to_string().trim().to_string()
 }
 
-fn property_visibility(prop: &syntax_nodes::PropertyDeclaration) -> &'static str {
-    let node: &parser::SyntaxNode = prop;
-    for token in node.children_with_tokens() {
-        if token.kind() == SyntaxKind::Identifier {
-            match token.as_token().unwrap().text() {
-                "in-out" => return "in-out",
-                "in" => return "in",
-                "out" => return "out",
-                "property" => return "",
-                _ => {}
+/// Format a default value expression for documentation output.
+fn format_default_expr(expr: &i_slint_compiler::expression_tree::Expression) -> String {
+    use i_slint_compiler::expression_tree::Expression;
+    match expr {
+        Expression::EnumerationValue(v) => {
+            v.enumeration.values.get(v.value).map(|s| s.to_string()).unwrap_or_default()
+        }
+        Expression::Cast { from, to } => {
+            if matches!(to, Type::Color | Type::Brush)
+                && let Expression::NumberLiteral(n, _) = from.as_ref()
+            {
+                let argb = *n as u32;
+                return format!("#{:06x}", argb & 0xFFFFFF);
             }
+            format_default_expr(from)
+        }
+        _ => {
+            let mut s = String::new();
+            i_slint_compiler::expression_tree::pretty_print(&mut s, expr).unwrap();
+            s
         }
     }
-    ""
 }
 
-fn callback_signature(cb: &syntax_nodes::CallbackDeclaration) -> String {
-    let params: Vec<String> = cb
-        .CallbackDeclarationParameter()
-        .map(|p| {
-            let pname = p
-                .DeclaredIdentifier()
-                .and_then(|d| identifier_text(&d))
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-            let ptype = type_text(&p.Type());
-            if pname.is_empty() { ptype } else { format!("{pname}: {ptype}") }
+/// Format a callback or function signature from a `Function` type.
+fn format_signature(func: &i_slint_compiler::langtype::Function) -> String {
+    let params: Vec<String> = func
+        .arg_names
+        .iter()
+        .zip(func.args.iter())
+        .filter(|(_, ty)| !matches!(ty, Type::ElementReference))
+        .map(|(name, ty)| {
+            if name.is_empty() {
+                format_type_name(ty)
+            } else {
+                format!("{name}: {}", format_type_name(ty))
+            }
         })
         .collect();
-    let ret = cb.ReturnType().map(|r| format!(" -> {}", type_text(&r.Type())));
-    format!("({}){}", params.join(", "), ret.unwrap_or_default())
+    let ret = if matches!(func.return_type, Type::Void) {
+        String::new()
+    } else {
+        format!(" -> {}", format_type_name(&func.return_type))
+    };
+    format!("({}){ret}", params.join(", "))
 }
 
-fn function_signature(f: &syntax_nodes::Function) -> String {
-    let params: Vec<String> = f
-        .ArgumentDeclaration()
-        .map(|a| {
-            format!(
-                "{}: {}",
-                identifier_text(&a.DeclaredIdentifier()).unwrap_or_default(),
-                type_text(&a.Type())
-            )
-        })
-        .collect();
-    let ret = f.ReturnType().map(|r| format!(" -> {}", type_text(&r.Type())));
-    format!("({}){}", params.join(", "), ret.unwrap_or_default())
+/// Convert a `PropertyVisibility` to the direction string used in docs.
+fn visibility_to_direction(v: PropertyVisibility) -> &'static str {
+    match v {
+        PropertyVisibility::Input => "in",
+        PropertyVisibility::Output => "out",
+        PropertyVisibility::InOut => "in-out",
+        _ => "",
+    }
 }
 
-// -- Member extraction --
+// -- Writing helpers --
 
-fn extract_members(elem_node: &syntax_nodes::Element) -> Vec<MemberDoc> {
-    let mut members = Vec::new();
-    let mut in_code_fence = false;
+/// Whether a builtin element has any documentation worth showing.
+fn has_documentation(builtin: &BuiltinElement) -> bool {
+    match builtin.docs.first() {
+        Some(BuiltinElementDocEntry::Text(t)) if !t.is_empty() => true,
+        _ => builtin.properties.values().any(|p| p.docs.is_some()),
+    }
+}
 
-    for child in elem_node.children_with_tokens() {
-        match child.kind() {
-            SyntaxKind::PropertyDeclaration => {
-                let p = syntax_nodes::PropertyDeclaration::from(child.into_node().unwrap());
-                if p.TwoWayBinding().is_some() {
-                    continue;
-                }
-                let doc = extract_doc_comment(&p);
-                let has_doc_comment = doc.is_some();
-                let raw = doc.unwrap_or_default();
-                let (description, doc_default) = extract_default(&raw);
-                let mut default_value = p
-                    .BindingExpression()
-                    .map(|b| {
-                        let n: &parser::SyntaxNode = &b;
-                        n.text().to_string().trim().trim_end_matches(';').trim().to_string()
-                    })
-                    .unwrap_or_default();
-                if default_value.is_empty()
-                    && let Some(d) = doc_default
+/// Extract and clean the element description from the first doc entry.
+fn element_description(builtin: &BuiltinElement) -> String {
+    match builtin.docs.first() {
+        Some(BuiltinElementDocEntry::Text(t)) => {
+            let mut d = t.clone();
+            extract_group(&mut d);
+            strip_annotation(&mut d, "\\draft");
+            strip_annotation(&mut d, "\\skip_inherited");
+            strip_annotation(&mut d, "\\skip_children");
+            let (desc, _) = split_footer(&d);
+            desc
+        }
+        _ => String::new(),
+    }
+}
+
+/// Collect all text from a builtin element for import detection.
+fn collect_builtin_text(builtin: &BuiltinElement, text: &mut String) {
+    for entry in &builtin.docs {
+        match entry {
+            BuiltinElementDocEntry::Text(t) => {
+                text.push(' ');
+                text.push_str(t);
+            }
+            BuiltinElementDocEntry::Member(name) => {
+                if let Some(info) = builtin.properties.get(name.as_str())
+                    && let Some(doc) = &info.docs
                 {
-                    default_value = d;
+                    text.push(' ');
+                    text.push_str(doc);
                 }
-                members.push(MemberDoc {
-                    name: identifier_text(&p.DeclaredIdentifier()).unwrap().to_string(),
-                    kind: MemberKind::Property,
-                    type_name: p.Type().map(|t| type_text(&t)).unwrap_or_default(),
-                    description,
-                    direction: property_visibility(&p).to_string(),
-                    default_value,
-                    has_doc_comment,
-                });
             }
-            SyntaxKind::CallbackDeclaration => {
-                let cb = syntax_nodes::CallbackDeclaration::from(child.into_node().unwrap());
-                if cb.TwoWayBinding().is_some() {
+        }
+    }
+}
+
+/// Collect all text from an element and its descendants for import detection.
+fn collect_all_text(builtin: &BuiltinElement, skip_children: bool) -> String {
+    let mut text = String::new();
+    collect_builtin_text(builtin, &mut text);
+    if !skip_children {
+        let mut seen = HashSet::new();
+        fn collect_children(
+            parent: &BuiltinElement,
+            text: &mut String,
+            seen: &mut HashSet<String>,
+        ) {
+            for (name, child) in &parent.additional_accepted_child_types {
+                if !seen.insert(name.to_string()) {
                     continue;
                 }
-                let doc = extract_doc_comment(&cb);
-                let has_doc_comment = doc.is_some();
-                members.push(MemberDoc {
-                    name: identifier_text(&cb.DeclaredIdentifier()).unwrap().to_string(),
-                    kind: MemberKind::Callback,
-                    type_name: callback_signature(&cb),
-                    description: doc.unwrap_or_default(),
-                    direction: String::new(),
-                    default_value: String::new(),
-                    has_doc_comment,
-                });
-            }
-            SyntaxKind::Function => {
-                let f = syntax_nodes::Function::from(child.into_node().unwrap());
-                let doc = extract_doc_comment(&f);
-                let has_doc_comment = doc.is_some();
-                members.push(MemberDoc {
-                    name: identifier_text(&f.DeclaredIdentifier()).unwrap().to_string(),
-                    kind: MemberKind::Function,
-                    type_name: function_signature(&f),
-                    description: doc.unwrap_or_default(),
-                    direction: String::new(),
-                    default_value: String::new(),
-                    has_doc_comment,
-                });
-            }
-            SyntaxKind::Comment => {
-                if let Some(t) = child.as_token() {
-                    let text = t.text();
-                    if let Some(content) =
-                        text.strip_prefix("//! ").or_else(|| text.strip_prefix("//!"))
-                    {
-                        // Track code fences: lines starting with `#` inside a
-                        // code fence are not markdown headings.
-                        let is_heading = content.starts_with('#') && !in_code_fence;
-                        if content.starts_with("```") || content.starts_with("~~~") {
-                            in_code_fence = !in_code_fence;
-                        }
-
-                        // Merge consecutive non-heading //! lines into one block.
-                        if !is_heading
-                            && let Some(last) = members.last_mut()
-                            && last.kind == MemberKind::SectionHeader
-                        {
-                            last.description.push('\n');
-                            last.description.push_str(content);
-                            continue;
-                        }
-                        members.push(MemberDoc {
-                            name: String::new(),
-                            kind: MemberKind::SectionHeader,
-                            type_name: String::new(),
-                            description: content.to_string(),
-                            direction: String::new(),
-                            default_value: String::new(),
-                            has_doc_comment: true,
-                        });
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    members
-}
-
-// -- Inheritance resolution --
-
-fn resolve_inheritance(
-    components: &mut BTreeMap<String, ElementDoc>,
-    inheritance: &HashMap<String, String>,
-) {
-    let names: Vec<String> = components.keys().cloned().collect();
-    for name in &names {
-        if components[name].skip_inherited {
-            continue;
-        }
-
-        // Build ancestor chain.
-        let mut chain = Vec::new();
-        let mut cur = name.clone();
-        while let Some(parent) = inheritance.get(&cur) {
-            if chain.contains(parent) {
-                break;
-            }
-            chain.push(parent.clone());
-            cur = parent.clone();
-        }
-        if chain.is_empty() {
-            continue;
-        }
-
-        // Collect inherited members, ancestors first.
-        let mut inherited = Vec::new();
-        for ancestor in chain.iter().rev() {
-            if let Some(parent_elem) = components.get(ancestor) {
-                for m in &parent_elem.members {
-                    if m.kind == MemberKind::SectionHeader
-                        || !inherited.iter().any(|im: &MemberDoc| im.name == m.name)
-                    {
-                        inherited.push(m.clone());
-                    }
-                }
+                collect_builtin_text(child, text);
+                collect_children(child, text, seen);
             }
         }
-
-        let elem = components.get_mut(name).unwrap();
-        let own_names: HashSet<String> = elem.members.iter().map(|m| m.name.clone()).collect();
-        inherited.retain(|m| m.kind == MemberKind::SectionHeader || !own_names.contains(&m.name));
-        inherited.append(&mut elem.members);
-        elem.members = inherited;
+        collect_children(builtin, &mut text, &mut seen);
     }
-}
-
-/// Walk up the inheritance chain to find the first value for which
-/// `getter` returns `Some`.
-fn resolve_inherited<T: Clone>(
-    name: &str,
-    components: &BTreeMap<String, ElementDoc>,
-    inheritance: &HashMap<String, String>,
-    getter: fn(&ElementDoc) -> Option<&T>,
-) -> Option<T> {
-    let mut current = name;
-    loop {
-        if let Some(elem) = components.get(current)
-            && let Some(val) = getter(elem)
-        {
-            return Some(val.clone());
-        }
-        match inheritance.get(current) {
-            Some(parent) => current = parent,
-            None => return None,
-        }
-    }
-}
-
-/// Convenience wrapper: resolve a `String` field, treating empty as absent.
-fn resolve_inherited_field(
-    name: &str,
-    components: &BTreeMap<String, ElementDoc>,
-    inheritance: &HashMap<String, String>,
-    getter: fn(&ElementDoc) -> &String,
-) -> String {
-    let mut current = name;
-    loop {
-        if let Some(elem) = components.get(current) {
-            let val = getter(elem);
-            if !val.is_empty() {
-                return val.clone();
-            }
-        }
-        match inheritance.get(current) {
-            Some(parent) => current = parent,
-            None => return String::new(),
-        }
-    }
-}
-
-/// Build an `ElementDoc` for export, resolving inherited fields.
-fn build_exported_doc(
-    export_name: String,
-    internal_name: &str,
-    elem: &ElementDoc,
-    components: &BTreeMap<String, ElementDoc>,
-    inheritance: &HashMap<String, String>,
-) -> ElementDoc {
-    ElementDoc {
-        name: export_name,
-        is_global: elem.is_global,
-        description: resolve_inherited_field(internal_name, components, inheritance, |e| {
-            &e.description
-        }),
-        footer: resolve_inherited_field(internal_name, components, inheritance, |e| &e.footer),
-        draft: elem.draft,
-        group: resolve_inherited(internal_name, components, inheritance, |e| e.group.as_ref()),
-        skip_inherited: false,
-        skip_children: elem.skip_children,
-        members: elem.members.clone(),
-        children: elem.children.clone(),
-    }
-}
-
-// -- Parsing builtins.slint --
-
-fn extract_builtin_element_docs() -> (Vec<ElementDoc>, BTreeMap<String, ElementDoc>) {
-    let builtins_path = crate::root_dir().join("internal/compiler/builtins.slint");
-    let source = std::fs::read_to_string(&builtins_path)
-        .unwrap_or_else(|e| panic!("Failed to read {builtins_path:?}: {e}"));
-
-    let mut diag = i_slint_compiler::diagnostics::BuildDiagnostics::default();
-    let root = parser::parse(source, Some(builtins_path.as_ref()), &mut diag);
-    if diag.has_errors() {
-        panic!("Error parsing builtins.slint: {:?}", diag.to_string_vec());
-    }
-    let doc: syntax_nodes::Document = root.into();
-
-    // Map exported_name -> internal_name for `export { X as Y }`.
-    let mut export_aliases = HashMap::<String, String>::new();
-    for export_list in doc.ExportsList() {
-        for spec in export_list.ExportSpecifier() {
-            let internal = identifier_text(&spec.ExportIdentifier()).unwrap().to_string();
-            let exported = identifier_text(&spec.ExportName().unwrap()).unwrap().to_string();
-            export_aliases.insert(exported, internal);
-        }
-    }
-
-    let mut components = BTreeMap::<String, ElementDoc>::new();
-    let mut inheritance = HashMap::<String, String>::new();
-
-    for c in doc.Component().chain(doc.ExportsList().filter_map(|e| e.Component())) {
-        let id = identifier_text(&c.DeclaredIdentifier()).unwrap().to_string();
-        let is_global =
-            c.child_text(SyntaxKind::Identifier).is_some_and(|t| t.as_str() == "global");
-        let elem_node = c.Element();
-
-        if let Some(base) = elem_node.QualifiedName() {
-            inheritance.insert(id.clone(), identifier_text(&base).unwrap().to_string());
-        }
-
-        let mut description = extract_doc_comment(&c).unwrap_or_default();
-        let group = extract_group(&mut description);
-        let draft = strip_annotation(&mut description, "\\draft");
-        let (desc, footer) = split_footer(&description);
-        description = desc;
-        let skip_inherited = strip_annotation(&mut description, "\\skip_inherited");
-        let skip_children = strip_annotation(&mut description, "\\skip_children");
-
-        let children = elem_node
-            .SubElement()
-            .filter_map(|sub| {
-                sub.Element()
-                    .QualifiedName()
-                    .and_then(|qn| identifier_text(&qn))
-                    .map(|s| s.to_string())
-            })
-            .collect();
-
-        components.insert(
-            id,
-            ElementDoc {
-                name: String::new(),
-                is_global,
-                description,
-                footer,
-                draft,
-                group,
-                skip_inherited,
-                skip_children,
-                members: extract_members(&elem_node),
-                children,
-            },
-        );
-    }
-
-    resolve_inheritance(&mut components, &inheritance);
-
-    // Collect exported elements.
-    let mut result = Vec::new();
-    let mut seen = HashSet::new();
-
-    // First pass: directly exported components (export component X { ... }).
-    for internal_name in components.keys() {
-        let is_directly_exported = doc.ExportsList().any(|e| {
-            e.Component().is_some_and(|c| {
-                identifier_text(&c.DeclaredIdentifier()).unwrap().as_str() == internal_name
-            })
-        });
-        if !is_directly_exported {
-            continue;
-        }
-        let export_name = export_aliases
-            .iter()
-            .find(|(_, v)| v.as_str() == internal_name)
-            .map(|(k, _)| k.clone())
-            .unwrap_or_else(|| internal_name.clone());
-        seen.insert(export_name.clone());
-        let elem = &components[internal_name];
-        result.push(build_exported_doc(
-            export_name,
-            internal_name,
-            elem,
-            &components,
-            &inheritance,
-        ));
-    }
-
-    // Second pass: re-exported aliases (export { X as Y }).
-    for (export_name, internal_name) in &export_aliases {
-        if seen.contains(export_name) {
-            continue;
-        }
-        if let Some(elem) = components.get(internal_name) {
-            result.push(build_exported_doc(
-                export_name.clone(),
-                internal_name,
-                elem,
-                &components,
-                &inheritance,
-            ));
-        }
-    }
-
-    // Third pass: non-exported components with a group (e.g. MenuBar).
-    let seen_internal: HashSet<&str> = export_aliases.values().map(|s| s.as_str()).collect();
-    for (name, elem) in &components {
-        if seen.contains(name.as_str()) || seen_internal.contains(name.as_str()) {
-            continue;
-        }
-        let doc = build_exported_doc(name.clone(), name, elem, &components, &inheritance);
-        if doc.group.is_none() {
-            continue;
-        }
-        seen.insert(name.clone());
-        result.push(doc);
-    }
-
-    result.sort_by(|a, b| a.name.cmp(&b.name));
-    (result, components)
-}
-
-// -- MDX output --
-
-/// Build a set of internal component names that have their own doc page.
-fn components_with_own_page(all: &BTreeMap<String, ElementDoc>) -> HashSet<String> {
-    all.iter()
-        .filter(|(_, e)| !e.description.is_empty() || e.members.iter().any(|m| m.has_doc_comment))
-        .map(|(k, _)| k.clone())
-        .collect()
+    text
 }
 
 fn write_slint_property(
     file: &mut impl Write,
-    m: &MemberDoc,
+    name: &str,
+    info: &BuiltinPropertyInfo,
     heading: &str,
     enums: &HashSet<String>,
     structs: &HashSet<String>,
     sc: &mut ScreenshotCounter,
 ) -> std::io::Result<()> {
-    let (type_attr, enum_name, struct_name) = if enums.contains(&m.type_name) {
-        ("enum", Some(&m.type_name), None)
-    } else if structs.contains(&m.type_name) {
-        ("struct", None, Some(&m.type_name))
+    let type_name = format_type_name(&info.ty);
+    let raw_doc = info.docs.as_deref().unwrap_or("");
+    let (description, doc_default) = extract_default(raw_doc);
+    let mut default_value = match &info.default_value {
+        BuiltinPropertyDefault::Expr(expr) => format_default_expr(expr),
+        _ => String::new(),
+    };
+    if default_value.is_empty()
+        && let Some(d) = doc_default
+    {
+        default_value = d;
+    }
+
+    let (type_attr, is_enum, is_struct) = if enums.contains(&type_name) {
+        ("enum", true, false)
+    } else if structs.contains(&type_name) {
+        ("struct", false, true)
     } else {
-        (m.type_name.as_str(), None, None)
+        (type_name.as_str(), false, false)
     };
 
-    writeln!(file, "{heading} {}", m.name)?;
-    write!(file, "<SlintProperty propName=\"{}\" typeName=\"{type_attr}\"", m.name)?;
-    if let Some(en) = enum_name {
-        write!(file, " enumName=\"{en}\"")?;
+    writeln!(file, "{heading} {name}")?;
+    write!(file, "<SlintProperty propName=\"{name}\" typeName=\"{type_attr}\"")?;
+    if is_enum {
+        write!(file, " enumName=\"{type_name}\"")?;
     }
-    if let Some(sn) = struct_name {
-        write!(file, " structName=\"{sn}\"")?;
+    if is_struct {
+        write!(file, " structName=\"{type_name}\"")?;
     }
-    if m.direction == "out" || m.direction == "in-out" {
-        write!(file, " propertyVisibility=\"{}\"", m.direction)?;
+    let direction = visibility_to_direction(info.property_visibility);
+    if direction == "out" || direction == "in-out" {
+        write!(file, " propertyVisibility=\"{direction}\"")?;
     }
-    if !m.default_value.is_empty() {
-        write!(file, " defaultValue=\"{}\"", m.default_value.replace('"', "&quot;"))?;
+    if !default_value.is_empty() {
+        write!(file, " defaultValue=\"{}\"", default_value.replace('"', "&quot;"))?;
     }
-    if m.description.is_empty() {
+    if description.is_empty() {
         writeln!(file, "/>")?;
     } else {
         writeln!(file, ">")?;
-        writeln!(file, "{}", transform_code_fences(&m.description, sc).trim_end())?;
+        writeln!(file, "{}", transform_code_fences(&description, sc).trim_end())?;
         writeln!(file, "</SlintProperty>")?;
     }
     writeln!(file)?;
     Ok(())
 }
 
-/// Write properties, callbacks, functions, and section headers.
-/// Automatically inserts `## Properties` / `## Callbacks` / `## Functions`
-/// headings unless a `//!` section header already provides them.
-fn write_members(
+/// Write a documented member (property, callback, or function) with auto-generated
+/// section headings when entering a new kind for the first time.
+fn write_member(
     file: &mut impl Write,
-    members: &[MemberDoc],
+    name: &str,
+    info: &BuiltinPropertyInfo,
+    in_properties: &mut bool,
+    in_callbacks: &mut bool,
+    in_functions: &mut bool,
     enums: &HashSet<String>,
     structs: &HashSet<String>,
     sc: &mut ScreenshotCounter,
 ) -> std::io::Result<()> {
-    // If the first documented thing is a section header, don't auto-generate "## Properties".
-    let has_leading_section = members
-        .iter()
-        .find(|m| m.kind == MemberKind::SectionHeader || m.kind == MemberKind::Property)
-        .is_some_and(|m| m.kind == MemberKind::SectionHeader);
+    match &info.ty {
+        ty if ty.is_property_type() => {
+            if !*in_properties && !*in_callbacks && !*in_functions {
+                writeln!(file, "## Properties")?;
+                writeln!(file)?;
+                *in_properties = true;
+            }
+            write_slint_property(file, name, info, "###", enums, structs, sc)?;
+        }
+        Type::Callback(func) => {
+            if !*in_callbacks {
+                writeln!(file, "## Callbacks")?;
+                writeln!(file)?;
+                *in_callbacks = true;
+            }
+            writeln!(file, "### {name}{}", format_signature(func))?;
+            if let Some(doc) = &info.docs
+                && !doc.is_empty()
+            {
+                writeln!(file, "{}", transform_code_fences(doc, sc).trim_end())?;
+            }
+            writeln!(file)?;
+        }
+        Type::Function(func) => {
+            if !*in_functions {
+                writeln!(file, "## Functions")?;
+                writeln!(file)?;
+                *in_functions = true;
+            }
+            writeln!(file, "### {name}{}", format_signature(func))?;
+            if let Some(doc) = &info.docs {
+                writeln!(file, "{}", transform_code_fences(doc, sc).trim_end())?;
+            }
+            writeln!(file)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Normalize whitespace in `//!` section text: ensure each markdown heading
+/// is preceded by a blank line, skip headings inside code fences, and
+/// collapse runs of multiple blank lines into one.
+fn normalize_section_text(text: &str) -> String {
+    let mut result = String::with_capacity(text.len() + 32);
+    let mut blank_run = 0u32;
+    let mut in_code_fence = false;
+    for line in text.lines() {
+        if line.starts_with("```") || line.starts_with("~~~") {
+            in_code_fence = !in_code_fence;
+        }
+        if line.trim().is_empty() {
+            blank_run += 1;
+            continue;
+        }
+        // Before a non-blank line, emit at most one blank line.
+        if blank_run > 0 && !result.is_empty() {
+            result.push('\n');
+        }
+        blank_run = 0;
+        // Ensure a blank line before headings (outside code fences).
+        if line.starts_with('#')
+            && !in_code_fence
+            && !result.is_empty()
+            && !result.ends_with("\n\n")
+        {
+            result.push('\n');
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+    if result.ends_with('\n') && !text.ends_with('\n') {
+        result.pop();
+    }
+    result
+}
+
+/// Write members directly from a builtin element's doc entries.
+/// Automatically inserts `## Properties` / `## Callbacks` / `## Functions`
+/// headings unless a `//!` section header already provides them.
+fn write_members(
+    file: &mut impl Write,
+    builtin: &BuiltinElement,
+    enums: &HashSet<String>,
+    structs: &HashSet<String>,
+    sc: &mut ScreenshotCounter,
+) -> std::io::Result<()> {
+    let start = if builtin.docs.is_empty() { 0 } else { 1 };
+
+    // If the first body entry is a text section, don't auto-generate "## Properties".
+    let has_leading_section =
+        builtin.docs.get(start).is_some_and(|e| matches!(e, BuiltinElementDocEntry::Text(_)));
     let mut in_properties = has_leading_section;
     let mut in_callbacks = false;
     let mut in_functions = false;
-
-    for m in members {
-        match m.kind {
-            MemberKind::SectionHeader => {
-                let desc = m.description.trim_end();
-                if desc.starts_with("## Properties") {
-                    in_properties = true;
+    for entry in &builtin.docs[start..] {
+        match entry {
+            BuiltinElementDocEntry::Text(text) => {
+                let trimmed = text.trim_matches('\n');
+                for line in trimmed.lines() {
+                    if line.starts_with("## Properties") {
+                        in_properties = true;
+                    }
+                    if line.starts_with("## Callbacks") {
+                        in_callbacks = true;
+                    }
+                    if line.starts_with("## Functions") {
+                        in_functions = true;
+                    }
                 }
-                if desc.starts_with("## Callbacks") {
-                    in_callbacks = true;
-                }
-                if desc.starts_with("## Functions") {
-                    in_functions = true;
-                }
-                writeln!(file, "{}", transform_code_fences(desc, sc))?;
+                // Ensure blank lines before markdown headings so the
+                // output matches the expected MDX spacing.
+                let spaced = normalize_section_text(trimmed);
+                writeln!(file, "{}", transform_code_fences(&spaced, sc))?;
                 writeln!(file)?;
             }
-            MemberKind::Property if m.has_doc_comment => {
-                if !in_properties && !in_callbacks && !in_functions {
-                    writeln!(file, "## Properties")?;
-                    writeln!(file)?;
-                    in_properties = true;
+            BuiltinElementDocEntry::Member(name) => {
+                let Some(info) = builtin.properties.get(name.as_str()) else { continue };
+                if info.docs.is_none() {
+                    continue;
                 }
-                write_slint_property(file, m, "###", enums, structs, sc)?;
+                write_member(
+                    file,
+                    name,
+                    info,
+                    &mut in_properties,
+                    &mut in_callbacks,
+                    &mut in_functions,
+                    enums,
+                    structs,
+                    sc,
+                )?;
             }
-            MemberKind::Callback if m.has_doc_comment => {
-                if !in_callbacks {
-                    writeln!(file, "## Callbacks")?;
-                    writeln!(file)?;
-                    in_callbacks = true;
-                }
-                writeln!(file, "### {}{}", m.name, m.type_name)?;
-                if !m.description.is_empty() {
-                    writeln!(file, "{}", transform_code_fences(&m.description, sc).trim_end())?;
-                }
-                writeln!(file)?;
-            }
-            MemberKind::Function if m.has_doc_comment => {
-                if !in_functions {
-                    writeln!(file, "## Functions")?;
-                    writeln!(file)?;
-                    in_functions = true;
-                }
-                writeln!(file, "### {}{}", m.name, m.type_name)?;
-                writeln!(file, "{}", transform_code_fences(&m.description, sc).trim_end())?;
-                writeln!(file)?;
-            }
-            _ => {}
         }
     }
+
     Ok(())
 }
 
@@ -907,8 +589,7 @@ fn write_members(
 fn write_sub_element(
     file: &mut impl Write,
     child_name: &str,
-    child: &ElementDoc,
-    all_components: &BTreeMap<String, ElementDoc>,
+    child: &BuiltinElement,
     enums: &HashSet<String>,
     structs: &HashSet<String>,
     seen: &mut HashSet<String>,
@@ -917,56 +598,71 @@ fn write_sub_element(
     if !seen.insert(child_name.to_string()) {
         return Ok(());
     }
-    let has_doc = !child.description.is_empty() || child.members.iter().any(|m| m.has_doc_comment);
-    if !has_doc {
+    if !has_documentation(child) {
         return Ok(());
     }
 
+    let mut raw_desc = match child.docs.first() {
+        Some(BuiltinElementDocEntry::Text(t)) => t.clone(),
+        _ => String::new(),
+    };
+    let skip_children = strip_annotation(&mut raw_desc, "\\skip_children");
+    let description = element_description(child);
+
     writeln!(file, "## `{child_name}`")?;
     writeln!(file)?;
-    if !child.description.is_empty() {
-        writeln!(file, "{}", transform_code_fences(&child.description, sc).trim_end())?;
+    if !description.is_empty() {
+        writeln!(file, "{}", transform_code_fences(&description, sc).trim_end())?;
         writeln!(file)?;
     }
 
-    let props: Vec<_> = child
-        .members
-        .iter()
-        .filter(|m| m.kind == MemberKind::Property && m.has_doc_comment)
-        .collect();
-    let cbs: Vec<_> = child
-        .members
-        .iter()
-        .filter(|m| m.kind == MemberKind::Callback && m.has_doc_comment)
-        .collect();
-    let fns: Vec<_> = child
-        .members
-        .iter()
-        .filter(|m| m.kind == MemberKind::Function && m.has_doc_comment)
-        .collect();
+    // Collect documented members by kind, preserving doc entry order.
+    let start = if child.docs.is_empty() { 0 } else { 1 };
+    let mut props: Vec<(&str, &BuiltinPropertyInfo)> = Vec::new();
+    let mut cbs: Vec<(&str, &BuiltinPropertyInfo)> = Vec::new();
+    let mut fns: Vec<(&str, &BuiltinPropertyInfo)> = Vec::new();
+
+    for entry in &child.docs[start..] {
+        if let BuiltinElementDocEntry::Member(name) = entry
+            && let Some(info) = child.properties.get(name.as_str())
+        {
+            if info.docs.is_none() {
+                continue;
+            }
+            match &info.ty {
+                ty if ty.is_property_type() => props.push((name, info)),
+                Type::Callback(_) => cbs.push((name, info)),
+                Type::Function(_) => fns.push((name, info)),
+                _ => {}
+            }
+        }
+    }
 
     // Use grouped (####) headings when there are multiple member kinds.
-    let grouped = (props.len() + cbs.len() + fns.len()) > 0
-        && [!props.is_empty(), !cbs.is_empty(), !fns.is_empty()].iter().filter(|&&b| b).count() > 1;
-    let (prop_h, cb_h, fn_h) =
-        if grouped { ("####", "####", "####") } else { ("###", "###", "###") };
+    let kind_count =
+        [!props.is_empty(), !cbs.is_empty(), !fns.is_empty()].iter().filter(|&&b| b).count();
+    let grouped = kind_count > 1;
+    let h = if grouped { "####" } else { "###" };
 
     if !props.is_empty() {
         if grouped {
             writeln!(file, "### Properties of `{child_name}`")?;
             writeln!(file)?;
         }
-        for p in &props {
-            write_slint_property(file, p, prop_h, enums, structs, sc)?;
+        for (name, info) in &props {
+            write_slint_property(file, name, info, h, enums, structs, sc)?;
         }
     }
     if !cbs.is_empty() {
         writeln!(file, "### Callbacks of `{child_name}`")?;
         writeln!(file)?;
-        for c in &cbs {
-            writeln!(file, "{cb_h} {}{}", c.name, c.type_name)?;
-            if !c.description.is_empty() {
-                writeln!(file, "{}", transform_code_fences(&c.description, sc).trim_end())?;
+        for (name, info) in &cbs {
+            let Type::Callback(func) = &info.ty else { continue };
+            writeln!(file, "{h} {name}{}", format_signature(func))?;
+            if let Some(doc) = &info.docs
+                && !doc.is_empty()
+            {
+                writeln!(file, "{}", transform_code_fences(doc, sc).trim_end())?;
             }
             writeln!(file)?;
         }
@@ -974,62 +670,30 @@ fn write_sub_element(
     if !fns.is_empty() {
         writeln!(file, "### Functions of `{child_name}`")?;
         writeln!(file)?;
-        for f in &fns {
-            writeln!(file, "{fn_h} {}{}", f.name, f.type_name)?;
-            writeln!(file, "{}", transform_code_fences(&f.description, sc).trim_end())?;
+        for (name, info) in &fns {
+            let Type::Function(func) = &info.ty else { continue };
+            writeln!(file, "{h} {name}{}", format_signature(func))?;
+            if let Some(doc) = &info.docs {
+                writeln!(file, "{}", transform_code_fences(doc, sc).trim_end())?;
+            }
             writeln!(file)?;
         }
     }
 
     // Recurse into grandchildren.
-    for gc_name in &child.children {
-        if let Some(gc) = all_components.get(gc_name.as_str()) {
-            write_sub_element(file, gc_name, gc, all_components, enums, structs, seen, sc)?;
+    if !skip_children {
+        for (gc_name, gc) in &child.additional_accepted_child_types {
+            write_sub_element(file, gc_name, gc, enums, structs, seen, sc)?;
         }
     }
 
     Ok(())
 }
 
-/// Collect all text from an element and its descendants for import detection.
-fn collect_all_text(elem: &ElementDoc, all: &BTreeMap<String, ElementDoc>) -> String {
-    let mut text = format!("{} {}", elem.description, elem.footer);
-    for m in &elem.members {
-        text.push(' ');
-        text.push_str(&m.description);
-    }
-    if elem.skip_children {
-        return text;
-    }
-    let mut seen = HashSet::new();
-    fn collect_children(
-        names: &[String],
-        all: &BTreeMap<String, ElementDoc>,
-        text: &mut String,
-        seen: &mut HashSet<String>,
-    ) {
-        for name in names {
-            if !seen.insert(name.clone()) {
-                continue;
-            }
-            if let Some(child) = all.get(name.as_str()) {
-                text.push(' ');
-                text.push_str(&child.description);
-                for m in &child.members {
-                    text.push(' ');
-                    text.push_str(&m.description);
-                }
-                collect_children(&child.children, all, text, seen);
-            }
-        }
-    }
-    collect_children(&elem.children, all, &mut text, &mut seen);
-    text
-}
-
 /// Generate .mdx page files for each exported builtin element.
 pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
-    let (elements, all_components) = extract_builtin_element_docs();
+    let register = i_slint_compiler::typeregister::TypeRegister::builtin_experimental();
+    let register = register.borrow();
     let root_dir = crate::root_dir();
     let generated_dir = root_dir.join("docs/astro/src/content/docs/reference/generated");
     create_dir_all(&generated_dir)?;
@@ -1038,20 +702,46 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
     let enum_names: HashSet<String> = mdx::extract_enum_docs(true).keys().cloned().collect();
     let struct_names: HashSet<String> =
         mdx::extract_builtin_structs(true).keys().cloned().collect();
-    let own_page = components_with_own_page(&all_components);
 
-    for elem in &elements {
-        if elem.draft {
+    // Collect exported elements.
+    let mut elements = Vec::new();
+    for (export_name, element_type) in register.all_elements() {
+        match element_type {
+            ElementType::Builtin(b) => {
+                elements.push((export_name.to_string(), false, b));
+            }
+            ElementType::Component(c) if c.is_global() => {
+                if let ElementType::Builtin(b) = &c.root_element.borrow().base_type {
+                    elements.push((c.id.to_string(), true, b.clone()));
+                }
+            }
+            _ => {}
+        }
+    }
+    elements.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Generate a page for each exported element with documentation.
+    for (name, is_global, builtin) in &elements {
+        let mut description = match builtin.docs.first() {
+            Some(BuiltinElementDocEntry::Text(text)) => text.clone(),
+            _ => continue,
+        };
+        if description.is_empty() {
             continue;
         }
-        let has_docs =
-            !elem.description.is_empty() || elem.members.iter().any(|m| m.has_doc_comment);
-        if !has_docs {
+
+        let group = extract_group(&mut description);
+        let draft = strip_annotation(&mut description, "\\draft");
+        if draft {
             continue;
         }
+        let (desc, footer) = split_footer(&description);
+        description = desc;
+        strip_annotation(&mut description, "\\skip_inherited");
+        let skip_children = strip_annotation(&mut description, "\\skip_children");
 
-        let filename = format!("{}.mdx", elem.name.to_ascii_lowercase());
-        let path = match elem.group.as_deref() {
+        let filename = format!("{}.mdx", name.to_ascii_lowercase());
+        let path = match group.as_deref() {
             Some(group) if !group.is_empty() => {
                 let subdir = generated_dir.join(group);
                 create_dir_all(&subdir)?;
@@ -1065,23 +755,22 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
 
         // Frontmatter.
         let slug_stem = filename.strip_suffix(".mdx").unwrap();
-        let slug = match elem.group.as_deref() {
+        let slug = match group.as_deref() {
             Some(group) if !group.is_empty() => format!("reference/{group}/{slug_stem}"),
             _ => format!("reference/{slug_stem}"),
         };
         writeln!(file, "---")?;
-        writeln!(file, "title: {}", elem.name)?;
-        if elem.is_global {
-            writeln!(file, "description: {} Namespace", elem.name)?;
+        writeln!(file, "title: {name}")?;
+        if *is_global {
+            writeln!(file, "description: {name} Namespace")?;
         } else {
-            writeln!(file, "description: {} element api.", elem.name)?;
+            writeln!(file, "description: {name} element api.")?;
         }
         writeln!(file, "slug: {slug}")?;
         writeln!(file, "---")?;
 
         // Imports.
-        let all_text = collect_all_text(elem, &all_components);
-        // Always needed.
+        let all_text = collect_all_text(builtin, skip_children);
         writeln!(file)?;
         writeln!(
             file,
@@ -1093,21 +782,22 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
                 "import CodeSnippetMD from '@slint/common-files/src/components/CodeSnippetMD.astro';"
             )?;
         }
-        // Sorted struct/enum imports.
         let mut extra_imports = Vec::new();
-        for name in &struct_names {
-            if all_text.contains(&format!("<{name} />")) || all_text.contains(&format!("<{name}/>"))
+        for sname in &struct_names {
+            if all_text.contains(&format!("<{sname} />"))
+                || all_text.contains(&format!("<{sname}/>"))
             {
                 extra_imports.push(format!(
-                    "import {name} from '/src/content/docs/reference/generated/structs/{name}.md';"
+                    "import {sname} from '/src/content/docs/reference/generated/structs/{sname}.md';"
                 ));
             }
         }
-        for name in &enum_names {
-            if all_text.contains(&format!("<{name} />")) || all_text.contains(&format!("<{name}/>"))
+        for ename in &enum_names {
+            if all_text.contains(&format!("<{ename} />"))
+                || all_text.contains(&format!("<{ename}/>"))
             {
                 extra_imports.push(format!(
-                    "import {name} from '/src/content/docs/reference/generated/enums/{name}.md';"
+                    "import {ename} from '/src/content/docs/reference/generated/enums/{ename}.md';"
                 ));
             }
         }
@@ -1123,43 +813,36 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
         }
         writeln!(file)?;
 
-        let mut sc = ScreenshotCounter::new(&elem.name);
+        let mut sc = ScreenshotCounter::new(name);
 
         // Description.
-        if !elem.description.is_empty() {
-            writeln!(file, "{}", transform_code_fences(&elem.description, &mut sc).trim_end())?;
+        if !description.is_empty() {
+            writeln!(file, "{}", transform_code_fences(&description, &mut sc).trim_end())?;
             writeln!(file)?;
         }
 
         // Members.
-        write_members(&mut file, &elem.members, &enum_names, &struct_names, &mut sc)?;
+        write_members(&mut file, builtin, &enum_names, &struct_names, &mut sc)?;
 
         // Sub-elements (recursive, with cycle protection).
-        // Skip children that have their own page.
-        if !elem.skip_children {
+        if !skip_children {
             let mut seen_children = HashSet::new();
-            for child_name in &elem.children {
-                if own_page.contains(child_name) {
-                    continue;
-                }
-                if let Some(child) = all_components.get(child_name) {
-                    write_sub_element(
-                        &mut file,
-                        child_name,
-                        child,
-                        &all_components,
-                        &enum_names,
-                        &struct_names,
-                        &mut seen_children,
-                        &mut sc,
-                    )?;
-                }
+            for (child_name, child) in &builtin.additional_accepted_child_types {
+                write_sub_element(
+                    &mut file,
+                    child_name,
+                    child,
+                    &enum_names,
+                    &struct_names,
+                    &mut seen_children,
+                    &mut sc,
+                )?;
             }
         }
 
         // Footer.
-        if !elem.footer.is_empty() {
-            writeln!(file, "{}", transform_code_fences(&elem.footer, &mut sc).trim_end())?;
+        if !footer.is_empty() {
+            writeln!(file, "{}", transform_code_fences(&footer, &mut sc).trim_end())?;
         }
         file.flush()?;
     }

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -5,7 +5,7 @@
 // the compiler's TypeRegister.
 
 use i_slint_compiler::langtype::{
-    BuiltinElement, BuiltinElementDocEntry, BuiltinPropertyDefault, BuiltinPropertyInfo,
+    BuiltinElement, ElementDocEntry, BuiltinPropertyDefault, BuiltinPropertyInfo,
     ElementType, Type,
 };
 use i_slint_compiler::object_tree::PropertyVisibility;
@@ -312,7 +312,7 @@ fn visibility_to_direction(v: PropertyVisibility) -> &'static str {
 /// Whether a builtin element has any documentation worth showing.
 fn has_documentation(builtin: &BuiltinElement) -> bool {
     match builtin.docs.first() {
-        Some(BuiltinElementDocEntry::Text(t)) if !t.is_empty() => true,
+        Some(ElementDocEntry::Text(t)) if !t.is_empty() => true,
         _ => builtin.properties.values().any(|p| p.docs.is_some()),
     }
 }
@@ -320,7 +320,7 @@ fn has_documentation(builtin: &BuiltinElement) -> bool {
 /// Extract and clean the element description from the first doc entry.
 fn element_description(builtin: &BuiltinElement) -> String {
     match builtin.docs.first() {
-        Some(BuiltinElementDocEntry::Text(t)) => {
+        Some(ElementDocEntry::Text(t)) => {
             let mut d = t.clone();
             extract_group(&mut d);
             strip_annotation(&mut d, "\\draft");
@@ -337,11 +337,11 @@ fn element_description(builtin: &BuiltinElement) -> String {
 fn collect_builtin_text(builtin: &BuiltinElement, text: &mut String) {
     for entry in &builtin.docs {
         match entry {
-            BuiltinElementDocEntry::Text(t) => {
+            ElementDocEntry::Text(t) => {
                 text.push(' ');
                 text.push_str(t);
             }
-            BuiltinElementDocEntry::Member(name) => {
+            ElementDocEntry::Member(name) => {
                 if let Some(info) = builtin.properties.get(name.as_str())
                     && let Some(doc) = &info.docs
                 {
@@ -537,13 +537,13 @@ fn write_members(
 
     // If the first body entry is a text section, don't auto-generate "## Properties".
     let has_leading_section =
-        builtin.docs.get(start).is_some_and(|e| matches!(e, BuiltinElementDocEntry::Text(_)));
+        builtin.docs.get(start).is_some_and(|e| matches!(e, ElementDocEntry::Text(_)));
     let mut in_properties = has_leading_section;
     let mut in_callbacks = false;
     let mut in_functions = false;
     for entry in &builtin.docs[start..] {
         match entry {
-            BuiltinElementDocEntry::Text(text) => {
+            ElementDocEntry::Text(text) => {
                 let trimmed = text.trim_matches('\n');
                 for line in trimmed.lines() {
                     if line.starts_with("## Properties") {
@@ -562,7 +562,7 @@ fn write_members(
                 writeln!(file, "{}", transform_code_fences(&spaced, sc))?;
                 writeln!(file)?;
             }
-            BuiltinElementDocEntry::Member(name) => {
+            ElementDocEntry::Member(name) => {
                 let Some(info) = builtin.properties.get(name.as_str()) else { continue };
                 if info.docs.is_none() {
                     continue;
@@ -602,11 +602,7 @@ fn write_sub_element(
         return Ok(());
     }
 
-    let mut raw_desc = match child.docs.first() {
-        Some(BuiltinElementDocEntry::Text(t)) => t.clone(),
-        _ => String::new(),
-    };
-    let skip_children = strip_annotation(&mut raw_desc, "\\skip_children");
+    let skip_children = matches!(child.docs.first(), Some(ElementDocEntry::Text(t)) if t.contains("\\skip_children"));
     let description = element_description(child);
 
     writeln!(file, "## `{child_name}`")?;
@@ -623,7 +619,7 @@ fn write_sub_element(
     let mut fns: Vec<(&str, &BuiltinPropertyInfo)> = Vec::new();
 
     for entry in &child.docs[start..] {
-        if let BuiltinElementDocEntry::Member(name) = entry
+        if let ElementDocEntry::Member(name) = entry
             && let Some(info) = child.properties.get(name.as_str())
         {
             if info.docs.is_none() {
@@ -723,7 +719,7 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
     // Generate a page for each exported element with documentation.
     for (name, is_global, builtin) in &elements {
         let mut description = match builtin.docs.first() {
-            Some(BuiltinElementDocEntry::Text(text)) => text.clone(),
+            Some(ElementDocEntry::Text(text)) => text.clone(),
             _ => continue,
         };
         if description.is_empty() {

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -4,8 +4,9 @@
 // Generate mdx documentation files for builtin elements using data from
 // the compiler's TypeRegister.
 
+use i_slint_compiler::doc_comments::ElementDocEntry;
 use i_slint_compiler::langtype::{
-    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, ElementDocEntry, ElementType, Type,
+    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, ElementType, Type,
 };
 use i_slint_compiler::object_tree::PropertyVisibility;
 

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -5,8 +5,7 @@
 // the compiler's TypeRegister.
 
 use i_slint_compiler::langtype::{
-    BuiltinElement, ElementDocEntry, BuiltinPropertyDefault, BuiltinPropertyInfo,
-    ElementType, Type,
+    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, ElementDocEntry, ElementType, Type,
 };
 use i_slint_compiler::object_tree::PropertyVisibility;
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1293,7 +1293,6 @@ component Menu {
 /// }
 /// ```
 /// \skip_children
-/// \group:window
 component MenuBar {
     //-is_non_item_type
     //-disallow_global_types_as_child_elements
@@ -1389,13 +1388,6 @@ export component ContextMenuArea inherits Empty {
     in property <bool> enabled: true;
 }
 
-/// `Window` is the root of the tree of elements that are visible on the screen.
-///
-/// The `Window` geometry will be restricted by its layout constraints: Setting the `width` will result in a fixed width,
-/// and the window manager will respect the `min-width` and `max-width` so the window can't be resized bigger
-/// or smaller. The initial width can be controlled with the `preferred-width` property. The same applies to the `Window`s height.
-///
-/// Use the <Link type="MenuBar" /> element to declare a menu bar for the window.
 component WindowItem {
     in-out property <length> width;
     in-out property <length> height;
@@ -1440,6 +1432,13 @@ component WindowItem {
     }
 }
 
+/// `Window` is the root of the tree of elements that are visible on the screen.
+///
+/// The `Window` geometry will be restricted by its layout constraints: Setting the `width` will result in a fixed width,
+/// and the window manager will respect the `min-width` and `max-width` so the window can't be resized bigger
+/// or smaller. The initial width can be controlled with the `preferred-width` property. The same applies to the `Window`s height.
+///
+/// Use the <Link type="MenuBar" /> element to declare a menu bar for the window.
 /// \group:window
 export component Window inherits WindowItem {
     MenuBar { }

--- a/internal/compiler/doc_comments.rs
+++ b/internal/compiler/doc_comments.rs
@@ -3,8 +3,22 @@
 
 //! Extract `///` doc comments from the syntax tree.
 
+use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::langtype::{BuiltinElement, ElementDocEntry};
 use crate::parser::{SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
+
+/// Strip a doc-comment prefix (`///` or `//!`) from a line.
+/// Returns the content after the prefix if the line matches exactly
+/// `prefix` or `prefix` followed by a space and content.
+/// Rejects lines like `////` or `//!!`.
+fn strip_doc_prefix<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+    let rest = line.strip_prefix(prefix)?;
+    match rest.strip_prefix(' ') {
+        Some(content) => Some(content),
+        None if rest.is_empty() => Some(""),
+        None => None,
+    }
+}
 
 /// Walk backwards across sibling tokens/nodes collecting consecutive
 /// `///` doc comment lines immediately before `anchor`. Returns the
@@ -17,9 +31,9 @@ fn collect_before(anchor: &SyntaxNode) -> Option<String> {
         match cur.kind() {
             SyntaxKind::Whitespace => {}
             SyntaxKind::Comment => {
-                let text = cur.as_token().unwrap().text().to_string();
-                if text.starts_with("///") {
-                    lines.push(text);
+                let text = cur.as_token().unwrap().text();
+                if let Some(content) = strip_doc_prefix(text, "///") {
+                    lines.push(content.to_string());
                 } else if text.starts_with("//") {
                     // Skip regular comments and //-annotations.
                 } else {
@@ -34,9 +48,9 @@ fn collect_before(anchor: &SyntaxNode) -> Option<String> {
                         match child.kind() {
                             SyntaxKind::Whitespace => {}
                             SyntaxKind::Comment => {
-                                let t = child.as_token().unwrap().text().to_string();
-                                if t.starts_with("///") {
-                                    lines.push(t);
+                                let t = child.as_token().unwrap().text();
+                                if let Some(content) = strip_doc_prefix(t, "///") {
+                                    lines.push(content.to_string());
                                 } else if t.starts_with("//") {
                                     // skip
                                 } else {
@@ -58,13 +72,7 @@ fn collect_before(anchor: &SyntaxNode) -> Option<String> {
         return None;
     }
     lines.reverse();
-    Some(
-        lines
-            .iter()
-            .map(|t| t.strip_prefix("/// ").or_else(|| t.strip_prefix("///")).unwrap_or(""))
-            .collect::<Vec<_>>()
-            .join("\n"),
-    )
+    Some(lines.join("\n"))
 }
 
 /// Extract the `///` doc comment before a syntax node. Also checks
@@ -87,6 +95,7 @@ pub(crate) fn doc_comment(anchor: &SyntaxNode) -> Option<String> {
 pub(crate) fn element_doc_entries(
     component: &SyntaxNode,
     element: &syntax_nodes::Element,
+    diag: &mut BuildDiagnostics,
 ) -> Vec<ElementDocEntry> {
     let description = doc_comment(component).unwrap_or_default();
 
@@ -99,19 +108,25 @@ pub(crate) fn element_doc_entries(
         }
     };
 
+    let mut doc_comment_span = None;
     for child in element.children_with_tokens() {
         match child.kind() {
+            SyntaxKind::Whitespace => {}
             SyntaxKind::Comment => {
                 if let Some(t) = child.as_token() {
                     let text = t.text();
-                    if let Some(content) =
-                        text.strip_prefix("//! ").or_else(|| text.strip_prefix("//!"))
-                    {
+                    if strip_doc_prefix(text, "///").is_some() {
+                        doc_comment_span = Some(child.to_source_location());
+                    } else if let Some(content) = strip_doc_prefix(text, "//!") {
+                        if let Some(span) = doc_comment_span.take() {
+                            diag.push_warning_with_span("`///` doc comment not attached to a declaration".into(), span);
+                        }
                         section_lines.push(content.to_string());
                     }
                 }
             }
             SyntaxKind::PropertyDeclaration => {
+                doc_comment_span = None;
                 let p = syntax_nodes::PropertyDeclaration::from(child.into_node().unwrap());
                 if p.TwoWayBinding().is_some() {
                     continue;
@@ -121,6 +136,7 @@ pub(crate) fn element_doc_entries(
                 entries.push(ElementDocEntry::Member(name));
             }
             SyntaxKind::CallbackDeclaration => {
+                doc_comment_span = None;
                 let cb = syntax_nodes::CallbackDeclaration::from(child.into_node().unwrap());
                 if cb.TwoWayBinding().is_some() {
                     continue;
@@ -130,13 +146,21 @@ pub(crate) fn element_doc_entries(
                 entries.push(ElementDocEntry::Member(name));
             }
             SyntaxKind::Function => {
+                doc_comment_span = None;
                 let f = syntax_nodes::Function::from(child.into_node().unwrap());
                 flush_section(&mut section_lines, &mut entries);
                 let name = identifier_text(&f.DeclaredIdentifier()).unwrap();
                 entries.push(ElementDocEntry::Member(name));
             }
-            _ => {}
+            _ => {
+                if let Some(span) = doc_comment_span.take() {
+                    diag.push_warning_with_span("`///` doc comment not attached to a declaration".into(), span);
+                }
+            }
         }
+    }
+    if let Some(span) = doc_comment_span.take() {
+        diag.push_warning_with_span("`///` doc comment not attached to a declaration".into(), span);
     }
     flush_section(&mut section_lines, &mut entries);
     entries

--- a/internal/compiler/doc_comments.rs
+++ b/internal/compiler/doc_comments.rs
@@ -1,0 +1,159 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Extract `///` doc comments from the syntax tree.
+
+use crate::langtype::{BuiltinElement, ElementDocEntry};
+use crate::parser::{SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
+
+/// Walk backwards across sibling tokens/nodes collecting consecutive
+/// `///` doc comment lines immediately before `anchor`. Returns the
+/// concatenated text with the `/// ` prefix stripped, or `None` if
+/// no doc comment was present.
+fn collect_before(anchor: &SyntaxNode) -> Option<String> {
+    let mut lines = Vec::new();
+    let mut cursor = anchor.node.prev_sibling_or_token();
+    while let Some(cur) = cursor {
+        match cur.kind() {
+            SyntaxKind::Whitespace => {}
+            SyntaxKind::Comment => {
+                let text = cur.as_token().unwrap().text().to_string();
+                if text.starts_with("///") {
+                    lines.push(text);
+                } else if text.starts_with("//") {
+                    // Skip regular comments and //-annotations.
+                } else {
+                    break;
+                }
+            }
+            SyntaxKind::ExportsList => {
+                // Doc comments may sit inside a preceding `export { ... }` list.
+                if let Some(list) = cur.as_node() {
+                    let mut last = list.last_child_or_token();
+                    while let Some(child) = last {
+                        match child.kind() {
+                            SyntaxKind::Whitespace => {}
+                            SyntaxKind::Comment => {
+                                let t = child.as_token().unwrap().text().to_string();
+                                if t.starts_with("///") {
+                                    lines.push(t);
+                                } else if t.starts_with("//") {
+                                    // skip
+                                } else {
+                                    break;
+                                }
+                            }
+                            _ => break,
+                        }
+                        last = child.prev_sibling_or_token();
+                    }
+                }
+                break;
+            }
+            _ => break,
+        }
+        cursor = cur.prev_sibling_or_token();
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    lines.reverse();
+    Some(
+        lines
+            .iter()
+            .map(|t| t.strip_prefix("/// ").or_else(|| t.strip_prefix("///")).unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+/// Extract the `///` doc comment before a syntax node. Also checks
+/// above the enclosing `ExportsList` when the node is inside one.
+pub(crate) fn doc_comment(anchor: &SyntaxNode) -> Option<String> {
+    if let Some(doc) = collect_before(anchor) {
+        return Some(doc);
+    }
+    if let Some(parent) = anchor.parent()
+        && parent.kind() == SyntaxKind::ExportsList
+    {
+        return collect_before(&parent);
+    }
+    None
+}
+
+/// Extract the `///` description before the component and the ordered
+/// body entries (`//!` text and member references) from inside it.
+/// The description is included as the first `Text` entry.
+pub(crate) fn element_doc_entries(
+    component: &SyntaxNode,
+    element: &syntax_nodes::Element,
+) -> Vec<ElementDocEntry> {
+    let description = doc_comment(component).unwrap_or_default();
+
+    let mut entries = vec![ElementDocEntry::Text(description)];
+    let mut section_lines: Vec<String> = Vec::new();
+    let flush_section = |lines: &mut Vec<String>, entries: &mut Vec<ElementDocEntry>| {
+        if !lines.is_empty() {
+            entries.push(ElementDocEntry::Text(lines.join("\n")));
+            lines.clear();
+        }
+    };
+
+    for child in element.children_with_tokens() {
+        match child.kind() {
+            SyntaxKind::Comment => {
+                if let Some(t) = child.as_token() {
+                    let text = t.text();
+                    if let Some(content) =
+                        text.strip_prefix("//! ").or_else(|| text.strip_prefix("//!"))
+                    {
+                        section_lines.push(content.to_string());
+                    }
+                }
+            }
+            SyntaxKind::PropertyDeclaration => {
+                let p = syntax_nodes::PropertyDeclaration::from(child.into_node().unwrap());
+                if p.TwoWayBinding().is_some() {
+                    continue;
+                }
+                flush_section(&mut section_lines, &mut entries);
+                let name = identifier_text(&p.DeclaredIdentifier()).unwrap();
+                entries.push(ElementDocEntry::Member(name));
+            }
+            SyntaxKind::CallbackDeclaration => {
+                let cb = syntax_nodes::CallbackDeclaration::from(child.into_node().unwrap());
+                if cb.TwoWayBinding().is_some() {
+                    continue;
+                }
+                flush_section(&mut section_lines, &mut entries);
+                let name = identifier_text(&cb.DeclaredIdentifier()).unwrap();
+                entries.push(ElementDocEntry::Member(name));
+            }
+            SyntaxKind::Function => {
+                let f = syntax_nodes::Function::from(child.into_node().unwrap());
+                flush_section(&mut section_lines, &mut entries);
+                let name = identifier_text(&f.DeclaredIdentifier()).unwrap();
+                entries.push(ElementDocEntry::Member(name));
+            }
+            _ => {}
+        }
+    }
+    flush_section(&mut section_lines, &mut entries);
+    entries
+}
+
+/// Assemble the final doc entries for an element, prepending inherited
+/// parent entries after the description.
+pub(crate) fn assemble(
+    mut entries: Vec<ElementDocEntry>,
+    parent: Option<&BuiltinElement>,
+) -> Vec<ElementDocEntry> {
+    let skip_inherited = matches!(entries.first(), Some(ElementDocEntry::Text(desc)) if desc.contains("\\skip_inherited"));
+
+    if !skip_inherited && let Some(parent) = parent {
+        // Splice inherited parent body (everything after parent's description)
+        // right after our own description (entries[0]).
+        entries.splice(1..1, parent.docs[1..].iter().cloned());
+    }
+    entries
+}

--- a/internal/compiler/doc_comments.rs
+++ b/internal/compiler/doc_comments.rs
@@ -4,8 +4,19 @@
 //! Extract `///` doc comments from the syntax tree.
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
-use crate::langtype::{BuiltinElement, ElementDocEntry};
+use crate::langtype::BuiltinElement;
 use crate::parser::{SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
+use smol_str::SmolStr;
+
+/// One entry in the documentation of a builtin element, preserving the
+/// source order from `builtins.slint`.
+#[derive(Debug, Clone)]
+pub enum ElementDocEntry {
+    /// Free-form documentation text (from `///` or `//!` comments).
+    Text(String),
+    /// Reference to a property, callback, or function by name.
+    Member(SmolStr),
+}
 
 /// Strip a doc-comment prefix (`///` or `//!`) from a line.
 /// Returns the content after the prefix if the line matches exactly
@@ -130,21 +141,15 @@ pub(crate) fn element_doc_entries(
             }
             SyntaxKind::PropertyDeclaration => {
                 doc_comment_span = None;
-                let p = syntax_nodes::PropertyDeclaration::from(child.into_node().unwrap());
-                if p.TwoWayBinding().is_some() {
-                    continue;
-                }
                 flush_section(&mut section_lines, &mut entries);
+                let p = syntax_nodes::PropertyDeclaration::from(child.into_node().unwrap());
                 let name = identifier_text(&p.DeclaredIdentifier()).unwrap();
                 entries.push(ElementDocEntry::Member(name));
             }
             SyntaxKind::CallbackDeclaration => {
                 doc_comment_span = None;
-                let cb = syntax_nodes::CallbackDeclaration::from(child.into_node().unwrap());
-                if cb.TwoWayBinding().is_some() {
-                    continue;
-                }
                 flush_section(&mut section_lines, &mut entries);
+                let cb = syntax_nodes::CallbackDeclaration::from(child.into_node().unwrap());
                 let name = identifier_text(&cb.DeclaredIdentifier()).unwrap();
                 entries.push(ElementDocEntry::Member(name));
             }
@@ -186,4 +191,89 @@ pub(crate) fn assemble(
         entries.splice(1..1, parent.docs[1..].iter().cloned());
     }
     entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::BuildDiagnostics;
+    use crate::parser::{self, syntax_nodes};
+
+    /// Parse a mini `.slint` document and return the first Component node
+    /// and its Element, along with diagnostics.
+    fn parse_component(source: &str) -> (SyntaxNode, syntax_nodes::Element, BuildDiagnostics) {
+        let mut diag = BuildDiagnostics::default();
+        let node = parser::parse(source.into(), None, &mut diag);
+        assert!(!diag.has_errors(), "parse errors: {:?}", diag.to_string_vec());
+        let doc: syntax_nodes::Document = node.into();
+        let comp = doc.Component().next().expect("no component found");
+        let elem = comp.Element();
+        (comp.into(), elem, BuildDiagnostics::default())
+    }
+
+    #[test]
+    fn test_strip_doc_prefix() {
+        assert_eq!(strip_doc_prefix("/// hello", "///"), Some("hello"));
+        assert_eq!(strip_doc_prefix("///", "///"), Some(""));
+        assert_eq!(strip_doc_prefix("////", "///"), None);
+        assert_eq!(strip_doc_prefix("//! section", "//!"), Some("section"));
+        assert_eq!(strip_doc_prefix("//!", "//!"), Some(""));
+        assert_eq!(strip_doc_prefix("//!!", "//!"), None);
+    }
+
+    #[test]
+    fn test_doc_comment_before_component() {
+        let (comp, _, _) = parse_component(
+            "/// My component\ncomponent Foo inherits Rectangle {}",
+        );
+        assert_eq!(doc_comment(&comp), Some("My component".into()));
+    }
+
+    #[test]
+    fn test_element_doc_entries_basic() {
+        let (comp, elem, mut diag) = parse_component(
+            "/// Description\ncomponent Foo {\n  in property <int> bar;\n}",
+        );
+        let entries = element_doc_entries(&comp, &elem, &mut diag);
+        assert!(diag.is_empty(), "unexpected diag: {:?}", diag.to_string_vec());
+        assert!(matches!(&entries[0], ElementDocEntry::Text(t) if t == "Description"));
+        assert!(matches!(&entries[1], ElementDocEntry::Member(n) if n == "bar"));
+    }
+
+    #[test]
+    fn test_element_doc_entries_section_text() {
+        let (comp, elem, mut diag) = parse_component(
+            "component Foo {\n  //! section\n  in property <int> x;\n}",
+        );
+        let entries = element_doc_entries(&comp, &elem, &mut diag);
+        assert!(diag.is_empty(), "unexpected diag: {:?}", diag.to_string_vec());
+        // entries[0] = empty description, entries[1] = section text, entries[2] = member
+        assert!(matches!(&entries[0], ElementDocEntry::Text(t) if t.is_empty()));
+        assert!(matches!(&entries[1], ElementDocEntry::Text(t) if t == "section"));
+        assert!(matches!(&entries[2], ElementDocEntry::Member(n) if n == "x"));
+    }
+
+    #[test]
+    fn test_element_doc_entries_warns_orphan_doc_comment() {
+        let (comp, elem, mut diag) = parse_component(
+            "component Foo {\n  /// orphan\n}",
+        );
+        let _entries = element_doc_entries(&comp, &elem, &mut diag);
+        assert!(
+            diag.to_string_vec().iter().any(|m| m.contains("not attached to a declaration")),
+            "expected warning about orphan doc comment, got: {:?}",
+            diag.to_string_vec(),
+        );
+    }
+
+    #[test]
+    fn test_element_doc_entries_callback_and_function() {
+        let (comp, elem, mut diag) = parse_component(
+            "component Foo {\n  callback clicked();\n  function do-stuff() {}\n}",
+        );
+        let entries = element_doc_entries(&comp, &elem, &mut diag);
+        assert!(diag.is_empty(), "unexpected diag: {:?}", diag.to_string_vec());
+        assert!(matches!(&entries[1], ElementDocEntry::Member(n) if n == "clicked"));
+        assert!(matches!(&entries[2], ElementDocEntry::Member(n) if n == "do-stuff"));
+    }
 }

--- a/internal/compiler/doc_comments.rs
+++ b/internal/compiler/doc_comments.rs
@@ -223,17 +223,14 @@ mod tests {
 
     #[test]
     fn test_doc_comment_before_component() {
-        let (comp, _, _) = parse_component(
-            "/// My component\ncomponent Foo inherits Rectangle {}",
-        );
+        let (comp, _, _) = parse_component("/// My component\ncomponent Foo inherits Rectangle {}");
         assert_eq!(doc_comment(&comp), Some("My component".into()));
     }
 
     #[test]
     fn test_element_doc_entries_basic() {
-        let (comp, elem, mut diag) = parse_component(
-            "/// Description\ncomponent Foo {\n  in property <int> bar;\n}",
-        );
+        let (comp, elem, mut diag) =
+            parse_component("/// Description\ncomponent Foo {\n  in property <int> bar;\n}");
         let entries = element_doc_entries(&comp, &elem, &mut diag);
         assert!(diag.is_empty(), "unexpected diag: {:?}", diag.to_string_vec());
         assert!(matches!(&entries[0], ElementDocEntry::Text(t) if t == "Description"));
@@ -242,9 +239,8 @@ mod tests {
 
     #[test]
     fn test_element_doc_entries_section_text() {
-        let (comp, elem, mut diag) = parse_component(
-            "component Foo {\n  //! section\n  in property <int> x;\n}",
-        );
+        let (comp, elem, mut diag) =
+            parse_component("component Foo {\n  //! section\n  in property <int> x;\n}");
         let entries = element_doc_entries(&comp, &elem, &mut diag);
         assert!(diag.is_empty(), "unexpected diag: {:?}", diag.to_string_vec());
         // entries[0] = empty description, entries[1] = section text, entries[2] = member
@@ -255,9 +251,7 @@ mod tests {
 
     #[test]
     fn test_element_doc_entries_warns_orphan_doc_comment() {
-        let (comp, elem, mut diag) = parse_component(
-            "component Foo {\n  /// orphan\n}",
-        );
+        let (comp, elem, mut diag) = parse_component("component Foo {\n  /// orphan\n}");
         let _entries = element_doc_entries(&comp, &elem, &mut diag);
         assert!(
             diag.to_string_vec().iter().any(|m| m.contains("not attached to a declaration")),
@@ -268,9 +262,8 @@ mod tests {
 
     #[test]
     fn test_element_doc_entries_callback_and_function() {
-        let (comp, elem, mut diag) = parse_component(
-            "component Foo {\n  callback clicked();\n  function do-stuff() {}\n}",
-        );
+        let (comp, elem, mut diag) =
+            parse_component("component Foo {\n  callback clicked();\n  function do-stuff() {}\n}");
         let entries = element_doc_entries(&comp, &elem, &mut diag);
         assert!(diag.is_empty(), "unexpected diag: {:?}", diag.to_string_vec());
         assert!(matches!(&entries[1], ElementDocEntry::Member(n) if n == "clicked"));

--- a/internal/compiler/doc_comments.rs
+++ b/internal/compiler/doc_comments.rs
@@ -119,7 +119,10 @@ pub(crate) fn element_doc_entries(
                         doc_comment_span = Some(child.to_source_location());
                     } else if let Some(content) = strip_doc_prefix(text, "//!") {
                         if let Some(span) = doc_comment_span.take() {
-                            diag.push_warning_with_span("`///` doc comment not attached to a declaration".into(), span);
+                            diag.push_warning_with_span(
+                                "`///` doc comment not attached to a declaration".into(),
+                                span,
+                            );
                         }
                         section_lines.push(content.to_string());
                     }
@@ -154,7 +157,10 @@ pub(crate) fn element_doc_entries(
             }
             _ => {
                 if let Some(span) = doc_comment_span.take() {
-                    diag.push_warning_with_span("`///` doc comment not attached to a declaration".into(), span);
+                    diag.push_warning_with_span(
+                        "`///` doc comment not attached to a declaration".into(),
+                        span,
+                    );
                 }
             }
         }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -375,6 +375,8 @@ pub struct BuiltinPropertyInfo {
     /// When != None, this is the initial value that we will have to set if no other binding were specified
     pub default_value: BuiltinPropertyDefault,
     pub property_visibility: PropertyVisibility,
+    /// Raw `///` doc comment from builtins.slint, if any.
+    pub docs: Option<String>,
 }
 
 impl BuiltinPropertyInfo {
@@ -383,6 +385,7 @@ impl BuiltinPropertyInfo {
             ty,
             default_value: BuiltinPropertyDefault::None,
             property_visibility: PropertyVisibility::InOut,
+            docs: None,
         }
     }
 
@@ -397,6 +400,7 @@ impl From<BuiltinFunction> for BuiltinPropertyInfo {
             ty: Type::Function(function.ty()),
             default_value: BuiltinPropertyDefault::BuiltinFunction(function),
             property_visibility: PropertyVisibility::Public,
+            docs: None,
         }
     }
 }
@@ -837,6 +841,20 @@ pub struct BuiltinElement {
     pub default_size_binding: DefaultSizeBinding,
     /// When true this is an internal type not shown in the auto-completion
     pub is_internal: bool,
+    /// Documentation sections from builtins.slint, preserving source order.
+    /// `Text` entries come from `///` (element-level) and `//!` (section) comments;
+    /// `Member` entries reference a property, callback, or function by name.
+    pub docs: Vec<BuiltinElementDocEntry>,
+}
+
+/// One entry in the documentation of a builtin element, preserving the
+/// source order from `builtins.slint`.
+#[derive(Debug, Clone)]
+pub enum BuiltinElementDocEntry {
+    /// Free-form documentation text (from `///` or `//!` comments).
+    Text(String),
+    /// Reference to a property, callback, or function by name.
+    Member(SmolStr),
 }
 
 impl BuiltinElement {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -844,17 +844,7 @@ pub struct BuiltinElement {
     /// Documentation sections from builtins.slint, preserving source order.
     /// `Text` entries come from `///` (element-level) and `//!` (section) comments;
     /// `Member` entries reference a property, callback, or function by name.
-    pub docs: Vec<ElementDocEntry>,
-}
-
-/// One entry in the documentation of a builtin element, preserving the
-/// source order from `builtins.slint`.
-#[derive(Debug, Clone)]
-pub enum ElementDocEntry {
-    /// Free-form documentation text (from `///` or `//!` comments).
-    Text(String),
-    /// Reference to a property, callback, or function by name.
-    Member(SmolStr),
+    pub docs: Vec<crate::doc_comments::ElementDocEntry>,
 }
 
 impl BuiltinElement {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -844,13 +844,13 @@ pub struct BuiltinElement {
     /// Documentation sections from builtins.slint, preserving source order.
     /// `Text` entries come from `///` (element-level) and `//!` (section) comments;
     /// `Member` entries reference a property, callback, or function by name.
-    pub docs: Vec<BuiltinElementDocEntry>,
+    pub docs: Vec<ElementDocEntry>,
 }
 
 /// One entry in the documentation of a builtin element, preserving the
 /// source order from `builtins.slint`.
 #[derive(Debug, Clone)]
-pub enum BuiltinElementDocEntry {
+pub enum ElementDocEntry {
     /// Free-form documentation text (from `///` or `//!` comments).
     Text(String),
     /// Reference to a property, callback, or function by name.

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 pub mod builtin_macros;
 pub mod data_uri;
 pub mod diagnostics;
-pub(crate) mod doc_comments;
+pub mod doc_comments;
 pub mod embedded_resources;
 pub mod expression_tree;
 pub mod fileaccess;

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -19,6 +19,7 @@ use std::rc::Rc;
 pub mod builtin_macros;
 pub mod data_uri;
 pub mod diagnostics;
+pub(crate) mod doc_comments;
 pub mod embedded_resources;
 pub mod expression_tree;
 pub mod fileaccess;

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -12,8 +12,8 @@ use std::rc::Rc;
 
 use crate::expression_tree::Expression;
 use crate::langtype::{
-    BuiltinElement, BuiltinPrivateStruct, BuiltinPropertyDefault, BuiltinPropertyInfo,
-    DefaultSizeBinding, ElementType, Function, NativeClass, Type,
+    BuiltinElement, BuiltinElementDocEntry, BuiltinPrivateStruct, BuiltinPropertyDefault,
+    BuiltinPropertyInfo, DefaultSizeBinding, ElementType, Function, NativeClass, Type,
 };
 use crate::object_tree::{self, *};
 use crate::parser::{SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
@@ -93,6 +93,8 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                         }
                     }
 
+                    info.docs = docs::doc_comment(&p);
+
                     if let Some(e) = p.BindingExpression() {
                         let ty = info.ty.clone();
                         info.default_value = BuiltinPropertyDefault::Expr(compiled(e, register, ty));
@@ -101,28 +103,27 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                     (prop_name, info)
                 })
                 .chain(e.CallbackDeclaration().map(|s| {
-                    (
-                        identifier_text(&s.DeclaredIdentifier()).unwrap(),
-                        BuiltinPropertyInfo::new(Type::Callback(Rc::new(Function{
-                            args: s
-                                .CallbackDeclarationParameter()
-                                .map(|a| {
-                                    object_tree::type_from_node(a.Type(), *diag.borrow_mut(), register)
-                                })
-                                .collect(),
-                            return_type: s.ReturnType().map(|a| {
-                                object_tree::type_from_node(
-                                    a.Type(),
-                                    *diag.borrow_mut(),
-                                    register,
-                                )
-                            }).unwrap_or(Type::Void),
-                            arg_names: s
-                                .CallbackDeclarationParameter()
-                                .map(|a| a.DeclaredIdentifier().and_then(|x| identifier_text(&x)).unwrap_or_default())
-                                .collect()
-                        }))),
-                    )
+                    let mut info = BuiltinPropertyInfo::new(Type::Callback(Rc::new(Function{
+                        args: s
+                            .CallbackDeclarationParameter()
+                            .map(|a| {
+                                object_tree::type_from_node(a.Type(), *diag.borrow_mut(), register)
+                            })
+                            .collect(),
+                        return_type: s.ReturnType().map(|a| {
+                            object_tree::type_from_node(
+                                a.Type(),
+                                *diag.borrow_mut(),
+                                register,
+                            )
+                        }).unwrap_or(Type::Void),
+                        arg_names: s
+                            .CallbackDeclarationParameter()
+                            .map(|a| a.DeclaredIdentifier().and_then(|x| identifier_text(&x)).unwrap_or_default())
+                            .collect()
+                    })));
+                    info.docs = docs::doc_comment(&s);
+                    (identifier_text(&s.DeclaredIdentifier()).unwrap(), info)
                 }))
         );
         n.deprecated_aliases = e
@@ -173,12 +174,11 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                 args.push(object_tree::type_from_node(a.Type(), *diag.borrow_mut(), register));
                 arg_names.push(identifier_text(&a.DeclaredIdentifier()).unwrap_or_default());
             }
-            (
-                name,
-                BuiltinPropertyInfo::new(Type::Function(
-                    Function { return_type, args, arg_names }.into(),
-                )),
-            )
+            let mut info = BuiltinPropertyInfo::new(Type::Function(
+                Function { return_type, args, arg_names }.into(),
+            ));
+            info.docs = docs::doc_comment(&f);
+            (name, info)
         }));
 
         let mut builtin = BuiltinElement::new(Rc::new(n));
@@ -189,6 +189,15 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
         }
         properties
             .extend(builtin.native_class.properties.iter().map(|(k, v)| (k.clone(), v.clone())));
+        let (description, body) = docs::element_doc_entries(&c, &e);
+        let parent_builtin = match &base {
+            Base::NativeParent(p) => Some(p.as_ref()),
+            _ => None,
+        };
+        // Assemble docs as [description, inherited parent body, own body].
+        // docs[0] is always the description so children can skip it
+        // with `parent.docs[1..]`.
+        builtin.docs = docs::assemble(description, parent_builtin, body);
 
         builtin.disallow_global_types_as_child_elements =
             parse_annotation("disallow_global_types_as_child_elements", &e).is_some();
@@ -291,4 +300,162 @@ fn parse_annotation(key: &str, node: &SyntaxNode) -> Option<Option<SmolStr>> {
         }
     }
     None
+}
+
+/// Extract `///` doc comments from the syntax tree of `builtins.slint`.
+mod docs {
+    use super::*;
+
+    /// Walk backwards across sibling tokens/nodes collecting consecutive
+    /// `///` doc comment lines immediately before `anchor`. Returns the
+    /// concatenated text with the `/// ` prefix stripped, or `None` if
+    /// no doc comment was present.
+    fn collect_before(anchor: &SyntaxNode) -> Option<String> {
+        let mut lines = Vec::new();
+        let mut cursor = anchor.node.prev_sibling_or_token();
+        while let Some(cur) = cursor {
+            match cur.kind() {
+                SyntaxKind::Whitespace => {}
+                SyntaxKind::Comment => {
+                    let text = cur.as_token().unwrap().text().to_string();
+                    if text.starts_with("///") {
+                        lines.push(text);
+                    } else if text.starts_with("//") {
+                        // Skip regular comments and //-annotations.
+                    } else {
+                        break;
+                    }
+                }
+                SyntaxKind::ExportsList => {
+                    // Doc comments may sit inside a preceding `export { ... }` list.
+                    if let Some(list) = cur.as_node() {
+                        let mut last = list.last_child_or_token();
+                        while let Some(child) = last {
+                            match child.kind() {
+                                SyntaxKind::Whitespace => {}
+                                SyntaxKind::Comment => {
+                                    let t = child.as_token().unwrap().text().to_string();
+                                    if t.starts_with("///") {
+                                        lines.push(t);
+                                    } else if t.starts_with("//") {
+                                        // skip
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                _ => break,
+                            }
+                            last = child.prev_sibling_or_token();
+                        }
+                    }
+                    break;
+                }
+                _ => break,
+            }
+            cursor = cur.prev_sibling_or_token();
+        }
+        if lines.is_empty() {
+            return None;
+        }
+        lines.reverse();
+        Some(
+            lines
+                .iter()
+                .map(|t| t.strip_prefix("/// ").or_else(|| t.strip_prefix("///")).unwrap_or(""))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+
+    /// Extract the `///` doc comment before a syntax node. Also checks
+    /// above the enclosing `ExportsList` when the node is inside one.
+    pub(super) fn doc_comment(anchor: &SyntaxNode) -> Option<String> {
+        if let Some(doc) = collect_before(anchor) {
+            return Some(doc);
+        }
+        if let Some(parent) = anchor.parent()
+            && parent.kind() == SyntaxKind::ExportsList
+        {
+            return collect_before(&parent);
+        }
+        None
+    }
+
+    /// Extract the `///` description before the component and the ordered
+    /// body entries (`//!` text and member references) from inside it.
+    pub(super) fn element_doc_entries(
+        component: &SyntaxNode,
+        element: &syntax_nodes::Element,
+    ) -> (Option<String>, Vec<BuiltinElementDocEntry>) {
+        let description = doc_comment(component);
+
+        let mut entries = Vec::new();
+        let mut section_lines: Vec<String> = Vec::new();
+        let flush_section = |lines: &mut Vec<String>, entries: &mut Vec<BuiltinElementDocEntry>| {
+            if !lines.is_empty() {
+                entries.push(BuiltinElementDocEntry::Text(lines.join("\n")));
+                lines.clear();
+            }
+        };
+
+        for child in element.children_with_tokens() {
+            match child.kind() {
+                SyntaxKind::Comment => {
+                    if let Some(t) = child.as_token() {
+                        let text = t.text();
+                        if let Some(content) =
+                            text.strip_prefix("//! ").or_else(|| text.strip_prefix("//!"))
+                        {
+                            section_lines.push(content.to_string());
+                        }
+                    }
+                }
+                SyntaxKind::PropertyDeclaration => {
+                    let p = syntax_nodes::PropertyDeclaration::from(child.into_node().unwrap());
+                    if p.TwoWayBinding().is_some() {
+                        continue;
+                    }
+                    flush_section(&mut section_lines, &mut entries);
+                    let name = identifier_text(&p.DeclaredIdentifier()).unwrap();
+                    entries.push(BuiltinElementDocEntry::Member(name));
+                }
+                SyntaxKind::CallbackDeclaration => {
+                    let cb = syntax_nodes::CallbackDeclaration::from(child.into_node().unwrap());
+                    if cb.TwoWayBinding().is_some() {
+                        continue;
+                    }
+                    flush_section(&mut section_lines, &mut entries);
+                    let name = identifier_text(&cb.DeclaredIdentifier()).unwrap();
+                    entries.push(BuiltinElementDocEntry::Member(name));
+                }
+                SyntaxKind::Function => {
+                    let f = syntax_nodes::Function::from(child.into_node().unwrap());
+                    flush_section(&mut section_lines, &mut entries);
+                    let name = identifier_text(&f.DeclaredIdentifier()).unwrap();
+                    entries.push(BuiltinElementDocEntry::Member(name));
+                }
+                _ => {}
+            }
+        }
+        flush_section(&mut section_lines, &mut entries);
+        (description, entries)
+    }
+
+    /// Assemble the final doc entries for an element:
+    /// `[description, inherited parent body, own body]`.
+    pub(super) fn assemble(
+        description: Option<String>,
+        parent: Option<&BuiltinElement>,
+        body: Vec<BuiltinElementDocEntry>,
+    ) -> Vec<BuiltinElementDocEntry> {
+        let desc = description.unwrap_or_default();
+        let skip_inherited = desc.contains("\\skip_inherited");
+
+        let mut result = vec![BuiltinElementDocEntry::Text(desc)];
+        if !skip_inherited && let Some(parent) = parent {
+            result.extend(parent.docs[1..].iter().cloned());
+        }
+        result.extend(body);
+        result
+    }
 }

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use crate::expression_tree::Expression;
 use crate::langtype::{
-    BuiltinElement, BuiltinElementDocEntry, BuiltinPrivateStruct, BuiltinPropertyDefault,
+    BuiltinElement, BuiltinPrivateStruct, BuiltinPropertyDefault,
     BuiltinPropertyInfo, DefaultSizeBinding, ElementType, Function, NativeClass, Type,
 };
 use crate::object_tree::{self, *};
@@ -189,7 +189,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
         }
         properties
             .extend(builtin.native_class.properties.iter().map(|(k, v)| (k.clone(), v.clone())));
-        let (description, body) = docs::element_doc_entries(&c, &e);
+        let entries = docs::element_doc_entries(&c, &e);
         let parent_builtin = match &base {
             Base::NativeParent(p) => Some(p.as_ref()),
             _ => None,
@@ -197,7 +197,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
         // Assemble docs as [description, inherited parent body, own body].
         // docs[0] is always the description so children can skip it
         // with `parent.docs[1..]`.
-        builtin.docs = docs::assemble(description, parent_builtin, body);
+        builtin.docs = docs::assemble(entries, parent_builtin);
 
         builtin.disallow_global_types_as_child_elements =
             parse_annotation("disallow_global_types_as_child_elements", &e).is_some();
@@ -302,160 +302,4 @@ fn parse_annotation(key: &str, node: &SyntaxNode) -> Option<Option<SmolStr>> {
     None
 }
 
-/// Extract `///` doc comments from the syntax tree of `builtins.slint`.
-mod docs {
-    use super::*;
-
-    /// Walk backwards across sibling tokens/nodes collecting consecutive
-    /// `///` doc comment lines immediately before `anchor`. Returns the
-    /// concatenated text with the `/// ` prefix stripped, or `None` if
-    /// no doc comment was present.
-    fn collect_before(anchor: &SyntaxNode) -> Option<String> {
-        let mut lines = Vec::new();
-        let mut cursor = anchor.node.prev_sibling_or_token();
-        while let Some(cur) = cursor {
-            match cur.kind() {
-                SyntaxKind::Whitespace => {}
-                SyntaxKind::Comment => {
-                    let text = cur.as_token().unwrap().text().to_string();
-                    if text.starts_with("///") {
-                        lines.push(text);
-                    } else if text.starts_with("//") {
-                        // Skip regular comments and //-annotations.
-                    } else {
-                        break;
-                    }
-                }
-                SyntaxKind::ExportsList => {
-                    // Doc comments may sit inside a preceding `export { ... }` list.
-                    if let Some(list) = cur.as_node() {
-                        let mut last = list.last_child_or_token();
-                        while let Some(child) = last {
-                            match child.kind() {
-                                SyntaxKind::Whitespace => {}
-                                SyntaxKind::Comment => {
-                                    let t = child.as_token().unwrap().text().to_string();
-                                    if t.starts_with("///") {
-                                        lines.push(t);
-                                    } else if t.starts_with("//") {
-                                        // skip
-                                    } else {
-                                        break;
-                                    }
-                                }
-                                _ => break,
-                            }
-                            last = child.prev_sibling_or_token();
-                        }
-                    }
-                    break;
-                }
-                _ => break,
-            }
-            cursor = cur.prev_sibling_or_token();
-        }
-        if lines.is_empty() {
-            return None;
-        }
-        lines.reverse();
-        Some(
-            lines
-                .iter()
-                .map(|t| t.strip_prefix("/// ").or_else(|| t.strip_prefix("///")).unwrap_or(""))
-                .collect::<Vec<_>>()
-                .join("\n"),
-        )
-    }
-
-    /// Extract the `///` doc comment before a syntax node. Also checks
-    /// above the enclosing `ExportsList` when the node is inside one.
-    pub(super) fn doc_comment(anchor: &SyntaxNode) -> Option<String> {
-        if let Some(doc) = collect_before(anchor) {
-            return Some(doc);
-        }
-        if let Some(parent) = anchor.parent()
-            && parent.kind() == SyntaxKind::ExportsList
-        {
-            return collect_before(&parent);
-        }
-        None
-    }
-
-    /// Extract the `///` description before the component and the ordered
-    /// body entries (`//!` text and member references) from inside it.
-    pub(super) fn element_doc_entries(
-        component: &SyntaxNode,
-        element: &syntax_nodes::Element,
-    ) -> (Option<String>, Vec<BuiltinElementDocEntry>) {
-        let description = doc_comment(component);
-
-        let mut entries = Vec::new();
-        let mut section_lines: Vec<String> = Vec::new();
-        let flush_section = |lines: &mut Vec<String>, entries: &mut Vec<BuiltinElementDocEntry>| {
-            if !lines.is_empty() {
-                entries.push(BuiltinElementDocEntry::Text(lines.join("\n")));
-                lines.clear();
-            }
-        };
-
-        for child in element.children_with_tokens() {
-            match child.kind() {
-                SyntaxKind::Comment => {
-                    if let Some(t) = child.as_token() {
-                        let text = t.text();
-                        if let Some(content) =
-                            text.strip_prefix("//! ").or_else(|| text.strip_prefix("//!"))
-                        {
-                            section_lines.push(content.to_string());
-                        }
-                    }
-                }
-                SyntaxKind::PropertyDeclaration => {
-                    let p = syntax_nodes::PropertyDeclaration::from(child.into_node().unwrap());
-                    if p.TwoWayBinding().is_some() {
-                        continue;
-                    }
-                    flush_section(&mut section_lines, &mut entries);
-                    let name = identifier_text(&p.DeclaredIdentifier()).unwrap();
-                    entries.push(BuiltinElementDocEntry::Member(name));
-                }
-                SyntaxKind::CallbackDeclaration => {
-                    let cb = syntax_nodes::CallbackDeclaration::from(child.into_node().unwrap());
-                    if cb.TwoWayBinding().is_some() {
-                        continue;
-                    }
-                    flush_section(&mut section_lines, &mut entries);
-                    let name = identifier_text(&cb.DeclaredIdentifier()).unwrap();
-                    entries.push(BuiltinElementDocEntry::Member(name));
-                }
-                SyntaxKind::Function => {
-                    let f = syntax_nodes::Function::from(child.into_node().unwrap());
-                    flush_section(&mut section_lines, &mut entries);
-                    let name = identifier_text(&f.DeclaredIdentifier()).unwrap();
-                    entries.push(BuiltinElementDocEntry::Member(name));
-                }
-                _ => {}
-            }
-        }
-        flush_section(&mut section_lines, &mut entries);
-        (description, entries)
-    }
-
-    /// Assemble the final doc entries for an element:
-    /// `[description, inherited parent body, own body]`.
-    pub(super) fn assemble(
-        description: Option<String>,
-        parent: Option<&BuiltinElement>,
-        body: Vec<BuiltinElementDocEntry>,
-    ) -> Vec<BuiltinElementDocEntry> {
-        let desc = description.unwrap_or_default();
-        let skip_inherited = desc.contains("\\skip_inherited");
-
-        let mut result = vec![BuiltinElementDocEntry::Text(desc)];
-        if !skip_inherited && let Some(parent) = parent {
-            result.extend(parent.docs[1..].iter().cloned());
-        }
-        result.extend(body);
-        result
-    }
-}
+use crate::doc_comments as docs;

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -12,8 +12,8 @@ use std::rc::Rc;
 
 use crate::expression_tree::Expression;
 use crate::langtype::{
-    BuiltinElement, BuiltinPrivateStruct, BuiltinPropertyDefault,
-    BuiltinPropertyInfo, DefaultSizeBinding, ElementType, Function, NativeClass, Type,
+    BuiltinElement, BuiltinPrivateStruct, BuiltinPropertyDefault, BuiltinPropertyInfo,
+    DefaultSizeBinding, ElementType, Function, NativeClass, Type,
 };
 use crate::object_tree::{self, *};
 use crate::parser::{SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -189,7 +189,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
         }
         properties
             .extend(builtin.native_class.properties.iter().map(|(k, v)| (k.clone(), v.clone())));
-        let entries = docs::element_doc_entries(&c, &e);
+        let entries = docs::element_doc_entries(&c, &e, &mut diag.borrow_mut());
         let parent_builtin = match &base {
             Base::NativeParent(p) => Some(p.as_ref()),
             _ => None,

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -551,16 +551,21 @@ impl TypeRegister {
         match &mut register.elements.get_mut("Timer").unwrap() {
             ElementType::Builtin(b) => {
                 let timer = Rc::get_mut(b).unwrap();
-                timer
-                    .properties
-                    .insert("start".into(), BuiltinPropertyInfo::from(BuiltinFunction::StartTimer));
-                timer
-                    .properties
-                    .insert("stop".into(), BuiltinPropertyInfo::from(BuiltinFunction::StopTimer));
-                timer.properties.insert(
-                    "restart".into(),
-                    BuiltinPropertyInfo::from(BuiltinFunction::RestartTimer),
-                );
+                // `start` / `stop` / `restart` are declared as stub
+                // functions in `builtins.slint` so their doc comments get
+                // picked up, then replaced here with the real builtin
+                // implementations. Carry the docs over onto the
+                // replacements.
+                for (name, func) in [
+                    ("start", BuiltinFunction::StartTimer),
+                    ("stop", BuiltinFunction::StopTimer),
+                    ("restart", BuiltinFunction::RestartTimer),
+                ] {
+                    let existing_docs = timer.properties.get(name).and_then(|p| p.docs.clone());
+                    let mut info = BuiltinPropertyInfo::from(func);
+                    info.docs = existing_docs;
+                    timer.properties.insert(name.into(), info);
+                }
             }
             _ => unreachable!(),
         }
@@ -577,15 +582,32 @@ impl TypeRegister {
                     source_location: None,
                 }
             }),
+            docs: None,
         };
 
         match &mut register.elements.get_mut("TextInput").unwrap() {
             ElementType::Builtin(b) => {
                 let text_input = Rc::get_mut(b).unwrap();
-                text_input.properties.insert(
-                    "set-selection-offsets".into(),
-                    BuiltinPropertyInfo::from(BuiltinFunction::SetSelectionOffsets),
-                );
+                // Replace the stub function with the real builtin
+                // implementation, carrying over docs and arg names.
+                let existing = text_input.properties.get("set-selection-offsets");
+                let existing_docs = existing.and_then(|p| p.docs.clone());
+                let arg_names = existing.and_then(|p| {
+                    if let Type::Function(f) = &p.ty { Some(f.arg_names.clone()) } else { None }
+                });
+                let mut info = BuiltinPropertyInfo::from(BuiltinFunction::SetSelectionOffsets);
+                info.docs = existing_docs;
+                if let (Some(names), Type::Function(f)) = (arg_names, &info.ty) {
+                    let mut func = (**f).clone();
+                    // The BuiltinFunction type includes an implicit ElementReference
+                    // first arg; skip it to match the public-facing arg names.
+                    func.arg_names =
+                        std::iter::repeat_n(SmolStr::default(), func.args.len() - names.len())
+                            .chain(names)
+                            .collect();
+                    info.ty = Type::Function(Rc::new(func));
+                }
+                text_input.properties.insert("set-selection-offsets".into(), info);
                 text_input.properties.insert("font-metrics".into(), font_metrics_prop.clone());
             }
 

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -120,7 +120,7 @@
         "href": "guide/backends-and-renderers/backend_linuxkms/"
     },
     "MenuBar": {
-        "href": "reference/window/menubar/"
+        "href": "reference/window/window/#menubar"
     },
     "Menu": {
         "href": "reference/window/contextmenuarea/#menu"

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -1782,7 +1782,7 @@ mod tests {
             ("add(..)", "add(${1:a}, ${2:b})"),
             ("caller()", "caller()"),
             ("clear-focus()", "clear-focus()"),
-            ("set-selection-offsets(..)", "set-selection-offsets(${1:int}, ${2:int})"),
+            ("set-selection-offsets(..)", "set-selection-offsets(${1:start}, ${2:end})"),
             ("my-callback(..)", "my-callback(${1:hello}, ${2:world})"),
         ]
         .map(|(label, insert_text)| CompletionItem {

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -413,7 +413,7 @@ export component Test { // not docs
         );
         // builtin property: signature + doc from builtins.slint
         let bg_tip = get_tooltip(&mut dc, find_tk("background: red", 0.into()));
-        assert_tooltip_contains(bg_tip.clone(), "property <brush> background");
+        assert_tooltip_contains(bg_tip.clone(), "```slint\nproperty <brush> background\n```");
         assert_tooltip_contains(bg_tip, "background brush"); // doc text
         // callbacks
         assert_tooltip(
@@ -434,7 +434,7 @@ export component Test { // not docs
         );
         assert_tooltip_contains(
             get_tooltip(&mut dc, find_tk("pointer-event", 5.into())),
-            "callback pointer-event(event: PointerEvent)",
+            "```slint\ncallback pointer-event(event: PointerEvent)\n```",
         );
         // functions
         assert_tooltip(

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -6,7 +6,8 @@ use crate::common::{
     token_info::{TokenInfo, token_info},
 };
 use crate::util;
-use i_slint_compiler::langtype::{BuiltinElement, ElementDocEntry, ElementType, Type};
+use i_slint_compiler::doc_comments::ElementDocEntry;
+use i_slint_compiler::langtype::{BuiltinElement, ElementType, Type};
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken};
 use itertools::Itertools as _;

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -168,7 +168,13 @@ fn from_property_in_element(
 }
 
 fn builtin_element_description(b: &BuiltinElement) -> &str {
-    b.docs.iter().find_map(|e| match e { ElementDocEntry::Text(t) => Some(t.as_str()), _ => None }).unwrap_or("")
+    b.docs
+        .iter()
+        .find_map(|e| match e {
+            ElementDocEntry::Text(t) => Some(t.as_str()),
+            _ => None,
+        })
+        .unwrap_or("")
 }
 
 /// Extract the prose description from a raw builtins.slint doc comment,

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -6,7 +6,7 @@ use crate::common::{
     token_info::{TokenInfo, token_info},
 };
 use crate::util;
-use i_slint_compiler::langtype::{BuiltinElement, BuiltinElementDocEntry, ElementType, Type};
+use i_slint_compiler::langtype::{BuiltinElement, ElementDocEntry, ElementType, Type};
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken};
 use itertools::Itertools as _;
@@ -37,7 +37,7 @@ pub fn get_tooltip(
             }
             ElementType::Builtin(b) => {
                 let raw = builtin_element_description(&b);
-                let cleaned = clean_builtin_doc(&raw);
+                let cleaned = clean_builtin_doc(raw);
                 let doc = if cleaned.is_empty() { None } else { Some(cleaned.as_str()) };
                 if b.is_global {
                     from_slint_code(&format!("global {}", b.name), doc)
@@ -167,15 +167,8 @@ fn from_property_in_element(
     from_property_in_type(&element.borrow().base_type, name, documentation)
 }
 
-/// Extract the first `Text` entry from a builtin element's doc entries.
-/// This is the `///` description before the element declaration.
-fn builtin_element_description(b: &BuiltinElement) -> String {
-    for entry in &b.docs {
-        if let BuiltinElementDocEntry::Text(text) = entry {
-            return text.clone();
-        }
-    }
-    String::new()
+fn builtin_element_description(b: &BuiltinElement) -> &str {
+    b.docs.iter().find_map(|e| match e { ElementDocEntry::Text(t) => Some(t.as_str()), _ => None }).unwrap_or("")
 }
 
 /// Extract the prose description from a raw builtins.slint doc comment,
@@ -186,7 +179,7 @@ fn clean_builtin_doc(raw: &str) -> String {
     let mut in_fence = false;
     for line in raw.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") || trimmed.starts_with(":::") {
             in_fence = !in_fence;
             continue;
         }

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -6,7 +6,7 @@ use crate::common::{
     token_info::{TokenInfo, token_info},
 };
 use crate::util;
-use i_slint_compiler::langtype::{ElementType, Type};
+use i_slint_compiler::langtype::{BuiltinElement, BuiltinElementDocEntry, ElementType, Type};
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken};
 use itertools::Itertools as _;
@@ -35,7 +35,16 @@ pub fn get_tooltip(
                     from_slint_code(&format!("component {}", c.id), documentation)
                 }
             }
-            ElementType::Builtin(b) => from_plain_text(format!("{} (builtin)", b.name)),
+            ElementType::Builtin(b) => {
+                let raw = builtin_element_description(&b);
+                let cleaned = clean_builtin_doc(&raw);
+                let doc = if cleaned.is_empty() { None } else { Some(cleaned.as_str()) };
+                if b.is_global {
+                    from_slint_code(&format!("global {}", b.name), doc)
+                } else {
+                    from_slint_code(&format!("component {} (builtin)", b.name), doc)
+                }
+            }
             _ => return None,
         },
         TokenInfo::ElementRc(e) => {
@@ -158,6 +167,50 @@ fn from_property_in_element(
     from_property_in_type(&element.borrow().base_type, name, documentation)
 }
 
+/// Extract the first `Text` entry from a builtin element's doc entries.
+/// This is the `///` description before the element declaration.
+fn builtin_element_description(b: &BuiltinElement) -> String {
+    for entry in &b.docs {
+        if let BuiltinElementDocEntry::Text(text) = entry {
+            return text.clone();
+        }
+    }
+    String::new()
+}
+
+/// Extract the prose description from a raw builtins.slint doc comment,
+/// stripping code fences, `\`-annotations, and `<Component />` MDX tags
+/// that don't render well in a tooltip.
+fn clean_builtin_doc(raw: &str) -> String {
+    let mut result = String::new();
+    let mut in_fence = false;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if trimmed.starts_with('\\') {
+            continue;
+        }
+        if trimmed.starts_with('<') && trimmed.ends_with("/>") {
+            continue;
+        }
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        result.push_str(line);
+    }
+    // Trim trailing blank lines.
+    while result.ends_with('\n') {
+        result.pop();
+    }
+    result
+}
+
 fn from_property_in_type(
     base: &ElementType,
     name: &str,
@@ -168,7 +221,15 @@ fn from_property_in_type(
         ElementType::Builtin(b) => {
             let resolved_name = b.native_class.lookup_alias(name).unwrap_or(name);
             let info = b.properties.get(resolved_name)?;
-            property_tooltip(&info.ty, name, false, documentation)
+            let cleaned;
+            let builtin_doc = match &info.docs {
+                Some(raw) => {
+                    cleaned = clean_builtin_doc(raw);
+                    if cleaned.is_empty() { None } else { Some(cleaned.as_str()) }
+                }
+                None => None,
+            };
+            property_tooltip(&info.ty, name, false, documentation.or(builtin_doc))
         }
         _ => None,
     }
@@ -214,12 +275,22 @@ fn from_plain_text(value: String) -> MarkupContent {
     MarkupContent { kind: lsp_types::MarkupKind::PlainText, value }
 }
 
+/// Format a tooltip with a Slint code signature and optional documentation.
+/// User-written `//` comments go inside the code fence (they're valid Slint).
+/// Builtin docs (plain prose) go outside as markdown.
 fn from_slint_code(value: &str, documentation: Option<&str>) -> MarkupContent {
-    let documentation = documentation.unwrap_or("");
-    MarkupContent {
-        kind: lsp_types::MarkupKind::Markdown,
-        value: format!("```slint\n{documentation}{value}\n```"),
-    }
+    let doc = documentation.unwrap_or("");
+    let value = if doc.is_empty() {
+        format!("```slint\n{value}\n```")
+    } else if doc.starts_with("//") || doc.starts_with("/*") {
+        // User-written comment — keep inside the code fence.
+        let sep = if doc.ends_with('\n') { "" } else { "\n" };
+        format!("```slint\n{doc}{sep}{value}\n```")
+    } else {
+        // Builtin doc — render as markdown above the code fence.
+        format!("{doc}\n```slint\n{value}\n```")
+    };
+    MarkupContent { kind: lsp_types::MarkupKind::Markdown, value }
 }
 
 #[cfg(test)]
@@ -308,6 +379,18 @@ export component Test { // not docs
             }
         }
 
+        #[track_caller]
+        fn assert_tooltip_contains(h: Option<Hover>, expected: &str) {
+            match h.unwrap().contents {
+                HoverContents::Markup(m) => assert!(
+                    m.value.contains(expected),
+                    "expected tooltip to contain {expected:?} but got {:?}",
+                    m.value
+                ),
+                x => panic!("Found {x:?} ({expected})"),
+            }
+        }
+
         // properties
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("hello: Glob", 0.into())),
@@ -317,10 +400,10 @@ export component Test { // not docs
             get_tooltip(&mut dc, find_tk("Glob.hello_world", 8.into())),
             "```slint\nproperty <{ a: int,b: float,}> hello-world\n```",
         );
-        assert_tooltip(
-            get_tooltip(&mut dc, find_tk("self.enabled", 5.into())),
-            "```slint\nproperty <bool> enabled\n```",
-        );
+        // builtin property: signature + doc from builtins.slint
+        let enabled_tip = get_tooltip(&mut dc, find_tk("self.enabled", 5.into()));
+        assert_tooltip_contains(enabled_tip.clone(), "property <bool> enabled");
+        assert_tooltip_contains(enabled_tip, "TouchArea"); // doc mentions TouchArea
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("fn_glob(local-prop)", 10.into())),
             "```slint\nproperty <int> local-prop\n```",
@@ -329,10 +412,10 @@ export component Test { // not docs
             get_tooltip(&mut dc, find_tk("root-prop.to-float", 1.into())),
             "```slint\n// root-prop is a property\nproperty <string> root-prop\n```",
         );
-        assert_tooltip(
-            get_tooltip(&mut dc, find_tk("background: red", 0.into())),
-            "```slint\nproperty <brush> background\n```",
-        );
+        // builtin property: signature + doc from builtins.slint
+        let bg_tip = get_tooltip(&mut dc, find_tk("background: red", 0.into()));
+        assert_tooltip_contains(bg_tip.clone(), "property <brush> background");
+        assert_tooltip_contains(bg_tip, "background brush"); // doc text
         // callbacks
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("self.www", 5.into())),
@@ -350,9 +433,9 @@ export component Test { // not docs
             get_tooltip(&mut dc, find_tk("row-pointer-event", 0.into())),
             "```slint\ncallback row-pointer-event(row: int, event: PointerEvent, position: Point)\n```",
         );
-        assert_tooltip(
+        assert_tooltip_contains(
             get_tooltip(&mut dc, find_tk("pointer-event", 5.into())),
-            "```slint\ncallback pointer-event(event: PointerEvent)\n```",
+            "callback pointer-event(event: PointerEvent)",
         );
         // functions
         assert_tooltip(
@@ -379,9 +462,9 @@ export component Test { // not docs
         );
 
         //components
-        assert_tooltip(
+        assert_tooltip_contains(
             get_tooltip(&mut dc, find_tk("Rectangle {", 8.into())),
-            "Rectangle (builtin)",
+            "component Rectangle (builtin)",
         );
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("the-ta := TA {", 11.into())),


### PR DESCRIPTION
Extract `///` doc comments from builtins.slint in load_builtins and store the raw text on BuiltinElement and BuiltinPropertyInfo so the LSP can show documentation tooltips for builtin elements and their properties/callbacks/functions.


Note: To simplify things, this moves the `MenuBar` to the `Window` documentation.
(And fix the Path/FocusScope docs that somehow was broken)
