### PR TITLE
slint-sc: Add empty runtime crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10461,6 +10461,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "slint-sc"
+version = "1.17.0"
+
+[[package]]
 name = "slint-tr-extractor"
 version = "1.17.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   'api/rs/build',
   'api/rs/macros',
   'api/rs/slint',
+  'api/slint-sc',
   'api/python/slint',
   'api/wasm-interpreter',
   'editors/zed',

--- a/api/slint-sc/Cargo.toml
+++ b/api/slint-sc/Cargo.toml
@@ -1,0 +1,20 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+[package]
+name = "slint-sc"
+description = "Runtime library for Slint SC, the safety-critical subset of Slint"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Slint-Software-3.0"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+categories = ["gui", "rendering::engine", "no-std", "embedded"]
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = []

--- a/api/slint-sc/LICENSES/GPL-3.0-only.txt
+++ b/api/slint-sc/LICENSES/GPL-3.0-only.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/GPL-3.0-only.txt

--- a/api/slint-sc/LICENSES/LicenseRef-Slint-Software-3.0.md
+++ b/api/slint-sc/LICENSES/LicenseRef-Slint-Software-3.0.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Software-3.0.md

--- a/api/slint-sc/README.md
+++ b/api/slint-sc/README.md
@@ -1,0 +1,25 @@
+# Slint SC
+
+Slint SC is the safety-critical subset of [Slint](https://slint.dev),
+designed to be certifiable under functional safety standards such as
+ISO 26262 (automotive), IEC 61508 (industrial), and related norms.
+
+It provides a drastically reduced feature set compared to the full
+Slint framework, with an emphasis on auditability, bounded resource
+usage, and deterministic behavior.
+
+This crate (`slint-sc`) is the runtime library.
+It's `no_std`, has zero external dependencies, and doesn't use
+dynamic memory allocation.
+
+## Documentation
+
+The Slint SC Safety Manual, Qualification Plan, and usage guide live in
+[`docs/safety/`](https://github.com/slint-ui/slint/tree/master/docs/safety)
+in the Slint repository.
+
+## Status
+
+Slint SC is an early prototype.
+The compiler mode exists but all language features are currently disabled
+and will be unlocked incrementally.

--- a/api/slint-sc/lib.rs
+++ b/api/slint-sc/lib.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+#![doc = include_str!("README.md")]
+#![no_std]
+#![forbid(unsafe_code)]

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -637,6 +637,7 @@ static LICENSE_FOR_FILE: LazyLock<Vec<(regex::Regex, &'static str)>> = LazyLock:
         ("^ui-libraries/material", MIT_LICENSE),
         ("^tests/manual/module-builds/", MIT_LICENSE),
         ("^tools/figma-inspector/", MIT_LICENSE),
+        ("^api/slint-sc/", DUAL_LICENSE_NO_ROYALTY_FREE),
         ("(^|/)(README|CONTRIBUTING|CHANGELOG|LICENSE)\\.md", TRIPLE_LICENSE),
         (".*\\.md$", MIT_LICENSE),
         (".*", TRIPLE_LICENSE),
@@ -649,6 +650,7 @@ static LICENSE_FOR_FILE: LazyLock<Vec<(regex::Regex, &'static str)>> = LazyLock:
 
 const TRIPLE_LICENSE: &str =
     "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0";
+const DUAL_LICENSE_NO_ROYALTY_FREE: &str = "GPL-3.0-only OR LicenseRef-Slint-Software-3.0";
 const MIT_LICENSE: &str = "MIT";
 const MIT_OR_APACHE2_LICENSE: &str = "MIT OR Apache-2.0";
 


### PR DESCRIPTION
Skeleton `no_std`, `no_alloc`, zero-dependency crate at `api/slint-sc/`. It's the runtime library for Slint SC, the safety-critical subset of Slint. Will be filled in as the compiler unlocks features.
