### PR TITLE
Docs: Remove "generated" from documentation URLs

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -307,15 +307,15 @@ export default defineConfig({
                                                 },
                                                 {
                                                     label: "FocusScope",
-                                                    slug: "reference/keyboard-input/focus-scope",
+                                                    slug: "reference/keyboard-input/focusscope",
                                                 },
                                                 {
                                                     label: "TextInput",
-                                                    slug: "reference/keyboard-input/text-input",
+                                                    slug: "reference/keyboard-input/textinput",
                                                 },
                                                 {
                                                     label: "TextInputInterface",
-                                                    slug: "reference/keyboard-input/text-input-interface",
+                                                    slug: "reference/keyboard-input/textinputinterface",
                                                 },
                                             ],
                                         },
@@ -328,21 +328,21 @@ export default defineConfig({
                                                 },
                                                 {
                                                     label: "GridLayout",
-                                                    slug: "reference/layouts/grid-layout",
+                                                    slug: "reference/layouts/gridlayout",
                                                 },
                                                 {
                                                     label: "HorizontalLayout",
-                                                    slug: "reference/layouts/horizontal-layout",
+                                                    slug: "reference/layouts/horizontallayout",
                                                 },
                                                 {
                                                     label: "VerticalLayout",
-                                                    slug: "reference/layouts/vertical-layout",
+                                                    slug: "reference/layouts/verticallayout",
                                                 },
                                                 // FlexboxLayout is experimental. When it ships, drop
                                                 // `draft: true` from flexbox-layout.mdx and uncomment:
                                                 // {
                                                 //     label: "FlexboxLayout",
-                                                //     slug: "reference/layouts/flexbox-layout",
+                                                //     slug: "reference/layouts/flexboxlayout",
                                                 // },
                                             ],
                                         },

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -276,7 +276,7 @@ export default defineConfig({
                                         },
                                         {
                                             label: "Timer",
-                                            slug: "reference/generated/timer",
+                                            slug: "reference/timer",
                                         },
                                     ],
                                 },
@@ -307,15 +307,15 @@ export default defineConfig({
                                                 },
                                                 {
                                                     label: "FocusScope",
-                                                    slug: "reference/generated/keyboard-input/focus-scope",
+                                                    slug: "reference/keyboard-input/focus-scope",
                                                 },
                                                 {
                                                     label: "TextInput",
-                                                    slug: "reference/generated/keyboard-input/text-input",
+                                                    slug: "reference/keyboard-input/text-input",
                                                 },
                                                 {
                                                     label: "TextInputInterface",
-                                                    slug: "reference/generated/keyboard-input/text-input-interface",
+                                                    slug: "reference/keyboard-input/text-input-interface",
                                                 },
                                             ],
                                         },
@@ -328,21 +328,21 @@ export default defineConfig({
                                                 },
                                                 {
                                                     label: "GridLayout",
-                                                    slug: "reference/generated/layouts/grid-layout",
+                                                    slug: "reference/layouts/grid-layout",
                                                 },
                                                 {
                                                     label: "HorizontalLayout",
-                                                    slug: "reference/generated/layouts/horizontal-layout",
+                                                    slug: "reference/layouts/horizontal-layout",
                                                 },
                                                 {
                                                     label: "VerticalLayout",
-                                                    slug: "reference/generated/layouts/vertical-layout",
+                                                    slug: "reference/layouts/vertical-layout",
                                                 },
                                                 // FlexboxLayout is experimental. When it ships, drop
                                                 // `draft: true` from flexbox-layout.mdx and uncomment:
                                                 // {
                                                 //     label: "FlexboxLayout",
-                                                //     slug: "reference/generated/layouts/flexbox-layout",
+                                                //     slug: "reference/layouts/flexbox-layout",
                                                 // },
                                             ],
                                         },
@@ -361,7 +361,7 @@ export default defineConfig({
                                     items: [
                                         {
                                             label: "Global Structs and Enums",
-                                            slug: "reference/generated/global-structs-enums",
+                                            slug: "reference/global-structs-enums",
                                         },
                                         {
                                             label: "Global Functions",
@@ -379,7 +379,7 @@ export default defineConfig({
                                         },
                                         {
                                             label: "Platform Namespace",
-                                            slug: "reference/generated/platform",
+                                            slug: "reference/platform",
                                         },
                                         {
                                             label: "FontWeight Namespace",
@@ -518,8 +518,8 @@ export default defineConfig({
                     ],
                     {
                         exclude: [
-                            "/reference/generated/enums/**",
-                            "/reference/generated/structs/**",
+                            "/reference/enums/**",
+                            "/reference/structs/**",
                         ],
                     },
                 ),

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -1050,7 +1050,7 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
-        let filename = format!("{}.mdx", mdx::to_kebab_case(&elem.name));
+        let filename = format!("{}.mdx", elem.name.to_ascii_lowercase());
         let path = match elem.group.as_deref() {
             Some(group) if !group.is_empty() => {
                 let subdir = generated_dir.join(group);

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -1064,6 +1064,11 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
         );
 
         // Frontmatter.
+        let slug_stem = filename.strip_suffix(".mdx").unwrap();
+        let slug = match elem.group.as_deref() {
+            Some(group) if !group.is_empty() => format!("reference/{group}/{slug_stem}"),
+            _ => format!("reference/{slug_stem}"),
+        };
         writeln!(file, "---")?;
         writeln!(file, "title: {}", elem.name)?;
         if elem.is_global {
@@ -1071,6 +1076,7 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             writeln!(file, "description: {} element api.", elem.name)?;
         }
+        writeln!(file, "slug: {slug}")?;
         writeln!(file, "---")?;
 
         // Imports.

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -37,6 +37,7 @@ fn write_global_structs_enums_index(
         r#"---
 title: Global Structs and Enums
 description: Global Structs and Enums
+slug: reference/global-structs-enums
 ---
 "#
     )?;
@@ -112,6 +113,7 @@ fn write_individual_enum_files(
             r#"---
 title: {0}
 description: {0} content
+slug: reference/enums/{0}
 ---
 
 <!-- Generated with slint-doc-generator from internal/commons/enums.rs -->
@@ -330,6 +332,7 @@ fn write_individual_struct_files(
             r#"---
 title: {0}
 description: {0} content
+slug: reference/structs/{0}
 ---
 
 <!-- Generated with slint-doc-generator from internal/common/builtin_structs.rs -->
@@ -387,6 +390,7 @@ fn generate_keys_docs() -> Result<(), Box<dyn std::error::Error>> {
 
     writeln!(file, "---")?;
     writeln!(file, "title: keys")?;
+    writeln!(file, "slug: reference/enums/keys")?;
     writeln!(file, "---")?;
     writeln!(file)?;
 

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -18,7 +18,7 @@
         "href": "reference/primitive-types/#brush"
     },
     "BorderRadiusRectangle": {
-        "href": "reference/generated/elements/rectangle/#border-radius-properties"
+        "href": "reference/elements/rectangle/#border-radius-properties"
     },
     "cache-rendering-hint": {
         "href": "reference/common/#cache-rendering-hint"
@@ -45,13 +45,13 @@
         "href": "reference/primitive-types/#easing"
     },
     "Edges": {
-        "href": "reference/generated/global-structs-enums/#edges"
+        "href": "reference/global-structs-enums/#edges"
     },
     "EnumType": {
-        "href": "reference/generated/global-structs-enums/"
+        "href": "reference/global-structs-enums/"
     },
     "EventResult": {
-        "href": "reference/generated/global-structs-enums/#eventresult"
+        "href": "reference/global-structs-enums/#eventresult"
     },
     "Expressions": {
         "href": "guide/language/coding/expressions-and-statements/"
@@ -60,7 +60,7 @@
         "href": "reference/primitive-types/#float"
     },
     "FocusReason": {
-        "href": "reference/generated/global-structs-enums/#focusreason"
+        "href": "reference/global-structs-enums/#focusreason"
     },
     "FocusHandling": {
         "href": "guide/development/focus/"
@@ -72,7 +72,7 @@
         "href": "reference/global-namespaces/font-weight/"
     },
     "GridLayout": {
-        "href": "reference/generated/layouts/grid-layout/"
+        "href": "reference/layouts/grid-layout/"
     },
     "Globals": {
         "href": "guide/language/coding/globals/"
@@ -81,10 +81,10 @@
         "href": "reference/std-widgets/layouts/horizontalbox/"
     },
     "HorizontalLayout": {
-        "href": "reference/generated/layouts/horizontal-layout/"
+        "href": "reference/layouts/horizontal-layout/"
     },
     "Image": {
-        "href": "reference/generated/elements/image/"
+        "href": "reference/elements/image/"
     },
     "ImageType": {
         "href": "reference/primitive-types/#image"
@@ -102,7 +102,7 @@
         "href": "reference/keyboard-input/overview/#key-bindings"
     },
     "KeyBinding": {
-        "href": "reference/generated/keyboard-input/focus-scope/#keybinding"
+        "href": "reference/keyboard-input/focus-scope/#keybinding"
     },
     "keys": {
         "href": "reference/primitive-types/#keys"
@@ -120,10 +120,10 @@
         "href": "guide/backends-and-renderers/backend_linuxkms/"
     },
     "MenuBar": {
-        "href": "reference/generated/window/menu-bar/"
+        "href": "reference/window/menu-bar/"
     },
     "Menu": {
-        "href": "reference/generated/window/context-menu-area/#menu"
+        "href": "reference/window/context-menu-area/#menu"
     },
     "Modules": {
         "href": "guide/language/coding/file/#modules"
@@ -138,7 +138,7 @@
         "href": "reference/std-widgets/globals/palette/"
     },
     "Path": {
-        "href": "reference/generated/elements/path/"
+        "href": "reference/elements/path/"
     },
     "percent": {
         "href": "reference/primitive-types/#percent"
@@ -147,10 +147,10 @@
         "href": "reference/primitive-types/#physical-length"
     },
     "PopupWindow": {
-        "href": "reference/generated/window/popup-window/"
+        "href": "reference/window/popup-window/"
     },
     "Point": {
-        "href": "reference/generated/global-structs-enums/#point"
+        "href": "reference/global-structs-enums/#point"
     },
     "ProgressIndicator": {
         "href": "reference/std-widgets/basic-widgets/progressindicator/"
@@ -159,13 +159,13 @@
         "href": "guide/language/concepts/reactivity/"
     },
     "Rectangle": {
-        "href": "reference/generated/elements/rectangle/"
+        "href": "reference/elements/rectangle/"
     },
     "relativeFontSize": {
         "href": "reference/primitive-types/#relative-font-size"
     },
     "Size": {
-        "href": "reference/generated/global-structs-enums/#size"
+        "href": "reference/global-structs-enums/#size"
     },
     "slintFile": {
         "href": "guide/language/coding/file/"
@@ -174,10 +174,10 @@
         "href": "reference/std-widgets/views/scrollview/"
     },
     "StyledText": {
-        "href": "reference/generated/elements/styled-text/"
+        "href": "reference/elements/styled-text/"
     },
     "SystemTrayIcon": {
-        "href": "reference/generated/window/system-tray-icon/"
+        "href": "reference/window/system-tray-icon/"
     },
     "styled_text": {
         "href": "reference/primitive-types/#styled-text"
@@ -186,7 +186,7 @@
         "href": "guide/language/coding/functions-and-callbacks/#callbacks"
     },
     "Flickable": {
-        "href": "reference/generated/gestures/flickable/"
+        "href": "reference/gestures/flickable/"
     },
     "StandardButton": {
         "href": "reference/std-widgets/basic-widgets/standardbutton/"
@@ -195,7 +195,7 @@
         "href": "reference/primitive-types/#string"
     },
     "StructType": {
-        "href": "reference/generated/global-structs-enums/"
+        "href": "reference/global-structs-enums/"
     },
     "StyleWidgets": {
         "href": "reference/std-widgets/style/"
@@ -204,16 +204,16 @@
         "href": "reference/std-widgets/globals/stylemetrics/"
     },
     "Text": {
-        "href": "reference/generated/elements/text/"
+        "href": "reference/elements/text/"
     },
     "TextEdit": {
         "href": "reference/std-widgets/views/textedit/"
     },
     "TextInput": {
-        "href": "reference/generated/keyboard-input/text-input/"
+        "href": "reference/keyboard-input/text-input/"
     },
     "Timer": {
-        "href": "reference/generated/timer/"
+        "href": "reference/timer/"
     },
     "Types": {
         "href": "reference/primitive-types/"
@@ -222,7 +222,7 @@
         "href": "reference/std-widgets/layouts/verticalbox/"
     },
     "VerticalLayout": {
-        "href": "reference/generated/layouts/vertical-layout/"
+        "href": "reference/layouts/vertical-layout/"
     },
     "VSCode": {
         "href": "guide/tooling/vscode/"
@@ -231,16 +231,16 @@
         "href": "guide/backends-and-renderers/backend_qt/"
     },
     "Window": {
-        "href": "reference/generated/window/window/"
+        "href": "reference/window/window/"
     },
     "Window.safe-area-insets": {
-        "href": "reference/generated/window/window/#safe-area-insets"
+        "href": "reference/window/window/#safe-area-insets"
     },
     "Window.virtual-keyboard-position": {
-        "href": "reference/generated/window/window/#virtual-keyboard-position"
+        "href": "reference/window/window/#virtual-keyboard-position"
     },
     "Window.virtual-keyboard-size": {
-        "href": "reference/generated/window/window/#virtual-keyboard-size"
+        "href": "reference/window/window/#virtual-keyboard-size"
     },
     "WinitBackend": {
         "href": "guide/backends-and-renderers/backend_winit/"

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -72,7 +72,7 @@
         "href": "reference/global-namespaces/font-weight/"
     },
     "GridLayout": {
-        "href": "reference/layouts/grid-layout/"
+        "href": "reference/layouts/gridlayout/"
     },
     "Globals": {
         "href": "guide/language/coding/globals/"
@@ -81,7 +81,7 @@
         "href": "reference/std-widgets/layouts/horizontalbox/"
     },
     "HorizontalLayout": {
-        "href": "reference/layouts/horizontal-layout/"
+        "href": "reference/layouts/horizontallayout/"
     },
     "Image": {
         "href": "reference/elements/image/"
@@ -102,7 +102,7 @@
         "href": "reference/keyboard-input/overview/#key-bindings"
     },
     "KeyBinding": {
-        "href": "reference/keyboard-input/focus-scope/#keybinding"
+        "href": "reference/keyboard-input/focusscope/#keybinding"
     },
     "keys": {
         "href": "reference/primitive-types/#keys"
@@ -120,10 +120,10 @@
         "href": "guide/backends-and-renderers/backend_linuxkms/"
     },
     "MenuBar": {
-        "href": "reference/window/menu-bar/"
+        "href": "reference/window/menubar/"
     },
     "Menu": {
-        "href": "reference/window/context-menu-area/#menu"
+        "href": "reference/window/contextmenuarea/#menu"
     },
     "Modules": {
         "href": "guide/language/coding/file/#modules"
@@ -147,7 +147,7 @@
         "href": "reference/primitive-types/#physical-length"
     },
     "PopupWindow": {
-        "href": "reference/window/popup-window/"
+        "href": "reference/window/popupwindow/"
     },
     "Point": {
         "href": "reference/global-structs-enums/#point"
@@ -174,10 +174,10 @@
         "href": "reference/std-widgets/views/scrollview/"
     },
     "StyledText": {
-        "href": "reference/elements/styled-text/"
+        "href": "reference/elements/styledtext/"
     },
     "SystemTrayIcon": {
-        "href": "reference/window/system-tray-icon/"
+        "href": "reference/window/systemtrayicon/"
     },
     "styled_text": {
         "href": "reference/primitive-types/#styled-text"
@@ -210,7 +210,7 @@
         "href": "reference/std-widgets/views/textedit/"
     },
     "TextInput": {
-        "href": "reference/keyboard-input/text-input/"
+        "href": "reference/keyboard-input/textinput/"
     },
     "Timer": {
         "href": "reference/timer/"
@@ -222,7 +222,7 @@
         "href": "reference/std-widgets/layouts/verticalbox/"
     },
     "VerticalLayout": {
-        "href": "reference/layouts/vertical-layout/"
+        "href": "reference/layouts/verticallayout/"
     },
     "VSCode": {
         "href": "guide/tooling/vscode/"


### PR DESCRIPTION
Add slug frontmatter to generated .mdx files so the URL path does not include the "generated" directory which is an implementation detail of the file organization.
