### PR TITLE
Deprecate calling `init()` explicitly

### DIFF
--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -470,7 +470,10 @@ impl LookupObject for ElementRc {
             _ => false,
         };
         if !is_global {
-            for (name, ty, _) in crate::typeregister::reserved_properties() {
+            for (name, ty, visibility) in crate::typeregister::reserved_properties() {
+                if visibility == PropertyVisibility::Private {
+                    continue;
+                }
                 let name = SmolStr::new_static(name);
                 let e =
                     expression_from_reference(NamedReference::new(self, name.clone()), &ty, None);

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1277,6 +1277,13 @@ impl Expression {
 
         arguments.extend(sub_expr);
 
+        if matches!(&function, Callable::Callback(nr) if nr.name() == "init") {
+            ctx.diag.push_warning(
+                "Calling 'init' explicitly does nothing and is deprecated".into(),
+                &node,
+            );
+        }
+
         let arguments = match function.ty() {
             Type::Function(function) | Type::Callback(function) => {
                 if arguments.len() != function.args.len() {

--- a/internal/compiler/tests/syntax/basic/init.slint
+++ b/internal/compiler/tests/syntax/basic/init.slint
@@ -1,0 +1,28 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component CallInit {
+    Rectangle {
+        init => {
+            self.x = 0;
+            self.init();
+//          >         <warning{Calling 'init' explicitly does nothing and is deprecated}
+        }
+    }
+    init => {
+        self.init();
+//      >         <warning{Calling 'init' explicitly does nothing and is deprecated}
+    }
+}
+
+export component CallInitFromOutside {
+    r := Rectangle {
+        init => {
+            self.x = 0;
+        }
+    }
+    init => {
+        r.init();
+//      >      <warning{Calling 'init' explicitly does nothing and is deprecated}
+    }
+}

--- a/tests/cases/callbacks/init.slint
+++ b/tests/cases/callbacks/init.slint
@@ -57,13 +57,19 @@ TestCase := Rectangle {
     init => {
         InitOrder.observed-order += "|root";
         ExportedGlobal.foo += 1;
+        // Calling init() explicitly does nothing
+        self.init();
+        root.init();
+        sub1.init();
+        sub2.init();
+        elem.init();
     }
-    Sub1 {
+    sub1 := Sub1 {
         init => {
             InitOrder.observed-order += "|sub1-use-site";
         }
     }
-    Sub2 {
+    sub2 := Sub2 {
     }
     Sub3 {
         some-value: "|sub3";
@@ -76,7 +82,7 @@ TestCase := Rectangle {
         }
     }
 
-    Rectangle {
+    elem := Rectangle {
         init => {
             InitOrder.observed-order += "|element";
         }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -1330,6 +1330,7 @@ mod tests {
             assert!(!res.iter().any(|ci| ci.label == "Clip"));
             assert!(!res.iter().any(|ci| ci.label == "NativeStyleMetrics"));
             assert!(!res.iter().any(|ci| ci.label == "SlintInternal"));
+            assert!(!res.iter().any(|ci| ci.label == "init"));
         }
     }
 
@@ -1794,6 +1795,7 @@ mod tests {
         assert_completions_found(expected, &res);
 
         assert!(!res.iter().any(|item| item.label.contains("test")));
+        assert!(!res.iter().any(|item| item.label.contains("init")));
     }
 
     #[test]


### PR DESCRIPTION
Should have been an error, but now it would be a breaking change to make it an error.