### PR TITLE
winit: Prospective fix for the ios build faillure

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1597,21 +1597,14 @@ impl WindowAdapterInternal for WinitWindowAdapter {
         self.winit_window_or_none
             .borrow()
             .as_window()
-            .and_then(|window| {
-                let outer_position = window.outer_position().ok()?;
-                let inner_position = window.inner_position().ok()?;
-                let outer_size = window.outer_size();
-                let surface_size = window.surface_size();
-                Some(i_slint_core::lengths::PhysicalEdges::new(
-                    inner_position.y - outer_position.y,
-                    outer_size.height as i32
-                        - (surface_size.height as i32)
-                        - (inner_position.y - outer_position.y),
-                    inner_position.x - outer_position.x,
-                    outer_size.width as i32
-                        - (surface_size.width as i32)
-                        - (inner_position.x - outer_position.x),
-                ))
+            .map(|window| {
+                let insets = window.safe_area();
+                i_slint_core::lengths::PhysicalEdges::new(
+                    insets.top as i32,
+                    insets.bottom as i32,
+                    insets.left as i32,
+                    insets.right as i32,
+                )
             })
             .unwrap_or_default()
     }


### PR DESCRIPTION
```
error[E0599]: no method named `inner_position` found for struct `std::sync::Arc<dyn winit::window::Window>` in the current scope
    --> internal/backends/winit/winitwindowadapter.rs:1602:45
     |
1602 |                 let inner_position = window.inner_position().ok()?;
     |                                             ^^^^^^^^^^^^^^
```

We can use the safe_area function now
