### PR TITLE
Implcitly export component / types that are import from external crates

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3074,6 +3074,23 @@ impl Exports {
         }
     }
 
+    #[cfg(feature = "experimental-library-module")]
+    pub fn add_library_reexport(
+        &mut self,
+        export_name: ExportedName,
+        comp_or_type: Either<Rc<Component>, Type>,
+    ) {
+        let export = (export_name, comp_or_type);
+
+        // If export is already added, just ignore it. We don't want to report a warning in this case,
+        // because it's expected that multiple library modules re-export the same component or type.
+        if let Err(insert_pos) =
+            self.components_or_types.binary_search_by(|entry| entry.0.cmp(&export.0))
+        {
+            self.components_or_types.insert(insert_pos, export);
+        }
+    }
+
     pub fn find(&self, name: &str) -> Option<Either<Rc<Component>, Type>> {
         self.components_or_types
             .binary_search_by(|(exported_name, _)| exported_name.as_str().cmp(name))

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1140,8 +1140,10 @@ impl TypeLoader {
 
                             #[cfg(feature = "experimental-library-module")]
                             if let Some(library_info) = import.library_info.as_mut() {
+                                let exports = reexports.get_or_insert_with(Exports::default);
                                 library_info.exports =
-                                    doc.exports.iter().map(|(exported_name, _compo_or_type)| {
+                                    doc.exports.iter().map(|(exported_name, compo_or_type)| {
+                                        exports.add_library_reexport(exported_name.clone(), compo_or_type.clone());
                                         exported_name.clone()
                                     }).collect();
                             }


### PR DESCRIPTION
Otherwise for example 'global' components need to be re-exported to expose their public API. This creates side effect, like 'bindings' will be treated as 'constant' expression, and logic will not work as expected.

fixes ##11717

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
