### PR TITLE
remote-viewer: map image resources to data URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9344,6 +9344,7 @@ name = "remote-viewer"
 version = "1.17.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "dashmap",
  "futures-util",
  "getifs",

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -329,7 +329,7 @@ fn handle_preview_message(msg: PreviewToLspMessage, ctx: &language::Context) {
                 tracing::debug!("Preview requested state, re-sending all documents");
                 language::send_state_to_preview(ctx);
             } else {
-                language::send_files_to_preview(ctx, &files);
+                language::send_files_to_preview(ctx, files);
             }
         }
         SendShowMessage { message } => {

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -324,9 +324,13 @@ async fn lsp_main(
 fn handle_preview_message(msg: PreviewToLspMessage, ctx: &language::Context) {
     use PreviewToLspMessage::*;
     match &msg {
-        RequestState { .. } => {
-            tracing::debug!("Preview requested state, re-sending all documents");
-            language::send_state_to_preview(ctx);
+        RequestState { files } => {
+            if files.is_empty() {
+                tracing::debug!("Preview requested state, re-sending all documents");
+                language::send_state_to_preview(ctx);
+            } else {
+                language::send_files_to_preview(ctx, &files);
+            }
         }
         SendShowMessage { message } => {
             match message.typ {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -123,6 +123,33 @@ pub fn send_state_to_preview(ctx: &Context) {
     }
 }
 
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
+pub fn send_files_to_preview(ctx: &Context, files: &[lsp_types::Url]) {
+    for url in files {
+        let Some(path) = url.to_file_path().ok() else {
+            tracing::warn!("Cannot convert URL to file path: {url}");
+            continue;
+        };
+        match std::fs::read(&path) {
+            Ok(contents) => {
+                tracing::debug!("Sending file {} ({} bytes) to preview", url, contents.len());
+                ctx.to_preview.send(
+                    &i_slint_preview_protocol::LspToPreviewMessage::SetContents {
+                        url: i_slint_preview_protocol::VersionedUrl::new(url.clone(), None),
+                        contents,
+                    },
+                );
+            }
+            Err(err) => {
+                tracing::warn!("Failed to read file {}: {err}", path.display());
+                ctx.to_preview.send(
+                    &i_slint_preview_protocol::LspToPreviewMessage::ForgetFile { url: url.clone() },
+                );
+            }
+        }
+    }
+}
+
 async fn register_file_watcher(ctx: &Context) -> common::Result<()> {
     use lsp_types::notification::Notification;
 

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -133,18 +133,16 @@ pub fn send_files_to_preview(ctx: &Context, files: &[lsp_types::Url]) {
         match std::fs::read(&path) {
             Ok(contents) => {
                 tracing::debug!("Sending file {} ({} bytes) to preview", url, contents.len());
-                ctx.to_preview.send(
-                    &i_slint_preview_protocol::LspToPreviewMessage::SetContents {
-                        url: i_slint_preview_protocol::VersionedUrl::new(url.clone(), None),
-                        contents,
-                    },
-                );
+                ctx.to_preview.send(&i_slint_preview_protocol::LspToPreviewMessage::SetContents {
+                    url: i_slint_preview_protocol::VersionedUrl::new(url.clone(), None),
+                    contents,
+                });
             }
             Err(err) => {
                 tracing::warn!("Failed to read file {}: {err}", path.display());
-                ctx.to_preview.send(
-                    &i_slint_preview_protocol::LspToPreviewMessage::ForgetFile { url: url.clone() },
-                );
+                ctx.to_preview.send(&i_slint_preview_protocol::LspToPreviewMessage::ForgetFile {
+                    url: url.clone(),
+                });
             }
         }
     }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -720,7 +720,7 @@ async fn handle_preview_to_lsp_message(
             if files.is_empty() {
                 crate::language::send_state_to_preview(ctx);
             } else {
-                send_files_to_preview(ctx, files);
+                crate::language::send_files_to_preview(ctx, &files);
             }
         }
         M::SendWorkspaceEdit { label, edit } => {
@@ -740,25 +740,3 @@ async fn handle_preview_to_lsp_message(
     Ok(())
 }
 
-#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
-fn send_files_to_preview(ctx: &Context, files: Vec<Url>) {
-    let to_preview = ctx.to_preview.clone();
-    common::spawn_local(futures_util::future::join_all(files.into_iter().map(|url| {
-        let to_preview = to_preview.clone();
-        async move {
-            match tokio::fs::read(url.to_file_path().unwrap()).await {
-                Ok(contents) => {
-                    use i_slint_preview_protocol::VersionedUrl;
-
-                    to_preview.send(&i_slint_preview_protocol::LspToPreviewMessage::SetContents {
-                        url: VersionedUrl::new(url, None),
-                        contents,
-                    });
-                }
-                Err(err) => {
-                    tracing::error!("Failed loading file: {err}");
-                }
-            }
-        }
-    })));
-}

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -739,4 +739,3 @@ async fn handle_preview_to_lsp_message(
     }
     Ok(())
 }
-

--- a/tools/remote-viewer/Cargo.toml
+++ b/tools/remote-viewer/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "net", "sync"
 futures-util = { version = "0.3.31", features = ["sink"] }
 anyhow = "1.0.100"
 postcard = { version = "1.1.3", features = ["alloc"] }
+base64 = "0.22.1"
 
 [target.'cfg(not(any(target_vendor = "apple", target_arch = "wasm32")))'.dependencies]
 mdns-sd = { version = "0.17.0", default-features = false, features = ["async"] }

--- a/tools/remote-viewer/src/compilation.rs
+++ b/tools/remote-viewer/src/compilation.rs
@@ -3,15 +3,18 @@
 
 use std::{path::PathBuf, rc::Weak};
 
+use i_slint_core::InternalToken;
+
 use crate::connection::Connection;
 
 pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compiler {
     let mut compiler = slint_interpreter::Compiler::new();
 
+    let file_loader_connection = connection.clone();
     compiler.set_file_loader(move |path: &std::path::Path| {
         // make path absolute in our virtual file system
         let path = PathBuf::from("/").join(path);
-        let connection = connection.clone();
+        let connection = file_loader_connection.clone();
         Box::pin(async move {
             Some(if let Some(connection) = connection.upgrade() {
                 connection
@@ -26,6 +29,39 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
             })
         })
     });
+
+    let mapper_connection = connection.clone();
+    compiler.compiler_configuration(InternalToken).resource_url_mapper =
+        Some(std::rc::Rc::new(move |url: &str| {
+            let connection = mapper_connection.clone();
+            let path = url.to_owned();
+            Box::pin(async move {
+                if path.starts_with("builtin:/") {
+                    return None;
+                }
+                let connection = connection.upgrade()?;
+                let file_content = connection.request_file(path.clone()).await.ok()?;
+
+                let extension = std::path::Path::new(&path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("png");
+
+                let mime_type = match extension {
+                    "svg" | "svgz" => "image/svg+xml",
+                    "png" => "image/png",
+                    "jpg" | "jpeg" => "image/jpeg",
+                    "gif" => "image/gif",
+                    "bmp" => "image/bmp",
+                    "webp" => "image/webp",
+                    _ => "application/octet-stream",
+                };
+
+                use base64::Engine as _;
+                let encoded = base64::engine::general_purpose::STANDARD.encode(&*file_content.contents);
+                Some(format!("data:{mime_type};base64,{encoded}"))
+            })
+        }));
 
     compiler
 }

--- a/tools/remote-viewer/src/compilation.rs
+++ b/tools/remote-viewer/src/compilation.rs
@@ -58,7 +58,8 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
                 };
 
                 use base64::Engine as _;
-                let encoded = base64::engine::general_purpose::STANDARD.encode(&*file_content.contents);
+                let encoded =
+                    base64::engine::general_purpose::STANDARD.encode(&*file_content.contents);
                 Some(format!("data:{mime_type};base64,{encoded}"))
             })
         }));

--- a/tools/remote-viewer/src/connection.rs
+++ b/tools/remote-viewer/src/connection.rs
@@ -304,7 +304,12 @@ impl Connection {
         }
         if request_file {
             self.send(i_slint_preview_protocol::PreviewToLspMessage::RequestState {
-                files: vec![Url::from_file_path(file).unwrap()],
+                files: vec![Url::from_file_path(&file).map_err(|()| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!("Invalid file path: {file}"),
+                    )
+                })?],
             })
             .map_err(std::io::Error::other)?;
         }


### PR DESCRIPTION
The remote viewer receives .slint sources from the LSP but image paths reference files on the host machine. Set a resource_url_mapper on the compiler that fetches image bytes via the existing connection and returns data: URIs which the interpreter already handles.

Also consolidate send_files_to_preview into language.rs (fixing a to_file_path().unwrap() in the old main.rs version) and harden request_file against non-file paths like builtin:/.

