### PR TITLE
SystemTrayIcon: expose host-shell color scheme as out-property and im…

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -611,7 +611,7 @@ fn gen_corelib(
             "slint_windowrc_set_logical_size",
             "slint_windowrc_set_physical_size",
             "slint_windowrc_color_scheme",
-            "slint_windowrc_accent_color",
+            "slint_accent_color",
             "slint_windowrc_supports_native_menu_bar",
             "slint_windowrc_setup_native_menu_bar",
             "slint_windowrc_setup_menu_bar_shortcuts",

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -610,8 +610,6 @@ fn gen_corelib(
             "slint_windowrc_size",
             "slint_windowrc_set_logical_size",
             "slint_windowrc_set_physical_size",
-            "slint_resolve_color_scheme",
-            "slint_accent_color",
             "slint_windowrc_supports_native_menu_bar",
             "slint_windowrc_setup_native_menu_bar",
             "slint_windowrc_setup_menu_bar_shortcuts",

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -610,7 +610,7 @@ fn gen_corelib(
             "slint_windowrc_size",
             "slint_windowrc_set_logical_size",
             "slint_windowrc_set_physical_size",
-            "slint_windowrc_color_scheme",
+            "slint_resolve_color_scheme",
             "slint_accent_color",
             "slint_windowrc_supports_native_menu_bar",
             "slint_windowrc_setup_native_menu_bar",

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -118,10 +118,6 @@ public:
         slint_windowrc_set_const_scale_factor(&inner, value);
     }
 
-    cbindgen_private::ColorScheme color_scheme() const
-    {
-        return slint_windowrc_color_scheme(&inner);
-    }
     bool supports_native_menu_bar() const
     {
         return slint_windowrc_supports_native_menu_bar(&inner);

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -122,12 +122,6 @@ public:
     {
         return slint_windowrc_color_scheme(&inner);
     }
-    Color accent_color() const
-    {
-        Color col;
-        slint_windowrc_accent_color(&inner, &col);
-        return col;
-    }
     bool supports_native_menu_bar() const
     {
         return slint_windowrc_supports_native_menu_bar(&inner);

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -39,6 +39,21 @@ pub use i_slint_backend_testing;
 pub use slint_interpreter;
 
 #[unsafe(no_mangle)]
+pub extern "C" fn slint_context_accent_color(
+    root: &i_slint_core::item_tree::ItemTreeRc,
+    out: &mut i_slint_core::graphics::Color,
+) {
+    *out = i_slint_core::window::accent_color(root);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_context_color_scheme(
+    root: &i_slint_core::item_tree::ItemTreeRc,
+) -> i_slint_core::items::ColorScheme {
+    i_slint_core::window::resolve_color_scheme(root)
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {
     assert_eq!(
         core::mem::size_of::<Rc<dyn WindowAdapter>>(),

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -50,7 +50,8 @@ pub extern "C" fn slint_context_accent_color(
 pub extern "C" fn slint_context_color_scheme(
     root: &i_slint_core::item_tree::ItemTreeRc,
 ) -> i_slint_core::items::ColorScheme {
-    i_slint_core::window::resolve_color_scheme(root)
+    i_slint_core::window::context_for_root(root)
+        .map_or(i_slint_core::items::ColorScheme::Unknown, |ctx| ctx.color_scheme(Some(root)))
 }
 
 #[unsafe(no_mangle)]

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -211,7 +211,7 @@ pub mod re_exports {
         set_bundled_languages, translate_from_bundle, translate_from_bundle_with_plural,
     };
     pub use i_slint_core::window::{
-        InputMethodRequest, WindowAdapter, WindowAdapterRc, WindowInner,
+        InputMethodRequest, WindowAdapter, WindowAdapterRc, WindowInner, accent_color,
     };
     pub use i_slint_core::{
         Color, Coord, SharedString, SharedVector, format, string::ToSharedString,

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -212,7 +212,7 @@ pub mod re_exports {
     };
     pub use i_slint_core::window::{
         InputMethodRequest, WindowAdapter, WindowAdapterRc, WindowInner, accent_color,
-        resolve_color_scheme,
+        context_for_root,
     };
     pub use i_slint_core::{
         Color, Coord, SharedString, SharedVector, format, string::ToSharedString,

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -212,6 +212,7 @@ pub mod re_exports {
     };
     pub use i_slint_core::window::{
         InputMethodRequest, WindowAdapter, WindowAdapterRc, WindowInner, accent_color,
+        resolve_color_scheme,
     };
     pub use i_slint_core::{
         Color, Coord, SharedString, SharedVector, format, string::ToSharedString,

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -38,7 +38,6 @@ pub struct AndroidWindowAdapter {
     pub(crate) event_queue: EventQueue,
     pub(crate) pending_redraw: Cell<bool>,
     pub(super) java_helper: JavaHelper,
-    pub(crate) color_scheme: core::pin::Pin<Box<Property<ColorScheme>>>,
     pub(crate) fullscreen: Cell<bool>,
     /// The offset at which the Slint view is drawn in the native window (account for status bar)
     pub offset: Cell<PhysicalPosition>,
@@ -164,10 +163,6 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
         });
     }
 
-    fn color_scheme(&self) -> ColorScheme {
-        self.color_scheme.as_ref().get()
-    }
-
     fn accent_color(&self) -> Color {
         self.java_helper.accent_color().unwrap_or_else(|e| print_jni_error(&self.app, e))
     }
@@ -184,15 +179,14 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
 impl AndroidWindowAdapter {
     pub fn new(app: AndroidApp) -> Rc<Self> {
         let java_helper = JavaHelper::new(&app).unwrap_or_else(|e| print_jni_error(&app, e));
-        let color_scheme = Box::pin(Property::new(
+        let initial_scheme =
             match java_helper.color_scheme().unwrap_or_else(|e| print_jni_error(&app, e)) {
                 0x10 => ColorScheme::Light,  // UI_MODE_NIGHT_NO(0x10)
                 0x20 => ColorScheme::Dark,   // UI_MODE_NIGHT_YES(0x20)
                 0x0 => ColorScheme::Unknown, // UI_MODE_NIGHT_UNDEFINED
                 _ => ColorScheme::Unknown,
-            },
-        ));
-        Rc::<Self>::new_cyclic(|w| Self {
+            };
+        let rc = Rc::<Self>::new_cyclic(|w| Self {
             app,
             window: Window::new(w.clone()),
             #[cfg(not(any(feature = "unstable-wgpu-27", feature = "unstable-wgpu-28")))]
@@ -204,14 +198,17 @@ impl AndroidWindowAdapter {
             requested_graphics_api: RefCell::new(None),
             event_queue: Default::default(),
             pending_redraw: Default::default(),
-            color_scheme,
             java_helper,
             fullscreen: Cell::new(false),
             offset: Default::default(),
             show_cursor_handles: Cell::new(false),
             long_press: RefCell::default(),
             last_pressed_state: Cell::new(ButtonState(0)),
-        })
+        });
+        i_slint_core::window::WindowInner::from_pub(&rc.window)
+            .context()
+            .set_color_scheme(initial_scheme);
+        rc
     }
 
     pub fn process_event(&self, event: &PollEvent<'_>) -> Result<ControlFlow<()>, PlatformError> {

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -10,7 +10,6 @@ use android_activity::{InputStatus, MainEvent, PollEvent};
 use i_slint_core::api::{
     LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, PlatformError, Window,
 };
-use i_slint_core::graphics::Color;
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventResult, KeyEventType, TouchPhase};
 use i_slint_core::items::ColorScheme;
 use i_slint_core::lengths::PhysicalEdges;
@@ -163,10 +162,6 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
         });
     }
 
-    fn accent_color(&self) -> Color {
-        self.java_helper.accent_color().unwrap_or_else(|e| print_jni_error(&self.app, e))
-    }
-
     fn safe_area_inset(&self) -> PhysicalEdges {
         if self.fullscreen.get() {
             Default::default()
@@ -186,6 +181,8 @@ impl AndroidWindowAdapter {
                 0x0 => ColorScheme::Unknown, // UI_MODE_NIGHT_UNDEFINED
                 _ => ColorScheme::Unknown,
             };
+        let initial_accent =
+            java_helper.accent_color().unwrap_or_else(|e| print_jni_error(&app, e));
         let rc = Rc::<Self>::new_cyclic(|w| Self {
             app,
             window: Window::new(w.clone()),
@@ -205,9 +202,9 @@ impl AndroidWindowAdapter {
             long_press: RefCell::default(),
             last_pressed_state: Cell::new(ButtonState(0)),
         });
-        i_slint_core::window::WindowInner::from_pub(&rc.window)
-            .context()
-            .set_color_scheme(initial_scheme);
+        let ctx = i_slint_core::window::WindowInner::from_pub(&rc.window).context();
+        ctx.set_color_scheme(initial_scheme);
+        ctx.set_accent_color(initial_accent);
         rc
     }
 

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -565,9 +565,11 @@ fn callback_set_night_mode<'local>(
                 0x0 => ColorScheme::Unknown, // UI_MODE_NIGHT_UNDEFINED
                 _ => ColorScheme::Unknown,
             };
-            i_slint_core::window::WindowInner::from_pub(&w.window)
-                .context()
-                .set_color_scheme(scheme);
+            let ctx = i_slint_core::window::WindowInner::from_pub(&w.window).context();
+            ctx.set_color_scheme(scheme);
+            if let Ok(accent) = w.java_helper.accent_color() {
+                ctx.set_accent_color(accent);
+            }
         }
     })
     .unwrap();

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -559,12 +559,15 @@ fn callback_set_night_mode<'local>(
 ) -> Result<(), jni::errors::Error> {
     i_slint_core::api::invoke_from_event_loop(move || {
         if let Some(w) = CURRENT_WINDOW.with_borrow(|x| x.upgrade()) {
-            w.color_scheme.as_ref().set(match night_mode {
+            let scheme = match night_mode {
                 0x10 => ColorScheme::Light,  // UI_MODE_NIGHT_NO(0x10)
                 0x20 => ColorScheme::Dark,   // UI_MODE_NIGHT_YES(0x20)
                 0x0 => ColorScheme::Unknown, // UI_MODE_NIGHT_UNDEFINED
                 _ => ColorScheme::Unknown,
-            });
+            };
+            i_slint_core::window::WindowInner::from_pub(&w.window)
+                .context()
+                .set_color_scheme(scheme);
         }
     })
     .unwrap();

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -19,6 +19,16 @@ use std::rc::Rc;
 use std::sync::{Arc, atomic::AtomicUsize};
 
 #[cfg(not(no_qt))]
+thread_local! {
+    /// Set once by [`Backend::bind_context`]; read from rust!() callbacks fired by the
+    /// Qt event filter installed on `qApp` so palette/theme changes can push the new
+    /// values onto the process-wide [`i_slint_core::SlintContext`] without going through
+    /// any specific [`qt_window::QtWindow`].
+    static QT_CONTEXT: std::cell::OnceCell<i_slint_core::SlintContextWeak> =
+        const { std::cell::OnceCell::new() };
+}
+
+#[cfg(not(no_qt))]
 mod qt_accessible;
 #[cfg(not(no_qt))]
 mod qt_widgets;
@@ -165,6 +175,20 @@ impl Backend {
 }
 
 impl i_slint_core::platform::Platform for Backend {
+    #[cfg(not(no_qt))]
+    fn bind_context(&self, ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
+        QT_CONTEXT.with(|cell| {
+            let _ = cell.set(ctx);
+        });
+        // Read the host shell's current values once and push them to the context, then
+        // install an `qApp`-level event filter that re-pushes whenever Qt reports a
+        // theme/palette change. The previous design did the read in `QtWindow::new` and
+        // the change-tracking in each window's `changeEvent`, which is wasteful when
+        // there are multiple windows and outright broken when there are zero windows.
+        update_palette_state();
+        install_palette_observer();
+    }
+
     fn create_window_adapter(
         &self,
     ) -> Result<Rc<dyn i_slint_core::window::WindowAdapter>, PlatformError> {
@@ -368,6 +392,64 @@ impl i_slint_core::platform::Platform for Backend {
             Err(i_slint_core::platform::PlatformError::Other("Failed to open URL".into()))
         }
     }
+}
+
+#[cfg(not(no_qt))]
+fn update_palette_state() {
+    use cpp::cpp;
+    let dark = cpp! {unsafe [] -> bool as "bool" {
+        return qApp->palette().color(QPalette::Window).valueF() < 0.5;
+    }};
+    let argb = cpp! {unsafe [] -> u32 as "QRgb" {
+        #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            return qApp->palette().color(QPalette::Accent).rgba();
+        #else
+            return qApp->palette().color(QPalette::Highlight).rgba();
+        #endif
+    }};
+    let scheme = if dark {
+        i_slint_core::items::ColorScheme::Dark
+    } else {
+        i_slint_core::items::ColorScheme::Light
+    };
+    let accent = i_slint_core::graphics::Color::from_argb_encoded(argb);
+    QT_CONTEXT.with(|cell| {
+        if let Some(ctx) = cell.get().and_then(|w| w.upgrade()) {
+            ctx.set_color_scheme(scheme);
+            ctx.set_accent_color(accent);
+        }
+    });
+}
+
+#[cfg(not(no_qt))]
+fn install_palette_observer() {
+    use cpp::cpp;
+    cpp! {{
+        #include <QtCore/QEvent>
+        #include <QtCore/QObject>
+        #include <QtWidgets/QApplication>
+
+        struct SlintPaletteObserver : QObject {
+            using QObject::QObject;
+            bool eventFilter(QObject *watched, QEvent *event) override {
+                if (watched == qApp
+                    && (event->type() == QEvent::ApplicationPaletteChange
+                        || event->type() == QEvent::ThemeChange)) {
+                    rust!(Slint_qt_palette_changed [] {
+                        crate::update_palette_state();
+                    });
+                }
+                return false;
+            }
+        };
+    }};
+    cpp! {unsafe [] {
+        ensure_initialized(true);
+        // Parented to qApp so it lives as long as the application and is cleaned up
+        // automatically on exit. installEventFilter doesn't take ownership.
+        auto *observer = new SlintPaletteObserver(qApp);
+        qApp->installEventFilter(observer);
+    }};
 }
 
 /// This helper trait can be used to obtain access to a pointer to a QtWidget for a given

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1862,7 +1862,19 @@ impl QtWindow {
         } else {
             ColorScheme::Light
         };
-        WindowInner::from_pub(&rc.window).context().set_color_scheme(initial_scheme);
+        let initial_accent = {
+            let argb = cpp! {unsafe [] -> u32 as "QRgb" {
+                #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+                    return qApp->palette().color(QPalette::Accent).rgba();
+                #else
+                    return qApp->palette().color(QPalette::Highlight).rgba();
+                #endif
+            }};
+            i_slint_core::graphics::Color::from_argb_encoded(argb)
+        };
+        let ctx = WindowInner::from_pub(&rc.window).context();
+        ctx.set_color_scheme(initial_scheme);
+        ctx.set_accent_color(initial_accent);
 
         rc
     }
@@ -2354,17 +2366,6 @@ impl WindowAdapterInternal for QtWindow {
                 }
             }};
         }
-    }
-
-    fn accent_color(&self) -> i_slint_core::graphics::Color {
-        let argb = cpp! {unsafe [] -> u32 as "QRgb" {
-            #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-                return qApp->palette().color(QPalette::Accent).rgba();
-            #else
-                return qApp->palette().color(QPalette::Highlight).rgba();
-            #endif
-        }};
-        i_slint_core::graphics::Color::from_argb_encoded(argb)
     }
 
     fn bring_to_front(&self) -> Result<(), i_slint_core::platform::PlatformError> {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -21,8 +21,8 @@ use i_slint_core::item_tree::{
     ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeWeak, ParentItemTraversalMode,
 };
 use i_slint_core::items::{
-    self, ColorScheme, FillRule, ImageRendering, ItemRc, ItemRef, Layer, LineCap, LineJoin,
-    MouseCursor, Opacity, PointerEventButton, RenderingResult, TextWrap,
+    self, FillRule, ImageRendering, ItemRc, ItemRef, Layer, LineCap, LineJoin, MouseCursor,
+    Opacity, PointerEventButton, RenderingResult, TextWrap,
 };
 use i_slint_core::layout::Orientation;
 use i_slint_core::lengths::{
@@ -32,7 +32,7 @@ use i_slint_core::lengths::{
 use i_slint_core::platform::{PlatformError, WindowEvent};
 use i_slint_core::textlayout::sharedparley::{self, GlyphRenderer, fontique, parley};
 use i_slint_core::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
-use i_slint_core::{ImageInner, Property, SharedString};
+use i_slint_core::{ImageInner, SharedString};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -42,7 +42,6 @@ use std::rc::{Rc, Weak};
 
 use crate::key_generated;
 use i_slint_core::renderer::Renderer;
-use std::cell::OnceCell;
 
 cpp! {{
     // Note: Do not include <QtWidgets> to avoid inclusion of gl.h (see #10989).
@@ -285,17 +284,6 @@ cpp! {{
                 bool active = isActiveWindow();
                 rust!(Slint_updateWindowActivation [rust_window: &QtWindow as "void*", active: bool as "bool"] {
                     rust_window.window.dispatch_event(WindowEvent::WindowActiveChanged(active));
-                });
-            } else if (event->type() == QEvent::PaletteChange || event->type() == QEvent::StyleChange) {
-                bool dark_color_scheme = qApp->palette().color(QPalette::Window).valueF() < 0.5;
-                rust!(Slint_updateWindowDarkColorScheme [rust_window: &QtWindow as "void*", dark_color_scheme: bool as "bool"] {
-                    if let Some(ds) = rust_window.color_scheme.get() {
-                        ds.as_ref().set(if dark_color_scheme {
-                            ColorScheme::Dark
-                        } else {
-                            ColorScheme::Light
-                        });
-                    }
                 });
             }
 
@@ -1854,28 +1842,6 @@ impl QtWindow {
             widget_ptr->rust_window = rust_window;
         }};
         ALL_WINDOWS.with(|aw| aw.borrow_mut().push(rc.self_weak.clone()));
-
-        let initial_scheme = if cpp! {unsafe [] -> bool as "bool" {
-            return qApp->palette().color(QPalette::Window).valueF() < 0.5;
-        }} {
-            ColorScheme::Dark
-        } else {
-            ColorScheme::Light
-        };
-        let initial_accent = {
-            let argb = cpp! {unsafe [] -> u32 as "QRgb" {
-                #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-                    return qApp->palette().color(QPalette::Accent).rgba();
-                #else
-                    return qApp->palette().color(QPalette::Highlight).rgba();
-                #endif
-            }};
-            i_slint_core::graphics::Color::from_argb_encoded(argb)
-        };
-        let ctx = WindowInner::from_pub(&rc.window).context();
-        ctx.set_color_scheme(initial_scheme);
-        ctx.set_accent_color(initial_accent);
-
         rc
     }
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1806,8 +1806,6 @@ pub struct QtWindow {
 
     tree_structure_changed: RefCell<bool>,
 
-    color_scheme: OnceCell<Pin<Box<Property<ColorScheme>>>>,
-
     // Last icon image set on the window
     window_icon_cache_key: RefCell<Option<ImageCacheKey>>,
 
@@ -1846,7 +1844,6 @@ impl QtWindow {
                 cache: Default::default(),
                 text_layout_cache: Default::default(),
                 tree_structure_changed: RefCell::new(false),
-                color_scheme: Default::default(),
                 window_icon_cache_key: Default::default(),
                 parent,
             }
@@ -1857,6 +1854,16 @@ impl QtWindow {
             widget_ptr->rust_window = rust_window;
         }};
         ALL_WINDOWS.with(|aw| aw.borrow_mut().push(rc.self_weak.clone()));
+
+        let initial_scheme = if cpp! {unsafe [] -> bool as "bool" {
+            return qApp->palette().color(QPalette::Window).valueF() < 0.5;
+        }} {
+            ColorScheme::Dark
+        } else {
+            ColorScheme::Light
+        };
+        WindowInner::from_pub(&rc.window).context().set_color_scheme(initial_scheme);
+
         rc
     }
 
@@ -2347,21 +2354,6 @@ impl WindowAdapterInternal for QtWindow {
                 }
             }};
         }
-    }
-
-    fn color_scheme(&self) -> ColorScheme {
-        let ds = self.color_scheme.get_or_init(|| {
-            Box::pin(Property::new(
-                if cpp! {unsafe [] -> bool as "bool" {
-                    return qApp->palette().color(QPalette::Window).valueF() < 0.5;
-                }} {
-                    ColorScheme::Dark
-                } else {
-                    ColorScheme::Light
-                },
-            ))
-        });
-        ds.as_ref().get()
     }
 
     fn accent_color(&self) -> i_slint_core::graphics::Color {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -384,6 +384,8 @@ impl BackendBuilder {
             #[cfg(target_family = "wasm")]
             spawn_event_loop: self.spawn_event_loop,
             custom_application_handler: self.custom_application_handler.into(),
+            #[cfg(xdg_desktop_settings)]
+            xdg_watcher: RefCell::new(None),
         })
     }
 }
@@ -599,6 +601,10 @@ pub struct Backend {
     event_loop_state: RefCell<Option<crate::event_loop::EventLoopState>>,
     shared_data: Rc<SharedBackendData>,
     custom_application_handler: RefCell<Option<Box<dyn crate::CustomApplicationHandler>>>,
+    /// Backend-wide XDG desktop portal watcher. Spawned in `bind_context`
+    /// and aborted on backend drop.
+    #[cfg(xdg_desktop_settings)]
+    xdg_watcher: RefCell<Option<i_slint_core::future::JoinHandle<()>>>,
 
     /// This hook is called before a Window is created.
     ///
@@ -666,7 +672,34 @@ impl Backend {
 
 const DEFAULT_CURSOR_FLASH_CYCLE: core::time::Duration = core::time::Duration::from_millis(1000);
 
+#[cfg(xdg_desktop_settings)]
+impl Drop for Backend {
+    fn drop(&mut self) {
+        if let Some(handle) = self.xdg_watcher.borrow_mut().take() {
+            handle.abort();
+        }
+    }
+}
+
 impl i_slint_core::platform::Platform for Backend {
+    fn bind_context(&self, _ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
+        #[cfg(xdg_desktop_settings)]
+        {
+            let strong_ctx = _ctx
+                .upgrade()
+                .expect("bind_context is called while the SlintContext is still alive");
+            let shared_weak = Rc::downgrade(&self.shared_data);
+            let ctx_weak = _ctx.clone();
+            if let Ok(handle) = strong_ctx.spawn_local(async move {
+                if let Err(err) = crate::xdg_desktop_settings::watch(shared_weak, ctx_weak).await {
+                    i_slint_core::debug_log!("Error watching for xdg desktop settings: {}", err);
+                }
+            }) {
+                *self.xdg_watcher.borrow_mut() = Some(handle);
+            }
+        }
+    }
+
     fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
         let mut attrs = WinitWindowAdapter::window_attributes()?;
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -478,7 +478,7 @@ impl WinitWindowAdapter {
         // new window, and the OS-specific query yields the accent color.
         cfg_if::cfg_if! {
             if #[cfg(xdg_desktop_settings)] {
-                let scheme = WindowInner::from_pub(self.window()).context().color_scheme();
+                let scheme = WindowInner::from_pub(self.window()).context().color_scheme(None);
                 winit_window.set_theme(match scheme {
                     ColorScheme::Dark => Some(winit::window::Theme::Dark),
                     ColorScheme::Light => Some(winit::window::Theme::Light),

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -7,6 +7,8 @@
 
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
+#[cfg(target_os = "macos")]
+use std::cell::OnceCell;
 use std::rc::Rc;
 use std::rc::Weak;
 use std::sync::Arc;
@@ -36,7 +38,6 @@ use corelib::items::{ItemRc, ItemRef};
 #[cfg(any(enable_accesskit, muda))]
 use crate::SlintEvent;
 use crate::{EventResult, SharedBackendData};
-use corelib::Property;
 use corelib::api::PhysicalSize;
 use corelib::layout::Orientation;
 use corelib::lengths::LogicalLength;
@@ -44,7 +45,6 @@ use corelib::platform::{PlatformError, WindowEvent};
 use corelib::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
 use corelib::{Coord, graphics::*};
 use i_slint_core::{self as corelib};
-use std::cell::OnceCell;
 #[cfg(any(enable_accesskit, muda))]
 use winit::event_loop::EventLoopProxy;
 use winit::window::{WindowAttributes, WindowButtons};
@@ -315,7 +315,6 @@ pub struct WinitWindowAdapter {
     window: corelib::api::Window,
     pub(crate) self_weak: Weak<Self>,
     pending_redraw: Cell<bool>,
-    accent_color: OnceCell<Pin<Box<Property<Color>>>>,
     constraints: Cell<corelib::window::LayoutConstraints>,
     /// Indicates if the window is shown, from the perspective of the API user.
     shown: Cell<WindowVisibility>,
@@ -387,7 +386,6 @@ impl WinitWindowAdapter {
             window: corelib::api::Window::new(self_weak.clone() as _),
             self_weak: self_weak.clone(),
             pending_redraw: Default::default(),
-            accent_color: Default::default(),
             constraints: Default::default(),
             shown: Default::default(),
             window_level: Default::default(),
@@ -477,9 +475,10 @@ impl WinitWindowAdapter {
 
         let winit_window = self.renderer.resume(active_event_loop, window_attributes)?;
 
-        // Push the host shell's color scheme to the SlintContext. With
-        // `xdg_desktop_settings` we let the portal watcher report it; otherwise winit
-        // exposes the system Light/Dark setting directly on the new window.
+        // Push the host shell's color scheme and accent color to the SlintContext. With
+        // `xdg_desktop_settings` we let the portal watcher report them; otherwise winit
+        // exposes the system Light/Dark setting directly on the new window, and the
+        // OS-specific query yields the accent color.
         cfg_if::cfg_if! {
             if #[cfg(xdg_desktop_settings)] {
                 if let Some(old_watch) = self.xdg_settings_watcher.replace(self.spawn_xdg_settings_watcher()) {
@@ -491,6 +490,9 @@ impl WinitWindowAdapter {
                     winit::window::Theme::Light => ColorScheme::Light,
                 });
                 self.set_color_scheme(initial_scheme);
+                #[cfg(target_os = "macos")]
+                self.setup_macos_color_observer();
+                self.set_accent_color(Self::query_system_accent_color());
             }
         }
 
@@ -822,10 +824,7 @@ impl WinitWindowAdapter {
     }
 
     pub fn set_accent_color(&self, color: Color) {
-        self.accent_color
-            .get_or_init(|| Box::pin(Property::new(Color::default())))
-            .as_ref()
-            .set(color);
+        WindowInner::from_pub(self.window()).context().set_accent_color(color);
     }
 
     fn query_system_accent_color() -> Color {
@@ -1499,17 +1498,6 @@ impl WindowAdapterInternal for WinitWindowAdapter {
             }
             _ => {}
         };
-    }
-
-    fn accent_color(&self) -> Color {
-        self.accent_color
-            .get_or_init(|| {
-                #[cfg(target_os = "macos")]
-                self.setup_macos_color_observer();
-                Box::pin(Property::new(Self::query_system_accent_color()))
-            })
-            .as_ref()
-            .get()
     }
 
     #[cfg(muda)]

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -315,7 +315,6 @@ pub struct WinitWindowAdapter {
     window: corelib::api::Window,
     pub(crate) self_weak: Weak<Self>,
     pending_redraw: Cell<bool>,
-    color_scheme: OnceCell<Pin<Box<Property<ColorScheme>>>>,
     accent_color: OnceCell<Pin<Box<Property<Color>>>>,
     constraints: Cell<corelib::window::LayoutConstraints>,
     /// Indicates if the window is shown, from the perspective of the API user.
@@ -388,7 +387,6 @@ impl WinitWindowAdapter {
             window: corelib::api::Window::new(self_weak.clone() as _),
             self_weak: self_weak.clone(),
             pending_redraw: Default::default(),
-            color_scheme: Default::default(),
             accent_color: Default::default(),
             constraints: Default::default(),
             shown: Default::default(),
@@ -478,6 +476,23 @@ impl WinitWindowAdapter {
         }
 
         let winit_window = self.renderer.resume(active_event_loop, window_attributes)?;
+
+        // Push the host shell's color scheme to the SlintContext. With
+        // `xdg_desktop_settings` we let the portal watcher report it; otherwise winit
+        // exposes the system Light/Dark setting directly on the new window.
+        cfg_if::cfg_if! {
+            if #[cfg(xdg_desktop_settings)] {
+                if let Some(old_watch) = self.xdg_settings_watcher.replace(self.spawn_xdg_settings_watcher()) {
+                    old_watch.abort();
+                }
+            } else {
+                let initial_scheme = winit_window.theme().map_or(ColorScheme::Unknown, |theme| match theme {
+                    winit::window::Theme::Dark => ColorScheme::Dark,
+                    winit::window::Theme::Light => ColorScheme::Light,
+                });
+                self.set_color_scheme(initial_scheme);
+            }
+        }
 
         let scale_factor =
             overriding_scale_factor.unwrap_or_else(|| winit_window.scale_factor() as f32);
@@ -862,10 +877,7 @@ impl WinitWindowAdapter {
     }
 
     pub fn set_color_scheme(&self, scheme: ColorScheme) {
-        self.color_scheme
-            .get_or_init(|| Box::pin(Property::new(ColorScheme::Unknown)))
-            .as_ref()
-            .set(scheme);
+        WindowInner::from_pub(self.window()).context().set_color_scheme(scheme);
 
         // Update the menubar theme
         #[cfg(target_os = "windows")]
@@ -1092,15 +1104,13 @@ impl WinitWindowAdapter {
 
             winit_window.set_visible(true);
 
-            // Make sure the dark color scheme property is up-to-date, as it may have been queried earlier when
-            // the window wasn't mapped yet.
-            if let Some(color_scheme_prop) = self.color_scheme.get()
-                && let Some(theme) = winit_window.theme()
-            {
-                color_scheme_prop.as_ref().set(match theme {
+            // Refresh the SlintContext color-scheme now that the window is mapped: on some platforms
+            // `winit_window.theme()` only reports a real value once the window is shown.
+            if let Some(theme) = winit_window.theme() {
+                self.set_color_scheme(match theme {
                     winit::window::Theme::Dark => ColorScheme::Dark,
                     winit::window::Theme::Light => ColorScheme::Light,
-                })
+                });
             }
 
             // In wasm a request_redraw() issued before show() results in a draw() even when the window
@@ -1489,33 +1499,6 @@ impl WindowAdapterInternal for WinitWindowAdapter {
             }
             _ => {}
         };
-    }
-
-    fn color_scheme(&self) -> ColorScheme {
-        self.color_scheme
-            .get_or_init(|| {
-                Box::pin(Property::new({
-                    cfg_if::cfg_if! {
-                        if #[cfg(not(xdg_desktop_settings))] {
-                            self.winit_window_or_none
-                                .borrow()
-                                .as_window()
-                                .and_then(|window| window.theme())
-                                .map_or(ColorScheme::Unknown, |theme| match theme {
-                                    winit::window::Theme::Dark => ColorScheme::Dark,
-                                    winit::window::Theme::Light => ColorScheme::Light,
-                                })
-                        } else {
-                            if let Some(old_watch) = self.xdg_settings_watcher.replace(self.spawn_xdg_settings_watcher()) {
-                                old_watch.abort()
-                            }
-                            ColorScheme::Unknown
-                        }
-                    }
-                }))
-            })
-            .as_ref()
-            .get()
     }
 
     fn accent_color(&self) -> Color {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -350,9 +350,6 @@ pub struct WinitWindowAdapter {
     winit_window_or_none: RefCell<WinitWindowOrNone>,
     window_existence_wakers: RefCell<Vec<core::task::Waker>>,
 
-    #[cfg(xdg_desktop_settings)]
-    xdg_settings_watcher: RefCell<Option<i_slint_core::future::JoinHandle<()>>>,
-
     #[cfg(target_os = "macos")]
     macos_color_observer: OnceCell<
         objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2::runtime::NSObjectProtocol>>,
@@ -404,8 +401,6 @@ impl WinitWindowAdapter {
             #[cfg(any(enable_accesskit, muda))]
             event_loop_proxy: proxy,
             window_event_filter: Cell::new(None),
-            #[cfg(xdg_desktop_settings)]
-            xdg_settings_watcher: Default::default(),
             #[cfg(target_os = "macos")]
             macos_color_observer: OnceCell::new(),
             #[cfg(muda)]
@@ -475,15 +470,21 @@ impl WinitWindowAdapter {
 
         let winit_window = self.renderer.resume(active_event_loop, window_attributes)?;
 
-        // Push the host shell's color scheme and accent color to the SlintContext. With
-        // `xdg_desktop_settings` we let the portal watcher report them; otherwise winit
-        // exposes the system Light/Dark setting directly on the new window, and the
-        // OS-specific query yields the accent color.
+        // Push the host shell's color scheme and accent color to the SlintContext.
+        // With `xdg_desktop_settings` the backend-wide portal watcher (spawned in
+        // `Backend::bind_context`) is responsible for that; we only echo the
+        // current scheme to this fresh winit window so its CSDs render correctly.
+        // Otherwise winit exposes the system Light/Dark setting directly on the
+        // new window, and the OS-specific query yields the accent color.
         cfg_if::cfg_if! {
             if #[cfg(xdg_desktop_settings)] {
-                if let Some(old_watch) = self.xdg_settings_watcher.replace(self.spawn_xdg_settings_watcher()) {
-                    old_watch.abort();
-                }
+                let scheme = WindowInner::from_pub(self.window()).context().color_scheme();
+                winit_window.set_theme(match scheme {
+                    ColorScheme::Dark => Some(winit::window::Theme::Dark),
+                    ColorScheme::Light => Some(winit::window::Theme::Light),
+                    ColorScheme::Unknown => None,
+                    _ => None,
+                });
             } else {
                 let initial_scheme = winit_window.theme().map_or(ColorScheme::Unknown, |theme| match theme {
                     winit::window::Theme::Dark => ColorScheme::Dark,
@@ -960,20 +961,6 @@ impl WinitWindowAdapter {
             WinitWindowOrNone::HasWindow { accesskit_adapter, .. } => callback(accesskit_adapter),
             WinitWindowOrNone::None(..) => {}
         }
-    }
-
-    #[cfg(xdg_desktop_settings)]
-    fn spawn_xdg_settings_watcher(&self) -> Option<i_slint_core::future::JoinHandle<()>> {
-        let window_inner = WindowInner::from_pub(self.window());
-        let self_weak = self.self_weak.clone();
-        window_inner
-            .context()
-            .spawn_local(async move {
-                if let Err(err) = crate::xdg_desktop_settings::watch(self_weak).await {
-                    i_slint_core::debug_log!("Error watching for xdg desktop settings: {}", err);
-                }
-            })
-            .ok()
     }
 
     /// Register an observer for macOS system color changes so that
@@ -1636,11 +1623,6 @@ impl Drop for WinitWindowAdapter {
         self.shared_backend_data.unregister_window(
             self.winit_window_or_none.borrow().as_window().map(|winit_window| winit_window.id()),
         );
-
-        #[cfg(xdg_desktop_settings)]
-        if let Some(xdg_watch_future) = self.xdg_settings_watcher.take() {
-            xdg_watch_future.abort();
-        }
 
         #[cfg(target_os = "macos")]
         if let Some(observer) = self.macos_color_observer.get() {

--- a/internal/backends/winit/xdg_desktop_settings.rs
+++ b/internal/backends/winit/xdg_desktop_settings.rs
@@ -3,10 +3,11 @@
 
 use std::rc::Weak;
 
+use i_slint_core::SlintContextWeak;
 use i_slint_core::graphics::Color;
 use i_slint_core::items::ColorScheme;
 
-use crate::WinitWindowAdapter;
+use crate::SharedBackendData;
 
 fn xdg_color_scheme_to_slint(value: zbus::zvariant::OwnedValue) -> ColorScheme {
     match value.downcast_ref::<u32>() {
@@ -20,6 +21,33 @@ fn xdg_accent_color_to_slint(value: zbus::zvariant::OwnedValue) -> Option<Color>
     // The accent-color setting returns a (ddd) tuple of RGB doubles in [0.0, 1.0]
     let (r, g, b) = value.downcast_ref::<(f64, f64, f64)>().ok()?;
     Some(Color::from_argb_f32(1.0, r as f32, g as f32, b as f32))
+}
+
+/// Writes the new color scheme to the SlintContext and pushes the matching
+/// winit theme to every currently-mapped window so that client-side decorations
+/// stay in sync.
+fn apply_color_scheme(
+    ctx_weak: &SlintContextWeak,
+    shared_data_weak: &Weak<SharedBackendData>,
+    scheme: ColorScheme,
+) {
+    if let Some(ctx) = ctx_weak.upgrade() {
+        ctx.set_color_scheme(scheme);
+    }
+    let Some(shared) = shared_data_weak.upgrade() else { return };
+    let theme = match scheme {
+        ColorScheme::Dark => Some(winit::window::Theme::Dark),
+        ColorScheme::Light => Some(winit::window::Theme::Light),
+        ColorScheme::Unknown => None,
+        _ => None,
+    };
+    for adapter_weak in shared.active_windows.borrow().values() {
+        if let Some(adapter) = adapter_weak.upgrade()
+            && let Some(winit_window) = adapter.winit_window()
+        {
+            winit_window.set_theme(theme);
+        }
+    }
 }
 
 async fn read_cursor_blink_settings(
@@ -45,7 +73,10 @@ async fn read_cursor_blink_settings(
     None
 }
 
-pub async fn watch(window_weak: Weak<WinitWindowAdapter>) -> zbus::Result<()> {
+pub async fn watch(
+    shared_data_weak: Weak<SharedBackendData>,
+    ctx_weak: SlintContextWeak,
+) -> zbus::Result<()> {
     let connection = zbus::Connection::session().await?;
     let settings_proxy: zbus::Proxy = zbus::proxy::Builder::new(&connection)
         .interface("org.freedesktop.portal.Settings")?
@@ -56,21 +87,20 @@ pub async fn watch(window_weak: Weak<WinitWindowAdapter>) -> zbus::Result<()> {
 
     let initial_value: zbus::zvariant::OwnedValue =
         settings_proxy.call("ReadOne", &("org.freedesktop.appearance", "color-scheme")).await?;
-
-    let Some(window) = window_weak.upgrade() else { return Ok(()) };
-    window.set_color_scheme(xdg_color_scheme_to_slint(initial_value));
+    apply_color_scheme(&ctx_weak, &shared_data_weak, xdg_color_scheme_to_slint(initial_value));
 
     let accent_result: zbus::Result<zbus::zvariant::OwnedValue> =
         settings_proxy.call("ReadOne", &("org.freedesktop.appearance", "accent-color")).await;
-    if let Some(color) = accent_result.ok().and_then(xdg_accent_color_to_slint) {
-        window.set_accent_color(color);
+    if let Some(color) = accent_result.ok().and_then(xdg_accent_color_to_slint)
+        && let Some(ctx) = ctx_weak.upgrade()
+    {
+        ctx.set_accent_color(color);
     }
 
-    let shared_data = window.shared_backend_data.clone();
-    drop(window);
-
-    if let Some(interval) = read_cursor_blink_settings(&settings_proxy).await {
-        shared_data.cursor_blink_interval.set(interval);
+    if let Some(interval) = read_cursor_blink_settings(&settings_proxy).await
+        && let Some(shared) = shared_data_weak.upgrade()
+    {
+        shared.cursor_blink_interval.set(interval);
     }
 
     use futures::stream::StreamExt;
@@ -85,34 +115,35 @@ pub async fn watch(window_weak: Weak<WinitWindowAdapter>) -> zbus::Result<()> {
     while let Some(Some((namespace, key, value))) = settings_stream.next().await {
         match (namespace.as_str(), key.as_str()) {
             ("org.freedesktop.appearance", "color-scheme") => {
-                let Some(window) = window_weak.upgrade() else { return Ok(()) };
-                window.set_color_scheme(xdg_color_scheme_to_slint(value));
+                apply_color_scheme(&ctx_weak, &shared_data_weak, xdg_color_scheme_to_slint(value));
             }
             ("org.freedesktop.appearance", "accent-color") => {
-                let Some(window) = window_weak.upgrade() else { return Ok(()) };
-                if let Some(color) = xdg_accent_color_to_slint(value) {
-                    window.set_accent_color(color);
+                if let Some(color) = xdg_accent_color_to_slint(value)
+                    && let Some(ctx) = ctx_weak.upgrade()
+                {
+                    ctx.set_accent_color(color);
                 }
             }
             ("org.gnome.desktop.interface", "cursor-blink") => {
                 if let Ok(enabled) = value.downcast_ref::<bool>() {
-                    if enabled {
-                        let interval = read_cursor_blink_settings(&settings_proxy)
+                    let interval = if enabled {
+                        read_cursor_blink_settings(&settings_proxy)
                             .await
-                            .unwrap_or(crate::DEFAULT_CURSOR_FLASH_CYCLE);
-                        shared_data.cursor_blink_interval.set(interval);
+                            .unwrap_or(crate::DEFAULT_CURSOR_FLASH_CYCLE)
                     } else {
-                        shared_data.cursor_blink_interval.set(core::time::Duration::ZERO);
+                        core::time::Duration::ZERO
+                    };
+                    if let Some(shared) = shared_data_weak.upgrade() {
+                        shared.cursor_blink_interval.set(interval);
                     }
                 }
             }
             ("org.gnome.desktop.interface", "cursor-blink-time") => {
                 if let Ok(ms) = value.downcast_ref::<i32>()
                     && ms > 0
+                    && let Some(shared) = shared_data_weak.upgrade()
                 {
-                    shared_data
-                        .cursor_blink_interval
-                        .set(core::time::Duration::from_millis(ms as u64));
+                    shared.cursor_blink_interval.set(core::time::Duration::from_millis(ms as u64));
                 }
             }
             _ => {}

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4497,7 +4497,13 @@ fn compile_builtin_function_call(
             )
         }
         BuiltinFunction::ColorScheme => {
-            format!("{}.color_scheme()", access_window_field(ctx))
+            // Route through the runtime helper so a `Palette.color-scheme` binding
+            // inside a SystemTrayIcon-rooted component naturally resolves against
+            // the tray's scheme without going through any window adapter.
+            format!(
+                "[&]{{ auto _root = (*{0}->root_weak.lock()).into_dyn(); return slint::cbindgen_private::slint_resolve_color_scheme(&_root); }}()",
+                ctx.generator_state.global_access
+            )
         }
         BuiltinFunction::AccentColor => {
             format!(

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4501,13 +4501,13 @@ fn compile_builtin_function_call(
             // inside a SystemTrayIcon-rooted component naturally resolves against
             // the tray's scheme without going through any window adapter.
             format!(
-                "[&]{{ auto _root = (*{0}->root_weak.lock()).into_dyn(); return slint::cbindgen_private::slint_resolve_color_scheme(&_root); }}()",
+                "[&]{{ auto _root = (*{0}->root_weak.lock()).into_dyn(); return slint::cbindgen_private::slint_context_color_scheme(&_root); }}()",
                 ctx.generator_state.global_access
             )
         }
         BuiltinFunction::AccentColor => {
             format!(
-                "[&]{{ auto _root = (*{0}->root_weak.lock()).into_dyn(); slint::Color col; slint::cbindgen_private::slint_accent_color(&_root, &col); return col; }}()",
+                "[&]{{ auto _root = (*{0}->root_weak.lock()).into_dyn(); slint::Color col; slint::cbindgen_private::slint_context_accent_color(&_root, &col); return col; }}()",
                 ctx.generator_state.global_access
             )
         }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4500,7 +4500,10 @@ fn compile_builtin_function_call(
             format!("{}.color_scheme()", access_window_field(ctx))
         }
         BuiltinFunction::AccentColor => {
-            format!("{}.accent_color()", access_window_field(ctx))
+            format!(
+                "[&]{{ auto _root = (*{0}->root_weak.lock()).into_dyn(); slint::Color col; slint::cbindgen_private::slint_accent_color(&_root, &col); return col; }}()",
+                ctx.generator_state.global_access
+            )
         }
         BuiltinFunction::SupportsNativeMenuBar => {
             format!("{}.supports_native_menu_bar()", access_window_field(ctx))

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3916,7 +3916,7 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::ColorScheme => {
             let window_adapter_tokens = access_window_adapter_field(ctx);
-            quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).color_scheme())
+            quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).context().color_scheme())
         }
         BuiltinFunction::AccentColor => {
             let window_adapter_tokens = access_window_adapter_field(ctx);

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3915,13 +3915,15 @@ fn compile_builtin_function_call(
             })
         }
         BuiltinFunction::ColorScheme => {
-            // Route through the runtime helper so a `Palette.color-scheme` binding
-            // inside a SystemTrayIcon-rooted component naturally resolves against
-            // the tray's scheme without going through any window adapter.
+            // A `Palette.color-scheme` binding inside a SystemTrayIcon-rooted component
+            // resolves against the tray's own scheme; everything else falls back to the
+            // process-wide value held by the SlintContext.
             let global_access = &ctx.generator_state.global_access;
-            quote!(sp::resolve_color_scheme(
-                &#global_access.root_item_tree_weak.upgrade().unwrap()
-            ))
+            quote!({
+                let _root = #global_access.root_item_tree_weak.upgrade().unwrap();
+                sp::context_for_root(&_root)
+                    .map_or(sp::ColorScheme::Unknown, |c| c.color_scheme(Some(&_root)))
+            })
         }
         BuiltinFunction::AccentColor => {
             let global_access = &ctx.generator_state.global_access;

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3915,8 +3915,13 @@ fn compile_builtin_function_call(
             })
         }
         BuiltinFunction::ColorScheme => {
-            let window_adapter_tokens = access_window_adapter_field(ctx);
-            quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).context().color_scheme())
+            // Route through the runtime helper so a `Palette.color-scheme` binding
+            // inside a SystemTrayIcon-rooted component naturally resolves against
+            // the tray's scheme without going through any window adapter.
+            let global_access = &ctx.generator_state.global_access;
+            quote!(sp::resolve_color_scheme(
+                &#global_access.root_item_tree_weak.upgrade().unwrap()
+            ))
         }
         BuiltinFunction::AccentColor => {
             let global_access = &ctx.generator_state.global_access;

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3919,8 +3919,8 @@ fn compile_builtin_function_call(
             quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).context().color_scheme())
         }
         BuiltinFunction::AccentColor => {
-            let window_adapter_tokens = access_window_adapter_field(ctx);
-            quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).accent_color())
+            let global_access = &ctx.generator_state.global_access;
+            quote!(sp::accent_color(&#global_access.root_item_tree_weak.upgrade().unwrap()))
         }
         BuiltinFunction::SupportsNativeMenuBar => {
             let window_adapter_tokens = access_window_adapter_field(ctx);

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -148,8 +148,8 @@ gettext-rs = { version = "0.7.1", optional = true, features = ["gettext-system"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSImage", "NSMenu", "NSMenuItem", "NSApplication", "objc2-core-foundation"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSData", "NSString", "NSGeometry", "NSObjCRuntime"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSImage", "NSMenu", "NSMenuItem", "NSApplication", "NSAppearance", "objc2-core-foundation"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSArray", "NSData", "NSDictionary", "NSKeyValueObserving", "NSString", "NSGeometry", "NSObjCRuntime"] }
 image = { workspace = true, default-features = false, features = ["png"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -8,8 +8,9 @@ use crate::input::InternalKeyboardModifierState;
 use crate::items::ColorScheme;
 use crate::platform::{EventLoopProxy, Platform};
 use alloc::boxed::Box;
-use alloc::rc::{Rc, Weak};
+use alloc::rc::Rc;
 use core::cell::Cell;
+use pin_weak::rc::PinWeak;
 
 crate::thread_local! {
     pub(crate) static GLOBAL_CONTEXT : once_cell::unsync::OnceCell<SlintContext>
@@ -17,12 +18,18 @@ crate::thread_local! {
 }
 
 #[pin_project::pin_project]
-pub(crate) struct SlintContextPinnedFields {
+pub(crate) struct SlintContextInner {
+    platform: Box<dyn Platform>,
+    pub(crate) window_count: core::cell::RefCell<isize>,
     /// Read by all translations, and marked dirty when the language changes so every
     /// translated string re-translates. The value is the currently selected language
     /// when bundling translations.
     #[pin]
     pub(crate) translations_dirty: Property<usize>,
+    pub(crate) translations_bundle_languages:
+        core::cell::RefCell<Option<alloc::vec::Vec<&'static str>>>,
+    #[cfg(feature = "tr")]
+    external_translator: core::cell::RefCell<Option<Box<dyn tr::Translator>>>,
     /// Process-wide color scheme. Backends' system-theme observers write here; bindings
     /// read from it through [`SlintContext::color_scheme`]. Window-less components like
     /// `SystemTrayIcon` rely on this as their default source.
@@ -33,20 +40,10 @@ pub(crate) struct SlintContextPinnedFields {
     /// transparent color when the platform doesn't expose one.
     #[pin]
     pub(crate) accent_color: Property<Color>,
-}
-
-pub(crate) struct SlintContextInner {
-    platform: Box<dyn Platform>,
-    pub(crate) window_count: core::cell::RefCell<isize>,
-    pub(crate) pinned_fields: core::pin::Pin<Box<SlintContextPinnedFields>>,
-    pub(crate) translations_bundle_languages:
-        core::cell::RefCell<Option<alloc::vec::Vec<&'static str>>>,
     pub(crate) window_shown_hook:
         core::cell::RefCell<Option<Box<dyn FnMut(&Rc<dyn crate::platform::WindowAdapter>)>>>,
     #[cfg(all(unix, not(target_os = "macos")))]
     xdg_app_id: core::cell::RefCell<Option<crate::SharedString>>,
-    #[cfg(feature = "tr")]
-    external_translator: core::cell::RefCell<Option<Box<dyn tr::Translator>>>,
     #[cfg(feature = "shared-parley")]
     pub(crate) font_context: core::cell::RefCell<parley::FontContext>,
     #[cfg(feature = "shared-swash")]
@@ -58,7 +55,7 @@ pub(crate) struct SlintContextInner {
 /// Currently it is not possible to have several platform at the same time in one process, but in the future it might be.
 /// See issue #4294
 #[derive(Clone)]
-pub struct SlintContext(pub(crate) Rc<SlintContextInner>);
+pub struct SlintContext(pub(crate) core::pin::Pin<Rc<SlintContextInner>>);
 
 impl SlintContext {
     /// Create a new context with a given platform
@@ -66,23 +63,18 @@ impl SlintContext {
         #[cfg(feature = "shared-parley")]
         let collection = i_slint_common::sharedfontique::create_collection(true);
 
-        Self(Rc::new(SlintContextInner {
+        Self(Rc::pin(SlintContextInner {
             platform,
             window_count: 0.into(),
-            pinned_fields: Box::pin(SlintContextPinnedFields {
-                translations_dirty: Property::new_named(0, "SlintContext::translations"),
-                color_scheme: Property::new_named(
-                    ColorScheme::Unknown,
-                    "SlintContext::color_scheme",
-                ),
-                accent_color: Property::new_named(Color::default(), "SlintContext::accent_color"),
-            }),
+            translations_dirty: Property::new_named(0, "SlintContext::translations"),
             translations_bundle_languages: Default::default(),
+            #[cfg(feature = "tr")]
+            external_translator: Default::default(),
+            color_scheme: Property::new_named(ColorScheme::Unknown, "SlintContext::color_scheme"),
+            accent_color: Property::new_named(Color::default(), "SlintContext::accent_color"),
             window_shown_hook: Default::default(),
             #[cfg(all(unix, not(target_os = "macos")))]
             xdg_app_id: Default::default(),
-            #[cfg(feature = "tr")]
-            external_translator: Default::default(),
             #[cfg(feature = "shared-parley")]
             font_context: {
                 let font_context = parley::FontContext {
@@ -136,25 +128,25 @@ impl SlintContext {
     /// Returns the process-wide color scheme. Reads register a property dependency,
     /// so bindings re-evaluate when the platform reports a system-theme change.
     pub fn color_scheme(&self) -> ColorScheme {
-        self.0.pinned_fields.as_ref().project_ref().color_scheme.get()
+        self.0.as_ref().project_ref().color_scheme.get()
     }
 
     /// Backend-side write path for the process-wide color scheme. Called by each
     /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
     pub fn set_color_scheme(&self, scheme: ColorScheme) {
-        self.0.pinned_fields.as_ref().project_ref().color_scheme.set(scheme);
+        self.0.as_ref().project_ref().color_scheme.set(scheme);
     }
 
     /// Returns the process-wide system accent color. Reads register a property dependency,
     /// so bindings re-evaluate when the platform reports an accent-color change.
     pub fn accent_color(&self) -> Color {
-        self.0.pinned_fields.as_ref().project_ref().accent_color.get()
+        self.0.as_ref().project_ref().accent_color.get()
     }
 
     /// Backend-side write path for the process-wide accent color. Called by each
     /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
     pub fn set_accent_color(&self, color: Color) {
-        self.0.pinned_fields.as_ref().project_ref().accent_color.set(color);
+        self.0.as_ref().project_ref().accent_color.set(color);
     }
 
     /// Add one to the counter of "things keeping the event loop alive".
@@ -196,7 +188,7 @@ impl SlintContext {
     #[cfg(feature = "tr")]
     pub fn set_external_translator(&self, translator: Option<Box<dyn tr::Translator>>) {
         *self.0.external_translator.borrow_mut() = translator;
-        self.0.pinned_fields.as_ref().project_ref().translations_dirty.mark_dirty();
+        self.0.as_ref().project_ref().translations_dirty.mark_dirty();
     }
 
     #[cfg(feature = "tr")]
@@ -210,7 +202,7 @@ impl SlintContext {
     /// Returns a weak handle to this context, suitable for stashing in places that must
     /// not keep the context alive (e.g. a backend that's owned by the context itself).
     pub fn downgrade(&self) -> SlintContextWeak {
-        SlintContextWeak(Rc::downgrade(&self.0))
+        SlintContextWeak(PinWeak::downgrade(self.0.clone()))
     }
 }
 
@@ -219,7 +211,7 @@ impl SlintContext {
 /// `set_platform` so they can spawn futures and write process-wide state without
 /// holding the context strongly.
 #[derive(Clone)]
-pub struct SlintContextWeak(Weak<SlintContextInner>);
+pub struct SlintContextWeak(PinWeak<SlintContextInner>);
 
 impl SlintContextWeak {
     /// Attempts to upgrade to a strong [`SlintContext`].

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -8,7 +8,7 @@ use crate::input::InternalKeyboardModifierState;
 use crate::items::ColorScheme;
 use crate::platform::{EventLoopProxy, Platform};
 use alloc::boxed::Box;
-use alloc::rc::Rc;
+use alloc::rc::{Rc, Weak};
 use core::cell::Cell;
 
 crate::thread_local! {
@@ -198,6 +198,26 @@ impl SlintContext {
             maybe_translator.as_ref()
         })
         .ok()
+    }
+
+    /// Returns a weak handle to this context, suitable for stashing in places that must
+    /// not keep the context alive (e.g. a backend that's owned by the context itself).
+    pub fn downgrade(&self) -> SlintContextWeak {
+        SlintContextWeak(Rc::downgrade(&self.0))
+    }
+}
+
+/// Weak handle to a [`SlintContext`]. Backends that opt into
+/// [`crate::platform::Platform::bind_context`] receive one of these right after
+/// `set_platform` so they can spawn futures and write process-wide state without
+/// holding the context strongly.
+#[derive(Clone)]
+pub struct SlintContextWeak(Weak<SlintContextInner>);
+
+impl SlintContextWeak {
+    /// Attempts to upgrade to a strong [`SlintContext`].
+    pub fn upgrade(&self) -> Option<SlintContext> {
+        self.0.upgrade().map(SlintContext)
     }
 }
 

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -4,6 +4,7 @@
 use crate::Property;
 use crate::api::PlatformError;
 use crate::input::InternalKeyboardModifierState;
+use crate::items::ColorScheme;
 use crate::platform::{EventLoopProxy, Platform};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -21,6 +22,10 @@ pub(crate) struct SlintContextInner {
     /// so that every translated string gets re-translated. The property's value is the current selected
     /// language when bundling translations.
     pub(crate) translations_dirty: core::pin::Pin<Box<Property<usize>>>,
+    /// Process-wide color scheme. Backends' system-theme observers write here; bindings read from
+    /// it through [`SlintContext::color_scheme`]. Window-less components like `SystemTrayIcon`
+    /// rely on this as their default source.
+    pub(crate) color_scheme: core::pin::Pin<Box<Property<ColorScheme>>>,
     pub(crate) translations_bundle_languages:
         core::cell::RefCell<Option<alloc::vec::Vec<&'static str>>>,
     pub(crate) window_shown_hook:
@@ -52,6 +57,10 @@ impl SlintContext {
             platform,
             window_count: 0.into(),
             translations_dirty: Box::pin(Property::new_named(0, "SlintContext::translations")),
+            color_scheme: Box::pin(Property::new_named(
+                ColorScheme::Unknown,
+                "SlintContext::color_scheme",
+            )),
             translations_bundle_languages: Default::default(),
             window_shown_hook: Default::default(),
             #[cfg(all(unix, not(target_os = "macos")))]
@@ -106,6 +115,18 @@ impl SlintContext {
 
     pub fn run_event_loop(&self) -> Result<(), PlatformError> {
         self.0.platform.run_event_loop()
+    }
+
+    /// Returns the process-wide color scheme. Reads register a property dependency,
+    /// so bindings re-evaluate when the platform reports a system-theme change.
+    pub fn color_scheme(&self) -> ColorScheme {
+        self.0.color_scheme.as_ref().get()
+    }
+
+    /// Backend-side write path for the process-wide color scheme. Called by each
+    /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
+    pub fn set_color_scheme(&self, scheme: ColorScheme) {
+        self.0.color_scheme.as_ref().set(scheme);
     }
 
     /// Add one to the counter of "things keeping the event loop alive".

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -16,21 +16,29 @@ crate::thread_local! {
         = const { once_cell::unsync::OnceCell::new() }
 }
 
+#[pin_project::pin_project]
+pub(crate) struct SlintContextPinnedFields {
+    /// Read by all translations, and marked dirty when the language changes so every
+    /// translated string re-translates. The value is the currently selected language
+    /// when bundling translations.
+    #[pin]
+    pub(crate) translations_dirty: Property<usize>,
+    /// Process-wide color scheme. Backends' system-theme observers write here; bindings
+    /// read from it through [`SlintContext::color_scheme`]. Window-less components like
+    /// `SystemTrayIcon` rely on this as their default source.
+    #[pin]
+    pub(crate) color_scheme: Property<ColorScheme>,
+    /// Process-wide system accent color. Backends' system-theme observers write here;
+    /// bindings read from it through [`SlintContext::accent_color`]. Defaults to a
+    /// transparent color when the platform doesn't expose one.
+    #[pin]
+    pub(crate) accent_color: Property<Color>,
+}
+
 pub(crate) struct SlintContextInner {
     platform: Box<dyn Platform>,
     pub(crate) window_count: core::cell::RefCell<isize>,
-    /// This property is read by all translations, and marked dirty when the language changes,
-    /// so that every translated string gets re-translated. The property's value is the current selected
-    /// language when bundling translations.
-    pub(crate) translations_dirty: core::pin::Pin<Box<Property<usize>>>,
-    /// Process-wide color scheme. Backends' system-theme observers write here; bindings read from
-    /// it through [`SlintContext::color_scheme`]. Window-less components like `SystemTrayIcon`
-    /// rely on this as their default source.
-    pub(crate) color_scheme: core::pin::Pin<Box<Property<ColorScheme>>>,
-    /// Process-wide system accent color. Backends' system-theme observers write here; bindings
-    /// read from it through [`SlintContext::accent_color`]. Defaults to a transparent color when
-    /// the platform doesn't expose one.
-    pub(crate) accent_color: core::pin::Pin<Box<Property<Color>>>,
+    pub(crate) pinned_fields: core::pin::Pin<Box<SlintContextPinnedFields>>,
     pub(crate) translations_bundle_languages:
         core::cell::RefCell<Option<alloc::vec::Vec<&'static str>>>,
     pub(crate) window_shown_hook:
@@ -61,15 +69,14 @@ impl SlintContext {
         Self(Rc::new(SlintContextInner {
             platform,
             window_count: 0.into(),
-            translations_dirty: Box::pin(Property::new_named(0, "SlintContext::translations")),
-            color_scheme: Box::pin(Property::new_named(
-                ColorScheme::Unknown,
-                "SlintContext::color_scheme",
-            )),
-            accent_color: Box::pin(Property::new_named(
-                Color::default(),
-                "SlintContext::accent_color",
-            )),
+            pinned_fields: Box::pin(SlintContextPinnedFields {
+                translations_dirty: Property::new_named(0, "SlintContext::translations"),
+                color_scheme: Property::new_named(
+                    ColorScheme::Unknown,
+                    "SlintContext::color_scheme",
+                ),
+                accent_color: Property::new_named(Color::default(), "SlintContext::accent_color"),
+            }),
             translations_bundle_languages: Default::default(),
             window_shown_hook: Default::default(),
             #[cfg(all(unix, not(target_os = "macos")))]
@@ -129,25 +136,25 @@ impl SlintContext {
     /// Returns the process-wide color scheme. Reads register a property dependency,
     /// so bindings re-evaluate when the platform reports a system-theme change.
     pub fn color_scheme(&self) -> ColorScheme {
-        self.0.color_scheme.as_ref().get()
+        self.0.pinned_fields.as_ref().project_ref().color_scheme.get()
     }
 
     /// Backend-side write path for the process-wide color scheme. Called by each
     /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
     pub fn set_color_scheme(&self, scheme: ColorScheme) {
-        self.0.color_scheme.as_ref().set(scheme);
+        self.0.pinned_fields.as_ref().project_ref().color_scheme.set(scheme);
     }
 
     /// Returns the process-wide system accent color. Reads register a property dependency,
     /// so bindings re-evaluate when the platform reports an accent-color change.
     pub fn accent_color(&self) -> Color {
-        self.0.accent_color.as_ref().get()
+        self.0.pinned_fields.as_ref().project_ref().accent_color.get()
     }
 
     /// Backend-side write path for the process-wide accent color. Called by each
     /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
     pub fn set_accent_color(&self, color: Color) {
-        self.0.accent_color.as_ref().set(color);
+        self.0.pinned_fields.as_ref().project_ref().accent_color.set(color);
     }
 
     /// Add one to the counter of "things keeping the event loop alive".
@@ -189,7 +196,7 @@ impl SlintContext {
     #[cfg(feature = "tr")]
     pub fn set_external_translator(&self, translator: Option<Box<dyn tr::Translator>>) {
         *self.0.external_translator.borrow_mut() = translator;
-        self.0.translations_dirty.mark_dirty();
+        self.0.pinned_fields.as_ref().project_ref().translations_dirty.mark_dirty();
     }
 
     #[cfg(feature = "tr")]

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -3,6 +3,7 @@
 
 use crate::Property;
 use crate::api::PlatformError;
+use crate::graphics::Color;
 use crate::input::InternalKeyboardModifierState;
 use crate::items::ColorScheme;
 use crate::platform::{EventLoopProxy, Platform};
@@ -26,6 +27,10 @@ pub(crate) struct SlintContextInner {
     /// it through [`SlintContext::color_scheme`]. Window-less components like `SystemTrayIcon`
     /// rely on this as their default source.
     pub(crate) color_scheme: core::pin::Pin<Box<Property<ColorScheme>>>,
+    /// Process-wide system accent color. Backends' system-theme observers write here; bindings
+    /// read from it through [`SlintContext::accent_color`]. Defaults to a transparent color when
+    /// the platform doesn't expose one.
+    pub(crate) accent_color: core::pin::Pin<Box<Property<Color>>>,
     pub(crate) translations_bundle_languages:
         core::cell::RefCell<Option<alloc::vec::Vec<&'static str>>>,
     pub(crate) window_shown_hook:
@@ -60,6 +65,10 @@ impl SlintContext {
             color_scheme: Box::pin(Property::new_named(
                 ColorScheme::Unknown,
                 "SlintContext::color_scheme",
+            )),
+            accent_color: Box::pin(Property::new_named(
+                Color::default(),
+                "SlintContext::accent_color",
             )),
             translations_bundle_languages: Default::default(),
             window_shown_hook: Default::default(),
@@ -127,6 +136,18 @@ impl SlintContext {
     /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
     pub fn set_color_scheme(&self, scheme: ColorScheme) {
         self.0.color_scheme.as_ref().set(scheme);
+    }
+
+    /// Returns the process-wide system accent color. Reads register a property dependency,
+    /// so bindings re-evaluate when the platform reports an accent-color change.
+    pub fn accent_color(&self) -> Color {
+        self.0.accent_color.as_ref().get()
+    }
+
+    /// Backend-side write path for the process-wide accent color. Called by each
+    /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
+    pub fn set_accent_color(&self, color: Color) {
+        self.0.accent_color.as_ref().set(color);
     }
 
     /// Add one to the counter of "things keeping the event loop alive".

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -5,6 +5,7 @@ use crate::Property;
 use crate::api::PlatformError;
 use crate::graphics::Color;
 use crate::input::InternalKeyboardModifierState;
+use crate::item_tree::{ItemRc, ItemTreeRc};
 use crate::items::ColorScheme;
 use crate::platform::{EventLoopProxy, Platform};
 use alloc::boxed::Box;
@@ -125,9 +126,22 @@ impl SlintContext {
         self.0.platform.run_event_loop()
     }
 
-    /// Returns the process-wide color scheme. Reads register a property dependency,
-    /// so bindings re-evaluate when the platform reports a system-theme change.
-    pub fn color_scheme(&self) -> ColorScheme {
+    /// Returns the effective color scheme for the given component root, or the
+    /// process-wide scheme when `root` is `None`. A `SystemTrayIcon`-rooted
+    /// component resolves against the tray's own scheme first, falling back to
+    /// the process-wide value when the tray reports `Unknown`. Reads register a
+    /// property dependency, so bindings re-evaluate when the platform reports a
+    /// system-theme change.
+    pub fn color_scheme(&self, root: Option<&ItemTreeRc>) -> ColorScheme {
+        if let Some(root) = root {
+            let root_item = ItemRc::new_root(root.clone());
+            if let Some(tray) = root_item.downcast::<crate::items::SystemTrayIcon>() {
+                let scheme = tray.as_pin_ref().color_scheme();
+                if scheme != ColorScheme::Unknown {
+                    return scheme;
+                }
+            }
+        }
         self.0.as_ref().project_ref().color_scheme.get()
     }
 

--- a/internal/core/items/system_tray.rs
+++ b/internal/core/items/system_tray.rs
@@ -15,7 +15,9 @@ use crate::input::{
     KeyEventResult, MouseEvent,
 };
 use crate::item_rendering::CachedRenderingData;
-use crate::items::{Item, ItemConsts, ItemRc, MouseCursor, Orientation, RenderingResult, VoidArg};
+use crate::items::{
+    ColorScheme, Item, ItemConsts, ItemRc, MouseCursor, Orientation, RenderingResult, VoidArg,
+};
 use crate::layout::LayoutInfo;
 use crate::lengths::{LogicalRect, LogicalSize};
 #[cfg(feature = "rtti")]
@@ -185,6 +187,7 @@ pub struct SystemTrayIcon {
     pub tooltip: Property<SharedString>,
     pub title: Property<SharedString>,
     pub visible: Property<bool>,
+    pub color_scheme: Property<ColorScheme>,
     pub activated: Callback<VoidArg>,
     pub cached_rendering_data: CachedRenderingData,
     data: SystemTrayIconDataBox,
@@ -221,6 +224,10 @@ impl SystemTrayIcon {
         tracker.as_ref().evaluate(|| {
             handle.rebuild_menu(vtable::VRc::borrow(menu_vrc), entries);
         });
+    }
+
+    pub fn set_color_scheme(self: Pin<&Self>, scheme: ColorScheme) {
+        Self::FIELD_OFFSETS.color_scheme().apply_pin(self).set(scheme);
     }
 
     /// Reconcile the SlintContext keepalive counter with this tray's state.

--- a/internal/core/items/system_tray/appkit.rs
+++ b/internal/core/items/system_tray/appkit.rs
@@ -11,18 +11,24 @@ use super::{Error, Params};
 use crate::SharedVector;
 use crate::graphics::Image;
 use crate::item_tree::ItemWeak;
-use crate::items::MenuEntry;
+use crate::items::{ColorScheme, MenuEntry};
 use crate::menus::MenuVTable;
 
+use core::ffi::c_void;
+
 use objc2::rc::Retained;
-use objc2::runtime::Sel;
+use objc2::runtime::{AnyObject, Sel};
 use objc2::{
     AllocAnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel,
 };
 use objc2_app_kit::{
+    NSAppearance, NSAppearanceCustomization, NSAppearanceNameAqua, NSAppearanceNameDarkAqua,
     NSImage, NSMenu, NSMenuItem, NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
 };
-use objc2_foundation::{NSData, NSObject, NSObjectProtocol, NSSize, NSString};
+use objc2_foundation::{
+    NSArray, NSData, NSDictionary, NSKeyValueChangeKey, NSKeyValueObservingOptions, NSObject,
+    NSObjectNSKeyValueObserverRegistration, NSObjectProtocol, NSSize, NSString, ns_string,
+};
 
 // Mirror the other backends' depth cap to protect against accidental infinite menu trees.
 const MAX_DEPTH: usize = 15;
@@ -85,6 +91,62 @@ fn activate_entry(self_weak: &ItemWeak, entry_index: usize) {
     }
 }
 
+struct AppearanceObserverIvars {
+    self_weak: ItemWeak,
+}
+
+define_class!(
+    #[unsafe(super = NSObject)]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = AppearanceObserverIvars]
+    struct AppearanceObserver;
+
+    unsafe impl NSObjectProtocol for AppearanceObserver {}
+
+    impl AppearanceObserver {
+        #[unsafe(method(observeValueForKeyPath:ofObject:change:context:))]
+        fn observe(
+            &self,
+            _key_path: Option<&NSString>,
+            of_object: Option<&AnyObject>,
+            _change: Option<&NSDictionary<NSKeyValueChangeKey, AnyObject>>,
+            _context: *mut c_void,
+        ) {
+            let Some(of_object) = of_object else { return };
+            let Some(status_item) = of_object.downcast_ref::<NSStatusItem>() else { return };
+            let Some(button) = status_item.button(self.mtm()) else { return };
+            let scheme = scheme_for_appearance(&button.effectiveAppearance());
+            let Some(item_rc) = self.ivars().self_weak.upgrade() else { return };
+            let Some(tray) = item_rc.downcast::<super::SystemTrayIcon>() else { return };
+            tray.as_pin_ref().set_color_scheme(scheme);
+        }
+    }
+);
+
+impl AppearanceObserver {
+    fn new(mtm: MainThreadMarker, self_weak: ItemWeak) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(AppearanceObserverIvars { self_weak });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+fn scheme_for_appearance(appearance: &NSAppearance) -> ColorScheme {
+    // `bestMatchFromAppearancesWithNames:` collapses the high-contrast / vibrant
+    // variants down to whichever of these two best matches, so we don't have to
+    // enumerate them. `None` means it didn't match either family — surface that
+    // as `Unknown` rather than guessing.
+    let names = [unsafe { NSAppearanceNameAqua }, unsafe { NSAppearanceNameDarkAqua }];
+    let candidates = NSArray::from_slice(&names);
+    let Some(best) = appearance.bestMatchFromAppearancesWithNames(&candidates) else {
+        return ColorScheme::Unknown;
+    };
+    if &*best == unsafe { NSAppearanceNameDarkAqua } {
+        ColorScheme::Dark
+    } else {
+        ColorScheme::Light
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Icon conversion: Slint `Image` -> `NSImage` via `NSBitmapImageRep`.
 // ---------------------------------------------------------------------------
@@ -126,6 +188,7 @@ fn image_to_nsimage(icon: &Image) -> Result<Retained<NSImage>, Error> {
 pub struct PlatformTray {
     status_item: Retained<NSStatusItem>,
     action_target: Retained<MenuAction>,
+    appearance_observer: Retained<AppearanceObserver>,
     mtm: MainThreadMarker,
 }
 
@@ -143,7 +206,7 @@ impl PlatformTray {
         let status_bar = NSStatusBar::systemStatusBar();
         let status_item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
 
-        let action_target = MenuAction::new(mtm, self_weak);
+        let action_target = MenuAction::new(mtm, self_weak.clone());
 
         if let Some(button) = status_item.button(mtm) {
             button.setImage(Some(&image));
@@ -166,7 +229,17 @@ impl PlatformTray {
             }
         }
 
-        Ok(Self { status_item, action_target, mtm })
+        let observer = AppearanceObserver::new(mtm, self_weak);
+        unsafe {
+            status_item.addObserver_forKeyPath_options_context(
+                &observer,
+                ns_string!("button.effectiveAppearance"),
+                NSKeyValueObservingOptions::Initial | NSKeyValueObservingOptions::New,
+                core::ptr::null_mut(),
+            );
+        }
+
+        Ok(Self { status_item, action_target, appearance_observer: observer, mtm })
     }
 
     pub fn rebuild_menu(
@@ -219,8 +292,12 @@ impl PlatformTray {
 
 impl Drop for PlatformTray {
     fn drop(&mut self) {
-        // Safe: PlatformTray is only constructed on the main thread and is owned by
-        // the SystemTrayIcon item, which is itself dropped on the event loop (main thread).
+        unsafe {
+            self.status_item.removeObserver_forKeyPath(
+                &self.appearance_observer,
+                ns_string!("button.effectiveAppearance"),
+            );
+        }
         let status_bar = NSStatusBar::systemStatusBar();
         status_bar.removeStatusItem(&self.status_item);
     }

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -98,7 +98,7 @@ pub use graphics::BorderRadius;
 #[doc(inline)]
 pub use data_transfer::DataTransfer;
 
-pub use context::{SlintContext, with_global_context};
+pub use context::{SlintContext, SlintContextWeak, with_global_context};
 
 #[cfg(not(slint_int_coord))]
 pub type Coord = f32;

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -63,6 +63,14 @@ pub trait Platform {
         Err(PlatformError::NoEventLoopProvider)
     }
 
+    /// Called once by `set_platform` immediately after the [`crate::SlintContext`]
+    /// has been constructed, to give the platform a weak handle to its own context.
+    /// Platforms can stash the handle and later use it to spawn futures or write
+    /// process-wide state without going through a window adapter. The default impl
+    /// drops the handle.
+    #[doc(hidden)]
+    fn bind_context(&self, _ctx: crate::SlintContextWeak, _: crate::InternalToken) {}
+
     #[doc(hidden)]
     #[deprecated(
         note = "i-slint-core takes care of closing behavior. Application should call run_event_loop_until_quit"
@@ -263,6 +271,8 @@ pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), SetPlat
             .set(crate::SlintContext::new(platform))
             .map_err(|_| SetPlatformError::AlreadySet)
             .unwrap();
+        let ctx = instance.get().unwrap();
+        ctx.platform().bind_context(ctx.downgrade(), crate::InternalToken);
         // Ensure a sane starting point for the animation tick.
         update_timers_and_animations();
         Ok(())

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -275,7 +275,7 @@ fn translate_gettext(
 fn global_translation_property() -> usize {
     crate::context::GLOBAL_CONTEXT.with(|ctx| {
         let Some(ctx) = ctx.get() else { return 0 };
-        ctx.0.pinned_fields.as_ref().project_ref().translations_dirty.get()
+        ctx.0.as_ref().project_ref().translations_dirty.get()
     })
 }
 
@@ -296,7 +296,7 @@ pub fn mark_all_translations_dirty() {
 
     crate::context::GLOBAL_CONTEXT.with(|ctx| {
         let Some(ctx) = ctx.get() else { return };
-        ctx.0.pinned_fields.as_ref().project_ref().translations_dirty.mark_dirty();
+        ctx.0.as_ref().project_ref().translations_dirty.mark_dirty();
     })
 }
 
@@ -364,7 +364,7 @@ pub fn set_bundled_languages(languages: &[&'static str]) {
             ctx.0.translations_bundle_languages.replace(Some(languages.to_vec()));
             #[cfg(feature = "std")]
             if let Some(idx) = index_for_locale(languages) {
-                ctx.0.pinned_fields.as_ref().project_ref().translations_dirty.set(idx);
+                ctx.0.as_ref().project_ref().translations_dirty.set(idx);
             }
         }
     });
@@ -408,7 +408,7 @@ pub fn select_bundled_translation(language: &str) -> Result<(), SelectBundledTra
             return Err(SelectBundledTranslationError::NoTranslationsBundled);
         };
         let idx = languages.iter().position(|x| *x == language);
-        let pinned = ctx.0.pinned_fields.as_ref().project_ref();
+        let pinned = ctx.0.as_ref().project_ref();
         if let Some(idx) = idx {
             pinned.translations_dirty.set(idx);
             Ok(())

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -275,7 +275,7 @@ fn translate_gettext(
 fn global_translation_property() -> usize {
     crate::context::GLOBAL_CONTEXT.with(|ctx| {
         let Some(ctx) = ctx.get() else { return 0 };
-        ctx.0.translations_dirty.as_ref().get()
+        ctx.0.pinned_fields.as_ref().project_ref().translations_dirty.get()
     })
 }
 
@@ -296,7 +296,7 @@ pub fn mark_all_translations_dirty() {
 
     crate::context::GLOBAL_CONTEXT.with(|ctx| {
         let Some(ctx) = ctx.get() else { return };
-        ctx.0.translations_dirty.mark_dirty();
+        ctx.0.pinned_fields.as_ref().project_ref().translations_dirty.mark_dirty();
     })
 }
 
@@ -364,7 +364,7 @@ pub fn set_bundled_languages(languages: &[&'static str]) {
             ctx.0.translations_bundle_languages.replace(Some(languages.to_vec()));
             #[cfg(feature = "std")]
             if let Some(idx) = index_for_locale(languages) {
-                ctx.0.translations_dirty.as_ref().set(idx);
+                ctx.0.pinned_fields.as_ref().project_ref().translations_dirty.set(idx);
             }
         }
     });
@@ -408,11 +408,12 @@ pub fn select_bundled_translation(language: &str) -> Result<(), SelectBundledTra
             return Err(SelectBundledTranslationError::NoTranslationsBundled);
         };
         let idx = languages.iter().position(|x| *x == language);
+        let pinned = ctx.0.pinned_fields.as_ref().project_ref();
         if let Some(idx) = idx {
-            ctx.0.translations_dirty.as_ref().set(idx);
+            pinned.translations_dirty.set(idx);
             Ok(())
         } else if language.is_empty() || language == "en" {
-            ctx.0.translations_dirty.as_ref().set(0);
+            pinned.translations_dirty.set(0);
             Ok(())
         } else {
             Err(SelectBundledTranslationError::LanguageNotFound {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1756,23 +1756,14 @@ impl WindowInner {
 /// Internal alias for `Rc<dyn WindowAdapter>`.
 pub type WindowAdapterRc = Rc<dyn WindowAdapter>;
 
-/// Runtime entry point for `BuiltinFunction::ColorScheme`. Returns the tray's own
-/// scheme when the root is a [`crate::items::SystemTrayIcon`], otherwise the
-/// component's [`crate::SlintContext`] value reached via its window adapter.
-pub fn resolve_color_scheme(root: &crate::item_tree::ItemTreeRc) -> crate::items::ColorScheme {
-    let root_item = ItemRc::new_root(root.clone());
-    if let Some(tray) = root_item.downcast::<crate::items::SystemTrayIcon>() {
-        let scheme = tray.as_pin_ref().color_scheme();
-        if scheme != crate::items::ColorScheme::Unknown {
-            return scheme;
-        }
-    }
+/// Resolve the [`crate::SlintContext`] associated with a component root by
+/// asking it for (or creating) its window adapter and reading the context off
+/// the resulting window. Returns `None` only when no adapter can be produced.
+pub fn context_for_root(root: &ItemTreeRc) -> Option<crate::SlintContext> {
     let comp_ref_pin = vtable::VRc::borrow_pin(root);
     let mut adapter = None;
     comp_ref_pin.as_ref().window_adapter(true, &mut adapter);
-    adapter.map_or(crate::items::ColorScheme::Unknown, |a| {
-        WindowInner::from_pub(a.window()).context().color_scheme()
-    })
+    adapter.map(|a| WindowInner::from_pub(a.window()).context().clone())
 }
 
 /// Runtime entry point for `BuiltinFunction::AccentColor`. Returns the accent color

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1756,6 +1756,25 @@ impl WindowInner {
 /// Internal alias for `Rc<dyn WindowAdapter>`.
 pub type WindowAdapterRc = Rc<dyn WindowAdapter>;
 
+/// Runtime entry point for `BuiltinFunction::ColorScheme`. Returns the tray's own
+/// scheme when the root is a [`crate::items::SystemTrayIcon`], otherwise the
+/// component's [`crate::SlintContext`] value reached via its window adapter.
+pub fn resolve_color_scheme(root: &crate::item_tree::ItemTreeRc) -> crate::items::ColorScheme {
+    let root_item = ItemRc::new_root(root.clone());
+    if let Some(tray) = root_item.downcast::<crate::items::SystemTrayIcon>() {
+        let scheme = tray.as_pin_ref().color_scheme();
+        if scheme != crate::items::ColorScheme::Unknown {
+            return scheme;
+        }
+    }
+    let comp_ref_pin = vtable::VRc::borrow_pin(root);
+    let mut adapter = None;
+    comp_ref_pin.as_ref().window_adapter(true, &mut adapter);
+    adapter.map_or(crate::items::ColorScheme::Unknown, |a| {
+        WindowInner::from_pub(a.window()).context().color_scheme()
+    })
+}
+
 /// Runtime entry point for `BuiltinFunction::AccentColor`. Returns the accent color
 /// from the component's [`crate::SlintContext`] reached via its window adapter, or
 /// transparent if none is associated.
@@ -1781,7 +1800,7 @@ pub mod ffi {
     use crate::api::{RenderingNotifier, RenderingState, SetRenderingNotifierError};
     use crate::graphics::Size;
     use crate::graphics::{Color, IntSize, Rgba8Pixel};
-    use crate::items::{ColorScheme, WindowItem};
+    use crate::items::WindowItem;
 
     /// This enum describes a low-level access to specific graphics APIs used
     /// by the renderer.
@@ -2183,23 +2202,23 @@ pub mod ffi {
         }
     }
 
-    /// Return whether the style is using a dark theme
-    #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_color_scheme(
-        handle: *const WindowAdapterRcOpaque,
-    ) -> ColorScheme {
-        unsafe {
-            let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-            WindowInner::from_pub(window_adapter.window()).context().color_scheme()
-        }
-    }
-
     /// Return the system accent color, or transparent if not available. The accent color
     /// is process-wide and lives on [`crate::SlintContext`], so this no longer needs a
     /// window-adapter handle.
     #[unsafe(no_mangle)]
     pub extern "C" fn slint_accent_color(root: &crate::item_tree::ItemTreeRc, out: &mut Color) {
         *out = super::accent_color(root);
+    }
+
+    /// C ABI counterpart of [`super::resolve_color_scheme`]. The C++ generator emits a call
+    /// to this for `BuiltinFunction::ColorScheme` so a `Palette.color-scheme` binding inside
+    /// a tray-rooted component resolves to the tray's scheme without forcing a window
+    /// adapter to be created.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn slint_resolve_color_scheme(
+        root: &crate::item_tree::ItemTreeRc,
+    ) -> crate::items::ColorScheme {
+        super::resolve_color_scheme(root)
     }
 
     /// Return whether the platform supports native menu bars

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1799,7 +1799,7 @@ pub mod ffi {
     use crate::SharedVector;
     use crate::api::{RenderingNotifier, RenderingState, SetRenderingNotifierError};
     use crate::graphics::Size;
-    use crate::graphics::{Color, IntSize, Rgba8Pixel};
+    use crate::graphics::{IntSize, Rgba8Pixel};
     use crate::items::WindowItem;
 
     /// This enum describes a low-level access to specific graphics APIs used
@@ -2200,25 +2200,6 @@ pub mod ffi {
             let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
             window_adapter.window().set_size(crate::api::LogicalSize::new(size.width, size.height));
         }
-    }
-
-    /// Return the system accent color, or transparent if not available. The accent color
-    /// is process-wide and lives on [`crate::SlintContext`], so this no longer needs a
-    /// window-adapter handle.
-    #[unsafe(no_mangle)]
-    pub extern "C" fn slint_accent_color(root: &crate::item_tree::ItemTreeRc, out: &mut Color) {
-        *out = super::accent_color(root);
-    }
-
-    /// C ABI counterpart of [`super::resolve_color_scheme`]. The C++ generator emits a call
-    /// to this for `BuiltinFunction::ColorScheme` so a `Palette.color-scheme` binding inside
-    /// a tray-rooted component resolves to the tray's scheme without forcing a window
-    /// adapter to be created.
-    #[unsafe(no_mangle)]
-    pub extern "C" fn slint_resolve_color_scheme(
-        root: &crate::item_tree::ItemTreeRc,
-    ) -> crate::items::ColorScheme {
-        super::resolve_color_scheme(root)
     }
 
     /// Return whether the platform supports native menu bars

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -9,7 +9,6 @@ use crate::api::{
     CloseRequestResponse, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize,
     PlatformError, Window, WindowPosition, WindowSize,
 };
-use crate::graphics::Color;
 use crate::input::{
     ClickState, FocusEvent, FocusReason, InternalKeyEvent, KeyEventResult, KeyEventType, Keys,
     MouseEvent, MouseInputState, PointerEventButton, TextCursorBlinker, TouchPhase, TouchState,
@@ -202,11 +201,6 @@ pub trait WindowAdapterInternal: core::any::Any {
     /// Handle focus change
     // used for accessibility
     fn handle_focus_change(&self, _old: Option<ItemRc>, _new: Option<ItemRc>) {}
-
-    /// Returns the system accent color, or transparent if the platform doesn't provide one.
-    fn accent_color(&self) -> Color {
-        Color::default()
-    }
 
     /// Returns whether we can have a native menu bar
     fn supports_native_menu_bar(&self) -> bool {
@@ -1277,13 +1271,6 @@ impl WindowInner {
         result
     }
 
-    /// Returns the system accent color, or transparent if unavailable.
-    pub fn accent_color(&self) -> Color {
-        self.window_adapter()
-            .internal(crate::InternalToken)
-            .map_or(Color::default(), |x| x.accent_color())
-    }
-
     /// Return whether the platform supports native menu bars
     pub fn supports_native_menu_bar(&self) -> bool {
         self.window_adapter()
@@ -1769,6 +1756,18 @@ impl WindowInner {
 /// Internal alias for `Rc<dyn WindowAdapter>`.
 pub type WindowAdapterRc = Rc<dyn WindowAdapter>;
 
+/// Runtime entry point for `BuiltinFunction::AccentColor`. Returns the accent color
+/// from the component's [`crate::SlintContext`] reached via its window adapter, or
+/// transparent if none is associated.
+pub fn accent_color(root: &crate::item_tree::ItemTreeRc) -> crate::graphics::Color {
+    let comp_ref_pin = vtable::VRc::borrow_pin(root);
+    let mut adapter = None;
+    comp_ref_pin.as_ref().window_adapter(true, &mut adapter);
+    adapter.map_or(crate::graphics::Color::default(), |a| {
+        WindowInner::from_pub(a.window()).context().accent_color()
+    })
+}
+
 /// This module contains the functions needed to interface with the event loop and window traits
 /// from outside the Rust language.
 #[cfg(feature = "ffi")]
@@ -1781,8 +1780,8 @@ pub mod ffi {
     use crate::SharedVector;
     use crate::api::{RenderingNotifier, RenderingState, SetRenderingNotifierError};
     use crate::graphics::Size;
-    use crate::graphics::{IntSize, Rgba8Pixel};
-    use crate::items::WindowItem;
+    use crate::graphics::{Color, IntSize, Rgba8Pixel};
+    use crate::items::{ColorScheme, WindowItem};
 
     /// This enum describes a low-level access to specific graphics APIs used
     /// by the renderer.
@@ -2195,16 +2194,12 @@ pub mod ffi {
         }
     }
 
-    /// Return the system accent color, or transparent if not available
+    /// Return the system accent color, or transparent if not available. The accent color
+    /// is process-wide and lives on [`crate::SlintContext`], so this no longer needs a
+    /// window-adapter handle.
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_accent_color(
-        handle: *const WindowAdapterRcOpaque,
-        out: &mut Color,
-    ) {
-        let window_adapter = unsafe { &*(handle as *const Rc<dyn WindowAdapter>) };
-        *out = window_adapter
-            .internal(crate::InternalToken)
-            .map_or(Color::default(), |x| x.accent_color());
+    pub extern "C" fn slint_accent_color(root: &crate::item_tree::ItemTreeRc, out: &mut Color) {
+        *out = super::accent_color(root);
     }
 
     /// Return whether the platform supports native menu bars

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -19,7 +19,7 @@ use crate::item_tree::{
     ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable, ItemTreeWeak, ItemWeak,
     ParentItemTraversalMode,
 };
-use crate::items::{ColorScheme, InputType, ItemRef, MenuEntry, MouseCursor, PopupClosePolicy};
+use crate::items::{InputType, ItemRef, MenuEntry, MouseCursor, PopupClosePolicy};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, SizeLengths};
 use crate::menus::MenuVTable;
 use crate::properties::{Property, PropertyTracker};
@@ -202,11 +202,6 @@ pub trait WindowAdapterInternal: core::any::Any {
     /// Handle focus change
     // used for accessibility
     fn handle_focus_change(&self, _old: Option<ItemRc>, _new: Option<ItemRc>) {}
-
-    /// returns the color scheme used
-    fn color_scheme(&self) -> ColorScheme {
-        ColorScheme::Unknown
-    }
 
     /// Returns the system accent color, or transparent if the platform doesn't provide one.
     fn accent_color(&self) -> Color {
@@ -1282,13 +1277,6 @@ impl WindowInner {
         result
     }
 
-    /// returns the color theme used
-    pub fn color_scheme(&self) -> ColorScheme {
-        self.window_adapter()
-            .internal(crate::InternalToken)
-            .map_or(ColorScheme::Unknown, |x| x.color_scheme())
-    }
-
     /// Returns the system accent color, or transparent if unavailable.
     pub fn accent_color(&self) -> Color {
         self.window_adapter()
@@ -2203,9 +2191,7 @@ pub mod ffi {
     ) -> ColorScheme {
         unsafe {
             let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-            window_adapter
-                .internal(crate::InternalToken)
-                .map_or(ColorScheme::Unknown, |x| x.color_scheme())
+            WindowInner::from_pub(window_adapter.window()).context().color_scheme()
         }
     }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -8,7 +8,7 @@ use corelib::graphics::{
     ConicGradientBrush, GradientStop, LinearGradientBrush, PathElement, RadialGradientBrush,
 };
 use corelib::input::FocusReason;
-use corelib::items::{ColorScheme, ItemRc, ItemRef, PropertyAnimation, WindowItem};
+use corelib::items::{ItemRc, ItemRef, PropertyAnimation, WindowItem};
 use corelib::menus::{Menu, MenuFromItemTree};
 use corelib::model::{Model, ModelExt, ModelRc, VecModel};
 use corelib::rtti::AnimatedBindingKind;
@@ -1437,12 +1437,12 @@ fn call_builtin_function(
             let a = a.clamp(0., 1.);
             Value::Brush(Brush::SolidColor(Color::from_oklch(l, c, h, a)))
         }
-        BuiltinFunction::ColorScheme => local_context
-            .component_instance
-            .window_adapter()
-            .internal(corelib::InternalToken)
-            .map_or(ColorScheme::Unknown, |x| x.color_scheme())
-            .into(),
+        BuiltinFunction::ColorScheme => corelib::window::WindowInner::from_pub(
+            local_context.component_instance.window_adapter().window(),
+        )
+        .context()
+        .color_scheme()
+        .into(),
         BuiltinFunction::AccentColor => {
             let color = local_context
                 .component_instance

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1441,7 +1441,9 @@ fn call_builtin_function(
             let root_weak =
                 vtable::VWeak::into_dyn(local_context.component_instance.root_weak().clone());
             let root = root_weak.upgrade().unwrap();
-            corelib::window::resolve_color_scheme(&root).into()
+            corelib::window::context_for_root(&root)
+                .map_or(corelib::items::ColorScheme::Unknown, |ctx| ctx.color_scheme(Some(&root)))
+                .into()
         }
         BuiltinFunction::AccentColor => {
             let root_weak =

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1444,12 +1444,10 @@ fn call_builtin_function(
         .color_scheme()
         .into(),
         BuiltinFunction::AccentColor => {
-            let color = local_context
-                .component_instance
-                .window_adapter()
-                .internal(corelib::InternalToken)
-                .map_or(corelib::Color::default(), |x| x.accent_color());
-            Value::Brush(corelib::Brush::SolidColor(color))
+            let root_weak =
+                vtable::VWeak::into_dyn(local_context.component_instance.root_weak().clone());
+            let root = root_weak.upgrade().unwrap();
+            Value::Brush(corelib::Brush::SolidColor(corelib::window::accent_color(&root)))
         }
         BuiltinFunction::SupportsNativeMenuBar => local_context
             .component_instance

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1437,12 +1437,12 @@ fn call_builtin_function(
             let a = a.clamp(0., 1.);
             Value::Brush(Brush::SolidColor(Color::from_oklch(l, c, h, a)))
         }
-        BuiltinFunction::ColorScheme => corelib::window::WindowInner::from_pub(
-            local_context.component_instance.window_adapter().window(),
-        )
-        .context()
-        .color_scheme()
-        .into(),
+        BuiltinFunction::ColorScheme => {
+            let root_weak =
+                vtable::VWeak::into_dyn(local_context.component_instance.root_weak().clone());
+            let root = root_weak.upgrade().unwrap();
+            corelib::window::resolve_color_scheme(&root).into()
+        }
         BuiltinFunction::AccentColor => {
             let root_weak =
                 vtable::VWeak::into_dyn(local_context.component_instance.root_weak().clone());

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -664,10 +664,8 @@ fn handle_builtin_function(
         }
         BuiltinFunction::ColorScheme => {
             local_context.window_adapter.as_ref().map_or(Value::Void, |win| {
-                i_slint_core::window::WindowInner::from_pub(win.window())
-                    .context()
-                    .color_scheme()
-                    .into()
+                let root = i_slint_core::window::WindowInner::from_pub(win.window()).component();
+                i_slint_core::window::resolve_color_scheme(&root).into()
             })
         }
         BuiltinFunction::MonthDayCount => {

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -664,8 +664,9 @@ fn handle_builtin_function(
         }
         BuiltinFunction::ColorScheme => {
             local_context.window_adapter.as_ref().map_or(Value::Void, |win| {
-                let root = i_slint_core::window::WindowInner::from_pub(win.window()).component();
-                i_slint_core::window::resolve_color_scheme(&root).into()
+                let inner = i_slint_core::window::WindowInner::from_pub(win.window());
+                let root = inner.component();
+                inner.context().color_scheme(Some(&root)).into()
             })
         }
         BuiltinFunction::MonthDayCount => {

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -664,8 +664,10 @@ fn handle_builtin_function(
         }
         BuiltinFunction::ColorScheme => {
             local_context.window_adapter.as_ref().map_or(Value::Void, |win| {
-                win.internal(i_slint_core::InternalToken)
-                    .map_or(Value::Void, |x| x.color_scheme().into())
+                i_slint_core::window::WindowInner::from_pub(win.window())
+                    .context()
+                    .color_scheme()
+                    .into()
             })
         }
         BuiltinFunction::MonthDayCount => {


### PR DESCRIPTION
…plement on macOS

Picking a tray icon that contrasts with its surroundings was previously a guess: the example used `Palette.color-scheme`, which reflects the application window's appearance, not the menu bar / tray area. On macOS the two can diverge, leaving the icon mis-contrasted against the actual menu bar.

Surface the tray-area color scheme directly on `SystemTrayIcon` so app code can bind to it without relying on window-level state. The macOS backend tracks it live by observing `button.effectiveAppearance` on the NSStatusItem via KVO; the compound key path is what makes the notification cross the boundary between AppKit's menu-bar host process and our app. Other backends leave the property at `Unknown` for now.

Fixes #11637

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
