### PR TITLE
docs: Render DropEvent by name in generated reference docs

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -707,7 +707,8 @@ impl BuiltinPrivateStruct {
             | Self::TableColumn
             | Self::MenuEntry
             | Self::InternalKeyEvent
-            | Self::Edges => {
+            | Self::Edges
+            | Self::DropEvent => {
                 let name: &'static str = self.into();
                 Some(SmolStr::new_static(name))
             }


### PR DESCRIPTION
`BuiltinPrivateStruct::slint_name()` returned `None` for `DropEvent`,
so the `Struct` `Display` impl fell back to an inline `{ field: type, ... }`
expansion. That made the slint-doc-generator emit
`### can-drop(event: { data: data-transfer, position: Point, })` into
`droparea.mdx`, which @mdx-js/rollup tried to parse as a JSX expression
and rejected, failing the astro docs build.