### PR TITLE
LSP: Improve preview highlighting

### DIFF
--- a/docs/astro/src/content/docs/guide/tooling/neo-vim.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/neo-vim.mdx
@@ -1,5 +1,5 @@
 ---
-// cSpell: ignore vimrc nvim lspconfig kosayoda
+// cSpell: ignore vimrc nvim lspconfig kosayoda akioweh
 title: (Neo-)Vim
 description: Vim and Neovim Configuration for Slint
 ---
@@ -71,6 +71,16 @@ You may also want to install a plugin that indicates when code actions are avail
 **Example with nvim-lightbulb**:
 
 ![Opening Live Preview from Neovim](../../../../assets/guide/tooling/nvim-show-preview.webp)
+
+#### Highlighting elements from Neovim
+
+To highlight elements in the live preview from Neovim directly, either:
+Use the "hover" LSP action (`K` by default) or enable the [document-highlight](https://neovim.io/doc/user/lsp/#vim.lsp.buf.document_highlight()) feature.
+When document highlighting is enabled, moving the caret over an element will automatically highlight it in the live preview, and moving the caret away will remove the highlight.
+
+:::tip[Personal Recommendation]
+The [akioweh/lsp-document-highlight](https://github.com/akioweh/lsp-document-highlight.nvim) plugin provides an easy way to configure the the document-highlight action without the flickering the default configuration will create.
+:::
 
 ### Tree-sitter
 

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -22,7 +22,9 @@ use i_slint_compiler::parser::{
     NodeOrToken, SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TextSize, syntax_nodes,
 };
 use i_slint_compiler::{diagnostics::BuildDiagnostics, langtype::Type};
+use i_slint_preview_protocol::LspToPreviewMessage;
 use itertools::Itertools;
+use lsp_types::TextDocumentPositionParams;
 use lsp_types::{
     ClientCapabilities, CodeActionOrCommand, CodeActionProviderCapability, CodeLens,
     CodeLensOptions, Color, ColorInformation, ColorPresentation, Command, CompletionOptions,
@@ -334,14 +336,24 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
         Ok(result)
     });
     rh.register::<HoverRequest>(|params, ctx| {
-        let result = token_descr(
+        let Some((token, _text_size)) = token_descr(
             &ctx.document_cache,
             &params.text_document_position_params.text_document.uri,
             &params.text_document_position_params.position,
-        )
-        .and_then(|(token, _)| hover::get_tooltip(&mut ctx.document_cache, token));
+        ) else {
+            return Ok(None);
+        };
 
-        Ok(result)
+        let hover = hover::get_tooltip(&mut ctx.document_cache, token.clone());
+
+        // we will show a tooltip in the editor, also update the highlight in the live preview
+        if hover.is_some() {
+            let (_document, preview) =
+                get_highlights_for_position(ctx, &params.text_document_position_params);
+            ctx.to_preview.send(&preview);
+        }
+
+        Ok(hover)
     });
     rh.register::<SignatureHelpRequest>(|params, ctx| {
         let result = token_descr(
@@ -412,78 +424,21 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
         Ok(semantic_tokens::get_semantic_tokens(&mut ctx.document_cache, &params.text_document))
     });
     rh.register::<DocumentHighlightRequest>(|params, ctx| {
-        let uri = params.text_document_position_params.text_document.uri;
-        if let Some((tk, _)) =
-            token_descr(&ctx.document_cache, &uri, &params.text_document_position_params.position)
-        {
-            let p = tk.parent();
-            let gp = p.parent();
+        tracing::trace!(
+            "DocumentHighlightRequest for {} at {:?}",
+            params.text_document_position_params.text_document.uri,
+            params.text_document_position_params.position
+        );
 
-            if p.kind() == SyntaxKind::DeclaredIdentifier
-                && gp.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Component)
-            {
-                let element = gp.as_ref().unwrap().child_node(SyntaxKind::Element).unwrap();
+        let (document_highlights, preview) =
+            get_highlights_for_position(ctx, &params.text_document_position_params);
 
-                ctx.to_preview.send(
-                    &i_slint_preview_protocol::LspToPreviewMessage::HighlightFromEditor {
-                        url: Some(uri),
-                        offset: element.text_range().start().into(),
-                    },
-                );
+        // Update the highlight in the live preview.
+        // We do this even if there are no highlights to clear any previous highlights.
+        ctx.to_preview.send(&preview);
 
-                let range = util::node_to_lsp_range(&p, ctx.document_cache.format);
-                return Ok(Some(vec![lsp_types::DocumentHighlight { range, kind: None }]));
-            }
-
-            if p.kind() == SyntaxKind::QualifiedName
-                && gp.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Element)
-            {
-                let range = util::node_to_lsp_range(&p, ctx.document_cache.format);
-
-                if gp
-                    .as_ref()
-                    .unwrap()
-                    .parent()
-                    .as_ref()
-                    .is_some_and(|n| n.kind() != SyntaxKind::Component)
-                {
-                    ctx.to_preview.send(
-                        &i_slint_preview_protocol::LspToPreviewMessage::HighlightFromEditor {
-                            url: Some(uri),
-                            offset: gp.unwrap().text_range().start().into(),
-                        },
-                    );
-                }
-                return Ok(Some(vec![lsp_types::DocumentHighlight { range, kind: None }]));
-            }
-
-            if let Some(value) = common::rename_element_id::find_element_ids(&tk, &p) {
-                ctx.to_preview.send(
-                    &i_slint_preview_protocol::LspToPreviewMessage::HighlightFromEditor {
-                        url: None,
-                        offset: 0,
-                    },
-                );
-                return Ok(Some(
-                    value
-                        .into_iter()
-                        .map(|r| lsp_types::DocumentHighlight {
-                            range: util::text_range_to_lsp_range(
-                                &p.source_file,
-                                r,
-                                ctx.document_cache.format,
-                            ),
-                            kind: None,
-                        })
-                        .collect(),
-                ));
-            }
-        }
-        ctx.to_preview.send(&i_slint_preview_protocol::LspToPreviewMessage::HighlightFromEditor {
-            url: None,
-            offset: 0,
-        });
-        Ok(None)
+        let not_empty = !document_highlights.is_empty();
+        Ok(not_empty.then_some(document_highlights))
     });
     rh.register::<Rename>(|params, ctx| {
         let uri = params.text_document_position.text_document.uri;
@@ -1474,6 +1429,73 @@ export component MainWindow inherits Window {
     }
 
     (!result.is_empty()).then_some(result)
+}
+
+/// Returns the list of DocumentHighlights, plus a LspToPreviewMessage::HighlightFromEditor  for the
+/// given position
+/// The list of DocumentHighlights will be empty if there is no highlight to show in the editor
+/// The HighlightFromEditor will have url=None if there is no highlight to show in the preview
+fn get_highlights_for_position(
+    ctx: &Context,
+    params: &TextDocumentPositionParams,
+) -> (Vec<lsp_types::DocumentHighlight>, LspToPreviewMessage) {
+    let uri = params.text_document.uri.clone();
+    if let Some((token, _)) = token_descr(&ctx.document_cache, &uri, &params.position) {
+        let parent = token.parent();
+        let grand_parent = parent.parent();
+
+        if parent.kind() == SyntaxKind::DeclaredIdentifier
+            && grand_parent.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Component)
+        {
+            let element = grand_parent.as_ref().unwrap().child_node(SyntaxKind::Element).unwrap();
+
+            let preview_highlight =
+                i_slint_preview_protocol::LspToPreviewMessage::HighlightFromEditor {
+                    url: Some(uri),
+                    offset: element.text_range().start().into(),
+                };
+
+            let range = util::node_to_lsp_range(&parent, ctx.document_cache.format);
+            return (vec![lsp_types::DocumentHighlight { range, kind: None }], preview_highlight);
+        }
+
+        if parent.kind() == SyntaxKind::QualifiedName
+            && grand_parent.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Element)
+        {
+            let great_grand_parent = grand_parent.as_ref().unwrap().parent();
+            let should_highlight_preview =
+                great_grand_parent.as_ref().is_some_and(|n| n.kind() != SyntaxKind::Component);
+            let preview_highlight =
+                i_slint_preview_protocol::LspToPreviewMessage::HighlightFromEditor {
+                    url: should_highlight_preview.then_some(uri),
+                    offset: grand_parent.unwrap().text_range().start().into(),
+                };
+            let range = util::node_to_lsp_range(&parent, ctx.document_cache.format);
+
+            return (vec![lsp_types::DocumentHighlight { range, kind: None }], preview_highlight);
+        }
+
+        if let Some(value) = common::rename_element_id::find_element_ids(&token, &parent) {
+            let preview_highlight =
+                i_slint_preview_protocol::LspToPreviewMessage::HighlightFromEditor {
+                    url: None,
+                    offset: 0,
+                };
+            let document_highlight = value
+                .into_iter()
+                .map(|r| lsp_types::DocumentHighlight {
+                    range: util::text_range_to_lsp_range(
+                        &parent.source_file,
+                        r,
+                        ctx.document_cache.format,
+                    ),
+                    kind: None,
+                })
+                .collect();
+            return (document_highlight, preview_highlight);
+        }
+    }
+    (vec![], LspToPreviewMessage::HighlightFromEditor { url: None, offset: 0 })
 }
 
 pub async fn startup_lsp(ctx: &mut Context) -> common::Result<()> {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1579,9 +1579,10 @@ fn set_preview_factory(
 }
 
 /// Highlight the element pointed at the offset in the path.
-/// When path is None, remove the highlight.
+/// When the URL is None, remove the highlight.
 pub fn highlight(url: Option<Url>, offset: TextSize) {
     let Some(path) = url.as_ref().and_then(|u| Url::to_file_path(u).ok()) else {
+        element_selection::unselect_element();
         return;
     };
 

--- a/tools/lsp/preview/outline.rs
+++ b/tools/lsp/preview/outline.rs
@@ -256,12 +256,16 @@ pub fn reset_outline(api: &ui::Api<'_>, root_component: Option<Rc<object_tree::C
 }
 
 pub fn setup(api: &ui::Api<'_>) {
-    api.on_outline_select_element(|uri, offset| {
+    api.on_outline_select_element(|uri, offset, notify_editor| {
         super::element_selection::select_element_at_source_code_position(
             crate::common::uri_to_file(&Url::parse(uri.as_str()).unwrap()).unwrap(),
             TextSize::new(offset as u32),
             None,
-            super::SelectionNotification::Now,
+            if notify_editor {
+                super::SelectionNotification::Now
+            } else {
+                super::SelectionNotification::Never
+            },
         );
     });
     api.on_outline_drop(|data, target_uri, target_offset, location| {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -467,7 +467,7 @@ export global Api {
 
     // ## Outline
     in-out property <[OutlineTreeNode]> outline;
-    callback outline-select-element(uri: string, offset: int);
+    callback outline-select-element(uri: string, offset: int, notify_editor: bool);
     // Data is either a "file:offset" for an element to move, or just a component index.
     callback outline-drop(data: string, uri: string, offset: int, location: DropLocation);
     callback outline-can-drop(data: string, uri: string, offset: int, location: DropLocation) -> bool;

--- a/tools/lsp/ui/views/outline-view.slint
+++ b/tools/lsp/ui/views/outline-view.slint
@@ -155,7 +155,7 @@ export component OutlineView inherits VerticalLayout {
                     }
                     ta := TouchArea {
                         clicked => {
-                            Api.outline-select-element(item.uri, item.offset);
+                            Api.outline-select-element(item.uri, item.offset, true);
                         }
                         double-clicked => {
                             item.is-expanded = !item.is-expanded;
@@ -163,6 +163,16 @@ export component OutlineView inherits VerticalLayout {
                         pointer-event(event) => {
                             if event.kind == PointerEventKind.cancel {
                                 open-timer.running = false;
+                            }
+                            if self.has-hover {
+                                // On hover, only update the outline selection in the
+                                // preview, but not in the editor, as that might cause too
+                                // many jumps in the editor.
+                                // Helix also has a bug, where updating the selection by the LSP
+                                // will cause a new split to appear, which we want to avoid doing just
+                                // by hovering.
+                                // See: https://github.com/helix-editor/helix/issues/15429
+                                Api.outline-select-element(item.uri, item.offset, false);
                             }
                         }
                     }


### PR DESCRIPTION
1. Update the preview highlight on hover
2. Fix the highlight not disappearing when moving the cursor
3. Document highlight behavior for Neovim

This makes the whole situation more intuitive.
The document highlights appear when moving the cursor and the
hover highlights appear when hovering with the mouse.
So now with both input methods it's very easy
and intuitive to highlight something in the preview.

By default, in Neovim, the document highlight feature is disabled,
so add the documentation on how to enable it and how
to use the hover as an alternative.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
