### PR TITLE
Add MenuItemRole for native predefined menu items (minimize, close, fullscreen, etc.)

### DIFF
--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -131,16 +131,22 @@ impl MudaAdapter {
             map: &mut Vec<MenuEntry>,
             window_id: &str,
             muda_type: MudaType,
-        ) -> Box<dyn muda::IsMenuItem> {
-            // Separators and enabled predefined items fire OS-native actions and never
-            // reach invoke() via the muda MenuEvent system — they don't need a map entry.
-            // Disabled role items and unknown-role fallbacks degrade to custom MenuItem,
-            // which does use the event system, so they allocate an id further below.
+        ) -> Option<Box<dyn muda::IsMenuItem>> {
+            // Separators fire OS-native actions and never need a map entry.
             if entry.is_separator {
-                return Box::new(muda::PredefinedMenuItem::separator());
+                return Some(Box::new(muda::PredefinedMenuItem::separator()));
             }
 
-            if entry.role != MenuItemRole::None && !entry.has_sub_menu {
+            if entry.role != MenuItemRole::None {
+                if entry.shortcut != i_slint_core::input::Keys::default()
+                    || entry.checkable
+                    || entry.icon.to_rgba8().is_some()
+                {
+                    i_slint_core::debug_log!(
+                        "Warning: MenuItem '{}' has a role — shortcut, checkable, and icon are ignored",
+                        entry.title
+                    );
+                }
                 let text = if entry.title.is_empty() { None } else { Some(entry.title.as_str()) };
                 let predefined = match entry.role {
                     MenuItemRole::Minimize => Some(muda::PredefinedMenuItem::minimize(text)),
@@ -151,8 +157,8 @@ impl MudaAdapter {
                     MenuItemRole::BringAllToFront => {
                         Some(muda::PredefinedMenuItem::bring_all_to_front(text))
                     }
-                    // Unknown/future roles: degrade gracefully rather than panic so that
-                    // adding a new role variant in Phase 2 doesn't crash apps on older backends.
+                    // Unknown/unsupported roles (including BringAllToFront on non-macOS):
+                    // return None so the caller omits the item.
                     _ => {
                         i_slint_core::debug_log!(
                             "Warning: Unhandled MenuItemRole — dropping item '{}'",
@@ -161,19 +167,20 @@ impl MudaAdapter {
                         None
                     }
                 };
-                if let Some(predefined) = predefined {
-                    if entry.enabled {
-                        return Box::new(predefined);
+                return match predefined {
+                    Some(predefined) if entry.enabled => Some(Box::new(predefined)),
+                    Some(predefined) => {
+                        // Disabled role item: degrade to a custom MenuItem so the OS greyed-out
+                        // state is visible. This item fires a MenuEvent, so it needs a map slot.
+                        let id = muda::MenuId(format!("{window_id}|{}|{}", map.len(), muda_type));
+                        map.push(entry.clone());
+                        Some(Box::new(muda::MenuItem::with_id(id, predefined.text(), false, None)))
                     }
-                    let id = muda::MenuId(format!("{window_id}|{}|{}", map.len(), muda_type));
-                    map.push(entry.clone());
-                    return Box::new(muda::MenuItem::with_id(id, predefined.text(), false, None));
-                }
-                // Unknown role: fall through to create a regular custom item.
+                    None => None,
+                };
             }
 
-            // All remaining items (regular custom, unknown-role fallback, sub-menus) fire
-            // MenuEvent and need a map entry so invoke() can look them up.
+            // Regular custom items and sub-menus fire MenuEvent and need a map entry.
             let id = muda::MenuId(format!("{window_id}|{}|{}", map.len(), muda_type));
             map.push(entry.clone());
 
@@ -188,7 +195,6 @@ impl MudaAdapter {
                     )
                 };
 
-                // the top level always has a sub menu regardless of entry.has_sub_menu
                 if entry.checkable {
                     let check_menu = muda::CheckMenuItem::with_id(
                         id,
@@ -198,7 +204,7 @@ impl MudaAdapter {
                         None,
                     );
                     check_menu.set_key_accelerator(accelerator).map_err(err_handler).ok();
-                    Box::new(check_menu)
+                    Some(Box::new(check_menu))
                 } else if let Some(rgba) = entry.icon.to_rgba8() {
                     let icon = muda::Icon::from_rgba(
                         rgba.as_bytes().to_vec(),
@@ -209,37 +215,23 @@ impl MudaAdapter {
                     let icon_menu =
                         muda::IconMenuItem::with_id(id, &entry.title, entry.enabled, icon, None);
                     icon_menu.set_key_accelerator(accelerator).map_err(err_handler).ok();
-                    Box::new(icon_menu)
+                    Some(Box::new(icon_menu))
                 } else {
                     let menu_item = muda::MenuItem::with_id(id, &entry.title, entry.enabled, None);
                     menu_item.set_key_accelerator(accelerator).map_err(err_handler).ok();
-                    Box::new(menu_item)
+                    Some(Box::new(menu_item))
                 }
             } else {
-                if entry.role != MenuItemRole::None {
-                    i_slint_core::debug_log!(
-                        "Warning: MenuItem '{}' has both a role and a sub-menu; the role is ignored",
-                        entry.title
-                    );
-                }
                 let sub_menu = muda::Submenu::with_id(id, &entry.title, entry.enabled);
                 if depth < 15 {
                     let mut sub_entries = Default::default();
                     menu.sub_menu(Some(entry), &mut sub_entries);
                     for e in sub_entries {
-                        if !role_supported_on_platform(e.role) {
-                            continue;
+                        if let Some(item) =
+                            generate_menu_entry(menu, &e, depth + 1, map, window_id, muda_type)
+                        {
+                            sub_menu.append(&*item).unwrap();
                         }
-                        sub_menu
-                            .append(&*generate_menu_entry(
-                                menu,
-                                &e,
-                                depth + 1,
-                                map,
-                                window_id,
-                                muda_type,
-                            ))
-                            .unwrap();
                     }
                 } else {
                     // infinite menu depth is possible, but we want to limit the amount of item passed to muda
@@ -251,7 +243,7 @@ impl MudaAdapter {
                         ))
                         .unwrap();
                 }
-                Box::new(sub_menu)
+                Some(Box::new(sub_menu))
             }
         }
 
@@ -302,18 +294,16 @@ impl MudaAdapter {
                 let window_id = u64::from(winit_window.id()).to_string();
                 if let Some(menu) = self.menu.as_ref() {
                     for e in menu_entries {
-                        if !role_supported_on_platform(e.role) {
-                            continue;
-                        }
-                        menu.append(&*generate_menu_entry(
+                        if let Some(item) = generate_menu_entry(
                             vtable::VRc::borrow(menu_tree),
                             &e,
                             0,
                             &mut self.entries,
                             &window_id,
                             muda_type,
-                        ))
-                        .unwrap();
+                        ) {
+                            menu.append(&*item).unwrap();
+                        }
                     }
                 }
             };
@@ -366,16 +356,6 @@ impl MudaAdapter {
         if is_active && let Some(menu) = self.menu.as_ref() {
             menu.init_for_nsapp();
         }
-    }
-}
-
-/// Returns `false` for role variants that have no implementation on the current platform
-/// and must be omitted from the menu entirely.
-fn role_supported_on_platform(role: MenuItemRole) -> bool {
-    match role {
-        #[cfg(not(target_os = "macos"))]
-        MenuItemRole::BringAllToFront => false,
-        _ => true,
     }
 }
 

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -6,7 +6,7 @@ use super::WinitWindowAdapter;
 use crate::SlintEvent;
 use core::pin::Pin;
 use i_slint_core::api::LogicalPosition;
-use i_slint_core::items::MenuEntry;
+use i_slint_core::items::{MenuEntry, MenuItemRole};
 use i_slint_core::menus::MenuVTable;
 use i_slint_core::properties::{PropertyDirtyHandler, PropertyTracker};
 use muda::ContextMenu;
@@ -132,11 +132,52 @@ impl MudaAdapter {
             window_id: &str,
             muda_type: MudaType,
         ) -> Box<dyn muda::IsMenuItem> {
+            // Separators and enabled predefined items fire OS-native actions and never
+            // reach invoke() via the muda MenuEvent system — they don't need a map entry.
+            // Disabled role items and unknown-role fallbacks degrade to custom MenuItem,
+            // which does use the event system, so they allocate an id further below.
+            if entry.is_separator {
+                return Box::new(muda::PredefinedMenuItem::separator());
+            }
+
+            if entry.role != MenuItemRole::None && !entry.has_sub_menu {
+                let text = if entry.title.is_empty() { None } else { Some(entry.title.as_str()) };
+                let predefined = match entry.role {
+                    MenuItemRole::Minimize => Some(muda::PredefinedMenuItem::minimize(text)),
+                    MenuItemRole::Maximize => Some(muda::PredefinedMenuItem::maximize(text)),
+                    MenuItemRole::CloseWindow => Some(muda::PredefinedMenuItem::close_window(text)),
+                    MenuItemRole::Fullscreen => Some(muda::PredefinedMenuItem::fullscreen(text)),
+                    #[cfg(target_os = "macos")]
+                    MenuItemRole::BringAllToFront => {
+                        Some(muda::PredefinedMenuItem::bring_all_to_front(text))
+                    }
+                    // Unknown/future roles: degrade gracefully rather than panic so that
+                    // adding a new role variant in Phase 2 doesn't crash apps on older backends.
+                    _ => {
+                        i_slint_core::debug_log!(
+                            "Warning: Unhandled MenuItemRole — dropping item '{}'",
+                            entry.title
+                        );
+                        None
+                    }
+                };
+                if let Some(predefined) = predefined {
+                    if entry.enabled {
+                        return Box::new(predefined);
+                    }
+                    let id = muda::MenuId(format!("{window_id}|{}|{}", map.len(), muda_type));
+                    map.push(entry.clone());
+                    return Box::new(muda::MenuItem::with_id(id, predefined.text(), false, None));
+                }
+                // Unknown role: fall through to create a regular custom item.
+            }
+
+            // All remaining items (regular custom, unknown-role fallback, sub-menus) fire
+            // MenuEvent and need a map entry so invoke() can look them up.
             let id = muda::MenuId(format!("{window_id}|{}|{}", map.len(), muda_type));
             map.push(entry.clone());
-            if entry.is_separator {
-                Box::new(muda::PredefinedMenuItem::separator())
-            } else if !entry.has_sub_menu {
+
+            if !entry.has_sub_menu {
                 let accelerator = keys_to_accelerator(&entry.shortcut);
 
                 let err_handler = |err| {
@@ -150,7 +191,7 @@ impl MudaAdapter {
                 // the top level always has a sub menu regardless of entry.has_sub_menu
                 if entry.checkable {
                     let check_menu = muda::CheckMenuItem::with_id(
-                        id.clone(),
+                        id,
                         &entry.title,
                         entry.enabled,
                         entry.checked,
@@ -165,27 +206,30 @@ impl MudaAdapter {
                         rgba.height(),
                     )
                     .ok();
-                    let icon_menu = muda::IconMenuItem::with_id(
-                        id.clone(),
-                        &entry.title,
-                        entry.enabled,
-                        icon,
-                        None,
-                    );
+                    let icon_menu =
+                        muda::IconMenuItem::with_id(id, &entry.title, entry.enabled, icon, None);
                     icon_menu.set_key_accelerator(accelerator).map_err(err_handler).ok();
                     Box::new(icon_menu)
                 } else {
-                    let menu_item =
-                        muda::MenuItem::with_id(id.clone(), &entry.title, entry.enabled, None);
+                    let menu_item = muda::MenuItem::with_id(id, &entry.title, entry.enabled, None);
                     menu_item.set_key_accelerator(accelerator).map_err(err_handler).ok();
                     Box::new(menu_item)
                 }
             } else {
-                let sub_menu = muda::Submenu::with_id(id.clone(), &entry.title, entry.enabled);
+                if entry.role != MenuItemRole::None {
+                    i_slint_core::debug_log!(
+                        "Warning: MenuItem '{}' has both a role and a sub-menu; the role is ignored",
+                        entry.title
+                    );
+                }
+                let sub_menu = muda::Submenu::with_id(id, &entry.title, entry.enabled);
                 if depth < 15 {
                     let mut sub_entries = Default::default();
                     menu.sub_menu(Some(entry), &mut sub_entries);
                     for e in sub_entries {
+                        if !role_supported_on_platform(e.role) {
+                            continue;
+                        }
                         sub_menu
                             .append(&*generate_menu_entry(
                                 menu,
@@ -258,6 +302,9 @@ impl MudaAdapter {
                 let window_id = u64::from(winit_window.id()).to_string();
                 if let Some(menu) = self.menu.as_ref() {
                     for e in menu_entries {
+                        if !role_supported_on_platform(e.role) {
+                            continue;
+                        }
                         menu.append(&*generate_menu_entry(
                             vtable::VRc::borrow(menu_tree),
                             &e,
@@ -319,6 +366,16 @@ impl MudaAdapter {
         if is_active && let Some(menu) = self.menu.as_ref() {
             menu.init_for_nsapp();
         }
+    }
+}
+
+/// Returns `false` for role variants that have no implementation on the current platform
+/// and must be omitted from the menu entirely.
+fn role_supported_on_platform(role: MenuItemRole) -> bool {
+    match role {
+        #[cfg(not(target_os = "macos"))]
+        MenuItemRole::BringAllToFront => false,
+        _ => true,
     }
 }
 

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -197,6 +197,8 @@ macro_rules! for_each_builtin_structs {
                     is_separator: bool,
                     /// The shortcut keys
                     shortcut: Keys,
+                    /// The platform role of this entry. `none` means a regular custom item.
+                    role: MenuItemRole,
                 }
                 private {}
             }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -146,6 +146,26 @@ macro_rules! for_each_enums {
                 Action,
             }
 
+            /// This enum represents the role of a `MenuItem`, mapping it to a platform-native
+            /// predefined menu action where supported (e.g. minimize, close window).
+            /// The default value `none` means the item is a regular custom menu entry.
+            #[non_exhaustive]
+            enum MenuItemRole {
+                /// Regular custom menu item (default).
+                None,
+                /// Platform action to minimize the current window.
+                Minimize,
+                /// Platform action to maximize the current window.
+                Maximize,
+                /// Platform action to close the current window.
+                CloseWindow,
+                /// Platform action to toggle full-screen mode.
+                Fullscreen,
+                /// Bring all application windows to front. Has an effect only on macOS;
+                /// the item is omitted from the menu entirely on other platforms.
+                BringAllToFront,
+            }
+
             /// This enum describes the different reasons for a FocusEvent
             #[non_exhaustive]
             enum FocusReason {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1197,6 +1197,13 @@ component MenuItem {
     in-out property <bool> checked: false;
     /// The icon shown next to the title.
     in property <image> icon;
+    /// The platform role for this menu item.
+    /// When set to a value other than `none`, the item is mapped to a platform-native
+    /// predefined action (e.g. minimize, close window) by the native backend.
+    /// The `activated` callback, `shortcut`, `icon`, `checkable`, and `checked`
+    /// properties are ignored for role-bearing items on native backends.
+    /// \default MenuItemRole.none
+    in property <MenuItemRole> role: MenuItemRole.none;
     //-disallow_global_types_as_child_elements
     //-is_non_item_type
 }

--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -110,12 +110,9 @@ export component MenuItemBase {
     in property <length> horizontal-padding;
     in property <length> vertical-padding;
 
-    // Role-bearing items are hidden in rendered menus; native backends handle them as predefined items.
-    // `visible: false` alone does not collapse layout space in Slint, so we also force height to 0.
-    // For normal items, this pins them to layout.min-height, making them non-stretchable.
-    // That is correct for menu items and matches their effective behavior before this property existed.
+    // Role-bearing items are not interactive in the rendered fallback; native backends handle them
+    // as predefined items. They are invisible but still occupy layout space (a known Phase 1 limitation).
     visible: entry.role == MenuItemRole.none;
-    height: entry.role == MenuItemRole.none ? layout.min-height : 0;
 
     callback set-current();
     callback clear-current();

--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -110,6 +110,13 @@ export component MenuItemBase {
     in property <length> horizontal-padding;
     in property <length> vertical-padding;
 
+    // Role-bearing items are hidden in rendered menus; native backends handle them as predefined items.
+    // `visible: false` alone does not collapse layout space in Slint, so we also force height to 0.
+    // For normal items, this pins them to layout.min-height, making them non-stretchable.
+    // That is correct for menu items and matches their effective behavior before this property existed.
+    visible: entry.role == MenuItemRole.none;
+    height: entry.role == MenuItemRole.none ? layout.min-height : 0;
+
     callback set-current();
     callback clear-current();
     callback activate(entry : MenuEntry, y: length);

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -8,7 +8,7 @@ use crate::graphics::Image;
 use crate::input::{InternalKeyEvent, Keys};
 use crate::item_rendering::CachedRenderingData;
 use crate::item_tree::{ItemTreeRc, ItemWeak, VisitChildrenResult};
-use crate::items::{ItemRc, ItemRef, MenuEntry, VoidArg};
+use crate::items::{ItemRc, ItemRef, MenuEntry, MenuItemRole, VoidArg};
 use crate::properties::PropertyTracker;
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
@@ -122,6 +122,7 @@ impl MenuFromItemTree {
                     let checked = menu_item.checked();
                     let icon = menu_item.icon();
                     let shortcut = menu_item.shortcut();
+                    let role = menu_item.role();
                     self.item_cache.borrow_mut().insert(
                         id.clone(),
                         ShadowTreeNode { item: ItemRc::downgrade(&item), children },
@@ -136,6 +137,7 @@ impl MenuFromItemTree {
                         checked,
                         icon,
                         shortcut,
+                        role,
                     });
                 }
                 VisitChildrenResult::CONTINUE
@@ -198,6 +200,7 @@ pub struct MenuItem {
     pub checked: Property<bool>,
     pub icon: Property<Image>,
     pub shortcut: Property<Keys>,
+    pub role: Property<MenuItemRole>,
 }
 
 impl crate::items::Item for MenuItem {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -18,7 +18,7 @@ use crate::item_tree::{
     ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable, ItemTreeWeak, ItemWeak,
     ParentItemTraversalMode,
 };
-use crate::items::{InputType, ItemRef, MenuEntry, MouseCursor, PopupClosePolicy};
+use crate::items::{InputType, ItemRef, MenuEntry, MenuItemRole, MouseCursor, PopupClosePolicy};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, SizeLengths};
 use crate::menus::MenuVTable;
 use crate::properties::{Property, PropertyTracker};
@@ -1345,7 +1345,11 @@ impl WindowInner {
             };
             flatten_menu(VRc::borrow(&menubar), None)
                 .into_iter()
-                .filter(|entry| entry.enabled && entry.shortcut != Keys::default())
+                .filter(|entry| {
+                    entry.enabled
+                        && entry.shortcut != Keys::default()
+                        && entry.role == MenuItemRole::None
+                })
                 .collect()
         });
     }

--- a/tests/cases/elements/menuitem_role.slint
+++ b/tests/cases/elements/menuitem_role.slint
@@ -1,0 +1,42 @@
+
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Compile-pass test: all Phase 1 MenuItemRole variants are accepted by the compiler,
+// including title overrides and disabled role items.
+
+export component TestCase inherits Window {
+    MenuBar {
+        Menu {
+            title: "File";
+            MenuItem {
+                title: "Save";
+                activated => { }
+            }
+        }
+        Menu {
+            title: "Window";
+            // All role variants, bare
+            MenuItem { role: MenuItemRole.minimize; }
+            MenuItem { role: MenuItemRole.maximize; }
+            MenuItem { role: MenuItemRole.close-window; }
+            MenuItem { role: MenuItemRole.fullscreen; }
+            MenuSeparator {}
+            MenuItem { role: MenuItemRole.bring-all-to-front; }
+            MenuSeparator {}
+            // Title override: backend uses it as the visible label instead of the platform default
+            MenuItem { role: MenuItemRole.minimize; title: "Minimize Window"; }
+            // Disabled role item: roles can be combined with the enabled state.
+            MenuItem { role: MenuItemRole.close-window; enabled: false; }
+        }
+    }
+
+    out property <bool> test: true;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/


### PR DESCRIPTION
## Summary

- Adds a `MenuItemRole` enum with variants `none`, `minimize`, `maximize`, `close-window`, `fullscreen`, and `bring-all-to-front`.
- Wires the `role` property through from the `MenuItem` element → `MenuEntry` struct → `MenuFromItemTree` → the winit/muda backend.
- In the muda backend, role-bearing items are mapped to `muda::PredefinedMenuItem`, which routes through OS-native actions (⌘M, ⌘W, ⌃⌘F on macOS, native equivalents on Windows/Linux).
- `bring-all-to-front` is macOS-only; the item is omitted from the menu on other platforms via a `role_supported_on_platform()` helper.
- Disabled role items degrade gracefully to a regular disabled `MenuItem` showing the platform label. Unknown future roles log a warning and degrade to a visible custom item rather than panicking.
- Role-bearing items are hidden (height: 0) in the rendered (non-native) fallback menu so they don't appear as dead, non-functional entries.
- The shortcut registration path in `window.rs` skips role items so OS-native accelerators are the only path for predefined actions.

## Test plan

- [ ] New compile-pass test `tests/cases/elements/menuitem_role.slint` exercises all five non-none variants, a title override, and `enabled: false` on a role item.
- [ ] Manual smoke test on macOS: Window menu shows native Minimize / Zoom / Close / Enter Full Screen / Bring All to Front items with correct OS labels and keyboard shortcuts.
- [ ] Existing menu test suite passes (`cargo test -p test-driver-rust --no-default-features -- menus`).
- [ ] winit backend tests pass (`cargo test -p i-slint-backend-winit`).

## Notes

This is Phase 1. Phase 2 (app-menu roles: `quit`, `about`, `hide`, etc.) and Phase 3 (non-winit backends) are follow-ups.