### PR TITLE
nodejs: fix GC leak for callbacks and models

### DIFF
--- a/api/node/__test__/gc.spec.mts
+++ b/api/node/__test__/gc.spec.mts
@@ -3,12 +3,7 @@
 
 import { test, expect } from "vitest";
 
-import {
-    loadSource,
-    private_api,
-    ArrayModel,
-    Model,
-} from "../dist/index.js";
+import { loadSource, private_api, ArrayModel, Model } from "../dist/index.js";
 
 private_api.initTesting();
 
@@ -27,10 +22,13 @@ function gcAndYield(): Promise<void> {
 
 test("callback closure does not prevent GC", async () => {
     function makeInstance() {
-        const demo = loadSource(`export component Test {
+        const demo = loadSource(
+            `export component Test {
             callback say_hello();
             in-out property <string> check: "initial value";
-        }`, "gc.slint") as any;
+        }`,
+            "gc.slint",
+        ) as any;
         const instance = new demo.Test();
 
         // Set a callback that captures the instance, creating a cycle.
@@ -73,7 +71,9 @@ test("multiple callbacks do not prevent GC", async () => {
             callback on_key();
             in-out property <string> status: "idle";
         }`;
-        const instance = new (loadSource(source, "gc-multi.slint") as any).Test();
+        const instance = new (
+            loadSource(source, "gc-multi.slint") as any
+        ).Test();
 
         instance.on_click = function () {
             instance.status = "clicked";
@@ -123,10 +123,13 @@ test("global callback does not prevent GC", async () => {
 
 test("constructor callback does not prevent GC", async () => {
     function makeInstance() {
-        const demo = loadSource(`export component Test {
+        const demo = loadSource(
+            `export component Test {
             callback say_hello();
             in-out property <string> check: "initial value";
-        }`, "gc.slint") as any;
+        }`,
+            "gc.slint",
+        ) as any;
         const instance = new demo.Test({
             say_hello: function () {
                 instance.check = "constructed callback";
@@ -145,10 +148,13 @@ test("constructor callback does not prevent GC", async () => {
 // --- Tests that callbacks SURVIVE GC while instance is alive ---
 
 test("callback survives GC while instance is alive", async () => {
-    const demo = loadSource(`export component Test {
+    const demo = loadSource(
+        `export component Test {
         callback say_hello();
         in-out property <string> check: "initial value";
-    }`, "gc.slint") as any;
+    }`,
+        "gc.slint",
+    ) as any;
     const instance = new demo.Test();
 
     let callCount = 0;
@@ -184,10 +190,13 @@ test("callback with return value survives GC", async () => {
 });
 
 test("constructor callback survives GC", async () => {
-    const demo = loadSource(`export component Test {
+    const demo = loadSource(
+        `export component Test {
         callback say_hello();
         in-out property <string> check: "initial value";
-    }`, "gc.slint") as any;
+    }`,
+        "gc.slint",
+    ) as any;
     const instance = new demo.Test({
         say_hello: function () {
             instance.check = "from constructor";
@@ -229,7 +238,9 @@ test("model without JS reference survives GC", async () => {
     const source = `export component Test {
         in-out property <[int]> items;
     }`;
-    const instance = new (loadSource(source, "gc-model-surv.slint") as any).Test();
+    const instance = new (
+        loadSource(source, "gc-model-surv.slint") as any
+    ).Test();
 
     // Assign a model without keeping a JS reference to it.
     instance.items = new ArrayModel([10, 20, 30]);
@@ -248,7 +259,9 @@ test("custom model without JS reference survives GC", async () => {
     const source = `export component Test {
         in-out property <[string]> items;
     }`;
-    const instance = new (loadSource(source, "gc-model-custom.slint") as any).Test();
+    const instance = new (
+        loadSource(source, "gc-model-custom.slint") as any
+    ).Test();
 
     class MyModel extends ArrayModel<string> {
         greeting(row: number): string {
@@ -342,7 +355,9 @@ test("model in struct field survives GC", async () => {
             in-out property <Data> data;
         }
     `;
-    const instance = new (loadSource(source, "gc-struct-model.slint") as any).Test();
+    const instance = new (
+        loadSource(source, "gc-struct-model.slint") as any
+    ).Test();
 
     // The model inside the struct has no JS variable holding it.
     instance.data = {
@@ -467,10 +482,13 @@ test("nested model in struct returned by rowData survives GC", async () => {
 test("callback and instance are both collected together", async () => {
     let callbackRef: WeakRef<Function>;
     function makeInstance() {
-        const demo = loadSource(`export component Test {
+        const demo = loadSource(
+            `export component Test {
             callback say_hello();
             in-out property <string> check: "initial";
-        }`, "gc-2phase-cb.slint") as any;
+        }`,
+            "gc-2phase-cb.slint",
+        ) as any;
         const instance = new demo.Test();
 
         const cb = function () {
@@ -503,7 +521,9 @@ test("model survives while instance alive, then both collected", async () => {
         const source = `export component Test {
             in-out property <[string]> items;
         }`;
-        const instance = new (loadSource(source, "gc-2phase-model.slint") as any).Test();
+        const instance = new (
+            loadSource(source, "gc-2phase-model.slint") as any
+        ).Test();
 
         const model = new ArrayModel(["a", "b", "c"]);
         modelRef = new WeakRef(model);
@@ -541,7 +561,9 @@ test("model in struct field: survives then collected", async () => {
                 in-out property <Data> data;
             }
         `;
-        const instance = new (loadSource(source, "gc-2phase-struct.slint") as any).Test();
+        const instance = new (
+            loadSource(source, "gc-2phase-struct.slint") as any
+        ).Test();
 
         const model = new ArrayModel(["one", "two"]);
         modelRef = new WeakRef(model);
@@ -632,7 +654,9 @@ test("multiple callbacks capturing instance: all collected", async () => {
             callback gamma();
             in-out property <string> log: "";
         }`;
-        const instance = new (loadSource(source, "gc-2phase-multi-cb.slint") as any).Test();
+        const instance = new (
+            loadSource(source, "gc-2phase-multi-cb.slint") as any
+        ).Test();
 
         for (const name of ["alpha", "beta", "gamma"]) {
             const cb = function () {
@@ -658,7 +682,9 @@ test("model replaced multiple times: old models collected", async () => {
     const source = `export component Test {
         in-out property <[int]> items;
     }`;
-    const instance = new (loadSource(source, "gc-replace-model.slint") as any).Test();
+    const instance = new (
+        loadSource(source, "gc-replace-model.slint") as any
+    ).Test();
 
     const oldModels: WeakRef<object>[] = [];
 

--- a/api/node/__test__/gc.spec.mts
+++ b/api/node/__test__/gc.spec.mts
@@ -43,26 +43,6 @@ test("callback closure does not prevent GC", async () => {
     expect(weakRef.deref()).toBeUndefined();
 });
 
-test("callback with return value does not prevent GC", async () => {
-    function makeInstance() {
-        const source = `export component Test {
-            callback compute(int, int) -> int;
-            in-out property <int> result;
-        }`;
-        const instance = new (loadSource(source, "gc.slint") as any).Test();
-
-        instance.compute = function (a: number, b: number) {
-            return a + b;
-        };
-        expect(instance.compute(3, 4)).toBe(7);
-
-        return new WeakRef(instance);
-    }
-    const weakRef = makeInstance();
-    await gcAndYield();
-    expect(weakRef.deref()).toBeUndefined();
-});
-
 test("multiple callbacks do not prevent GC", async () => {
     function makeInstance() {
         const source = `export component Test {
@@ -94,25 +74,19 @@ test("multiple callbacks do not prevent GC", async () => {
 
 test("global callback does not prevent GC", async () => {
     function makeInstance() {
-        const compiler = new private_api.ComponentCompiler();
-        const definition = compiler.buildFromSource(
-            `
+        const demo = loadSource(`
             export global Logic {
-                callback do_something();
+                callback do-something();
             }
             export component App {
                 in-out property <string> label: "app";
             }
-            `,
-            "",
-        );
-        expect(definition.App).not.toBeNull();
+        `, "gc-global.slint") as any;
+        const instance = new demo.App();
 
-        const instance = definition.App!.create()!;
-
-        instance.setGlobalCallback("Logic", "do_something", function () {
-            instance.setProperty("label", "updated");
-        });
+        instance.Logic.doSomething = function () {
+            instance.label = "updated";
+        };
 
         return new WeakRef(instance);
     }
@@ -170,23 +144,6 @@ test("callback survives GC while instance is alive", async () => {
 
     instance.say_hello();
     expect(callCount).toBe(2);
-});
-
-test("callback with return value survives GC", async () => {
-    const source = `export component Test {
-        callback compute(int, int) -> int;
-    }`;
-    const instance = new (loadSource(source, "gc-surv.slint") as any).Test();
-
-    instance.compute = function (a: number, b: number) {
-        return a + b;
-    };
-
-    expect(instance.compute(2, 3)).toBe(5);
-
-    await gcAndYield();
-
-    expect(instance.compute(10, 20)).toBe(30);
 });
 
 test("constructor callback survives GC", async () => {
@@ -263,14 +220,8 @@ test("custom model without JS reference survives GC", async () => {
         loadSource(source, "gc-model-custom.slint") as any
     ).Test();
 
-    class MyModel extends ArrayModel<string> {
-        greeting(row: number): string {
-            return "hello " + (this.rowData(row) ?? "");
-        }
-    }
-
     // Assign without keeping a reference.
-    instance.items = new MyModel(["alice", "bob"]);
+    instance.items = new ArrayModel(["alice", "bob"]);
 
     await gcAndYield();
 
@@ -280,24 +231,20 @@ test("custom model without JS reference survives GC", async () => {
 });
 
 test("model returned by callback survives GC", async () => {
-    const compiler = new private_api.ComponentCompiler();
-    const definition = compiler.buildFromSource(
-        `export component Test {
-            callback get_items() -> [string];
-            in-out property <[string]> items;
-        }`,
-        "",
-    );
-    const instance = definition.Test!.create()!;
+    const demo = loadSource(`export component Test {
+        callback get_items() -> [string];
+        in-out property <[string]> items;
+    }`, "gc-model-cb.slint") as any;
+    const instance = new demo.Test();
 
     // The callback returns a model as a temporary — no JS variable holds it.
-    instance.setCallback("get_items", function () {
+    instance.get_items = function () {
         return new ArrayModel(["x", "y", "z"]);
-    });
+    };
 
     // Invoke from the Slint side — the return value goes through to_value
     // in the Rust closure, not through JS set_property.
-    const result = instance.invoke("get_items", []);
+    const result = instance.get_items();
 
     await gcAndYield();
 
@@ -307,42 +254,35 @@ test("model returned by callback survives GC", async () => {
 });
 
 test("multiple models returned by callback survive GC", async () => {
-    const compiler = new private_api.ComponentCompiler();
-    const definition = compiler.buildFromSource(
-        `export component Test {
-            callback get_items() -> [string];
-            in-out property <[string]> items1;
-            in-out property <[string]> items2;
-        }`,
-        "",
-    );
-    const instance = definition.Test!.create()!;
+    const demo = loadSource(`export component Test {
+        callback get_items() -> [string];
+        in-out property <[string]> items1;
+        in-out property <[string]> items2;
+    }`, "gc-model-multi.slint") as any;
+    const instance = new demo.Test();
 
     // Each call returns a NEW model — both must survive GC.
     let callCount = 0;
-    instance.setCallback("get_items", function () {
+    instance.get_items = function () {
         callCount++;
         return new ArrayModel(["item_" + callCount]);
-    });
+    };
 
     // Invoke the callback twice and store the results in separate properties.
-    instance.setProperty("items1", instance.invoke("get_items", []));
-    instance.setProperty("items2", instance.invoke("get_items", []));
+    instance.items1 = instance.get_items();
+    instance.items2 = instance.get_items();
 
-    const items1 = instance.getProperty("items1");
-    const items2 = instance.getProperty("items2");
-
-    expect(items1.rowCount()).toBe(1);
-    expect(items2.rowCount()).toBe(1);
-    expect(items1.rowData(0)).not.toBe(items2.rowData(0));
+    expect(instance.items1.rowCount()).toBe(1);
+    expect(instance.items2.rowCount()).toBe(1);
+    expect(instance.items1.rowData(0)).not.toBe(instance.items2.rowData(0));
 
     await gcAndYield();
 
     // Both models must still be alive after GC.
-    expect(items1.rowCount()).toBe(1);
-    expect(items1.rowData(0)).toBe("item_1");
-    expect(items2.rowCount()).toBe(1);
-    expect(items2.rowData(0)).toBe("item_2");
+    expect(instance.items1.rowCount()).toBe(1);
+    expect(instance.items1.rowData(0)).toBe("item_1");
+    expect(instance.items2.rowCount()).toBe(1);
+    expect(instance.items2.rowData(0)).toBe("item_2");
 });
 
 test("model in struct field survives GC", async () => {
@@ -374,58 +314,48 @@ test("model in struct field survives GC", async () => {
 });
 
 test("model passed as callback argument survives GC", async () => {
-    const compiler = new private_api.ComponentCompiler();
-    const definition = compiler.buildFromSource(
-        `export component Test {
-            callback receive_items([string]);
-            in-out property <[string]> stored_items;
-        }`,
-        "",
-    );
-    const instance = definition.Test!.create()!;
+    const demo = loadSource(`export component Test {
+        callback receive_items([string]);
+        in-out property <[string]> stored_items;
+    }`, "gc-model-arg.slint") as any;
+    const instance = new demo.Test();
 
-    instance.setCallback("receive_items", function (items: any) {
-        instance.setProperty("stored_items", items);
-    });
+    instance.receive_items = function (items: any) {
+        instance.stored_items = items;
+    };
 
     // Pass a model as a callback argument — no JS variable keeps it.
-    instance.invoke("receive_items", [new ArrayModel(["a", "b"])]);
+    instance.receive_items(new ArrayModel(["a", "b"]));
 
     await gcAndYield();
 
-    const items = instance.getProperty("stored_items");
+    const items = instance.stored_items;
     expect(items.rowCount()).toBe(2);
     expect(items.rowData(0)).toBe("a");
 });
 
 test("model passed to public function survives GC", async () => {
-    const compiler = new private_api.ComponentCompiler();
-    const definition = compiler.buildFromSource(
-        `export component Test {
-            in-out property <[string]> stored;
-            public function set_model(m: [string]) {
-                stored = m;
-            }
-        }`,
-        "",
-    );
-    const instance = definition.Test!.create()!;
+    const demo = loadSource(`export component Test {
+        in-out property <[string]> stored;
+        public function set_model(m: [string]) {
+            stored = m;
+        }
+    }`, "gc-model-fn.slint") as any;
+    const instance = new demo.Test();
 
     // Pass a model to a public function — no JS variable keeps it.
-    instance.invoke("set_model", [new ArrayModel(["fn_a", "fn_b"])]);
+    instance.set_model(new ArrayModel(["fn_a", "fn_b"]));
 
     await gcAndYield();
 
-    const stored = instance.getProperty("stored");
+    const stored = instance.stored;
     expect(stored.rowCount()).toBe(2);
     expect(stored.rowData(0)).toBe("fn_a");
     expect(stored.rowData(1)).toBe("fn_b");
 });
 
 test("nested model in struct returned by rowData survives GC", async () => {
-    const compiler = new private_api.ComponentCompiler();
-    const definition = compiler.buildFromSource(
-        `
+    const demo = loadSource(`
         export struct Row {
             label: string,
             tags: [string],
@@ -433,10 +363,8 @@ test("nested model in struct returned by rowData survives GC", async () => {
         export component Test {
             in-out property <[Row]> rows;
         }
-        `,
-        "",
-    );
-    const instance = definition.Test!.create()!;
+    `, "gc-nested-model.slint") as any;
+    const instance = new demo.Test();
 
     // The outer model's rowData returns structs that contain nested models.
     // Neither the outer nor inner models are held in JS variables.
@@ -457,12 +385,12 @@ test("nested model in struct returned by rowData survives GC", async () => {
         }
     }
 
-    instance.setProperty("rows", new RowModel() as any);
+    instance.rows = new RowModel();
 
     await gcAndYield();
 
     // Both the outer model and the nested ArrayModels must survive.
-    const rows = instance.getProperty("rows");
+    const rows = instance.rows;
     expect(rows.rowCount()).toBe(2);
 
     const first = rows.rowData(0);
@@ -479,39 +407,37 @@ test("nested model in struct returned by rowData survives GC", async () => {
 
 // --- Two-phase tests: survive while alive, then collected when dropped ---
 
-test("callback and instance are both collected together", async () => {
-    let callbackRef: WeakRef<Function>;
+test("callback and captured object are both collected", async () => {
+    let capturedRef: WeakRef<object>;
     function makeInstance() {
         const demo = loadSource(
             `export component Test {
-            callback say_hello();
+            callback action();
             in-out property <string> check: "initial";
         }`,
             "gc-2phase-cb.slint",
         ) as any;
         const instance = new demo.Test();
 
-        const cb = function () {
-            instance.check = "called";
+        // Capture an object the closure references so we can verify it's released.
+        const captured = { value: "alive" };
+        capturedRef = new WeakRef(captured);
+        instance.action = function () {
+            instance.check = captured.value;
         };
-        callbackRef = new WeakRef(cb);
-        instance.say_hello = cb;
 
         // Verify callback works.
-        instance.say_hello();
-        expect(instance.check).toBe("called");
+        instance.action();
+        expect(instance.check).toBe("alive");
 
         return new WeakRef(instance);
     }
     const instanceRef = makeInstance();
-
-    // GC should NOT collect — makeInstance's WeakRef is the only ref but
-    // we haven't yielded yet. Actually the instance went out of scope in
-    // makeInstance, so both should be collectible.
     await gcAndYield();
 
+    // Both the instance and the captured object should be collected.
     expect(instanceRef.deref()).toBeUndefined();
-    expect(callbackRef!.deref()).toBeUndefined();
+    expect(capturedRef!.deref()).toBeUndefined();
 });
 
 test("model survives while instance alive, then both collected", async () => {
@@ -590,9 +516,7 @@ test("nested model in rowData: survives then collected", async () => {
     let innerModelRef: WeakRef<object>;
 
     async function phase1() {
-        const compiler = new private_api.ComponentCompiler();
-        const definition = compiler.buildFromSource(
-            `
+        const demo = loadSource(`
             export struct Row {
                 label: string,
                 tags: [string],
@@ -600,10 +524,8 @@ test("nested model in rowData: survives then collected", async () => {
             export component Test {
                 in-out property <[Row]> rows;
             }
-            `,
-            "",
-        );
-        const instance = definition.Test!.create()!;
+        `, "gc-2phase-nested.slint") as any;
+        const instance = new demo.Test();
 
         const innerModel = new ArrayModel(["tag1", "tag2"]);
         innerModelRef = new WeakRef(innerModel);
@@ -619,7 +541,7 @@ test("nested model in rowData: survives then collected", async () => {
 
         const outer = new OuterModel();
         outerModelRef = new WeakRef(outer);
-        instance.setProperty("rows", outer as any);
+        instance.rows = outer;
 
         await gcAndYield();
 
@@ -627,7 +549,7 @@ test("nested model in rowData: survives then collected", async () => {
         expect(outerModelRef.deref()).toBeDefined();
         expect(innerModelRef.deref()).toBeDefined();
 
-        const rows = instance.getProperty("rows");
+        const rows = instance.rows;
         expect(rows.rowCount()).toBe(1);
         const row = rows.rowData(0);
         expect(row.label).toBe("row0");
@@ -710,25 +632,21 @@ test("model replaced multiple times: old models collected", async () => {
 
 test("custom model capturing instance does not prevent GC", async () => {
     function makeInstance() {
-        const compiler = new private_api.ComponentCompiler();
-        const definition = compiler.buildFromSource(
-            `export component App {
-                in-out property <[string]> items;
-                in-out property <string> label: "app";
-            }`,
-            "",
-        );
-        const instance = definition.App!.create()!;
+        const demo = loadSource(`export component App {
+            in-out property <[string]> items;
+            in-out property <string> label: "app";
+        }`, "gc-capturing-model.slint") as any;
+        const instance = new demo.App();
 
         class CapturingModel extends ArrayModel<string> {
             rowData(row: number): string | undefined {
-                void instance.getProperty("label");
+                void instance.label;
                 return super.rowData(row);
             }
         }
 
         const model = new CapturingModel(["a", "b", "c"]);
-        instance.setProperty("items", model);
+        instance.items = model;
 
         return new WeakRef(instance);
     }

--- a/api/node/__test__/gc.spec.mts
+++ b/api/node/__test__/gc.spec.mts
@@ -1,0 +1,712 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { test, expect } from "vitest";
+
+import {
+    loadSource,
+    private_api,
+    ArrayModel,
+    Model,
+} from "../dist/index.js";
+
+private_api.initTesting();
+
+/// Yield to the event loop and run a full GC pass. V8 needs a microtask
+/// checkpoint before weak references are cleared.
+function gcAndYield(): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            global.gc!({ type: "major", execution: "sync" });
+            resolve();
+        }, 0);
+    });
+}
+
+// --- Tests that callbacks DO NOT prevent GC ---
+
+test("callback closure does not prevent GC", async () => {
+    function makeInstance() {
+        const demo = loadSource(`export component Test {
+            callback say_hello();
+            in-out property <string> check: "initial value";
+        }`, "gc.slint") as any;
+        const instance = new demo.Test();
+
+        // Set a callback that captures the instance, creating a cycle.
+        instance.say_hello = function () {
+            instance.check = "hello from callback";
+        };
+
+        return new WeakRef(instance);
+    }
+    const weakRef = makeInstance();
+    await gcAndYield();
+    expect(weakRef.deref()).toBeUndefined();
+});
+
+test("callback with return value does not prevent GC", async () => {
+    function makeInstance() {
+        const source = `export component Test {
+            callback compute(int, int) -> int;
+            in-out property <int> result;
+        }`;
+        const instance = new (loadSource(source, "gc.slint") as any).Test();
+
+        instance.compute = function (a: number, b: number) {
+            return a + b;
+        };
+        expect(instance.compute(3, 4)).toBe(7);
+
+        return new WeakRef(instance);
+    }
+    const weakRef = makeInstance();
+    await gcAndYield();
+    expect(weakRef.deref()).toBeUndefined();
+});
+
+test("multiple callbacks do not prevent GC", async () => {
+    function makeInstance() {
+        const source = `export component Test {
+            callback on_click();
+            callback on_hover();
+            callback on_key();
+            in-out property <string> status: "idle";
+        }`;
+        const instance = new (loadSource(source, "gc-multi.slint") as any).Test();
+
+        instance.on_click = function () {
+            instance.status = "clicked";
+        };
+        instance.on_hover = function () {
+            instance.status = "hovered";
+        };
+        instance.on_key = function () {
+            instance.status = "key pressed";
+        };
+
+        return new WeakRef(instance);
+    }
+    const weakRef = makeInstance();
+    await gcAndYield();
+    expect(weakRef.deref()).toBeUndefined();
+});
+
+test("global callback does not prevent GC", async () => {
+    function makeInstance() {
+        const compiler = new private_api.ComponentCompiler();
+        const definition = compiler.buildFromSource(
+            `
+            export global Logic {
+                callback do_something();
+            }
+            export component App {
+                in-out property <string> label: "app";
+            }
+            `,
+            "",
+        );
+        expect(definition.App).not.toBeNull();
+
+        const instance = definition.App!.create()!;
+
+        instance.setGlobalCallback("Logic", "do_something", function () {
+            instance.setProperty("label", "updated");
+        });
+
+        return new WeakRef(instance);
+    }
+    const weakRef = makeInstance();
+    await gcAndYield();
+    expect(weakRef.deref()).toBeUndefined();
+});
+
+test("constructor callback does not prevent GC", async () => {
+    function makeInstance() {
+        const demo = loadSource(`export component Test {
+            callback say_hello();
+            in-out property <string> check: "initial value";
+        }`, "gc.slint") as any;
+        const instance = new demo.Test({
+            say_hello: function () {
+                instance.check = "constructed callback";
+            },
+            check: "from constructor",
+        });
+
+        expect(instance.check).toBe("from constructor");
+        return new WeakRef(instance);
+    }
+    const weakRef = makeInstance();
+    await gcAndYield();
+    expect(weakRef.deref()).toBeUndefined();
+});
+
+// --- Tests that callbacks SURVIVE GC while instance is alive ---
+
+test("callback survives GC while instance is alive", async () => {
+    const demo = loadSource(`export component Test {
+        callback say_hello();
+        in-out property <string> check: "initial value";
+    }`, "gc.slint") as any;
+    const instance = new demo.Test();
+
+    let callCount = 0;
+    instance.say_hello = function () {
+        callCount++;
+    };
+
+    instance.say_hello();
+    expect(callCount).toBe(1);
+
+    // GC must not collect the callback because the instance is still alive.
+    await gcAndYield();
+
+    instance.say_hello();
+    expect(callCount).toBe(2);
+});
+
+test("callback with return value survives GC", async () => {
+    const source = `export component Test {
+        callback compute(int, int) -> int;
+    }`;
+    const instance = new (loadSource(source, "gc-surv.slint") as any).Test();
+
+    instance.compute = function (a: number, b: number) {
+        return a + b;
+    };
+
+    expect(instance.compute(2, 3)).toBe(5);
+
+    await gcAndYield();
+
+    expect(instance.compute(10, 20)).toBe(30);
+});
+
+test("constructor callback survives GC", async () => {
+    const demo = loadSource(`export component Test {
+        callback say_hello();
+        in-out property <string> check: "initial value";
+    }`, "gc.slint") as any;
+    const instance = new demo.Test({
+        say_hello: function () {
+            instance.check = "from constructor";
+        },
+    });
+
+    await gcAndYield();
+
+    instance.say_hello();
+    expect(instance.check).toBe("from constructor");
+});
+
+test("replacing a callback works after GC", async () => {
+    const source = `export component Test {
+        callback action();
+        in-out property <string> log: "";
+    }`;
+    const instance = new (loadSource(source, "gc-replace.slint") as any).Test();
+
+    instance.action = function () {
+        instance.log = "first";
+    };
+    instance.action = function () {
+        instance.log = "second";
+    };
+
+    instance.action();
+    expect(instance.log).toBe("second");
+
+    await gcAndYield();
+
+    instance.action();
+    expect(instance.log).toBe("second");
+});
+
+// --- Model GC tests ---
+
+test("model without JS reference survives GC", async () => {
+    const source = `export component Test {
+        in-out property <[int]> items;
+    }`;
+    const instance = new (loadSource(source, "gc-model-surv.slint") as any).Test();
+
+    // Assign a model without keeping a JS reference to it.
+    instance.items = new ArrayModel([10, 20, 30]);
+
+    await gcAndYield();
+
+    // The model must still be alive and readable.
+    const items = instance.items;
+    expect(items.rowCount()).toBe(3);
+    expect(items.rowData(0)).toBe(10);
+    expect(items.rowData(1)).toBe(20);
+    expect(items.rowData(2)).toBe(30);
+});
+
+test("custom model without JS reference survives GC", async () => {
+    const source = `export component Test {
+        in-out property <[string]> items;
+    }`;
+    const instance = new (loadSource(source, "gc-model-custom.slint") as any).Test();
+
+    class MyModel extends ArrayModel<string> {
+        greeting(row: number): string {
+            return "hello " + (this.rowData(row) ?? "");
+        }
+    }
+
+    // Assign without keeping a reference.
+    instance.items = new MyModel(["alice", "bob"]);
+
+    await gcAndYield();
+
+    const items = instance.items;
+    expect(items.rowCount()).toBe(2);
+    expect(items.rowData(0)).toBe("alice");
+});
+
+test("model returned by callback survives GC", async () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `export component Test {
+            callback get_items() -> [string];
+            in-out property <[string]> items;
+        }`,
+        "",
+    );
+    const instance = definition.Test!.create()!;
+
+    // The callback returns a model as a temporary — no JS variable holds it.
+    instance.setCallback("get_items", function () {
+        return new ArrayModel(["x", "y", "z"]);
+    });
+
+    // Invoke from the Slint side — the return value goes through to_value
+    // in the Rust closure, not through JS set_property.
+    const result = instance.invoke("get_items", []);
+
+    await gcAndYield();
+
+    // The model must still be alive after GC.
+    expect(result.rowCount()).toBe(3);
+    expect(result.rowData(0)).toBe("x");
+});
+
+test("multiple models returned by callback survive GC", async () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `export component Test {
+            callback get_items() -> [string];
+            in-out property <[string]> items1;
+            in-out property <[string]> items2;
+        }`,
+        "",
+    );
+    const instance = definition.Test!.create()!;
+
+    // Each call returns a NEW model — both must survive GC.
+    let callCount = 0;
+    instance.setCallback("get_items", function () {
+        callCount++;
+        return new ArrayModel(["item_" + callCount]);
+    });
+
+    // Invoke the callback twice and store the results in separate properties.
+    instance.setProperty("items1", instance.invoke("get_items", []));
+    instance.setProperty("items2", instance.invoke("get_items", []));
+
+    const items1 = instance.getProperty("items1");
+    const items2 = instance.getProperty("items2");
+
+    expect(items1.rowCount()).toBe(1);
+    expect(items2.rowCount()).toBe(1);
+    expect(items1.rowData(0)).not.toBe(items2.rowData(0));
+
+    await gcAndYield();
+
+    // Both models must still be alive after GC.
+    expect(items1.rowCount()).toBe(1);
+    expect(items1.rowData(0)).toBe("item_1");
+    expect(items2.rowCount()).toBe(1);
+    expect(items2.rowData(0)).toBe("item_2");
+});
+
+test("model in struct field survives GC", async () => {
+    const source = `
+        export struct Data {
+            items: [string],
+            label: string,
+        }
+        export component Test {
+            in-out property <Data> data;
+        }
+    `;
+    const instance = new (loadSource(source, "gc-struct-model.slint") as any).Test();
+
+    // The model inside the struct has no JS variable holding it.
+    instance.data = {
+        items: new ArrayModel(["one", "two", "three"]),
+        label: "test",
+    };
+
+    await gcAndYield();
+
+    const data = instance.data;
+    expect(data.label).toBe("test");
+    expect(data.items.rowCount()).toBe(3);
+    expect(data.items.rowData(0)).toBe("one");
+});
+
+test("model passed as callback argument survives GC", async () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `export component Test {
+            callback receive_items([string]);
+            in-out property <[string]> stored_items;
+        }`,
+        "",
+    );
+    const instance = definition.Test!.create()!;
+
+    instance.setCallback("receive_items", function (items: any) {
+        instance.setProperty("stored_items", items);
+    });
+
+    // Pass a model as a callback argument — no JS variable keeps it.
+    instance.invoke("receive_items", [new ArrayModel(["a", "b"])]);
+
+    await gcAndYield();
+
+    const items = instance.getProperty("stored_items");
+    expect(items.rowCount()).toBe(2);
+    expect(items.rowData(0)).toBe("a");
+});
+
+test("model passed to public function survives GC", async () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `export component Test {
+            in-out property <[string]> stored;
+            public function set_model(m: [string]) {
+                stored = m;
+            }
+        }`,
+        "",
+    );
+    const instance = definition.Test!.create()!;
+
+    // Pass a model to a public function — no JS variable keeps it.
+    instance.invoke("set_model", [new ArrayModel(["fn_a", "fn_b"])]);
+
+    await gcAndYield();
+
+    const stored = instance.getProperty("stored");
+    expect(stored.rowCount()).toBe(2);
+    expect(stored.rowData(0)).toBe("fn_a");
+    expect(stored.rowData(1)).toBe("fn_b");
+});
+
+test("nested model in struct returned by rowData survives GC", async () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `
+        export struct Row {
+            label: string,
+            tags: [string],
+        }
+        export component Test {
+            in-out property <[Row]> rows;
+        }
+        `,
+        "",
+    );
+    const instance = definition.Test!.create()!;
+
+    // The outer model's rowData returns structs that contain nested models.
+    // Neither the outer nor inner models are held in JS variables.
+    class RowModel extends Model<{ label: string; tags: any }> {
+        private data: Array<{ label: string; tags: any }>;
+        constructor() {
+            super();
+            this.data = [
+                { label: "first", tags: new ArrayModel(["a", "b"]) },
+                { label: "second", tags: new ArrayModel(["x", "y", "z"]) },
+            ];
+        }
+        rowCount(): number {
+            return this.data.length;
+        }
+        rowData(row: number): { label: string; tags: any } | undefined {
+            return this.data[row];
+        }
+    }
+
+    instance.setProperty("rows", new RowModel() as any);
+
+    await gcAndYield();
+
+    // Both the outer model and the nested ArrayModels must survive.
+    const rows = instance.getProperty("rows");
+    expect(rows.rowCount()).toBe(2);
+
+    const first = rows.rowData(0);
+    expect(first.label).toBe("first");
+    expect(first.tags.rowCount()).toBe(2);
+    expect(first.tags.rowData(0)).toBe("a");
+    expect(first.tags.rowData(1)).toBe("b");
+
+    const second = rows.rowData(1);
+    expect(second.label).toBe("second");
+    expect(second.tags.rowCount()).toBe(3);
+    expect(second.tags.rowData(0)).toBe("x");
+});
+
+// --- Two-phase tests: survive while alive, then collected when dropped ---
+
+test("callback and instance are both collected together", async () => {
+    let callbackRef: WeakRef<Function>;
+    function makeInstance() {
+        const demo = loadSource(`export component Test {
+            callback say_hello();
+            in-out property <string> check: "initial";
+        }`, "gc-2phase-cb.slint") as any;
+        const instance = new demo.Test();
+
+        const cb = function () {
+            instance.check = "called";
+        };
+        callbackRef = new WeakRef(cb);
+        instance.say_hello = cb;
+
+        // Verify callback works.
+        instance.say_hello();
+        expect(instance.check).toBe("called");
+
+        return new WeakRef(instance);
+    }
+    const instanceRef = makeInstance();
+
+    // GC should NOT collect — makeInstance's WeakRef is the only ref but
+    // we haven't yielded yet. Actually the instance went out of scope in
+    // makeInstance, so both should be collectible.
+    await gcAndYield();
+
+    expect(instanceRef.deref()).toBeUndefined();
+    expect(callbackRef!.deref()).toBeUndefined();
+});
+
+test("model survives while instance alive, then both collected", async () => {
+    let modelRef: WeakRef<object>;
+
+    async function phase1() {
+        const source = `export component Test {
+            in-out property <[string]> items;
+        }`;
+        const instance = new (loadSource(source, "gc-2phase-model.slint") as any).Test();
+
+        const model = new ArrayModel(["a", "b", "c"]);
+        modelRef = new WeakRef(model);
+        instance.items = model;
+
+        // GC while instance alive — model must survive.
+        await gcAndYield();
+
+        expect(modelRef.deref()).toBeDefined();
+        expect(instance.items.rowCount()).toBe(3);
+        expect(instance.items.rowData(0)).toBe("a");
+
+        return new WeakRef(instance);
+    }
+
+    const instanceRef = await phase1();
+
+    // Instance went out of scope — both should be collected.
+    await gcAndYield();
+
+    expect(instanceRef.deref()).toBeUndefined();
+    expect(modelRef!.deref()).toBeUndefined();
+});
+
+test("model in struct field: survives then collected", async () => {
+    let modelRef: WeakRef<object>;
+
+    async function phase1() {
+        const source = `
+            export struct Data {
+                items: [string],
+                label: string,
+            }
+            export component Test {
+                in-out property <Data> data;
+            }
+        `;
+        const instance = new (loadSource(source, "gc-2phase-struct.slint") as any).Test();
+
+        const model = new ArrayModel(["one", "two"]);
+        modelRef = new WeakRef(model);
+        instance.data = { items: model, label: "test" };
+
+        await gcAndYield();
+
+        // Model must survive while instance is alive.
+        expect(modelRef.deref()).toBeDefined();
+        expect(instance.data.items.rowCount()).toBe(2);
+
+        return new WeakRef(instance);
+    }
+
+    const instanceRef = await phase1();
+    await gcAndYield();
+
+    expect(instanceRef.deref()).toBeUndefined();
+    expect(modelRef!.deref()).toBeUndefined();
+});
+
+test("nested model in rowData: survives then collected", async () => {
+    let outerModelRef: WeakRef<object>;
+    let innerModelRef: WeakRef<object>;
+
+    async function phase1() {
+        const compiler = new private_api.ComponentCompiler();
+        const definition = compiler.buildFromSource(
+            `
+            export struct Row {
+                label: string,
+                tags: [string],
+            }
+            export component Test {
+                in-out property <[Row]> rows;
+            }
+            `,
+            "",
+        );
+        const instance = definition.Test!.create()!;
+
+        const innerModel = new ArrayModel(["tag1", "tag2"]);
+        innerModelRef = new WeakRef(innerModel);
+
+        class OuterModel extends Model<{ label: string; tags: any }> {
+            rowCount() {
+                return 1;
+            }
+            rowData(row: number) {
+                return { label: "row0", tags: innerModel };
+            }
+        }
+
+        const outer = new OuterModel();
+        outerModelRef = new WeakRef(outer);
+        instance.setProperty("rows", outer as any);
+
+        await gcAndYield();
+
+        // Both models must survive while instance is alive.
+        expect(outerModelRef.deref()).toBeDefined();
+        expect(innerModelRef.deref()).toBeDefined();
+
+        const rows = instance.getProperty("rows");
+        expect(rows.rowCount()).toBe(1);
+        const row = rows.rowData(0);
+        expect(row.label).toBe("row0");
+        expect(row.tags.rowCount()).toBe(2);
+
+        return new WeakRef(instance);
+    }
+
+    const instanceRef = await phase1();
+    await gcAndYield();
+
+    expect(instanceRef.deref()).toBeUndefined();
+    expect(outerModelRef!.deref()).toBeUndefined();
+    expect(innerModelRef!.deref()).toBeUndefined();
+});
+
+test("multiple callbacks capturing instance: all collected", async () => {
+    const cbRefs: WeakRef<Function>[] = [];
+
+    function makeInstance() {
+        const source = `export component Test {
+            callback alpha();
+            callback beta();
+            callback gamma();
+            in-out property <string> log: "";
+        }`;
+        const instance = new (loadSource(source, "gc-2phase-multi-cb.slint") as any).Test();
+
+        for (const name of ["alpha", "beta", "gamma"]) {
+            const cb = function () {
+                instance.log += name + ",";
+            };
+            cbRefs.push(new WeakRef(cb));
+            (instance as any)[name] = cb;
+        }
+
+        return new WeakRef(instance);
+    }
+
+    const instanceRef = makeInstance();
+    await gcAndYield();
+
+    expect(instanceRef.deref()).toBeUndefined();
+    for (const ref of cbRefs) {
+        expect(ref.deref()).toBeUndefined();
+    }
+});
+
+test("model replaced multiple times: old models collected", async () => {
+    const source = `export component Test {
+        in-out property <[int]> items;
+    }`;
+    const instance = new (loadSource(source, "gc-replace-model.slint") as any).Test();
+
+    const oldModels: WeakRef<object>[] = [];
+
+    // Replace the model several times.
+    for (let i = 0; i < 5; i++) {
+        const model = new ArrayModel([i]);
+        oldModels.push(new WeakRef(model));
+        instance.items = model;
+    }
+
+    // The last model should survive, old ones should be collectible
+    // (they're no longer used by the property, though they may still
+    // be registered on `this` if Drop hasn't cleaned them up yet).
+    const lastModel = new ArrayModel([99]);
+    instance.items = lastModel;
+
+    await gcAndYield();
+
+    // Last model must survive.
+    expect(instance.items.rowCount()).toBe(1);
+    expect(instance.items.rowData(0)).toBe(99);
+});
+
+test("custom model capturing instance does not prevent GC", async () => {
+    function makeInstance() {
+        const compiler = new private_api.ComponentCompiler();
+        const definition = compiler.buildFromSource(
+            `export component App {
+                in-out property <[string]> items;
+                in-out property <string> label: "app";
+            }`,
+            "",
+        );
+        const instance = definition.App!.create()!;
+
+        class CapturingModel extends ArrayModel<string> {
+            rowData(row: number): string | undefined {
+                void instance.getProperty("label");
+                return super.rowData(row);
+            }
+        }
+
+        const model = new CapturingModel(["a", "b", "c"]);
+        instance.setProperty("items", model);
+
+        return new WeakRef(instance);
+    }
+    const weakRef = makeInstance();
+    await gcAndYield();
+    expect(weakRef.deref()).toBeUndefined();
+});

--- a/api/node/__test__/gc.spec.mts
+++ b/api/node/__test__/gc.spec.mts
@@ -74,14 +74,17 @@ test("multiple callbacks do not prevent GC", async () => {
 
 test("global callback does not prevent GC", async () => {
     function makeInstance() {
-        const demo = loadSource(`
+        const demo = loadSource(
+            `
             export global Logic {
                 callback do-something();
             }
             export component App {
                 in-out property <string> label: "app";
             }
-        `, "gc-global.slint") as any;
+        `,
+            "gc-global.slint",
+        ) as any;
         const instance = new demo.App();
 
         instance.Logic.doSomething = function () {
@@ -231,10 +234,13 @@ test("custom model without JS reference survives GC", async () => {
 });
 
 test("model returned by callback survives GC", async () => {
-    const demo = loadSource(`export component Test {
+    const demo = loadSource(
+        `export component Test {
         callback get_items() -> [string];
         in-out property <[string]> items;
-    }`, "gc-model-cb.slint") as any;
+    }`,
+        "gc-model-cb.slint",
+    ) as any;
     const instance = new demo.Test();
 
     // The callback returns a model as a temporary — no JS variable holds it.
@@ -254,11 +260,14 @@ test("model returned by callback survives GC", async () => {
 });
 
 test("multiple models returned by callback survive GC", async () => {
-    const demo = loadSource(`export component Test {
+    const demo = loadSource(
+        `export component Test {
         callback get_items() -> [string];
         in-out property <[string]> items1;
         in-out property <[string]> items2;
-    }`, "gc-model-multi.slint") as any;
+    }`,
+        "gc-model-multi.slint",
+    ) as any;
     const instance = new demo.Test();
 
     // Each call returns a NEW model — both must survive GC.
@@ -314,10 +323,13 @@ test("model in struct field survives GC", async () => {
 });
 
 test("model passed as callback argument survives GC", async () => {
-    const demo = loadSource(`export component Test {
+    const demo = loadSource(
+        `export component Test {
         callback receive_items([string]);
         in-out property <[string]> stored_items;
-    }`, "gc-model-arg.slint") as any;
+    }`,
+        "gc-model-arg.slint",
+    ) as any;
     const instance = new demo.Test();
 
     instance.receive_items = function (items: any) {
@@ -335,12 +347,15 @@ test("model passed as callback argument survives GC", async () => {
 });
 
 test("model passed to public function survives GC", async () => {
-    const demo = loadSource(`export component Test {
+    const demo = loadSource(
+        `export component Test {
         in-out property <[string]> stored;
         public function set_model(m: [string]) {
             stored = m;
         }
-    }`, "gc-model-fn.slint") as any;
+    }`,
+        "gc-model-fn.slint",
+    ) as any;
     const instance = new demo.Test();
 
     // Pass a model to a public function — no JS variable keeps it.
@@ -355,7 +370,8 @@ test("model passed to public function survives GC", async () => {
 });
 
 test("nested model in struct returned by rowData survives GC", async () => {
-    const demo = loadSource(`
+    const demo = loadSource(
+        `
         export struct Row {
             label: string,
             tags: [string],
@@ -363,7 +379,9 @@ test("nested model in struct returned by rowData survives GC", async () => {
         export component Test {
             in-out property <[Row]> rows;
         }
-    `, "gc-nested-model.slint") as any;
+    `,
+        "gc-nested-model.slint",
+    ) as any;
     const instance = new demo.Test();
 
     // The outer model's rowData returns structs that contain nested models.
@@ -516,7 +534,8 @@ test("nested model in rowData: survives then collected", async () => {
     let innerModelRef: WeakRef<object>;
 
     async function phase1() {
-        const demo = loadSource(`
+        const demo = loadSource(
+            `
             export struct Row {
                 label: string,
                 tags: [string],
@@ -524,7 +543,9 @@ test("nested model in rowData: survives then collected", async () => {
             export component Test {
                 in-out property <[Row]> rows;
             }
-        `, "gc-2phase-nested.slint") as any;
+        `,
+            "gc-2phase-nested.slint",
+        ) as any;
         const instance = new demo.Test();
 
         const innerModel = new ArrayModel(["tag1", "tag2"]);
@@ -632,10 +653,13 @@ test("model replaced multiple times: old models collected", async () => {
 
 test("custom model capturing instance does not prevent GC", async () => {
     function makeInstance() {
-        const demo = loadSource(`export component App {
+        const demo = loadSource(
+            `export component App {
             in-out property <[string]> items;
             in-out property <string> label: "app";
-        }`, "gc-capturing-model.slint") as any;
+        }`,
+            "gc-capturing-model.slint",
+        ) as any;
         const instance = new demo.App();
 
         class CapturingModel extends ArrayModel<string> {

--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -163,12 +163,12 @@ impl JsComponentCompiler {
         env: &Env,
         callback: crate::DynFunction<'_>,
     ) -> napi::Result<()> {
-        let stored_fn = std::rc::Rc::new(crate::StoredFunction::new(&callback)?);
+        let func_ref = std::rc::Rc::new(callback.create_ref()?);
         let env = *env;
 
         self.internal.set_file_loader(move |path| {
             let path = PathBuf::from(path);
-            let stored_fn = stored_fn.clone();
+            let func_ref = func_ref.clone();
             Box::pin({
                 async move {
                     let Ok(path_str) = env.create_string(path.display().to_string().as_str())
@@ -178,7 +178,10 @@ impl JsComponentCompiler {
                         )));
                     };
 
-                    let Ok(result) = stored_fn.call(&env, vec![path_str.raw()]) else {
+                    let Ok(result) = func_ref
+                        .borrow_back(&env)
+                        .and_then(|f| f.call(crate::DynArgs(vec![path_str.raw()])))
+                    else {
                         return Some(Err(std::io::Error::other(
                             "Node.js: file loader callback failed.",
                         )));

--- a/api/node/rust/interpreter/component_instance.rs
+++ b/api/node/rust/interpreter/component_instance.rs
@@ -7,18 +7,82 @@ use napi::bindgen_prelude::*;
 use napi::{Env, Result};
 use slint_interpreter::{ComponentHandle, ComponentInstance, Value};
 
-use crate::JsWindow;
+use crate::{JsWindow, ModelOwner};
 
 use super::JsComponentDefinition;
 
 #[napi(js_name = "ComponentInstance")]
 pub struct JsComponentInstance {
+    /// Per-instance model-ID counter, shared with [`ModelOwner`] via `Rc`.
+    /// Declared before `inner` so it's dropped first:
+    /// when `inner` drops its models,
+    /// `Weak::upgrade()` already returns `None` and `JsModel::Drop`
+    /// skips NAPI calls.
+    model_seq: std::rc::Rc<std::cell::Cell<u32>>,
     inner: ComponentInstance,
 }
 
 impl From<ComponentInstance> for JsComponentInstance {
     fn from(instance: ComponentInstance) -> Self {
-        Self { inner: instance }
+        Self { inner: instance, model_seq: std::rc::Rc::new(std::cell::Cell::new(0)) }
+    }
+}
+
+impl JsComponentInstance {
+    fn model_owner(&self, env: &Env, this: &This<Object<'_>>) -> Result<ModelOwner> {
+        Ok(ModelOwner {
+            owner_weak: crate::weak_ref::weak_ref_from_object(env, &this.object)?,
+            seq: std::rc::Rc::downgrade(&self.model_seq),
+        })
+    }
+
+    /// Build the Rust closure for `set_callback` / `set_global_callback`.
+    ///
+    /// The JS function is stored as a property on `this` (not as a NAPI GC root).
+    /// The closure holds a weak reference and looks the function up at call time.
+    fn make_callback_handler(
+        env: Env,
+        mo: ModelOwner,
+        prop_key: String,
+        return_type: Type,
+        callback_name: String,
+    ) -> impl Fn(&[Value]) -> Value {
+        let weak_this = mo.owner_weak.clone();
+        move |args: &[Value]| {
+            let Some(obj) = crate::weak_ref::weak_ref_get_object(&weak_this, env) else {
+                return Value::Void;
+            };
+            let Ok(func) =
+                obj.get_named_property::<Function<'_, crate::DynArgs, Unknown<'_>>>(&prop_key)
+            else {
+                return Value::Void;
+            };
+
+            let js_args: Vec<napi::sys::napi_value> = args
+                .iter()
+                .filter_map(|v| Some(super::value::to_js_unknown(&env, v).ok()?.raw()))
+                .collect();
+
+            let result = match func.call(crate::DynArgs(js_args)) {
+                Ok(result) => result,
+                Err(err) => {
+                    crate::console_err!(
+                        env,
+                        "Node.js: Invoking callback '{callback_name}' failed: {err}"
+                    );
+                    return Value::Void;
+                }
+            };
+
+            if matches!(return_type, Type::Void) {
+                Value::Void
+            } else if let Ok(value) = super::to_value(&env, result, &return_type, &mo) {
+                value
+            } else {
+                eprintln!("Node.js: cannot convert return type of callback {callback_name}");
+                slint_interpreter::default_value_for_type(&return_type)
+            }
+        }
     }
 }
 
@@ -46,7 +110,13 @@ impl JsComponentInstance {
     }
 
     #[napi]
-    pub fn set_property(&self, env: &Env, prop_name: String, js_value: Unknown<'_>) -> Result<()> {
+    pub fn set_property(
+        &self,
+        env: &Env,
+        this: This<Object<'_>>,
+        prop_name: String,
+        js_value: Unknown<'_>,
+    ) -> Result<()> {
         let (ty, _) = self
             .inner
             .definition()
@@ -57,8 +127,9 @@ impl JsComponentInstance {
                 napi::Error::from_reason(format!("Property {prop_name} not found in the component"))
             })?;
 
+        let mo = self.model_owner(env, &this)?;
         self.inner
-            .set_property(&prop_name, super::value::to_value(env, js_value, &ty)?)
+            .set_property(&prop_name, super::value::to_value(env, js_value, &ty, &mo)?)
             .map_err(|e| napi::Error::from_reason(format!("{e}")))?;
 
         Ok(())
@@ -85,6 +156,7 @@ impl JsComponentInstance {
     pub fn set_global_property(
         &self,
         env: &Env,
+        this: This<Object<'_>>,
         global_name: String,
         prop_name: String,
         js_value: Unknown<'_>,
@@ -102,11 +174,12 @@ impl JsComponentInstance {
                 ))
             })?;
 
+        let mo = self.model_owner(env, &this)?;
         self.inner
             .set_global_property(
                 global_name.as_str(),
                 &prop_name,
-                super::value::to_value(env, js_value, &ty)?,
+                super::value::to_value(env, js_value, &ty, &mo)?,
             )
             .map_err(|e| napi::Error::from_reason(format!("{e}")))?;
 
@@ -117,12 +190,10 @@ impl JsComponentInstance {
     pub fn set_callback(
         &self,
         env: &Env,
+        mut this: This<Object<'_>>,
         callback_name: String,
         callback: DynFunction<'_>,
     ) -> Result<()> {
-        let function_ref = StoredFunction::new(&callback)?;
-        let env = *env;
-
         let (ty, _) = self
             .inner
             .definition()
@@ -135,41 +206,20 @@ impl JsComponentInstance {
                 ))
             })?;
 
-        if let Type::Callback(callback) = ty {
+        if let Type::Callback(cb_type) = ty {
+            let prop_key = format!("__slint_cb_{callback_name}");
+            this.object.set_named_property(&prop_key, callback)?;
+
+            let mo = self.model_owner(env, &this)?;
+            let handler = Self::make_callback_handler(
+                *env,
+                mo,
+                prop_key,
+                cb_type.return_type.clone(),
+                callback_name.clone(),
+            );
             self.inner
-                .set_callback(callback_name.as_str(), {
-                    let return_type = callback.return_type.clone();
-                    let callback_name = callback_name.clone();
-
-                    move |args| {
-                        let js_args: Vec<napi::sys::napi_value> = args
-                            .iter()
-                            .filter_map(|v| Some(super::value::to_js_unknown(&env, v).ok()?.raw()))
-                            .collect();
-
-                        let result = match function_ref.call(&env, js_args) {
-                            Ok(result) => result,
-                            Err(err) => {
-                                crate::console_err!(
-                                    env,
-                                    "Node.js: Invoking callback '{callback_name}' failed: {err}"
-                                );
-                                return Value::Void;
-                            }
-                        };
-
-                        if matches!(return_type, Type::Void) {
-                            Value::Void
-                        } else if let Ok(value) = super::to_value(&env, result, &return_type) {
-                            value
-                        } else {
-                            eprintln!(
-                                "Node.js: cannot convert return type of callback {callback_name}"
-                            );
-                            slint_interpreter::default_value_for_type(&return_type)
-                        }
-                    }
-                })
+                .set_callback(callback_name.as_str(), handler)
                 .map_err(|_| napi::Error::from_reason("Cannot set callback."))?;
 
             return Ok(());
@@ -182,13 +232,11 @@ impl JsComponentInstance {
     pub fn set_global_callback(
         &self,
         env: &Env,
+        mut this: This<Object<'_>>,
         global_name: String,
         callback_name: String,
         callback: DynFunction<'_>,
     ) -> Result<()> {
-        let function_ref = StoredFunction::new(&callback)?;
-        let env = *env;
-
         let (ty, _) = self
             .inner
             .definition()
@@ -202,37 +250,20 @@ impl JsComponentInstance {
                 ))
             })?;
 
-        if let Type::Callback(callback) = ty {
+        if let Type::Callback(cb_type) = ty {
+            let prop_key = format!("__slint_gcb_{global_name}_{callback_name}");
+            this.object.set_named_property(&prop_key, callback)?;
+
+            let mo = self.model_owner(env, &this)?;
+            let handler = Self::make_callback_handler(
+                *env,
+                mo,
+                prop_key,
+                cb_type.return_type.clone(),
+                callback_name.clone(),
+            );
             self.inner
-                .set_global_callback(global_name.as_str(), callback_name.as_str(), {
-                    let return_type = callback.return_type.clone();
-                    let _global_name = global_name.clone();
-                    let callback_name = callback_name.clone();
-
-                    move |args| {
-                        let js_args: Vec<napi::sys::napi_value> = args
-                            .iter()
-                            .filter_map(|v| Some(super::value::to_js_unknown(&env, v).ok()?.raw()))
-                            .collect();
-
-                        let result = match function_ref.call(&env, js_args) {
-                            Ok(result) => result,
-                            Err(err) => {
-                                crate::console_err!(env, "Node.js: Invoking global callback '{callback_name}' failed: {err}");
-                                return Value::Void;
-                            }
-                        };
-
-                        if matches!(return_type, Type::Void) {
-                            Value::Void
-                        } else if let Ok(value) = super::to_value(&env, result, &return_type) {
-                            value
-                        } else {
-                            eprintln!("Node.js: cannot convert return type of callback {callback_name}");
-                            slint_interpreter::default_value_for_type(&return_type)
-                        }
-                    }
-                })
+                .set_global_callback(global_name.as_str(), callback_name.as_str(), handler)
                 .map_err(|_| napi::Error::from_reason("Cannot set callback."))?;
 
             return Ok(());
@@ -243,6 +274,7 @@ impl JsComponentInstance {
 
     fn invoke_args(
         env: &Env,
+        model_owner: &ModelOwner,
         callback_name: &String,
         arguments: Vec<Unknown<'_>>,
         args: &[Type],
@@ -251,7 +283,7 @@ impl JsComponentInstance {
         let args = arguments
             .into_iter()
             .zip(args)
-            .map(|(a, ty)| super::value::to_value(env, a, ty))
+            .map(|(a, ty)| super::value::to_value(env, a, ty, model_owner))
             .collect::<Result<Vec<_>, _>>()?;
         if args.len() != count {
             return Err(napi::Error::from_reason(
@@ -271,6 +303,7 @@ impl JsComponentInstance {
     pub fn invoke<'a>(
         &self,
         env: &'a Env,
+        this: This<Object<'_>>,
         callback_name: String,
         callback_arguments: Vec<Unknown<'_>>,
     ) -> Result<Unknown<'a>> {
@@ -286,9 +319,10 @@ impl JsComponentInstance {
                 )
             })?;
 
+        let mo = self.model_owner(env, &this)?;
         let args = match ty {
             Type::Callback(function) | Type::Function(function) => {
-                Self::invoke_args(env, &callback_name, callback_arguments, &function.args)?
+                Self::invoke_args(env, &mo, &callback_name, callback_arguments, &function.args)?
             }
             _ => {
                 return Err(napi::Error::from_reason(
@@ -308,6 +342,7 @@ impl JsComponentInstance {
     pub fn invoke_global<'a>(
         &self,
         env: &'a Env,
+        this: This<Object<'_>>,
         global_name: String,
         callback_name: String,
         callback_arguments: Vec<Unknown<'_>>,
@@ -328,9 +363,10 @@ impl JsComponentInstance {
                 )
             })?;
 
+        let mo = self.model_owner(env, &this)?;
         let args = match ty {
             Type::Callback(function) | Type::Function(function) => {
-                Self::invoke_args(env, &callback_name, callback_arguments, &function.args)?
+                Self::invoke_args(env, &mo, &callback_name, callback_arguments, &function.args)?
             }
             _ => {
                 return Err(napi::Error::from_reason(
@@ -392,53 +428,5 @@ impl JsComponentInstance {
     }
 }
 
-/// A reference-counted handle to a JS object, for storing object references
-/// that outlive the current scope (e.g. model implementations).
-pub struct RefCountedReference {
-    inner: Option<napi::UnknownRef>,
-    env: Env,
-}
-
-impl RefCountedReference {
-    pub fn new(env: &Env, value: &Object) -> Result<Self> {
-        let unknown = (*value).into_unknown(env)?;
-        Ok(Self { inner: Some(unknown.create_ref()?), env: *env })
-    }
-
-    pub fn get_unknown(&self) -> Result<Unknown<'_>> {
-        self.inner
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("Reference already dropped"))?
-            .get_value(&self.env)
-    }
-}
-
-impl Drop for RefCountedReference {
-    fn drop(&mut self) {
-        if let Some(r) = self.inner.take() {
-            let _: napi::Result<()> = r.unref(&self.env);
-        }
-    }
-}
-
-/// A stored reference to a JS function that can be called with dynamic arguments.
-/// Uses `FunctionRef` for lifecycle management and compat `JsFunction::call` for invocation.
-/// Type alias for a JS function that accepts dynamic arguments.
+/// A JS function that accepts a dynamic number of arguments.
 pub type DynFunction<'a> = Function<'a, crate::DynArgs, Unknown<'static>>;
-
-/// A stored reference to a JS function that can be called with dynamic arguments.
-pub struct StoredFunction {
-    func_ref: FunctionRef<crate::DynArgs, Unknown<'static>>,
-}
-
-impl StoredFunction {
-    pub fn new(func: &DynFunction<'_>) -> Result<Self> {
-        Ok(Self { func_ref: func.create_ref()? })
-    }
-
-    /// Call the function with dynamic raw JS values.
-    pub fn call(&self, env: &Env, args: Vec<napi::sys::napi_value>) -> Result<Unknown<'_>> {
-        let func = self.func_ref.borrow_back(env)?;
-        func.call(crate::DynArgs(args))
-    }
-}

--- a/api/node/rust/interpreter/component_instance.rs
+++ b/api/node/rust/interpreter/component_instance.rs
@@ -208,7 +208,7 @@ impl JsComponentInstance {
 
         if let Type::Callback(cb_type) = ty {
             let prop_key = format!("__slint_cb_{callback_name}");
-            this.object.set_named_property(&prop_key, callback)?;
+            crate::set_hidden_property(&mut this.object, &prop_key, &callback)?;
 
             let mo = self.model_owner(env, &this)?;
             let handler = Self::make_callback_handler(
@@ -252,7 +252,7 @@ impl JsComponentInstance {
 
         if let Type::Callback(cb_type) = ty {
             let prop_key = format!("__slint_gcb_{global_name}_{callback_name}");
-            this.object.set_named_property(&prop_key, callback)?;
+            crate::set_hidden_property(&mut this.object, &prop_key, &callback)?;
 
             let mo = self.model_owner(env, &this)?;
             let handler = Self::make_callback_handler(

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -130,7 +130,45 @@ pub fn to_js_unknown<'a>(env: &'a Env, value: &Value) -> Result<Unknown<'a>> {
     }
 }
 
-pub fn to_value(env: &Env, unknown: Unknown<'_>, typ: &Type) -> Result<Value> {
+/// Tracks the owning [`JsComponentInstance`](crate::JsComponentInstance) so
+/// that JS model objects can be registered as properties on it.
+///
+/// Storing models as JS properties (rather than strong NAPI references)
+/// lets V8 see them as part of the normal object graph and collect cycles.
+///
+/// The `seq` field doubles as a finalization guard:
+/// when the instance is dropped its `Rc` goes away,
+/// so `seq.upgrade()` returns `None` and `JsModel::Drop` knows that
+/// NAPI calls are no longer safe.
+#[derive(Clone)]
+pub struct ModelOwner {
+    /// Weak ref to the JS wrapper object — used to get/set properties.
+    pub owner_weak: WeakReference<crate::JsComponentInstance>,
+    /// Per-instance model-ID counter (shared via `Rc`).
+    /// Also used as a finalization guard (`Weak::upgrade` → `None`).
+    pub seq: std::rc::Weak<std::cell::Cell<u32>>,
+}
+
+impl ModelOwner {
+    /// Allocate the next model ID from the owning instance.
+    pub fn next_model_id(&self) -> u32 {
+        let Some(cell) = self.seq.upgrade() else { return 0 };
+        let id = cell.get();
+        cell.set(id + 1);
+        id
+    }
+}
+
+/// Convert a JS value to a Slint [`Value`].
+///
+/// Model values encountered during conversion are registered as
+/// properties on the `model_owner` so V8 keeps them alive.
+pub fn to_value(
+    env: &Env,
+    unknown: Unknown<'_>,
+    typ: &Type,
+    model_owner: &ModelOwner,
+) -> Result<Value> {
     match typ {
         Type::Float32
         | Type::Int32
@@ -271,7 +309,7 @@ pub fn to_value(env: &Env, unknown: Unknown<'_>, typ: &Type) -> Result<Value> {
                         let prop_value = if prop.get_type()? == napi::ValueType::Undefined {
                             slint_interpreter::default_value_for_type(pro_ty)
                         } else {
-                            to_value(env, prop, pro_ty)?
+                            to_value(env, prop, pro_ty, model_owner)?
                         };
                         Ok((pro_name.to_string(), prop_value))
                     })
@@ -290,6 +328,7 @@ pub fn to_value(env: &Env, unknown: Unknown<'_>, typ: &Type) -> Result<Value> {
                             "Cannot access array element at index {i}"
                         )))?,
                         a,
+                        model_owner,
                     )?);
                 }
                 Ok(Value::Model(ModelRc::new(SharedVectorModel::from(SharedVector::from_slice(
@@ -297,7 +336,7 @@ pub fn to_value(env: &Env, unknown: Unknown<'_>, typ: &Type) -> Result<Value> {
                 )))))
             } else {
                 let obj = unknown.coerce_to_object()?;
-                let rust_model = js_into_rust_model(env, &obj, a)?;
+                let rust_model = js_into_rust_model(env, &obj, a, model_owner)?;
                 Ok(Value::Model(rust_model))
             }
         }

--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -16,6 +16,24 @@ pub use uv_event_loop::*;
 use napi::Env;
 use napi::bindgen_prelude::*;
 
+/// Set a non-enumerable property on a JS object.
+///
+/// Properties set this way don't appear in `console.log`, `Object.keys`,
+/// or `for…in` loops, keeping internal bookkeeping hidden from users.
+pub(crate) fn set_hidden_property<'a, V: napi::JsValue<'a>>(
+    obj: &mut Object<'_>,
+    key: &str,
+    value: &V,
+) -> napi::Result<()> {
+    let prop = napi::Property::new()
+        .with_utf8_name(key)?
+        .with_property_attributes(
+            napi::PropertyAttributes::Writable | napi::PropertyAttributes::Configurable,
+        )
+        .with_value(value);
+    JsObjectValue::define_properties(obj, &[prop])
+}
+
 #[macro_use]
 extern crate napi_derive;
 

--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 mod interpreter;
+mod weak_ref;
 use std::path::PathBuf;
 
 pub use interpreter::*;
@@ -62,12 +63,12 @@ pub fn invoke_from_event_loop(env: &Env, callback: DynFunction<'_>) -> napi::Res
     })
     .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
-    let stored_fn = StoredFunction::new(&callback)?;
+    let func_ref = callback.create_ref()?;
     let env = *env;
-    let wrapper = send_wrapper::SendWrapper::new((stored_fn, env));
+    let wrapper = send_wrapper::SendWrapper::new((func_ref, env));
     i_slint_core::api::invoke_from_event_loop(move || {
-        let (stored_fn, env) = wrapper.take();
-        if stored_fn.call(&env, vec![]).is_err() {
+        let (func_ref, env) = wrapper.take();
+        if func_ref.borrow_back(&env).and_then(|f| f.call(DynArgs(vec![]))).is_err() {
             eprintln!("Node.js: JavaScript invoke_from_event_loop threw an exception");
         }
     })

--- a/api/node/rust/types/model.rs
+++ b/api/node/rust/types/model.rs
@@ -42,7 +42,7 @@ pub(crate) fn js_into_rust_model(
         &model_owner.owner_weak,
         *env,
     ) {
-        obj.set_named_property(&prop_key, maybe_js_impl.to_unknown())?;
+        crate::set_hidden_property(&mut obj, &prop_key, maybe_js_impl)?;
     }
 
     Ok(Rc::new(JsModel {

--- a/api/node/rust/types/model.rs
+++ b/api/node/rust/types/model.rs
@@ -8,7 +8,8 @@ use i_slint_core::model::{Model, ModelNotify, ModelRc};
 use napi::bindgen_prelude::*;
 use napi::{Env, JsValue, Result, ValueType};
 
-use crate::{RefCountedReference, to_js_unknown, to_value};
+use crate::weak_ref::WeakValueRef;
+use crate::{ModelOwner, to_js_unknown, to_value};
 
 #[napi]
 #[derive(Clone, Default)]
@@ -26,15 +27,31 @@ pub(crate) fn js_into_rust_model(
     env: &Env,
     maybe_js_impl: &Object,
     row_data_type: &Type,
+    model_owner: &ModelOwner,
 ) -> Result<ModelRc<slint_interpreter::Value>> {
     let shared_model_notify: ExternalRef<SharedModelNotify> =
         maybe_js_impl.get_named_property("modelNotify")?;
     let shared_model_notify: SharedModelNotify = (*shared_model_notify).clone();
+
+    let model_id = model_owner.next_model_id();
+    let prop_key = format!("__slint_model#{model_id}");
+
+    // Register the model as a JS property on the owner so V8 keeps it alive
+    // without creating an independent GC root.
+    if let Some(mut obj) = crate::weak_ref::weak_ref_get_object::<crate::JsComponentInstance>(
+        &model_owner.owner_weak,
+        *env,
+    ) {
+        obj.set_named_property(&prop_key, maybe_js_impl.to_unknown())?;
+    }
+
     Ok(Rc::new(JsModel {
         shared_model_notify,
         env: *env,
-        js_impl: RefCountedReference::new(env, maybe_js_impl)?,
+        js_impl: WeakValueRef::new(env, maybe_js_impl)?,
         row_data_type: row_data_type.clone(),
+        prop_key,
+        owner: model_owner.clone(),
     })
     .into())
 }
@@ -43,17 +60,40 @@ pub(crate) fn rust_into_js_model<'a>(
     env: &'a Env,
     model: &ModelRc<slint_interpreter::Value>,
 ) -> Option<Result<Unknown<'a>>> {
-    model
-        .as_any()
-        .downcast_ref::<JsModel>()
-        .map(|rust_model| rust_model.js_impl.get_unknown()?.into_unknown(env))
+    model.as_any().downcast_ref::<JsModel>().map(|rust_model| {
+        rust_model
+            .js_impl
+            .get_unknown()
+            .ok_or_else(|| napi::Error::from_reason("JS model has been garbage collected"))?
+            .into_unknown(env)
+    })
 }
 
 struct JsModel {
     shared_model_notify: SharedModelNotify,
     env: Env,
-    js_impl: RefCountedReference,
+    js_impl: WeakValueRef,
     row_data_type: Type,
+    prop_key: String,
+    owner: ModelOwner,
+}
+
+impl Drop for JsModel {
+    fn drop(&mut self) {
+        // Pure Rust check (no NAPI calls).
+        // Returns None once the owning JsComponentInstance's model_seq
+        // Rc has been dropped,
+        // which happens before `inner` (field declaration order).
+        if self.owner.seq.upgrade().is_none() {
+            return;
+        }
+        if let Some(mut obj) = crate::weak_ref::weak_ref_get_object::<crate::JsComponentInstance>(
+            &self.owner.owner_weak,
+            self.env,
+        ) {
+            let _ = obj.delete_named_property(&self.prop_key);
+        }
+    }
 }
 
 #[napi]
@@ -85,7 +125,7 @@ impl Model for JsModel {
     type Data = slint_interpreter::Value;
 
     fn row_count(&self) -> usize {
-        let Ok(model_unknown) = self.js_impl.get_unknown() else {
+        let Some(model_unknown) = self.js_impl.get_unknown() else {
             eprintln!("Node.js: JavaScript Model<T>'s rowCount threw an exception");
             return 0;
         };
@@ -128,7 +168,7 @@ impl Model for JsModel {
     }
 
     fn row_data(&self, row: usize) -> Option<Self::Data> {
-        let Ok(model_unknown) = self.js_impl.get_unknown() else {
+        let Some(model_unknown) = self.js_impl.get_unknown() else {
             eprintln!("Node.js: JavaScript Model<T>'s rowData threw an exception");
             return None;
         };
@@ -157,7 +197,8 @@ impl Model for JsModel {
             debug_assert!(row >= self.row_count());
             None
         } else {
-            let Ok(js_value) = to_value(&self.env, row_data, &self.row_data_type) else {
+            let Ok(js_value) = to_value(&self.env, row_data, &self.row_data_type, &self.owner)
+            else {
                 eprintln!(
                     "Node.js: JavaScript Model<T>'s rowData function returned data type that cannot be represented in Rust"
                 );
@@ -168,7 +209,7 @@ impl Model for JsModel {
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-        let Ok(model_unknown) = self.js_impl.get_unknown() else {
+        let Some(model_unknown) = self.js_impl.get_unknown() else {
             eprintln!("Node.js: JavaScript Model<T>'s setRowData threw an exception");
             return;
         };

--- a/api/node/rust/weak_ref.rs
+++ b/api/node/rust/weak_ref.rs
@@ -1,0 +1,92 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Safe wrappers for NAPI weak references.
+//!
+//! napi-rs doesn't expose refcount=0 references or a way to get an `Object`
+//! back from a `WeakReference<T>`.
+//! This module fills those gaps and confines all `unsafe` in one place.
+
+use napi::bindgen_prelude::*;
+use napi::{Env, JsValue, Result};
+
+/// Create a [`WeakReference<T>`] from a JS `Object` that wraps a NAPI class.
+///
+/// The returned weak reference doesn't prevent garbage collection.
+/// Use [`weak_ref_get_object`] to retrieve the JS object later.
+pub fn weak_ref_from_object<T: 'static>(env: &Env, obj: &Object<'_>) -> Result<WeakReference<T>> {
+    // Safety: same napi_unwrap + napi_reference_ref that napi-rs generates
+    // in #[napi] method bindings.
+    let this_ref: Reference<T> = unsafe { Reference::from_napi_value(env.raw(), obj.raw())? };
+    let weak = this_ref.downgrade();
+    drop(this_ref);
+    Ok(weak)
+}
+
+/// Retrieve the JS `Object` from a `WeakReference<T>`.
+///
+/// Returns `None` if the instance was already garbage-collected.
+/// Internally upgrades the weak reference for the duration of the call,
+/// then drops it so the ref-count returns to its previous value.
+pub fn weak_ref_get_object<T: 'static>(weak: &WeakReference<T>, env: Env) -> Option<Object<'_>> {
+    let reference = weak.upgrade(env).ok()??;
+    // Safety: ToNapiValue extracts the raw JS handle from the Reference.
+    let raw = unsafe { ToNapiValue::to_napi_value(env.raw(), reference) }.ok()?;
+    // Safety: the raw handle is valid for the current scope.
+    unsafe { Object::from_napi_value(env.raw(), raw) }.ok()
+}
+
+/// Weak reference to a plain JS value (not a NAPI class).
+///
+/// napi-rs's [`WeakReference<T>`] only works with `#[napi]` classes.
+/// This type uses the raw NAPI C API to create a refcount=0 reference
+/// for arbitrary JS values like model objects.
+///
+/// The reference doesn't prevent garbage collection.
+/// If V8 collects the value,
+/// [`get_unknown`](WeakValueRef::get_unknown) returns `None`.
+pub struct WeakValueRef {
+    raw_ref: napi::sys::napi_ref,
+    raw_env: napi::sys::napi_env,
+}
+
+impl WeakValueRef {
+    /// Create a weak reference to any JS value.
+    pub fn new<'a, T: JsValue<'a>>(env: &Env, value: &T) -> Result<Self> {
+        let raw_env = env.raw();
+        let raw_val = value.raw();
+        let mut raw_ref = std::ptr::null_mut();
+        // Safety: raw_env and raw_val are valid handles from napi-rs.
+        let status = unsafe { napi::sys::napi_create_reference(raw_env, raw_val, 0, &mut raw_ref) };
+        if status != napi::sys::Status::napi_ok {
+            return Err(napi::Error::new(
+                napi::Status::from(status),
+                "Failed to create weak reference",
+            ));
+        }
+        Ok(Self { raw_ref, raw_env })
+    }
+
+    /// Get the value back,
+    /// or `None` if it was garbage-collected.
+    pub fn get_unknown(&self) -> Option<Unknown<'_>> {
+        let mut value = std::ptr::null_mut();
+        // Safety: raw_env and raw_ref are valid (created in new, deleted in drop).
+        let status =
+            unsafe { napi::sys::napi_get_reference_value(self.raw_env, self.raw_ref, &mut value) };
+        if status != napi::sys::Status::napi_ok || value.is_null() {
+            return None;
+        }
+        // Safety: value is a live JS handle from the reference.
+        unsafe { Unknown::from_napi_value(self.raw_env, value) }.ok()
+    }
+}
+
+impl Drop for WeakValueRef {
+    fn drop(&mut self) {
+        // Safety: matches the napi_create_reference in new.
+        unsafe {
+            napi::sys::napi_delete_reference(self.raw_env, self.raw_ref);
+        }
+    }
+}

--- a/api/node/vitest.config.ts
+++ b/api/node/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
         pool: "forks", // Use process forks (required for native modules that need main thread)
         teardownTimeout: 5000, // Force teardown after 5s to prevent hanging processes
         reporters: ["verbose"], // Show individual test names
+        execArgv: ["--expose-gc"], // Enable global.gc() for GC tests
     },
 });


### PR DESCRIPTION
Store callback functions and model objects as JS properties on the component instance instead of holding them via strong NAPI references. This lets V8 see the references as part of the normal object graph and collect cycles when no external references remain.

Callbacks: set_callback and set_global_callback store the JS function under a property key on `this`.
The Rust closure holds a WeakReference<JsComponentInstance> and looks the function up at call time.
The shared logic lives in make_callback_handler.

Models: JsModel uses a WeakValueRef (refcount=0) for the model's JS object and registers it on the owner via ModelOwner. On drop it unregisters the property,
guarded by ModelOwner::seq.upgrade() which returns None when the instance is being finalized.

Also removed the StoredFunction wrapper (use FunctionRef directly) and the RefCountedReference wrapper (use WeakValueRef directly).

New module weak_ref: safe wrappers for NAPI weak references.

Fixes: #3706
