### PR TITLE
feat: add Python API for styled-text values

### DIFF
--- a/api/python/slint/README.md
+++ b/api/python/slint/README.md
@@ -224,7 +224,7 @@ the mapping:
 | `color`       | `slint.Color` |     |
 | `brush`       | `slint.Brush` |     |
 | `image`       | `slint.Image` |     |
-| `styled-text` | `slint.StyledText` | `StyledText.from_markdown()` or `StyledText.from_plain_text()` |
+| `styled-text` | `slint.StyledText` | |
 | `length`      | `float`     |       |
 | `physical_length` | `float` |       |
 | `duration`    | `float`     | The number of milliseconds |

--- a/api/python/slint/README.md
+++ b/api/python/slint/README.md
@@ -224,6 +224,7 @@ the mapping:
 | `color`       | `slint.Color` |     |
 | `brush`       | `slint.Brush` |     |
 | `image`       | `slint.Image` |     |
+| `styled-text` | `slint.StyledText` | `StyledText.from_markdown()` or `StyledText.from_plain_text()` |
 | `length`      | `float`     |       |
 | `physical_length` | `float` |       |
 | `duration`    | `float`     | The number of milliseconds |

--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -416,6 +416,7 @@ pub enum PyValueType {
     Struct,
     Brush,
     Image,
+    StyledText,
     Enumeration,
     Keys,
 }
@@ -441,6 +442,7 @@ impl From<i_slint_compiler::langtype::Type> for PyValueType {
             Type::Brush => PyValueType::Brush,
             Type::Color => PyValueType::Brush,
             Type::Image => PyValueType::Image,
+            Type::StyledText => PyValueType::StyledText,
             Type::Enumeration(..) => PyValueType::Enumeration,
             Type::Keys => PyValueType::Keys,
             _ => unimplemented!(),

--- a/api/python/slint/lib.rs
+++ b/api/python/slint/lib.rs
@@ -19,6 +19,7 @@ mod brush;
 mod errors;
 mod keys;
 mod models;
+mod styled_text;
 mod timer;
 mod value;
 use i_slint_core::translations::Translator;
@@ -185,6 +186,7 @@ fn slint(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<brush::PyBrush>()?;
     m.add_class::<keys::PyKeys>()?;
     m.add_class::<data_transfer::PyDataTransfer>()?;
+    m.add_class::<styled_text::PyStyledText>()?;
     m.add_class::<models::PyModelBase>()?;
     m.add_class::<value::PyStruct>()?;
     m.add_class::<async_adapter::AsyncAdapter>()?;

--- a/api/python/slint/slint/__init__.py
+++ b/api/python/slint/slint/__init__.py
@@ -17,7 +17,7 @@ import typing
 from typing import Any
 import pathlib
 from .models import ListModel, Model
-from .slint import Image, Color, Brush, Keys, DataTransfer, Timer, TimerMode
+from .slint import Image, Color, Brush, Keys, DataTransfer, StyledText, Timer, TimerMode
 from .loop import SlintEventLoop
 from pathlib import Path
 from collections.abc import Coroutine
@@ -630,6 +630,7 @@ __all__ = [
     "Brush",
     "Keys",
     "DataTransfer",
+    "StyledText",
     "Model",
     "ListModel",
     "Timer",

--- a/api/python/slint/slint/slint.pyi
+++ b/api/python/slint/slint/slint.pyi
@@ -79,6 +79,29 @@ class DataTransfer:
     def __repr__(self) -> str: ...
     def __eq__(self, other: object) -> bool: ...
 
+class StyledText:
+    r"""
+    Python wrapper for Slint's `styled-text` type.
+    """
+
+    def __new__(cls) -> "StyledText": ...
+    @staticmethod
+    def from_plain_text(text: str) -> "StyledText":
+        r"""
+        Creates styled text from plain text.
+        """
+        ...
+
+    @staticmethod
+    def from_markdown(markdown: str) -> "StyledText":
+        r"""
+        Parses markdown.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
 class Image:
     r"""
     Image objects can be set on Slint Image elements for display. Construct Image objects from a path to an
@@ -195,6 +218,7 @@ class ValueType(Enum):
     Struct = auto()
     Brush = auto()
     Image = auto()
+    StyledText = auto()
     Keys = auto()
 
 class DiagnosticLevel(Enum):

--- a/api/python/slint/slint/slint.pyi
+++ b/api/python/slint/slint/slint.pyi
@@ -6,13 +6,14 @@
 
 import builtins
 import datetime
+import gettext
 import os
 import pathlib
 import typing
-from typing import Any, List
-from collections.abc import Callable, Buffer, Coroutine
+from collections.abc import Buffer, Callable, Coroutine
 from enum import Enum, auto
-import gettext
+from typing import Any, List
+
 from . import language as language
 
 class RgbColor:
@@ -95,7 +96,10 @@ class StyledText:
     @staticmethod
     def from_markdown(markdown: str) -> "StyledText":
         r"""
-        Parses markdown.
+        Parses markdown and returns a StyledText object.
+
+        Raises:
+            ValueError: If the markdown contains unsupported syntax.
         """
         ...
 

--- a/api/python/slint/styled_text.rs
+++ b/api/python/slint/styled_text.rs
@@ -27,7 +27,9 @@ impl PyStyledText {
         Self { styled_text: i_slint_core::styled_text::StyledText::from_plain_text(text) }
     }
 
-    /// Parses markdown.
+    /// Parses markdown and returns a StyledText object.
+    ///
+    /// Raises a ValueError if the markdown contains unsupported syntax.
     #[staticmethod]
     fn from_markdown(markdown: &str) -> PyResult<Self> {
         i_slint_core::styled_text::StyledText::from_markdown(markdown)

--- a/api/python/slint/styled_text.rs
+++ b/api/python/slint/styled_text.rs
@@ -1,0 +1,51 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use pyo3::prelude::*;
+use pyo3_stub_gen::{derive::gen_stub_pyclass, derive::gen_stub_pymethods};
+
+/// Python wrapper for Slint's `styled-text` type.
+#[gen_stub_pyclass]
+#[pyclass(name = "StyledText", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyStyledText {
+    pub styled_text: i_slint_core::styled_text::StyledText,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyStyledText {
+    /// Creates empty styled text.
+    #[new]
+    fn py_new() -> Self {
+        Self { styled_text: Default::default() }
+    }
+
+    /// Creates styled text from plain text.
+    #[staticmethod]
+    fn from_plain_text(text: &str) -> Self {
+        Self { styled_text: i_slint_core::styled_text::StyledText::from_plain_text(text) }
+    }
+
+    /// Parses markdown.
+    #[staticmethod]
+    fn from_markdown(markdown: &str) -> PyResult<Self> {
+        i_slint_core::styled_text::StyledText::from_markdown(markdown)
+            .map(|styled_text| Self { styled_text })
+            .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("StyledText({:?})", self.styled_text)
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.styled_text == other.styled_text
+    }
+}
+
+impl From<i_slint_core::styled_text::StyledText> for PyStyledText {
+    fn from(styled_text: i_slint_core::styled_text::StyledText) -> Self {
+        Self { styled_text }
+    }
+}

--- a/api/python/slint/tests/test_compiler.py
+++ b/api/python/slint/tests/test_compiler.py
@@ -1,9 +1,10 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+from pathlib import Path
+
 from slint import slint as native
 from slint.slint import ValueType
-from pathlib import Path
 
 
 def test_basic_compiler() -> None:
@@ -31,7 +32,7 @@ def test_basic_compiler() -> None:
             in property <image> imgprop;
             in property <brush> brushprop;
             in property <color> colprop;
-            in property <styled-text> styledprop;
+            in property <styled-text> styledtextprop;
             in property <[string]> modelprop;
 
             callback test-callback();
@@ -57,7 +58,7 @@ def test_basic_compiler() -> None:
         ("intprop", ValueType.Number),
         ("modelprop", ValueType.Model),
         ("strprop", ValueType.String),
-        ("styledprop", ValueType.StyledText),
+        ("styledtextprop", ValueType.StyledText),
     ]
 
     assert compdef.callbacks == ["test-callback"]

--- a/api/python/slint/tests/test_compiler.py
+++ b/api/python/slint/tests/test_compiler.py
@@ -31,6 +31,7 @@ def test_basic_compiler() -> None:
             in property <image> imgprop;
             in property <brush> brushprop;
             in property <color> colprop;
+            in property <styled-text> styledprop;
             in property <[string]> modelprop;
 
             callback test-callback();
@@ -56,6 +57,7 @@ def test_basic_compiler() -> None:
         ("intprop", ValueType.Number),
         ("modelprop", ValueType.Model),
         ("strprop", ValueType.String),
+        ("styledprop", ValueType.StyledText),
     ]
 
     assert compdef.callbacks == ["test-callback"]

--- a/api/python/slint/tests/test_instance.py
+++ b/api/python/slint/tests/test_instance.py
@@ -3,7 +3,7 @@
 
 import pytest
 from slint import slint as native
-from slint.slint import Image, Color, Brush
+from slint.slint import Image, Color, Brush, StyledText
 import os
 from pathlib import Path
 
@@ -32,6 +32,7 @@ def test_property_access() -> None:
             in property <image> imgprop;
             in property <brush> brushprop: Colors.rgb(255, 0, 255);
             in property <color> colprop: Colors.rgb(0, 255, 0);
+            in property <styled-text> styledprop: @markdown("Hello **Python**");
             in property <[string]> modelprop;
             in property <MyStruct> structprop: {
                 title: "builtin",
@@ -125,6 +126,23 @@ def test_property_access() -> None:
     instance.set_property("colprop", Color("rgb(128, 128, 128)"))
     brushval = instance.get_property("colprop")
     assert str(brushval.color) == "argb(255, 128, 128, 128)"
+
+    styledval = instance.get_property("styledprop")
+    assert isinstance(styledval, StyledText)
+    assert styledval == StyledText.from_markdown("Hello **Python**")
+
+    plain_text = StyledText.from_plain_text("Plain Python")
+    instance.set_property("styledprop", plain_text)
+    assert instance.get_property("styledprop") == plain_text
+
+    markdown_text = StyledText.from_markdown("Hello *again*")
+    instance.set_property("styledprop", markdown_text)
+    assert instance.get_property("styledprop") == markdown_text
+
+    assert StyledText.from_plain_text("same") == StyledText.from_markdown("same")
+
+    with pytest.raises(ValueError, match="Markdown headings are not supported"):
+        StyledText.from_markdown("# heading")
 
     with pytest.raises(ValueError, match="no such property"):
         instance.set_global_property("nonexistent", "theglobalprop", 42)

--- a/api/python/slint/value.rs
+++ b/api/python/slint/value.rs
@@ -60,6 +60,9 @@ impl<'py> IntoPyObject<'py> for SlintToPyValue {
                 type_collection.struct_to_py(structval, struct_type).into_bound_py_any(py)
             }
             Value::Brush(brush) => crate::brush::PyBrush::from(brush).into_bound_py_any(py),
+            Value::StyledText(styled_text) => {
+                crate::styled_text::PyStyledText::from(styled_text).into_bound_py_any(py)
+            }
             Value::EnumerationValue(enum_name, enum_value) => {
                 type_collection.enum_to_py(&enum_name, &enum_value, py)?.into_bound_py_any(py)
             }
@@ -353,6 +356,11 @@ impl TypeCollection {
             .or_else(|_| {
                 ob.extract::<PyRef<'_, crate::brush::PyBrush>>()
                     .map(|pybrush| slint_interpreter::Value::Brush(pybrush.brush.clone()))
+            })
+            .or_else(|_| {
+                ob.extract::<PyRef<'_, crate::styled_text::PyStyledText>>().map(|styled_text| {
+                    slint_interpreter::Value::StyledText(styled_text.styled_text.clone())
+                })
             })
             .or_else(|_| {
                 ob.extract::<PyRef<'_, PyKeys>>()

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -669,6 +669,7 @@ fn python_type_name(ty: &Type) -> SmolStr {
         Type::Image => SmolStr::new_static("slint.Image"),
         Type::Bool => SmolStr::new_static("bool"),
         Type::Brush => SmolStr::new_static("slint.Brush"),
+        Type::StyledText => SmolStr::new_static("slint.StyledText"),
         Type::Array(elem_type) => format_smolstr!("slint.Model[{}]", python_type_name(elem_type)),
         Type::Struct(s) => match &s.name {
             StructName::User { name, .. } => ident(name),

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -1,8 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//ignore: pyi
-
 export struct TestStruct {
     label: string,
     text: styled-text,
@@ -205,5 +203,43 @@ assert(instance.foo_bar.equals(StyledText.fromPlainText("foo bar")));
 let threw = false;
 try { StyledText.fromMarkdown("# heading"); } catch(e) { threw = true; }
 assert(threw);
+```
+```python
+instance = TestCase()
+
+# Compare t1/t2/t3 content with from_markdown
+assert instance.t1 == slint.StyledText.from_markdown("Hello World")
+assert instance.t2 == slint.StyledText.from_markdown("Hello \\*World\\*")
+assert instance.t3 == slint.StyledText.from_markdown("Hello *World*")
+
+# Default styled-text is a StyledText instance
+assert isinstance(instance.default_styled_text, slint.StyledText)
+assert instance.default_styled_text == slint.StyledText()
+
+# from_plain_text round-trip
+plain = slint.StyledText.from_plain_text("Hello World")
+instance.plain_text_prop = plain
+assert instance.plain_text_prop == plain
+
+# from_markdown round-trip
+md = slint.StyledText.from_markdown("Hello *World*")
+instance.t1 = md
+assert instance.t1 == md
+
+# from_plain_text and from_markdown produce the same result for unstyled text
+plain2 = slint.StyledText.from_plain_text("plain text")
+md2 = slint.StyledText.from_markdown("plain text")
+assert plain2 == md2
+
+# @markdown("foo bar") in .slint equals from_plain_text("foo bar")
+assert instance.foo_bar == slint.StyledText.from_plain_text("foo bar")
+
+# from_markdown raises for unsupported syntax
+threw = False
+try:
+    slint.StyledText.from_markdown("# heading")
+except ValueError:
+    threw = True
+assert threw
 ```
 */


### PR DESCRIPTION
Adds Python binding support for Slint's `styled-text` type

cc #11158