### PR TITLE
C++: expose public StyledText markdown parsing API

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -460,7 +460,7 @@ fn gen_corelib(
         .with_src(crate_dir.join("string.rs"))
         .with_src(crate_dir.join("styled_text.rs"))
         .with_src(crate_dir.join("slice.rs"))
-        .with_after_include("namespace slint { struct SharedString; namespace private_api { struct StyledText; } namespace cbindgen_private { using private_api::StyledText; }}")
+        .with_after_include("namespace slint { struct SharedString; struct StyledText; }")
         .generate()
         .context("Unable to generate bindings for slint_string_internal.h")?
         .write_to_file(include_dir.join("slint_string_internal.h"));

--- a/api/cpp/docs/types.md
+++ b/api/cpp/docs/types.md
@@ -22,6 +22,8 @@ The follow table summarizes the entire mapping:
  structure                   A :code:`class` of the same name     The order of the data member are in the same as in the slint declaration
  anonymous object            A :code:`std::tuple`                 The fields are in alphabetical order.
  enum                        An :code:`enum class`                The values are always converted to CamelCase. The order of the values is the same as in the declaration.
+ :code:`data-transfer`       :cpp:class:`slint::DataTransfer`      Data associated with a drag-drop transfer.
+ :code:`styled-text`         :cpp:class:`slint::StyledText`       Styled text parsed from markdown or plain text. Use :code:`StyledText::from_markdown()` or :code:`StyledText::from_plain_text()` to create.
  :code:`Point`               :cpp:class:`slint::LogicalPosition`  A struct with :code:`x` and :code:`y` fields, representing logical coordinates.
 ===========================  ===================================  =======================================================================================================================================
 ```

--- a/api/cpp/include/private/slint_string.h
+++ b/api/cpp/include/private/slint_string.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #pragma once
+#include <optional>
 #include <string_view>
 #include <span>
 #include "private/slint_string_internal.h"
@@ -225,11 +226,44 @@ private:
 
 namespace private_api {
 
-/// Styled text that has been parsed and seperated into paragraphs
+template<typename T>
+inline cbindgen_private::Slice<T> make_slice(const T *ptr, size_t len)
+{
+    return cbindgen_private::Slice<T> {
+        // Rust uses a NonNull, so even empty slices shouldn't use nullptr
+        .ptr = ptr ? const_cast<T *>(ptr) : reinterpret_cast<T *>(sizeof(T)),
+        .len = len,
+    };
+}
+
+template<typename T, size_t Extent>
+inline cbindgen_private::Slice<std::remove_const_t<T>> make_slice(std::span<T, Extent> span)
+{
+    return make_slice(span.data(), span.size());
+}
+
+inline cbindgen_private::Slice<uint8_t> string_to_slice(std::string_view str)
+{
+    return make_slice(reinterpret_cast<const uint8_t *>(str.data()), str.size());
+}
+
+inline std::string_view slice_to_string_view(cbindgen_private::Slice<uint8_t> str)
+{
+    return std::string_view(reinterpret_cast<const char *>(str.ptr), str.len);
+}
+
+}
+
+/// Styled text that has been parsed and separated into paragraphs.
+///
+/// Use `StyledText::from_markdown()` to parse a markdown string, or
+/// `StyledText::from_plain_text()` to wrap plain text without formatting.
+///
+/// Assign the result to a `styled-text` property in a Slint component to display it.
 struct StyledText
 {
 public:
-    /// Creates an default styled text.
+    /// Creates a default (empty) styled text.
     StyledText() { cbindgen_private::slint_styled_text_new(this); }
     /// Destroys this StyledText.
     ~StyledText() { cbindgen_private::slint_styled_text_drop(this); }
@@ -258,35 +292,32 @@ public:
         return cbindgen_private::slint_styled_text_eq(&a, &b);
     }
 
+#if !defined(SLINT_FEATURE_FREESTANDING) || defined(DOXYGEN)
+    /// Creates styled text from plain text without applying markdown parsing.
+    static StyledText from_plain_text(std::string_view text)
+    {
+        StyledText result;
+        cbindgen_private::slint_styled_text_from_plain_text(
+                private_api::string_to_slice(text), &result);
+        return result;
+    }
+
+    /// Parses markdown into styled text.
+    ///
+    /// Returns `std::nullopt` if the markdown contains unsupported syntax.
+    static std::optional<StyledText> from_markdown(std::string_view markdown)
+    {
+        StyledText result;
+        if (cbindgen_private::slint_styled_text_from_markdown(
+                    private_api::string_to_slice(markdown), &result)) {
+            return result;
+        }
+        return std::nullopt;
+    }
+#endif
+
 private:
     void *inner;
 };
 
-template<typename T>
-inline cbindgen_private::Slice<T> make_slice(const T *ptr, size_t len)
-{
-    return cbindgen_private::Slice<T> {
-        // Rust uses a NonNull, so even empty slices shouldn't use nullptr
-        .ptr = ptr ? const_cast<T *>(ptr) : reinterpret_cast<T *>(sizeof(T)),
-        .len = len,
-    };
-}
-
-template<typename T, size_t Extent>
-inline cbindgen_private::Slice<std::remove_const_t<T>> make_slice(std::span<T, Extent> span)
-{
-    return make_slice(span.data(), span.size());
-}
-
-inline cbindgen_private::Slice<uint8_t> string_to_slice(std::string_view str)
-{
-    return make_slice(reinterpret_cast<const uint8_t *>(str.data()), str.size());
-}
-
-inline std::string_view slice_to_string_view(cbindgen_private::Slice<uint8_t> str)
-{
-    return std::string_view(reinterpret_cast<const char *>(str.ptr), str.len);
-}
-
-}
 }

--- a/api/cpp/include/private/slint_string.h
+++ b/api/cpp/include/private/slint_string.h
@@ -297,8 +297,8 @@ public:
     static StyledText from_plain_text(std::string_view text)
     {
         StyledText result;
-        cbindgen_private::slint_styled_text_from_plain_text(
-                private_api::string_to_slice(text), &result);
+        cbindgen_private::slint_styled_text_from_plain_text(private_api::string_to_slice(text),
+                                                            &result);
         return result;
     }
 

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -304,13 +304,64 @@ TEST_CASE("SharedVector")
 
 TEST_CASE("StyledText")
 {
-    auto empty_arguments = std::array<slint::private_api::StyledText, 0> {};
+    auto empty_arguments = std::array<slint::StyledText, 0> {};
     auto text = slint::private_api::parse_markdown(
             "Hello *world*", slint::private_api::make_slice(std::span(empty_arguments)));
-    auto text_argument = std::array<slint::private_api::StyledText, 1> { text };
+    auto text_argument = std::array<slint::StyledText, 1> { text };
     // \u{e541} is MARKDOWN_INTERPOLATION_PLACEHOLDER defined in internal/common/styled_text.rs
     auto text2 = slint::private_api::parse_markdown(
             u8"Text: \uE541", slint::private_api::make_slice(std::span(text_argument)));
+}
+
+TEST_CASE("StyledText public API")
+{
+    using slint::StyledText;
+    using slint::SharedString;
+
+    SECTION("from_plain_text")
+    {
+        auto text = StyledText::from_plain_text("Hello world");
+        auto text2 = StyledText::from_plain_text("Hello world");
+        REQUIRE(text == text2);
+
+        auto empty = StyledText::from_plain_text("");
+        REQUIRE(!(text == empty));
+    }
+
+    SECTION("from_markdown success")
+    {
+        auto result = StyledText::from_markdown("Hello *world*!");
+        REQUIRE(result.has_value());
+
+        auto result2 = StyledText::from_markdown("Hello *world*!");
+        REQUIRE(result2.has_value());
+        REQUIRE(*result == *result2);
+    }
+
+    SECTION("from_markdown error")
+    {
+        auto result = StyledText::from_markdown("# heading");
+        REQUIRE(!result.has_value());
+    }
+
+    SECTION("from_plain_text vs from_markdown")
+    {
+        auto plain = StyledText::from_plain_text("plain text");
+        auto md = StyledText::from_markdown("plain text");
+        REQUIRE(md.has_value());
+        REQUIRE(plain == *md);
+    }
+
+    SECTION("copy and assign")
+    {
+        auto original = StyledText::from_plain_text("test");
+        StyledText copy(original);
+        REQUIRE(copy == original);
+
+        StyledText assigned;
+        assigned = original;
+        REQUIRE(assigned == original);
+    }
 }
 
 TEST_CASE("DataTransfer")

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -315,8 +315,8 @@ TEST_CASE("StyledText")
 
 TEST_CASE("StyledText public API")
 {
-    using slint::StyledText;
     using slint::SharedString;
+    using slint::StyledText;
 
     SECTION("from_plain_text")
     {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -566,7 +566,7 @@ impl CppType for Type {
             Type::LayoutCache => Some("slint::SharedVector<float>".into()),
             Type::ArrayOfU16 => Some("slint::SharedVector<uint16_t>".into()),
             Type::Easing => Some("slint::cbindgen_private::EasingCurve".into()),
-            Type::StyledText => Some("slint::private_api::StyledText".into()),
+            Type::StyledText => Some("slint::StyledText".into()),
             _ => None,
         }
     }

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -114,6 +114,35 @@ pub mod ffi {
     pub unsafe extern "C" fn slint_styled_text_clone(out: *mut StyledText, ss: &StyledText) {
         unsafe { core::ptr::write(out, ss.clone()) }
     }
+
+    #[cfg(feature = "std")]
+    #[unsafe(no_mangle)]
+    /// Create a styled text from plain text
+    pub extern "C" fn slint_styled_text_from_plain_text(
+        text: crate::slice::Slice<u8>,
+        out: &mut StyledText,
+    ) {
+        let text = unsafe { core::str::from_utf8_unchecked(text.as_slice()) };
+        *out = StyledText::from_plain_text(text);
+    }
+
+    #[cfg(feature = "std")]
+    #[unsafe(no_mangle)]
+    /// Parse markdown into styled text. Returns true on success.
+    /// On failure, resets `out` to default.
+    pub extern "C" fn slint_styled_text_from_markdown(
+        markdown: crate::slice::Slice<u8>,
+        out: &mut StyledText,
+    ) -> bool {
+        let markdown = unsafe { core::str::from_utf8_unchecked(markdown.as_slice()) };
+        match StyledText::from_markdown(markdown) {
+            Ok(styled) => {
+                *out = styled;
+                true
+            }
+            Err(_) => false,
+        }
+    }
 }
 
 pub fn parse_markdown(_format_string: &str, _args: &[StyledText]) -> StyledText {


### PR DESCRIPTION
Move StyledText from private_api to the public slint namespace and add from_plain_text() and from_markdown() static methods, mirroring the Rust API.

CC: #11158
