### PR TITLE
winit: Also ignore WindowEvent::AxisMotion when pending mouse event

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -508,6 +508,9 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 });
             }
 
+            WindowEvent::AxisMotion { .. } => {
+                // Ignored, but happens often and is also ignored for the purpose of bundling CursorMoved.
+            }
             _ => {}
         }
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -204,7 +204,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
         }
 
         let runtime_window = WindowInner::from_pub(window.window());
-        if !matches!(event, WindowEvent::CursorMoved { .. }) {
+        if !matches!(event, WindowEvent::CursorMoved { .. } | WindowEvent::AxisMotion { .. }) {
             self.flush_pending_mouse_move();
         }
 


### PR DESCRIPTION
We also get a lot of WindowEvent::AxisMotion in between the WindowEvent::CursorMoved when the mouse cursor moves faster than Slint can process the events
