### PR TITLE
Test: The popup has it's own ItemTree different to the parents one

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1664,7 +1664,11 @@ mod tests {
 
     crate::item_tree::ItemTreeVTable_static!(static TEST_COMPONENT_VT for TestItemTree);
 
-    fn create_one_node_component() -> VRc<ItemTreeVTable, vtable::Dyn> {
+    fn create_one_node_component(
+        window_item: Option<WindowItem>,
+    ) -> (std::rc::Weak<WindowAdapter>, VRc<ItemTreeVTable, vtable::Dyn>) {
+        let window_adapter = WindowAdapter::new();
+        let weak = Rc::downgrade(&window_adapter);
         let component = VRc::new(TestItemTree {
             parent_component: None,
             item_tree: vec![ItemTreeNode::Item {
@@ -1677,15 +1681,15 @@ mod tests {
             subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
 
-            window_adapter: WindowAdapter::new(),
-            window_item: None,
+            window_adapter,
+            window_item,
         });
-        VRc::into_dyn(component)
+        (weak, VRc::into_dyn(component))
     }
 
     #[test]
     fn test_tree_traversal_one_node_structure() {
-        let component = create_one_node_component();
+        let component = create_one_node_component(None).1;
 
         let item = ItemRc::new_root(component.clone());
 
@@ -1697,7 +1701,7 @@ mod tests {
 
     #[test]
     fn test_tree_traversal_one_node_forward_focus() {
-        let component = create_one_node_component();
+        let component = create_one_node_component(None).1;
 
         let item = ItemRc::new_root(component.clone());
 
@@ -1707,7 +1711,7 @@ mod tests {
 
     #[test]
     fn test_tree_traversal_one_node_backward_focus() {
-        let component = create_one_node_component();
+        let component = create_one_node_component(None).1;
 
         let item = ItemRc::new_root(component.clone());
 
@@ -2467,8 +2471,10 @@ mod tests {
     }
 
     // It does not contain any dynamic elements
-    fn create_subsubtree_items() -> (std::rc::Weak<WindowAdapter>, VRc<ItemTreeVTable>) {
-        let window_adapter = WindowAdapter::new();
+    fn create_subsubtree_items(
+        window_adapter: Option<std::rc::Rc<WindowAdapter>>,
+    ) -> (std::rc::Weak<WindowAdapter>, VRc<ItemTreeVTable>) {
+        let window_adapter = window_adapter.unwrap_or(WindowAdapter::new());
         let weak = Rc::downgrade(&window_adapter);
         let mut window_item = WindowItem::default();
         window_item.width = Property::new(LogicalLength::new(30.));
@@ -2695,7 +2701,7 @@ mod tests {
 
     #[test]
     fn test_map_to_anchestor() {
-        let item_tree = create_subsubtree_items().1;
+        let item_tree = create_subsubtree_items(None).1;
         let root = ItemRc::new_root(item_tree);
         let first_child = root.first_child().unwrap();
         let first_child_of_first_child = first_child.first_child().unwrap();
@@ -2724,7 +2730,7 @@ mod tests {
 
     #[test]
     fn test_map_to_window() {
-        let item_tree = create_subsubtree_items().1;
+        let item_tree = create_subsubtree_items(None).1;
         let root = ItemRc::new_root(item_tree);
         let first_child = root.first_child().unwrap();
         let first_child_of_first_child = first_child.first_child().unwrap();
@@ -2768,16 +2774,22 @@ mod tests {
     #[test]
     fn test_map_to_native_window_popup() {
         const POPUP_LOCATION: LogicalPosition = LogicalPosition::new(20., 33.);
-        let (window_adapter_weak, item_tree) = create_subsubtree_items();
+        let mut window_item = WindowItem::default();
+        window_item.width = Property::new(LogicalLength::new(30.));
+        window_item.height = Property::new(LogicalLength::new(30.));
+        // A popup has it's own ItemTreeVTable
+        let (window_adapter_weak, parent) = create_one_node_component(Some(window_item));
+        let popup_component =
+            create_subsubtree_items(Some(window_adapter_weak.upgrade().unwrap())).1;
         window_adapter_weak.upgrade().unwrap().window.0.show_popup(
-            &item_tree,
+            &popup_component,
             POPUP_LOCATION,
             crate::items::PopupClosePolicy::NoAutoClose,
-            &ItemRc::new_root(item_tree.clone()),
+            &ItemRc::new_root(parent.clone()),
             false,
         );
 
-        let root = ItemRc::new_root(item_tree);
+        let root = ItemRc::new_root(popup_component);
         let first_child = root.first_child().unwrap();
         let first_child_of_first_child = first_child.first_child().unwrap();
 
@@ -2806,7 +2818,7 @@ mod tests {
     #[test]
     fn test_map_to_window_popup() {
         const POPUP_LOCATION: LogicalPosition = LogicalPosition::new(20., 33.);
-        let (window_adapter_weak, item_tree) = create_subsubtree_items();
+        let (window_adapter_weak, item_tree) = create_subsubtree_items(None);
         window_adapter_weak.upgrade().unwrap().window.0.show_popup(
             &item_tree,
             POPUP_LOCATION,
@@ -2836,10 +2848,9 @@ mod tests {
     }
 
     // Includes also dynamic elements
-    fn create_subsubtree_items_dynamic_elements()
-    -> (std::rc::Weak<WindowAdapter>, VRc<ItemTreeVTable>) {
-        let window_adapter = WindowAdapter::new();
-        let weak = Rc::downgrade(&window_adapter);
+    fn create_subsubtree_items_dynamic_elements(
+        window_adapter: Rc<WindowAdapter>,
+    ) -> VRc<ItemTreeVTable> {
         let mut window_item = WindowItem::default();
         window_item.width = Property::new(LogicalLength::new(30.));
         window_item.height = Property::new(LogicalLength::new(30.));
@@ -2891,7 +2902,7 @@ mod tests {
             window_item: None,
         })]]);
 
-        (weak, VRc::into_dyn(item_tree))
+        VRc::into_dyn(item_tree)
     }
 
     // This time the element is a child of a dynamic element with a different item tree
@@ -2899,12 +2910,20 @@ mod tests {
     #[test]
     fn test_map_to_native_window_popup_dynamic_element() {
         const POPUP_LOCATION: LogicalPosition = LogicalPosition::new(20., 33.);
-        let (window_adapter_weak, item_tree) = create_subsubtree_items_dynamic_elements();
+
+        let mut window_item = WindowItem::default();
+        window_item.width = Property::new(LogicalLength::new(30.));
+        window_item.height = Property::new(LogicalLength::new(30.));
+
+        // A popup has it's own ItemTreeVTable
+        let (window_adapter_weak, parent) = create_one_node_component(Some(window_item));
+        let popup_component =
+            create_subsubtree_items_dynamic_elements(window_adapter_weak.upgrade().unwrap());
         window_adapter_weak.upgrade().unwrap().window.0.show_popup(
-            &item_tree,
+            &popup_component,
             POPUP_LOCATION,
             crate::items::PopupClosePolicy::NoAutoClose,
-            &ItemRc::new_root(item_tree.clone()),
+            &ItemRc::new_root(parent.clone()),
             false,
         );
 
@@ -2915,7 +2934,7 @@ mod tests {
         let popup = active_popups.first().unwrap();
         assert!(matches!(popup.location, crate::window::PopupWindowLocation::ChildWindow { .. }));
 
-        let root = ItemRc::new_root(item_tree);
+        let root = ItemRc::new_root(popup_component);
         let first_child = root.first_child().unwrap();
         // Check if the first item is a dynamic tree!
         let comp_ref_pin = vtable::VRc::borrow_pin(&root.item_tree);


### PR DESCRIPTION
- [ ] ~~If the change modifies a visible behavior, it changes the documentation accordingly~~
- [x] If possible, the change is auto-tested
- [ ] ~~If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`~~
- [ ] ~~If the change is noteworthy, the commit message should contain `ChangeLog: ...`~~
The testcase was initially implemented wrongly
