### PR TITLE
C++: Make slint::Timer binary compatible in C++ and Rust

### DIFF
--- a/api/cpp/include/private/slint_timer.h
+++ b/api/cpp/include/private/slint_timer.h
@@ -125,7 +125,7 @@ struct Timer
     }
 
 private:
-    uint64_t id = 0;
+    uintptr_t id = 0;
 };
 
 } // namespace slint


### PR DESCRIPTION
In C++ we used a u64, which is >= the usize of Rust's Timer, but if we want to store a slint::Timer in a struct field that's shared between C++ and Rust, they need to be exactly identical.

cc #11659

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
