### PR TITLE
Fix ListView scrolling with non-uniformly sized items

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -238,7 +238,9 @@ cpp! {{
             rust!(Slint_mouseWheelEvent [rust_window: &QtWindow as "void*", pos: qttypes::QPointF as "QPointF", delta: qttypes::QPoint as "QPoint", phase: usize as "int"] {
                 let position = LogicalPoint::new(pos.x as _, pos.y as _);
                 let phase = match phase as _ {
-                    key_generated::Qt_ScrollPhase_NoScrollPhase => TouchPhase::Cancelled,
+                    // If we don't know the scroll phase, this is likely a mouse wheel scroll, which
+                    // should be mapped to TouchPhase::Moved to align with the winit backend.
+                    key_generated::Qt_ScrollPhase_NoScrollPhase => TouchPhase::Moved,
                     key_generated::Qt_ScrollPhase_ScrollBegin => TouchPhase::Started,
                     key_generated::Qt_ScrollPhase_ScrollUpdate => TouchPhase::Moved,
                     key_generated::Qt_ScrollPhase_ScrollEnd => TouchPhase::Ended,

--- a/internal/core/animations/physics_simulation.rs
+++ b/internal/core/animations/physics_simulation.rs
@@ -59,10 +59,12 @@ impl ConstantDecelerationParameters {
     // * `distance` - the distance to cover with this animation
     // * `duration_secs` - the duration of the animation in seconds
     pub fn new_with_distance(distance: f32, duration_secs: f32) -> Self {
+        debug_assert!(duration_secs > 0., "Duration must be greater than zero");
+
         // The initial velocity and deceleration are calculated based on the distance and duration to cover the given distance in the given time.
         //
         // The calculation is based on the equations of motion for constant acceleration:
-        //      - v0 * t + 0.5 * a * t^2 = d
+        //      => v0 * t + 0.5 * a * t^2 = d
         //
         //
         // Where t = duration_secs, d = distance, v0 = initial_velocity and a = -deceleration
@@ -91,6 +93,12 @@ impl ConstantDecelerationParameters {
 
     /// Calculates the remaining distance to the limit value at a given time based on the initial velocity and deceleration.
     pub fn remaining_distance(&self, time_elapsed: core::time::Duration) -> f32 {
+        debug_assert!(self.deceleration != 0., "deceleration must not be zero");
+        debug_assert!(
+            self.deceleration.signum() == self.initial_velocity.signum(),
+            "deceleration must actually decelerate the velocity"
+        );
+
         // The animation stops if the velocity becomes zero.
         // Therefore we can calculate the animation duration based on the initial velocity and deceleration:
         //          v0 + a * t = 0

--- a/internal/core/animations/physics_simulation.rs
+++ b/internal/core/animations/physics_simulation.rs
@@ -25,15 +25,18 @@ enum Direction {
 /// Common simulation trait
 /// All simulations must implement this trait
 pub trait Simulation {
-    fn step(&mut self, new_tick: Instant) -> (f32, bool);
-    fn curr_value(&self) -> f32;
+    fn step(&mut self, current: &mut f32, new_tick: Instant) -> bool;
 }
 
 /// Trait to convert parameter objects into a simulation
 /// All parameter objects must implement this trait!
 pub trait Parameter {
     type Output;
-    fn simulation(self, start_value: f32, limit_value: f32) -> Self::Output;
+    fn simulation(
+        self,
+        start_value: f32,
+        limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
+    ) -> Self::Output;
 }
 
 /// Input parameters for the `ConstantDeceleration` simulation
@@ -51,7 +54,11 @@ impl ConstantDecelerationParameters {
 
 impl Parameter for ConstantDecelerationParameters {
     type Output = ConstantDeceleration;
-    fn simulation(self, start_value: f32, limit_value: f32) -> Self::Output {
+    fn simulation(
+        self,
+        start_value: f32,
+        limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
+    ) -> Self::Output {
         ConstantDeceleration::new(start_value, limit_value, self)
     }
 }
@@ -62,8 +69,7 @@ impl Parameter for ConstantDecelerationParameters {
 pub struct ConstantDeceleration {
     /// If the limit is not reached, it is also fine. Also exceeding the limit can be ok,
     /// but at the end of the animation the limit shall not be exceeded
-    limit_value: f32,
-    curr_val: f32,
+    limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
     velocity: f32,
     data: ConstantDecelerationParameters,
     direction: Direction,
@@ -77,18 +83,22 @@ impl ConstantDeceleration {
     /// * `limit_value` - value at which the simulation ends if the velocity did not get zero before
     /// * `initial_velocity` - the initial velocity of the point
     /// * `data` - the properties of this simulation
-    pub fn new(start_value: f32, limit_value: f32, data: ConstantDecelerationParameters) -> Self {
+    pub fn new(
+        start_value: f32,
+        limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
+        data: ConstantDecelerationParameters,
+    ) -> Self {
         Self::new_internal(start_value, limit_value, data, crate::animations::current_tick())
     }
 
     fn new_internal(
         start_value: f32,
-        limit_value: f32,
+        limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
         mut data: ConstantDecelerationParameters,
         start_time: Instant,
     ) -> Self {
         let mut initial_velocity = data.initial_velocity;
-        let direction = if start_value == limit_value {
+        let direction = if start_value == limit_value.as_ref().get() {
             if initial_velocity >= 0. {
                 data.deceleration = f32::abs(data.deceleration);
                 Direction::Increasing
@@ -96,7 +106,7 @@ impl ConstantDeceleration {
                 data.deceleration = -f32::abs(data.deceleration);
                 Direction::Decreasing
             }
-        } else if start_value < limit_value {
+        } else if start_value < limit_value.as_ref().get() {
             data.deceleration = f32::abs(data.deceleration);
             assert!(initial_velocity >= 0.); // Makes no sense yet that the velocity goes into the other direction
             initial_velocity = f32::abs(initial_velocity);
@@ -108,17 +118,12 @@ impl ConstantDeceleration {
             Direction::Decreasing
         };
 
-        Self {
-            limit_value,
-            curr_val: start_value,
-            velocity: initial_velocity,
-            data,
-            direction,
-            start_time,
-        }
+        Self { limit_value, velocity: initial_velocity, data, direction, start_time }
     }
 
-    fn step_internal(&mut self, new_tick: Instant) -> (f32, bool) {
+    fn step_internal(&mut self, current: &mut f32, new_tick: Instant) -> bool {
+        let limit_value = self.limit_value.as_ref().get();
+
         // We have to prevent go go beyond the limit where velocity gets zero
         let duration = f32::min(
             new_tick.duration_since(self.start_time).as_secs_f32(),
@@ -129,40 +134,36 @@ impl ConstantDeceleration {
 
         let new_velocity = self.velocity - duration * self.data.deceleration;
 
-        self.curr_val += duration * (self.velocity + new_velocity) / 2.; // Trapezoidal integration
+        *current += duration * (self.velocity + new_velocity) / 2.; // Trapezoidal integration
         self.velocity = new_velocity;
 
         match self.direction {
             Direction::Increasing => {
-                if self.curr_val >= self.limit_value {
-                    self.curr_val = self.limit_value;
+                if *current >= limit_value {
+                    *current = limit_value;
                     self.velocity = 0.;
-                    return (self.curr_val, true);
+                    return true;
                 } else if self.velocity <= 0. {
-                    return (self.curr_val, true);
+                    return true;
                 }
             }
             Direction::Decreasing => {
-                if self.curr_val <= self.limit_value {
-                    self.curr_val = self.limit_value;
+                if *current <= limit_value {
+                    *current = limit_value;
                     self.velocity = 0.;
-                    return (self.curr_val, true);
+                    return true;
                 } else if self.velocity >= 0. {
-                    return (self.curr_val, true);
+                    return true;
                 }
             }
         }
-        (self.curr_val, false)
+        false
     }
 }
 
 impl Simulation for ConstantDeceleration {
-    fn curr_value(&self) -> f32 {
-        self.curr_val
-    }
-
-    fn step(&mut self, new_tick: Instant) -> (f32, bool) {
-        self.step_internal(new_tick)
+    fn step(&mut self, current: &mut f32, new_tick: Instant) -> bool {
+        self.step_internal(current, new_tick)
     }
 }
 
@@ -177,6 +178,10 @@ mod tests {
         };
     }
 
+    fn test_limit_property(value: f32) -> core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>> {
+        alloc::boxed::Box::pin(crate::Property::new(value))
+    }
+
     #[test]
     fn constant_deceleration_start_eq_limit() {
         const START_VALUE: f32 = 10.;
@@ -186,12 +191,17 @@ mod tests {
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
         let time = Instant::now();
-        let mut simulation =
-            ConstantDeceleration::new_internal(START_VALUE, LIMIT_VALUE, parameters, time.clone());
+        let mut simulation = ConstantDeceleration::new_internal(
+            START_VALUE,
+            test_limit_property(LIMIT_VALUE),
+            parameters,
+            time,
+        );
 
-        let res = simulation.step(time + Duration::from_hours(10));
-        assert_eq!(res.1, true);
-        assert_eq!(res.0, START_VALUE);
+        let mut current = START_VALUE;
+        let finished = simulation.step(&mut current, time + Duration::from_hours(10));
+        assert_eq!(finished, true);
+        assert_eq!(current, START_VALUE);
     }
 
     /// The velocity becomes zero before we are reaching the limit
@@ -205,17 +215,22 @@ mod tests {
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
         let mut time = Instant::now();
-        let mut simulation =
-            ConstantDeceleration::new_internal(START_VALUE, LIMIT_VALUE, parameters, time.clone());
+        let mut simulation = ConstantDeceleration::new_internal(
+            START_VALUE,
+            test_limit_property(LIMIT_VALUE),
+            parameters,
+            time,
+        );
+        let mut current = START_VALUE;
 
         // Velocity does not become zero
         let mut duration = Duration::from_secs(1);
         assert!(DECELERATION * duration.as_secs_f32() < INITIAL_VELOCITY);
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_approx_eq!(
-            res,
+            current,
             START_VALUE + INITIAL_VELOCITY * duration.as_secs_f32()
                 - 0.5 * DECELERATION * duration.as_secs_f32().powi(2)
         );
@@ -224,15 +239,15 @@ mod tests {
         duration = Duration::from_hours(10);
         assert!(Duration::from_secs((INITIAL_VELOCITY / DECELERATION) as u64) < duration);
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
         assert_approx_eq!(
-            res,
+            current,
             START_VALUE + INITIAL_VELOCITY * INITIAL_VELOCITY / DECELERATION
                 - 0.5 * DECELERATION * (INITIAL_VELOCITY / DECELERATION).powi(2)
         );
 
-        assert!(res < LIMIT_VALUE); // We reached velocity zero before we reached the position limit
+        assert!(current < LIMIT_VALUE); // We reached velocity zero before we reached the position limit
     }
 
     /// We reach the position limit before the velocity got zero
@@ -245,15 +260,20 @@ mod tests {
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
         let mut time = Instant::now();
-        let mut simulation =
-            ConstantDeceleration::new_internal(START_VALUE, LIMIT_VALUE, parameters, time.clone());
+        let mut simulation = ConstantDeceleration::new_internal(
+            START_VALUE,
+            test_limit_property(LIMIT_VALUE),
+            parameters,
+            time,
+        );
+        let mut current = START_VALUE;
 
         let duration = Duration::from_secs(1);
         assert!(f32::abs(DECELERATION * duration.as_secs_f32()) < f32::abs(INITIAL_VELOCITY)); // We don't reach the limit where the velocity gets zero
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
-        assert_eq!(res, LIMIT_VALUE); // Limit reached
+        assert_eq!(current, LIMIT_VALUE); // Limit reached
     }
 
     /// We don't reach the position limit. Before the velocity gets zero
@@ -268,16 +288,21 @@ mod tests {
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
         let mut time = Instant::now();
-        let mut simulation =
-            ConstantDeceleration::new_internal(START_VALUE, LIMIT_VALUE, parameters, time.clone());
+        let mut simulation = ConstantDeceleration::new_internal(
+            START_VALUE,
+            test_limit_property(LIMIT_VALUE),
+            parameters,
+            time,
+        );
+        let mut current = START_VALUE;
 
         let mut duration = Duration::from_secs(1);
         assert!(f32::abs(DECELERATION * duration.as_secs_f32()) < f32::abs(INITIAL_VELOCITY));
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_eq!(
-            res,
+            current,
             START_VALUE + INITIAL_VELOCITY * duration.as_secs_f32()
                 - INITIAL_VELOCITY.signum() * 0.5 * DECELERATION * duration.as_secs_f32().powi(2)
         );
@@ -285,10 +310,10 @@ mod tests {
         duration = Duration::from_hours(10);
         assert!(Duration::from_secs((INITIAL_VELOCITY / DECELERATION) as u64) < duration);
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
         assert_eq!(
-            res,
+            current,
             START_VALUE + INITIAL_VELOCITY * f32::abs(INITIAL_VELOCITY / DECELERATION)
                 - 0.5
                     * INITIAL_VELOCITY.signum()
@@ -296,7 +321,7 @@ mod tests {
                     * (INITIAL_VELOCITY / DECELERATION).powi(2)
         );
 
-        assert!(res > LIMIT_VALUE); // We reached velocity zero before we reached the position limit
+        assert!(current > LIMIT_VALUE); // We reached velocity zero before we reached the position limit
     }
 
     /// We reach the position limit before the velocity got zero
@@ -310,15 +335,20 @@ mod tests {
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
         let mut time = Instant::now();
-        let mut simulation =
-            ConstantDeceleration::new_internal(START_VALUE, LIMIT_VALUE, parameters, time.clone());
+        let mut simulation = ConstantDeceleration::new_internal(
+            START_VALUE,
+            test_limit_property(LIMIT_VALUE),
+            parameters,
+            time,
+        );
+        let mut current = START_VALUE;
 
         let duration = Duration::from_secs(3);
         assert!(f32::abs(DECELERATION * duration.as_secs_f32()) > f32::abs(INITIAL_VELOCITY)); // We don't reach the limit where the velocity gets zero
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
-        assert_eq!(res, LIMIT_VALUE); // Limit reached
+        assert_eq!(current, LIMIT_VALUE); // Limit reached
     }
 }
 
@@ -364,7 +394,11 @@ impl ConstantDecelerationSpringDamperParameters {
 #[cfg(test)]
 impl Parameter for ConstantDecelerationSpringDamperParameters {
     type Output = ConstantDecelerationSpringDamper;
-    fn simulation(self, start_value: f32, limit_value: f32) -> Self::Output {
+    fn simulation(
+        self,
+        start_value: f32,
+        limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
+    ) -> Self::Output {
         ConstantDecelerationSpringDamper::new(start_value, limit_value, self)
     }
 }
@@ -386,9 +420,8 @@ enum State {
 pub struct ConstantDecelerationSpringDamper {
     /// If the limit is not reached, it is also fine. Also exceeding the limit can be ok,
     /// but at the end of the animation the limit shall not be exceeded
-    limit_value: f32,
+    limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
     curr_val_zeroed: f32,
-    curr_val: f32,
     velocity: f32,
     data: ConstantDecelerationSpringDamperParameters,
     direction: Direction,
@@ -407,7 +440,7 @@ pub struct ConstantDecelerationSpringDamper {
 impl ConstantDecelerationSpringDamper {
     pub fn new(
         start_value: f32,
-        limit_value: f32,
+        limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
         data: ConstantDecelerationSpringDamperParameters,
     ) -> Self {
         Self::new_internal(start_value, limit_value, data, crate::animations::current_tick())
@@ -415,13 +448,13 @@ impl ConstantDecelerationSpringDamper {
 
     fn new_internal(
         start_value: f32,
-        limit_value: f32,
+        limit_value: core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>>,
         mut data: ConstantDecelerationSpringDamperParameters,
         start_time: Instant,
     ) -> Self {
         let mut initial_velocity = data.initial_velocity;
         let mut state = State::Deceleration;
-        let direction = if start_value == limit_value {
+        let direction = if start_value == limit_value.as_ref().get() {
             state = State::Done;
             if initial_velocity >= 0. {
                 data.deceleration = f32::abs(data.deceleration);
@@ -430,7 +463,7 @@ impl ConstantDecelerationSpringDamper {
                 data.deceleration = -f32::abs(data.deceleration);
                 Direction::Decreasing
             }
-        } else if start_value < limit_value {
+        } else if start_value < limit_value.as_ref().get() {
             data.deceleration = f32::abs(data.deceleration);
             assert!(initial_velocity >= 0.); // Makes no sense yet that the velocity goes into the other direction
             initial_velocity = f32::abs(initial_velocity);
@@ -455,7 +488,6 @@ impl ConstantDecelerationSpringDamper {
 
         Self {
             limit_value,
-            curr_val: start_value,
             curr_val_zeroed: 0.,
             velocity: initial_velocity,
             data,
@@ -470,15 +502,23 @@ impl ConstantDecelerationSpringDamper {
         }
     }
 
-    fn step_internal(&mut self, new_tick: Instant) -> (f32, bool) {
+    fn new_value(&self) -> f32 {
+        self.limit_value.as_ref().get() + self.curr_val_zeroed
+    }
+
+    fn step_internal(&mut self, current: &mut f32, new_tick: Instant) -> bool {
         match self.state {
-            State::Deceleration => self.state_deceleration(new_tick),
-            State::SpringDamper => self.state_spring_damper(new_tick),
-            State::Done => (self.curr_value(), true),
+            State::Deceleration => self.state_deceleration(current, new_tick),
+            State::SpringDamper => self.state_spring_damper(current, new_tick),
+            State::Done => {
+                *current = self.new_value();
+                true
+            }
         }
     }
 
-    fn state_deceleration(&mut self, new_tick: Instant) -> (f32, bool) {
+    fn state_deceleration(&mut self, current: &mut f32, new_tick: Instant) -> bool {
+        let limit_value = self.limit_value.as_ref().get();
         let duration_unlimited = new_tick.duration_since(self.start_time);
         // We have to prevent go go beyond the limit where velocity gets zero
         let duration = f32::min(
@@ -489,7 +529,7 @@ impl ConstantDecelerationSpringDamper {
         self.start_time = new_tick;
 
         let new_velocity = self.velocity - (duration * self.data.deceleration);
-        let new_val = self.curr_val + (duration * (self.velocity + new_velocity) / 2.); // Trapezoidal integration
+        let new_val = *current + (duration * (self.velocity + new_velocity) / 2.); // Trapezoidal integration
 
         enum S {
             LimitReached,
@@ -498,9 +538,9 @@ impl ConstantDecelerationSpringDamper {
         }
 
         let s = match self.direction {
-            Direction::Increasing if new_val > self.limit_value => S::LimitReached,
+            Direction::Increasing if new_val > limit_value => S::LimitReached,
             Direction::Increasing if new_velocity <= 0. => S::VelocityZero,
-            Direction::Decreasing if new_val < self.limit_value => S::LimitReached,
+            Direction::Decreasing if new_val < limit_value => S::LimitReached,
             Direction::Decreasing if new_velocity >= 0. => S::VelocityZero,
             _ => S::None,
         };
@@ -511,8 +551,7 @@ impl ConstantDecelerationSpringDamper {
                 // time when reaching the limit
                 // solving p_limit = p_old + v_old * dt - 0.5 * a * dt^2
                 let root = f32::sqrt(
-                    self.velocity.powi(2)
-                        - self.data.deceleration * (self.limit_value - self.curr_val) as f32,
+                    self.velocity.powi(2) - self.data.deceleration * (limit_value - *current),
                 );
                 // The smaller is the relevant. The larger is when the initial velocity got zero and due to the constant acceleration we turn
                 let dt = f32::min(
@@ -522,7 +561,7 @@ impl ConstantDecelerationSpringDamper {
 
                 self.velocity -= dt * self.data.deceleration; // Velocity at limit value point. Solved `new_val` equation for new_velocity
                 self.curr_val_zeroed = 0.;
-                self.curr_val = self.limit_value;
+                *current = limit_value;
 
                 const X0: f32 = 0.; // Relative point
                 self.constant_a = self.velocity.signum()
@@ -534,6 +573,7 @@ impl ConstantDecelerationSpringDamper {
                 self.constant_phi =
                     f32::atan(self.w_d * X0 / (self.velocity + self.damping_ratio * self.w_n * X0));
                 self.state_spring_damper(
+                    current,
                     new_tick
                         + (duration_unlimited
                             - core::time::Duration::from_millis((dt * 1000.) as u64)),
@@ -541,18 +581,18 @@ impl ConstantDecelerationSpringDamper {
             }
             S::VelocityZero => {
                 self.velocity = 0.;
-                self.curr_val = new_val;
-                (self.curr_val, true)
+                *current = new_val;
+                true
             }
             S::None => {
                 self.velocity = new_velocity;
-                self.curr_val = new_val;
-                (self.curr_val, false)
+                *current = new_val;
+                false
             }
         }
     }
 
-    fn state_spring_damper(&mut self, new_tick: Instant) -> (f32, bool) {
+    fn state_spring_damper(&mut self, current: &mut f32, new_tick: Instant) -> bool {
         // Here we use absolute time because it simplifies the equation
         let t = (new_tick - self.start_time).as_secs_f32();
         // Underdamped spring damper equation
@@ -562,36 +602,34 @@ impl ConstantDecelerationSpringDamper {
             * f32::sin(self.w_d * t + self.constant_phi);
         self.curr_val_zeroed = new_val; // relative value
 
+        let limit_value = self.limit_value.as_ref().get();
         let max_time = 2. * core::f32::consts::PI / self.w_d;
-        let current_val = self.curr_value();
+        let current_val = self.new_value();
+        *current = current_val;
         let finished = match self.direction {
             Direction::Increasing => {
                 // We are coming back from a value higher than the limit
-                current_val < self.limit_value || t > max_time
+                current_val < limit_value || t > max_time
             }
             Direction::Decreasing => {
                 // We are coming back from a value lower than the limit
-                current_val > self.limit_value || t > max_time
+                current_val > limit_value || t > max_time
             }
         };
         if finished {
             self.velocity = 0.;
-            self.curr_val = self.limit_value;
+            *current = limit_value;
             self.curr_val_zeroed = 0.;
             self.state = State::Done;
         }
-        (current_val, finished)
+        finished
     }
 }
 
 #[cfg(test)]
 impl Simulation for ConstantDecelerationSpringDamper {
-    fn curr_value(&self) -> f32 {
-        self.curr_val + self.curr_val_zeroed
-    }
-
-    fn step(&mut self, new_tick: Instant) -> (f32, bool) {
-        self.step_internal(new_tick)
+    fn step(&mut self, current: &mut f32, new_tick: Instant) -> bool {
+        self.step_internal(current, new_tick)
     }
 }
 
@@ -599,12 +637,6 @@ impl Simulation for ConstantDecelerationSpringDamper {
 mod tests_spring_damper {
     use super::*;
     use core::{f32::consts::PI, time::Duration};
-
-    macro_rules! assert_approx_eq {
-        ($a:expr, $b:expr) => {
-            assert!(($a - $b).abs() < 1e-4, "{} != {}", $a, $b);
-        };
-    }
 
     #[test]
     fn calculate_parameters() {
@@ -640,13 +672,14 @@ mod tests_spring_damper {
         let time = Instant::now();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
-            LIMIT_VALUE,
+            test_limit_property(LIMIT_VALUE),
             parameters,
-            time.clone(),
+            time,
         );
-        let res = simulation.step(time);
-        assert_eq!(res.0, START_VALUE);
-        assert_eq!(res.1, true);
+        let mut current = START_VALUE;
+        let finished = simulation.step(&mut current, time);
+        assert_eq!(current, START_VALUE);
+        assert_eq!(finished, true);
         assert_eq!(simulation.state, State::Done);
     }
 
@@ -664,17 +697,22 @@ mod tests_spring_damper {
         );
 
         let mut time = Instant::now();
-        let mut simulation =
-            ConstantDecelerationSpringDamper::new_internal(10., 2000., parameters, time.clone());
+        let mut simulation = ConstantDecelerationSpringDamper::new_internal(
+            10.,
+            test_limit_property(2000.),
+            parameters,
+            time,
+        );
+        let mut current = 10.;
 
         // Velocity does not become zero
         let mut duration = Duration::from_secs(1);
         assert!(DECELERATION * duration.as_secs_f32() < INITIAL_VELOCITY);
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_approx_eq!(
-            res,
+            current,
             10. + 50. * duration.as_secs_f32()
                 - 0.5 * DECELERATION * duration.as_secs_f32().powi(2)
         );
@@ -683,15 +721,15 @@ mod tests_spring_damper {
         duration = Duration::from_hours(10);
         assert!(Duration::from_secs((INITIAL_VELOCITY / DECELERATION) as u64) < duration);
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
         assert_approx_eq!(
-            res,
+            current,
             10. + 50. * INITIAL_VELOCITY / DECELERATION
                 - 0.5 * DECELERATION * (INITIAL_VELOCITY / DECELERATION).powi(2)
         );
 
-        assert!(res < 2000.); // We reached velocity zero before we reached the position limit
+        assert!(current < 2000.); // We reached velocity zero before we reached the position limit
     }
 
     /// We don't reach the position limit. Before the velocity gets zero
@@ -713,18 +751,19 @@ mod tests_spring_damper {
         let mut time = Instant::now();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
-            LIMIT_VALUE,
+            test_limit_property(LIMIT_VALUE),
             parameters,
-            time.clone(),
+            time,
         );
+        let mut current = START_VALUE;
 
         let mut duration = Duration::from_secs(1);
         assert!(f32::abs(DECELERATION * duration.as_secs_f32()) < f32::abs(INITIAL_VELOCITY));
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_eq!(
-            res,
+            current,
             START_VALUE + INITIAL_VELOCITY * duration.as_secs_f32()
                 - INITIAL_VELOCITY.signum() * 0.5 * DECELERATION * duration.as_secs_f32().powi(2)
         );
@@ -732,10 +771,10 @@ mod tests_spring_damper {
         duration = Duration::from_hours(10);
         assert!(Duration::from_secs((INITIAL_VELOCITY / DECELERATION) as u64) < duration);
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
         assert_eq!(
-            res,
+            current,
             START_VALUE + INITIAL_VELOCITY * f32::abs(INITIAL_VELOCITY / DECELERATION)
                 - 0.5
                     * INITIAL_VELOCITY.signum()
@@ -743,7 +782,7 @@ mod tests_spring_damper {
                     * (INITIAL_VELOCITY / DECELERATION).powi(2)
         );
 
-        assert!(res > LIMIT_VALUE); // We reached velocity zero before we reached the position limit
+        assert!(current > LIMIT_VALUE); // We reached velocity zero before we reached the position limit
     }
 
     /// We reach the position limit before the velocity got zero and so we run into the spring damper system
@@ -764,30 +803,31 @@ mod tests_spring_damper {
         let mut time = Instant::now();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
-            LIMIT_VALUE,
+            test_limit_property(LIMIT_VALUE),
             parameters,
-            time.clone(),
+            time,
         );
+        let mut current = START_VALUE;
 
         let duration = Duration::from_secs(1);
         assert!(f32::abs(DECELERATION) * duration.as_secs_f32() < f32::abs(INITIAL_VELOCITY)); // We don't reach the limit where the velocity gets zero
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_eq!(simulation.state, State::Deceleration);
-        assert!(res < LIMIT_VALUE); // We are still in the constant deceleration state
+        assert!(current < LIMIT_VALUE); // We are still in the constant deceleration state
 
         time += Duration::from_secs((HALF_PERIOD_TIME / 2.) as u64);
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_eq!(simulation.state, State::SpringDamper);
-        assert!(res > LIMIT_VALUE);
+        assert!(current > LIMIT_VALUE);
 
         time += Duration::from_hours(10);
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
         assert_eq!(simulation.state, State::Done);
-        assert_eq!(res, LIMIT_VALUE);
+        assert_eq!(current, LIMIT_VALUE);
     }
 
     /// We reach the position limit before the velocity got zero and so we run into the spring damper system
@@ -808,29 +848,30 @@ mod tests_spring_damper {
         let mut time = Instant::now();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
-            LIMIT_VALUE,
+            test_limit_property(LIMIT_VALUE),
             parameters,
-            time.clone(),
+            time,
         );
+        let mut current = START_VALUE;
 
         let duration = Duration::from_secs(1);
         assert!(f32::abs(DECELERATION) * duration.as_secs_f32() < f32::abs(INITIAL_VELOCITY)); // We don't reach the limit where the velocity gets zero
         time += duration;
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_eq!(simulation.state, State::Deceleration);
-        assert!(res > LIMIT_VALUE); // We are still in the constant deceleration state
+        assert!(current > LIMIT_VALUE); // We are still in the constant deceleration state
 
         time += Duration::from_secs((HALF_PERIOD_TIME / 2.) as u64);
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, false);
         assert_eq!(simulation.state, State::SpringDamper);
-        assert!(res < LIMIT_VALUE);
+        assert!(current < LIMIT_VALUE);
 
         time += Duration::from_hours(10);
-        let (res, finished) = simulation.step(time);
+        let finished = simulation.step(&mut current, time);
         assert_eq!(finished, true);
         assert_eq!(simulation.state, State::Done);
-        assert_eq!(res, LIMIT_VALUE);
+        assert_eq!(current, LIMIT_VALUE);
     }
 }

--- a/internal/core/animations/physics_simulation.rs
+++ b/internal/core/animations/physics_simulation.rs
@@ -50,6 +50,63 @@ impl ConstantDecelerationParameters {
     pub fn new(initial_velocity: f32, deceleration: f32) -> Self {
         Self { initial_velocity, deceleration }
     }
+
+    /// Creates a new `ConstantDecelerationParameters` parameter object based on the distance
+    /// to travel and duration of the animation.
+    /// The deceleration is chosen such that the animation covers the given distance at the end of
+    /// the animation and the velocity becomes zero at the same time (after duration_secs).
+    ///
+    // * `distance` - the distance to cover with this animation
+    // * `duration_secs` - the duration of the animation in seconds
+    pub fn new_with_distance(distance: f32, duration_secs: f32) -> Self {
+        // The initial velocity and deceleration are calculated based on the distance and duration to cover the given distance in the given time.
+        //
+        // The calculation is based on the equations of motion for constant acceleration:
+        //      - v0 * t + 0.5 * a * t^2 = d
+        //
+        //
+        // Where t = duration_secs, d = distance, v0 = initial_velocity and a = -deceleration
+        // Warning! a is acceleration, not deceleration, so we need to flip the sign at the end
+        //
+        // We want to reach the limit value at the end of the animation, and the velocity should become zero at the same time, so we can determine `a` based on:
+        //          v0 + a * t = 0
+        //
+        //      => a = -v0 / t
+        //
+        // Then we can solve for `v0` and `a`:
+        //
+        //     v0 * t + 0.5 * -(v0 / t) * t^2 = d
+        //     v0 * t + 0.5 * -v0 * t = d
+        //     v0 * (t + -0.5 * t) = d
+        //     v0 * (0.5 * t) = d
+        //     => v0 = d / (0.5 * t)
+        //
+        let d = distance;
+        let t = duration_secs;
+        let v0 = d / (0.5 * t);
+        let a = -(v0 / t);
+        // deceleration: therefore -a
+        Self::new(v0, -a)
+    }
+
+    /// Calculates the remaining distance to the limit value at a given time based on the initial velocity and deceleration.
+    pub fn remaining_distance(&self, time_elapsed: core::time::Duration) -> f32 {
+        // The animation stops if the velocity becomes zero.
+        // Therefore we can calculate the animation duration based on the initial velocity and deceleration:
+        //          v0 + a * t = 0
+        //          => t = -v0 / a
+        // Note: our deceleration is `-a` negated
+        let total_duration = self.initial_velocity / self.deceleration;
+
+        if time_elapsed.as_secs_f32() < total_duration {
+            // Based on the equations of motion for constant acceleration we can calculate the remaining distance at a given time:
+            0.5 * (-self.deceleration)
+                * (total_duration.powi(2) - time_elapsed.as_secs_f32().powi(2))
+                + self.initial_velocity * (total_duration - time_elapsed.as_secs_f32())
+        } else {
+            0.
+        }
+    }
 }
 
 impl Parameter for ConstantDecelerationParameters {

--- a/internal/core/animations/physics_simulation.rs
+++ b/internal/core/animations/physics_simulation.rs
@@ -9,8 +9,8 @@
 //! - `ConstantDeceleration`
 //! - `ConstantDecelerationSpringDamper` with spring damper simulation when reaching the limit
 
-use crate::animations::Instant;
-#[cfg(all(test, not(feature = "std")))]
+use crate::{Coord, animations::Instant};
+#[cfg(not(feature = "std"))]
 use num_traits::Float;
 
 /// The direction the simulation is running
@@ -92,7 +92,7 @@ impl ConstantDecelerationParameters {
     }
 
     /// Calculates the remaining distance to the limit value at a given time based on the initial velocity and deceleration.
-    pub fn remaining_distance(&self, time_elapsed: core::time::Duration) -> f32 {
+    pub fn remaining_distance(&self, time_elapsed: core::time::Duration) -> Coord {
         debug_assert!(self.deceleration != 0., "deceleration must not be zero");
         debug_assert!(
             self.deceleration.signum() == self.initial_velocity.signum(),
@@ -108,11 +108,12 @@ impl ConstantDecelerationParameters {
 
         if time_elapsed.as_secs_f32() < total_duration {
             // Based on the equations of motion for constant acceleration we can calculate the remaining distance at a given time:
-            0.5 * (-self.deceleration)
+            (0.5 * (-self.deceleration)
                 * (total_duration.powi(2) - time_elapsed.as_secs_f32().powi(2))
-                + self.initial_velocity * (total_duration - time_elapsed.as_secs_f32())
+                + self.initial_velocity * (total_duration - time_elapsed.as_secs_f32()))
+                as Coord
         } else {
-            0.
+            Coord::default()
         }
     }
 }
@@ -233,19 +234,20 @@ impl Simulation for ConstantDeceleration {
 }
 
 #[cfg(test)]
+macro_rules! assert_approx_eq {
+    ($a:expr, $b:expr) => {
+        assert!(($a - $b).abs() < 1e-4, "{} != {}", $a, $b);
+    };
+}
+#[cfg(test)]
+fn test_limit_property(value: f32) -> core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>> {
+    alloc::boxed::Box::pin(crate::Property::new(value))
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use core::time::Duration;
-
-    macro_rules! assert_approx_eq {
-        ($a:expr, $b:expr) => {
-            assert!(($a - $b).abs() < 1e-4, "{} != {}", $a, $b);
-        };
-    }
-
-    fn test_limit_property(value: f32) -> core::pin::Pin<alloc::boxed::Box<crate::Property<f32>>> {
-        alloc::boxed::Box::pin(crate::Property::new(value))
-    }
 
     #[test]
     fn constant_deceleration_start_eq_limit() {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -514,18 +514,18 @@ impl FlickableDataInner {
                     // At the time of writing, in practice this means we must use a physics animation.
                     let [limit_x, limit_y] = Self::flick_limits(flick_rc, delta);
 
-                    let x_simulation = (delta.x != 0.).then(|| {
+                    let x_simulation = (delta.x != Coord::default()).then(|| {
                         let simulation = ConstantDecelerationParameters::new_with_distance(
-                            delta.x,
+                            delta.x as f32,
                             WHEEL_SCROLL_DURATION.as_secs_f32(),
                         );
                         viewport_x.set_physic_animation_value(limit_x, simulation.clone());
                         simulation
                     });
 
-                    let y_simulation = (delta.y != 0.).then(|| {
+                    let y_simulation = (delta.y != Coord::default()).then(|| {
                         let simulation = ConstantDecelerationParameters::new_with_distance(
-                            delta.y,
+                            delta.y as f32,
                             WHEEL_SCROLL_DURATION.as_secs_f32(),
                         );
                         viewport_y.set_physic_animation_value(limit_y, simulation.clone());
@@ -597,7 +597,7 @@ impl FlickableDataInner {
             let property = Box::pin(Property::new(0.0));
             property.set_binding({
                 let calculate_limits = calculate_limits.clone();
-                move || calculate_limits().map(|limit| limit.x_length().get()).unwrap_or(0.0)
+                move || calculate_limits().map(|limit| limit.x_length().get() as f32).unwrap_or(0.0)
             });
             property
         } else {
@@ -607,7 +607,7 @@ impl FlickableDataInner {
         let limit_y = if flick_velocity.y < 0 as Coord {
             let property = Box::pin(Property::new(0.0));
             property.set_binding(move || {
-                calculate_limits().map(|limit| limit.y_length().get()).unwrap_or(0.0)
+                calculate_limits().map(|limit| limit.y_length().get() as f32).unwrap_or(0.0)
             });
             property
         } else {
@@ -631,13 +631,13 @@ impl FlickableDataInner {
 
                 {
                     let simulation =
-                        ConstantDecelerationParameters::new(mean_velocity.x, DECELERATION);
+                        ConstantDecelerationParameters::new(mean_velocity.x as f32, DECELERATION);
                     viewport_x.set_physic_animation_value(limit_x, simulation);
                 }
 
                 {
                     let animation_y =
-                        ConstantDecelerationParameters::new(mean_velocity.y, DECELERATION);
+                        ConstantDecelerationParameters::new(mean_velocity.y as f32, DECELERATION);
                     viewport_y.set_physic_animation_value(limit_y, animation_y);
                 }
 

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -686,10 +686,10 @@ impl FlickableData {
                 inner.velocity_rb = VelocityRingBuffer::default();
                 inner.pressed_mouse_state = Some((crate::animations::current_tick(), *position));
                 inner.last_mouse_position = *position;
-                let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
-                x.remove_binding(); // Stop animation by removing the binding
-                let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
-                y.remove_binding(); // Stop animation by removing the binding
+                let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
+                viewport_x.remove_binding(); // Stop animation by removing the binding
+                let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
+                viewport_y.remove_binding(); // Stop animation by removing the binding
 
                 if inner.capture_events.is_some() {
                     InputEventFilterResult::Intercept
@@ -709,26 +709,10 @@ impl FlickableData {
                 let do_intercept = inner.capture_events.is_some()
                     || inner.pressed_mouse_state.is_some_and(
                         |(pressed_time, pressed_mouse_position)| {
-                            if crate::animations::current_tick() - pressed_time > DURATION_THRESHOLD
-                            {
-                                return false;
-                            }
-                            // Check if the mouse was moved more than the DISTANCE_THRESHOLD in a
-                            // direction in which the flickable can flick
-                            let diff = *position - pressed_mouse_position;
-                            let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
-                            let w = geo.width_length();
-                            let h = geo.height_length();
-                            let vw =
-                                (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get();
-                            let vh =
-                                (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get();
-                            let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick).get();
-                            let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick).get();
-                            let zero = LogicalLength::zero();
-                            ((vw > w || x != zero) && abs(diff.x_length()) > DISTANCE_THRESHOLD)
-                                || ((vh > h || y != zero)
-                                    && abs(diff.y_length()) > DISTANCE_THRESHOLD)
+                            let mouse_delta = *position - pressed_mouse_position;
+
+                            crate::animations::current_tick() - pressed_time <= DURATION_THRESHOLD
+                                && self.should_capture_mouse_direction(mouse_delta, flick, flick_rc)
                         },
                     );
                 if do_intercept {
@@ -796,6 +780,27 @@ impl FlickableData {
         }
     }
 
+    fn should_capture_mouse_direction(
+        &self,
+        mouse_delta: LogicalVector,
+        flick: Pin<&Flickable>,
+        flick_rc: &ItemRc,
+    ) -> bool {
+        let flickable_geometry = Flickable::geometry_without_virtual_keyboard(flick_rc);
+        let flickable_width = flickable_geometry.width_length();
+        let flickable_height = flickable_geometry.height_length();
+        let viewport_width = flick.viewport_width();
+        let viewport_height = flick.viewport_height();
+        let zero = LogicalLength::zero();
+
+        // We should capture the mouse movement, if the flickable can move in this
+        // axis, and the mouse has moved more than the threshold in this axis.
+        ((viewport_width > flickable_width || flick.viewport_x() != zero)
+            && abs(mouse_delta.x_length()) > DISTANCE_THRESHOLD)
+            || ((viewport_height > flickable_height || flick.viewport_y() != zero)
+                && abs(mouse_delta.y_length()) > DISTANCE_THRESHOLD)
+    }
+
     fn handle_mouse(
         &self,
         flick: Pin<&Flickable>,
@@ -837,67 +842,67 @@ impl FlickableData {
                 // So to correctly calculate the mouse delta, we need to use the position of
                 // the mouse in the flickables coordinate system and never the viewport coordinate
                 // system.
-                if let Some((_pressed_time, pressed_mouse_position)) = inner.pressed_mouse_state {
+                if let Some((_pressed_time, _pressed_mouse_position)) = inner.pressed_mouse_state {
                     let mouse_delta = *position - inner.last_mouse_position;
-                    let total_mouse_delta = *position - pressed_mouse_position;
-                    inner.last_mouse_position = *position;
-
                     inner.velocity_rb.push(crate::animations::current_tick(), mouse_delta);
 
-                    let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
-                    let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
-                    let current_viewport_position =
-                        LogicalPoint::from_lengths(viewport_x.get(), viewport_y.get());
-
-                    // We calculate the new viewport position by adding the mouse delta in the flickable
-                    // coordinate system to the current viewport position.
-                    // Do not rely on the existing viewport position to be stable, as e.g. the
-                    // ListView will continuously update it.
-                    // So we cannot calculate the delta in viewport coordinates.
-                    let new_viewport_position = current_viewport_position + mouse_delta;
-
-                    let should_capture = || {
-                        let flickable_geometry =
-                            Flickable::geometry_without_virtual_keyboard(flick_rc);
-                        let flickable_width = flickable_geometry.width_length();
-                        let flickable_height = flickable_geometry.height_length();
-                        let viewport_width =
-                            (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get();
-                        let viewport_height =
-                            (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get();
-                        let zero = LogicalLength::zero();
-
-                        // We should capture the mouse movement, if the flickable can move in this
-                        // axis, and the mouse has moved more than the threshold in this axis.
-                        ((viewport_width > flickable_width || viewport_x.get() != zero)
-                            && abs(total_mouse_delta.x_length()) > DISTANCE_THRESHOLD)
-                            || ((viewport_height > flickable_height || viewport_y.get() != zero)
-                                && abs(total_mouse_delta.y_length()) > DISTANCE_THRESHOLD)
-                    };
-
-                    if inner.capture_events.is_some_and(|f| f == CaptureEvents::MouseOrTouchScreen)
-                        || should_capture()
+                    let is_capturing = inner
+                        .capture_events
+                        .is_some_and(|f| f == CaptureEvents::MouseOrTouchScreen);
+                    if is_capturing
+                        || self.should_capture_mouse_direction(mouse_delta, flick, flick_rc)
                     {
                         // The drag event is meant to move the viewport, set it to the new position
                         // and start capturing mouse events.
-                        let new_pos = ensure_in_bound(flick, new_viewport_position, flick_rc);
+                        let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
+                        let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
+                        let current_viewport_position =
+                            LogicalPoint::from_lengths(viewport_x.get(), viewport_y.get());
 
-                        viewport_x.set(new_pos.x_length());
-                        viewport_y.set(new_pos.y_length());
-                        if current_viewport_position != new_pos {
+                        // We calculate the new viewport position by adding the mouse delta in the flickable
+                        // coordinate system to the current viewport position.
+                        // Do not rely on the existing viewport position to be stable, as e.g. the
+                        // ListView will continuously update it.
+                        // So we cannot calculate the delta in viewport coordinates.
+                        let new_viewport_position = current_viewport_position + mouse_delta;
+                        let new_viewport_position =
+                            ensure_in_bound(flick, new_viewport_position, flick_rc);
+
+                        viewport_x.set(new_viewport_position.x_length());
+                        viewport_y.set(new_viewport_position.y_length());
+                        if current_viewport_position != new_viewport_position {
                             (Flickable::FIELD_OFFSETS.flicked()).apply_pin(flick).call(&());
                         }
 
+                        // Only update the mouse position if we are actually applying the delta.
+                        // When the drag starts, there is a short dead zone that is determined by the
+                        // DISTANCE_THRESHOLD. We want to apply that threshold to the
+                        // delta once we've overcome it, so we need to update the position that we
+                        // calculate the delta from only after we've cleared the deadzone and are
+                        // actually moving.
+                        //
+                        // Note: As an alternative to updating the last_mouse_position to the new mouse position,
+                        // we could also update it by the amount that the viewport actually moved.
+                        // This would cause the mouse to stick to a given position in the viewport
+                        // instead of starting to drift if the drag goes into the viewport limits.
+                        // Then this code would need to be:
+                        //
+                        //  inner.last_mouse_position += new_viewport_position - current_viewport_position;
+                        //
+                        // But at least for a touchscreen, the current behavior is more intuitive.
+                        inner.last_mouse_position = *position;
+
                         inner.capture_events = Some(CaptureEvents::MouseOrTouchScreen);
+
                         InputEventResult::GrabMouse
-                    } else if abs(viewport_x.get() - new_viewport_position.x_length())
-                        > DISTANCE_THRESHOLD
-                        || abs(viewport_y.get() - new_viewport_position.y_length())
-                            > DISTANCE_THRESHOLD
+                    } else if abs(mouse_delta.x_length()) > DISTANCE_THRESHOLD
+                        || abs(mouse_delta.y_length()) > DISTANCE_THRESHOLD
                     {
                         // drag in a unsupported direction gives up the grab
                         InputEventResult::EventIgnored
                     } else {
+                        // the mouse was moved, but not enough to start the drag, we still want to accept further events
+                        // so that we may pass the threshold at some point
                         InputEventResult::EventAccepted
                     }
                 } else {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -7,11 +7,11 @@
 //! The `Flickable` item
 
 use super::{
-    Item, ItemConsts, ItemRc, ItemRendererRef, KeyEventResult, PointerEventButton,
-    PropertyAnimation, RenderingResult, VoidArg,
+    Item, ItemConsts, ItemRc, ItemRendererRef, KeyEventResult, PointerEventButton, RenderingResult,
+    VoidArg,
 };
+use crate::animations::Instant;
 use crate::animations::physics_simulation;
-use crate::animations::{EasingCurve, Instant};
 use crate::input::InternalKeyEvent;
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, MouseEvent, TouchPhase,
@@ -39,7 +39,7 @@ use i_slint_core_macros::*;
 #[allow(unused)]
 use num_traits::Float;
 mod data_ringbuffer;
-use data_ringbuffer::PositionTimeRingBuffer;
+use data_ringbuffer::VelocityRingBuffer;
 
 /// Deceleration during the animation. It slows down the initial velocity of the simulation
 /// so that the simulation stops at some point if it didn't reach the limit
@@ -49,7 +49,6 @@ const DECELERATION: f32 = 2000.;
 /// information to derive a fling velocity.
 /// The unit is: millisecond
 const WHEEL_SCROLL_DURATION: Duration = Duration::from_millis(180);
-const WHEEL_SCROLL_EASING: EasingCurve = EasingCurve::CubicBezier([0.0, 0.0, 0.58, 1.0]);
 /// The maximum duration between a move and a release event to start an animation
 /// If the duration is larger than this value, no animation will be executed because
 /// it is not desired
@@ -148,7 +147,7 @@ impl Item for Flickable {
                 || pos.y < 0 as _
                 || pos.x_length() > geometry.width_length()
                 || pos.y_length() > geometry.height_length())
-                && self.data.inner.borrow().pressed_time.is_none()
+                && self.data.inner.borrow().pressed_mouse_state.is_none()
             {
                 return InputEventFilterResult::Intercept;
             }
@@ -389,11 +388,14 @@ enum CaptureEvents {
 
 #[derive(Default)]
 struct FlickableDataInner {
-    /// The position in which the press was made
+    /// The time and position in which the press was made
+    ///
+    /// The position is in the coordinate system of the flickable, not of the viewport.
+    pressed_mouse_state: Option<(Instant, LogicalPoint)>,
+    /// The last mouse position received, used to calculate the delta when flicking with the mouse.
     ///
     /// This position is in the coordinate system of the flickable, not of the viewport.
-    pressed_mouse_position: LogicalPoint,
-    pressed_time: Option<Instant>,
+    last_mouse_position: LogicalPoint,
     /// Set to true if the flickable is flicking and capturing all mouse event, not forwarding back to the children
     capture_events: Option<CaptureEvents>,
     /// Heuristics for filtering scroll events from children after we have scrolled ourselves.
@@ -403,13 +405,13 @@ struct FlickableDataInner {
     /// stop filtering scroll event until the next scroll event.
     last_scroll_event: Option<(Instant, LogicalPoint)>,
 
-    /// Ringbuffer to store the last move events. From those data the velocity can be
+    /// Ringbuffer to store the last move deltas. From those data the velocity can be
     /// calculated required for the animation after the release event
-    ///
-    /// The position is in the coordinate system of the flickable, not of the viewport.
-    position_time_rb: PositionTimeRingBuffer<5>,
+    velocity_rb: VelocityRingBuffer<5>,
 
-    final_pos: Option<LogicalPoint>,
+    /// The animation details of the currently running animation for smooth mouse wheel scrolling.
+    /// This allows us to add the missing delta of the animation to the next scroll event if the user scrolls again
+    /// before the animation is finished.
     running_animation: Option<(
         Instant,
         physics_simulation::ConstantDecelerationParameters,
@@ -497,18 +499,16 @@ impl FlickableDataInner {
                 viewport_x.set(new_pos.x_length());
                 viewport_y.set(new_pos.y_length());
                 self.last_scroll_event = Some((crate::animations::current_tick(), position));
-                self.final_pos = None;
             }
             TouchPhase::Started => {
-                self.position_time_rb = PositionTimeRingBuffer::default();
+                self.velocity_rb = VelocityRingBuffer::default();
                 self.capture_events = Some(CaptureEvents::MouseWheel);
                 self.last_scroll_event = Some((crate::animations::current_tick(), position));
-                self.final_pos = None;
             }
             TouchPhase::Moved => {
                 if self.capture_events.is_some_and(|capture| capture == CaptureEvents::MouseWheel) {
                     // Touchpad case with different phases
-                    self.position_time_rb.push(crate::animations::current_tick(), new_pos);
+                    self.velocity_rb.push(crate::animations::current_tick(), new_pos - current_pos);
                     viewport_x.set(new_pos.x_length());
                     viewport_y.set(new_pos.y_length());
                 } else {
@@ -632,13 +632,10 @@ impl FlickableDataInner {
     }
 
     fn animate(&self, flick: Pin<&Flickable>, flick_rc: &ItemRc) {
-        if let Some(last_time) = self.position_time_rb.last_time() {
-            let (time, dist) = self.position_time_rb.diff();
-            let millis = time.as_millis();
-
+        if let Some(last_time) = self.velocity_rb.last_time() {
+            let mean_velocity = self.velocity_rb.mean_velocity();
             if self.capture_events.is_some()
-                && dist.square_length() > (DISTANCE_THRESHOLD.get() * DISTANCE_THRESHOLD.get()) as _
-                && millis > 0
+                && mean_velocity.square_length() > 0 as Coord
                 && crate::animations::current_tick().duration_since(last_time) < MAX_DURATION
             {
                 let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
@@ -664,7 +661,7 @@ impl FlickableDataInner {
                         })
                 };
 
-                let limit_x = if dist.x < 0 as Coord {
+                let limit_x = if mean_velocity.x < 0 as Coord {
                     let property = Box::pin(Property::new(0.0));
                     property.set_binding({
                         let calculate_limits = calculate_limits.clone();
@@ -677,7 +674,7 @@ impl FlickableDataInner {
                     Box::pin(Property::new(0.0))
                 };
 
-                let limit_y = if dist.y < 0 as Coord {
+                let limit_y = if mean_velocity.y < 0 as Coord {
                     let property = Box::pin(Property::new(0.0));
                     property.set_binding(move || {
                         calculate_limits().map(|limit| limit.y_length().get()).unwrap_or(0.0)
@@ -689,7 +686,7 @@ impl FlickableDataInner {
 
                 {
                     let simulation = physics_simulation::ConstantDecelerationParameters::new(
-                        dist.x as f32 / (millis as f32 / 1000.),
+                        mean_velocity.x,
                         DECELERATION,
                     );
                     viewport_x.set_physic_animation_value(limit_x, simulation);
@@ -697,13 +694,13 @@ impl FlickableDataInner {
 
                 {
                     let animation_y = physics_simulation::ConstantDecelerationParameters::new(
-                        dist.y as f32 / (millis as f32 / 1000.),
+                        mean_velocity.y,
                         DECELERATION,
                     );
                     viewport_y.set_physic_animation_value(limit_y, animation_y);
                 }
 
-                if dist.x != 0 as Coord || dist.y != 0 as Coord {
+                if mean_velocity.x != 0 as Coord || mean_velocity.y != 0 as Coord {
                     (Flickable::FIELD_OFFSETS.flicked()).apply_pin(flick).call(&());
                 }
             }
@@ -745,9 +742,9 @@ impl FlickableData {
         let mut inner = self.inner.borrow_mut();
         match event {
             MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
-                inner.position_time_rb = PositionTimeRingBuffer::default();
-                inner.pressed_mouse_position = *position;
-                inner.pressed_time = Some(crate::animations::current_tick());
+                inner.velocity_rb = VelocityRingBuffer::default();
+                inner.pressed_mouse_state = Some((crate::animations::current_tick(), *position));
+                inner.last_mouse_position = *position;
                 let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
                 x.remove_binding(); // Stop animation by removing the binding
                 let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
@@ -760,7 +757,7 @@ impl FlickableData {
                 }
             }
             MouseEvent::Exit | MouseEvent::Released { button: PointerEventButton::Left, .. } => {
-                inner.pressed_time = None;
+                inner.pressed_mouse_state = None;
                 if inner.capture_events.is_some() {
                     InputEventFilterResult::Intercept
                 } else {
@@ -769,28 +766,33 @@ impl FlickableData {
             }
             MouseEvent::Moved { position, .. } => {
                 let do_intercept = inner.capture_events.is_some()
-                    || inner.pressed_time.is_some_and(|pressed_time| {
-                        if crate::animations::current_tick() - pressed_time > DURATION_THRESHOLD {
-                            return false;
-                        }
-                        // Check if the mouse was moved more than the DISTANCE_THRESHOLD in a
-                        // direction in which the flickable can flick
-                        let diff = *position - inner.pressed_mouse_position;
-                        let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
-                        let w = geo.width_length();
-                        let h = geo.height_length();
-                        let vw = (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get();
-                        let vh =
-                            (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get();
-                        let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick).get();
-                        let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick).get();
-                        let zero = LogicalLength::zero();
-                        ((vw > w || x != zero) && abs(diff.x_length()) > DISTANCE_THRESHOLD)
-                            || ((vh > h || y != zero) && abs(diff.y_length()) > DISTANCE_THRESHOLD)
-                    });
+                    || inner.pressed_mouse_state.is_some_and(
+                        |(pressed_time, pressed_mouse_position)| {
+                            if crate::animations::current_tick() - pressed_time > DURATION_THRESHOLD
+                            {
+                                return false;
+                            }
+                            // Check if the mouse was moved more than the DISTANCE_THRESHOLD in a
+                            // direction in which the flickable can flick
+                            let diff = *position - pressed_mouse_position;
+                            let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
+                            let w = geo.width_length();
+                            let h = geo.height_length();
+                            let vw =
+                                (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get();
+                            let vh =
+                                (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get();
+                            let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick).get();
+                            let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick).get();
+                            let zero = LogicalLength::zero();
+                            ((vw > w || x != zero) && abs(diff.x_length()) > DISTANCE_THRESHOLD)
+                                || ((vh > h || y != zero)
+                                    && abs(diff.y_length()) > DISTANCE_THRESHOLD)
+                        },
+                    );
                 if do_intercept {
                     InputEventFilterResult::Intercept
-                } else if inner.pressed_time.is_some() {
+                } else if inner.pressed_mouse_state.is_some() {
                     InputEventFilterResult::ForwardAndInterceptGrab
                 } else {
                     InputEventFilterResult::ForwardEvent
@@ -870,16 +872,15 @@ impl FlickableData {
                 if inner.capture_events.is_some_and(|f| f == CaptureEvents::MouseOrTouchScreen) {
                     let was_capturing = true;
                     inner.animate(flick, flick_rc);
-                    inner.final_pos = None;
                     inner.capture_events = None;
-                    inner.pressed_time = None;
+                    inner.pressed_mouse_state = None;
                     if was_capturing {
                         InputEventResult::EventAccepted
                     } else {
                         InputEventResult::EventIgnored
                     }
                 } else if inner.capture_events.is_none() {
-                    inner.pressed_time = None;
+                    inner.pressed_mouse_state = None;
                     InputEventResult::EventIgnored
                 } else {
                     InputEventResult::EventIgnored
@@ -895,16 +896,12 @@ impl FlickableData {
                 // So to correctly calculate the mouse delta, we need to use the position of
                 // the mouse in the flickables coordinate system and never the viewport coordinate
                 // system.
-                if inner.pressed_time.is_some() {
-                    inner.final_pos = None;
-                    let last_mouse_position = inner
-                        .position_time_rb
-                        .last_position()
-                        .unwrap_or(inner.pressed_mouse_position);
-                    let mouse_delta = *position - last_mouse_position;
-                    let total_mouse_delta = *position - inner.pressed_mouse_position;
+                if let Some((_pressed_time, pressed_mouse_position)) = inner.pressed_mouse_state {
+                    let mouse_delta = *position - inner.last_mouse_position;
+                    let total_mouse_delta = *position - pressed_mouse_position;
+                    inner.last_mouse_position = *position;
 
-                    inner.position_time_rb.push(crate::animations::current_tick(), *position);
+                    inner.velocity_rb.push(crate::animations::current_tick(), mouse_delta);
 
                     let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
                     let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -878,7 +878,7 @@ impl FlickableData {
                         // When the drag starts, there is a short dead zone that is determined by the
                         // DISTANCE_THRESHOLD. We want to apply that threshold to the
                         // delta once we've overcome it, so we need to update the position that we
-                        // calculate the delta from only after we've cleared the deadzone and are
+                        // calculate the delta from only after we've cleared the dead zone and are
                         // actually moving.
                         //
                         // Note: As an alternative to updating the last_mouse_position to the new mouse position,

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -471,6 +471,11 @@ impl FlickableDataInner {
 
         let new_pos = ensure_in_bound(flick, old_pos + delta, flick_rc);
 
+        if phase != TouchPhase::Ended {
+            viewport_x.remove_binding();
+            viewport_y.remove_binding();
+        }
+
         match phase {
             TouchPhase::Cancelled => {
                 viewport_x.set(new_pos.x_length());
@@ -539,21 +544,56 @@ impl FlickableDataInner {
             {
                 let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
                 let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
-                let vw = (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get();
-                let vh = (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get();
-                let limit_x =
-                    if dist.x < 0 as Coord { -vw } else { euclid::Length::new(Coord::default()) };
-                let limit_y =
-                    if dist.y < 0 as Coord { -vh } else { euclid::Length::new(Coord::default()) };
 
-                let limit =
-                    ensure_in_bound(flick, LogicalPoint::from_lengths(limit_x, limit_y), flick_rc);
+                let flick_weak = flick_rc.downgrade();
+                let calculate_limits = move || {
+                    flick_weak
+                        .upgrade()
+                        .and_then(|flick_rc| {
+                            flick_rc.downcast::<Flickable>().map(move |flick| (flick_rc, flick))
+                        })
+                        .map(|(flick_rc, flick)| {
+                            let flick = flick.as_pin_ref();
+                            ensure_in_bound(
+                                flick,
+                                LogicalPoint::from_lengths(
+                                    -flick.viewport_width(),
+                                    -flick.viewport_height(),
+                                ),
+                                &flick_rc,
+                            )
+                        })
+                };
+
+                let limit_x = if dist.x < 0 as Coord {
+                    let property = Box::pin(Property::new(0.0));
+                    property.set_binding({
+                        let calculate_limits = calculate_limits.clone();
+                        move || {
+                            calculate_limits().map(|limit| limit.x_length().get()).unwrap_or(0.0)
+                        }
+                    });
+                    property
+                } else {
+                    Box::pin(Property::new(0.0))
+                };
+
+                let limit_y = if dist.y < 0 as Coord {
+                    let property = Box::pin(Property::new(0.0));
+                    property.set_binding(move || {
+                        calculate_limits().map(|limit| limit.y_length().get()).unwrap_or(0.0)
+                    });
+                    property
+                } else {
+                    Box::pin(Property::new(0.0))
+                };
+
                 {
                     let simulation = physics_simulation::ConstantDecelerationParameters::new(
                         dist.x as f32 / (millis as f32 / 1000.),
                         DECELERATION,
                     );
-                    viewport_x.set_physic_animation_value(limit.x_length(), simulation);
+                    viewport_x.set_physic_animation_value(limit_x, simulation);
                 }
 
                 {
@@ -561,7 +601,7 @@ impl FlickableDataInner {
                         dist.y as f32 / (millis as f32 / 1000.),
                         DECELERATION,
                     );
-                    viewport_y.set_physic_animation_value(limit.y_length(), animation_y);
+                    viewport_y.set_physic_animation_value(limit_y, animation_y);
                 }
 
                 if dist.x != 0 as Coord || dist.y != 0 as Coord {
@@ -610,9 +650,9 @@ impl FlickableData {
                 inner.pressed_mouse_position = *position;
                 inner.pressed_time = Some(crate::animations::current_tick());
                 let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
-                x.set(x.get()); // Stop animation by removing the binding
+                x.remove_binding(); // Stop animation by removing the binding
                 let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
-                y.set(y.get()); // Stop animation by removing the binding
+                y.remove_binding(); // Stop animation by removing the binding
 
                 if inner.capture_events.is_some() {
                     InputEventFilterResult::Intercept
@@ -772,9 +812,11 @@ impl FlickableData {
                     let current_viewport_position =
                         LogicalPoint::from_lengths(viewport_x.get(), viewport_y.get());
 
-                    // We calculate the new viewport position by adding the mouse delta to the current viewport position.
+                    // We calculate the new viewport position by adding the mouse delta in the flickable
+                    // coordinate system to the current viewport position.
                     // Do not rely on the existing viewport position to be stable, as e.g. the
                     // ListView will continuously update it.
+                    // So we cannot calculate the delta in viewport coordinates.
                     let new_viewport_position = current_viewport_position + mouse_delta;
 
                     let should_capture = || {
@@ -799,6 +841,8 @@ impl FlickableData {
                     if inner.capture_events.is_some_and(|f| f == CaptureEvents::MouseOrTouchScreen)
                         || should_capture()
                     {
+                        // The drag event is meant to move the viewport, set it to the new position
+                        // and start capturing mouse events.
                         let new_pos = ensure_in_bound(flick, new_viewport_position, flick_rc);
 
                         viewport_x.set(new_pos.x_length());

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -48,7 +48,7 @@ const DECELERATION: f32 = 2000.;
 /// Fixed-duration animation used for wheel scrolling, where we don't have enough phase
 /// information to derive a fling velocity.
 /// The unit is: millisecond
-const WHEEL_SCROLL_DURATION: i32 = 180;
+const WHEEL_SCROLL_DURATION: Duration = Duration::from_millis(180);
 const WHEEL_SCROLL_EASING: EasingCurve = EasingCurve::CubicBezier([0.0, 0.0, 0.58, 1.0]);
 /// The maximum duration between a move and a release event to start an animation
 /// If the duration is larger than this value, no animation will be executed because
@@ -390,6 +390,8 @@ enum CaptureEvents {
 #[derive(Default)]
 struct FlickableDataInner {
     /// The position in which the press was made
+    ///
+    /// This position is in the coordinate system of the flickable, not of the viewport.
     pressed_mouse_position: LogicalPoint,
     pressed_time: Option<Instant>,
     /// Set to true if the flickable is flicking and capturing all mouse event, not forwarding back to the children
@@ -403,20 +405,19 @@ struct FlickableDataInner {
 
     /// Ringbuffer to store the last move events. From those data the velocity can be
     /// calculated required for the animation after the release event
+    ///
+    /// The position is in the coordinate system of the flickable, not of the viewport.
     position_time_rb: PositionTimeRingBuffer<5>,
 
     final_pos: Option<LogicalPoint>,
+    running_animation: Option<(
+        Instant,
+        physics_simulation::ConstantDecelerationParameters,
+        physics_simulation::ConstantDecelerationParameters,
+    )>,
 }
 
 impl FlickableDataInner {
-    fn wheel_scroll_animation() -> PropertyAnimation {
-        PropertyAnimation {
-            duration: WHEEL_SCROLL_DURATION,
-            easing: WHEEL_SCROLL_EASING,
-            ..Default::default()
-        }
-    }
-
     fn should_capture_scroll(&self, timeout: Duration, position: LogicalPoint) -> bool {
         self.last_scroll_event.is_some_and(|(last_time, last_position)| {
             // Note: Squared length for MCU support, which use i32 coords.
@@ -442,7 +443,7 @@ impl FlickableDataInner {
     fn process_wheel_event(
         &mut self,
         flick: Pin<&Flickable>,
-        delta: LogicalVector,
+        mut delta: LogicalVector,
         position: LogicalPoint,
         phase: TouchPhase,
         flick_rc: &ItemRc,
@@ -459,21 +460,36 @@ impl FlickableDataInner {
 
         let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
         let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
-        let mut old_pos = LogicalPoint::from_lengths(viewport_x.get(), viewport_y.get());
+        let current_pos = LogicalPoint::from_lengths(viewport_x.get(), viewport_y.get());
 
         if self.capture_events.is_none()
             && matches!(phase, TouchPhase::Moved)
-            && let Some(pos) = self.final_pos
+            && let Some((start_time, x_simulation, y_simulation)) = &self.running_animation
         {
-            // If the animation is not finished, we use final value of the animation, otherwise we slow the scrolling down
-            old_pos = pos;
+            let animation_duration = crate::animations::current_tick().duration_since(*start_time);
+            if animation_duration < WHEEL_SCROLL_DURATION {
+                let missing = |sim: &physics_simulation::ConstantDecelerationParameters| {
+                    0.5 * (-sim.deceleration)
+                        * (WHEEL_SCROLL_DURATION.as_secs_f32().powi(2)
+                            - animation_duration.as_secs_f32().powi(2))
+                        + sim.initial_velocity
+                            * (WHEEL_SCROLL_DURATION.as_secs_f32()
+                                - animation_duration.as_secs_f32())
+                };
+                let missing_x = missing(x_simulation);
+                let missing_y = missing(y_simulation);
+
+                // If the animation is not finished, we add the remaining animations delta.
+                delta += LogicalVector::new(missing_x, missing_y);
+            }
         }
 
-        let new_pos = ensure_in_bound(flick, old_pos + delta, flick_rc);
+        let new_pos = ensure_in_bound(flick, current_pos + delta, flick_rc);
 
         if phase != TouchPhase::Ended {
             viewport_x.remove_binding();
             viewport_y.remove_binding();
+            self.running_animation = None;
         }
 
         match phase {
@@ -497,10 +513,93 @@ impl FlickableDataInner {
                     viewport_y.set(new_pos.y_length());
                 } else {
                     // Mousewheel case with no phase
-                    let animation = Self::wheel_scroll_animation();
-                    viewport_x.set_animated_value(new_pos.x_length(), animation.clone());
-                    viewport_y.set_animated_value(new_pos.y_length(), animation);
-                    self.final_pos = Some(new_pos);
+                    let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
+                    let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
+
+                    let flick_weak = flick_rc.downgrade();
+                    let calculate_limits = move || {
+                        flick_weak
+                            .upgrade()
+                            .and_then(|flick_rc| {
+                                flick_rc.downcast::<Flickable>().map(move |flick| (flick_rc, flick))
+                            })
+                            .map(|(flick_rc, flick)| {
+                                let flick = flick.as_pin_ref();
+                                ensure_in_bound(
+                                    flick,
+                                    LogicalPoint::from_lengths(
+                                        -flick.viewport_width(),
+                                        -flick.viewport_height(),
+                                    ),
+                                    &flick_rc,
+                                )
+                            })
+                    };
+
+                    let dist = new_pos - current_pos;
+
+                    let limit_x = if dist.x < 0 as Coord {
+                        let property = Box::pin(Property::new(0.0));
+                        property.set_binding({
+                            let calculate_limits = calculate_limits.clone();
+                            move || {
+                                calculate_limits()
+                                    .map(|limit| limit.x_length().get())
+                                    .unwrap_or(0.0)
+                            }
+                        });
+                        property
+                    } else {
+                        Box::pin(Property::new(0.0))
+                    };
+
+                    let limit_y = if dist.y < 0 as Coord {
+                        let property = Box::pin(Property::new(0.0));
+                        property.set_binding(move || {
+                            calculate_limits().map(|limit| limit.y_length().get()).unwrap_or(0.0)
+                        });
+                        property
+                    } else {
+                        Box::pin(Property::new(0.0))
+                    };
+
+                    let x_simulation = {
+                        // v0 * t + 0.5 * a * t^2 = d
+                        // v0 * t + 0.5 * -(v0 / t) * t^2 = d
+                        // v0 * t + 0.5 * -v0 * t = d
+                        // v0 * (t + -0.5 * t) = d
+                        // v0 * (0.5 t) = d
+                        // => v0 = d / (0.5 t)
+
+                        let d = dist.x;
+                        let v0 = d / (0.5 * WHEEL_SCROLL_DURATION.as_secs_f32());
+                        let a = -(v0 / WHEEL_SCROLL_DURATION.as_secs_f32());
+                        let simulation = physics_simulation::ConstantDecelerationParameters::new(
+                            v0, // deceleration: therefore -a
+                            -a,
+                        );
+                        viewport_x.set_physic_animation_value(limit_x, simulation.clone());
+                        simulation
+                    };
+
+                    let y_simulation = {
+                        let d = dist.y;
+                        let v0 = d / (0.5 * WHEEL_SCROLL_DURATION.as_secs_f32());
+                        let a = -(v0 / WHEEL_SCROLL_DURATION.as_secs_f32());
+                        let simulation = physics_simulation::ConstantDecelerationParameters::new(
+                            v0, // deceleration: therefore -a
+                            -a,
+                        );
+                        viewport_y.set_physic_animation_value(limit_y, simulation.clone());
+                        simulation
+                    };
+
+                    if dist.x != 0 as Coord || dist.y != 0 as Coord {
+                        (Flickable::FIELD_OFFSETS.flicked()).apply_pin(flick).call(&());
+                    }
+
+                    self.running_animation =
+                        Some((crate::animations::current_tick(), x_simulation, y_simulation));
                 }
                 self.last_scroll_event = Some((crate::animations::current_tick(), position));
             }
@@ -517,8 +616,8 @@ impl FlickableDataInner {
             }
         }
 
-        let flicked =
-            old_pos.x_length() != new_pos.x_length() || old_pos.y_length() != new_pos.y_length();
+        let flicked = current_pos.x_length() != new_pos.x_length()
+            || current_pos.y_length() != new_pos.y_length();
         if flicked {
             (Flickable::FIELD_OFFSETS.flicked()).apply_pin(flick).call(&());
             InputEventResult::EventAccepted

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -11,7 +11,7 @@ use super::{
     VoidArg,
 };
 use crate::animations::Instant;
-use crate::animations::physics_simulation;
+use crate::animations::physics_simulation::ConstantDecelerationParameters;
 use crate::input::InternalKeyEvent;
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, MouseEvent, TouchPhase,
@@ -412,11 +412,7 @@ struct FlickableDataInner {
     /// The animation details of the currently running animation for smooth mouse wheel scrolling.
     /// This allows us to add the missing delta of the animation to the next scroll event if the user scrolls again
     /// before the animation is finished.
-    running_animation: Option<(
-        Instant,
-        physics_simulation::ConstantDecelerationParameters,
-        physics_simulation::ConstantDecelerationParameters,
-    )>,
+    running_animation: Option<(Instant, [Option<ConstantDecelerationParameters>; 2])>,
 }
 
 impl FlickableDataInner {
@@ -457,6 +453,8 @@ impl FlickableDataInner {
             // Release the capture immediately, this event is not meant for this Flickable.
             self.capture_events = None;
             self.last_scroll_event = None;
+            self.running_animation = None;
+            self.velocity_rb = VelocityRingBuffer::default();
             return InputEventResult::EventIgnored;
         }
 
@@ -466,27 +464,21 @@ impl FlickableDataInner {
 
         if self.capture_events.is_none()
             && matches!(phase, TouchPhase::Moved)
-            && let Some((start_time, x_simulation, y_simulation)) = &self.running_animation
+            && let Some((start_time, [x_simulation, y_simulation])) = &self.running_animation
         {
+            // If the animation is not finished, we add the remaining animations delta.
             let animation_duration = crate::animations::current_tick().duration_since(*start_time);
-            if animation_duration < WHEEL_SCROLL_DURATION {
-                let missing = |sim: &physics_simulation::ConstantDecelerationParameters| {
-                    0.5 * (-sim.deceleration)
-                        * (WHEEL_SCROLL_DURATION.as_secs_f32().powi(2)
-                            - animation_duration.as_secs_f32().powi(2))
-                        + sim.initial_velocity
-                            * (WHEEL_SCROLL_DURATION.as_secs_f32()
-                                - animation_duration.as_secs_f32())
-                };
-                let missing_x = missing(x_simulation);
-                let missing_y = missing(y_simulation);
 
-                // If the animation is not finished, we add the remaining animations delta.
-                delta += LogicalVector::new(missing_x, missing_y);
+            if let Some(x_simulation) = x_simulation {
+                delta.x += x_simulation.remaining_distance(animation_duration);
+            }
+            if let Some(y_simulation) = y_simulation {
+                delta.y += y_simulation.remaining_distance(animation_duration);
             }
         }
 
         let new_pos = ensure_in_bound(flick, current_pos + delta, flick_rc);
+        delta = new_pos - current_pos;
 
         if phase != TouchPhase::Ended {
             viewport_x.remove_binding();
@@ -513,93 +505,39 @@ impl FlickableDataInner {
                     viewport_y.set(new_pos.y_length());
                 } else {
                     // Mousewheel case with no phase
-                    let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
-                    let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
+                    // Add a short animation that covers the delta for smooth scrolling
+                    //
+                    // Note that this animation must support the viewport_x/_y and width/height
+                    // changing, as e.g. the ListView might resize the viewport if it gets a new size
+                    // estimate.
+                    //
+                    // At the time of writing, in practice this means we must use a physics animation.
+                    let [limit_x, limit_y] = Self::flick_limits(flick_rc, delta);
 
-                    let flick_weak = flick_rc.downgrade();
-                    let calculate_limits = move || {
-                        flick_weak
-                            .upgrade()
-                            .and_then(|flick_rc| {
-                                flick_rc.downcast::<Flickable>().map(move |flick| (flick_rc, flick))
-                            })
-                            .map(|(flick_rc, flick)| {
-                                let flick = flick.as_pin_ref();
-                                ensure_in_bound(
-                                    flick,
-                                    LogicalPoint::from_lengths(
-                                        -flick.viewport_width(),
-                                        -flick.viewport_height(),
-                                    ),
-                                    &flick_rc,
-                                )
-                            })
-                    };
-
-                    let dist = new_pos - current_pos;
-
-                    let limit_x = if dist.x < 0 as Coord {
-                        let property = Box::pin(Property::new(0.0));
-                        property.set_binding({
-                            let calculate_limits = calculate_limits.clone();
-                            move || {
-                                calculate_limits()
-                                    .map(|limit| limit.x_length().get())
-                                    .unwrap_or(0.0)
-                            }
-                        });
-                        property
-                    } else {
-                        Box::pin(Property::new(0.0))
-                    };
-
-                    let limit_y = if dist.y < 0 as Coord {
-                        let property = Box::pin(Property::new(0.0));
-                        property.set_binding(move || {
-                            calculate_limits().map(|limit| limit.y_length().get()).unwrap_or(0.0)
-                        });
-                        property
-                    } else {
-                        Box::pin(Property::new(0.0))
-                    };
-
-                    let x_simulation = {
-                        // v0 * t + 0.5 * a * t^2 = d
-                        // v0 * t + 0.5 * -(v0 / t) * t^2 = d
-                        // v0 * t + 0.5 * -v0 * t = d
-                        // v0 * (t + -0.5 * t) = d
-                        // v0 * (0.5 t) = d
-                        // => v0 = d / (0.5 t)
-
-                        let d = dist.x;
-                        let v0 = d / (0.5 * WHEEL_SCROLL_DURATION.as_secs_f32());
-                        let a = -(v0 / WHEEL_SCROLL_DURATION.as_secs_f32());
-                        let simulation = physics_simulation::ConstantDecelerationParameters::new(
-                            v0, // deceleration: therefore -a
-                            -a,
+                    let x_simulation = (delta.x != 0.).then(|| {
+                        let simulation = ConstantDecelerationParameters::new_with_distance(
+                            delta.x,
+                            WHEEL_SCROLL_DURATION.as_secs_f32(),
                         );
                         viewport_x.set_physic_animation_value(limit_x, simulation.clone());
                         simulation
-                    };
+                    });
 
-                    let y_simulation = {
-                        let d = dist.y;
-                        let v0 = d / (0.5 * WHEEL_SCROLL_DURATION.as_secs_f32());
-                        let a = -(v0 / WHEEL_SCROLL_DURATION.as_secs_f32());
-                        let simulation = physics_simulation::ConstantDecelerationParameters::new(
-                            v0, // deceleration: therefore -a
-                            -a,
+                    let y_simulation = (delta.y != 0.).then(|| {
+                        let simulation = ConstantDecelerationParameters::new_with_distance(
+                            delta.y,
+                            WHEEL_SCROLL_DURATION.as_secs_f32(),
                         );
                         viewport_y.set_physic_animation_value(limit_y, simulation.clone());
                         simulation
-                    };
+                    });
 
-                    if dist.x != 0 as Coord || dist.y != 0 as Coord {
+                    if delta.x != 0 as Coord || delta.y != 0 as Coord {
                         (Flickable::FIELD_OFFSETS.flicked()).apply_pin(flick).call(&());
                     }
 
                     self.running_animation =
-                        Some((crate::animations::current_tick(), x_simulation, y_simulation));
+                        Some((crate::animations::current_tick(), [x_simulation, y_simulation]));
                 }
                 self.last_scroll_event = Some((crate::animations::current_tick(), position));
             }
@@ -631,6 +569,54 @@ impl FlickableDataInner {
         }
     }
 
+    fn flick_limits(
+        flick_rc: &ItemRc,
+        flick_velocity: LogicalVector,
+    ) -> [Pin<Box<Property<f32>>>; 2] {
+        let flick_weak = flick_rc.downgrade();
+        let calculate_limits = move || {
+            flick_weak
+                .upgrade()
+                .and_then(|flick_rc| {
+                    flick_rc.downcast::<Flickable>().map(move |flick| (flick_rc, flick))
+                })
+                .map(|(flick_rc, flick)| {
+                    let flick = flick.as_pin_ref();
+                    ensure_in_bound(
+                        flick,
+                        LogicalPoint::from_lengths(
+                            -flick.viewport_width(),
+                            -flick.viewport_height(),
+                        ),
+                        &flick_rc,
+                    )
+                })
+        };
+
+        let limit_x = if flick_velocity.x < 0 as Coord {
+            let property = Box::pin(Property::new(0.0));
+            property.set_binding({
+                let calculate_limits = calculate_limits.clone();
+                move || calculate_limits().map(|limit| limit.x_length().get()).unwrap_or(0.0)
+            });
+            property
+        } else {
+            Box::pin(Property::new(0.0))
+        };
+
+        let limit_y = if flick_velocity.y < 0 as Coord {
+            let property = Box::pin(Property::new(0.0));
+            property.set_binding(move || {
+                calculate_limits().map(|limit| limit.y_length().get()).unwrap_or(0.0)
+            });
+            property
+        } else {
+            Box::pin(Property::new(0.0))
+        };
+
+        [limit_x, limit_y]
+    }
+
     fn animate(&self, flick: Pin<&Flickable>, flick_rc: &ItemRc) {
         if let Some(last_time) = self.velocity_rb.last_time() {
             let mean_velocity = self.velocity_rb.mean_velocity();
@@ -641,62 +627,17 @@ impl FlickableDataInner {
                 let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
                 let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
 
-                let flick_weak = flick_rc.downgrade();
-                let calculate_limits = move || {
-                    flick_weak
-                        .upgrade()
-                        .and_then(|flick_rc| {
-                            flick_rc.downcast::<Flickable>().map(move |flick| (flick_rc, flick))
-                        })
-                        .map(|(flick_rc, flick)| {
-                            let flick = flick.as_pin_ref();
-                            ensure_in_bound(
-                                flick,
-                                LogicalPoint::from_lengths(
-                                    -flick.viewport_width(),
-                                    -flick.viewport_height(),
-                                ),
-                                &flick_rc,
-                            )
-                        })
-                };
-
-                let limit_x = if mean_velocity.x < 0 as Coord {
-                    let property = Box::pin(Property::new(0.0));
-                    property.set_binding({
-                        let calculate_limits = calculate_limits.clone();
-                        move || {
-                            calculate_limits().map(|limit| limit.x_length().get()).unwrap_or(0.0)
-                        }
-                    });
-                    property
-                } else {
-                    Box::pin(Property::new(0.0))
-                };
-
-                let limit_y = if mean_velocity.y < 0 as Coord {
-                    let property = Box::pin(Property::new(0.0));
-                    property.set_binding(move || {
-                        calculate_limits().map(|limit| limit.y_length().get()).unwrap_or(0.0)
-                    });
-                    property
-                } else {
-                    Box::pin(Property::new(0.0))
-                };
+                let [limit_x, limit_y] = Self::flick_limits(flick_rc, mean_velocity);
 
                 {
-                    let simulation = physics_simulation::ConstantDecelerationParameters::new(
-                        mean_velocity.x,
-                        DECELERATION,
-                    );
+                    let simulation =
+                        ConstantDecelerationParameters::new(mean_velocity.x, DECELERATION);
                     viewport_x.set_physic_animation_value(limit_x, simulation);
                 }
 
                 {
-                    let animation_y = physics_simulation::ConstantDecelerationParameters::new(
-                        mean_velocity.y,
-                        DECELERATION,
-                    );
+                    let animation_y =
+                        ConstantDecelerationParameters::new(mean_velocity.y, DECELERATION);
                     viewport_y.set_physic_animation_value(limit_y, animation_y);
                 }
 

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -390,10 +390,8 @@ enum CaptureEvents {
 #[derive(Default)]
 struct FlickableDataInner {
     /// The position in which the press was made
-    pressed_pos: LogicalPoint,
+    pressed_mouse_position: LogicalPoint,
     pressed_time: Option<Instant>,
-    pressed_viewport_pos: LogicalPoint,
-    pressed_viewport_size: LogicalSize,
     /// Set to true if the flickable is flicking and capturing all mouse event, not forwarding back to the children
     capture_events: Option<CaptureEvents>,
     /// Heuristics for filtering scroll events from children after we have scrolled ourselves.
@@ -609,16 +607,8 @@ impl FlickableData {
         match event {
             MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
                 inner.position_time_rb = PositionTimeRingBuffer::default();
-                inner.pressed_pos = *position;
+                inner.pressed_mouse_position = *position;
                 inner.pressed_time = Some(crate::animations::current_tick());
-                inner.pressed_viewport_pos = LogicalPoint::from_lengths(
-                    (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick).get(),
-                    (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick).get(),
-                );
-                inner.pressed_viewport_size = LogicalSize::from_lengths(
-                    (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get(),
-                    (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get(),
-                );
                 let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
                 x.set(x.get()); // Stop animation by removing the binding
                 let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
@@ -646,7 +636,7 @@ impl FlickableData {
                         }
                         // Check if the mouse was moved more than the DISTANCE_THRESHOLD in a
                         // direction in which the flickable can flick
-                        let diff = *position - inner.pressed_pos;
+                        let diff = *position - inner.pressed_mouse_position;
                         let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
                         let w = geo.width_length();
                         let h = geo.height_length();
@@ -757,63 +747,72 @@ impl FlickableData {
                 }
             }
             MouseEvent::Moved { position, .. } => {
+                // Important constraint: The viewport_y might not be stable, and might jump around
+                // wildly!
+                // This is especially the case if a ListView is involved, which will continuously
+                // update its own viewport_y to keep the current item visible, which can cause the
+                // viewport_y to jump.
+                //
+                // So to correctly calculate the mouse delta, we need to use the position of
+                // the mouse in the flickables coordinate system and never the viewport coordinate
+                // system.
                 if inner.pressed_time.is_some() {
                     inner.final_pos = None;
+                    let last_mouse_position = inner
+                        .position_time_rb
+                        .last_position()
+                        .unwrap_or(inner.pressed_mouse_position);
+                    let mouse_delta = *position - last_mouse_position;
+                    let total_mouse_delta = *position - inner.pressed_mouse_position;
+
                     inner.position_time_rb.push(crate::animations::current_tick(), *position);
-                    let current_viewport_size = LogicalSize::from_lengths(
-                        (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get(),
-                        (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get(),
-                    );
 
-                    // Update reference points when the size of the viewport changes to
-                    // avoid 'jumping' during scrolling.
-                    // This happens when the height estimate of a ListView changes after
-                    // new items are loaded.
-                    if current_viewport_size != inner.pressed_viewport_size {
-                        inner.pressed_viewport_size = current_viewport_size;
+                    let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
+                    let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
+                    let current_viewport_position =
+                        LogicalPoint::from_lengths(viewport_x.get(), viewport_y.get());
 
-                        inner.pressed_viewport_pos = LogicalPoint::from_lengths(
-                            (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick).get(),
-                            (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick).get(),
-                        );
+                    // We calculate the new viewport position by adding the mouse delta to the current viewport position.
+                    // Do not rely on the existing viewport position to be stable, as e.g. the
+                    // ListView will continuously update it.
+                    let new_viewport_position = current_viewport_position + mouse_delta;
 
-                        inner.pressed_pos = *position;
-                    };
-
-                    let new_pos = inner.pressed_viewport_pos + (*position - inner.pressed_pos);
-
-                    let x = (Flickable::FIELD_OFFSETS.viewport_x()).apply_pin(flick);
-                    let y = (Flickable::FIELD_OFFSETS.viewport_y()).apply_pin(flick);
                     let should_capture = || {
-                        let geo = Flickable::geometry_without_virtual_keyboard(flick_rc);
-                        let w = geo.width_length();
-                        let h = geo.height_length();
-                        let vw = (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get();
-                        let vh =
+                        let flickable_geometry =
+                            Flickable::geometry_without_virtual_keyboard(flick_rc);
+                        let flickable_width = flickable_geometry.width_length();
+                        let flickable_height = flickable_geometry.height_length();
+                        let viewport_width =
+                            (Flickable::FIELD_OFFSETS.viewport_width()).apply_pin(flick).get();
+                        let viewport_height =
                             (Flickable::FIELD_OFFSETS.viewport_height()).apply_pin(flick).get();
                         let zero = LogicalLength::zero();
-                        ((vw > w || x.get() != zero)
-                            && abs(x.get() - new_pos.x_length()) > DISTANCE_THRESHOLD)
-                            || ((vh > h || y.get() != zero)
-                                && abs(y.get() - new_pos.y_length()) > DISTANCE_THRESHOLD)
+
+                        // We should capture the mouse movement, if the flickable can move in this
+                        // axis, and the mouse has moved more than the threshold in this axis.
+                        ((viewport_width > flickable_width || viewport_x.get() != zero)
+                            && abs(total_mouse_delta.x_length()) > DISTANCE_THRESHOLD)
+                            || ((viewport_height > flickable_height || viewport_y.get() != zero)
+                                && abs(total_mouse_delta.y_length()) > DISTANCE_THRESHOLD)
                     };
 
                     if inner.capture_events.is_some_and(|f| f == CaptureEvents::MouseOrTouchScreen)
                         || should_capture()
                     {
-                        let new_pos = ensure_in_bound(flick, new_pos, flick_rc);
+                        let new_pos = ensure_in_bound(flick, new_viewport_position, flick_rc);
 
-                        let old_pos = (x.get(), y.get());
-                        x.set(new_pos.x_length());
-                        y.set(new_pos.y_length());
-                        if old_pos.0 != new_pos.x_length() || old_pos.1 != new_pos.y_length() {
+                        viewport_x.set(new_pos.x_length());
+                        viewport_y.set(new_pos.y_length());
+                        if current_viewport_position != new_pos {
                             (Flickable::FIELD_OFFSETS.flicked()).apply_pin(flick).call(&());
                         }
 
                         inner.capture_events = Some(CaptureEvents::MouseOrTouchScreen);
                         InputEventResult::GrabMouse
-                    } else if abs(x.get() - new_pos.x_length()) > DISTANCE_THRESHOLD
-                        || abs(y.get() - new_pos.y_length()) > DISTANCE_THRESHOLD
+                    } else if abs(viewport_x.get() - new_viewport_position.x_length())
+                        > DISTANCE_THRESHOLD
+                        || abs(viewport_y.get() - new_viewport_position.y_length())
+                            > DISTANCE_THRESHOLD
                     {
                         // drag in a unsupported direction gives up the grab
                         InputEventResult::EventIgnored

--- a/internal/core/items/flickable/data_ringbuffer.rs
+++ b/internal/core/items/flickable/data_ringbuffer.rs
@@ -55,6 +55,11 @@ impl<const N: usize> PositionTimeRingBuffer<N> {
         if !self.empty() { Some(self.values[self.latest_index()].0) } else { None }
     }
 
+    /// Returns the last position value added to the buffer if not empty otherwise None
+    pub fn last_position(&self) -> Option<LogicalPoint> {
+        if !self.empty() { Some(self.values[self.latest_index()].1) } else { None }
+    }
+
     /// Returns the difference between the oldest and the newest point
     pub fn diff(&self) -> (Duration, Vector2D<Coord, LogicalPx>) {
         if self.full {

--- a/internal/core/items/flickable/data_ringbuffer.rs
+++ b/internal/core/items/flickable/data_ringbuffer.rs
@@ -80,7 +80,7 @@ impl<const N: usize> VelocityRingBuffer<N> {
             index = (index + 1) % N;
         }
 
-        total_delta / duration.as_secs_f32()
+        (total_delta.cast::<f32>() / duration.as_secs_f32()).cast::<Coord>()
     }
 }
 

--- a/internal/core/items/flickable/data_ringbuffer.rs
+++ b/internal/core/items/flickable/data_ringbuffer.rs
@@ -1,40 +1,39 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! This module contains a simple ringbuffer to store time and location tuples. It is used in the flickable to
-//! determine the initial velocity of the animation
+//! This module contains a simple ringbuffer to store time and delta tuples.
+//! It is used in the flickable to determine the initial velocity of the animation.
 
 use crate::Coord;
 use crate::animations::Instant;
-use crate::lengths::LogicalPoint;
-use crate::lengths::LogicalPx;
+use crate::lengths::{LogicalPx, LogicalVector};
 use core::time::Duration;
 use euclid::Vector2D;
 
-/// Simple ringbuffer storing time and position tuples
+/// Simple ringbuffer storing time and delta tuples
 #[derive(Debug)]
-pub(crate) struct PositionTimeRingBuffer<const N: usize> {
+pub(crate) struct VelocityRingBuffer<const N: usize> {
     /// Pointing to the next free element
     curr_index: usize,
     /// Indicates if the buffer is full
     full: bool,
-    values: [(Instant, LogicalPoint); N],
+    values: [(Instant, Vector2D<Coord, LogicalPx>); N],
 }
 
-impl<const N: usize> Default for PositionTimeRingBuffer<N> {
+impl<const N: usize> Default for VelocityRingBuffer<N> {
     fn default() -> Self {
-        Self { curr_index: 0, full: false, values: [(Instant::now(), LogicalPoint::default()); N] }
+        Self { curr_index: 0, full: false, values: [(Instant::now(), Vector2D::default()); N] }
     }
 }
 
-impl<const N: usize> PositionTimeRingBuffer<N> {
+impl<const N: usize> VelocityRingBuffer<N> {
     /// Indicates if the buffer is empty
     pub fn empty(&self) -> bool {
         !(self.full || self.curr_index > 0)
     }
 
     /// Add a new element to the ringbuffer
-    pub fn push(&mut self, time: Instant, value: LogicalPoint) {
+    pub fn push(&mut self, time: Instant, value: LogicalVector) {
         if self.curr_index < self.values.len() {
             self.values[self.curr_index] = (time, value);
         }
@@ -50,31 +49,38 @@ impl<const N: usize> PositionTimeRingBuffer<N> {
         if self.curr_index > 0 { self.curr_index - 1 } else { N - 1 }
     }
 
+    fn len(&self) -> usize {
+        if self.full { N } else { self.curr_index }
+    }
+
     /// Returns the last time value added to the buffer if not empty otherwise None
     pub fn last_time(&self) -> Option<Instant> {
         if !self.empty() { Some(self.values[self.latest_index()].0) } else { None }
     }
 
-    /// Returns the last position value added to the buffer if not empty otherwise None
-    pub fn last_position(&self) -> Option<LogicalPoint> {
-        if !self.empty() { Some(self.values[self.latest_index()].1) } else { None }
-    }
-
-    /// Returns the difference between the oldest and the newest point
-    pub fn diff(&self) -> (Duration, Vector2D<Coord, LogicalPx>) {
-        if self.full {
-            let oldest = self.values[self.curr_index];
-            let newest = if self.curr_index > 0 {
-                self.values[self.curr_index - 1]
-            } else {
-                self.values[self.values.len() - 1]
-            };
-            (newest.0.duration_since(oldest.0), newest.1 - oldest.1)
-        } else {
-            let oldest = self.values[0];
-            let newest = self.values[usize::max(0, self.curr_index - 1)];
-            (newest.0.duration_since(oldest.0), newest.1 - oldest.1)
+    pub fn mean_velocity(&self) -> LogicalVector {
+        let len = self.len();
+        if len < 2 {
+            return Default::default();
         }
+
+        let oldest_index = if self.full { self.curr_index } else { 0 };
+        let newest_index = self.latest_index();
+        let duration = self.values[newest_index].0.duration_since(self.values[oldest_index].0);
+        if duration == Duration::ZERO {
+            return Default::default();
+        }
+
+        // The oldest recorded delta happened before the oldest timestamp in the covered time span,
+        // so it does not belong to the average velocity between oldest and newest.
+        let mut total_delta = LogicalVector::default();
+        let mut index = (oldest_index + 1) % N;
+        for _ in 1..len {
+            total_delta += self.values[index].1;
+            index = (index + 1) % N;
+        }
+
+        total_delta / duration.as_secs_f32()
     }
 }
 
@@ -82,116 +88,111 @@ impl<const N: usize> PositionTimeRingBuffer<N> {
 mod tests {
     use super::*;
     use crate::animations::Instant;
-    use crate::lengths::LogicalPoint;
     use core::time::Duration;
 
     #[test]
     fn test_empty_buffer() {
-        let buffer: PositionTimeRingBuffer<5> = PositionTimeRingBuffer::default();
+        let buffer: VelocityRingBuffer<5> = VelocityRingBuffer::default();
         assert!(buffer.empty());
         assert_eq!(buffer.curr_index, 0);
         assert!(!buffer.full);
         assert_eq!(buffer.last_time(), None);
+        assert_eq!(buffer.mean_velocity(), Vector2D::default());
     }
 
     #[test]
     fn test_push_single_element() {
-        let mut buffer: PositionTimeRingBuffer<5> = PositionTimeRingBuffer::default();
+        let mut buffer: VelocityRingBuffer<5> = VelocityRingBuffer::default();
         let time = Instant::now();
-        let point = LogicalPoint::new(10.0, 20.0);
+        let delta = Vector2D::new(10.0, 20.0);
 
-        buffer.push(time, point);
+        buffer.push(time, delta);
 
         assert!(!buffer.empty());
         assert_eq!(buffer.curr_index, 1);
         assert!(!buffer.full);
         assert_eq!(buffer.latest_index(), 0);
         assert_eq!(buffer.last_time(), Some(time));
-
-        assert_eq!(buffer.diff(), (Duration::from_millis(0), Vector2D::new(0., 0.)));
+        assert_eq!(buffer.mean_velocity(), Vector2D::default());
     }
 
     /// Buffer not complete full
     #[test]
     fn test_push_two_elements() {
-        let mut buffer: PositionTimeRingBuffer<5> = PositionTimeRingBuffer::default();
+        let mut buffer: VelocityRingBuffer<5> = VelocityRingBuffer::default();
         let time = Instant::now();
 
-        buffer.push(time, LogicalPoint::new(10.0, 20.0));
-        buffer.push(time + Duration::from_millis(13), LogicalPoint::new(13.0, -5.0));
+        buffer.push(time, Vector2D::new(10.0, 20.0));
+        buffer.push(time + Duration::from_millis(100), Vector2D::new(13.0, -5.0));
 
         assert!(!buffer.empty());
         assert_eq!(buffer.curr_index, 2);
         assert!(!buffer.full);
         assert_eq!(buffer.latest_index(), 1);
-        assert_eq!(buffer.last_time(), Some(time + Duration::from_millis(13)));
+        assert_eq!(buffer.last_time(), Some(time + Duration::from_millis(100)));
 
-        assert_eq!(buffer.diff(), (Duration::from_millis(13), Vector2D::new(3., -25.)));
+        assert_eq!(buffer.mean_velocity(), Vector2D::new(130.0, -50.0));
     }
 
     #[test]
     fn test_push_until_full() {
-        let mut buffer: PositionTimeRingBuffer<5> = PositionTimeRingBuffer::default();
+        let mut buffer: VelocityRingBuffer<5> = VelocityRingBuffer::default();
         let base_time = Instant::now();
 
         // Push elements to fill the buffer
         for i in 0..5 {
-            let time = base_time + Duration::from_millis(i * 3 as u64);
-            let point = LogicalPoint::new(i as f32, -2. * i as f32);
-            buffer.push(time, point);
+            let time = base_time + Duration::from_millis(i * 100);
+            buffer.push(time, Vector2D::new(1.0, -2.0));
         }
 
         assert!(!buffer.empty());
         assert_eq!(buffer.curr_index, 0);
         assert!(buffer.full);
-        assert_eq!(buffer.last_time(), Some(base_time + Duration::from_millis(4 * 3)));
+        assert_eq!(buffer.last_time(), Some(base_time + Duration::from_millis(400)));
         assert_eq!(buffer.latest_index(), 4);
 
-        assert_eq!(buffer.diff(), (Duration::from_millis(12), Vector2D::new(4., -8.)));
+        assert_eq!(buffer.mean_velocity(), Vector2D::new(10.0, -20.0));
     }
 
     #[test]
     fn test_push_beyond_capacity() {
         const CAP: usize = 5;
-        let mut buffer: PositionTimeRingBuffer<CAP> = PositionTimeRingBuffer::default();
+        let mut buffer: VelocityRingBuffer<CAP> = VelocityRingBuffer::default();
         let base_time = Instant::now();
 
         // Push more than capacity
         for i in 0..(CAP + 2) {
-            let time = base_time + Duration::from_millis(i as u64);
-            let point = LogicalPoint::new(i as f32, i as f32 * 2. + 100.);
-            buffer.push(time, point);
+            let time = base_time + Duration::from_millis(i as u64 * 100);
+            buffer.push(time, Vector2D::new(1.0, 2.0));
         }
 
         assert!(!buffer.empty());
         assert!(buffer.full);
         assert_eq!(buffer.curr_index, 2);
         assert_eq!(buffer.latest_index(), 1);
-        assert_eq!(buffer.last_time(), Some(base_time + Duration::from_millis(6)));
+        assert_eq!(buffer.last_time(), Some(base_time + Duration::from_millis(600)));
 
-        assert_eq!(buffer.diff(), (Duration::from_millis(4), Vector2D::new(4., 4. * 2.)));
+        assert_eq!(buffer.mean_velocity(), Vector2D::new(10.0, 20.0));
     }
 
     #[test]
     fn test_push_beyond_capacity_wrap_back() {
         const CAP: usize = 5;
-        let mut buffer: PositionTimeRingBuffer<CAP> = PositionTimeRingBuffer::default();
+        let mut buffer: VelocityRingBuffer<CAP> = VelocityRingBuffer::default();
         let base_time = Instant::now();
 
         // Push more than capacity
         for i in 0..CAP {
-            let time = base_time + Duration::from_millis(i as u64);
-            let point = LogicalPoint::new(i as f32 * 3., i as f32 * -2. + 100.);
-            buffer.push(time, point);
+            let time = base_time + Duration::from_millis(i as u64 * 100);
+            buffer.push(time, Vector2D::new(3.0, -2.0));
         }
 
         assert!(!buffer.empty());
         assert!(buffer.full);
         assert_eq!(buffer.curr_index, 0);
         assert_eq!(buffer.latest_index(), CAP - 1);
-        assert_eq!(buffer.last_time(), Some(base_time + Duration::from_millis(4)));
+        assert_eq!(buffer.last_time(), Some(base_time + Duration::from_millis(400)));
 
-        // Wrapping back must be done
-        assert_eq!(buffer.diff(), (Duration::from_millis(4), Vector2D::new(4. * 3., 4. * -2.)));
+        assert_eq!(buffer.mean_velocity(), Vector2D::new(30.0, -20.0));
     }
 }

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -320,15 +320,17 @@ fn update_visible_instances(
         viewport_height.set(LogicalLength::new(state.cached_item_height * row_count as Coord));
         viewport_width.set(LogicalLength::new(vp_width));
         // If an animation is ongoing we should not interrupt it
-        if !viewport_y.has_binding() {
-            let new_viewport_y = -state.anchor_y + new_offset_y;
-            if new_viewport_y != viewport_y.get().get() {
-                viewport_y.set(LogicalLength::new(new_viewport_y));
-            }
-            state.previous_viewport_y = new_viewport_y;
-        } else {
-            state.previous_viewport_y = viewport_y.get().0;
+        let new_viewport_y = -state.anchor_y + new_offset_y;
+        // Important: Use get_internal here, the viewport_y may have a binding on it (especially
+        // a physical animation).
+        // We must not yet trigger a re-evaluation of that binding, as we have already updated the
+        // viewport_width and viewport_height, but the viewport_y is not yet consistent.
+        // So the physics animations limit value may be inconsistent.
+        if new_viewport_y != viewport_y.get_internal().get() {
+            viewport_y.set(LogicalLength::new(new_viewport_y));
         }
+        state.previous_viewport_y = new_viewport_y;
+
         break;
     }
 

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -319,7 +319,6 @@ fn update_visible_instances(
         state.anchor_y = state.cached_item_height * state.offset as Coord;
         viewport_height.set(LogicalLength::new(state.cached_item_height * row_count as Coord));
         viewport_width.set(LogicalLength::new(vp_width));
-        // If an animation is ongoing we should not interrupt it
         let new_viewport_y = -state.anchor_y + new_offset_y;
         // Important: Use get_internal here, the viewport_y may have a binding on it (especially
         // a physical animation).
@@ -327,6 +326,9 @@ fn update_visible_instances(
         // viewport_width and viewport_height, but the viewport_y is not yet consistent.
         // So the physics animations limit value may be inconsistent.
         if new_viewport_y != viewport_y.get_internal().get() {
+            // If a physics animation is ongoing (e.g. due to a flick), we should not interrupt it.
+            // The physics animation implements intercept_set, and is therefore not interrupted by
+            // a call to set() - so it's okay to just use a normal set here.
             viewport_y.set(LogicalLength::new(new_viewport_y));
         }
         state.previous_viewport_y = new_viewport_y;

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -997,11 +997,6 @@ impl<T: Clone> Property<T> {
         })
     }
 
-    /// Remove the binding of this property if any.
-    pub fn remove_binding(&self) {
-        self.handle.remove_binding();
-    }
-
     /// Change the value of this property
     ///
     /// If other properties have binding depending of this property, these properties will

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -997,6 +997,11 @@ impl<T: Clone> Property<T> {
         })
     }
 
+    /// Remove the binding of this property if any.
+    pub fn remove_binding(&self) {
+        self.handle.remove_binding();
+    }
+
     /// Change the value of this property
     ///
     /// If other properties have binding depending of this property, these properties will

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{
-    animations::physics_simulation,
+    animations::physics_simulation::{self, Simulation},
     items::{AnimationDirection, PropertyAnimation},
     lengths::LogicalLength,
 };
@@ -37,25 +37,26 @@ where
     }
 
     /// Single iteration of the animation
-    pub fn compute_interpolated_value(&mut self) -> (crate::Coord, bool) {
+    pub fn update_value(&mut self, target: &mut crate::Coord) -> bool {
         match self.state {
             AnimationState::Delaying => {
                 // Decide on next state:
                 self.state = AnimationState::Animating { current_iteration: 0 };
-                self.compute_interpolated_value()
+                self.update_value(target)
             }
             AnimationState::Animating { current_iteration: _ } => {
-                let (val, finished) = self.simulation.step(crate::animations::current_tick());
+                // TODO: Pass in Coord directly?
+                let mut value: f32 = *target as f32;
+                let finished = self.simulation.step(&mut value, crate::animations::current_tick());
+                *target = value as crate::Coord;
                 if finished {
                     self.state = AnimationState::Done { iteration_count: 0 };
-                    self.compute_interpolated_value()
+                    true
                 } else {
-                    (val as crate::Coord, false)
+                    false
                 }
             }
-            AnimationState::Done { iteration_count: _ } => {
-                (self.simulation.curr_value() as crate::Coord, true)
-            }
+            AnimationState::Done { iteration_count: _ } => true,
         }
     }
 }
@@ -365,36 +366,41 @@ impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
     }
 }
 
-impl<T> Property<Length<crate::Coord, T>> {
+unsafe impl<Unit, S: Simulation> BindingCallable<Length<crate::Coord, Unit>>
+    for RefCell<PropertyPhysicsAnimationData<S>>
+{
+    fn evaluate(self: Pin<&Self>, value: &mut Length<crate::Coord, Unit>) -> BindingResult {
+        let finished = self.borrow_mut().update_value(&mut value.0);
+        if finished {
+            BindingResult::RemoveBinding
+        } else {
+            crate::animations::CURRENT_ANIMATION_DRIVER
+                .with(|driver| driver.set_has_active_animations());
+            BindingResult::KeepBinding
+        }
+    }
+
+    // This binding should not be removed if the value is updated externally.
+    fn intercept_set(self: Pin<&Self>, _value: &Length<crate::Coord, Unit>) -> bool {
+        true
+    }
+}
+
+impl<Unit> Property<Length<crate::Coord, Unit>> {
     /// Change the value by using a physics animation
     pub fn set_physic_animation_value<
         S: physics_simulation::Simulation + 'static,
         AD: physics_simulation::Parameter<Output = S>,
     >(
         &self,
-        value: Length<crate::Coord, T>,
+        limit_value: Pin<Box<Property<f32>>>,
         simulation_data: AD,
     ) {
-        let d = RefCell::new(PropertyPhysicsAnimationData::new(
-            simulation_data.simulation(self.get_internal().0 as f32, value.0 as f32),
-        ));
         // Safety: the BindingCallable will cast its argument to T
         unsafe {
-            self.handle.set_binding(
-                move |val: &mut Length<crate::Coord, T>| {
-                    let (value, finished) = d.borrow_mut().compute_interpolated_value();
-                    *val = Length::new(value);
-                    if finished {
-                        BindingResult::RemoveBinding
-                    } else {
-                        crate::animations::CURRENT_ANIMATION_DRIVER
-                            .with(|driver| driver.set_has_active_animations());
-                        BindingResult::KeepBinding
-                    }
-                },
-                #[cfg(slint_debug_property)]
-                self.debug_name.borrow().as_str(),
-            );
+            self.handle.set_binding::<Length<crate::Coord, Unit>, core::cell::RefCell<PropertyPhysicsAnimationData<S>>>(RefCell::new(PropertyPhysicsAnimationData::new(
+                simulation_data.simulation(self.get_internal().0 as f32, limit_value),
+            )));
         }
         self.handle.mark_dirty(
             #[cfg(slint_debug_property)]

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -287,6 +287,18 @@ impl InterpolatedPropertyValue for LogicalLength {
 }
 
 impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
+    /// Evaluate the property and remove the (animation) binding of this property.
+    ///
+    /// Note that a binding can intercept this via intercept_set_binding and still remain on the property.
+    /// (e.g. two-way-bindings will not be removed with this call!)
+    pub fn remove_binding(self: Pin<&Self>) {
+        // FIXME: This is a bit of a hack, set_animated_value will call set_binding on the internal handle,
+        // which will call intercept_set_binding, which will check if the binding should be removed or not.
+        // In the case of two-way bindings, we want to keep the binding, but reset the value to the current one,
+        // so that any animation binding is removed, but the two-way-binding is kept.
+        self.set_animated_value(self.get(), PropertyAnimation::default());
+    }
+
     /// Change the value of this property, by animating (interpolating) from the current property's value
     /// to the specified parameter value. The animation is done according to the parameters described by
     /// the PropertyAnimation object.

--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -56,22 +56,14 @@ assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 0.);
 
 // now, scroll down
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 202.0) });
-assert_eq!(instance.get_inner_x(), 0.);
-assert_eq!(instance.get_outer_y(), 0.);
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 200.0) });
-assert_eq!(instance.get_inner_x(), 0.);
-assert_eq!(instance.get_outer_y(), 0.);
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 198.0) });
-assert_eq!(instance.get_inner_x(), 0.);
-assert_eq!(instance.get_outer_y(), 2.);
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 170.0) });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 270.0) });
+// should move the outer one now, it has passed the threshold when moving up already
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 30.);
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 150.0) });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 250.0) });
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 50.);
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 150.0) });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 250.0) });
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 50.);
 slint_testing::mock_elapsed_time(100);
@@ -90,6 +82,9 @@ instance.window().dispatch_event(WindowEvent::PointerPressed { position: Logical
 slint_testing::mock_elapsed_time(16);
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 500.);
+// TODO: A small movement will currently break this the delayed pressed event, as the outer flickable
+// is then accepting the event, which cancels the delayed pressed event!
+// instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(95.0, 100.0) });
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(90.0, 100.0) });
 slint_testing::mock_elapsed_time(120); // we need to wait enough because of the delay in the outer one
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(90.0, 100.0) });

--- a/tests/cases/elements/listview_differing_heights.slint
+++ b/tests/cases/elements/listview_differing_heights.slint
@@ -1,0 +1,249 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Tests that ListView can handle items with different heights using all three scrolling methods:
+// 1. mouse/touch dragging
+// 2. scroll wheel
+// 3. touchpad two-finger scrolling (scroll wheel with a touchphase)
+
+import { ListView, ScrollView } from "std-widgets.slint";
+export component Test inherits Window {
+    width: 600px;
+    height: 600px;
+
+    listview := ListView {
+        mouse-drag-pan-enabled: true;
+
+        for i in 100: Rectangle {
+            height: (i.mod(10) * 50 + 10) * 1px;
+            background: i.mod(2) == 0 ? @linear-gradient(0deg, blue, darkblue) : @linear-gradient(0deg, red, darkred);
+            Text {
+                text: i;
+                font-size: 24px;
+            }
+            TouchArea {
+                // used to detect which element is currently in the middle of the viewport
+                clicked => {
+                    root.clicked-index = i;
+                }
+            }
+        }
+    }
+
+    out property <length> height_ <=> self.height;
+    out property <length> viewport-y <=> listview.viewport-y;
+    out property <length> viewport-height <=> listview.viewport-height;
+
+    out property <int> clicked-index: 0;
+}
+
+
+/*
+
+```rust
+use slint::{platform::PointerEventButton, platform::WindowEvent, LogicalPosition};
+use slint_testing::{LogicalPoint, MouseEvent, TouchPhase};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ScrollDirection {
+    Down,
+    Up,
+}
+
+impl ScrollDirection {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Down => "down",
+            Self::Up => "up",
+        }
+    }
+
+    fn delta_y(self, delta: f32) -> f32 {
+        match self {
+            Self::Down => -delta,
+            Self::Up => delta,
+        }
+    }
+}
+
+let instance = Test::new().unwrap();
+let window = instance.window();
+let inner = slint_testing::WindowInner::from_pub(&window);
+let scroll_position = LogicalPoint::new(300.0, 300.0);
+
+let send_event = |event| {
+    window.dispatch_event(event);
+};
+
+let send_pressed_event = |x, y| {
+    send_event(WindowEvent::PointerPressed {
+        position: LogicalPosition::new(x, y),
+        button: PointerEventButton::Left,
+    });
+};
+
+let send_released_event = |x, y| {
+    send_event(WindowEvent::PointerReleased {
+        position: LogicalPosition::new(x, y),
+        button: PointerEventButton::Left,
+    });
+};
+
+let send_moved_event = |x, y| {
+    send_event(WindowEvent::PointerMoved { position: LogicalPosition::new(x, y) });
+};
+
+let send_wheel_event = |delta_y, phase| {
+    inner.process_mouse_input(MouseEvent::Wheel {
+        position: scroll_position,
+        delta_x: 0.0,
+        delta_y,
+        phase,
+    });
+};
+
+let probe_index = |direction| {
+    let probe_y = match direction {
+        ScrollDirection::Down => instance.get_height_() - 1.0,
+        ScrollDirection::Up => 1.0,
+    };
+    send_pressed_event(300.0, probe_y);
+    send_released_event(300.0, probe_y);
+    instance.get_clicked_index()
+};
+
+let wait_for_scroll_animation = || {
+    let mut current_viewport_y = instance.get_viewport_y();
+    loop {
+        slint_testing::mock_elapsed_time(16);
+        let new_viewport_y = instance.get_viewport_y();
+        if current_viewport_y == new_viewport_y {
+            break;
+        }
+        current_viewport_y = new_viewport_y;
+    }
+};
+
+let assert_scroll_progress = |current_index: &mut i32, direction: ScrollDirection, method_name: &str| {
+    let new_index = probe_index(direction);
+    let progressed = match direction {
+        ScrollDirection::Down => new_index >= *current_index,
+        ScrollDirection::Up => new_index <= *current_index,
+    };
+    assert!(
+        progressed,
+        "Expected to scroll {} with {}, but the index went from {} to {}",
+        direction.name(),
+        method_name,
+        *current_index,
+        new_index
+    );
+    *current_index = new_index;
+};
+
+let run_bidirectional_scroll_test = |method_name: &str, scroll_step: &mut dyn FnMut(ScrollDirection)| {
+    let target_viewport_y = |direction| match direction {
+        ScrollDirection::Down => -instance.get_viewport_height() + instance.get_height_(),
+        ScrollDirection::Up => 0.0,
+    };
+
+    for direction in [ScrollDirection::Down, ScrollDirection::Up] {
+        let mut current_index = probe_index(direction);
+        let target_index = match direction {
+            ScrollDirection::Down => 99,
+            ScrollDirection::Up => 0,
+        };
+
+        while match direction {
+            ScrollDirection::Down => instance.get_viewport_y() > target_viewport_y(direction),
+            ScrollDirection::Up => instance.get_viewport_y() < target_viewport_y(direction),
+        } {
+            // Note: probing the index sends click events, which would disturb the
+            // active scroll gesture or its velocity calculation. Only probe before
+            // the gesture starts and after the animation settled.
+            scroll_step(direction);
+            wait_for_scroll_animation();
+
+            assert_scroll_progress(&mut current_index, direction, method_name);
+        }
+
+        let viewport_y = instance.get_viewport_y();
+        let expected_viewport_y = target_viewport_y(direction);
+        assert_eq!(
+            viewport_y,
+            expected_viewport_y,
+            "Expected {} scrolling with {} to reach {}, but got {}",
+            direction.name(),
+            method_name,
+            expected_viewport_y,
+            viewport_y
+        );
+        assert_eq!(
+            instance.get_clicked_index(),
+            target_index,
+            "Expected {} scrolling with {} to reach element {}, but got {}",
+            direction.name(),
+            method_name,
+            target_index,
+            instance.get_clicked_index()
+        );
+    }
+};
+
+// Test scrolling with mouse dragging.
+let mut mouse_drag_step = |direction| {
+    match direction {
+        ScrollDirection::Down => {
+            send_pressed_event(300.0, 300.0);
+            slint_testing::mock_elapsed_time(16);
+
+            send_moved_event(300.0, 200.0);
+            slint_testing::mock_elapsed_time(16);
+
+            send_moved_event(300.0, 150.0);
+            slint_testing::mock_elapsed_time(16);
+
+            send_released_event(300.0, 100.0);
+            slint_testing::mock_elapsed_time(16);
+        }
+        ScrollDirection::Up => {
+            send_pressed_event(300.0, 50.0);
+            slint_testing::mock_elapsed_time(16);
+
+            send_moved_event(300.0, 100.0);
+            slint_testing::mock_elapsed_time(16);
+
+            send_moved_event(300.0, 150.0);
+            slint_testing::mock_elapsed_time(16);
+
+            send_released_event(300.0, 200.0);
+            slint_testing::mock_elapsed_time(16);
+        }
+    }
+};
+run_bidirectional_scroll_test("mouse dragging", &mut mouse_drag_step);
+
+// Test scrolling with mouse wheel events. Regular wheel events only use TouchPhase::Moved.
+let mut mouse_wheel_step = |direction: ScrollDirection| {
+    send_wheel_event(direction.delta_y(400.0), TouchPhase::Moved);
+};
+run_bidirectional_scroll_test("mouse wheel", &mut mouse_wheel_step);
+
+// Test scrolling with touchpad events. Touchpad scrolling uses Started/Moved/Ended.
+let mut touchpad_step = |direction: ScrollDirection| {
+    send_wheel_event(0.0, TouchPhase::Started);
+    slint_testing::mock_elapsed_time(16);
+
+    send_wheel_event(direction.delta_y(250.0), TouchPhase::Moved);
+    slint_testing::mock_elapsed_time(16);
+
+    send_wheel_event(direction.delta_y(150.0), TouchPhase::Moved);
+    slint_testing::mock_elapsed_time(16);
+
+    send_wheel_event(0.0, TouchPhase::Ended);
+    slint_testing::mock_elapsed_time(16);
+};
+run_bidirectional_scroll_test("touchpad scrolling", &mut touchpad_step);
+```
+
+*/

--- a/tests/cases/elements/listview_differing_heights.slint
+++ b/tests/cases/elements/listview_differing_heights.slint
@@ -4,7 +4,7 @@
 // Tests that ListView can handle items with different heights using all three scrolling methods:
 // 1. mouse/touch dragging
 // 2. scroll wheel
-// 3. touchpad two-finger scrolling (scroll wheel with a touchphase)
+// 3. touchpad two-finger scrolling (scroll wheel with a touch phase)
 
 import { ListView, ScrollView } from "std-widgets.slint";
 export component Test inherits Window {


### PR DESCRIPTION
- **Flickable: Fix viewport_y updating while scrolling**
- **Fix the ListView**

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Fixes: https://github.com/slint-ui/slint/issues/11672
