### PR TITLE
Add accessible-live property

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -36,6 +36,10 @@ fn enums(path: &Path) -> anyhow::Result<()> {
             writeln!(enums_priv, "using slint::Orientation;")?;
             &mut enums_pub
         }};
+        (AccessibleLive) => {{
+            writeln!(enums_priv, "using slint::AccessibleLive;")?;
+            &mut enums_pub
+        }};
         ($_:ident) => {
             &mut enums_priv
         };

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -391,6 +391,21 @@ public:
         return std::nullopt;
     }
 
+    /// Returns the accessible-live of that element, if any.
+    std::optional<AccessibleLive> accessible_live() const
+    {
+        if (auto str = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Live)) {
+            if (*str == "off")
+                return AccessibleLive::Off;
+            if (*str == "polite")
+                return AccessibleLive::Polite;
+            if (*str == "assertive")
+                return AccessibleLive::Assertive;
+        }
+        return std::nullopt;
+    }
+
     /// Invokes the expand accessibility action of that element
     /// (`accessible-action-expand`).
     void invoke_accessible_expand_action() const

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -408,6 +408,13 @@ The orientation of the element when it makes sense, such as a `Slider` or a `Scr
 technologies can use this to inform the user whether the widget is laid out horizontally or vertically.
 </SlintProperty>
 
+### accessible-live
+<SlintProperty typeName="enum" enumName="AccessibleLive">
+Marks the element as a live region whose textual content should be announced by assistive
+technologies when it changes. Use `polite` for non-urgent updates and `assertive` for updates that
+should interrupt the user. The default `off` disables live announcements.
+</SlintProperty>
+
 ### accessible-value-maximum
 <SlintProperty typeName="float" propName="accessible-value-maximum" default="0">
 The maximum value of the item. This is used for example by spin boxes.

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -109,4 +109,4 @@ pub fn configure_test_fonts() {
     .unwrap();
 }
 
-pub use i_slint_core::items::{AccessibleRole, Orientation};
+pub use i_slint_core::items::{AccessibleLive, AccessibleRole, Orientation};

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -794,6 +794,17 @@ impl ElementHandle {
             .and_then(|s| s.parse().ok())
     }
 
+    /// Returns the value of the `accessible-live` property, if present.
+    pub fn accessible_live(&self) -> Option<crate::AccessibleLive> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item
+            .upgrade()
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Live))
+            .and_then(|s| s.parse().ok())
+    }
+
     /// Returns the size of the element in logical pixels. This corresponds to the value of the `width` and
     /// `height` properties in Slint code. Returns a zero size if the element is not valid.
     pub fn size(&self) -> i_slint_core::api::LogicalSize {

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -7,7 +7,7 @@ use std::ptr::NonNull;
 use std::rc::Weak;
 
 use accesskit::{
-    Action, ActionRequest, Node, NodeId, Orientation, Role, Toggled, Tree, TreeId, TreeUpdate,
+    Action, ActionRequest, Live, Node, NodeId, Orientation, Role, Toggled, Tree, TreeId, TreeUpdate,
 };
 use i_slint_core::SharedString;
 use i_slint_core::accessibility::{
@@ -673,6 +673,17 @@ impl NodeCollection {
             node.set_orientation(match orientation {
                 i_slint_core::items::Orientation::Horizontal => Orientation::Horizontal,
                 i_slint_core::items::Orientation::Vertical => Orientation::Vertical,
+            });
+        }
+
+        if let Some(live) = item
+            .accessible_string_property(AccessibleStringProperty::Live)
+            .and_then(|s| s.parse::<i_slint_core::items::AccessibleLive>().ok())
+        {
+            node.set_live(match live {
+                i_slint_core::items::AccessibleLive::Off => Live::Off,
+                i_slint_core::items::AccessibleLive::Polite => Live::Polite,
+                i_slint_core::items::AccessibleLive::Assertive => Live::Assertive,
             });
         }
 

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -500,6 +500,19 @@ macro_rules! for_each_enums {
                 RadioButton,
             }
 
+            /// This enum represents the different values of the `accessible-live` property.
+            /// It indicates that an element is a live region whose content changes should be
+            /// announced by assistive technologies.
+            // (on purpose not #[non_exhaustive])
+            enum AccessibleLive {
+                /// The element is not a live region.
+                Off,
+                /// Updates are announced when the user is idle.
+                Polite,
+                /// Updates are announced as soon as possible.
+                Assertive,
+            }
+
             /// This enum represents the different values of the `sort-order` property.
             /// It's used to sort a `StandardTableView` by a column.
             #[non_exhaustive]

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -44,7 +44,7 @@ pub fn lower_accessibility_properties(component: &Rc<Component>, diag: &mut Buil
 
             for prop_name in crate::typeregister::reserved_accessibility_properties()
                 .map(|x| x.0)
-                .chain(["accessible-role", "accessible-orientation"])
+                .chain(["accessible-role", "accessible-orientation", "accessible-live"])
             {
                 if accessible_role_set {
                     if elem.borrow().is_binding_set(prop_name, false) {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -335,6 +335,11 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
                 Type::Enumeration(BUILTIN.with(|e| e.enums.Orientation.clone())),
                 PropertyVisibility::Input,
             ),
+            (
+                "accessible-live",
+                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleLive.clone())),
+                PropertyVisibility::Input,
+            ),
         ]))
         .chain(std::iter::once(("init", noarg_callback_type(), PropertyVisibility::Private)))
 }

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -30,6 +30,7 @@ pub enum AccessibleStringProperty {
     ItemSelectable,
     ItemSelected,
     Label,
+    Live,
     Orientation,
     PlaceholderText,
     ReadOnly,

--- a/tests/cases/accessibility/live.slint
+++ b/tests/cases/accessibility/live.slint
@@ -1,0 +1,95 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test the accessible-live property.
+
+export component TestCase inherits Window {
+    width: 300phx;
+    height: 300phx;
+
+    in-out property <AccessibleLive> status-live: AccessibleLive.polite;
+
+    VerticalLayout {
+        Rectangle {
+            accessible-role: text;
+            accessible-label: "off-region";
+            accessible-live: AccessibleLive.off;
+        }
+        Rectangle {
+            accessible-role: text;
+            accessible-label: "polite-region";
+            accessible-live: AccessibleLive.polite;
+        }
+        Rectangle {
+            accessible-role: text;
+            accessible-label: "assertive-region";
+            accessible-live: AccessibleLive.assertive;
+        }
+        Rectangle {
+            accessible-role: text;
+            accessible-label: "dynamic-region";
+            accessible-live: root.status-live;
+        }
+        Rectangle {
+            accessible-role: text;
+            accessible-label: "no-live";
+        }
+    }
+}
+
+
+/*
+
+```rust
+use slint_testing::AccessibleLive;
+
+let instance = TestCase::new().unwrap();
+
+let off = slint_testing::ElementHandle::find_by_accessible_label(&instance, "off-region").next().unwrap();
+assert_eq!(off.accessible_live(), Some(AccessibleLive::Off));
+
+let polite = slint_testing::ElementHandle::find_by_accessible_label(&instance, "polite-region").next().unwrap();
+assert_eq!(polite.accessible_live(), Some(AccessibleLive::Polite));
+
+let assertive = slint_testing::ElementHandle::find_by_accessible_label(&instance, "assertive-region").next().unwrap();
+assert_eq!(assertive.accessible_live(), Some(AccessibleLive::Assertive));
+
+let d = slint_testing::ElementHandle::find_by_accessible_label(&instance, "dynamic-region").next().unwrap();
+assert_eq!(d.accessible_live(), Some(AccessibleLive::Polite));
+instance.set_status_live(AccessibleLive::Assertive);
+assert_eq!(d.accessible_live(), Some(AccessibleLive::Assertive));
+
+let none = slint_testing::ElementHandle::find_by_accessible_label(&instance, "no-live").next().unwrap();
+// Element has no accessible-live binding, so the property is not exposed.
+assert!(none.accessible_live().is_none());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+auto off = slint::testing::ElementHandle::find_by_accessible_label(handle, "off-region");
+assert_eq(off.size(), 1);
+assert(off[0].accessible_live().has_value());
+assert(*off[0].accessible_live() == slint::AccessibleLive::Off);
+
+auto polite = slint::testing::ElementHandle::find_by_accessible_label(handle, "polite-region");
+assert_eq(polite.size(), 1);
+assert(*polite[0].accessible_live() == slint::AccessibleLive::Polite);
+
+auto assertive = slint::testing::ElementHandle::find_by_accessible_label(handle, "assertive-region");
+assert_eq(assertive.size(), 1);
+assert(*assertive[0].accessible_live() == slint::AccessibleLive::Assertive);
+
+auto d = slint::testing::ElementHandle::find_by_accessible_label(handle, "dynamic-region");
+assert_eq(d.size(), 1);
+assert(*d[0].accessible_live() == slint::AccessibleLive::Polite);
+instance.set_status_live(slint::AccessibleLive::Assertive);
+assert(*d[0].accessible_live() == slint::AccessibleLive::Assertive);
+
+auto none = slint::testing::ElementHandle::find_by_accessible_label(handle, "no-live");
+assert_eq(none.size(), 1);
+assert(!none[0].accessible_live().has_value());
+```
+
+*/


### PR DESCRIPTION
<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Accessible property to mark some regions with dynamic content as important to assistive technologies so they can report changes automatically to the user, even if the element does not have the focus. Common examples include status bars or message lists in a chat application.

Qt also support live regions since 6.8 but you have to fire the events yourself. With Slint's property trackers that currently mean multiple events for a single change, so I'm not including that here.