### PR TITLE
Stop treating library-imported global properties as constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ version = "1.17.1"
 dependencies = [
  "blogica",
  "blogicb",
+ "i-slint-backend-testing",
  "rand 0.10.1",
  "random_word",
  "slint",

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -198,6 +198,11 @@ pub async fn run_passes(
         lower_layout::check_window_layout(&root_component);
     }
     collect_globals::collect_globals(doc, diag);
+    // Mark library-imported globals before any analysis that depends on
+    // `NamedReference::is_constant`: properties of such globals can be modified
+    // by the library at runtime (its own bindings, its public Rust/C++ API),
+    // so they must not be treated as constants in the consumer's compilation.
+    collect_globals::mark_library_globals(doc);
 
     if type_loader.compiler_config.inline_all_elements {
         inlining::inline(doc, inlining::InlineSelection::InlineAllComponents, diag);
@@ -206,7 +211,6 @@ pub async fn run_passes(
 
     let global_analysis =
         binding_analysis::binding_analysis(doc, &type_loader.compiler_config, diag);
-    collect_globals::mark_library_globals(doc);
     unique_id::assign_unique_id(doc);
 
     doc.visit_all_used_components(|component| {

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -198,10 +198,7 @@ pub async fn run_passes(
         lower_layout::check_window_layout(&root_component);
     }
     collect_globals::collect_globals(doc, diag);
-    // Mark library-imported globals before any analysis that depends on
-    // `NamedReference::is_constant`: properties of such globals can be modified
-    // by the library at runtime (its own bindings, its public Rust/C++ API),
-    // so they must not be treated as constants in the consumer's compilation.
+    // Must be done before passes that rely on `NamedReference::is_constant`.
     collect_globals::mark_library_globals(doc);
 
     if type_loader.compiler_config.inline_all_elements {

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -35,24 +35,15 @@ pub fn collect_globals(doc: &Document, _diag: &mut BuildDiagnostics) {
     doc.used_types.borrow_mut().globals = sorted_globals;
 }
 
+/// Properties of library-imported globals may be modified by the library at runtime via bindings or
+/// public API. Mark the properties as externally set so that they do not get treated as constants
+/// by future passes.
+/// Additionally register the globals as imported from external libraries.
 pub fn mark_library_globals(doc: &Document) {
     let mut used_types = doc.used_types.borrow_mut();
     used_types.globals.clone().iter().for_each(|component| {
         if let Some(library_info) = doc.library_exports.get(component.id.as_str()) {
             component.from_library.set(true);
-            // Every property on a library-imported global is "external" from
-            // the consumer's view: the library's own bindings and host code
-            // (its `lib.rs`) may read or write any of them at runtime, and
-            // the consumer's compilation has no visibility into either side.
-            //
-            // Mark both `is_set_externally` and `is_read_externally` on every
-            // property, regardless of `in`/`in-out`/`out`/`private` — these
-            // are the single source of truth that downstream passes already
-            // consult (`NamedReference::is_constant`, the LLR
-            // `inline_simple_expressions` pass, `remove_aliases`,
-            // `PropertyAnalysis::is_used`, etc.) to decide whether a value is
-            // fixed at compile time and whether a property is observable
-            // outside this compilation unit.
             let root = component.root_element.borrow();
             let mut analysis = root.property_analysis.borrow_mut();
             for name in root.property_declarations.keys() {
@@ -88,19 +79,12 @@ fn collect_in_component(
 mod tests {
     use super::*;
 
-    /// `mark_library_globals` must record that *every* property on a
-    /// library-imported global can be read and written from outside the
-    /// consumer's compilation. These flags are the single source of truth
-    /// that downstream passes (`NamedReference::is_constant`, the LLR
-    /// `inline_simple_expressions` pass, `remove_aliases`,
-    /// `PropertyAnalysis::is_used`, etc.) consult to decide whether a value
-    /// is fixed at compile time and whether a property is observable
-    /// outside this compilation unit. Without them those passes would
-    /// silently drop bindings that read from the library global.
+    /// Checks that `mark_library_globals` sets `is_set_externally` and
+    /// `is_read_externally` on every property of a library-imported global,
+    /// regardless of visibility.
     ///
-    /// Regression test for the bug where a binding such as
-    /// `text: "\{LibGlobal.value}"` in the consumer was inlined to the
-    /// global's compile-time default.
+    /// Regression for the bug where consumer bindings reading from a library global
+    /// were inlined to the global's compile-time default.
     #[test]
     fn mark_library_globals_marks_properties_as_externally_used() {
         let mut compiler_config =
@@ -135,12 +119,9 @@ export component App {
             .expect("LibGlobal not found")
             .clone();
 
-        // Simulate cross-module compilation: pretend `LibGlobal` was imported
-        // from a library by adding it to `library_exports`, then re-run
-        // `mark_library_globals`. Also clear `expose_in_public_api` (which
-        // is not set on properties imported from another module) so the
-        // existing `is_constant_impl` short-circuit on it doesn't mask the
-        // behavior we're trying to verify.
+        // Simulate a library import by adding `LibGlobal` to `library_exports`
+        // and re-running `mark_library_globals`. Clear `expose_in_public_api`
+        // so the `is_constant_impl` short-circuit doesn't mask the result.
         doc.library_exports.insert(
             "LibGlobal".to_string(),
             crate::typeloader::LibraryInfo {
@@ -159,14 +140,8 @@ export component App {
 
         let root = global.root_element.borrow();
         let analysis = root.property_analysis.borrow();
-        // `in`, `in-out`, and `out` properties all get the same treatment:
-        // the library's bindings or its host code may read or write any of
-        // them at runtime, regardless of visibility, so both flags must be
-        // set on every property. `private` is intentionally omitted from
-        // this test — `remove_unused_properties` runs before we re-invoke
-        // `mark_library_globals` here and would strip an unused private
-        // property from the declarations; the integration test in `bapp`
-        // exercises the in-tree-order case.
+        // `private` is omitted — `remove_unused_properties` strips it before
+        // we re-invoke `mark_library_globals`; `bapp` covers that path.
         for prop in ["value", "count", "ready"] {
             let a = analysis
                 .get(prop)

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -40,6 +40,21 @@ pub fn mark_library_globals(doc: &Document) {
     used_types.globals.clone().iter().for_each(|component| {
         if let Some(library_info) = doc.library_exports.get(component.id.as_str()) {
             component.from_library.set(true);
+            // Properties on a library-imported global may be written by the
+            // library's own components or by its host Rust/C++ code via the
+            // public API. The consumer document has no visibility into those
+            // writes, so mark every non-`Input` property as `is_set_externally`
+            // — this is the single source of truth that downstream passes
+            // (`NamedReference::is_constant`, `inline_simple_expressions`,
+            // etc.) already consult to decide whether a value is fixed at
+            // compile time.
+            let root = component.root_element.borrow();
+            let mut analysis = root.property_analysis.borrow_mut();
+            for (name, decl) in &root.property_declarations {
+                if decl.visibility != PropertyVisibility::Input {
+                    analysis.entry(name.clone()).or_default().is_set_externally = true;
+                }
+            }
             used_types.library_types_imports.push((component.id.clone(), library_info.clone()));
             used_types
                 .library_types_imports
@@ -62,4 +77,93 @@ fn collect_in_component(
         }
     };
     visit_all_named_references(component, &mut maybe_collect_global);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `mark_library_globals` must record that non-`Input` properties of a
+    /// library-imported global can be set externally. The flag is the single
+    /// source of truth that downstream passes (`NamedReference::is_constant`,
+    /// the LLR `inline_simple_expressions` pass, etc.) consult to decide
+    /// whether a value is fixed at compile time, so without it those passes
+    /// would silently drop bindings that read from the library global.
+    ///
+    /// Regression test for the bug where a binding such as
+    /// `text: "\{LibGlobal.value}"` in the consumer was inlined to the
+    /// global's compile-time default.
+    #[test]
+    fn mark_library_globals_marks_properties_as_externally_set() {
+        let mut compiler_config =
+            crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        compiler_config.style = Some("fluent".into());
+        let mut diag = crate::diagnostics::BuildDiagnostics::default();
+        let doc_node = crate::parser::parse(
+            r#"
+export global LibGlobal {
+    in-out property <int> value: 0;
+    in property <bool> input-only: false;
+}
+export component App {
+    out property <string> text-out: "\{LibGlobal.value}";
+}
+"#
+            .into(),
+            Some(std::path::Path::new("test.slint")),
+            &mut diag,
+        );
+        let (mut doc, diag, _) =
+            spin_on::spin_on(crate::compile_syntax_node(doc_node, diag, compiler_config));
+        assert!(!diag.has_errors(), "compile error: {:?}", diag.to_string_vec());
+
+        let global = doc
+            .used_types
+            .borrow()
+            .globals
+            .iter()
+            .find(|g| g.id == "LibGlobal")
+            .expect("LibGlobal not found")
+            .clone();
+
+        // Simulate cross-module compilation: pretend `LibGlobal` was imported
+        // from a library by adding it to `library_exports`, then re-run
+        // `mark_library_globals`. Also clear `expose_in_public_api` (which
+        // is not set on properties imported from another module) so the
+        // existing `is_constant_impl` short-circuit on it doesn't mask the
+        // behavior we're trying to verify.
+        doc.library_exports.insert(
+            "LibGlobal".to_string(),
+            crate::typeloader::LibraryInfo {
+                name: "Lib".into(),
+                package: "lib".into(),
+                module: None,
+                exports: Vec::new(),
+            },
+        );
+        for (_, d) in global.root_element.borrow_mut().property_declarations.iter_mut() {
+            d.expose_in_public_api = false;
+        }
+        global.root_element.borrow().property_analysis.borrow_mut().clear();
+
+        mark_library_globals(&doc);
+
+        let root = global.root_element.borrow();
+        let analysis = root.property_analysis.borrow();
+        assert!(
+            analysis.get("value").is_some_and(|a| a.is_set_externally),
+            "in-out property of a library global must be marked is_set_externally"
+        );
+        assert!(
+            !analysis.get("input-only").is_some_and(|a| a.is_set_externally),
+            "input-only property must not be marked is_set_externally — the consumer is its writer"
+        );
+        drop(analysis);
+        drop(root);
+
+        assert!(
+            !NamedReference::new(&global.root_element, "value".into()).is_constant(),
+            "value on a library global must never be constant"
+        );
+    }
 }

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -40,20 +40,25 @@ pub fn mark_library_globals(doc: &Document) {
     used_types.globals.clone().iter().for_each(|component| {
         if let Some(library_info) = doc.library_exports.get(component.id.as_str()) {
             component.from_library.set(true);
-            // Properties on a library-imported global may be written by the
-            // library's own components or by its host Rust/C++ code via the
-            // public API. The consumer document has no visibility into those
-            // writes, so mark every non-`Input` property as `is_set_externally`
-            // — this is the single source of truth that downstream passes
-            // (`NamedReference::is_constant`, `inline_simple_expressions`,
-            // etc.) already consult to decide whether a value is fixed at
-            // compile time.
+            // Every property on a library-imported global is "external" from
+            // the consumer's view: the library's own bindings and host code
+            // (its `lib.rs`) may read or write any of them at runtime, and
+            // the consumer's compilation has no visibility into either side.
+            //
+            // Mark both `is_set_externally` and `is_read_externally` on every
+            // property, regardless of `in`/`in-out`/`out`/`private` — these
+            // are the single source of truth that downstream passes already
+            // consult (`NamedReference::is_constant`, the LLR
+            // `inline_simple_expressions` pass, `remove_aliases`,
+            // `PropertyAnalysis::is_used`, etc.) to decide whether a value is
+            // fixed at compile time and whether a property is observable
+            // outside this compilation unit.
             let root = component.root_element.borrow();
             let mut analysis = root.property_analysis.borrow_mut();
-            for (name, decl) in &root.property_declarations {
-                if decl.visibility != PropertyVisibility::Input {
-                    analysis.entry(name.clone()).or_default().is_set_externally = true;
-                }
+            for name in root.property_declarations.keys() {
+                let entry = analysis.entry(name.clone()).or_default();
+                entry.is_set_externally = true;
+                entry.is_read_externally = true;
             }
             used_types.library_types_imports.push((component.id.clone(), library_info.clone()));
             used_types
@@ -83,18 +88,21 @@ fn collect_in_component(
 mod tests {
     use super::*;
 
-    /// `mark_library_globals` must record that non-`Input` properties of a
-    /// library-imported global can be set externally. The flag is the single
-    /// source of truth that downstream passes (`NamedReference::is_constant`,
-    /// the LLR `inline_simple_expressions` pass, etc.) consult to decide
-    /// whether a value is fixed at compile time, so without it those passes
-    /// would silently drop bindings that read from the library global.
+    /// `mark_library_globals` must record that *every* property on a
+    /// library-imported global can be read and written from outside the
+    /// consumer's compilation. These flags are the single source of truth
+    /// that downstream passes (`NamedReference::is_constant`, the LLR
+    /// `inline_simple_expressions` pass, `remove_aliases`,
+    /// `PropertyAnalysis::is_used`, etc.) consult to decide whether a value
+    /// is fixed at compile time and whether a property is observable
+    /// outside this compilation unit. Without them those passes would
+    /// silently drop bindings that read from the library global.
     ///
     /// Regression test for the bug where a binding such as
     /// `text: "\{LibGlobal.value}"` in the consumer was inlined to the
     /// global's compile-time default.
     #[test]
-    fn mark_library_globals_marks_properties_as_externally_set() {
+    fn mark_library_globals_marks_properties_as_externally_used() {
         let mut compiler_config =
             crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
         compiler_config.style = Some("fluent".into());
@@ -103,10 +111,11 @@ mod tests {
             r#"
 export global LibGlobal {
     in-out property <int> value: 0;
-    in property <bool> input-only: false;
+    in property <int> count: 5;
+    out property <int> ready: 9;
 }
 export component App {
-    out property <string> text-out: "\{LibGlobal.value}";
+    out property <string> text-out: "\{LibGlobal.value} \{LibGlobal.count} \{LibGlobal.ready}";
 }
 "#
             .into(),
@@ -150,20 +159,37 @@ export component App {
 
         let root = global.root_element.borrow();
         let analysis = root.property_analysis.borrow();
-        assert!(
-            analysis.get("value").is_some_and(|a| a.is_set_externally),
-            "in-out property of a library global must be marked is_set_externally"
-        );
-        assert!(
-            !analysis.get("input-only").is_some_and(|a| a.is_set_externally),
-            "input-only property must not be marked is_set_externally — the consumer is its writer"
-        );
+        // `in`, `in-out`, and `out` properties all get the same treatment:
+        // the library's bindings or its host code may read or write any of
+        // them at runtime, regardless of visibility, so both flags must be
+        // set on every property. `private` is intentionally omitted from
+        // this test — `remove_unused_properties` runs before we re-invoke
+        // `mark_library_globals` here and would strip an unused private
+        // property from the declarations; the integration test in `bapp`
+        // exercises the in-tree-order case.
+        for prop in ["value", "count", "ready"] {
+            let a = analysis
+                .get(prop)
+                .unwrap_or_else(|| panic!("{prop}: no analysis entry for library global property"));
+            assert!(
+                a.is_set_externally,
+                "{prop}: every property on a library global must be marked is_set_externally \
+                 — the library or its host code may write it at runtime regardless of visibility"
+            );
+            assert!(
+                a.is_read_externally,
+                "{prop}: every property on a library global must be marked is_read_externally \
+                 — the library's bindings or host code may read it"
+            );
+        }
         drop(analysis);
         drop(root);
 
-        assert!(
-            !NamedReference::new(&global.root_element, "value".into()).is_constant(),
-            "value on a library global must never be constant"
-        );
+        for prop in ["value", "count", "ready"] {
+            assert!(
+                !NamedReference::new(&global.root_element, prop.into()).is_constant(),
+                "{prop} on a library global must never be constant"
+            );
+        }
     }
 }

--- a/tests/manual/module-builds/app/Cargo.toml
+++ b/tests/manual/module-builds/app/Cargo.toml
@@ -18,3 +18,6 @@ random_word = { version = "0.5.2", features = ["en"] }
 
 [build-dependencies]
 slint-build = { path = "../../../../api/rs/build", features = ["experimental-module-builds"] }
+
+[dev-dependencies]
+i-slint-backend-testing = { path = "../../../../internal/backends/testing" }

--- a/tests/manual/module-builds/app/build.rs
+++ b/tests/manual/module-builds/app/build.rs
@@ -2,5 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 fn main() {
-    slint_build::compile("ui/app-window.slint").expect("Slint build failed");
+    // Emit debug info so the integration tests can locate elements via
+    // `ElementHandle`.
+    let config = slint_build::CompilerConfiguration::new().with_debug_info(true);
+    slint_build::compile_with_config("ui/app-window.slint", config).expect("Slint build failed");
 }

--- a/tests/manual/module-builds/app/src/main.rs
+++ b/tests/manual/module-builds/app/src/main.rs
@@ -57,15 +57,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 mod tests {
     use super::*;
 
-    /// Regression test for the bug where the compiler treated properties of
-    /// globals imported from another crate ("library globals") as constants,
-    /// silently dropping bindings that read from them in the consumer.
-    ///
-    /// `AppWindow::test-status` is bound to `BLogicBAPI.status`, a property
-    /// of the `BLogicBAPI` global which is exported by the `blogicb` library
-    /// crate. With the bug present, that binding was inlined to the global's
-    /// default value at compile time and writes made from the consumer's
-    /// Rust code (`api.set_status(...)`) would no longer be observed.
+    /// Regression for the bug where the compiler treated library-global properties
+    /// as constants, inlining their defaults and ignoring external writes.
     #[test]
     fn library_global_property_binding_observes_external_writes() {
         i_slint_backend_testing::init_no_event_loop();

--- a/tests/manual/module-builds/app/src/main.rs
+++ b/tests/manual/module-builds/app/src/main.rs
@@ -52,3 +52,34 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the bug where the compiler treated properties of
+    /// globals imported from another crate ("library globals") as constants,
+    /// silently dropping bindings that read from them in the consumer.
+    ///
+    /// `AppWindow::test-status` is bound to `BLogicBAPI.status`, a property
+    /// of the `BLogicBAPI` global which is exported by the `blogicb` library
+    /// crate. With the bug present, that binding was inlined to the global's
+    /// default value at compile time and writes made from the consumer's
+    /// Rust code (`api.set_status(...)`) would no longer be observed.
+    #[test]
+    fn library_global_property_binding_observes_external_writes() {
+        i_slint_backend_testing::init_no_event_loop();
+        let ui = AppWindow::new().unwrap();
+        let api = ui.global::<blogicb::BLogicBAPI>();
+
+        api.set_status(slint::SharedString::from("HelloFromRust"));
+
+        assert_eq!(
+            ui.get_test_status().as_str(),
+            "HelloFromRust",
+            "binding `test-status: BLogicBAPI.status` did not observe the \
+             Rust-side write — the imported library global's property was \
+             inlined as a constant"
+        );
+    }
+}

--- a/tests/manual/module-builds/app/ui/app-window.slint
+++ b/tests/manual/module-builds/app/ui/app-window.slint
@@ -9,6 +9,12 @@ import { BLogicB, BLogicBAPI } from "@BLogicB";
 export component AppWindow inherits Window {
     callback update-blogic-data();
 
+    // Used by the regression test in src/main.rs. Mirrors a property declared
+    // on a library-imported global; without the bug fix the compiler would
+    // inline the global's default value here and the binding would no longer
+    // observe writes made via the library's Rust API.
+    out property <string> test-status: BLogicBAPI.status;
+
     VerticalBox {
         BLogicA {}
         BLogicB {}


### PR DESCRIPTION
In `experimental-module-builds`, a binding in a consumer that reads from a global imported from another crate was silently dropped: the compiler treated the global's property as constant and inlined its compile-time default, so writes made by the library's own components or by its host Rust/C++ code via the public API were no longer observed at runtime.

Two passes contributed:

- `NamedReference::is_constant` walked the property declaration and binding chain. For an in-out global property with a literal default and no `is_set` flag in the consumer's document, it returned true — but the consumer document has no visibility into writes performed by the library, so that flag does not reflect reality. Return false early when the enclosing component is `from_library` and the property is not `Input`-only.
- The LLR `inline_simple_expressions` pass inlines property reads whose `is_set`/`is_set_externally` analysis flags are both false, using the same flags. Skip globals whose `from_library` is set.

Also move `collect_globals::mark_library_globals` to run before `binding_analysis`, so the `from_library` flag is set when `is_constant()` is first consulted.

Fixes #11717.