### PR TITLE
parley: Fall back to '.' when font lacks U+2026 for elide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+ - FemtoVG/Skia (parley): Fixed `TextOverflow::Elide` silently no-op when the resolved font
+   lacks U+2026 (e.g. Noto Sans Arabic). Falls back to U+002E (`.`) so a truncation
+   indicator is always drawn.
+
 ## [1.16.1] - 2026-04-23
 
  - `ListView`: Fixed compiler panic with a graceful fallback in the dirty region computation.

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -443,18 +443,35 @@ fn layout(
     let max_physical_width = options.max_width.map(|max_width| max_width * scale_factor);
     let max_physical_height = options.max_height.map(|max_height| max_height * scale_factor);
 
-    // Returned None if failed to get the elipsis glyph for some rare reason.
+    // Returns None if failed to get a truncation-indicator glyph.
+    //
+    // Tries U+2026 (HORIZONTAL ELLIPSIS, `…`) first. If parley's font
+    // resolution returns a notdef glyph (id 0 — the OpenType missing-glyph
+    // indicator), this happens because the resolved font lacks `…` in its
+    // cmap. Several common Arabic fonts (e.g. Noto Sans Arabic, Noto Naskh
+    // Arabic, Noto Kufi Arabic) ship without U+2026, and without a fallback
+    // the elision silently noops: text gets clipped at max_width with no
+    // visible truncation indicator.
+    //
+    // Falls back to U+002E (FULL STOP, `.`) — universally present in
+    // any font with the ASCII range. The single-dot indicator is less
+    // conventional than `…` but unambiguously communicates truncation.
     let get_elipsis_glyph = |font_context: &mut parley::FontContext| {
-        let mut layout = layout_builder.build(font_context, "…", None, None, None);
-        layout.break_all_lines(None);
-        let line = layout.lines().next()?;
-        let item = line.items().next()?;
-        let run = match item {
-            parley::layout::PositionedLayoutItem::GlyphRun(run) => Some(run),
-            _ => return None,
-        }?;
-        let glyph = run.positioned_glyphs().next()?;
-        Some((glyph, run.run().font().clone()))
+        for &candidate in &["…", "."] {
+            let mut layout = layout_builder.build(font_context, candidate, None, None, None);
+            layout.break_all_lines(None);
+            let Some(line) = layout.lines().next() else { continue };
+            let Some(item) = line.items().next() else { continue };
+            let run = match item {
+                parley::layout::PositionedLayoutItem::GlyphRun(run) => run,
+                _ => continue,
+            };
+            let Some(glyph) = run.positioned_glyphs().next() else { continue };
+            if glyph.id != 0 {
+                return Some((glyph, run.run().font().clone()));
+            }
+        }
+        None
     };
 
     let elision_info =


### PR DESCRIPTION
## Problem

`TextOverflow::Elide` silently no-ops when the resolved font lacks U+2026 (HORIZONTAL ELLIPSIS, `…`) in its glyph table. Several common Arabic fonts ship without `…`:

- Noto Sans Arabic (Regular + Bold)
- Noto Sans Arabic UI (Regular + Bold)
- Noto Naskh Arabic (Regular + Bold + UI variants)
- Noto Kufi Arabic (Regular + Bold)

With one of those fonts as the resolved font for a `Text { overflow: elide; }` element, the text gets clipped at `max_width` with no visible truncation indicator. Latin text works because Latin fonts include `…`.

## Root cause

`sharedparley::layout::get_elipsis_glyph` builds a single-string parley layout for `"…"`, takes the first positioned glyph, and uses it as the truncation indicator. When parley shapes `"…"` with a font that lacks the codepoint, parley returns the OpenType `.notdef` glyph (id 0, typically rendered as an invisible/zero-width box). `get_elipsis_glyph` returned that notdef glyph as if it were valid, so `glyphs_with_elision` then trimmed text + drew an invisible elipsis = silent clip.

## Fix

Iterate `["…", "."]` as candidate truncation indicators. After shaping each, check `glyph.id != 0` — if the resolved font produced a real glyph, use it; otherwise fall through to the next candidate. The single dot is universally present in any font with the ASCII range, so the fallback always succeeds.

The single-dot indicator is less conventional than `…` but unambiguously communicates truncation. Consumers who want full `…` can opt into an Arabic font that includes it (Amiri, Cairo, IBM Plex Sans Arabic, etc.).

## Test plan

- Manual: set a `Text { text: <long string>; overflow: elide; }` with `font-family: "Noto Sans Arabic"`. Before: clean clip with no indicator. After: trailing `.` at the truncation point.
- Existing `tests/screenshots/cases/text/text-elided.slint` continues to pass — the fallback only kicks in when `…` is unavailable, so Latin-font test cases are unaffected.

## Related

Companion PR #(TBD) — `parley: Render elipsis on the leading edge for RTL/right-aligned overflow` — fixes the parallel bug where right-aligned text never triggers elision regardless of font support.
