### PR TITLE
slint-sc: Reject all type and expressions

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2221,6 +2221,9 @@ pub fn type_from_node(
 
         let prop_type = tr.lookup_qualified(&qualified_type.members);
 
+        #[cfg(feature = "slint-sc")]
+        diag.slint_sc_error(&format!("The type '{qualified_type}' is"), &qualified_type_node);
+
         if prop_type == Type::Invalid && tr.lookup_element(&qualified_type.to_smolstr()).is_err() {
             diag.push_error(format!("Unknown type '{qualified_type}'"), &qualified_type_node);
         } else if !prop_type.is_property_type() {
@@ -2231,8 +2234,12 @@ pub fn type_from_node(
         }
         prop_type
     } else if let Some(object_node) = node.ObjectType() {
+        #[cfg(feature = "slint-sc")]
+        diag.slint_sc_error("Inline struct types are", &object_node);
         type_struct_from_node(object_node, diag, tr, None)
     } else if let Some(array_node) = node.ArrayType() {
+        #[cfg(feature = "slint-sc")]
+        diag.slint_sc_error("Array types are", &array_node);
         Type::Array(Rc::new(type_from_node(array_node.Type(), diag, tr)))
     } else {
         assert!(diag.has_errors());

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -373,70 +373,133 @@ impl Expression {
             .find_map(|child| match child {
                 NodeOrToken::Node(node) => match node.kind() {
                     SyntaxKind::Expression => Some(Self::from_expression_node(node.into(), ctx)),
-                    SyntaxKind::AtImageUrl => Some(Self::from_at_image_url_node(node.into(), ctx)),
-                    SyntaxKind::AtGradient => Some(Self::from_at_gradient(node.into(), ctx)),
-                    SyntaxKind::AtTr => Some(Self::from_at_tr(node.into(), ctx)),
-                    SyntaxKind::AtMarkdown => Some(Self::from_at_markdown(node.into(), ctx)),
-                    SyntaxKind::AtKeys => Some(Self::from_at_keys_node(node.into(), ctx)),
+                    SyntaxKind::AtImageUrl => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("@image-url() expressions are", &node);
+                        Some(Self::from_at_image_url_node(node.into(), ctx))
+                    }
+                    SyntaxKind::AtGradient => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("@gradient expressions are", &node);
+                        Some(Self::from_at_gradient(node.into(), ctx))
+                    }
+                    SyntaxKind::AtTr => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("@tr() expressions are", &node);
+                        Some(Self::from_at_tr(node.into(), ctx))
+                    }
+                    SyntaxKind::AtMarkdown => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("@markdown() expressions are", &node);
+                        Some(Self::from_at_markdown(node.into(), ctx))
+                    }
+                    SyntaxKind::AtKeys => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("@keys() expressions are", &node);
+                        Some(Self::from_at_keys_node(node.into(), ctx))
+                    }
                     SyntaxKind::QualifiedName => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Identifier references are", &node);
                         Some(Self::from_qualified_name_node(node.clone().into(), ctx))
                     }
                     SyntaxKind::FunctionCallExpression => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Function calls are", &node);
                         Some(Self::from_function_call_node(node.into(), ctx))
                     }
                     SyntaxKind::MemberAccess => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Member access expressions are", &node);
                         Some(Self::from_member_access_node(node.into(), ctx))
                     }
                     SyntaxKind::IndexExpression => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Index expressions are", &node);
                         Some(Self::from_index_expression_node(node.into(), ctx))
                     }
                     SyntaxKind::SelfAssignment => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Self-assignment expressions are", &node);
                         Some(Self::from_self_assignment_node(node.into(), ctx))
                     }
                     SyntaxKind::BinaryExpression => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Binary expressions are", &node);
                         Some(Self::from_binary_expression_node(node.into(), ctx))
                     }
                     SyntaxKind::UnaryOpExpression => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Unary expressions are", &node);
                         Some(Self::from_unaryop_expression_node(node.into(), ctx))
                     }
                     SyntaxKind::ConditionalExpression => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Conditional expressions are", &node);
                         Some(Self::from_conditional_expression_node(node.into(), ctx))
                     }
                     SyntaxKind::ObjectLiteral => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Object literal expressions are", &node);
                         Some(Self::from_object_literal_node(node.into(), ctx))
                     }
-                    SyntaxKind::Array => Some(Self::from_array_node(node.into(), ctx)),
-                    SyntaxKind::CodeBlock => Some(Self::from_codeblock_node(node.into(), ctx)),
+                    SyntaxKind::Array => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Array expressions are", &node);
+                        Some(Self::from_array_node(node.into(), ctx))
+                    }
+                    SyntaxKind::CodeBlock => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Code blocks are", &node);
+                        Some(Self::from_codeblock_node(node.into(), ctx))
+                    }
                     SyntaxKind::StringTemplate => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("String interpolation expressions are", &node);
                         Some(Self::from_string_template_node(node.into(), ctx))
                     }
                     _ => None,
                 },
                 NodeOrToken::Token(token) => match token.kind() {
-                    SyntaxKind::StringLiteral => Some(
-                        crate::literals::unescape_string_reporting(Some(&token), ctx.diag, &token)
+                    SyntaxKind::StringLiteral => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("String literals are", &token);
+                        Some(
+                            crate::literals::unescape_string_reporting(
+                                Some(&token),
+                                ctx.diag,
+                                &token,
+                            )
                             .map(Self::StringLiteral)
                             .unwrap_or(Self::Invalid),
-                    ),
-                    SyntaxKind::NumberLiteral => Some(
-                        crate::literals::parse_number_literal(token.text().into()).unwrap_or_else(
-                            |e| {
-                                ctx.diag.push_error(e.to_string(), &node);
-                                Self::Invalid
-                            },
-                        ),
-                    ),
-                    SyntaxKind::ColorLiteral => Some(
-                        i_slint_common::color_parsing::parse_color_literal(token.text())
-                            .map(|i| Expression::Cast {
-                                from: Box::new(Expression::NumberLiteral(i as _, Unit::None)),
-                                to: Type::Color,
-                            })
-                            .unwrap_or_else(|| {
-                                ctx.diag.push_error("Invalid color literal".into(), &node);
-                                Self::Invalid
-                            }),
-                    ),
+                        )
+                    }
+                    SyntaxKind::NumberLiteral => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Number literals are", &token);
+                        Some(
+                            crate::literals::parse_number_literal(token.text().into())
+                                .unwrap_or_else(|e| {
+                                    ctx.diag.push_error(e.to_string(), &node);
+                                    Self::Invalid
+                                }),
+                        )
+                    }
+                    SyntaxKind::ColorLiteral => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Color literals are", &token);
+                        Some(
+                            i_slint_common::color_parsing::parse_color_literal(token.text())
+                                .map(|i| Expression::Cast {
+                                    from: Box::new(Expression::NumberLiteral(i as _, Unit::None)),
+                                    to: Type::Color,
+                                })
+                                .unwrap_or_else(|| {
+                                    ctx.diag.push_error("Invalid color literal".into(), &node);
+                                    Self::Invalid
+                                }),
+                        )
+                    }
 
                     _ => None,
                 },

--- a/internal/compiler/tests/syntax/slint-sc/animations.slint
+++ b/internal/compiler/tests/syntax/slint-sc/animations.slint
@@ -8,7 +8,9 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> val;
 //  >                        <error{Property declarations are not supported in Slint SC}
+//                   > <^error{The type 'int' is not supported in Slint SC}
     animate val { duration: 100ms; }
 //  >                              <error{Animations are not supported in Slint SC}
 //                >      <^error{Bindings are not supported in Slint SC}
+//                          >   <^^error{Number literals are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/bindings.slint
@@ -8,8 +8,11 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     width: 100px;
 //  >   <error{Bindings are not supported in Slint SC}
+//         >   <^error{Number literals are not supported in Slint SC}
     height: 50px;
 //  >    <error{Bindings are not supported in Slint SC}
+//          >  <^error{Number literals are not supported in Slint SC}
     background: red;
 //  >        <error{Bindings are not supported in Slint SC}
+//              > <^error{Identifier references are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
+++ b/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
@@ -8,6 +8,8 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> val: 0;
 //  >                           <error{Property declarations are not supported in Slint SC}
+//                   > <^error{The type 'int' is not supported in Slint SC}
+//                             ^^^error{Number literals are not supported in Slint SC}
     changed val => { }
 //  >error{Change callbacks are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/dialog.slint
+++ b/internal/compiler/tests/syntax/slint-sc/dialog.slint
@@ -9,4 +9,5 @@ export component Test inherits Dialog {
     Text { text: "hello"; }
 //  >   <error{The builtin element 'Text' is not supported in Slint SC}
 //         >  <^error{Bindings are not supported in Slint SC}
+//               >     <^^error{String literals are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/elements.slint
+++ b/internal/compiler/tests/syntax/slint-sc/elements.slint
@@ -8,35 +8,45 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     width: 100px;
 //  >   <error{Bindings are not supported in Slint SC}
+//         >   <^error{Number literals are not supported in Slint SC}
     height: 100px;
 //  >    <error{Bindings are not supported in Slint SC}
+//          >   <^error{Number literals are not supported in Slint SC}
 
     Rectangle {
 //  >        <error{The builtin element 'Rectangle' is not supported in Slint SC}
         x: 10px;
 //      ^error{Bindings are not supported in Slint SC}
+//         >  <^error{Number literals are not supported in Slint SC}
         width: 20px;
 //      >   <error{Bindings are not supported in Slint SC}
+//             >  <^error{Number literals are not supported in Slint SC}
         height: 20px;
 //      >    <error{Bindings are not supported in Slint SC}
+//              >  <^error{Number literals are not supported in Slint SC}
         background: red;
 //      >        <error{Bindings are not supported in Slint SC}
+//                  > <^error{Identifier references are not supported in Slint SC}
     }
 
     Image {
 //  >    <error{The builtin element 'Image' is not supported in Slint SC}
         source: @image-url("");
 //      >    <error{Bindings are not supported in Slint SC}
+//              >            <^error{@image-url() expressions are not supported in Slint SC}
         width: 10px;
 //      >   <error{Bindings are not supported in Slint SC}
+//             >  <^error{Number literals are not supported in Slint SC}
         height: 10px;
 //      >    <error{Bindings are not supported in Slint SC}
+//              >  <^error{Number literals are not supported in Slint SC}
     }
 
     Text {
 //  >   <error{The builtin element 'Text' is not supported in Slint SC}
         text: "hello";
 //      >  <error{Bindings are not supported in Slint SC}
+//            >     <^error{String literals are not supported in Slint SC}
     }
 
     TouchArea {

--- a/internal/compiler/tests/syntax/slint-sc/expressions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/expressions.slint
@@ -1,0 +1,119 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// All expressions are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    // number literals
+    property <int> a: 42;
+//  >                   <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                    ><^^error{Number literals are not supported in Slint SC}
+    // binary expressions and identifier references
+    property <int> b: a + 1;
+//  >                      <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                    >   <^^error{Binary expressions are not supported in Slint SC}
+//                    ><^^^error{Identifier references are not supported in Slint SC}
+//                        ^^^^^error{Number literals are not supported in Slint SC}
+    // comparison
+    property <bool> c: a > 0;
+//  >                       <error{Property declarations are not supported in Slint SC}
+//            >  <^error{The type 'bool' is not supported in Slint SC}
+//                     >   <^^error{Binary expressions are not supported in Slint SC}
+//                     ><^^^error{Identifier references are not supported in Slint SC}
+//                         ^^^^^error{Number literals are not supported in Slint SC}
+    // conditional (ternary)
+    property <int> d: c ? 1 : 0;
+//  >                          <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                    >       <^^error{Conditional expressions are not supported in Slint SC}
+//                    ><^^^error{Identifier references are not supported in Slint SC}
+//                        ^^^^^error{Number literals are not supported in Slint SC}
+//                            ^^^^^^error{Number literals are not supported in Slint SC}
+    // string literals
+    property <string> e: "hello";
+//  >                           <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'string' is not supported in Slint SC}
+//                       >     <^^error{String literals are not supported in Slint SC}
+    // string interpolation
+    property <string> f: "val: \{a}";
+//  >                               <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'string' is not supported in Slint SC}
+//                       >         <^^error{String interpolation expressions are not supported in Slint SC}
+//                               ^^^^error{Identifier references are not supported in Slint SC}
+    // color literals
+    property <color> g: #ff0000;
+//  >                          <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'color' is not supported in Slint SC}
+//                      >     <^^error{Color literals are not supported in Slint SC}
+    // unary expressions
+    property <int> h: -a;
+//  >                   <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                    ><^^error{Unary expressions are not supported in Slint SC}
+//                     ^^^^error{Identifier references are not supported in Slint SC}
+    // @image-url
+    property <image> i: @image-url("");
+//  >                                 <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'image' is not supported in Slint SC}
+//                      >            <^^error{@image-url() expressions are not supported in Slint SC}
+    // @tr
+    property <string> j: @tr("hello");
+//  >                                <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'string' is not supported in Slint SC}
+//                       >          <^^error{@tr() expressions are not supported in Slint SC}
+    // @gradient
+    property <brush> k: @linear-gradient(0deg, red, blue);
+//  >                                                    <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'brush' is not supported in Slint SC}
+//                      >                               <^^error{@gradient expressions are not supported in Slint SC}
+//                                       >  <^^^error{Number literals are not supported in Slint SC}
+//                                             > <^^^^error{Identifier references are not supported in Slint SC}
+//                                                  >  <^^^^^error{Identifier references are not supported in Slint SC}
+    // array expression
+    property <[int]> l: [1, 2, 3];
+//  >                            <error{Property declarations are not supported in Slint SC}
+//            >   <^error{Array types are not supported in Slint SC}
+//             > <^^error{The type 'int' is not supported in Slint SC}
+//                      >       <^^^error{Array expressions are not supported in Slint SC}
+//                       ^^^^^error{Number literals are not supported in Slint SC}
+//                          ^^^^^^error{Number literals are not supported in Slint SC}
+//                             ^^^^^^^error{Number literals are not supported in Slint SC}
+    // object literal
+    property <{x: int, y: int}> m: { x: 1, y: 2 };
+//  >                                            <error{Property declarations are not supported in Slint SC}
+//            >              <^error{Inline struct types are not supported in Slint SC}
+//                > <^^error{The type 'int' is not supported in Slint SC}
+//                        > <^^^error{The type 'int' is not supported in Slint SC}
+//                                 >            <^^^^error{Object literal expressions are not supported in Slint SC}
+//                                      ^^^^^^error{Number literals are not supported in Slint SC}
+//                                            ^^^^^^^error{Number literals are not supported in Slint SC}
+    // member access
+    property <int> n: m.x;
+//  >                    <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                    > <^^error{Identifier references are not supported in Slint SC}
+    // self-assignment (via callback handler context)
+    // index expression
+    property <int> o: l[0];
+//  >                     <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                    >  <^^error{Index expressions are not supported in Slint SC}
+//                    ^^^^error{Identifier references are not supported in Slint SC}
+//                      ^^^^^error{Number literals are not supported in Slint SC}
+    // function call
+    property <int> p: Math.max(1, 2);
+//  >                               <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                    >            <^^error{Function calls are not supported in Slint SC}
+//                             ^^^^error{Number literals are not supported in Slint SC}
+//                                ^^^^^error{Number literals are not supported in Slint SC}
+    // code block
+    property <int> q: { 42 };
+//  >                       <error{Property declarations are not supported in Slint SC}
+//            > <^error{The type 'int' is not supported in Slint SC}
+//                      ><^^error{Number literals are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/expressions_extra.slint
+++ b/internal/compiler/tests/syntax/slint-sc/expressions_extra.slint
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Additional expression types rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    // @markdown
+    property <string> a: @markdown("hello");
+//  >                                      <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'string' is not supported in Slint SC}
+//                       >                <^^error{@markdown() expressions are not supported in Slint SC}
+//                       >                 <^^^error{Cannot convert styled-text to string}
+    // @keys (used in key-event-filter context)
+    property <string> b: @keys(Return);
+//  >                                 <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'string' is not supported in Slint SC}
+//                       >           <^^error{@keys() expressions are not supported in Slint SC}
+//                       >            <^^^error{Cannot convert keys to string}
+    // self-assignment
+    callback clicked();
+//  >                 <error{Callback declarations are not supported in Slint SC}
+    clicked => { self.a += "x"; }
+//  >error{Callback handlers are not supported in Slint SC}
+//               >           <^error{Self-assignment expressions are not supported in Slint SC}
+//               >     <^^error{Identifier references are not supported in Slint SC}
+//                         > <^^^error{String literals are not supported in Slint SC}
+}
+//<<<<error{Callback handlers are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
+++ b/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
@@ -10,8 +10,13 @@ export component Test inherits Window {
     for i in [1, 2, 3]: Rectangle { }
 //  >                               <error{Repeated elements (for-in) are not supported in Slint SC}
 //                      >        <^error{The builtin element 'Rectangle' is not supported in Slint SC}
+//           >       <^^error{Array expressions are not supported in Slint SC}
+//            ^^^^error{Number literals are not supported in Slint SC}
+//               ^^^^^error{Number literals are not supported in Slint SC}
+//                  ^^^^^^error{Number literals are not supported in Slint SC}
 
     if true: Rectangle { }
 //  >                    <error{Conditional elements (if) are not supported in Slint SC}
 //           >        <^error{The builtin element 'Rectangle' is not supported in Slint SC}
+//     >  <^^error{Identifier references are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/functions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/functions.slint
@@ -8,4 +8,6 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     public function my-func() -> int { return 42; }
 //  >                                             <error{Function declarations are not supported in Slint SC}
+//                               >  <^error{The type 'int' is not supported in Slint SC}
+//                                            ><^^error{Number literals are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/globals.slint
+++ b/internal/compiler/tests/syntax/slint-sc/globals.slint
@@ -7,6 +7,8 @@ global MyGlobal {
 //     >      <error{Globals are not supported in Slint SC}
     in-out property <int> value: 42;
 //  >                              <error{Property declarations are not supported in Slint SC}
+//                   > <^error{The type 'int' is not supported in Slint SC}
+//                               ><^^error{Number literals are not supported in Slint SC}
 }
 
 export component Test inherits Window {

--- a/internal/compiler/tests/syntax/slint-sc/init_callback.slint
+++ b/internal/compiler/tests/syntax/slint-sc/init_callback.slint
@@ -8,5 +8,7 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     init => { debug("hello"); }
 //  >error{Callback handlers are not supported in Slint SC}
+//            >            <^error{Function calls are not supported in Slint SC}
+//                  >     <^^error{String literals are not supported in Slint SC}
 }
 //<<<<error{Callback handlers are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/path.slint
+++ b/internal/compiler/tests/syntax/slint-sc/path.slint
@@ -10,7 +10,9 @@ export component Test inherits Window {
 //  >   <error{The builtin element 'Path' is not supported in Slint SC}
         width: 100px;
 //      >   <error{Bindings are not supported in Slint SC}
+//             >   <^error{Number literals are not supported in Slint SC}
         height: 100px;
 //      >    <error{Bindings are not supported in Slint SC}
+//              >   <^error{Number literals are not supported in Slint SC}
     }
 }

--- a/internal/compiler/tests/syntax/slint-sc/properties.slint
+++ b/internal/compiler/tests/syntax/slint-sc/properties.slint
@@ -8,8 +8,14 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> a: 1;
 //  >                         <error{Property declarations are not supported in Slint SC}
+//                   > <^error{The type 'int' is not supported in Slint SC}
+//                           ^^^error{Number literals are not supported in Slint SC}
     property <string> s: "hello";
 //  >                           <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'string' is not supported in Slint SC}
+//                       >     <^^error{String literals are not supported in Slint SC}
     out property <color> c: red;
 //  >                          <error{Property declarations are not supported in Slint SC}
+//                >   <^error{The type 'color' is not supported in Slint SC}
+//                          > <^^error{Identifier references are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/states.slint
+++ b/internal/compiler/tests/syntax/slint-sc/states.slint
@@ -8,11 +8,15 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <bool> active;
 //  >                            <error{Property declarations are not supported in Slint SC}
+//                   >  <^error{The type 'bool' is not supported in Slint SC}
 
     states [
 //  >error{States are not supported in Slint SC}
         on when active: { }
+//              >    <error{Identifier references are not supported in Slint SC}
         off when !active: { }
+//               >     <error{Unary expressions are not supported in Slint SC}
+//                >    <^error{Identifier references are not supported in Slint SC}
     ]
 //  <error{States are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/structs.slint
+++ b/internal/compiler/tests/syntax/slint-sc/structs.slint
@@ -6,7 +6,9 @@
 struct MyStruct {
 //     >      <error{Struct declarations are not supported in Slint SC}
     x: int,
+//     > <error{The type 'int' is not supported in Slint SC}
     y: int,
+//     > <error{The type 'int' is not supported in Slint SC}
 }
 
 export component Test inherits Window {

--- a/internal/compiler/tests/syntax/slint-sc/timer.slint
+++ b/internal/compiler/tests/syntax/slint-sc/timer.slint
@@ -11,5 +11,6 @@ export component Test inherits Window {
 //  >    <error{The builtin element 'Timer' is not supported in Slint SC}
         interval: 1s;
 //      >      <error{Bindings are not supported in Slint SC}
+//                ><^error{Number literals are not supported in Slint SC}
     }
 }

--- a/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
@@ -8,7 +8,10 @@ export component Test inherits Window {
 //                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> a: 1;
 //  >                         <error{Property declarations are not supported in Slint SC}
+//                   > <^error{The type 'int' is not supported in Slint SC}
+//                           ^^^error{Number literals are not supported in Slint SC}
     in-out property <int> b <=> a;
 //  >                            <error{Property declarations are not supported in Slint SC}
-//                          >    <^error{Two-way bindings are not supported in Slint SC}
+//                   > <^error{The type 'int' is not supported in Slint SC}
+//                          >    <^^error{Two-way bindings are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/types.slint
+++ b/internal/compiler/tests/syntax/slint-sc/types.slint
@@ -1,0 +1,36 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// All types are rejected in Slint SC mode, including arrays and inline structs.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    property <[string]> a;
+//  >                    <error{Property declarations are not supported in Slint SC}
+//            >      <^error{Array types are not supported in Slint SC}
+//             >    <^^error{The type 'string' is not supported in Slint SC}
+    property <{foo: int, bar: color}> b;
+//  >                                  <error{Property declarations are not supported in Slint SC}
+//            >                    <^error{Inline struct types are not supported in Slint SC}
+//                  > <^^error{The type 'int' is not supported in Slint SC}
+//                            >   <^^^error{The type 'color' is not supported in Slint SC}
+    property <bool> c;
+//  >                <error{Property declarations are not supported in Slint SC}
+//            >  <^error{The type 'bool' is not supported in Slint SC}
+    property <float> d;
+//  >                 <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'float' is not supported in Slint SC}
+    property <image> e;
+//  >                 <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'image' is not supported in Slint SC}
+    property <length> f;
+//  >                  <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+    property <duration> g;
+//  >                    <error{Property declarations are not supported in Slint SC}
+//            >      <^error{The type 'duration' is not supported in Slint SC}
+    property <brush> h;
+//  >                 <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'brush' is not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/units.slint
+++ b/internal/compiler/tests/syntax/slint-sc/units.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Number literals with units are rejected in Slint SC mode.
+
+export component Test inherits Window {
+//               >  <error{Component declarations are not supported in Slint SC}
+//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
+    property <length> a: 100px;
+//  >                         <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+//                       >   <^^error{Number literals are not supported in Slint SC}
+    property <length> b: 50phx;
+//  >                         <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+//                       >   <^^error{Number literals are not supported in Slint SC}
+    property <length> c: 2cm;
+//  >                       <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+//                       > <^^error{Number literals are not supported in Slint SC}
+    property <length> d: 10mm;
+//  >                        <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+//                       >  <^^error{Number literals are not supported in Slint SC}
+    property <length> e: 1in;
+//  >                       <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+//                       > <^^error{Number literals are not supported in Slint SC}
+    property <length> f: 72pt;
+//  >                        <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+//                       >  <^^error{Number literals are not supported in Slint SC}
+    property <duration> g: 100ms;
+//  >                           <error{Property declarations are not supported in Slint SC}
+//            >      <^error{The type 'duration' is not supported in Slint SC}
+//                         >   <^^error{Number literals are not supported in Slint SC}
+    property <duration> h: 1s;
+//  >                        <error{Property declarations are not supported in Slint SC}
+//            >      <^error{The type 'duration' is not supported in Slint SC}
+//                         ><^^error{Number literals are not supported in Slint SC}
+    property <angle> i: 90deg;
+//  >                        <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'angle' is not supported in Slint SC}
+//                      >   <^^error{Number literals are not supported in Slint SC}
+    property <angle> j: 0.5turn;
+//  >                          <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'angle' is not supported in Slint SC}
+//                      >     <^^error{Number literals are not supported in Slint SC}
+    property <float> k: 50%;
+//  >                      <error{Property declarations are not supported in Slint SC}
+//            >   <^error{The type 'float' is not supported in Slint SC}
+//                      > <^^error{Number literals are not supported in Slint SC}
+    property <length> l: 2rem;
+//  >                        <error{Property declarations are not supported in Slint SC}
+//            >    <^error{The type 'length' is not supported in Slint SC}
+//                       >  <^^error{Number literals are not supported in Slint SC}
+}


### PR DESCRIPTION
Emit an error for every type used in property declarations and struct fields (e.g. "The type 'int' is not supported in Slint SC") Emit errors for every expression kind.
