### PR TITLE
winit: Remove WakeEventLoopWorkaround workaround

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -42,10 +42,6 @@ use winit::window::ResizeDirection;
 /// This enum captures run-time specific events that can be dispatched to the event loop in
 /// addition to the winit events.
 pub enum CustomEvent {
-    /// On wasm request_redraw doesn't wake the event loop, so we need to manually send an event
-    /// so that the event loop can run
-    #[cfg(target_arch = "wasm32")]
-    WakeEventLoopWorkaround,
     /// Slint internal: Invoke the
     UserEvent(Box<dyn FnOnce() + Send>),
     /// Emitted from quit_event_loop with the current event loop generation
@@ -59,8 +55,6 @@ pub enum CustomEvent {
 impl std::fmt::Debug for CustomEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            #[cfg(target_arch = "wasm32")]
-            Self::WakeEventLoopWorkaround => write!(f, "WakeEventLoopWorkaround"),
             Self::UserEvent(_) => write!(f, "UserEvent"),
             Self::Exit(_) => write!(f, "Exit"),
             #[cfg(enable_accesskit)]
@@ -585,10 +579,6 @@ impl winit::application::ApplicationHandler for EventLoopState {
                             deferred_action.invoke(window.window());
                         }
                     }
-                }
-                #[cfg(target_arch = "wasm32")]
-                CustomEvent::WakeEventLoopWorkaround => {
-                    event_loop.set_control_flow(ControlFlow::Poll);
                 }
                 #[cfg(muda)]
                 CustomEvent::Muda(event) => {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -794,18 +794,6 @@ impl i_slint_core::platform::Platform for Backend {
                 event: Box<dyn FnOnce() + Send>,
             ) -> Result<(), EventLoopError> {
                 let mut queue = self.1.lock().unwrap();
-                // Calling send_event is usually done by winit at the bottom of the stack,
-                // in event handlers, and thus winit might decide to process the event
-                // immediately within that stack.
-                // To prevent re-entrancy issues that might happen by getting the application
-                // event processed on top of the current stack, set winit in Poll mode so that
-                // events are queued and process on top of a clean stack during a requested animation
-                // frame a few moments later.
-                // This also allows batching multiple post_event calls and redraw their state changes
-                // all at once.
-                #[cfg(target_arch = "wasm32")]
-                queue.push_back(CustomEvent::WakeEventLoopWorkaround);
-
                 queue.push_back(CustomEvent::UserEvent(event));
                 drop(queue);
                 self.0.wake_up();


### PR DESCRIPTION
Shouldn't be needed anymore in winit 0.31

