### PR TITLE
slint-sc: Add compiler mode with all features disabled

### DIFF
--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -22,6 +22,9 @@ cpp = []
 rust = ["quote", "proc-macro2"]
 python = ["dep:pathdiff", "dep:serde", "smol_str/serde", "dep:serde_json", "dep:flate2", "dep:base64"]
 
+# Safety-critical subset: enables the SlintSc output format and compile-time checks
+slint-sc = ["quote", "proc-macro2"]
+
 # Support for proc_macro spans in the token (only useful for use within a proc macro)
 proc_macro_span = ["quote", "proc-macro2"]
 

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -365,6 +365,10 @@ pub struct BuildDiagnostics {
     /// When false, throw error for experimental features
     pub enable_experimental: bool,
 
+    /// When true, reject features not supported by the safety-critical subset
+    #[cfg(feature = "slint-sc")]
+    pub slint_sc: bool,
+
     /// This is the list of all loaded files (with or without diagnostic)
     /// does not include the main file.
     /// FIXME: this doesn't really belong in the diagnostics, it should be somehow returned in another way
@@ -413,6 +417,22 @@ impl BuildDiagnostics {
     }
     pub fn push_compiler_error(&mut self, error: Diagnostic) {
         self.inner.push(error);
+    }
+
+    /// If in safety-critical mode, push an error saying that `feature` is not
+    /// supported.
+    ///
+    /// Errors are suppressed for builtin files (paths starting with `builtin:`)
+    /// since those are loaded automatically by the compiler and are not user code.
+    #[cfg(feature = "slint-sc")]
+    pub fn slint_sc_error(&mut self, feature: &str, source: &dyn Spanned) {
+        if self.slint_sc
+            && !source
+                .source_file()
+                .is_some_and(|sf| sf.path().to_string_lossy().starts_with("builtin:"))
+        {
+            self.push_error(format!("{feature} not supported in Slint SC"), source);
+        }
     }
 
     pub fn push_property_deprecation_warning(

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -27,6 +27,8 @@ pub mod cpp_live_preview;
 pub mod rust;
 #[cfg(feature = "rust")]
 pub mod rust_live_preview;
+#[cfg(feature = "slint-sc")]
+pub mod slint_sc;
 
 #[cfg(feature = "python")]
 pub mod python;
@@ -37,6 +39,10 @@ pub enum OutputFormat {
     Cpp(cpp::Config),
     #[cfg(feature = "rust")]
     Rust,
+    /// Safety-critical subset of Slint.  Generates minimal Rust code
+    /// targeting the `slint-sc` runtime crate.
+    #[cfg(feature = "slint-sc")]
+    SlintSc,
     Interpreter,
     Llr,
     #[cfg(feature = "python")]
@@ -67,6 +73,8 @@ impl std::str::FromStr for OutputFormat {
             "cpp" => Ok(Self::Cpp(cpp::Config::default())),
             #[cfg(feature = "rust")]
             "rust" => Ok(Self::Rust),
+            #[cfg(feature = "slint-sc")]
+            "slint-sc" | "rust-sc" => Ok(Self::SlintSc),
             "llr" => Ok(Self::Llr),
             #[cfg(feature = "python")]
             "python" => Ok(Self::Python),
@@ -94,6 +102,11 @@ pub fn generate(
         #[cfg(feature = "rust")]
         OutputFormat::Rust => {
             let output = rust::generate(doc, compiler_config)?;
+            write!(destination, "{output}")?;
+        }
+        #[cfg(feature = "slint-sc")]
+        OutputFormat::SlintSc => {
+            let output = slint_sc::generate(doc, compiler_config)?;
             write!(destination, "{output}")?;
         }
         OutputFormat::Interpreter => {

--- a/internal/compiler/generator/slint_sc.rs
+++ b/internal/compiler/generator/slint_sc.rs
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Stub code generator for the Slint SC (safety-critical) runtime.
+
+use crate::CompilerConfiguration;
+use crate::object_tree::Document;
+use proc_macro2::TokenStream;
+
+/// Public entry point called from `generator::generate`.
+pub fn generate(
+    _doc: &Document,
+    _compiler_config: &CompilerConfiguration,
+) -> std::io::Result<TokenStream> {
+    Ok(TokenStream::new())
+}

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -239,6 +239,9 @@ impl CompilerConfiguration {
 
         let debug_info = std::env::var_os("SLINT_EMIT_DEBUG_INFO").is_some();
 
+        #[cfg(feature = "slint-sc")]
+        let slint_sc = matches!(output_format, OutputFormat::SlintSc);
+
         let cpp_namespace = match output_format {
             #[cfg(feature = "cpp")]
             OutputFormat::Cpp(config) => match config.namespace {
@@ -278,7 +281,7 @@ impl CompilerConfiguration {
             library_name: None,
             rust_module: None,
             #[cfg(feature = "slint-sc")]
-            slint_sc: matches!(output_format, OutputFormat::SlintSc),
+            slint_sc,
         }
     }
 }

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -184,6 +184,12 @@ pub struct CompilerConfiguration {
 
     /// Specify the Rust module to place the generated code in.
     pub rust_module: Option<String>,
+
+    /// Set automatically when the output format is `SlintSc`.
+    /// The compiler rejects all features not supported by the
+    /// safety-critical subset.
+    #[cfg(feature = "slint-sc")]
+    pub(crate) slint_sc: bool,
 }
 
 impl CompilerConfiguration {
@@ -271,6 +277,8 @@ impl CompilerConfiguration {
                 .map(|x| x.into()),
             library_name: None,
             rust_module: None,
+            #[cfg(feature = "slint-sc")]
+            slint_sc: matches!(output_format, OutputFormat::SlintSc),
         }
     }
 }
@@ -290,6 +298,10 @@ fn prepare_for_compile(
     }
 
     diagnostics.enable_experimental = compiler_config.enable_experimental;
+    #[cfg(feature = "slint-sc")]
+    {
+        diagnostics.slint_sc = compiler_config.slint_sc;
+    }
 
     typeloader::TypeLoader::new(compiler_config, diagnostics)
 }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -92,10 +92,25 @@ impl Document {
         let mut inner_components = Vec::new();
         let mut inner_types = Vec::new();
 
+        #[cfg(feature = "slint-sc")]
+        for import in &imports {
+            if matches!(
+                import.import_kind,
+                ImportKind::ImportList(_) | ImportKind::ModuleReexport(_)
+            ) {
+                diag.slint_sc_error("Imports are", &import.import_uri_token);
+            }
+        }
+
         let mut process_component =
             |n: syntax_nodes::Component,
              diag: &mut BuildDiagnostics,
              local_registry: &mut TypeRegister| {
+                // Globals already get their own "Globals are not supported" message
+                #[cfg(feature = "slint-sc")]
+                if n.child_text(SyntaxKind::Identifier).as_deref() != Some("global") {
+                    diag.slint_sc_error("Component declarations are", &n.DeclaredIdentifier());
+                }
                 let compo = Component::from_node(n, diag, local_registry);
                 if !local_registry.add(compo.clone()) {
                     diag.push_warning(format!("Component '{}' is replacing a previously defined component with the same name", compo.id), &compo.node.clone().unwrap().DeclaredIdentifier());
@@ -106,6 +121,8 @@ impl Document {
                               diag: &mut BuildDiagnostics,
                               local_registry: &mut TypeRegister,
                               inner_types: &mut Vec<Type>| {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Struct declarations are", &n.DeclaredIdentifier());
             let ty = type_struct_from_node(
                 n.ObjectType(),
                 diag,
@@ -127,6 +144,8 @@ impl Document {
                             diag: &mut BuildDiagnostics,
                             local_registry: &mut TypeRegister,
                             inner_types: &mut Vec<Type>| {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Enum declarations are", &n.DeclaredIdentifier());
             let Some(name) = parser::identifier_text(&n.DeclaredIdentifier()) else {
                 assert!(diag.has_errors());
                 return;
@@ -170,7 +189,9 @@ impl Document {
 
         for n in node.children() {
             match n.kind() {
-                SyntaxKind::Component => process_component(n.into(), diag, &mut local_registry),
+                SyntaxKind::Component => {
+                    process_component(n.into(), diag, &mut local_registry);
+                }
                 SyntaxKind::StructDeclaration => {
                     process_struct(n.into(), diag, &mut local_registry, &mut inner_types)
                 }
@@ -451,7 +472,11 @@ impl Component {
                 node.Element(),
                 "root".into(),
                 match node.child_text(SyntaxKind::Identifier) {
-                    Some(t) if t == "global" => ElementType::Global,
+                    Some(t) if t == "global" => {
+                        #[cfg(feature = "slint-sc")]
+                        diag.slint_sc_error("Globals are", &node.DeclaredIdentifier());
+                        ElementType::Global
+                    }
                     Some(t) if t == "interface" => {
                         if !diag.enable_experimental && !tr.expose_internal_types {
                             diag.push_error("'interface' is an experimental feature".into(), &node);
@@ -1077,7 +1102,25 @@ impl Element {
                     );
                     ElementType::Error
                 }
-                Ok(ty) => ty,
+                Ok(ty) => {
+                    #[cfg(feature = "slint-sc")]
+                    match &ty {
+                        ElementType::Builtin(b) => {
+                            diag.slint_sc_error(
+                                &format!("The builtin element '{}' is", b.name),
+                                &base_node,
+                            );
+                        }
+                        ElementType::Component(_) => {
+                            diag.slint_sc_error(
+                                "Inheriting from user-defined components is",
+                                &base_node,
+                            );
+                        }
+                        _ => {}
+                    }
+                    ty
+                }
                 Err(err) => {
                     diag.push_error(err, &base_node);
                     ElementType::Error
@@ -1158,6 +1201,8 @@ impl Element {
         )> = Vec::new();
 
         for prop_decl in node.PropertyDeclaration() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Property declarations are", &prop_decl);
             let prop_type = prop_decl
                 .Type()
                 .map(|type_node| type_from_node(type_node, diag, tr))
@@ -1254,6 +1299,8 @@ impl Element {
             }
 
             if let Some(csn) = prop_decl.TwoWayBinding() {
+                #[cfg(feature = "slint-sc")]
+                diag.slint_sc_error("Two-way bindings are", &csn);
                 two_way_bindings.push((prop_name.into(), csn, prop_decl.DeclaredIdentifier()));
             }
         }
@@ -1298,6 +1345,8 @@ impl Element {
         apply_default_type_properties(&mut r);
 
         for sig_decl in node.CallbackDeclaration() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Callback declarations are", &sig_decl);
             let name =
                 unwrap_or_continue!(parser::identifier_text(&sig_decl.DeclaredIdentifier()); diag);
 
@@ -1386,6 +1435,8 @@ impl Element {
         interfaces::apply_callbacks(&mut r, &implemented_interface, diag);
 
         for func in node.Function() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Function declarations are", &func);
             let name =
                 unwrap_or_continue!(parser::identifier_text(&func.DeclaredIdentifier()); diag);
 
@@ -1494,6 +1545,8 @@ impl Element {
         }
 
         for con_node in node.CallbackConnection() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Callback handlers are", &con_node);
             let unresolved_name = unwrap_or_continue!(parser::identifier_text(&con_node); diag);
             let PropertyLookupResult { resolved_name, property_type, .. } =
                 r.lookup_property(&unresolved_name);
@@ -1533,6 +1586,8 @@ impl Element {
         }
 
         for anim in node.PropertyAnimation() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Animations are", &anim);
             if let Some(star) = anim.child_token(SyntaxKind::Star) {
                 diag.push_error(
                     "catch-all property is only allowed within transitions".into(),
@@ -1600,6 +1655,8 @@ impl Element {
         }
 
         for ch in node.PropertyChangedCallback() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Change callbacks are", &ch);
             let Some(prop) = parser::identifier_text(&ch.DeclaredIdentifier()) else { continue };
             let lookup_result = r.lookup_property(&prop);
             if !lookup_result.is_valid() {
@@ -1693,6 +1750,8 @@ impl Element {
                 }
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
+                #[cfg(feature = "slint-sc")]
+                diag.slint_sc_error("The @children placeholder is", &se);
                 if children_placeholder.is_some() {
                     diag.push_error(
                         "The @children placeholder can only appear once in an element".into(),
@@ -1719,6 +1778,10 @@ impl Element {
             }
         }
 
+        #[cfg(feature = "slint-sc")]
+        for s_node in node.States() {
+            diag.slint_sc_error("States are", &s_node);
+        }
         for state in node.States().flat_map(|s| s.State()) {
             let s = State {
                 id: parser::identifier_text(&state.DeclaredIdentifier()).unwrap_or_default(),
@@ -1748,6 +1811,8 @@ impl Element {
         }
 
         for ts in node.Transitions() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Transitions are", &ts);
             if !is_legacy_syntax {
                 diag.push_error("'transitions' block are no longer supported. Use 'in {...}' and 'out {...}' directly in the state definition".into(), &ts);
             }
@@ -1815,6 +1880,8 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> ElementRc {
+        #[cfg(feature = "slint-sc")]
+        diag.slint_sc_error("Repeated elements (for-in) are", &node);
         let e = Element::from_sub_element_node(
             node.SubElement(),
             parent.borrow().base_type.clone(),
@@ -1869,6 +1936,8 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> ElementRc {
+        #[cfg(feature = "slint-sc")]
+        diag.slint_sc_error("Conditional elements (if) are", &node);
         let rei = RepeatedElementInfo {
             model: Expression::Uncompiled(node.Expression().into()),
             model_data_id: SmolStr::default(),
@@ -1918,6 +1987,8 @@ impl Element {
         diag: &mut BuildDiagnostics,
     ) {
         for (name_token, b) in bindings {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Bindings are", &name_token);
             let unresolved_name = crate::parser::normalize_identifier(name_token.text());
             let lookup_result = self.lookup_property(&unresolved_name);
             if !lookup_result.property_type.is_property_type() {
@@ -2861,6 +2932,8 @@ impl Exports {
                 .filter(|exports| exports.ExportModule().is_none())
                 .flat_map(|exports| exports.ExportSpecifier())
                 .filter_map(|export_specifier| {
+                    #[cfg(feature = "slint-sc")]
+                    diag.slint_sc_error("Export specifiers are", &export_specifier);
                     let (internal_name, exported_name) =
                         ExportedName::from_export_specifier(&export_specifier);
                     Some((

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -144,6 +144,9 @@ pub(super) fn get_implemented_interface(
 
     let implements_specifier = parent.ImplementsSpecifier()?;
 
+    #[cfg(feature = "slint-sc")]
+    diag.slint_sc_error("'implements' is", &implements_specifier);
+
     if !diag.enable_experimental && !tr.expose_internal_types {
         diag.push_error("'implements' is an experimental feature".into(), &implements_specifier);
         return None;
@@ -494,6 +497,9 @@ pub(super) fn apply_uses_statement(
     let Some(uses_specifier) = uses_specifier else {
         return;
     };
+
+    #[cfg(feature = "slint-sc")]
+    diag.slint_sc_error("'uses' is", &uses_specifier);
 
     if !diag.enable_experimental && !tr.expose_internal_types {
         diag.push_error("'uses' is an experimental feature".into(), &uses_specifier);

--- a/internal/compiler/tests/syntax/slint-sc/animations.slint
+++ b/internal/compiler/tests/syntax/slint-sc/animations.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Animations are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    in-out property <int> val;
+//  >                        <error{Property declarations are not supported in Slint SC}
+    animate val { duration: 100ms; }
+//  >                              <error{Animations are not supported in Slint SC}
+//                >      <^error{Bindings are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/bindings.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Bindings are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    width: 100px;
+//  >   <error{Bindings are not supported in Slint SC}
+    height: 50px;
+//  >    <error{Bindings are not supported in Slint SC}
+    background: red;
+//  >        <error{Bindings are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/callbacks.slint
+++ b/internal/compiler/tests/syntax/slint-sc/callbacks.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Callbacks are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    callback clicked();
+//  >                 <error{Callback declarations are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
+++ b/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Change callbacks (changed) are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    in-out property <int> val: 0;
+//  >                           <error{Property declarations are not supported in Slint SC}
+    changed val => { }
+//  >error{Change callbacks are not supported in Slint SC}
+}
+//<<<<error{Change callbacks are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/children_placeholder.slint
+++ b/internal/compiler/tests/syntax/slint-sc/children_placeholder.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The @children placeholder is rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    @children
+//  >       <error{The @children placeholder is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
+++ b/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Component declarations (exported or not) are rejected in Slint SC mode.
+
+component Helper inherits Window { }
+//        >    <error{Component declarations are not supported in Slint SC}
+//                        >     <^error{The builtin element 'Window' is not supported in Slint SC}
+//>                                  <^^<<warning{Component is neither used nor exported}
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/dialog.slint
+++ b/internal/compiler/tests/syntax/slint-sc/dialog.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Dialog is rejected in Slint SC mode.
+
+export component Test inherits Dialog {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Dialog' is not supported in Slint SC}
+    Text { text: "hello"; }
+//  >   <error{The builtin element 'Text' is not supported in Slint SC}
+//         >  <^error{Bindings are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/elements.slint
+++ b/internal/compiler/tests/syntax/slint-sc/elements.slint
@@ -1,0 +1,53 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// All builtin elements are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    width: 100px;
+//  >   <error{Bindings are not supported in Slint SC}
+    height: 100px;
+//  >    <error{Bindings are not supported in Slint SC}
+
+    Rectangle {
+//  >        <error{The builtin element 'Rectangle' is not supported in Slint SC}
+        x: 10px;
+//      ^error{Bindings are not supported in Slint SC}
+        width: 20px;
+//      >   <error{Bindings are not supported in Slint SC}
+        height: 20px;
+//      >    <error{Bindings are not supported in Slint SC}
+        background: red;
+//      >        <error{Bindings are not supported in Slint SC}
+    }
+
+    Image {
+//  >    <error{The builtin element 'Image' is not supported in Slint SC}
+        source: @image-url("");
+//      >    <error{Bindings are not supported in Slint SC}
+        width: 10px;
+//      >   <error{Bindings are not supported in Slint SC}
+        height: 10px;
+//      >    <error{Bindings are not supported in Slint SC}
+    }
+
+    Text {
+//  >   <error{The builtin element 'Text' is not supported in Slint SC}
+        text: "hello";
+//      >  <error{Bindings are not supported in Slint SC}
+    }
+
+    TouchArea {
+//  >        <error{The builtin element 'TouchArea' is not supported in Slint SC}
+    }
+
+    Flickable {
+//  >        <error{The builtin element 'Flickable' is not supported in Slint SC}
+    }
+
+    FocusScope {
+//  >         <error{The builtin element 'FocusScope' is not supported in Slint SC}
+    }
+}

--- a/internal/compiler/tests/syntax/slint-sc/enums.slint
+++ b/internal/compiler/tests/syntax/slint-sc/enums.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Enum declarations are rejected in Slint SC mode.
+
+enum MyEnum { a, b, c }
+//   >    <error{Enum declarations are not supported in Slint SC}
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
+++ b/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Export specifier lists are rejected in Slint SC mode.
+
+component Foo inherits Window { }
+//        > <error{Component declarations are not supported in Slint SC}
+//                     >     <^error{The builtin element 'Window' is not supported in Slint SC}
+
+export { Foo }
+//       >  <error{Export specifiers are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
+++ b/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
@@ -1,0 +1,17 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Repeated and conditional elements are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+
+    for i in [1, 2, 3]: Rectangle { }
+//  >                               <error{Repeated elements (for-in) are not supported in Slint SC}
+//                      >        <^error{The builtin element 'Rectangle' is not supported in Slint SC}
+
+    if true: Rectangle { }
+//  >                    <error{Conditional elements (if) are not supported in Slint SC}
+//           >        <^error{The builtin element 'Rectangle' is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/functions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/functions.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Functions are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    public function my-func() -> int { return 42; }
+//  >                                             <error{Function declarations are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/globals.slint
+++ b/internal/compiler/tests/syntax/slint-sc/globals.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Globals are rejected in Slint SC mode.
+
+global MyGlobal {
+//     >      <error{Globals are not supported in Slint SC}
+    in-out property <int> value: 42;
+//  >                              <error{Property declarations are not supported in Slint SC}
+}
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/imports.slint
+++ b/internal/compiler/tests/syntax/slint-sc/imports.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Imports are rejected in Slint SC mode.
+
+import { Button } from "std-widgets.slint";
+//                     >                 <error{Imports are not supported in Slint SC}
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/inheritance.slint
+++ b/internal/compiler/tests/syntax/slint-sc/inheritance.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Inheriting from user-defined components is rejected in Slint SC mode.
+
+component Base inherits Window { }
+//        >  <error{Component declarations are not supported in Slint SC}
+//                      >     <^error{The builtin element 'Window' is not supported in Slint SC}
+
+export component Test inherits Base {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >   <^error{Inheriting from user-defined components is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/init_callback.slint
+++ b/internal/compiler/tests/syntax/slint-sc/init_callback.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// init callbacks are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    init => { debug("hello"); }
+//  >error{Callback handlers are not supported in Slint SC}
+}
+//<<<<error{Callback handlers are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/layout.slint
+++ b/internal/compiler/tests/syntax/slint-sc/layout.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Layouts are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+
+    HorizontalLayout {
+//  >               <error{The builtin element 'HorizontalLayout' is not supported in Slint SC}
+        Rectangle { }
+//      >        <error{The builtin element 'Rectangle' is not supported in Slint SC}
+    }
+}

--- a/internal/compiler/tests/syntax/slint-sc/path.slint
+++ b/internal/compiler/tests/syntax/slint-sc/path.slint
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Path element is rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    Path {
+//  >   <error{The builtin element 'Path' is not supported in Slint SC}
+        width: 100px;
+//      >   <error{Bindings are not supported in Slint SC}
+        height: 100px;
+//      >    <error{Bindings are not supported in Slint SC}
+    }
+}

--- a/internal/compiler/tests/syntax/slint-sc/popup.slint
+++ b/internal/compiler/tests/syntax/slint-sc/popup.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// PopupWindow is rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+
+    popup := PopupWindow {
+//           >          <error{The builtin element 'PopupWindow' is not supported in Slint SC}
+    }
+}

--- a/internal/compiler/tests/syntax/slint-sc/properties.slint
+++ b/internal/compiler/tests/syntax/slint-sc/properties.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Property declarations are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    in-out property <int> a: 1;
+//  >                         <error{Property declarations are not supported in Slint SC}
+    property <string> s: "hello";
+//  >                           <error{Property declarations are not supported in Slint SC}
+    out property <color> c: red;
+//  >                          <error{Property declarations are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/states.slint
+++ b/internal/compiler/tests/syntax/slint-sc/states.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// States and transitions are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    in-out property <bool> active;
+//  >                            <error{Property declarations are not supported in Slint SC}
+
+    states [
+//  >error{States are not supported in Slint SC}
+        on when active: { }
+        off when !active: { }
+    ]
+//  <error{States are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/structs.slint
+++ b/internal/compiler/tests/syntax/slint-sc/structs.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Struct declarations are rejected in Slint SC mode.
+
+struct MyStruct {
+//     >      <error{Struct declarations are not supported in Slint SC}
+    x: int,
+    y: int,
+}
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/timer.slint
+++ b/internal/compiler/tests/syntax/slint-sc/timer.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Timers are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+
+    Timer {
+//  >    <error{The builtin element 'Timer' is not supported in Slint SC}
+        interval: 1s;
+//      >      <error{Bindings are not supported in Slint SC}
+    }
+}

--- a/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Two-way bindings are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    in-out property <int> a: 1;
+//  >                         <error{Property declarations are not supported in Slint SC}
+    in-out property <int> b <=> a;
+//  >                            <error{Property declarations are not supported in Slint SC}
+//                          >    <^error{Two-way bindings are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -61,6 +61,11 @@ fn syntax_tests() -> std::io::Result<()> {
         let entry = entry?;
         if entry.file_type().is_ok_and(|f| f.is_dir()) {
             let path = entry.path();
+            // Skip slint-sc tests when the feature is not enabled
+            #[cfg(not(feature = "slint-sc"))]
+            if path.file_name().is_some_and(|n| n == "slint-sc") {
+                continue;
+            }
             for test_entry in path.read_dir()? {
                 let test_entry = test_entry?;
                 let path = test_entry.path();
@@ -423,9 +428,15 @@ fn process_file_source(
         i_slint_compiler::parser::parse(source.clone(), Some(path), &mut parse_diagnostics);
 
     let has_parse_error = parse_diagnostics.has_errors();
-    let mut compiler_config = i_slint_compiler::CompilerConfiguration::new(
-        i_slint_compiler::generator::OutputFormat::Interpreter,
-    );
+    #[cfg(feature = "slint-sc")]
+    let output_format = if path.to_str().unwrap_or("").contains("slint-sc") {
+        i_slint_compiler::generator::OutputFormat::SlintSc
+    } else {
+        i_slint_compiler::generator::OutputFormat::Interpreter
+    };
+    #[cfg(not(feature = "slint-sc"))]
+    let output_format = i_slint_compiler::generator::OutputFormat::Interpreter;
+    let mut compiler_config = i_slint_compiler::CompilerConfiguration::new(output_format);
     compiler_config.library_paths = [(
         "test-lib".into(),
         concat!(env!("CARGO_MANIFEST_DIR"), "/tests/typeloader/library").into(),


### PR DESCRIPTION
Add a SlintSc output format.

Every language feature is rejected for now in that mode