### PR TITLE
compiler: Extract UTF-16 column conversion helpers in diagnostics

### DIFF
--- a/internal/common/lib.rs
+++ b/internal/common/lib.rs
@@ -17,6 +17,7 @@ pub mod key_codes;
 pub mod sharedfontique;
 
 pub mod styled_text;
+pub mod unicode_utils;
 
 pub const DEFAULT_DECIMAL_SEPARATOR: char = '.';
 

--- a/internal/common/unicode_utils.rs
+++ b/internal/common/unicode_utils.rs
@@ -1,0 +1,104 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! UTF-16 ↔ UTF-8 offset conversion utilities.
+//!
+//! Slint uses UTF-8 byte offsets internally. Platform protocols and language
+//! servers often use UTF-16 code unit offsets. This module converts between
+//! the two without allocating.
+
+/// Converts a UTF-8 byte offset to a UTF-16 code unit offset.
+///
+/// `byte_offset` must lie on a valid UTF-8 character boundary within `text`.
+/// In debug builds an assertion fires for invalid offsets.
+pub fn byte_offset_to_utf16_offset(text: &str, byte_offset: usize) -> usize {
+    debug_assert!(
+        text.is_char_boundary(byte_offset),
+        "byte_offset {byte_offset} is not on a UTF-8 character boundary"
+    );
+    text[..byte_offset.min(text.len())].chars().map(|c| c.len_utf16()).sum()
+}
+
+/// Converts a UTF-16 code unit offset to a UTF-8 byte offset.
+///
+/// If the offset falls in the middle of a surrogate pair or beyond the end of
+/// the string, it is clamped to the next character boundary or `text.len()`.
+pub fn utf16_offset_to_byte_offset_clamped(text: &str, utf16_offset: usize) -> usize {
+    let mut counter = 0;
+    for (idx, c) in text.char_indices() {
+        if counter >= utf16_offset {
+            return idx;
+        }
+        counter += c.len_utf16();
+    }
+    text.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_byte_to_utf16() {
+        let cases: &[(&str, usize, usize)] = &[
+            ("hello", 0, 0),
+            ("hello", 3, 3), // ASCII: byte == UTF-16 code unit
+            ("hello", 5, 5),
+            ("", 0, 0),
+            ("日本語", 0, 0),
+            ("日本語", 3, 1), // BMP: 3 bytes → 1 code unit
+            ("日本語", 6, 2),
+            ("日本語", 9, 3),
+            ("a😀b", 0, 0),
+            ("a😀b", 1, 1),
+            ("a😀b", 5, 3), // emoji: 4 bytes → 2 code units
+            ("a😀b", 6, 4),
+        ];
+        for &(text, byte_col, expected) in cases {
+            assert_eq!(
+                byte_offset_to_utf16_offset(text, byte_col),
+                expected,
+                "byte_offset_to_utf16_offset({text:?}, {byte_col})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_utf16_to_byte_clamped() {
+        let cases: &[(&str, usize, usize)] = &[
+            ("hello", 0, 0),
+            ("hello", 3, 3), // ASCII
+            ("hello", 5, 5),
+            ("hello", 100, 5), // beyond end → clamped to text.len()
+            ("", 0, 0),
+            ("", 5, 0),
+            ("日本語", 0, 0),
+            ("日本語", 1, 3), // BMP
+            ("日本語", 2, 6),
+            ("日本語", 3, 9),
+            ("a😀b", 0, 0),
+            ("a😀b", 1, 1),
+            ("a😀b", 2, 5), // mid-surrogate → clamp past emoji
+            ("a😀b", 3, 5),
+            ("a😀b", 4, 6),
+        ];
+        for &(text, utf16_col, expected) in cases {
+            assert_eq!(
+                utf16_offset_to_byte_offset_clamped(text, utf16_col),
+                expected,
+                "utf16_offset_to_byte_offset_clamped({text:?}, {utf16_col})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let text = "héllo 日本語 😀 world";
+        for (byte_idx, _) in text.char_indices() {
+            let utf16 = byte_offset_to_utf16_offset(text, byte_idx);
+            assert_eq!(utf16_offset_to_byte_offset_clamped(text, utf16), byte_idx);
+        }
+        let utf16 = byte_offset_to_utf16_offset(text, text.len());
+        assert_eq!(utf16_offset_to_byte_offset_clamped(text, utf16), text.len());
+    }
+}

--- a/internal/common/unicode_utils.rs
+++ b/internal/common/unicode_utils.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip() {
-        let text = "héllo 日本語 😀 world";
+        let text = "héllo 日本語 😀 world"; // cspell:disable-line
         for (byte_idx, _) in text.char_indices() {
             let utf16 = byte_offset_to_utf16_offset(text, byte_idx);
             assert_eq!(utf16_offset_to_byte_offset_clamped(text, utf16), byte_idx);

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -102,7 +102,10 @@ impl SourceFileInner {
             if format == ByteFormat::Utf16
                 && let Some(source) = &self.source
             {
-                return i_slint_common::unicode_utils::byte_offset_to_utf16_offset(&source[line_begin..], col);
+                return i_slint_common::unicode_utils::byte_offset_to_utf16_offset(
+                    &source[line_begin..],
+                    col,
+                );
             }
             col
         };
@@ -137,7 +140,10 @@ impl SourceFileInner {
             if format == ByteFormat::Utf16
                 && let Some(source) = &self.source
             {
-                return i_slint_common::unicode_utils::utf16_offset_to_byte_offset_clamped(&source[line_begin..], col);
+                return i_slint_common::unicode_utils::utf16_offset_to_byte_offset_clamped(
+                    &source[line_begin..],
+                    col,
+                );
             }
             col
         };

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -130,7 +130,9 @@ impl SourceFileInner {
     /// Returns a tuple with the line (starting at 1) and column number (starting at 1)
     pub fn line_column(&self, offset: usize, format: ByteFormat) -> (usize, usize) {
         let adjust_utf16 = |line_begin, col| {
-            if format == ByteFormat::Utf16 && let Some(source) = &self.source {
+            if format == ByteFormat::Utf16
+                && let Some(source) = &self.source
+            {
                 return byte_col_to_utf16_col(&source[line_begin..], col);
             }
             col
@@ -163,7 +165,9 @@ impl SourceFileInner {
     /// Returns the offset that corresponds to the line/column
     pub fn offset(&self, line: usize, column: usize, format: ByteFormat) -> usize {
         let adjust_utf16 = |line_begin, col| {
-            if format == ByteFormat::Utf16 && let Some(source) = &self.source {
+            if format == ByteFormat::Utf16
+                && let Some(source) = &self.source
+            {
                 return utf16_col_to_byte_col(&source[line_begin..], col);
             }
             col

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -130,10 +130,8 @@ impl SourceFileInner {
     /// Returns a tuple with the line (starting at 1) and column number (starting at 1)
     pub fn line_column(&self, offset: usize, format: ByteFormat) -> (usize, usize) {
         let adjust_utf16 = |line_begin, col| {
-            if format == ByteFormat::Utf16 {
-                if let Some(source) = &self.source {
-                    return byte_col_to_utf16_col(&source[line_begin..], col);
-                }
+            if format == ByteFormat::Utf16 && let Some(source) = &self.source {
+                return byte_col_to_utf16_col(&source[line_begin..], col);
             }
             col
         };
@@ -165,10 +163,8 @@ impl SourceFileInner {
     /// Returns the offset that corresponds to the line/column
     pub fn offset(&self, line: usize, column: usize, format: ByteFormat) -> usize {
         let adjust_utf16 = |line_begin, col| {
-            if format == ByteFormat::Utf16 {
-                if let Some(source) = &self.source {
-                    return utf16_col_to_byte_col(&source[line_begin..], col);
-                }
+            if format == ByteFormat::Utf16 && let Some(source) = &self.source {
+                return utf16_col_to_byte_col(&source[line_begin..], col);
             }
             col
         };

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -65,37 +65,6 @@ pub trait Spanned {
     }
 }
 
-/// Converts a UTF-8 byte column offset to a UTF-16 code unit column offset.
-/// `line_text` must start at the beginning of the line; `byte_col` must be
-/// on a valid UTF-8 character boundary within `line_text`.
-fn byte_col_to_utf16_col(line_text: &str, byte_col: usize) -> usize {
-    debug_assert!(
-        line_text.is_char_boundary(byte_col),
-        "byte_col {byte_col} is not on a UTF-8 character boundary"
-    );
-    line_text[..byte_col].encode_utf16().count()
-}
-
-/// Converts a UTF-16 code unit column offset to a UTF-8 byte column offset.
-/// `line_text` must start at the beginning of the line.
-/// If `utf16_col` equals the total UTF-16 length of `line_text`, returns
-/// `line_text.len()`. If it is beyond that, returns `utf16_col` unchanged
-/// (same graceful-degradation behaviour as the original inline loop).
-fn utf16_col_to_byte_col(line_text: &str, utf16_col: usize) -> usize {
-    let mut counter = 0;
-    for (idx, c) in line_text.char_indices() {
-        if counter >= utf16_col {
-            return idx;
-        }
-        counter += c.len_utf16();
-    }
-    if counter >= utf16_col {
-        line_text.len() // utf16_col is exactly at end of string
-    } else {
-        utf16_col // truly out of range: preserve original fallback
-    }
-}
-
 #[derive(Default)]
 pub struct SourceFileInner {
     path: PathBuf,
@@ -133,7 +102,7 @@ impl SourceFileInner {
             if format == ByteFormat::Utf16
                 && let Some(source) = &self.source
             {
-                return byte_col_to_utf16_col(&source[line_begin..], col);
+                return i_slint_common::unicode_utils::byte_offset_to_utf16_offset(&source[line_begin..], col);
             }
             col
         };
@@ -168,7 +137,7 @@ impl SourceFileInner {
             if format == ByteFormat::Utf16
                 && let Some(source) = &self.source
             {
-                return utf16_col_to_byte_col(&source[line_begin..], col);
+                return i_slint_common::unicode_utils::utf16_offset_to_byte_offset_clamped(&source[line_begin..], col);
             }
             col
         };
@@ -705,47 +674,5 @@ component MainWindow inherits Window {
                 column += 1;
             }
         }
-    }
-
-    #[test]
-    fn test_byte_col_to_utf16_col() {
-        assert_eq!(byte_col_to_utf16_col("hello", 0), 0);
-        assert_eq!(byte_col_to_utf16_col("hello", 3), 3); // ASCII: byte == UTF-16
-        assert_eq!(byte_col_to_utf16_col("hello", 5), 5);
-        assert_eq!(byte_col_to_utf16_col("日本語", 0), 0);
-        assert_eq!(byte_col_to_utf16_col("日本語", 3), 1); // BMP: 3 bytes → 1 code unit
-        assert_eq!(byte_col_to_utf16_col("日本語", 6), 2);
-        assert_eq!(byte_col_to_utf16_col("a😀b", 1), 1);
-        assert_eq!(byte_col_to_utf16_col("a😀b", 5), 3); // emoji: 4 bytes → 2 code units
-        assert_eq!(byte_col_to_utf16_col("a😀b", 6), 4);
-        assert_eq!(byte_col_to_utf16_col("", 0), 0);
-    }
-
-    #[test]
-    fn test_utf16_col_to_byte_col() {
-        assert_eq!(utf16_col_to_byte_col("hello", 0), 0);
-        assert_eq!(utf16_col_to_byte_col("hello", 3), 3); // ASCII
-        assert_eq!(utf16_col_to_byte_col("hello", 5), 5);
-        assert_eq!(utf16_col_to_byte_col("日本語", 0), 0);
-        assert_eq!(utf16_col_to_byte_col("日本語", 1), 3); // BMP
-        assert_eq!(utf16_col_to_byte_col("日本語", 2), 6);
-        assert_eq!(utf16_col_to_byte_col("a😀b", 1), 1);
-        assert_eq!(utf16_col_to_byte_col("a😀b", 2), 5); // mid-surrogate → after emoji
-        assert_eq!(utf16_col_to_byte_col("a😀b", 3), 5);
-        assert_eq!(utf16_col_to_byte_col("a😀b", 4), 6);
-        // Out-of-range: returns utf16_col unchanged (graceful degradation)
-        assert_eq!(utf16_col_to_byte_col("hello", 100), 100);
-    }
-
-    #[test]
-    fn test_col_roundtrip() {
-        let text = "héllo 日本語 😀 world";
-        for (byte_idx, _) in text.char_indices() {
-            let utf16 = byte_col_to_utf16_col(text, byte_idx);
-            assert_eq!(utf16_col_to_byte_col(text, utf16), byte_idx);
-        }
-        // Also check end of string
-        let utf16 = byte_col_to_utf16_col(text, text.len());
-        assert_eq!(utf16_col_to_byte_col(text, utf16), text.len());
     }
 }

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -65,6 +65,37 @@ pub trait Spanned {
     }
 }
 
+/// Converts a UTF-8 byte column offset to a UTF-16 code unit column offset.
+/// `line_text` must start at the beginning of the line; `byte_col` must be
+/// on a valid UTF-8 character boundary within `line_text`.
+fn byte_col_to_utf16_col(line_text: &str, byte_col: usize) -> usize {
+    debug_assert!(
+        line_text.is_char_boundary(byte_col),
+        "byte_col {byte_col} is not on a UTF-8 character boundary"
+    );
+    line_text[..byte_col].encode_utf16().count()
+}
+
+/// Converts a UTF-16 code unit column offset to a UTF-8 byte column offset.
+/// `line_text` must start at the beginning of the line.
+/// If `utf16_col` equals the total UTF-16 length of `line_text`, returns
+/// `line_text.len()`. If it is beyond that, returns `utf16_col` unchanged
+/// (same graceful-degradation behaviour as the original inline loop).
+fn utf16_col_to_byte_col(line_text: &str, utf16_col: usize) -> usize {
+    let mut counter = 0;
+    for (idx, c) in line_text.char_indices() {
+        if counter >= utf16_col {
+            return idx;
+        }
+        counter += c.len_utf16();
+    }
+    if counter >= utf16_col {
+        line_text.len() // utf16_col is exactly at end of string
+    } else {
+        utf16_col // truly out of range: preserve original fallback
+    }
+}
+
 #[derive(Default)]
 pub struct SourceFileInner {
     path: PathBuf,
@@ -99,12 +130,12 @@ impl SourceFileInner {
     /// Returns a tuple with the line (starting at 1) and column number (starting at 1)
     pub fn line_column(&self, offset: usize, format: ByteFormat) -> (usize, usize) {
         let adjust_utf16 = |line_begin, col| {
-            if format == ByteFormat::Utf8 {
-                col
-            } else {
-                let Some(source) = &self.source else { return col };
-                source[line_begin..][..col].encode_utf16().count()
+            if format == ByteFormat::Utf16 {
+                if let Some(source) = &self.source {
+                    return byte_col_to_utf16_col(&source[line_begin..], col);
+                }
             }
+            col
         };
 
         let line_offsets = self.line_offsets();
@@ -134,19 +165,12 @@ impl SourceFileInner {
     /// Returns the offset that corresponds to the line/column
     pub fn offset(&self, line: usize, column: usize, format: ByteFormat) -> usize {
         let adjust_utf16 = |line_begin, col| {
-            if format == ByteFormat::Utf8 {
-                col
-            } else {
-                let Some(source) = &self.source else { return col };
-                let mut utf16_counter = 0;
-                for (utf8_index, c) in source[line_begin..].char_indices() {
-                    if utf16_counter >= col {
-                        return utf8_index;
-                    }
-                    utf16_counter += c.len_utf16();
+            if format == ByteFormat::Utf16 {
+                if let Some(source) = &self.source {
+                    return utf16_col_to_byte_col(&source[line_begin..], col);
                 }
-                col
             }
+            col
         };
 
         let col_offset = column.saturating_sub(1);
@@ -681,5 +705,47 @@ component MainWindow inherits Window {
                 column += 1;
             }
         }
+    }
+
+    #[test]
+    fn test_byte_col_to_utf16_col() {
+        assert_eq!(byte_col_to_utf16_col("hello", 0), 0);
+        assert_eq!(byte_col_to_utf16_col("hello", 3), 3); // ASCII: byte == UTF-16
+        assert_eq!(byte_col_to_utf16_col("hello", 5), 5);
+        assert_eq!(byte_col_to_utf16_col("日本語", 0), 0);
+        assert_eq!(byte_col_to_utf16_col("日本語", 3), 1); // BMP: 3 bytes → 1 code unit
+        assert_eq!(byte_col_to_utf16_col("日本語", 6), 2);
+        assert_eq!(byte_col_to_utf16_col("a😀b", 1), 1);
+        assert_eq!(byte_col_to_utf16_col("a😀b", 5), 3); // emoji: 4 bytes → 2 code units
+        assert_eq!(byte_col_to_utf16_col("a😀b", 6), 4);
+        assert_eq!(byte_col_to_utf16_col("", 0), 0);
+    }
+
+    #[test]
+    fn test_utf16_col_to_byte_col() {
+        assert_eq!(utf16_col_to_byte_col("hello", 0), 0);
+        assert_eq!(utf16_col_to_byte_col("hello", 3), 3); // ASCII
+        assert_eq!(utf16_col_to_byte_col("hello", 5), 5);
+        assert_eq!(utf16_col_to_byte_col("日本語", 0), 0);
+        assert_eq!(utf16_col_to_byte_col("日本語", 1), 3); // BMP
+        assert_eq!(utf16_col_to_byte_col("日本語", 2), 6);
+        assert_eq!(utf16_col_to_byte_col("a😀b", 1), 1);
+        assert_eq!(utf16_col_to_byte_col("a😀b", 2), 5); // mid-surrogate → after emoji
+        assert_eq!(utf16_col_to_byte_col("a😀b", 3), 5);
+        assert_eq!(utf16_col_to_byte_col("a😀b", 4), 6);
+        // Out-of-range: returns utf16_col unchanged (graceful degradation)
+        assert_eq!(utf16_col_to_byte_col("hello", 100), 100);
+    }
+
+    #[test]
+    fn test_col_roundtrip() {
+        let text = "héllo 日本語 😀 world";
+        for (byte_idx, _) in text.char_indices() {
+            let utf16 = byte_col_to_utf16_col(text, byte_idx);
+            assert_eq!(utf16_col_to_byte_col(text, utf16), byte_idx);
+        }
+        // Also check end of string
+        let utf16 = byte_col_to_utf16_col(text, text.len());
+        assert_eq!(utf16_col_to_byte_col(text, utf16), text.len());
     }
 }


### PR DESCRIPTION
## Summary

`SourceFileInner::line_column` and `::offset` each contained an inline `adjust_utf16` closure implementing a UTF-8 ↔ UTF-16 column conversion. The core algorithms were duplicated. This PR extracts them as two private free functions:

- `byte_col_to_utf16_col`: UTF-8 byte column → UTF-16 code unit column
- `utf16_col_to_byte_col`: UTF-16 code unit column → UTF-8 byte column

This is a follow-up to #10873, which noted in a comment that `diagnostics.rs` had overlapping logic with the new `unicode_utils` module, but that pulling `i-slint-compiler` into a dependency on `i-slint-core` to share the code would be the wrong direction. A private helper in `diagnostics.rs` itself is the right scope.

## Changes

- `byte_col_to_utf16_col` gets a `debug_assert!` for invalid byte boundaries, consistent with `unicode_utils::byte_offset_to_utf16_offset`
- `utf16_col_to_byte_col` correctly handles the end-of-string case (where `utf16_col` equals the total UTF-16 length) by returning `text.len()`, while preserving the original graceful-degradation fallback (`utf16_col` unchanged) for truly out-of-range input
- Unit tests and a roundtrip test covering ASCII, BMP, and supplementary (surrogate-pair) code points

## Verification

- `cargo test -p i-slint-compiler` — 292 tests pass
- `cargo test -p slint-lsp` — 284 tests pass, including `test_map_position`