### PR TITLE
CI: Reduce job count and narrow path filters

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -23,23 +23,38 @@ slint:
  - 'api/**'
  - 'cmake/**'
  - 'demos/**'
- - 'docker/**'
- - 'docs/**'
- - 'editors/**'
  - 'helper_crates/**'
  - 'internal/**'
- - 'logo/**'
  - 'scripts/**'
  - 'tests/**'
  - 'tools/compiler/**'
  - 'tools/figma_import/**'
  - 'tools/lsp/**'
- - 'tools/slintpad/**'
  - 'tools/tr-extractor/**'
  - 'tools/updater/**'
  - 'tools/viewer/**'
  - 'xtask/**'
  - *files_in_root
+ - *ci_config
+
+# Qt backend and widget definitions — gates the Qt test step in build_and_test
+qt:
+ - 'internal/backends/qt/**'
+ - 'internal/compiler/widgets/qt/**'
+ - 'tests/cases/widgets/**'
+
+# Docs build needs most Rust code because it also checks for doc warnings
+docs_build:
+ - 'docs/**'
+ - 'api/**'
+ - 'internal/**'
+ - 'helper_crates/**'
+ - 'tools/lsp/**'
+ - *ci_config
+
+# Tree-sitter grammar
+tree_sitter:
+ - 'editors/tree-sitter-slint/**'
  - *ci_config
 
 figma_inspector:

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -38,6 +38,11 @@ on:
                 required: false
                 type: boolean
                 default: true
+            run_qt:
+                description: 'Run Qt widget tests'
+                required: false
+                type: boolean
+                default: true
             timeout_minutes:
                 description: 'Timeout in minutes'
                 required: false
@@ -114,7 +119,7 @@ jobs:
                   SLINT_CREATE_SCREENSHOTS: 1
               shell: bash
             - name: Run tests (qt)
-              if: runner.os != 'Windows'
+              if: runner.os != 'Windows' && inputs.run_qt
               run: "cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python qt:: -- --test-threads=1"
               shell: bash
             - name: live-preview for rust test

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -123,6 +123,7 @@ jobs:
               run: "cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python qt:: -- --test-threads=1"
               shell: bash
             - name: live-preview for rust test
+              if: runner.os == 'Linux'
               env:
                 SLINT_LIVE_PREVIEW: 1
               run: cargo test --locked --verbose --all-features --features slint/live-preview -p test-driver-rust -- --skip=_qt::t

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,9 @@ jobs:
         servo_example: ${{ inputs.full || steps.filter.outputs.servo_example == 'true' }}
         bevy_examples: ${{ inputs.full || steps.filter.outputs.bevy_examples == 'true' }}
         rust_files: ${{ inputs.full || steps.filter.outputs.rust_files == 'true' }}
+        qt: ${{ inputs.full || steps.filter.outputs.qt == 'true' }}
+        docs_build: ${{ inputs.full || steps.filter.outputs.docs_build == 'true' }}
+        tree_sitter: ${{ inputs.full || steps.filter.outputs.tree_sitter == 'true' }}
       steps:
         - uses: actions/checkout@v6
           if: ${{ !inputs.full }}
@@ -94,6 +97,7 @@ jobs:
             name: ${{ matrix.name }}
             rust_version: ${{ matrix.rust_version }}
             extra_args: ${{ matrix.extra_args }}
+            run_qt: ${{ needs.files-changed.outputs.qt == 'true' }}
             save_if: ${{ github.ref == 'refs/heads/master' }}
 
     # For changes to Slint internals, do a quick test on Linux for Node.js only.
@@ -445,7 +449,7 @@ jobs:
 
     docs:
         needs: files-changed
-        if: ${{ !inputs.full && needs.files-changed.outputs.slint == 'true' }}
+        if: ${{ !inputs.full && needs.files-changed.outputs.docs_build == 'true' }}
         uses: ./.github/workflows/build_docs.yaml
         secrets:
           READ_WRITE_PRIVATE_KEY: ${{ secrets.READ_WRITE_PRIVATE_KEY }}
@@ -467,7 +471,7 @@ jobs:
 
     tree-sitter:
         needs: files-changed
-        if: ${{ needs.files-changed.outputs.slint == 'true' }}
+        if: ${{ needs.files-changed.outputs.tree_sitter == 'true' }}
         uses: ./.github/workflows/tree_sitter.yaml
         with:
             latest: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,12 +161,11 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: ubuntu-22.04
-                      rust_version: "1.92"
+                    # Linux C++ is covered by cpp_test_driver_32bit
                     - os: macos-14
                       rust_version: beta
                     - os: windows-2022
-                      rust_version: stable
+                      rust_version: "1.92"
         runs-on: ${{ matrix.os }}
 
         steps:
@@ -174,12 +173,6 @@ jobs:
             - uses: ./.github/actions/install-linux-dependencies
               with:
                   force-gcc-10: true
-            - name: Install Qt
-              if: runner.os == 'Linux'
-              uses: jurplel/install-qt-action@v4
-              with:
-                  version: "5.15.2"
-                  cache: true
             - name: Set default style
               if: runner.os != 'Windows'
               run: echo "SLINT_STYLE=native" >> $GITHUB_ENV


### PR DESCRIPTION
- Narrow the slint path filter: removed docs/\*\*, editors/\*\*, tools/slintpad/\*\*, docker/\*\*, logo/\*\* — each already has a dedicated filter or is irrelevant to build_and_test. A docs-only or editor-only change no longer triggers the full test suite.
- New docs_build filter for the docs job, covering docs/\*\*, api/\*\*, internal/\*\*, helper_crates/\*\*, tools/lsp/\*\* (broad because the docs build also checks for rustdoc warnings).
- New tree_sitter filter (editors/tree-sitter-slint/\*\*) so tree-sitter tests only run when the grammar changes.
- New qt filter (internal/backends/qt/\*\*, internal/compiler/widgets/qt/\*\*, tests/cases/widgets/\*\*) to gate the serial Qt test step in build_and_test. Qt widget tests are skipped when Qt-related code hasn't changed.
- Live-preview test pass limited to Linux: the interpreter-based re-run of all test cases is platform-independent; running it once is sufficient.
- Drop Linux from cpp_test_driver matrix: Linux C++ is already covered by cpp_test_driver_32bit. MSRV (1.92) testing moves to Windows.

