### PR TITLE
file_watcher: filter transient NotFound IO errors from notify backend

### DIFF
--- a/internal/interpreter/file_watcher.rs
+++ b/internal/interpreter/file_watcher.rs
@@ -346,7 +346,11 @@ fn worker_loop(
                     on_error(err);
                 }
             }
-            WorkerMessage::RawEvent(Err(err)) => on_error(err),
+            WorkerMessage::RawEvent(Err(err)) => {
+                if !is_transient_watch_error(&err) {
+                    on_error(err);
+                }
+            }
             WorkerMessage::Shutdown => break,
         }
     }
@@ -402,12 +406,13 @@ fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
 }
 
 fn is_transient_watch_error(err: &notify::Error) -> bool {
-    matches!(
-        err.kind,
+    match &err.kind {
         notify::ErrorKind::PathNotFound
-            | notify::ErrorKind::WatchNotFound
-            | notify::ErrorKind::Generic(_)
-    )
+        | notify::ErrorKind::WatchNotFound
+        | notify::ErrorKind::Generic(_) => true,
+        notify::ErrorKind::Io(e) => e.kind() == std::io::ErrorKind::NotFound,
+        _ => false,
+    }
 }
 
 fn worker_stopped_error() -> notify::Error {
@@ -706,5 +711,17 @@ mod tests {
 
         ctx.write("thing/thing.slint", "export component Thing { in property<string> x; }");
         ctx.expect_event(&watched_nested, FileChangeKind::Created);
+    }
+
+    #[test]
+    fn removing_watched_directory_does_not_report_spurious_errors() {
+        let mut ctx = TestContext::new();
+        let watched = ctx.write("project/src/main.slint", "export component App { }");
+
+        ctx.watch(&["project/src/main.slint"]);
+        ctx.remove_dir_all("project");
+        ctx.expect_event(&watched, FileChangeKind::Deleted);
+        ctx.settle();
+        ctx.assert_no_errors();
     }
 }


### PR DESCRIPTION
The notify backend can emit Io(NotFound) errors when a watched directory disappears. Filter these as transient, like we already do for PathNotFound and WatchNotFound.

(Prospective) fix for the flaky refreshing_after_probe_directory_is_removed_recovers_cleanly test.
