### PR TITLE
Add MCP event log for processed window events

### DIFF
--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -83,11 +83,10 @@ fn ensure_event_tracking() -> Result<(), i_slint_core::api::EventLoopError> {
         let state = shared_state();
         let previous_hook = i_slint_core::context::set_window_event_hook(None)
             .map_err(|_| i_slint_core::api::EventLoopError::NoEventLoopProvider)?;
-        let previous_hook = RefCell::new(previous_hook);
 
         i_slint_core::context::set_window_event_hook(Some(Box::new(
             move |adapter, event, result| {
-                if let Some(prev) = previous_hook.borrow_mut().as_mut() {
+                if let Some(prev) = previous_hook.as_ref() {
                     prev(adapter, event, result);
                 }
                 state.record_window_event(adapter, event, result);
@@ -123,6 +122,7 @@ pub(crate) struct IntrospectionState {
     event_log: RefCell<VecDeque<proto::RecordedEvent>>,
     next_event_sequence: Cell<u64>,
     dropped_event_count: Cell<u64>,
+    recording_enabled: Cell<bool>,
 }
 
 impl IntrospectionState {
@@ -134,6 +134,7 @@ impl IntrospectionState {
             event_log: Default::default(),
             next_event_sequence: Default::default(),
             dropped_event_count: Default::default(),
+            recording_enabled: Cell::new(false),
         }
     }
 
@@ -287,6 +288,9 @@ impl IntrospectionState {
         event: &i_slint_core::platform::WindowEvent,
         result: i_slint_core::context::WindowEventDispatchResult,
     ) {
+        if !self.recording_enabled.get() {
+            return;
+        }
         let sequence = self.next_event_sequence.get();
         self.next_event_sequence.set(sequence.saturating_add(1));
 
@@ -357,6 +361,19 @@ impl IntrospectionState {
     pub fn clear_event_log(&self) {
         self.event_log.borrow_mut().clear();
         self.dropped_event_count.set(0);
+    }
+
+    pub fn start_recording(&self) {
+        self.clear_event_log();
+        self.recording_enabled.set(true);
+    }
+
+    pub fn stop_recording(&self) -> proto::StopEventRecordingResponse {
+        self.recording_enabled.set(false);
+        let events: Vec<_> = self.event_log.borrow().iter().cloned().collect();
+        let dropped_count = self.dropped_event_count.get();
+        self.clear_event_log();
+        proto::StopEventRecordingResponse { events, dropped_count }
     }
 
     pub fn window_properties(
@@ -475,9 +492,6 @@ fn convert_event_dispatch_result(
     match result {
         i_slint_core::context::WindowEventDispatchResult::Processed => {
             proto::RecordedEventResult::Processed
-        }
-        i_slint_core::context::WindowEventDispatchResult::Accepted => {
-            proto::RecordedEventResult::Accepted
         }
         i_slint_core::context::WindowEventDispatchResult::Ignored => {
             proto::RecordedEventResult::Ignored
@@ -773,6 +787,19 @@ pub(crate) mod dispatch {
         proto::ClearEventLogResponse {}
     }
 
+    pub(crate) fn start_event_recording(
+        state: &IntrospectionState,
+    ) -> proto::StartEventRecordingResponse {
+        state.start_recording();
+        proto::StartEventRecordingResponse {}
+    }
+
+    pub(crate) fn stop_event_recording(
+        state: &IntrospectionState,
+    ) -> proto::StopEventRecordingResponse {
+        state.stop_recording()
+    }
+
     pub(crate) fn invoke_accessibility_action(
         state: &IntrospectionState,
         element: ArenaIndex,
@@ -891,7 +918,7 @@ fn test_event_log_filters_since_sequence_and_window() {
             sequence: 1,
             window_handle: Some(index_to_handle(second_window)),
             source: proto::RecordedEventSource::Runtime.into(),
-            result: proto::RecordedEventResult::Accepted.into(),
+            result: proto::RecordedEventResult::Processed.into(),
             ..Default::default()
         },
         proto::RecordedEvent {

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -26,6 +26,10 @@ pub(crate) mod proto;
 const ELEMENT_HANDLE_CAP: usize = 10_000;
 const EVENT_LOG_CAP: usize = 1024;
 
+fn bump(counter: &Cell<u64>) {
+    counter.set(counter.get().saturating_add(1));
+}
+
 thread_local! {
     static SHARED_STATE: RefCell<Option<Rc<IntrospectionState>>> = const { RefCell::new(None) };
     static WINDOW_TRACKING_HOOK_INSTALLED: Cell<bool> = const { Cell::new(false) };
@@ -123,6 +127,7 @@ pub(crate) struct IntrospectionState {
     next_event_sequence: Cell<u64>,
     dropped_event_count: Cell<u64>,
     unknown_event_count: Cell<u64>,
+    unknown_event_warned: Cell<bool>,
     recording_enabled: Cell<bool>,
 }
 
@@ -136,6 +141,7 @@ impl IntrospectionState {
             next_event_sequence: Default::default(),
             dropped_event_count: Default::default(),
             unknown_event_count: Default::default(),
+            unknown_event_warned: Cell::new(false),
             recording_enabled: Cell::new(false),
         }
     }
@@ -297,11 +303,15 @@ impl IntrospectionState {
         let proto_event = match convert_window_event_to_proto(event) {
             Ok(e) => e,
             Err(UnknownEventVariant) => {
-                eprintln!(
-                    "MCP/systest event recorder: skipping unknown WindowEvent variant {event:?} — \
-                     conversion code is out of sync with i_slint_core::platform"
-                );
-                self.unknown_event_count.set(self.unknown_event_count.get().saturating_add(1));
+                // Log once per process; the counter carries the magnitude.
+                if !self.unknown_event_warned.replace(true) {
+                    eprintln!(
+                        "MCP/systest event recorder: unknown WindowEvent variant {event:?} — \
+                         conversion code is out of sync with i_slint_core::platform. \
+                         Further occurrences are silent; see unknown_event_count."
+                    );
+                }
+                bump(&self.unknown_event_count);
                 return;
             }
         };
@@ -314,18 +324,26 @@ impl IntrospectionState {
             .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
             .unwrap_or_default();
 
-        let mut log = self.event_log.borrow_mut();
-        while log.len() >= EVENT_LOG_CAP {
-            log.pop_front();
-            self.dropped_event_count.set(self.dropped_event_count.get().saturating_add(1));
-        }
-        log.push_back(proto::RecordedEvent {
+        self.push_recorded_event(proto::RecordedEvent {
             sequence,
             timestamp_ms,
             window_handle: self.window_handle_for_adapter(adapter).map(index_to_handle),
             event: Some(proto_event),
             result: convert_event_dispatch_result(result).into(),
         });
+    }
+
+    /// Push a recorded event, evicting the oldest entries until the log is
+    /// strictly below `EVENT_LOG_CAP`. Each evicted entry bumps
+    /// `dropped_event_count`. This is the single source of truth for the
+    /// eviction policy; tests should drive eviction through this method.
+    fn push_recorded_event(&self, event: proto::RecordedEvent) {
+        let mut log = self.event_log.borrow_mut();
+        while log.len() >= EVENT_LOG_CAP {
+            log.pop_front();
+            bump(&self.dropped_event_count);
+        }
+        log.push_back(event);
     }
 
     #[cfg(feature = "system-testing")]
@@ -387,10 +405,9 @@ impl IntrospectionState {
 
     pub fn stop_recording(&self) -> proto::StopEventRecordingResponse {
         self.recording_enabled.set(false);
-        let events: Vec<_> = self.event_log.borrow().iter().cloned().collect();
-        let dropped_count = self.dropped_event_count.get();
-        let unknown_event_count = self.unknown_event_count.get();
-        self.clear_event_log();
+        let events: Vec<_> = self.event_log.borrow_mut().drain(..).collect();
+        let dropped_count = self.dropped_event_count.replace(0);
+        let unknown_event_count = self.unknown_event_count.replace(0);
         proto::StopEventRecordingResponse { events, dropped_count, unknown_event_count }
     }
 
@@ -968,14 +985,9 @@ fn test_event_log_filters_since_sequence_and_window() {
 fn test_event_log_eviction_at_cap() {
     let state = IntrospectionState::new();
 
-    // Fill the log to capacity directly, simulating EVENT_LOG_CAP + 10 recorded events.
+    // Push EVENT_LOG_CAP + 10 events through the real eviction path.
     for seq in 0..(EVENT_LOG_CAP + 10) as u64 {
-        let mut log = state.event_log.borrow_mut();
-        while log.len() >= EVENT_LOG_CAP {
-            log.pop_front();
-            state.dropped_event_count.set(state.dropped_event_count.get().saturating_add(1));
-        }
-        log.push_back(proto::RecordedEvent {
+        state.push_recorded_event(proto::RecordedEvent {
             sequence: seq,
             result: proto::RecordedEventResult::Accepted.into(),
             ..Default::default()

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -772,6 +772,21 @@ pub(crate) mod dispatch {
         state.take_snapshot_response(window, image_mime_type)
     }
 
+    pub(crate) fn event_log(
+        state: &IntrospectionState,
+        window: Option<ArenaIndex>,
+        since_sequence: u64,
+        max_events: u32,
+        clear_after_read: bool,
+    ) -> proto::EventLogResponse {
+        state.query_event_log(window, since_sequence, max_events, clear_after_read)
+    }
+
+    pub(crate) fn clear_event_log(state: &IntrospectionState) -> proto::ClearEventLogResponse {
+        state.clear_event_log();
+        proto::ClearEventLogResponse {}
+    }
+
     pub(crate) fn start_event_recording(
         state: &IntrospectionState,
     ) -> proto::StartEventRecordingResponse {

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -326,7 +326,7 @@ impl IntrospectionState {
             .filter(|event| {
                 window_index.is_none_or(|window_index| {
                     event.window_handle.as_ref().is_some_and(|handle| {
-                        handle_to_index(handle.clone())
+                        handle_to_index(*handle)
                             .is_ok_and(|event_window| event_window == window_index)
                     })
                 })

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -489,7 +489,9 @@ pub(crate) fn convert_window_event_to_proto(
             Event::KeyReleased(proto::KeyReleasedEvent { text: text.to_string() })
         }
         WindowEvent::ScaleFactorChanged { scale_factor } => {
-            Event::ScaleFactorChanged(proto::ScaleFactorChangedEvent { scale_factor: *scale_factor })
+            Event::ScaleFactorChanged(proto::ScaleFactorChangedEvent {
+                scale_factor: *scale_factor,
+            })
         }
         WindowEvent::Resized { size } => Event::Resized(proto::ResizedEvent {
             size: Some(proto::LogicalSize { width: size.width, height: size.height }),

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -772,21 +772,6 @@ pub(crate) mod dispatch {
         state.take_snapshot_response(window, image_mime_type)
     }
 
-    pub(crate) fn event_log(
-        state: &IntrospectionState,
-        window: Option<ArenaIndex>,
-        since_sequence: u64,
-        max_events: u32,
-        clear_after_read: bool,
-    ) -> proto::EventLogResponse {
-        state.query_event_log(window, since_sequence, max_events, clear_after_read)
-    }
-
-    pub(crate) fn clear_event_log(state: &IntrospectionState) -> proto::ClearEventLogResponse {
-        state.clear_event_log();
-        proto::ClearEventLogResponse {}
-    }
-
     pub(crate) fn start_event_recording(
         state: &IntrospectionState,
     ) -> proto::StartEventRecordingResponse {

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -314,6 +314,7 @@ impl IntrospectionState {
         });
     }
 
+    #[cfg(feature = "system-testing")]
     pub fn query_event_log(
         &self,
         window_index: Option<ArenaIndex>,
@@ -772,6 +773,7 @@ pub(crate) mod dispatch {
         state.take_snapshot_response(window, image_mime_type)
     }
 
+    #[cfg(feature = "system-testing")]
     pub(crate) fn event_log(
         state: &IntrospectionState,
         window: Option<ArenaIndex>,
@@ -782,6 +784,7 @@ pub(crate) mod dispatch {
         state.query_event_log(window, since_sequence, max_events, clear_after_read)
     }
 
+    #[cfg(feature = "system-testing")]
     pub(crate) fn clear_event_log(state: &IntrospectionState) -> proto::ClearEventLogResponse {
         state.clear_event_log();
         proto::ClearEventLogResponse {}

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -122,6 +122,7 @@ pub(crate) struct IntrospectionState {
     event_log: RefCell<VecDeque<proto::RecordedEvent>>,
     next_event_sequence: Cell<u64>,
     dropped_event_count: Cell<u64>,
+    unknown_event_count: Cell<u64>,
     recording_enabled: Cell<bool>,
 }
 
@@ -134,6 +135,7 @@ impl IntrospectionState {
             event_log: Default::default(),
             next_event_sequence: Default::default(),
             dropped_event_count: Default::default(),
+            unknown_event_count: Default::default(),
             recording_enabled: Cell::new(false),
         }
     }
@@ -291,6 +293,19 @@ impl IntrospectionState {
         if !self.recording_enabled.get() {
             return;
         }
+
+        let proto_event = match convert_window_event_to_proto(event) {
+            Ok(e) => e,
+            Err(UnknownEventVariant) => {
+                eprintln!(
+                    "MCP/systest event recorder: skipping unknown WindowEvent variant {event:?} — \
+                     conversion code is out of sync with i_slint_core::platform"
+                );
+                self.unknown_event_count.set(self.unknown_event_count.get().saturating_add(1));
+                return;
+            }
+        };
+
         let sequence = self.next_event_sequence.get();
         self.next_event_sequence.set(sequence.saturating_add(1));
 
@@ -300,7 +315,7 @@ impl IntrospectionState {
             .unwrap_or_default();
 
         let mut log = self.event_log.borrow_mut();
-        if log.len() >= EVENT_LOG_CAP {
+        while log.len() >= EVENT_LOG_CAP {
             log.pop_front();
             self.dropped_event_count.set(self.dropped_event_count.get().saturating_add(1));
         }
@@ -308,8 +323,7 @@ impl IntrospectionState {
             sequence,
             timestamp_ms,
             window_handle: self.window_handle_for_adapter(adapter).map(index_to_handle),
-            source: proto::RecordedEventSource::Runtime.into(),
-            event: Some(convert_window_event_to_proto(event)),
+            event: Some(proto_event),
             result: convert_event_dispatch_result(result).into(),
         });
     }
@@ -319,7 +333,7 @@ impl IntrospectionState {
         &self,
         window_index: Option<ArenaIndex>,
         since_sequence: u64,
-        max_events: u32,
+        max_events: u64,
         clear_after_read: bool,
     ) -> proto::EventLogResponse {
         let max_events = if max_events == 0 { 200 } else { max_events.min(1000) } as usize;
@@ -350,6 +364,7 @@ impl IntrospectionState {
             // it as sinceSequence on the next poll without arithmetic.
             next_sequence,
             dropped_count: self.dropped_event_count.get(),
+            unknown_event_count: self.unknown_event_count.get(),
         };
         if clear_after_read {
             self.event_log
@@ -362,6 +377,7 @@ impl IntrospectionState {
     pub fn clear_event_log(&self) {
         self.event_log.borrow_mut().clear();
         self.dropped_event_count.set(0);
+        self.unknown_event_count.set(0);
     }
 
     pub fn start_recording(&self) {
@@ -373,8 +389,9 @@ impl IntrospectionState {
         self.recording_enabled.set(false);
         let events: Vec<_> = self.event_log.borrow().iter().cloned().collect();
         let dropped_count = self.dropped_event_count.get();
+        let unknown_event_count = self.unknown_event_count.get();
         self.clear_event_log();
-        proto::StopEventRecordingResponse { events, dropped_count }
+        proto::StopEventRecordingResponse { events, dropped_count, unknown_event_count }
     }
 
     pub fn window_properties(
@@ -409,90 +426,97 @@ impl IntrospectionState {
     }
 }
 
+/// Returned when a [`i_slint_core::platform::WindowEvent`] or
+/// [`i_slint_core::platform::PointerEventButton`] variant has no proto mapping —
+/// indicates the conversion code is out of date with the core enums.
+#[derive(Debug)]
+pub(crate) struct UnknownEventVariant;
+
 pub(crate) fn convert_window_event_to_proto(
     event: &i_slint_core::platform::WindowEvent,
-) -> proto::WindowEvent {
+) -> Result<proto::WindowEvent, UnknownEventVariant> {
     use i_slint_core::platform::WindowEvent;
     use proto::window_event::Event;
 
     let event = match event {
         WindowEvent::PointerPressed { position, button } => {
-            Some(Event::PointerPressed(proto::PointerPressEvent {
+            Event::PointerPressed(proto::PointerPressEvent {
                 position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
-                button: convert_pointer_event_button_to_proto(*button).into(),
-            }))
+                button: convert_pointer_event_button_to_proto(*button)?.into(),
+            })
         }
         WindowEvent::PointerReleased { position, button } => {
-            Some(Event::PointerReleased(proto::PointerReleaseEvent {
+            Event::PointerReleased(proto::PointerReleaseEvent {
                 position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
-                button: convert_pointer_event_button_to_proto(*button).into(),
-            }))
+                button: convert_pointer_event_button_to_proto(*button)?.into(),
+            })
         }
-        WindowEvent::PointerMoved { position } => {
-            Some(Event::PointerMoved(proto::PointerMoveEvent {
-                position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
-            }))
-        }
+        WindowEvent::PointerMoved { position } => Event::PointerMoved(proto::PointerMoveEvent {
+            position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
+        }),
         WindowEvent::PointerScrolled { position, delta_x, delta_y } => {
-            Some(Event::PointerScrolled(proto::PointerScrolledEvent {
+            Event::PointerScrolled(proto::PointerScrolledEvent {
                 position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
                 delta_x: *delta_x,
                 delta_y: *delta_y,
-            }))
+            })
         }
-        WindowEvent::PointerExited => Some(Event::PointerExited(proto::PointerExitedEvent {})),
+        WindowEvent::PointerExited => Event::PointerExited(proto::PointerExitedEvent {}),
         WindowEvent::KeyPressed { text } => {
-            Some(Event::KeyPressed(proto::KeyPressedEvent { text: text.to_string() }))
+            Event::KeyPressed(proto::KeyPressedEvent { text: text.to_string() })
         }
         WindowEvent::KeyPressRepeated { text } => {
-            Some(Event::KeyPressRepeated(proto::KeyPressRepeatedEvent { text: text.to_string() }))
+            Event::KeyPressRepeated(proto::KeyPressRepeatedEvent { text: text.to_string() })
         }
         WindowEvent::KeyReleased { text } => {
-            Some(Event::KeyReleased(proto::KeyReleasedEvent { text: text.to_string() }))
+            Event::KeyReleased(proto::KeyReleasedEvent { text: text.to_string() })
         }
         WindowEvent::ScaleFactorChanged { scale_factor } => {
-            Some(Event::ScaleFactorChanged(proto::ScaleFactorChangedEvent {
-                scale_factor: *scale_factor,
-            }))
+            Event::ScaleFactorChanged(proto::ScaleFactorChangedEvent { scale_factor: *scale_factor })
         }
-        WindowEvent::Resized { size } => Some(Event::Resized(proto::ResizedEvent {
+        WindowEvent::Resized { size } => Event::Resized(proto::ResizedEvent {
             size: Some(proto::LogicalSize { width: size.width, height: size.height }),
-        })),
-        WindowEvent::CloseRequested => Some(Event::CloseRequested(proto::CloseRequestedEvent {})),
+        }),
+        WindowEvent::CloseRequested => Event::CloseRequested(proto::CloseRequestedEvent {}),
         WindowEvent::WindowActiveChanged(active) => {
-            Some(Event::WindowActiveChanged(proto::WindowActiveChangedEvent { active: *active }))
+            Event::WindowActiveChanged(proto::WindowActiveChangedEvent { active: *active })
         }
         // All current variants are covered above. This arm exists only because
-        // WindowEvent is #[non_exhaustive]; future variants will log with event: None.
+        // WindowEvent is #[non_exhaustive]; future variants are reported as a bug
+        // via record_window_event's unknown_event_count.
         #[allow(unreachable_patterns)]
-        _ => None,
+        _ => return Err(UnknownEventVariant),
     };
 
-    proto::WindowEvent { event }
+    Ok(proto::WindowEvent { event: Some(event) })
 }
 
 fn convert_pointer_event_button_to_proto(
     button: i_slint_core::platform::PointerEventButton,
-) -> proto::PointerEventButton {
-    match button {
+) -> Result<proto::PointerEventButton, UnknownEventVariant> {
+    Ok(match button {
         i_slint_core::platform::PointerEventButton::Left => proto::PointerEventButton::Left,
         i_slint_core::platform::PointerEventButton::Right => proto::PointerEventButton::Right,
         i_slint_core::platform::PointerEventButton::Middle => proto::PointerEventButton::Middle,
         i_slint_core::platform::PointerEventButton::Back => proto::PointerEventButton::Back,
         i_slint_core::platform::PointerEventButton::Forward => proto::PointerEventButton::Forward,
         i_slint_core::platform::PointerEventButton::Other => proto::PointerEventButton::Other,
-        // PointerEventButton is #[non_exhaustive]; future buttons map to Other.
+        // PointerEventButton is #[non_exhaustive]; future buttons surface as a bug
+        // via record_window_event's unknown_event_count.
         #[allow(unreachable_patterns)]
-        _ => proto::PointerEventButton::Other,
-    }
+        _ => return Err(UnknownEventVariant),
+    })
 }
 
 fn convert_event_dispatch_result(
     result: i_slint_core::context::WindowEventDispatchResult,
 ) -> proto::RecordedEventResult {
     match result {
-        i_slint_core::context::WindowEventDispatchResult::Processed => {
-            proto::RecordedEventResult::Processed
+        i_slint_core::context::WindowEventDispatchResult::Accepted => {
+            proto::RecordedEventResult::Accepted
+        }
+        i_slint_core::context::WindowEventDispatchResult::Rejected => {
+            proto::RecordedEventResult::Rejected
         }
         i_slint_core::context::WindowEventDispatchResult::Ignored => {
             proto::RecordedEventResult::Ignored
@@ -778,7 +802,7 @@ pub(crate) mod dispatch {
         state: &IntrospectionState,
         window: Option<ArenaIndex>,
         since_sequence: u64,
-        max_events: u32,
+        max_events: u64,
         clear_after_read: bool,
     ) -> proto::EventLogResponse {
         state.query_event_log(window, since_sequence, max_events, clear_after_read)
@@ -913,21 +937,18 @@ fn test_event_log_filters_since_sequence_and_window() {
         proto::RecordedEvent {
             sequence: 0,
             window_handle: Some(index_to_handle(first_window)),
-            source: proto::RecordedEventSource::Runtime.into(),
-            result: proto::RecordedEventResult::Processed.into(),
+            result: proto::RecordedEventResult::Accepted.into(),
             ..Default::default()
         },
         proto::RecordedEvent {
             sequence: 1,
             window_handle: Some(index_to_handle(second_window)),
-            source: proto::RecordedEventSource::Runtime.into(),
-            result: proto::RecordedEventResult::Processed.into(),
+            result: proto::RecordedEventResult::Accepted.into(),
             ..Default::default()
         },
         proto::RecordedEvent {
             sequence: 2,
             window_handle: Some(index_to_handle(first_window)),
-            source: proto::RecordedEventSource::Runtime.into(),
             result: proto::RecordedEventResult::Ignored.into(),
             ..Default::default()
         },
@@ -950,14 +971,13 @@ fn test_event_log_eviction_at_cap() {
     // Fill the log to capacity directly, simulating EVENT_LOG_CAP + 10 recorded events.
     for seq in 0..(EVENT_LOG_CAP + 10) as u64 {
         let mut log = state.event_log.borrow_mut();
-        if log.len() >= EVENT_LOG_CAP {
+        while log.len() >= EVENT_LOG_CAP {
             log.pop_front();
             state.dropped_event_count.set(state.dropped_event_count.get().saturating_add(1));
         }
         log.push_back(proto::RecordedEvent {
             sequence: seq,
-            source: proto::RecordedEventSource::Runtime.into(),
-            result: proto::RecordedEventResult::Processed.into(),
+            result: proto::RecordedEventResult::Accepted.into(),
             ..Default::default()
         });
         state.next_event_sequence.set(seq + 1);
@@ -986,8 +1006,7 @@ fn test_event_log_pagination_cursor_advances_to_returned_page() {
     for seq in 0..3 {
         state.event_log.borrow_mut().push_back(proto::RecordedEvent {
             sequence: seq,
-            source: proto::RecordedEventSource::Runtime.into(),
-            result: proto::RecordedEventResult::Processed.into(),
+            result: proto::RecordedEventResult::Accepted.into(),
             ..Default::default()
         });
     }
@@ -1008,8 +1027,7 @@ fn test_event_log_clear_keeps_sequence_monotonic() {
     state.next_event_sequence.set(42);
     state.event_log.borrow_mut().push_back(proto::RecordedEvent {
         sequence: 41,
-        source: proto::RecordedEventSource::Runtime.into(),
-        result: proto::RecordedEventResult::Processed.into(),
+        result: proto::RecordedEventResult::Accepted.into(),
         ..Default::default()
     });
 
@@ -1021,15 +1039,18 @@ fn test_event_log_clear_keeps_sequence_monotonic() {
 #[test]
 fn test_pointer_event_button_mapping_preserves_extended_buttons() {
     assert_eq!(
-        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Back),
+        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Back)
+            .unwrap(),
         proto::PointerEventButton::Back
     );
     assert_eq!(
-        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Forward),
+        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Forward)
+            .unwrap(),
         proto::PointerEventButton::Forward
     );
     assert_eq!(
-        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Other),
+        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Other)
+            .unwrap(),
         proto::PointerEventButton::Other
     );
     assert_eq!(

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -10,7 +10,7 @@ use i_slint_core::window::WindowAdapter;
 use i_slint_core::window::WindowInner;
 use slotmap::{Key, KeyData, SlotMap};
 use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::rc::{Rc, Weak};
 
 use crate::{ElementHandle, ElementRoot, LayoutKind};
@@ -24,10 +24,12 @@ pub(crate) mod proto;
 
 /// Maximum number of element handles kept in the arena before evicting the oldest.
 const ELEMENT_HANDLE_CAP: usize = 10_000;
+const EVENT_LOG_CAP: usize = 1024;
 
 thread_local! {
     static SHARED_STATE: RefCell<Option<Rc<IntrospectionState>>> = const { RefCell::new(None) };
-    static HOOK_INSTALLED: Cell<bool> = const { Cell::new(false) };
+    static WINDOW_TRACKING_HOOK_INSTALLED: Cell<bool> = const { Cell::new(false) };
+    static EVENT_TRACKING_HOOK_INSTALLED: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Returns the shared introspection state, creating it if needed.
@@ -47,9 +49,9 @@ pub(crate) fn shared_state() -> Rc<IntrospectionState> {
 /// Safe to call multiple times — only installs once.
 /// Chains with any previously installed hook.
 pub(crate) fn ensure_window_tracking() -> Result<(), i_slint_core::api::EventLoopError> {
-    HOOK_INSTALLED.with(|installed| {
+    WINDOW_TRACKING_HOOK_INSTALLED.with(|installed| {
         if installed.get() {
-            return Ok(());
+            return ensure_event_tracking();
         }
         installed.set(true);
 
@@ -65,6 +67,32 @@ pub(crate) fn ensure_window_tracking() -> Result<(), i_slint_core::api::EventLoo
             }
             state.add_window(adapter);
         })))
+        .map_err(|_| i_slint_core::api::EventLoopError::NoEventLoopProvider)?;
+
+        ensure_event_tracking()
+    })
+}
+
+fn ensure_event_tracking() -> Result<(), i_slint_core::api::EventLoopError> {
+    EVENT_TRACKING_HOOK_INSTALLED.with(|installed| {
+        if installed.get() {
+            return Ok(());
+        }
+        installed.set(true);
+
+        let state = shared_state();
+        let previous_hook = i_slint_core::context::set_window_event_hook(None)
+            .map_err(|_| i_slint_core::api::EventLoopError::NoEventLoopProvider)?;
+        let previous_hook = RefCell::new(previous_hook);
+
+        i_slint_core::context::set_window_event_hook(Some(Box::new(
+            move |adapter, event, result| {
+                if let Some(prev) = previous_hook.borrow_mut().as_mut() {
+                    prev(adapter, event, result);
+                }
+                state.record_window_event(adapter, event, result);
+            },
+        )))
         .map_err(|_| i_slint_core::api::EventLoopError::NoEventLoopProvider)?;
 
         Ok(())
@@ -92,6 +120,9 @@ pub(crate) struct IntrospectionState {
     pub windows: RefCell<SlotMap<ArenaIndex, TrackedWindow>>,
     pub element_handles: RefCell<SlotMap<ArenaIndex, ElementHandle>>,
     element_handle_order: RefCell<VecDeque<ArenaIndex>>,
+    event_log: RefCell<VecDeque<proto::RecordedEvent>>,
+    next_event_sequence: Cell<u64>,
+    dropped_event_count: Cell<u64>,
 }
 
 impl IntrospectionState {
@@ -100,6 +131,9 @@ impl IntrospectionState {
             windows: Default::default(),
             element_handles: Default::default(),
             element_handle_order: Default::default(),
+            event_log: Default::default(),
+            next_event_sequence: Default::default(),
+            dropped_event_count: Default::default(),
         }
     }
 
@@ -117,6 +151,16 @@ impl IntrospectionState {
 
     pub fn window_handles(&self) -> Vec<ArenaIndex> {
         self.windows.borrow().iter().map(|(index, _)| index).collect()
+    }
+
+    fn window_handle_for_adapter(&self, adapter: &Rc<dyn WindowAdapter>) -> Option<ArenaIndex> {
+        self.windows.borrow().iter().find_map(|(index, tracked)| {
+            tracked
+                .window_adapter
+                .upgrade()
+                .filter(|tracked_adapter| Rc::ptr_eq(tracked_adapter, adapter))
+                .map(|_| index)
+        })
     }
 
     pub fn window_adapter(
@@ -147,7 +191,7 @@ impl IntrospectionState {
         let mut order = self.element_handle_order.borrow_mut();
         order.push_back(index);
         if arena.len() > ELEMENT_HANDLE_CAP {
-            let root_indices: std::collections::HashSet<ArenaIndex> =
+            let root_indices: HashSet<ArenaIndex> =
                 self.windows.borrow().iter().map(|(_, w)| w.root_element_handle).collect();
             let mut budget = order.len();
             while arena.len() > ELEMENT_HANDLE_CAP && budget > 0 {
@@ -237,6 +281,84 @@ impl IntrospectionState {
         Ok(())
     }
 
+    pub fn record_window_event(
+        &self,
+        adapter: &Rc<dyn WindowAdapter>,
+        event: &i_slint_core::platform::WindowEvent,
+        result: i_slint_core::context::WindowEventDispatchResult,
+    ) {
+        let sequence = self.next_event_sequence.get();
+        self.next_event_sequence.set(sequence.saturating_add(1));
+
+        let timestamp_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+            .unwrap_or_default();
+
+        let mut log = self.event_log.borrow_mut();
+        if log.len() >= EVENT_LOG_CAP {
+            log.pop_front();
+            self.dropped_event_count.set(self.dropped_event_count.get().saturating_add(1));
+        }
+        log.push_back(proto::RecordedEvent {
+            sequence,
+            timestamp_ms,
+            window_handle: self.window_handle_for_adapter(adapter).map(index_to_handle),
+            source: proto::RecordedEventSource::Runtime.into(),
+            event: Some(convert_window_event_to_proto(event)),
+            result: convert_event_dispatch_result(result).into(),
+        });
+    }
+
+    pub fn query_event_log(
+        &self,
+        window_index: Option<ArenaIndex>,
+        since_sequence: u64,
+        max_events: u32,
+        clear_after_read: bool,
+    ) -> proto::EventLogResponse {
+        let max_events = if max_events == 0 { 200 } else { max_events.min(1000) } as usize;
+        let events: Vec<_> = self
+            .event_log
+            .borrow()
+            .iter()
+            .filter(|event| event.sequence >= since_sequence)
+            .filter(|event| {
+                window_index.is_none_or(|window_index| {
+                    event.window_handle.as_ref().is_some_and(|handle| {
+                        handle_to_index(handle.clone())
+                            .is_ok_and(|event_window| event_window == window_index)
+                    })
+                })
+            })
+            .take(max_events)
+            .cloned()
+            .collect();
+        let next_sequence = events
+            .last()
+            .map(|event| event.sequence.saturating_add(1))
+            .unwrap_or_else(|| self.next_event_sequence.get());
+        let returned_sequences: HashSet<u64> = events.iter().map(|event| event.sequence).collect();
+        let response = proto::EventLogResponse {
+            events,
+            // Pass the next unread sequence number directly so callers can use
+            // it as sinceSequence on the next poll without arithmetic.
+            next_sequence,
+            dropped_count: self.dropped_event_count.get(),
+        };
+        if clear_after_read {
+            self.event_log
+                .borrow_mut()
+                .retain(|event| !returned_sequences.contains(&event.sequence));
+        }
+        response
+    }
+
+    pub fn clear_event_log(&self) {
+        self.event_log.borrow_mut().clear();
+        self.dropped_event_count.set(0);
+    }
+
     pub fn window_properties(
         &self,
         window_index: ArenaIndex,
@@ -266,6 +388,100 @@ impl IntrospectionState {
     ) -> Result<proto::TakeSnapshotResponse, String> {
         let window_contents_as_encoded_image = self.take_snapshot(window_index, image_mime_type)?;
         Ok(proto::TakeSnapshotResponse { window_contents_as_encoded_image })
+    }
+}
+
+pub(crate) fn convert_window_event_to_proto(
+    event: &i_slint_core::platform::WindowEvent,
+) -> proto::WindowEvent {
+    use i_slint_core::platform::WindowEvent;
+    use proto::window_event::Event;
+
+    let event = match event {
+        WindowEvent::PointerPressed { position, button } => {
+            Some(Event::PointerPressed(proto::PointerPressEvent {
+                position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
+                button: convert_pointer_event_button_to_proto(*button).into(),
+            }))
+        }
+        WindowEvent::PointerReleased { position, button } => {
+            Some(Event::PointerReleased(proto::PointerReleaseEvent {
+                position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
+                button: convert_pointer_event_button_to_proto(*button).into(),
+            }))
+        }
+        WindowEvent::PointerMoved { position } => {
+            Some(Event::PointerMoved(proto::PointerMoveEvent {
+                position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
+            }))
+        }
+        WindowEvent::PointerScrolled { position, delta_x, delta_y } => {
+            Some(Event::PointerScrolled(proto::PointerScrolledEvent {
+                position: Some(proto::LogicalPosition { x: position.x, y: position.y }),
+                delta_x: *delta_x,
+                delta_y: *delta_y,
+            }))
+        }
+        WindowEvent::PointerExited => Some(Event::PointerExited(proto::PointerExitedEvent {})),
+        WindowEvent::KeyPressed { text } => {
+            Some(Event::KeyPressed(proto::KeyPressedEvent { text: text.to_string() }))
+        }
+        WindowEvent::KeyPressRepeated { text } => {
+            Some(Event::KeyPressRepeated(proto::KeyPressRepeatedEvent { text: text.to_string() }))
+        }
+        WindowEvent::KeyReleased { text } => {
+            Some(Event::KeyReleased(proto::KeyReleasedEvent { text: text.to_string() }))
+        }
+        WindowEvent::ScaleFactorChanged { scale_factor } => {
+            Some(Event::ScaleFactorChanged(proto::ScaleFactorChangedEvent {
+                scale_factor: *scale_factor,
+            }))
+        }
+        WindowEvent::Resized { size } => Some(Event::Resized(proto::ResizedEvent {
+            size: Some(proto::LogicalSize { width: size.width, height: size.height }),
+        })),
+        WindowEvent::CloseRequested => Some(Event::CloseRequested(proto::CloseRequestedEvent {})),
+        WindowEvent::WindowActiveChanged(active) => {
+            Some(Event::WindowActiveChanged(proto::WindowActiveChangedEvent { active: *active }))
+        }
+        // All current variants are covered above. This arm exists only because
+        // WindowEvent is #[non_exhaustive]; future variants will log with event: None.
+        #[allow(unreachable_patterns)]
+        _ => None,
+    };
+
+    proto::WindowEvent { event }
+}
+
+fn convert_pointer_event_button_to_proto(
+    button: i_slint_core::platform::PointerEventButton,
+) -> proto::PointerEventButton {
+    match button {
+        i_slint_core::platform::PointerEventButton::Left => proto::PointerEventButton::Left,
+        i_slint_core::platform::PointerEventButton::Right => proto::PointerEventButton::Right,
+        i_slint_core::platform::PointerEventButton::Middle => proto::PointerEventButton::Middle,
+        i_slint_core::platform::PointerEventButton::Back => proto::PointerEventButton::Back,
+        i_slint_core::platform::PointerEventButton::Forward => proto::PointerEventButton::Forward,
+        i_slint_core::platform::PointerEventButton::Other => proto::PointerEventButton::Other,
+        // PointerEventButton is #[non_exhaustive]; future buttons map to Other.
+        #[allow(unreachable_patterns)]
+        _ => proto::PointerEventButton::Other,
+    }
+}
+
+fn convert_event_dispatch_result(
+    result: i_slint_core::context::WindowEventDispatchResult,
+) -> proto::RecordedEventResult {
+    match result {
+        i_slint_core::context::WindowEventDispatchResult::Processed => {
+            proto::RecordedEventResult::Processed
+        }
+        i_slint_core::context::WindowEventDispatchResult::Accepted => {
+            proto::RecordedEventResult::Accepted
+        }
+        i_slint_core::context::WindowEventDispatchResult::Ignored => {
+            proto::RecordedEventResult::Ignored
+        }
     }
 }
 
@@ -442,6 +658,9 @@ pub(crate) fn convert_pointer_event_button(
         proto::PointerEventButton::Left => i_slint_core::platform::PointerEventButton::Left,
         proto::PointerEventButton::Right => i_slint_core::platform::PointerEventButton::Right,
         proto::PointerEventButton::Middle => i_slint_core::platform::PointerEventButton::Middle,
+        proto::PointerEventButton::Back => i_slint_core::platform::PointerEventButton::Back,
+        proto::PointerEventButton::Forward => i_slint_core::platform::PointerEventButton::Forward,
+        proto::PointerEventButton::Other => i_slint_core::platform::PointerEventButton::Other,
     }
 }
 
@@ -539,6 +758,21 @@ pub(crate) mod dispatch {
         state.take_snapshot_response(window, image_mime_type)
     }
 
+    pub(crate) fn event_log(
+        state: &IntrospectionState,
+        window: Option<ArenaIndex>,
+        since_sequence: u64,
+        max_events: u32,
+        clear_after_read: bool,
+    ) -> proto::EventLogResponse {
+        state.query_event_log(window, since_sequence, max_events, clear_after_read)
+    }
+
+    pub(crate) fn clear_event_log(state: &IntrospectionState) -> proto::ClearEventLogResponse {
+        state.clear_event_log();
+        proto::ClearEventLogResponse {}
+    }
+
     pub(crate) fn invoke_accessibility_action(
         state: &IntrospectionState,
         element: ArenaIndex,
@@ -634,6 +868,151 @@ fn test_handle_to_index_rejects_out_of_range_parts() {
     );
     assert!(
         handle_to_index(proto::Handle { index: 42, generation: u64::from(u32::MAX) + 1 }).is_err()
+    );
+}
+
+#[test]
+fn test_event_log_filters_since_sequence_and_window() {
+    let state = IntrospectionState::new();
+    let mut window_indices = SlotMap::with_key();
+    let first_window = window_indices.insert(());
+    let second_window = window_indices.insert(());
+
+    state.next_event_sequence.set(3);
+    state.event_log.borrow_mut().extend([
+        proto::RecordedEvent {
+            sequence: 0,
+            window_handle: Some(index_to_handle(first_window)),
+            source: proto::RecordedEventSource::Runtime.into(),
+            result: proto::RecordedEventResult::Processed.into(),
+            ..Default::default()
+        },
+        proto::RecordedEvent {
+            sequence: 1,
+            window_handle: Some(index_to_handle(second_window)),
+            source: proto::RecordedEventSource::Runtime.into(),
+            result: proto::RecordedEventResult::Accepted.into(),
+            ..Default::default()
+        },
+        proto::RecordedEvent {
+            sequence: 2,
+            window_handle: Some(index_to_handle(first_window)),
+            source: proto::RecordedEventSource::Runtime.into(),
+            result: proto::RecordedEventResult::Ignored.into(),
+            ..Default::default()
+        },
+    ]);
+
+    let response = state.query_event_log(Some(first_window), 1, 10, true);
+    assert_eq!(response.events.len(), 1);
+    assert_eq!(response.events[0].sequence, 2);
+    assert_eq!(response.next_sequence, 3);
+    // clear_after_read removes only returned events.
+    let remaining = state.query_event_log(None, 0, 10, false);
+    assert_eq!(remaining.events.iter().map(|event| event.sequence).collect::<Vec<_>>(), vec![0, 1]);
+    assert_eq!(remaining.next_sequence, 2);
+}
+
+#[test]
+fn test_event_log_eviction_at_cap() {
+    let state = IntrospectionState::new();
+
+    // Fill the log to capacity directly, simulating EVENT_LOG_CAP + 10 recorded events.
+    for seq in 0..(EVENT_LOG_CAP + 10) as u64 {
+        let mut log = state.event_log.borrow_mut();
+        if log.len() >= EVENT_LOG_CAP {
+            log.pop_front();
+            state.dropped_event_count.set(state.dropped_event_count.get().saturating_add(1));
+        }
+        log.push_back(proto::RecordedEvent {
+            sequence: seq,
+            source: proto::RecordedEventSource::Runtime.into(),
+            result: proto::RecordedEventResult::Processed.into(),
+            ..Default::default()
+        });
+        state.next_event_sequence.set(seq + 1);
+    }
+
+    assert_eq!(state.event_log.borrow().len(), EVENT_LOG_CAP);
+    assert_eq!(state.dropped_event_count.get(), 10);
+
+    // The oldest retained event should have sequence 10 (the first 10 were evicted).
+    let response = state.query_event_log(None, 0, 1, false);
+    assert_eq!(response.events[0].sequence, 10);
+    assert_eq!(response.dropped_count, 10);
+    assert_eq!(response.next_sequence, 11);
+
+    // After clear, dropped count and log reset, but the sequence cursor remains monotonic.
+    state.clear_event_log();
+    assert!(state.event_log.borrow().is_empty());
+    assert_eq!(state.dropped_event_count.get(), 0);
+    assert_eq!(state.next_event_sequence.get(), (EVENT_LOG_CAP + 10) as u64);
+    assert_eq!(state.query_event_log(None, 0, 1, false).next_sequence, (EVENT_LOG_CAP + 10) as u64);
+}
+
+#[test]
+fn test_event_log_pagination_cursor_advances_to_returned_page() {
+    let state = IntrospectionState::new();
+    for seq in 0..3 {
+        state.event_log.borrow_mut().push_back(proto::RecordedEvent {
+            sequence: seq,
+            source: proto::RecordedEventSource::Runtime.into(),
+            result: proto::RecordedEventResult::Processed.into(),
+            ..Default::default()
+        });
+    }
+    state.next_event_sequence.set(3);
+
+    let first_page = state.query_event_log(None, 0, 1, false);
+    assert_eq!(first_page.events[0].sequence, 0);
+    assert_eq!(first_page.next_sequence, 1);
+
+    let second_page = state.query_event_log(None, first_page.next_sequence, 1, false);
+    assert_eq!(second_page.events[0].sequence, 1);
+    assert_eq!(second_page.next_sequence, 2);
+}
+
+#[test]
+fn test_event_log_clear_keeps_sequence_monotonic() {
+    let state = IntrospectionState::new();
+    state.next_event_sequence.set(42);
+    state.event_log.borrow_mut().push_back(proto::RecordedEvent {
+        sequence: 41,
+        source: proto::RecordedEventSource::Runtime.into(),
+        result: proto::RecordedEventResult::Processed.into(),
+        ..Default::default()
+    });
+
+    state.clear_event_log();
+    assert_eq!(state.next_event_sequence.get(), 42);
+    assert_eq!(state.query_event_log(None, 42, 10, false).next_sequence, 42);
+}
+
+#[test]
+fn test_pointer_event_button_mapping_preserves_extended_buttons() {
+    assert_eq!(
+        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Back),
+        proto::PointerEventButton::Back
+    );
+    assert_eq!(
+        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Forward),
+        proto::PointerEventButton::Forward
+    );
+    assert_eq!(
+        convert_pointer_event_button_to_proto(i_slint_core::platform::PointerEventButton::Other),
+        proto::PointerEventButton::Other
+    );
+    assert_eq!(
+        convert_pointer_event_button(proto::PointerEventButton::Back),
+        i_slint_core::platform::PointerEventButton::Back
+    );
+    assert_eq!(
+        convert_pointer_event_button(proto::PointerEventButton::Forward),
+        i_slint_core::platform::PointerEventButton::Forward
+    );
+    assert_eq!(
+        convert_pointer_event_button(proto::PointerEventButton::Other),
+        i_slint_core::platform::PointerEventButton::Other
     );
 }
 

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -115,15 +115,15 @@ const TOOLS: &[ToolDef] = &[
         optional_fields: &["eventType"],
     },
     ToolDef {
-        name: "get_event_log",
-        description: "Read the bounded event log for dispatched window/input events. Pass the nextSequence value from the previous response as sinceSequence to poll incrementally. The response includes nextSequence (use as sinceSequence on the next call), droppedCount (events evicted when the 1024-entry cap was reached), and an events array. Omit maxEvents for the default page size. Use after interactions to verify that Slint received and processed pointer, key, resize, scale, close, and active-state events.",
-        request_type: "RequestEventLog",
-        optional_fields: &["windowHandle", "sinceSequence", "maxEvents", "clearAfterRead"],
+        name: "start_event_recording",
+        description: "Clear the event log and begin recording window/input events. Call this before the interaction you want to observe, then call stop_event_recording when done.",
+        request_type: "RequestStartEventRecording",
+        optional_fields: &[],
     },
     ToolDef {
-        name: "clear_event_log",
-        description: "Clear the event log and reset the dropped-event counter. Useful before performing an interaction whose processed events should be verified.",
-        request_type: "RequestClearEventLog",
+        name: "stop_event_recording",
+        description: "Stop recording and return all events collected since the last start_event_recording call. The response includes an events array and droppedCount (events evicted when the 1024-entry cap was reached). Use to verify that Slint received and processed pointer, key, resize, scale, close, and active-state events.",
+        request_type: "RequestStopEventRecording",
         optional_fields: &[],
     },
 ];
@@ -378,22 +378,14 @@ async fn handle_tool_call(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
         }
-        "get_event_log" => {
-            let p: proto::RequestEventLog = deserialize_params(args)?;
-            let window_index = p.window_handle.map(handle_to_index).transpose()?;
-            let response = dispatch::event_log(
-                state,
-                window_index,
-                p.since_sequence,
-                p.max_events,
-                p.clear_after_read,
-            );
+        "start_event_recording" => {
+            let response = dispatch::start_event_recording(state);
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
         }
-        "clear_event_log" => {
-            let response = dispatch::clear_event_log(state);
+        "stop_event_recording" => {
+            let response = dispatch::stop_event_recording(state);
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
@@ -464,7 +456,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "5. get_element_properties → full details on a specific element\n",
                     "6. take_screenshot → visual snapshot (returned as inline image)\n",
                     "7. Interact: click_element, drag_element, set_element_value, invoke_accessibility_action, dispatch_key_event\n",
-                    "8. get_event_log → verify the runtime received and processed expected input/window events\n",
+                    "8. start_event_recording → then interact → stop_event_recording to verify the runtime received and processed expected input/window events\n",
                     "9. take_screenshot again to verify the visual effect\n\n",
 
                     "# Handle format\n\n",
@@ -481,7 +473,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "- ElementAccessibilityAction: Default_, Increment, Decrement, Expand\n",
                     "- KeyEventType: PressAndRelease, Press, Release\n",
                     "- RecordedEventSource: Runtime\n",
-                    "- RecordedEventResult: Processed, Accepted, Ignored\n",
+                    "- RecordedEventResult: Processed, Ignored\n",
                     "- LayoutKind: NotALayout, HorizontalLayout, VerticalLayout, GridLayout, FlexboxLayout\n",
                     "Omitted enum fields default to the first value (e.g. Left, SingleClick, PressAndRelease).\n\n",
 

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -114,6 +114,18 @@ const TOOLS: &[ToolDef] = &[
         request_type: "RequestDispatchKeyEvent",
         optional_fields: &["eventType"],
     },
+    ToolDef {
+        name: "get_event_log",
+        description: "Read the bounded event log for dispatched window/input events. Pass the nextSequence value from the previous response as sinceSequence to poll incrementally. The response includes nextSequence (use as sinceSequence on the next call), droppedCount (events evicted when the 1024-entry cap was reached), and an events array. Omit maxEvents for the default page size. Use after interactions to verify that Slint received and processed pointer, key, resize, scale, close, and active-state events.",
+        request_type: "RequestEventLog",
+        optional_fields: &["windowHandle", "sinceSequence", "maxEvents", "clearAfterRead"],
+    },
+    ToolDef {
+        name: "clear_event_log",
+        description: "Clear the event log and reset the dropped-event counter. Useful before performing an interaction whose processed events should be verified.",
+        request_type: "RequestClearEventLog",
+        optional_fields: &[],
+    },
 ];
 
 fn tool_definitions() -> Value {
@@ -366,6 +378,26 @@ async fn handle_tool_call(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
         }
+        "get_event_log" => {
+            let p: proto::RequestEventLog = deserialize_params(args)?;
+            let window_index = p.window_handle.map(handle_to_index).transpose()?;
+            let response = dispatch::event_log(
+                state,
+                window_index,
+                p.since_sequence,
+                p.max_events,
+                p.clear_after_read,
+            );
+            Ok(ToolResult::Json(
+                serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
+            ))
+        }
+        "clear_event_log" => {
+            let response = dispatch::clear_event_log(state);
+            Ok(ToolResult::Json(
+                serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
+            ))
+        }
         _ => Err(format!("Unknown tool: {name}")),
     }
 }
@@ -432,7 +464,8 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "5. get_element_properties → full details on a specific element\n",
                     "6. take_screenshot → visual snapshot (returned as inline image)\n",
                     "7. Interact: click_element, drag_element, set_element_value, invoke_accessibility_action, dispatch_key_event\n",
-                    "8. take_screenshot again to verify the effect\n\n",
+                    "8. get_event_log → verify the runtime received and processed expected input/window events\n",
+                    "9. take_screenshot again to verify the visual effect\n\n",
 
                     "# Handle format\n\n",
                     "All handles are JSON objects with string-valued fields: {\"index\": \"0\", \"generation\": \"0\"}. ",
@@ -443,10 +476,12 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "# Enum values\n\n",
                     "Enum fields accept PascalCase strings:\n",
                     "- AccessibleRole: Unknown, Button, Checkbox, Combobox, List, Slider, Spinbox, Tab, TabList, Text, Table, Tree, ProgressIndicator, TextInput, Switch, ListItem, TabPanel, Groupbox, Image, RadioButton\n",
-                    "- PointerEventButton: Left, Right, Middle\n",
+                    "- PointerEventButton: Left, Right, Middle, Back, Forward, Other\n",
                     "- ClickAction: SingleClick, DoubleClick\n",
                     "- ElementAccessibilityAction: Default_, Increment, Decrement, Expand\n",
                     "- KeyEventType: PressAndRelease, Press, Release\n",
+                    "- RecordedEventSource: Runtime\n",
+                    "- RecordedEventResult: Processed, Accepted, Ignored\n",
                     "- LayoutKind: NotALayout, HorizontalLayout, VerticalLayout, GridLayout, FlexboxLayout\n",
                     "Omitted enum fields default to the first value (e.g. Left, SingleClick, PressAndRelease).\n\n",
 
@@ -1051,7 +1086,7 @@ mod tests {
     fn test_tool_definitions_structure() {
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 12);
+        assert_eq!(tools.len(), TOOLS.len());
         for tool in tools {
             assert!(tool.get("name").and_then(|v| v.as_str()).is_some());
             assert!(tool.get("description").and_then(|v| v.as_str()).is_some());

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -122,7 +122,7 @@ const TOOLS: &[ToolDef] = &[
     },
     ToolDef {
         name: "stop_event_recording",
-        description: "Stop recording and return all events collected since the last start_event_recording call. The response includes an events array and droppedCount (events evicted when the 1024-entry cap was reached). Use to verify that Slint received and processed pointer, key, resize, scale, close, and active-state events.",
+        description: "Stop recording and return all events collected since the last start_event_recording call. The response includes an events array, droppedCount (events evicted when the 1024-entry cap was reached), and unknownEventCount (non-zero indicates a Slint bug: an event variant has no proto mapping). Use to verify that Slint received and processed pointer, key, resize, scale, close, and active-state events.",
         request_type: "RequestStopEventRecording",
         optional_fields: &[],
     },
@@ -472,8 +472,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "- ClickAction: SingleClick, DoubleClick\n",
                     "- ElementAccessibilityAction: Default_, Increment, Decrement, Expand\n",
                     "- KeyEventType: PressAndRelease, Press, Release\n",
-                    "- RecordedEventSource: Runtime\n",
-                    "- RecordedEventResult: Processed, Ignored\n",
+                    "- RecordedEventResult: Accepted, Rejected, Ignored\n",
                     "- LayoutKind: NotALayout, HorizontalLayout, VerticalLayout, GridLayout, FlexboxLayout\n",
                     "Omitted enum fields default to the first value (e.g. Left, SingleClick, PressAndRelease).\n\n",
 

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -472,7 +472,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "- ClickAction: SingleClick, DoubleClick\n",
                     "- ElementAccessibilityAction: Default_, Increment, Decrement, Expand\n",
                     "- KeyEventType: PressAndRelease, Press, Release\n",
-                    "- RecordedEventResult: Accepted, Rejected, Ignored\n",
+                    "- RecordedEventResult: Unspecified, Accepted, Rejected, Ignored (Unspecified appears only on malformed data)\n",
                     "- LayoutKind: NotALayout, HorizontalLayout, VerticalLayout, GridLayout, FlexboxLayout\n",
                     "Omitted enum fields default to the first value (e.g. Left, SingleClick, PressAndRelease).\n\n",
 

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -142,9 +142,12 @@ enum AccessibleRole {
 }
 
 enum RecordedEventResult {
-    Accepted = 0;
-    Rejected = 1;
-    Ignored = 2;
+    // Default; only appears when a deserializer reads a corrupt or
+    // partially-populated RecordedEvent. The recorder never writes this.
+    Unspecified = 0;
+    Accepted = 1;
+    Rejected = 2;
+    Ignored = 3;
 }
 
 message ElementQueryInstruction {

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -147,8 +147,7 @@ enum RecordedEventSource {
 
 enum RecordedEventResult {
     Processed = 0;
-    Accepted = 1;
-    Ignored = 2;
+    Ignored = 1;
 }
 
 message ElementQueryInstruction {
@@ -238,6 +237,12 @@ message RequestEventLog {
 message RequestClearEventLog {
 }
 
+message RequestStartEventRecording {
+}
+
+message RequestStopEventRecording {
+}
+
 message RequestToAUT {
     oneof msg {
         RequestWindowListMessage request_window_list = 1;
@@ -255,6 +260,8 @@ message RequestToAUT {
         RequestGetElementTree request_get_element_tree = 13;
         RequestEventLog request_event_log = 14;
         RequestClearEventLog request_clear_event_log = 15;
+        RequestStartEventRecording request_start_event_recording = 16;
+        RequestStopEventRecording request_stop_event_recording = 17;
     }
 }
 
@@ -375,6 +382,14 @@ message EventLogResponse {
 message ClearEventLogResponse {
 }
 
+message StartEventRecordingResponse {
+}
+
+message StopEventRecordingResponse {
+    repeated RecordedEvent events = 1;
+    uint64 dropped_count = 2;
+}
+
 message AUTResponse {
     oneof msg {
         ErrorResponse error = 1;
@@ -393,5 +408,7 @@ message AUTResponse {
         GetElementTreeResponse get_element_tree_response = 14;
         EventLogResponse event_log_response = 15;
         ClearEventLogResponse clear_event_log_response = 16;
+        StartEventRecordingResponse start_event_recording_response = 17;
+        StopEventRecordingResponse stop_event_recording_response = 18;
     }
 }

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -23,6 +23,9 @@ enum PointerEventButton {
     Left = 0;
     Right = 1;
     Middle = 2;
+    Back = 3;
+    Forward = 4;
+    Other = 5;
 }
 
 enum ClickAction {
@@ -53,6 +56,21 @@ message PointerScrolledEvent {
 message PointerExitedEvent {
 }
 
+message ScaleFactorChangedEvent {
+    float scale_factor = 1;
+}
+
+message ResizedEvent {
+    LogicalSize size = 1;
+}
+
+message CloseRequestedEvent {
+}
+
+message WindowActiveChangedEvent {
+    bool active = 1;
+}
+
 message KeyPressedEvent {
     string text = 1;
 }
@@ -75,6 +93,10 @@ message WindowEvent {
         KeyPressedEvent key_pressed = 6;
         KeyPressRepeatedEvent key_press_repeated = 7;
         KeyReleasedEvent key_released = 8;
+        ScaleFactorChangedEvent scale_factor_changed = 9;
+        ResizedEvent resized = 10;
+        CloseRequestedEvent close_requested = 11;
+        WindowActiveChangedEvent window_active_changed = 12;
     }
 }
 
@@ -117,6 +139,16 @@ enum AccessibleRole {
     Image = 18;
     RadioButton = 19;
     RadioGroup = 20;
+}
+
+enum RecordedEventSource {
+    Runtime = 0;
+}
+
+enum RecordedEventResult {
+    Processed = 0;
+    Accepted = 1;
+    Ignored = 2;
 }
 
 message ElementQueryInstruction {
@@ -196,6 +228,16 @@ message RequestQueryElementDescendants {
     bool find_all = 3;
 }
 
+message RequestEventLog {
+    Handle window_handle = 1;
+    uint64 since_sequence = 2;
+    uint32 max_events = 3;
+    bool clear_after_read = 4;
+}
+
+message RequestClearEventLog {
+}
+
 message RequestToAUT {
     oneof msg {
         RequestWindowListMessage request_window_list = 1;
@@ -211,6 +253,8 @@ message RequestToAUT {
         RequestElementDrag request_element_drag = 11;
         RequestDispatchKeyEvent request_dispatch_key_event = 12;
         RequestGetElementTree request_get_element_tree = 13;
+        RequestEventLog request_event_log = 14;
+        RequestClearEventLog request_clear_event_log = 15;
     }
 }
 
@@ -311,6 +355,26 @@ message ElementQueryResponse {
     repeated Handle element_handles = 1;
 }
 
+message RecordedEvent {
+    uint64 sequence = 1;
+    uint64 timestamp_ms = 2;
+    Handle window_handle = 3;
+    RecordedEventSource source = 4;
+    WindowEvent event = 5;
+    RecordedEventResult result = 6;
+}
+
+message EventLogResponse {
+    repeated RecordedEvent events = 1;
+    // The next sequence number to use as sinceSequence on the following poll.
+    // Zero when no events have ever been recorded (or after a clear).
+    uint64 next_sequence = 2;
+    uint64 dropped_count = 3;
+}
+
+message ClearEventLogResponse {
+}
+
 message AUTResponse {
     oneof msg {
         ErrorResponse error = 1;
@@ -327,5 +391,7 @@ message AUTResponse {
         ElementDragResponse element_drag_response = 12;
         DispatchKeyEventResponse dispatch_key_event_response = 13;
         GetElementTreeResponse get_element_tree_response = 14;
+        EventLogResponse event_log_response = 15;
+        ClearEventLogResponse clear_event_log_response = 16;
     }
 }

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -141,13 +141,10 @@ enum AccessibleRole {
     RadioGroup = 20;
 }
 
-enum RecordedEventSource {
-    Runtime = 0;
-}
-
 enum RecordedEventResult {
-    Processed = 0;
-    Ignored = 1;
+    Accepted = 0;
+    Rejected = 1;
+    Ignored = 2;
 }
 
 message ElementQueryInstruction {
@@ -230,7 +227,7 @@ message RequestQueryElementDescendants {
 message RequestEventLog {
     Handle window_handle = 1;
     uint64 since_sequence = 2;
-    uint32 max_events = 3;
+    uint64 max_events = 3;
     bool clear_after_read = 4;
 }
 
@@ -363,10 +360,11 @@ message ElementQueryResponse {
 }
 
 message RecordedEvent {
+    reserved 4;
+    reserved "source";
     uint64 sequence = 1;
     uint64 timestamp_ms = 2;
     Handle window_handle = 3;
-    RecordedEventSource source = 4;
     WindowEvent event = 5;
     RecordedEventResult result = 6;
 }
@@ -377,6 +375,10 @@ message EventLogResponse {
     // Zero when no events have ever been recorded (or after a clear).
     uint64 next_sequence = 2;
     uint64 dropped_count = 3;
+    // Number of events skipped because their variant could not be converted to
+    // proto. Non-zero indicates a bug: the conversion code is out of sync with
+    // i_slint_core::platform::WindowEvent / PointerEventButton.
+    uint64 unknown_event_count = 4;
 }
 
 message ClearEventLogResponse {
@@ -388,6 +390,8 @@ message StartEventRecordingResponse {
 message StopEventRecordingResponse {
     repeated RecordedEvent events = 1;
     uint64 dropped_count = 2;
+    // See EventLogResponse.unknown_event_count.
+    uint64 unknown_event_count = 3;
 }
 
 message AUTResponse {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -188,6 +188,24 @@ impl TestingClient {
                     find_all,
                 )?)
             }
+            Req::RequestEventLog(proto::RequestEventLog {
+                window_handle,
+                since_sequence,
+                max_events,
+                clear_after_read,
+            }) => {
+                let window_index = window_handle.map(handle_to_index).transpose()?;
+                Resp::EventLogResponse(dispatch::event_log(
+                    &self.state,
+                    window_index,
+                    since_sequence,
+                    max_events,
+                    clear_after_read,
+                ))
+            }
+            Req::RequestClearEventLog(..) => {
+                Resp::ClearEventLogResponse(dispatch::clear_event_log(&self.state))
+            }
             // MCP-only tools — not supported over the binary system-testing transport
             Req::RequestDispatchKeyEvent(..) | Req::RequestGetElementTree(..) => {
                 return Err("this request is only supported via the MCP transport".into());
@@ -341,6 +359,24 @@ fn convert_window_event(
         }
         Event::KeyReleased(proto::KeyReleasedEvent { text }) => {
             i_slint_core::platform::WindowEvent::KeyReleased { text: text.into() }
+        }
+        Event::ScaleFactorChanged(proto::ScaleFactorChangedEvent { scale_factor }) => {
+            i_slint_core::platform::WindowEvent::ScaleFactorChanged { scale_factor }
+        }
+        Event::Resized(proto::ResizedEvent { size }) => {
+            i_slint_core::platform::WindowEvent::Resized {
+                size: {
+                    let size =
+                        size.ok_or_else(|| "Missing logical size in resize event".to_string())?;
+                    i_slint_core::api::LogicalSize { width: size.width, height: size.height }
+                },
+            }
+        }
+        Event::CloseRequested(proto::CloseRequestedEvent {}) => {
+            i_slint_core::platform::WindowEvent::CloseRequested
+        }
+        Event::WindowActiveChanged(proto::WindowActiveChangedEvent { active }) => {
+            i_slint_core::platform::WindowEvent::WindowActiveChanged(active)
         }
     })
 }

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -206,6 +206,12 @@ impl TestingClient {
             Req::RequestClearEventLog(..) => {
                 Resp::ClearEventLogResponse(dispatch::clear_event_log(&self.state))
             }
+            Req::RequestStartEventRecording(..) => {
+                Resp::StartEventRecordingResponse(dispatch::start_event_recording(&self.state))
+            }
+            Req::RequestStopEventRecording(..) => {
+                Resp::StopEventRecordingResponse(dispatch::stop_event_recording(&self.state))
+            }
             // MCP-only tools — not supported over the binary system-testing transport
             Req::RequestDispatchKeyEvent(..) | Req::RequestGetElementTree(..) => {
                 return Err("this request is only supported via the MCP transport".into());
@@ -217,6 +223,7 @@ impl TestingClient {
 pub fn init() -> Result<(), EventLoopError> {
     introspection::ensure_window_tracking()?;
     let state = introspection::shared_state();
+    state.start_recording();
 
     let Some(client) = TestingClient::new(state) else {
         return Ok(());

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -27,7 +27,7 @@ pub use crate::{format, string::SharedString, string::ToSharedString};
 impl From<crate::input::KeyEventResult> for WindowEventDispatchResult {
     fn from(value: crate::input::KeyEventResult) -> Self {
         match value {
-            crate::input::KeyEventResult::EventAccepted => Self::Accepted,
+            crate::input::KeyEventResult::EventAccepted => Self::Processed,
             crate::input::KeyEventResult::EventIgnored => Self::Ignored,
         }
     }
@@ -734,7 +734,7 @@ impl Window {
             crate::platform::WindowEvent::CloseRequested => {
                 if self.0.request_close() {
                     self.hide()?;
-                    WindowEventDispatchResult::Accepted
+                    WindowEventDispatchResult::Processed
                 } else {
                     WindowEventDispatchResult::Ignored
                 }
@@ -745,15 +745,8 @@ impl Window {
             }
         };
         if let Some(event_for_hook) = event_for_hook {
-            // Take the hook out before calling to allow re-entrant dispatch without a BorrowMutError.
-            let hook = self.0.context().0.window_event_hook.borrow_mut().take();
-            if let Some(mut hook) = hook {
+            if let Some(hook) = self.0.context().0.window_event_hook.borrow().as_ref() {
                 hook(&self.0.window_adapter(), &event_for_hook, dispatch_result);
-                // Restore only if nothing replaced it during the call.
-                let mut slot = self.0.context().0.window_event_hook.borrow_mut();
-                if slot.is_none() {
-                    *slot = Some(hook);
-                }
             }
         }
         Ok(())

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -27,7 +27,7 @@ pub use crate::{format, string::SharedString, string::ToSharedString};
 impl From<crate::input::KeyEventResult> for WindowEventDispatchResult {
     fn from(value: crate::input::KeyEventResult) -> Self {
         match value {
-            crate::input::KeyEventResult::EventAccepted => Self::Processed,
+            crate::input::KeyEventResult::EventAccepted => Self::Accepted,
             crate::input::KeyEventResult::EventIgnored => Self::Ignored,
         }
     }
@@ -663,7 +663,7 @@ impl Window {
                     click_count: 0,
                     touch_finger_id: 0,
                 });
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
             crate::platform::WindowEvent::PointerReleased { position, button } => {
                 self.0.process_mouse_input(MouseEvent::Released {
@@ -672,14 +672,14 @@ impl Window {
                     click_count: 0,
                     touch_finger_id: 0,
                 });
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
             crate::platform::WindowEvent::PointerMoved { position } => {
                 self.0.process_mouse_input(MouseEvent::Moved {
                     position: position.to_euclid().cast(),
                     touch_finger_id: 0,
                 });
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
             crate::platform::WindowEvent::PointerScrolled { position, delta_x, delta_y } => {
                 self.0.process_mouse_input(MouseEvent::Wheel {
@@ -688,11 +688,11 @@ impl Window {
                     delta_y: delta_y as _,
                     phase: TouchPhase::Cancelled,
                 });
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
             crate::platform::WindowEvent::PointerExited => {
                 self.0.process_mouse_input(MouseEvent::Exit);
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
 
             crate::platform::WindowEvent::KeyPressed { text } => self
@@ -721,7 +721,7 @@ impl Window {
                 .into(),
             crate::platform::WindowEvent::ScaleFactorChanged { scale_factor } => {
                 self.0.set_scale_factor(scale_factor);
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
             crate::platform::WindowEvent::Resized { size } => {
                 self.0.set_window_item_geometry(size.to_euclid());
@@ -729,19 +729,19 @@ impl Window {
                 if let Some(item_rc) = self.0.focus_item.borrow().upgrade() {
                     item_rc.try_scroll_into_visible();
                 }
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
             crate::platform::WindowEvent::CloseRequested => {
                 if self.0.request_close() {
                     self.hide()?;
-                    WindowEventDispatchResult::Processed
+                    WindowEventDispatchResult::Accepted
                 } else {
-                    WindowEventDispatchResult::Ignored
+                    WindowEventDispatchResult::Rejected
                 }
             }
             crate::platform::WindowEvent::WindowActiveChanged(bool) => {
                 self.0.set_active(bool);
-                WindowEventDispatchResult::Processed
+                WindowEventDispatchResult::Accepted
             }
         };
         if let Some(event_for_hook) = event_for_hook

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -7,6 +7,7 @@ This module contains types that are public and re-exported in the slint-rs as we
 
 #![warn(missing_docs)]
 
+use crate::context::WindowEventDispatchResult;
 use crate::input::{InternalKeyEvent, KeyEventType, MouseEvent, TouchPhase};
 use crate::window::{WindowAdapter, WindowInner};
 use alloc::boxed::Box;
@@ -22,6 +23,15 @@ pub use crate::graphics::{
 pub use crate::input::Keys;
 pub use crate::sharedvector::SharedVector;
 pub use crate::{format, string::SharedString, string::ToSharedString};
+
+impl From<crate::input::KeyEventResult> for WindowEventDispatchResult {
+    fn from(value: crate::input::KeyEventResult) -> Self {
+        match value {
+            crate::input::KeyEventResult::EventAccepted => Self::Accepted,
+            crate::input::KeyEventResult::EventIgnored => Self::Ignored,
+        }
+    }
+}
 
 /// A position represented in the coordinate space of logical pixels. That is the space before applying
 /// a display device specific scale factor.
@@ -642,7 +652,10 @@ impl Window {
         &self,
         event: crate::platform::WindowEvent,
     ) -> Result<(), PlatformError> {
-        match event {
+        // Only clone the event when a hook is installed to avoid allocation on the hot path.
+        let event_for_hook =
+            self.0.context().0.window_event_hook.borrow().is_some().then(|| event.clone());
+        let dispatch_result = match event {
             crate::platform::WindowEvent::PointerPressed { position, button } => {
                 self.0.process_mouse_input(MouseEvent::Pressed {
                     position: position.to_euclid().cast(),
@@ -650,6 +663,7 @@ impl Window {
                     click_count: 0,
                     touch_finger_id: 0,
                 });
+                WindowEventDispatchResult::Processed
             }
             crate::platform::WindowEvent::PointerReleased { position, button } => {
                 self.0.process_mouse_input(MouseEvent::Released {
@@ -658,12 +672,14 @@ impl Window {
                     click_count: 0,
                     touch_finger_id: 0,
                 });
+                WindowEventDispatchResult::Processed
             }
             crate::platform::WindowEvent::PointerMoved { position } => {
                 self.0.process_mouse_input(MouseEvent::Moved {
                     position: position.to_euclid().cast(),
                     touch_finger_id: 0,
                 });
+                WindowEventDispatchResult::Processed
             }
             crate::platform::WindowEvent::PointerScrolled { position, delta_x, delta_y } => {
                 self.0.process_mouse_input(MouseEvent::Wheel {
@@ -672,34 +688,40 @@ impl Window {
                     delta_y: delta_y as _,
                     phase: TouchPhase::Cancelled,
                 });
+                WindowEventDispatchResult::Processed
             }
             crate::platform::WindowEvent::PointerExited => {
                 self.0.process_mouse_input(MouseEvent::Exit);
+                WindowEventDispatchResult::Processed
             }
 
-            crate::platform::WindowEvent::KeyPressed { text } => {
-                self.0.process_key_input(InternalKeyEvent {
+            crate::platform::WindowEvent::KeyPressed { text } => self
+                .0
+                .process_key_input(InternalKeyEvent {
                     event_type: KeyEventType::KeyPressed,
                     key_event: crate::input::KeyEvent { text, ..Default::default() },
                     ..Default::default()
-                });
-            }
-            crate::platform::WindowEvent::KeyPressRepeated { text } => {
-                self.0.process_key_input(InternalKeyEvent {
+                })
+                .into(),
+            crate::platform::WindowEvent::KeyPressRepeated { text } => self
+                .0
+                .process_key_input(InternalKeyEvent {
                     event_type: KeyEventType::KeyPressed,
                     key_event: crate::input::KeyEvent { text, repeat: true, ..Default::default() },
                     ..Default::default()
-                });
-            }
-            crate::platform::WindowEvent::KeyReleased { text } => {
-                self.0.process_key_input(InternalKeyEvent {
+                })
+                .into(),
+            crate::platform::WindowEvent::KeyReleased { text } => self
+                .0
+                .process_key_input(InternalKeyEvent {
                     event_type: KeyEventType::KeyReleased,
                     key_event: crate::input::KeyEvent { text, ..Default::default() },
                     ..Default::default()
-                });
-            }
+                })
+                .into(),
             crate::platform::WindowEvent::ScaleFactorChanged { scale_factor } => {
                 self.0.set_scale_factor(scale_factor);
+                WindowEventDispatchResult::Processed
             }
             crate::platform::WindowEvent::Resized { size } => {
                 self.0.set_window_item_geometry(size.to_euclid());
@@ -707,14 +729,33 @@ impl Window {
                 if let Some(item_rc) = self.0.focus_item.borrow().upgrade() {
                     item_rc.try_scroll_into_visible();
                 }
+                WindowEventDispatchResult::Processed
             }
             crate::platform::WindowEvent::CloseRequested => {
                 if self.0.request_close() {
                     self.hide()?;
+                    WindowEventDispatchResult::Accepted
+                } else {
+                    WindowEventDispatchResult::Ignored
                 }
             }
-            crate::platform::WindowEvent::WindowActiveChanged(bool) => self.0.set_active(bool),
+            crate::platform::WindowEvent::WindowActiveChanged(bool) => {
+                self.0.set_active(bool);
+                WindowEventDispatchResult::Processed
+            }
         };
+        if let Some(event_for_hook) = event_for_hook {
+            // Take the hook out before calling to allow re-entrant dispatch without a BorrowMutError.
+            let hook = self.0.context().0.window_event_hook.borrow_mut().take();
+            if let Some(mut hook) = hook {
+                hook(&self.0.window_adapter(), &event_for_hook, dispatch_result);
+                // Restore only if nothing replaced it during the call.
+                let mut slot = self.0.context().0.window_event_hook.borrow_mut();
+                if slot.is_none() {
+                    *slot = Some(hook);
+                }
+            }
+        }
         Ok(())
     }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -744,10 +744,10 @@ impl Window {
                 WindowEventDispatchResult::Processed
             }
         };
-        if let Some(event_for_hook) = event_for_hook {
-            if let Some(hook) = self.0.context().0.window_event_hook.borrow().as_ref() {
-                hook(&self.0.window_adapter(), &event_for_hook, dispatch_result);
-            }
+        if let Some(event_for_hook) = event_for_hook
+            && let Some(hook) = self.0.context().0.window_event_hook.borrow().as_ref()
+        {
+            hook(&self.0.window_adapter(), &event_for_hook, dispatch_result);
         }
         Ok(())
     }

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -317,9 +317,7 @@ pub fn set_window_event_hook(
     GLOBAL_CONTEXT.with(|p| match p.get() {
         Some(ctx) => {
             let mut slot = ctx.0.window_event_hook.try_borrow_mut().map_err(|_| {
-                PlatformError::Other(
-                    alloc::string::String::from("event hook is currently in use"),
-                )
+                PlatformError::Other(alloc::string::String::from("event hook is currently in use"))
             })?;
             Ok(core::mem::replace(&mut *slot, hook))
         }

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -7,19 +7,20 @@ use crate::graphics::Color;
 use crate::input::InternalKeyboardModifierState;
 use crate::item_tree::{ItemRc, ItemTreeRc};
 use crate::items::ColorScheme;
-use crate::platform::{EventLoopProxy, Platform};
+use crate::platform::{EventLoopProxy, Platform, WindowAdapter, WindowEvent};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::cell::Cell;
 use pin_weak::rc::PinWeak;
 
+pub(crate) type WindowEventHook =
+    Box<dyn Fn(&Rc<dyn WindowAdapter>, &WindowEvent, WindowEventDispatchResult)>;
+
 /// Result of dispatching a window event through Slint's runtime.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WindowEventDispatchResult {
-    /// The event was processed, but the runtime does not expose a more specific result.
+    /// The event was processed by the runtime.
     Processed,
-    /// The event was accepted by an item or runtime handler.
-    Accepted,
     /// The event was ignored by the item tree.
     Ignored,
 }
@@ -58,17 +59,7 @@ pub(crate) struct SlintContextInner {
     pub(crate) accent_color: Property<Color>,
     pub(crate) window_shown_hook:
         core::cell::RefCell<Option<Box<dyn FnMut(&Rc<dyn crate::platform::WindowAdapter>)>>>,
-    pub(crate) window_event_hook: core::cell::RefCell<
-        Option<
-            Box<
-                dyn FnMut(
-                    &Rc<dyn crate::platform::WindowAdapter>,
-                    &crate::platform::WindowEvent,
-                    WindowEventDispatchResult,
-                ),
-            >,
-        >,
-    >,
+    pub(crate) window_event_hook: core::cell::RefCell<Option<WindowEventHook>>,
     #[cfg(all(unix, not(target_os = "macos")))]
     xdg_app_id: core::cell::RefCell<Option<crate::SharedString>>,
     #[cfg(feature = "shared-parley")]
@@ -321,29 +312,17 @@ pub fn set_window_shown_hook(
 /// Internal function to set a hook that's invoked after a window event was dispatched.
 /// This is used by the system testing module. Returns a previously set hook, if any.
 pub fn set_window_event_hook(
-    hook: Option<
-        Box<
-            dyn FnMut(
-                &Rc<dyn crate::platform::WindowAdapter>,
-                &crate::platform::WindowEvent,
-                WindowEventDispatchResult,
-            ),
-        >,
-    >,
-) -> Result<
-    Option<
-        Box<
-            dyn FnMut(
-                &Rc<dyn crate::platform::WindowAdapter>,
-                &crate::platform::WindowEvent,
-                WindowEventDispatchResult,
-            ),
-        >,
-    >,
-    PlatformError,
-> {
+    hook: Option<WindowEventHook>,
+) -> Result<Option<WindowEventHook>, PlatformError> {
     GLOBAL_CONTEXT.with(|p| match p.get() {
-        Some(ctx) => Ok(ctx.0.window_event_hook.replace(hook)),
+        Some(ctx) => {
+            let mut slot = ctx.0.window_event_hook.try_borrow_mut().map_err(|_| {
+                PlatformError::Other(
+                    alloc::string::String::from("event hook is currently in use"),
+                )
+            })?;
+            Ok(core::mem::replace(&mut *slot, hook))
+        }
         None => Err(PlatformError::NoPlatform),
     })
 }

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -13,6 +13,17 @@ use alloc::rc::Rc;
 use core::cell::Cell;
 use pin_weak::rc::PinWeak;
 
+/// Result of dispatching a window event through Slint's runtime.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WindowEventDispatchResult {
+    /// The event was processed, but the runtime does not expose a more specific result.
+    Processed,
+    /// The event was accepted by an item or runtime handler.
+    Accepted,
+    /// The event was ignored by the item tree.
+    Ignored,
+}
+
 crate::thread_local! {
     pub(crate) static GLOBAL_CONTEXT : once_cell::unsync::OnceCell<SlintContext>
         = const { once_cell::unsync::OnceCell::new() }
@@ -47,6 +58,17 @@ pub(crate) struct SlintContextInner {
     pub(crate) accent_color: Property<Color>,
     pub(crate) window_shown_hook:
         core::cell::RefCell<Option<Box<dyn FnMut(&Rc<dyn crate::platform::WindowAdapter>)>>>,
+    pub(crate) window_event_hook: core::cell::RefCell<
+        Option<
+            Box<
+                dyn FnMut(
+                    &Rc<dyn crate::platform::WindowAdapter>,
+                    &crate::platform::WindowEvent,
+                    WindowEventDispatchResult,
+                ),
+            >,
+        >,
+    >,
     #[cfg(all(unix, not(target_os = "macos")))]
     xdg_app_id: core::cell::RefCell<Option<crate::SharedString>>,
     #[cfg(feature = "shared-parley")]
@@ -84,7 +106,7 @@ impl SlintContext {
             color_scheme: Property::new_named(ColorScheme::Unknown, "SlintContext::color_scheme"),
             accent_color: Property::new_named(Color::default(), "SlintContext::accent_color"),
             window_shown_hook: Default::default(),
-
+            window_event_hook: Default::default(),
             #[cfg(all(unix, not(target_os = "macos")))]
             xdg_app_id: Default::default(),
             #[cfg(feature = "shared-parley")]
@@ -292,6 +314,36 @@ pub fn set_window_shown_hook(
 ) -> Result<Option<Box<dyn FnMut(&Rc<dyn crate::platform::WindowAdapter>)>>, PlatformError> {
     GLOBAL_CONTEXT.with(|p| match p.get() {
         Some(ctx) => Ok(ctx.0.window_shown_hook.replace(hook)),
+        None => Err(PlatformError::NoPlatform),
+    })
+}
+
+/// Internal function to set a hook that's invoked after a window event was dispatched.
+/// This is used by the system testing module. Returns a previously set hook, if any.
+pub fn set_window_event_hook(
+    hook: Option<
+        Box<
+            dyn FnMut(
+                &Rc<dyn crate::platform::WindowAdapter>,
+                &crate::platform::WindowEvent,
+                WindowEventDispatchResult,
+            ),
+        >,
+    >,
+) -> Result<
+    Option<
+        Box<
+            dyn FnMut(
+                &Rc<dyn crate::platform::WindowAdapter>,
+                &crate::platform::WindowEvent,
+                WindowEventDispatchResult,
+            ),
+        >,
+    >,
+    PlatformError,
+> {
+    GLOBAL_CONTEXT.with(|p| match p.get() {
+        Some(ctx) => Ok(ctx.0.window_event_hook.replace(hook)),
         None => Err(PlatformError::NoPlatform),
     })
 }

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -19,9 +19,14 @@ pub(crate) type WindowEventHook =
 /// Result of dispatching a window event through Slint's runtime.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WindowEventDispatchResult {
-    /// The event was processed by the runtime.
-    Processed,
-    /// The event was ignored by the item tree.
+    /// A receiver handled the event (e.g. a key handler consumed it, or the
+    /// runtime acted on a resize / scale / close).
+    Accepted,
+    /// A receiver actively refused the event (e.g. a `close-requested` callback
+    /// prevented the window from closing).
+    Rejected,
+    /// The event fell through without being handled (e.g. a key event with no
+    /// matching handler).
     Ignored,
 }
 


### PR DESCRIPTION
## Summary

- add an internal window-event dispatch hook and shared testing-backend event ring buffer
- expose get_event_log and clear_event_log MCP tools, plus systest responses for the same log
- record pointer/key/window events with sequence cursors, dropped counts, and key processing results
- preserve extended pointer buttons and keep event-log pagination/clear cursors monotonic

## Testing

- cargo check -p i-slint-backend-testing --features mcp,system-testing
- SLINT_EMIT_DEBUG_INFO=1 cargo test -p i-slint-backend-testing --features mcp,system-testing
- manual gallery MCP run: clicked controls, focused TextEdit, dispatched key events, verified get_event_log and text value updates
