### PR TITLE
Tooltip: reject references to ToolTip elements from outside

### DIFF
--- a/internal/compiler/passes/lower_tooltips.rs
+++ b/internal/compiler/passes/lower_tooltips.rs
@@ -54,6 +54,41 @@ const OFFSET: &str = "offset";
 const DELAY: &str = "delay";
 const TEXT: &str = "text";
 
+/// Report an error and replace any named reference that points to the tooltip element itself.
+/// References to the tooltip's *children* are caught later by `lower_popups::check_no_reference_to_popup`
+/// once the children have been moved into the generated PopupWindow component.
+fn check_no_reference_to_tooltip(
+    tooltip_element: &ElementRc,
+    parent_element: &ElementRc,
+    component: &Rc<Component>,
+    diag: &mut BuildDiagnostics,
+) {
+    let dummy_ref = NamedReference::new(parent_element, SmolStr::new_static(WIDTH));
+
+    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |source_elem, _| {
+        if Rc::ptr_eq(source_elem, tooltip_element) {
+            return;
+        }
+        visit_all_named_references_in_element(source_elem, |nr| {
+            if !Rc::ptr_eq(&nr.element(), tooltip_element) {
+                return;
+            }
+            let id = tooltip_element.borrow().id.clone();
+            let prop_name = nr.name();
+            let what = if id.is_empty() {
+                format!("property or callback '{prop_name}'")
+            } else {
+                format!("property or callback '{id}.{prop_name}'")
+            };
+            diag.push_error(
+                format!("Cannot access {what} inside of a ToolTip from enclosing component"),
+                &*tooltip_element.borrow(),
+            );
+            *nr = dummy_ref.clone();
+        });
+    });
+}
+
 fn build_tooltip_content(
     popup_id: &SmolStr,
     enclosing_component: &std::rc::Weak<Component>,
@@ -450,7 +485,9 @@ fn lower_tooltips_in_component(
             return;
         }
 
-        let (tooltip_config, enclosing_component, popup_id, popup_id_for_text, custom_children) = {
+        check_no_reference_to_tooltip(&tooltip_candidate, elem, component, diag);
+
+        let (tooltip_config, enclosing_component, popup_id, custom_children) = {
             let mut elem_borrow = elem.borrow_mut();
             let tooltip_config = elem_borrow.children.remove(tooltip_child_index);
             let custom_children = if has_custom_content {
@@ -462,15 +499,13 @@ fn lower_tooltips_in_component(
             let popup_id =
                 format_smolstr!("{}{}", TOOLTIP_POPUP_ID_PREFIX, tooltip_popup_id_counter);
             tooltip_popup_id_counter += 1;
-            let popup_id_for_text = popup_id.clone();
-            (tooltip_config, enclosing_component, popup_id, popup_id_for_text, custom_children)
+            (tooltip_config, enclosing_component, popup_id, custom_children)
         };
 
         let parent_width = NamedReference::new(elem, SmolStr::new_static(WIDTH));
         let parent_height = NamedReference::new(elem, SmolStr::new_static(HEIGHT));
 
-        let tooltip_area =
-            build_tooltip_area(&popup_id_for_text, &enclosing_component, &tooltip_area_type);
+        let tooltip_area = build_tooltip_area(&popup_id, &enclosing_component, &tooltip_area_type);
         let copied_binding = |source_property: &str, target_property: &str| {
             if let Some(binding) = tooltip_config.borrow().bindings.get(source_property) {
                 tooltip_area
@@ -493,7 +528,7 @@ fn lower_tooltips_in_component(
         let tooltip_text = (!has_custom_content)
             .then(|| NamedReference::new(&tooltip_area, SmolStr::new_static(TEXT)));
         let tooltip_content = build_tooltip_content(
-            &popup_id_for_text,
+            &popup_id,
             &enclosing_component,
             tooltip_impl_type,
             tooltip_text,
@@ -526,6 +561,9 @@ fn lower_tooltips_in_component(
             )]
             .into_iter()
             .collect(),
+            // Carry the ToolTip's source location so diagnostics from
+            // lower_popups point back to the original ToolTip element.
+            debug: tooltip_config.borrow().debug.clone(),
             ..Default::default()
         };
         let popup_window_rc = popup_window.make_rc();

--- a/internal/compiler/tests/syntax/elements/tooltip_access_from_outside.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_access_from_outside.slint
@@ -1,0 +1,51 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test inherits Window {
+    // Access a named text-mode tooltip's text property.
+    Rectangle {
+        tt := ToolTip {
+//            >      <error{Cannot access property or callback 'tt.text' inside of a ToolTip from enclosing component}
+            text: "Hello";
+        }
+    }
+    property <string> val: tt.text;
+
+    // Access a named tooltip's delay property.
+    Rectangle {
+        tt2 := ToolTip {
+//             >      <error{Cannot access property or callback 'tt2.delay' inside of a ToolTip from enclosing component}
+            text: "tip";
+        }
+    }
+    property <duration> d: tt2.delay;
+
+    // Multiple references to the same tooltip produce multiple errors.
+    Rectangle {
+        tt3 := ToolTip {
+//             >      <error{Cannot access property or callback 'tt3.text' inside of a ToolTip from enclosing component}
+//             >      <^error{Cannot access property or callback 'tt3.offset' inside of a ToolTip from enclosing component}
+            text: "multi";
+        }
+    }
+    property <string> a: tt3.text;
+    property <length> b: tt3.offset;
+
+    // Named custom-content tooltip — access the tooltip element itself.
+    Rectangle {
+        tt4 := ToolTip {
+//             >      <error{Cannot access property or callback 'tt4.delay' inside of a ToolTip from enclosing component}
+            Rectangle { background: red; }
+        }
+    }
+    property <duration> cd: tt4.delay;
+
+    // Access a named child inside a custom-content tooltip.
+    Rectangle {
+        ToolTip {
+//      >      <error{Cannot access property or callback 'inner.background' inside of a PopupWindow from enclosing component}
+            inner := Rectangle { background: blue; }
+        }
+    }
+    property <color> c: inner.background;
+}

--- a/tests/cases/elements/tooltip_on_button.slint
+++ b/tests/cases/elements/tooltip_on_button.slint
@@ -6,7 +6,7 @@ import { Button } from "std-widgets.slint";
 export component TestCase {
     width: 220px;
     height: 120px;
-    in-out property <bool> tooltip-created;
+    in-out property <int> init-count;
 
     Button {
         x: 30px;
@@ -18,7 +18,7 @@ export component TestCase {
         ToolTip {
             placement: above-element;
             Rectangle {
-                init => { root.tooltip-created = true; }
+                init => { root.init-count += 1; }
             }
         }
     }
@@ -30,14 +30,17 @@ export component TestCase {
 use slint::{platform::WindowEvent, LogicalPosition};
 
 let instance = TestCase::new().unwrap();
-assert!(!instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 0);
 
+// Hover over the button; tooltip init has not fired yet.
 instance.window().dispatch_event(WindowEvent::PointerMoved {
     position: LogicalPosition::new(80.0, 58.0),
 });
-assert!(!instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 0);
+
+// After the delay, the tooltip is shown and init fires exactly once.
 slint_testing::mock_elapsed_time(600);
-assert!(instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 1);
 ```
 
 */

--- a/tests/cases/elements/tooltip_popup_overlay.slint
+++ b/tests/cases/elements/tooltip_popup_overlay.slint
@@ -4,7 +4,7 @@
 export component TestCase {
     width: 200phx;
     height: 200phx;
-    in-out property <bool> tooltip-created;
+    in-out property <int> init-count;
     Rectangle {
         x: 0px;
         y: 0px;
@@ -15,7 +15,7 @@ export component TestCase {
             placement: below-element;
             Rectangle {
                 init => {
-                    root.tooltip-created = true;
+                    root.init-count += 1;
                 }
             }
         }
@@ -28,8 +28,9 @@ export component TestCase {
 use slint::{platform::WindowEvent, LogicalPosition};
 
 let instance = TestCase::new().unwrap();
-assert!(!instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 0);
 
+// Hover then leave before the delay fires: tooltip must not appear.
 instance.window().dispatch_event(WindowEvent::PointerMoved {
     position: LogicalPosition::new(50.0, 50.0),
 });
@@ -37,14 +38,15 @@ instance.window().dispatch_event(WindowEvent::PointerMoved {
     position: LogicalPosition::new(250.0, 250.0),
 });
 slint_testing::mock_elapsed_time(600);
-assert!(!instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 0);
 
+// Hover and stay: tooltip appears after the delay.
 instance.window().dispatch_event(WindowEvent::PointerMoved {
     position: LogicalPosition::new(50.0, 50.0),
 });
-assert!(!instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 0);
 slint_testing::mock_elapsed_time(600);
-assert!(instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 1);
 ```
 
 */

--- a/tests/cases/elements/tooltip_toucharea_hover_coexist.slint
+++ b/tests/cases/elements/tooltip_toucharea_hover_coexist.slint
@@ -5,7 +5,7 @@ export component TestCase {
     width: 200px;
     height: 120px;
 
-    in-out property <bool> tooltip-created;
+    in-out property <int> init-count;
     out property <bool> touch-hover <=> ta.has-hover;
 
     ta := TouchArea {
@@ -15,7 +15,7 @@ export component TestCase {
         ToolTip {
             placement: above-element;
             Rectangle {
-                init => { root.tooltip-created = true; }
+                init => { root.init-count += 1; }
             }
         }
     }
@@ -28,16 +28,20 @@ use slint::{platform::WindowEvent, LogicalPosition};
 
 let instance = TestCase::new().unwrap();
 assert!(!instance.get_touch_hover());
-assert!(!instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 0);
 
+// Hover enters: TouchArea gets hover, but tooltip init has not fired yet (delay pending).
 instance.window().dispatch_event(WindowEvent::PointerMoved {
     position: LogicalPosition::new(20.0, 20.0),
 });
 assert!(instance.get_touch_hover());
+assert_eq!(instance.get_init_count(), 0);
 
+// After the delay, the tooltip popup is shown and init fires.
 slint_testing::mock_elapsed_time(600);
-assert!(instance.get_tooltip_created());
+assert_eq!(instance.get_init_count(), 1);
 
+// Moving out hides the tooltip and clears hover.
 instance.window().dispatch_event(WindowEvent::PointerMoved {
     position: LogicalPosition::new(250.0, 250.0),
 });


### PR DESCRIPTION
Accessing a named ToolTip's properties from the enclosing component caused a panic ("NamedReference to a dead element") because the lowering pass removes the ToolTip from the tree. Detect and report this as a proper diagnostic, and replace the dangling reference so later passes don't crash.

Also strengthen existing tooltip tests to use an init counter instead of a boolean flag, verifying init fires exactly once at the right time.

