### PR TITLE
Add Drag and Drop example and remove experimental marker from DnD types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dnd-kanban"
+version = "1.17.0"
+dependencies = [
+ "slint",
+ "slint-build",
+]
+
+[[package]]
 name = "doctests"
 version = "1.17.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   'examples/mcu-embassy',
   'examples/uefi-demo',
   'examples/async-io',
+  'examples/dnd-kanban',
   'examples/system_tray',
   'demos/weather-demo',
   'demos/usecases/rust',

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -169,6 +169,10 @@ export default defineConfig({
                                             label: "Custom Controls",
                                             slug: "guide/development/custom-controls",
                                         },
+                                        {
+                                            label: "Drag and Drop",
+                                            slug: "guide/development/drag-and-drop",
+                                        },
                                         "guide/development/best-practices",
                                         "guide/development/third-party-libraries",
                                     ],
@@ -222,10 +226,6 @@ export default defineConfig({
                                                   {
                                                       label: "FlexboxLayout",
                                                       slug: "guide/experimental/flexboxlayout",
-                                                  },
-                                                  {
-                                                      label: "Drag and Drop",
-                                                      slug: "guide/experimental/drag-and-drop",
                                                   },
                                                   {
                                                       label: "Interface",

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -299,6 +299,13 @@ export default defineConfig({
                                             },
                                         },
                                         {
+                                            label: "Drag and Drop",
+                                            autogenerate: {
+                                                directory:
+                                                    "reference/generated/drag-and-drop",
+                                            },
+                                        },
+                                        {
                                             label: "Keyboard Input",
                                             items: [
                                                 {

--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -1,6 +1,6 @@
 ---
 title: Drag and Drop
-description: Experimental DragArea and DropArea elements.
+description: DragArea and DropArea elements.
 ---
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -13,9 +13,6 @@ multi-filetype transfer mechanisms supported by various platforms. Due to the co
 this type, there is currently no way to interact with it from Slint code. To either create
 or fetch data from a `data-transfer` you need to register callbacks so that the host can
 handle it.
-
-> **Note**: These elements are experimental and subject to change.
-> Tracking issue: [slint-ui/slint#1967](https://github.com/slint-ui/slint/issues/1967).
 
 ## Example
 

--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -2,17 +2,15 @@
 title: Drag and Drop
 description: DragArea and DropArea elements.
 ---
-import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
+import Link from '@slint/common-files/src/components/Link.astro';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-`DragArea` and `DropArea` let the user drag data from one part of the UI and drop it on another.
-They can also accept drops from other applications on platforms that support it.
+Use <Link type="DragArea" /> and <Link type="DropArea" /> to move data between parts of the UI with a drag-and-drop gesture.
+On platforms that support it, a <Link type="DropArea" /> also accepts drops from other applications.
 
-The `data` field stores a `data-transfer` value, which is a type that abstracts over the
-multi-filetype transfer mechanisms supported by various platforms. Due to the complexity of
-this type, there is currently no way to interact with it from Slint code. To either create
-or fetch data from a `data-transfer` you need to register callbacks so that the host can
-handle it.
+The payload is a `data-transfer` value, which abstracts over the file-type transfer mechanisms supported by each platform.
+`data-transfer` values are opaque in Slint code:
+construct and read them via callbacks implemented in the host language.
 
 ## Example
 
@@ -95,55 +93,3 @@ fn main() {
 ```
 </TabItem>
 </Tabs>
-
-## DragArea
-
-`DragArea` is a non-visual element that makes its content draggable.
-When the user presses the mouse inside it and moves past a small threshold, a drag operation starts.
-Any child elements are still interactive: a simple click does not start a drag.
-
-### enabled
-<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
-When `false`, the element does not start drag operations.
-</SlintProperty>
-
-### data
-<SlintProperty propName="data" typeName="data-transfer">
-The payload that is transferred to the `DropArea` when the drop happens.
-</SlintProperty>
-
-## DropArea
-
-`DropArea` is a non-visual element that accepts drops from a `DragArea` (or from another application).
-It calls `can-drop` as the cursor moves over it to decide whether to accept the drag, and `dropped` when the user releases the mouse.
-
-### enabled
-<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
-When `false`, the element does not accept any drops.
-</SlintProperty>
-
-### contains-drag
-<SlintProperty propName="contains-drag" typeName="bool" defaultValue="false">
-Output property.
-Set to `true` while an accepted drag hovers over the area, and `false` otherwise.
-Use it to give visual feedback, for example by changing a background color.
-</SlintProperty>
-
-### can-drop(event: DropEvent) -> bool
-Called while the cursor moves over the area during a drag.
-Return `true` to accept the drag, or `false` to reject it.
-When the drag is accepted, `contains-drag` becomes `true` and the cursor changes to a "copy" shape.
-
-### dropped(event: DropEvent)
-Called when the user releases the mouse over the area after `can-drop` returned `true`.
-Use this callback to read `event.data` and apply the drop.
-
-## DropEvent
-
-`DropEvent` is the struct passed to the `can-drop` and `dropped` callbacks.
-
-| Field       | Type              | Description                                             |
-| ----------- | ----------------- | ------------------------------------------------------- |
-| `mime-type` | `string`          | The MIME type set on the source `DragArea`.             |
-| `data`      | `string`          | The payload set on the source `DragArea`.               |
-| `position`  | `LogicalPosition` | The cursor position in the `DropArea`'s local coordinates. |

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -285,6 +285,18 @@ See also the <Link type="Image" label="Image element"/>.
 
 </SlintProperty>
 
+### data-transfer
+<SlintProperty propName="data" typeName="data-transfer" defaultValue='an empty data-transfer'>
+
+A `data-transfer` value is the payload carried by drag-and-drop and clipboard operations.
+It abstracts over the file-type transfer mechanisms supported by each platform.
+
+The type is opaque in Slint code:
+construct a `data-transfer` value and read its content via callbacks implemented in the host language.
+See <Link type="DragAndDrop" /> for an end-to-end example.
+
+</SlintProperty>
+
 ## Animation
 ### easing
 <SlintProperty propName="easing" typeName="easing" defaultValue='linear'>

--- a/docs/common/src/utils/utils.ts
+++ b/docs/common/src/utils/utils.ts
@@ -70,6 +70,7 @@ export type KnownType =
     | "bool"
     | "brush"
     | "color"
+    | "data-transfer"
     | "duration"
     | "easing"
     | "enum"
@@ -115,6 +116,11 @@ export function getTypeInfo(typeName: KnownType): TypeInfo {
             return {
                 href: linkMap.color.href,
                 defaultValue: "a transparent color",
+            };
+        case "data-transfer":
+            return {
+                href: linkMap.data_transfer.href,
+                defaultValue: "an empty data-transfer",
             };
         case "duration":
             return {

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -200,7 +200,7 @@ pub struct StructDoc {
 }
 
 pub fn extract_builtin_structs(
-    include_experimental: bool,
+    _include_experimental: bool,
 ) -> std::collections::BTreeMap<String, StructDoc> {
     // `Point` should be in the documentation, but it's not inside of `for_each_builtin_structs`,
     // so we manually create its entry first.
@@ -307,10 +307,6 @@ pub fn extract_builtin_structs(
 
     // Internal type
     structs.remove("MenuEntry");
-    if !include_experimental {
-        // Experimental type
-        structs.remove("DropEvent");
-    }
 
     structs
 }

--- a/examples/dnd-kanban/Cargo.toml
+++ b/examples/dnd-kanban/Cargo.toml
@@ -1,0 +1,21 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "dnd-kanban"
+version = "1.17.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+build = "build.rs"
+publish = false
+license = "MIT"
+
+[[bin]]
+path = "main.rs"
+name = "dnd-kanban"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }
+
+[build-dependencies]
+slint-build = { path = "../../api/rs/build" }

--- a/examples/dnd-kanban/build.rs
+++ b/examples/dnd-kanban/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    slint_build::compile("kanban.slint").unwrap();
+}

--- a/examples/dnd-kanban/kanban.slint
+++ b/examples/dnd-kanban/kanban.slint
@@ -1,0 +1,166 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Palette } from "std-widgets.slint";
+
+export struct TaskData {
+    id: int,
+    title: string,
+}
+
+// Bridges between Slint's opaque `data-transfer` type and the typed
+// Rust payload we attach via `DataTransfer::set_user_data`. The
+// implementations live in Rust.
+export global Api {
+    pure callback make-data(task: TaskData, source-column: int, source-index: int) -> data-transfer;
+    pure callback can-drop(data: data-transfer, target-column: int) -> bool;
+    callback drop-task(data: data-transfer, target-column: int);
+}
+
+// Color palette that follows the system color scheme via `Palette`
+// (provided by `std-widgets`). Each property picks a dark or light variant.
+global Theme {
+    out property <bool> dark: Palette.color-scheme == ColorScheme.dark;
+    out property <color> window-bg:       dark ? #0d1117 : #ffffff;
+    out property <color> column-bg:       dark ? #161b22 : #f6f8fa;
+    out property <color> column-drop-bg:  dark ? #1d2733 : #eaf5ff;
+    out property <color> column-border:   dark ? #30363d : #d0d7de;
+    out property <color> card-bg:         dark ? #21262d : #ffffff;
+    out property <color> card-border:     dark ? #30363d : #d0d7de;
+    out property <color> shadow:          dark ? #00000066 : #00000018;
+    out property <color> text-primary:    dark ? #e6edf3 : #1f2328;
+    out property <color> text-secondary:  dark ? #768390 : #57606a;
+}
+
+component Card inherits Rectangle {
+    in property <TaskData> task;
+    in property <int> source-column;
+    in property <int> source-index;
+
+    height: 56px;
+    background: Theme.card-bg;
+    border-radius: 6px;
+    border-width: 1px;
+    border-color: Theme.card-border;
+    drop-shadow-blur: 6px;
+    drop-shadow-offset-y: 2px;
+    drop-shadow-color: Theme.shadow;
+
+    DragArea {
+        data: Api.make-data(root.task, root.source-column, root.source-index);
+
+        Text {
+            x: 12px;
+            width: parent.width - 24px;
+            text: root.task.title;
+            vertical-alignment: center;
+            color: Theme.text-primary;
+            overflow: elide;
+        }
+    }
+}
+
+component KanbanColumn inherits Rectangle {
+    in property <string> title;
+    in property <int> column-id;
+    in property <[TaskData]> tasks;
+    in property <color> accent;
+
+    background: drop-area.contains-drag ? Theme.column-drop-bg : Theme.column-bg;
+    border-radius: 10px;
+    border-width: 1px;
+    border-color: drop-area.contains-drag ? root.accent : Theme.column-border;
+    animate background, border-color { duration: 120ms; }
+
+    VerticalLayout {
+        padding: 12px;
+        spacing: 10px;
+
+        HorizontalLayout {
+            spacing: 8px;
+            Rectangle {
+                width: 10px;
+                height: 10px;
+                y: (parent.height - self.height) / 2;
+                border-radius: 5px;
+                background: root.accent;
+            }
+            Text {
+                text: root.title;
+                font-size: 15px;
+                font-weight: 700;
+                color: Theme.text-primary;
+                vertical-alignment: center;
+            }
+            Text {
+                text: root.tasks.length;
+                color: Theme.text-secondary;
+                vertical-alignment: center;
+                horizontal-alignment: right;
+                horizontal-stretch: 1;
+            }
+        }
+
+        drop-area := DropArea {
+            vertical-stretch: 1;
+            can-drop(event) => Api.can-drop(event.data, root.column-id);
+            dropped(event) => Api.drop-task(event.data, root.column-id);
+
+            VerticalLayout {
+                spacing: 8px;
+                alignment: start;
+                for task[i] in root.tasks: Card {
+                    task: task;
+                    source-column: root.column-id;
+                    source-index: i;
+                }
+            }
+        }
+    }
+}
+
+export component MainWindow inherits Window {
+    title: "Slint Kanban — Drag & Drop";
+    preferred-width: 760px;
+    preferred-height: 480px;
+    background: Theme.window-bg;
+
+    in-out property <[TaskData]> todo;
+    in-out property <[TaskData]> doing;
+    in-out property <[TaskData]> done;
+
+    VerticalLayout {
+        padding: 16px;
+        spacing: 12px;
+
+        Text {
+            text: "Drag a card between columns";
+            font-size: 18px;
+            font-weight: 700;
+            color: Theme.text-primary;
+        }
+
+        HorizontalLayout {
+            spacing: 12px;
+
+            KanbanColumn {
+                title: "Todo";
+                column-id: 0;
+                tasks: root.todo;
+                accent: Theme.dark ? #e3b341 : #d29922;
+            }
+            KanbanColumn {
+                title: "In Progress";
+                column-id: 1;
+                tasks: root.doing;
+                accent: Theme.dark ? #58a6ff : #1f6feb;
+            }
+            KanbanColumn {
+                title: "Done";
+                column-id: 2;
+                tasks: root.done;
+                accent: Theme.dark ? #3fb950 : #1a7f37;
+            }
+        }
+    }
+}

--- a/examples/dnd-kanban/main.rs
+++ b/examples/dnd-kanban/main.rs
@@ -1,0 +1,77 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+use std::rc::Rc;
+
+use slint::{DataTransfer, VecModel};
+
+slint::include_modules!();
+
+// What we attach to each `DataTransfer` via `set_user_data`. A clone of
+// the `TaskData` plus where it came from, so the drop handler can move
+// it without searching the source column by id.
+#[derive(Clone)]
+struct DragPayload {
+    task: TaskData,
+    source_column: usize,
+    source_index: usize,
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    let window = MainWindow::new()?;
+
+    let todo = Rc::new(VecModel::from(vec![
+        TaskData { id: 1, title: "Write release notes".into() },
+        TaskData { id: 2, title: "Reply to mailing list".into() },
+        TaskData { id: 3, title: "Triage open issues".into() },
+    ]));
+    let doing = Rc::new(VecModel::from(vec![
+        TaskData { id: 4, title: "Polish drag-and-drop example".into() },
+        TaskData { id: 5, title: "Review kanban PR".into() },
+    ]));
+    let done =
+        Rc::new(VecModel::from(vec![TaskData { id: 6, title: "Set up project skeleton".into() }]));
+
+    window.set_todo(todo.clone().into());
+    window.set_doing(doing.clone().into());
+    window.set_done(done.clone().into());
+
+    let columns = [todo, doing, done];
+    let api = window.global::<Api>();
+
+    api.on_make_data(|task, source_column, source_index| {
+        let mut transfer = DataTransfer::default();
+        transfer.set_user_data(Rc::new(DragPayload {
+            task,
+            source_column: source_column as usize,
+            source_index: source_index as usize,
+        }));
+        transfer
+    });
+
+    api.on_can_drop(|data, target| {
+        data.user_data()
+            .and_then(|rc| rc.downcast::<DragPayload>().ok())
+            .is_some_and(|p| p.source_column != target as usize)
+    });
+
+    api.on_drop_task({
+        let columns = columns.clone();
+        move |data, target| {
+            let target = target as usize;
+            let Some(payload) = data.user_data().and_then(|rc| rc.downcast::<DragPayload>().ok())
+            else {
+                return;
+            };
+            if target >= columns.len() || payload.source_column == target {
+                return;
+            }
+            // The clone we put in `user_data` is what we move; we just delete
+            // the source row.
+            columns[payload.source_column].remove(payload.source_index);
+            columns[target].push(payload.task.clone());
+        }
+    });
+
+    window.run()
+}

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -112,10 +112,10 @@ macro_rules! for_each_builtin_structs {
             struct DropEvent {
                 @name = BuiltinPrivateStruct::DropEvent,
                 export {
-                    /// The data to be accessed.
+                    /// The payload set on the source `DragArea`.
                     data: DataTransfer,
 
-                    /// The current mouse position in coordinates of the `DropArea` element
+                    /// The cursor position in the `DropArea`'s local coordinates.
                     position: LogicalPosition,
                 }
                 private {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1160,18 +1160,46 @@ export component ScaleRotateGestureHandler {
     //-default_size_binding:expands_to_parent_geometry
 }
 
+/// Use `DragArea` to make any part of the UI draggable.
+/// A drag starts when the user presses the mouse inside the area and moves past a small threshold,
+/// and the value bound to `data` becomes the drag payload delivered to a <Link type="DropArea" />.
+/// A click doesn't start a drag, so child elements like <Link type="TouchArea" /> stay interactive.
+///
+/// The payload is a `data-transfer` value, which abstracts over the file-type transfer mechanisms supported by each platform.
+/// `data-transfer` values are opaque in Slint code:
+/// construct and read them via callbacks implemented in the host language.
+///
+/// See <Link type="DragAndDrop" /> for a usage guide and a complete example.
+/// \group:drag-and-drop
 export component DragArea {
+    /// Set to `false` to stop the `DragArea` from starting drags.
+    /// Events still reach the child elements.
     in property <bool> enabled: true;
     //out property <bool> dragging;
+    /// The payload that's transferred to a <Link type="DropArea" /> when a drop happens.
     in property <data-transfer> data;
     //-default_size_binding:expands_to_parent_geometry
-
 }
 
+/// Use `DropArea` to accept drops coming from a <Link type="DragArea" />, or from another application on platforms that support it.
+/// The `can-drop` callback runs while the cursor moves over the area to decide whether to accept the drag.
+/// The `dropped` callback runs when the user releases the mouse inside the area after `can-drop` returned `true`.
+///
+/// See <Link type="DragAndDrop" /> for a usage guide and a complete example.
+/// \group:drag-and-drop
 export component DropArea {
+    /// Set to `false` to stop the `DropArea` from accepting any drops.
     in property <bool> enabled: true;
+    /// Return `true` from this callback to accept the drag, or `false` to reject it.
+    /// While the drag is accepted, `contains-drag` is `true` and the cursor changes to a "copy" shape.
+    /// The argument is a <Link type="DropEvent" /> describing the drag.
     callback can-drop(event: DropEvent) -> bool;
+    /// Invoked when the user releases the mouse over the area after `can-drop` returned `true`.
+    /// Use this callback to read `event.data` and apply the drop.
+    /// The argument is a <Link type="DropEvent" /> describing the drop.
     callback dropped(event: DropEvent);
+    /// `true` while an accepted drag hovers over the area, `false` otherwise.
+    /// Bind it to a visual property to give the user feedback, for example a background color.
     out property <bool> contains-drag;
     //-default_size_binding:expands_to_parent_geometry
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -637,11 +637,6 @@ impl TypeRegister {
         register.elements.remove("ComponentContainer").unwrap();
         register.types.remove("component-factory").unwrap();
 
-        register.types.remove("data-transfer").unwrap();
-        register.elements.remove("DragArea").unwrap();
-        register.elements.remove("DropArea").unwrap();
-        register.types.remove("DropEvent").unwrap(); // Also removed in docs/slint-doc-generator
-
         register.elements.remove("FlexboxLayout").unwrap();
         register.types.remove("FlexboxLayoutDirection").unwrap();
         register.types.remove("FlexboxLayoutAlignContent").unwrap();

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -29,6 +29,21 @@
     "color": {
         "href": "reference/primitive-types/#color"
     },
+    "DragAndDrop": {
+        "href": "guide/development/drag-and-drop/"
+    },
+    "data_transfer": {
+        "href": "reference/primitive-types/#data-transfer"
+    },
+    "DragArea": {
+        "href": "reference/drag-and-drop/dragarea/"
+    },
+    "DropArea": {
+        "href": "reference/drag-and-drop/droparea/"
+    },
+    "DropEvent": {
+        "href": "reference/global-structs-enums/#dropevent"
+    },
     "ComponentLibraries": {
         "href": "guide/language/coding/file/#component-libraries"
     },
@@ -211,6 +226,9 @@
     },
     "TextInput": {
         "href": "reference/keyboard-input/textinput/"
+    },
+    "TouchArea": {
+        "href": "reference/gestures/toucharea/"
     },
     "Timer": {
         "href": "reference/timer/"


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Short clip of the example:

https://github.com/user-attachments/assets/5c01f382-3aa9-4723-a9a0-2157a8e04bac


The example in Rust only at the moment, but the plan is to extend it with the other programming language as their `DataTransfer` gets exposed.
