### PR TITLE
CI: disable rust-cache cache-bin on macOS

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -70,4 +70,8 @@ runs:
           if: inputs.cache == 'true'
           with:
               key: ${{ inputs.key }}-1
+              # Workaround for https://github.com/Swatinem/rust-cache/issues/341:
+              # on the updated macOS runner image, cache-bin's restored cargo/rustc
+              # dispatches as rustup-init and fails with "unexpected argument".
+              cache-bin: ${{ runner.os == 'macOS' && 'false' || 'true' }}
               save-if: ${{ inputs.save_if }}


### PR DESCRIPTION
Workaround for Swatinem/rust-cache#341: the new macOS runner image breaks the restored cargo/rustc proxies under cache-bin: true so they dispatch as rustup-init and fail with "unexpected argument 'test'" when invoked.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
