### PR TITLE
gallery: move TabWidget demo to its own page

### DIFF
--- a/examples/gallery/gallery.slint
+++ b/examples/gallery/gallery.slint
@@ -2,7 +2,17 @@
 // SPDX-License-Identifier: MIT
 
 import { CheckBox, StandardListView } from "std-widgets.slint";
-import { AboutPage, ControlsPage, EasingsPage, ListViewPage, StyledTextPage, TableViewPage, TableViewPageAdapter, TextEditPage } from "ui/pages/pages.slint";
+import {
+    AboutPage,
+    ControlsPage,
+    TabWidgetPage,
+    EasingsPage,
+    ListViewPage,
+    StyledTextPage,
+    TableViewPage,
+    TableViewPageAdapter,
+    TextEditPage,
+} from "ui/pages/pages.slint";
 import { GallerySettings } from "ui/gallery_settings.slint";
 import { SideBar } from "ui/side_bar.slint";
 
@@ -10,7 +20,7 @@ export { TableViewPageAdapter }
 
 export component App inherits Window {
     preferred-width: 700px;
-    preferred-height: 500px;
+    preferred-height: 700px;
     title: @tr("Slint Widgets Gallery");
     icon: @image-url("../../logo/slint-logo-small-light.png");
 
@@ -21,39 +31,75 @@ export component App inherits Window {
                 title: @tr("MenuBar" => "Open");
                 shortcut: @keys(Control + O);
             }
+
             Menu {
                 title: @tr("MenuBar" => "Open Recent");
-                for x in 10: MenuItem { title: @tr("MenuBar" => "Recent {}", x+1);  }
+                for x in 10: MenuItem {
+                    title: @tr("MenuBar" => "Recent {}", x + 1);
+                }
             }
-            MenuSeparator {}
-            MenuItem { title: @tr("MenuBar" => "Save"); }
+
+            MenuSeparator { }
+
+            MenuItem {
+                title: @tr("MenuBar" => "Save");
+            }
+
             Menu {
                 title: @tr("MenuBar" => "Save As");
-                for x in 10: MenuItem { title: @tr("MenuBar" => "Name {}", x+1);  }
+                for x in 10: MenuItem {
+                    title: @tr("MenuBar" => "Name {}", x + 1);
+                }
             }
-            MenuSeparator {}
-            MenuItem { title: @tr("MenuBar" => "MenuItem with Icon"); icon: @image-url("thumbsup.png"); }
-            MenuItem { title: @tr("MenuBar" => "MenuItem with Checkmark"); checkable: true; checked: true; }
+
+            MenuSeparator { }
+
+            MenuItem {
+                title: @tr("MenuBar" => "MenuItem with Icon");
+                icon: @image-url("thumbsup.png");
+            }
+
+            MenuItem {
+                title: @tr("MenuBar" => "MenuItem with Checkmark");
+                checkable: true;
+                checked: true;
+            }
         }
+
         Menu {
             title: @tr("MenuBar" => "Edit");
-            MenuItem { title: @tr("MenuBar" => "Copy"); }
-            MenuItem { title: @tr("MenuBar" => "Paste"); }
+            MenuItem {
+                title: @tr("MenuBar" => "Copy");
+            }
+
+            MenuItem {
+                title: @tr("MenuBar" => "Paste");
+            }
         }
     }
 
     HorizontalLayout {
         side-bar := SideBar {
             title: @tr("Slint Widgets Gallery");
-            model: [@tr("Menu" => "Controls"), @tr("Menu" => "ListView"), @tr("Menu" => "TableView"), @tr("Menu" => "TextEdit"), @tr("Menu" => "Easings"), @tr("Menu" => "StyledText"), @tr("Menu" => "About")];
+            model: [
+                @tr("Menu" => "Controls"),
+                @tr("Menu" => "TabWidget"),
+                @tr("Menu" => "ListView"),
+                @tr("Menu" => "TableView"),
+                @tr("Menu" => "TextEdit"),
+                @tr("Menu" => "Easings"),
+                @tr("Menu" => "StyledText"),
+                @tr("Menu" => "About")
+            ];
         }
 
-        if(side-bar.current-item == 0) : ControlsPage {}
-        if(side-bar.current-item == 1) : ListViewPage {}
-        if(side-bar.current-item == 2) : TableViewPage {}
-        if(side-bar.current-item == 3) : TextEditPage {}
-        if(side-bar.current-item == 4) : EasingsPage {}
-        if(side-bar.current-item == 5) : StyledTextPage {}
-        if(side-bar.current-item == 6) : AboutPage {}
+        if(side-bar.current-item == 0): ControlsPage { }
+        if(side-bar.current-item == 1): TabWidgetPage { }
+        if(side-bar.current-item == 2): ListViewPage { }
+        if(side-bar.current-item == 3): TableViewPage { }
+        if(side-bar.current-item == 4): TextEditPage { }
+        if(side-bar.current-item == 5): EasingsPage { }
+        if(side-bar.current-item == 6): StyledTextPage { }
+        if(side-bar.current-item == 7): AboutPage { }
     }
 }

--- a/examples/gallery/ui/pages/controls_page.slint
+++ b/examples/gallery/ui/pages/controls_page.slint
@@ -8,7 +8,6 @@ import {
     ComboBox,
     CheckBox,
     LineEdit,
-    TabWidget,
     VerticalBox,
     HorizontalBox,
     Slider,
@@ -284,64 +283,6 @@ export component ControlsPage inherits Page {
                 text: @tr("indeterminate");
                 checked <=> progress-indicator.indeterminate;
                 enabled: GallerySettings.widgets-enabled;
-            }
-        }
-    }
-
-    GroupBox {
-        title: @tr("TabWidget");
-
-        TabWidget {
-            Tab {
-                title: @tr("Tab 1");
-
-                VerticalBox {
-                    alignment: start;
-
-                    GroupBox {
-                        title: @tr("Content of tab 1");
-
-                        HorizontalBox {
-                            alignment: start;
-
-                            Button {
-                                text: @tr("Click me");
-                                enabled: GallerySettings.widgets-enabled;
-                            }
-                        }
-                    }
-                }
-            }
-
-            Tab {
-                title: @tr("Tab 2");
-
-                VerticalBox {
-                    alignment: start;
-
-                    GroupBox {
-                        title: @tr("Content of tab 2");
-
-                        VerticalBox {
-                            alignment: start;
-
-                            CheckBox {
-                                text: @tr("Check me");
-                                enabled: GallerySettings.widgets-enabled;
-                            }
-                        }
-                    }
-                }
-            }
-
-            Tab {
-                title: @tr("Tab 3");
-
-                VerticalBox {
-                    Text {
-                        text: @tr("Content of tab 3");
-                    }
-                }
             }
         }
     }

--- a/examples/gallery/ui/pages/pages.slint
+++ b/examples/gallery/ui/pages/pages.slint
@@ -3,6 +3,7 @@
 
 export { AboutPage } from "about_page.slint";
 export { ControlsPage } from "controls_page.slint";
+export { TabWidgetPage } from "tab_widget_page.slint";
 export { EasingsPage } from "easings_page.slint";
 export { ListViewPage } from "list_view_page.slint";
 export { StyledTextPage } from "styled_text_page.slint";

--- a/examples/gallery/ui/pages/tab_widget_page.slint
+++ b/examples/gallery/ui/pages/tab_widget_page.slint
@@ -1,0 +1,76 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import {
+    Button,
+    GroupBox,
+    TabWidget,
+    VerticalBox,
+    HorizontalBox,
+    CheckBox,
+} from "std-widgets.slint";
+import { GallerySettings } from "../gallery_settings.slint";
+import { Page } from "page.slint";
+
+export component TabWidgetPage inherits Page {
+    title: @tr("TabWidget");
+    description: @tr("TabWidget groups content into tabs. Each tab has a title and content. The widget can be imported from \"std-widgets.slint\".");
+
+    GroupBox {
+        title: @tr("TabWidget");
+
+        TabWidget {
+            Tab {
+                title: @tr("Tab 1");
+
+                VerticalBox {
+                    alignment: start;
+
+                    GroupBox {
+                        title: @tr("Content of tab 1");
+
+                        HorizontalBox {
+                            alignment: start;
+
+                            Button {
+                                text: @tr("Click me");
+                                enabled: GallerySettings.widgets-enabled;
+                            }
+                        }
+                    }
+                }
+            }
+
+            Tab {
+                title: @tr("Tab 2");
+
+                VerticalBox {
+                    alignment: start;
+
+                    GroupBox {
+                        title: @tr("Content of tab 2");
+
+                        VerticalBox {
+                            alignment: start;
+
+                            CheckBox {
+                                text: @tr("Check me");
+                                enabled: GallerySettings.widgets-enabled;
+                            }
+                        }
+                    }
+                }
+            }
+
+            Tab {
+                title: @tr("Tab 3");
+
+                VerticalBox {
+                    Text {
+                        text: @tr("Content of tab 3");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #11747 

Extract the TabWidget showcase from ControlsPage into TabWidgetPage and add a dedicated sidebar entry so the widget gallery stays easier to browse.
