### PR TITLE
skills: package slint skill as a Cursor plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "slint",
+  "description": "Cursor plugins for building and debugging Slint GUI applications",
+  "owner": {
+    "name": "Slint",
+    "email": "info@slint.dev"
+  },
+  "plugins": [
+    {
+      "name": "slint",
+      "description": "Enhances Cursor's ability to work with, debug, and build Slint GUI applications",
+      "source": "./skills",
+      "version": "0.1.0",
+      "category": "development",
+      "keywords": ["slint", "gui", "ui", "declarative", "rust", "cpp", "embedded"]
+    }
+  ]
+}

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -163,7 +163,9 @@ path = [
   "ui-libraries/material/examples/gallery/ui/themes/**.json",
 
   ".claude-plugin/*.json",
+  ".cursor-plugin/*.json",
   "skills/.claude-plugin/*.json",
+  "skills/.cursor-plugin/*.json",
   "skills/**/SKILL.md",
 ]
 precedence = "aggregate"

--- a/skills/.cursor-plugin/plugin.json
+++ b/skills/.cursor-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "slint",
+  "version": "0.1.0",
+  "description": "Enhances Cursor's ability to work with, debug, and build Slint GUI applications",
+  "author": {
+    "name": "Slint",
+    "email": "info@slint.dev"
+  },
+  "homepage": "https://slint.dev",
+  "repository": "https://github.com/slint-ui/slint",
+  "license": "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0",
+  "skills": "./slint"
+}


### PR DESCRIPTION
Mirrors the existing Claude Code plugin layout under .cursor-plugin/ so the same skills/slint/SKILL.md is discoverable by Cursor's plugin system. REUSE.toml is updated to cover the new manifest files under the same MIT annotation as the Claude manifests.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
