### PR TITLE
Prospective fix for esp-idf build

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -42,6 +42,8 @@ std = [
   "i-slint-common/color-parsing",
   "i-slint-common/markdown",
   "taffy/std",
+  "dep:ksni",
+  "dep:async-channel",
 ]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
@@ -154,8 +156,8 @@ image = { workspace = true, default-features = false, features = ["png"] }
 windows = { workspace = true, features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(all(target_family = "unix", not(target_vendor = "apple"), not(target_os = "android")))'.dependencies]
-ksni = { version = "0.3.3", default-features = false, features = ["async-io", "blocking"] }
-async-channel = "2"
+ksni = { version = "0.3.3", optional = true, default-features = false, features = ["async-io", "blocking"] }
+async-channel = { version = "2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.0", optional = true }

--- a/internal/core/items/system_tray.rs
+++ b/internal/core/items/system_tray.rs
@@ -38,7 +38,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "windows")] {
         mod windows;
         use self::windows::PlatformTray;
-    } else if #[cfg(all(target_family = "unix", not(target_vendor = "apple"), not(target_os = "android")))] {
+    } else if #[cfg(all(feature = "std", target_family = "unix", not(target_vendor = "apple"), not(target_os = "android")))] {
         mod ksni;
         use self::ksni::PlatformTray;
     } else {


### PR DESCRIPTION
esp-idf sets cfg(unix), but we want the system tray only when std is enabled.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
