### PR TITLE
Make AccessibleLive enum non-exhaustive

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -684,6 +684,7 @@ impl NodeCollection {
                 i_slint_core::items::AccessibleLive::Off => Live::Off,
                 i_slint_core::items::AccessibleLive::Polite => Live::Polite,
                 i_slint_core::items::AccessibleLive::Assertive => Live::Assertive,
+                _ => Live::Off,
             });
         }
 

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -503,7 +503,7 @@ macro_rules! for_each_enums {
             /// This enum represents the different values of the `accessible-live` property.
             /// It indicates that an element is a live region whose content changes should be
             /// announced by assistive technologies.
-            // (on purpose not #[non_exhaustive])
+            #[non_exhaustive]
             enum AccessibleLive {
                 /// The element is not a live region.
                 Off,


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

As asked by @ogoffart in #11646