### PR TITLE
doc: Clarify Window.show/hide docs

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1462,13 +1462,11 @@ component WindowItem {
     out property <Size> virtual-keyboard-size;
     /// Request that the window be closed. This triggers the `close-requested` callback,
     /// giving the application a chance to cancel the close. Returns `true` if the close
-    /// was dispatched, or `false` if the call was ignored because this `Window` is not
-    /// the application's top-level window.
+    /// was dispatched, or `false` if the application declined.
     function close() -> bool {
     }
-    /// Hide this window. The window is made invisible but the application remains running.
-    /// Use `show()` to make the window visible again. Calling this function on a `Window`
-    /// that is not the application's top-level window is a no-op.
+    /// Hide this window. This also drops the strong reference on the window, so if this was
+    /// the last reference, the event loop will quit.
     function hide() {
     }
 }


### PR DESCRIPTION
Refer less to implementation details and mention that hide() may indeed end up terminating the event loop.

Amends 9d495e2f8b8679a20826d4824e93bca9060d7f57

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
