### PR TITLE
node: expose public StyledText markdown parsing API

### DIFF
--- a/api/node/README.md
+++ b/api/node/README.md
@@ -196,6 +196,7 @@ The types used for properties in .slint design markup each translate to specific
 | `angle` | `Number` | The angle in degrees |
 | structure | `Object` | Structures are mapped to JavaScript objects where each structure field is a property. |
 | array | `Array` or any implementation of Model | |
+| `styled-text` | `StyledText` | Use `StyledText.fromMarkdown()` or `StyledText.fromPlainText()` to create. |
 | enumeration | `String` | The value of an enum |
 
 ### Arrays and Models

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -448,7 +448,7 @@ test("StyledText.fromMarkdown throws on invalid color", () => {
 test("StyledText.fromMarkdown reports multiple errors", () => {
     let thrownError: any;
     try {
-        StyledText.fromMarkdown("<div>block</div>\n<img src=\"x\">");
+        StyledText.fromMarkdown('<div>block</div>\n<img src="x">');
     } catch (error) {
         thrownError = error;
     }

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -409,8 +409,55 @@ test("loadSource styled-text with inline markdown expression", () => {
     expect(result.equals(expected)).toBe(true);
 });
 
-test("StyledText.fromMarkdown throws on unsupported syntax", () => {
-    expect(() => StyledText.fromMarkdown("<div>not supported</div>")).toThrow();
+test("StyledText.fromMarkdown throws on unsupported HTML tag", () => {
+    let thrownError: any;
+    try {
+        StyledText.fromMarkdown("<span>text</span>");
+    } catch (error) {
+        thrownError = error;
+    }
+    expect(thrownError).toBeDefined();
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError.message).toBe("HTML tag <span> is not supported");
+});
+
+test("StyledText.fromMarkdown throws on unsupported markdown syntax", () => {
+    let thrownError: any;
+    try {
+        StyledText.fromMarkdown("![alt](image.png)");
+    } catch (error) {
+        thrownError = error;
+    }
+    expect(thrownError).toBeDefined();
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError.message).toBe("Markdown images are not supported");
+});
+
+test("StyledText.fromMarkdown throws on invalid color", () => {
+    let thrownError: any;
+    try {
+        StyledText.fromMarkdown('<font color="notacolor">text</font>');
+    } catch (error) {
+        thrownError = error;
+    }
+    expect(thrownError).toBeDefined();
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError.message).toBe("Invalid color value 'notacolor'");
+});
+
+test("StyledText.fromMarkdown reports multiple errors", () => {
+    let thrownError: any;
+    try {
+        StyledText.fromMarkdown("<div>block</div>\n<img src=\"x\">");
+    } catch (error) {
+        thrownError = error;
+    }
+    expect(thrownError).toBeDefined();
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError.message).toContain("are not supported");
+    // The message contains multiple errors separated by newlines
+    const lines = thrownError.message.split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(2);
 });
 
 test("file loader", () => {

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -5,7 +5,12 @@ import { test, expect } from "vitest";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { loadFile, loadSource, CompileError, StyledText } from "../dist/index.js";
+import {
+    loadFile,
+    loadSource,
+    CompileError,
+    StyledText,
+} from "../dist/index.js";
 
 const dirname = path.dirname(
     fileURLToPath(import.meta.url).replace("build", "__test__"),

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -5,7 +5,7 @@ import { test, expect } from "vitest";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { loadFile, loadSource, CompileError } from "../dist/index.js";
+import { loadFile, loadSource, CompileError, StyledText } from "../dist/index.js";
 
 const dirname = path.dirname(
     fileURLToPath(import.meta.url).replace("build", "__test__"),
@@ -315,6 +315,93 @@ test("loadFile enum", () => {
     test.check = demo.TestEnum.c;
 
     expect(test.check).toStrictEqual("c");
+});
+
+test("loadSource styled-text property get/set", () => {
+    const source = `export component App {
+        in-out property <styled-text> content;
+    }`;
+    const demo = loadSource(source, "api.spec.ts") as any;
+    const app = new demo.App();
+
+    const st = StyledText.fromPlainText("hello world");
+    app.content = st;
+
+    const result = app.content;
+    expect(result).toBeInstanceOf(StyledText);
+    expect(result.equals(st)).toBe(true);
+});
+
+test("loadSource styled-text property with markdown", () => {
+    const source = `export component App {
+        in-out property <styled-text> content;
+    }`;
+    const demo = loadSource(source, "api.spec.ts") as any;
+    const app = new demo.App();
+
+    const st = StyledText.fromMarkdown("**bold** and *italic*");
+    app.content = st;
+
+    const result = app.content;
+    expect(result).toBeInstanceOf(StyledText);
+    expect(result.equals(st)).toBe(true);
+});
+
+test("loadSource styled-text default is returned as StyledText", () => {
+    const source = `export component App {
+        in-out property <styled-text> content;
+    }`;
+    const demo = loadSource(source, "api.spec.ts") as any;
+    const app = new demo.App();
+
+    const result = app.content;
+    expect(result).toBeInstanceOf(StyledText);
+});
+
+test("loadSource styled-text in callback argument", () => {
+    const source = `export component App {
+        in-out property <styled-text> content;
+        callback format(styled-text) -> styled-text;
+    }`;
+    const demo = loadSource(source, "api.spec.ts") as any;
+    const app = new demo.App({
+        format: (st: InstanceType<typeof StyledText>) => {
+            expect(st).toBeInstanceOf(StyledText);
+            return StyledText.fromPlainText("formatted");
+        },
+    });
+
+    const input = StyledText.fromPlainText("input");
+    const result = app.format(input);
+    expect(result).toBeInstanceOf(StyledText);
+    expect(result.equals(StyledText.fromPlainText("formatted"))).toBe(true);
+});
+
+test("loadSource styled-text constructor parameter", () => {
+    const source = `export component App {
+        in-out property <styled-text> content;
+    }`;
+    const demo = loadSource(source, "api.spec.ts") as any;
+    const st = StyledText.fromPlainText("initial");
+    const app = new demo.App({ content: st });
+
+    const result = app.content;
+    expect(result).toBeInstanceOf(StyledText);
+    expect(result.equals(st)).toBe(true);
+});
+
+test("loadSource styled-text with inline markdown expression", () => {
+    const source = `export component App {
+        out property <styled-text> content: @markdown("hello **world**");
+    }`;
+    const demo = loadSource(source, "api.spec.ts") as any;
+    const app = new demo.App();
+
+    const result = app.content;
+    expect(result).toBeInstanceOf(StyledText);
+
+    const expected = StyledText.fromMarkdown("hello **world**");
+    expect(result.equals(expected)).toBe(true);
 });
 
 test("file loader", () => {

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -409,6 +409,10 @@ test("loadSource styled-text with inline markdown expression", () => {
     expect(result.equals(expected)).toBe(true);
 });
 
+test("StyledText.fromMarkdown throws on unsupported syntax", () => {
+    expect(() => StyledText.fromMarkdown("<div>not supported</div>")).toThrow();
+});
+
 test("file loader", () => {
     const testSource = `export component Test {
        in-out property <string> text: "Hello World";

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -8,6 +8,7 @@ import { read, ImageColorModel } from "image-js";
 import { captureAsyncStderr } from "./helpers/utils.js";
 import {
     private_api,
+    StyledText,
     type ImageData,
     ArrayModel,
     type Model,
@@ -1076,4 +1077,55 @@ test("throw exception set color", () => {
         expect(thrownError.code).toBe("GenericFailure");
         expect(thrownError.message).toBe("Property red is missing");
     }
+});
+
+test("StyledText from plain text", () => {
+    const st = StyledText.fromPlainText("hello world");
+    expect(st).toBeDefined();
+});
+
+test("StyledText from markdown", () => {
+    const st = StyledText.fromMarkdown("**bold** text");
+    expect(st).toBeDefined();
+});
+
+test("StyledText equality", () => {
+    const a = StyledText.fromPlainText("hello");
+    const b = StyledText.fromPlainText("hello");
+    const c = StyledText.fromPlainText("world");
+    expect(a.equals(b)).toBe(true);
+    expect(a.equals(c)).toBe(false);
+});
+
+test("get/set styled-text properties", () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `export component App { in-out property <styled-text> content; }`,
+        "",
+    );
+    const instance = createNonNullInstance(definition);
+
+    const st = StyledText.fromPlainText("hello");
+    instance.setProperty("content", st);
+
+    const result = instance.getProperty("content");
+    expect(result).toBeDefined();
+    expect(result).toBeInstanceOf(StyledText);
+    expect((result as InstanceType<typeof StyledText>).equals(st)).toBe(true);
+});
+
+test("get/set styled-text from markdown property", () => {
+    const compiler = new private_api.ComponentCompiler();
+    const definition = compiler.buildFromSource(
+        `export component App { in-out property <styled-text> content; }`,
+        "",
+    );
+    const instance = createNonNullInstance(definition);
+
+    const st = StyledText.fromMarkdown("**bold** text");
+    instance.setProperty("content", st);
+
+    const result = instance.getProperty("content");
+    expect(result).toBeInstanceOf(StyledText);
+    expect((result as InstanceType<typeof StyledText>).equals(st)).toBe(true);
 });

--- a/api/node/cover.md
+++ b/api/node/cover.md
@@ -299,6 +299,7 @@ The types used for properties in .slint design markup each translate to specific
 | `angle` | `Number` | The angle in degrees |
 | `relative-font-size` | `Number` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | structure | `Object` | Structures are mapped to JavaScript objects where each structure field is a property. |
+| `styled-text` | `StyledText` | Use `StyledText.fromMarkdown()` or `StyledText.fromPlainText()` to create. |
 | array | {@link Model} | |
 
 ### Arrays and Models

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use crate::{
-    ReadOnlyRustModel, RgbaColor, SlintBrush, SlintImageData, SlintKeys, js_into_rust_model,
-    rust_into_js_model,
+    ReadOnlyRustModel, RgbaColor, SlintBrush, SlintImageData, SlintKeys, SlintStyledText,
+    js_into_rust_model, rust_into_js_model,
 };
 use i_slint_compiler::langtype::Type;
 use i_slint_core::graphics::{Image, Rgba8Pixel, SharedPixelBuffer};
@@ -126,6 +126,12 @@ pub fn to_js_unknown<'a>(env: &'a Env, value: &Value) -> Result<Unknown<'a>> {
             }
         }
         Value::EnumerationValue(_, value) => value.as_str().into_unknown(env),
+        Value::StyledText(styled_text) => {
+            SlintStyledText::from(styled_text.clone())
+                .into_instance(env)?
+                .as_object(env)
+                .into_unknown(env)
+        }
         _ => ().into_unknown(env),
     }
 }
@@ -372,8 +378,13 @@ pub fn to_value(
         | Type::LayoutCache
         | Type::ArrayOfU16
         | Type::ElementReference
-        | Type::StyledText
         | Type::DataTransfer => Err(napi::Error::from_reason("reason")),
+        Type::StyledText => {
+            let obj = unknown.coerce_to_object()?;
+            let styled_instance: ClassInstance<SlintStyledText> =
+                ClassInstance::from_unknown(obj.into_unknown(env)?)?;
+            Ok(Value::StyledText(styled_instance.inner.clone()))
+        }
     }
 }
 

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -126,12 +126,10 @@ pub fn to_js_unknown<'a>(env: &'a Env, value: &Value) -> Result<Unknown<'a>> {
             }
         }
         Value::EnumerationValue(_, value) => value.as_str().into_unknown(env),
-        Value::StyledText(styled_text) => {
-            SlintStyledText::from(styled_text.clone())
-                .into_instance(env)?
-                .as_object(env)
-                .into_unknown(env)
-        }
+        Value::StyledText(styled_text) => SlintStyledText::from(styled_text.clone())
+            .into_instance(env)?
+            .as_object(env)
+            .into_unknown(env),
         _ => ().into_unknown(env),
     }
 }

--- a/api/node/rust/types.rs
+++ b/api/node/rust/types.rs
@@ -18,3 +18,6 @@ pub use point::*;
 
 mod size;
 pub use size::*;
+
+mod styled_text;
+pub use styled_text::*;

--- a/api/node/rust/types/styled_text.rs
+++ b/api/node/rust/types/styled_text.rs
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use i_slint_core::styled_text::StyledText;
+
+/// Styled text parsed from markdown or plain text.
+///
+/// Use `StyledText.fromMarkdown()` or `StyledText.fromPlainText()` to create instances.
+/// Assign the result to a `styled-text` property in a Slint component to display it.
+#[napi(js_name = "StyledText")]
+pub struct SlintStyledText {
+    pub(crate) inner: StyledText,
+}
+
+impl From<StyledText> for SlintStyledText {
+    fn from(styled_text: StyledText) -> Self {
+        Self { inner: styled_text }
+    }
+}
+
+#[napi]
+impl SlintStyledText {
+    /// Creates styled text from plain text without applying markdown parsing.
+    #[napi(factory)]
+    pub fn from_plain_text(text: String) -> Self {
+        Self { inner: StyledText::from_plain_text(&text) }
+    }
+
+    /// Parses markdown into styled text.
+    ///
+    /// Throws an error if the markdown contains unsupported syntax.
+    #[napi(factory)]
+    pub fn from_markdown(markdown: String) -> napi::Result<Self> {
+        StyledText::from_markdown(&markdown)
+            .map(|st| Self { inner: st })
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Returns `true` if this styled text is equal to `other`.
+    #[napi]
+    pub fn equals(&self, other: &SlintStyledText) -> bool {
+        self.inner == other.inner
+    }
+}

--- a/api/node/rust/types/styled_text.rs
+++ b/api/node/rust/types/styled_text.rs
@@ -28,7 +28,7 @@ impl SlintStyledText {
 
     /// Parses markdown into styled text.
     ///
-    /// Throws an error if the markdown contains unsupported syntax.
+    /// @throws {Error} if the markdown contains unsupported syntax.
     #[napi(factory)]
     pub fn from_markdown(markdown: String) -> napi::Result<Self> {
         StyledText::from_markdown(&markdown)

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -7,6 +7,7 @@ export {
     DiagnosticLevel,
     RgbaColor,
     Brush,
+    StyledText,
 } from "../rust-module.cjs";
 
 import { Model } from "./models";

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -58,9 +58,9 @@ export component TestCase inherits Window {
     property <string> my-color: "blue";
     property <string> bad-color: "not-a-color";
 
-    out property<styled-text> t1: s1.text;
-    out property<styled-text> t2: s2.text;
-    out property<styled-text> t3: s3.text;
+    in-out property<styled-text> t1: s1.text;
+    in-out property<styled-text> t2: s2.text;
+    in-out property<styled-text> t3: s3.text;
     // Regression test for #11471 - StyledText type must have a default,
     // otherwise it crashes when left out of a struct declaration!
     out property<TestStruct> default-struct : {
@@ -68,6 +68,8 @@ export component TestCase inherits Window {
     };
     property<styled-text> unset-styled-text;
     out property<styled-text> default-styled-text: unset-styled-text;
+    in-out property<styled-text> plain-text-prop;
+    out property<styled-text> foo-bar: @markdown("foo bar");
 
     out property<length> w1: s1.preferred-width;
     out property<length> w2: s2.preferred-width;
@@ -101,6 +103,27 @@ assert!(instance.get_test());
 assert_eq!(instance.get_default_struct().text, StyledText::default());
 assert_eq!(instance.get_default_styled_text(), StyledText::default());
 
+// Public API: from_plain_text round-trip
+let plain = StyledText::from_plain_text("Hello World");
+instance.set_plain_text_prop(plain.clone());
+assert_eq!(instance.get_plain_text_prop(), plain);
+
+// Public API: from_markdown round-trip
+let md = StyledText::from_markdown("Hello *World*").unwrap();
+instance.set_t1(md.clone());
+assert_eq!(instance.get_t1(), md);
+
+// from_plain_text and from_markdown produce the same result for unstyled text
+let plain2 = StyledText::from_plain_text("plain text");
+let md2 = StyledText::from_markdown("plain text").unwrap();
+assert_eq!(plain2, md2);
+
+// @markdown("foo bar") in .slint equals from_plain_text("foo bar")
+assert_eq!(instance.get_foo_bar(), StyledText::from_plain_text("foo bar"));
+
+// Public API: from_markdown rejects unsupported syntax
+assert!(StyledText::from_markdown("# heading").is_err());
+
 // s11 uses an invalid interpolated color — check that it logged a debug_log error
 let logs = slint_testing::access_testing_window(instance.window(), |w| w.take_debug_log());
 let has_color_error = logs.iter().any(|l| l.contains("Invalid color value") && l.contains("not-a-color"));
@@ -109,12 +132,78 @@ assert!(has_color_error, "Expected debug_log about invalid color, got: {logs:?}"
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
+
+// Compare t1/t2/t3 content with from_markdown
+assert(instance.get_t1() == *slint::StyledText::from_markdown("Hello World"));
+assert(instance.get_t2() == *slint::StyledText::from_markdown("Hello \\*World\\*"));
+assert(instance.get_t3() == *slint::StyledText::from_markdown("Hello *World*"));
+
 assert(instance.get_w1() == 66.0);
 assert(instance.get_w2() == 80.0);
 assert(instance.get_w3() == 64.0);
 assert(instance.get_w4() == 64.0);
 assert(instance.get_w5() == 65.0);
 assert(instance.get_test());
-assert(instance.get_default_styled_text() == slint::private_api::StyledText());
+assert(instance.get_default_styled_text() == slint::StyledText());
+
+// from_plain_text round-trip
+auto plain = slint::StyledText::from_plain_text("Hello World");
+handle->set_plain_text_prop(plain);
+assert(handle->get_plain_text_prop() == plain);
+
+// from_markdown round-trip
+auto md = slint::StyledText::from_markdown("Hello *World*");
+assert(md.has_value());
+handle->set_t1(*md);
+assert(handle->get_t1() == *md);
+
+// from_plain_text and from_markdown produce the same result for unstyled text
+auto plain2 = slint::StyledText::from_plain_text("plain text");
+auto md2 = slint::StyledText::from_markdown("plain text");
+assert(md2.has_value());
+assert(plain2 == *md2);
+
+// @markdown("foo bar") in .slint equals from_plain_text("foo bar")
+assert(instance.get_foo_bar() == slint::StyledText::from_plain_text("foo bar"));
+
+// from_markdown returns nullopt for unsupported syntax
+auto bad = slint::StyledText::from_markdown("# heading");
+assert(!bad.has_value());
+```
+```js
+var instance = new slint.TestCase({});
+let StyledText = slintlib.StyledText;
+
+// Compare t1/t2/t3 content with fromMarkdown
+assert(instance.t1.equals(StyledText.fromMarkdown("Hello World")));
+assert(instance.t2.equals(StyledText.fromMarkdown("Hello \\*World\\*")));
+assert(instance.t3.equals(StyledText.fromMarkdown("Hello *World*")));
+
+// Default styled-text is a StyledText instance
+let def = instance.default_styled_text;
+assert(def instanceof StyledText);
+
+// fromPlainText round-trip
+let plain = StyledText.fromPlainText("Hello World");
+instance.plain_text_prop = plain;
+assert(instance.plain_text_prop.equals(plain));
+
+// fromMarkdown round-trip
+let md = StyledText.fromMarkdown("Hello *World*");
+instance.t1 = md;
+assert(instance.t1.equals(md));
+
+// fromPlainText and fromMarkdown produce the same result for unstyled text
+let plain2 = StyledText.fromPlainText("plain text");
+let md2 = StyledText.fromMarkdown("plain text");
+assert(plain2.equals(md2));
+
+// @markdown("foo bar") in .slint equals fromPlainText("foo bar")
+assert(instance.foo_bar.equals(StyledText.fromPlainText("foo bar")));
+
+// fromMarkdown throws for unsupported syntax
+let threw = false;
+try { StyledText.fromMarkdown("# heading"); } catch(e) { threw = true; }
+assert(threw);
 ```
 */


### PR DESCRIPTION
Add a StyledText class to the Node.js API with fromPlainText() and fromMarkdown() factory methods, mirroring the C++ and Rust APIs. Wire up value conversion so styled-text properties can be read and written from JavaScript.

Also extend tests/cases/types/styled_text.slint with C++ and JS test blocks that compare t1/t2/t3 content via from_markdown and exercise round-trips, plain-text equivalence, and error handling.

cc: #11158
