### PR TITLE
CI: Install wasm-pack from its new location on GitHub

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -17,7 +17,7 @@
 node = "24"
 pnpm = "10.29.3"
 taplo = "0.9.3"
-"ubi:drager/wasm-pack" = "0.13.1"
+"ubi:wasm-bindgen/wasm-pack" = "0.13.1"
 uv = "0.10.4"
 
 [task_config]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -104,7 +104,7 @@ dir = "editors/vscode"
 sources = ["tools/lsp/Cargo.toml", "tools/lsp/**/*.rs", "tools/lsp/ui/**/*.slint"]
 outputs = ["tools/lsp/pkg/*"]
 run = "pnpm run build:wasm_lsp"
-tools = { "ubi:drager/wasm-pack" = "0.13.1" }
+tools = { "ubi:wasm-bindgen/wasm-pack" = "0.13.1" }
 depends = ["prepare:pnpm-install"]
 
 ["build:interpreter:wasm"]
@@ -113,7 +113,7 @@ dir = "tools/slintpad"
 sources = ["api/wasm-interpreter/Cargo.toml", "api/wasm-interpreter/src/**/*.rs"]
 outputs = ["api/wasm-interpreter/pkg/*"]
 run = "pnpm run build:wasm_interpreter"
-tools = { "ubi:drager/wasm-pack" = "0.13.1" }
+tools = { "ubi:wasm-bindgen/wasm-pack" = "0.13.1" }
 depends = ["prepare:pnpm-install"]
 
 ["prepare:pnpm-install"]

--- a/docs/astro/src/content/docs/guide/platforms/web.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/web.mdx
@@ -65,7 +65,7 @@ pub fn main() {
 }
 ```
 
-Build the application using [wasm-pack](https://drager.github.io/wasm-pack/).
+Build the application using [wasm-pack](https://wasm-bindgen.github.io/wasm-pack/).
 
 ```bash
 wasm-pack build --release --target web


### PR DESCRIPTION
The old releases aren't there anymore. Amends b3461942af65ec39af65d73e4c375fcd2ef24f7e

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
