### PR TITLE
node,python: enable skia by default, remove CI feature-swap hack

### DIFF
--- a/.github/actions/install-linux-dependencies/action.yaml
+++ b/.github/actions/install-linux-dependencies/action.yaml
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-# cSpell: ignore libxcb libxkbcommon xfixes
+# cSpell: ignore libxcb libxkbcommon xfixes libgbm
 ---
 name: Install Linux dependencies
 description: Set up Linux dependencies for Slint
@@ -27,7 +27,7 @@ runs:
           if: runner.os == 'Linux'
           run: |
               sudo apt-get update
-              sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev libinput-dev libfontconfig-dev ${{ inputs.extra-packages }}
+              sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev libinput-dev libgbm-dev libfontconfig-dev ${{ inputs.extra-packages }}
           shell: bash
         - name: Install Linux dependencies
           if: ${{ runner.os == 'Linux' && (inputs.old-ubuntu != 'true')}}

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -235,7 +235,7 @@ jobs:
                   sed -i "s|export const NODE_DOCS_BASE_URL = \".*\"|export const NODE_DOCS_BASE_URL = \"$base_url\"|" docs/nodejs/src/node-site-config.mjs
                   sed -i "s|export const NODE_DOCS_BASE_PATH = \".*\"|export const NODE_DOCS_BASE_PATH = \"$base_path\"|" docs/nodejs/src/node-site-config.mjs
             - name: "Build NAPI and TypeScript (api/node)"
-              run: pnpm run build
+              run: pnpm run build:minimal
               working-directory: api/node
             - name: "Node.js API Starlight site"
               run: pnpm run build
@@ -243,7 +243,7 @@ jobs:
             - name: Setup headless display
               uses: pyvista/setup-headless-display-action@v4
             - name: "Python docs"
-              run: uv run build_docs.py
+              run: uv run --config-setting build-args='--no-default-features' build_docs.py
               working-directory: api/python/slint
             - name: "Prepare docs for website structure"
               run: |

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -110,19 +110,6 @@ jobs:
                   if [ "$RELEASE_INPUT" != "true" ]; then
                       pnpm version $PKG_VERSION
                   fi
-            - uses: baptiste0928/cargo-install@v3
-              with:
-                  crate: taplo-cli
-            - name: Prepare feature config for binaries
-              working-directory: api/node
-              shell: bash
-              run: |
-                cat Cargo.toml | taplo format --option column_width=100000 --stdin-filepath=Cargo.toml - | \
-                  perl -p -e 's,^\s*default\s*=.*,,' | \
-                  perl -p -e 's,# binaries:\s?,,' > Cargo.toml.new
-                cat Cargo.toml.new | taplo format --stdin-filepath=Cargo.toml - > Cargo.toml
-                rm Cargo.toml.new
-                taplo get -f Cargo.toml features.default
             - name: Build binary
               shell: bash
               working-directory: api/node

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -47,20 +47,6 @@ jobs:
               with:
                 python-version: '3.12'
             - uses: ./.github/actions/setup-rust
-            - uses: baptiste0928/cargo-install@v3
-              with:
-                  crate: taplo-cli
-            - name: Prepare feature config for binaries
-              working-directory: api/python/slint
-              shell: bash
-              run: |
-                cat Cargo.toml | taplo format --option column_width=100000 --stdin-filepath=Cargo.toml - | \
-                  perl -p -e 's,^\s*default\s*=.*,,' | \
-                  perl -p -e 's,# binaries:\s?,,' > Cargo.toml.new
-                cat Cargo.toml.new | taplo format --stdin-filepath=Cargo.toml - > Cargo.toml
-                rm Cargo.toml.new
-                taplo get -f Cargo.toml features.default
-
             - name: Build a binary wheel
               uses: PyO3/maturin-action@v1
               with:
@@ -81,20 +67,6 @@ jobs:
             - uses: ./.github/actions/setup-rust
               with:
                   target: "aarch64-apple-ios aarch64-apple-ios-sim"
-            - uses: baptiste0928/cargo-install@v3
-              with:
-                  crate: taplo-cli
-            - name: Prepare feature config for binaries
-              working-directory: api/python/slint
-              shell: bash
-              run: |
-                cat Cargo.toml | taplo format --option column_width=100000 --stdin-filepath=Cargo.toml - | \
-                  perl -p -e 's,^\s*default\s*=.*,,' | \
-                  perl -p -e 's,# binaries:\s?,,' > Cargo.toml.new
-                cat Cargo.toml.new | taplo format --stdin-filepath=Cargo.toml - > Cargo.toml
-                rm Cargo.toml.new
-                taplo get -f Cargo.toml features.default
-
             - name: Build iOS wheels
               uses: pypa/cibuildwheel@v3.4.1
               with:
@@ -115,19 +87,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: baptiste0928/cargo-install@v3
-              with:
-                  crate: taplo-cli
-            - name: Prepare feature config for binaries
-              working-directory: api/python/slint
-              shell: bash
-              run: |
-                cat Cargo.toml | taplo format --option column_width=100000 --stdin-filepath=Cargo.toml - | \
-                  perl -p -e 's,^\s*default\s*=.*,,' | \
-                  perl -p -e 's,# binaries:\s?,,' > Cargo.toml.new
-                cat Cargo.toml.new | taplo format --stdin-filepath=Cargo.toml - > Cargo.toml
-                rm Cargo.toml.new
-                taplo get -f Cargo.toml features.default
             - name: Build source package
               uses: PyO3/maturin-action@v1
               with:

--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -22,9 +22,8 @@ crate-type = ["cdylib"]
 path = "rust/lib.rs"
 
 [features]
-default = ["backend-winit", "renderer-femtovg", "renderer-software", "accessibility"]
 # Keep in sync with features in nightly_snapshot.yaml, cpp_package.yaml, slint_tool_binary.yaml, and api/python/slint/Cargo.toml
-# binaries: default = ["backend-linuxkms-noseat", "backend-winit", "renderer-femtovg", "renderer-skia", "accessibility"]
+default = ["backend-linuxkms-noseat", "backend-winit", "renderer-femtovg", "renderer-skia", "accessibility"]
 
 backend-qt = ["slint-interpreter/backend-qt"]
 backend-winit = ["slint-interpreter/backend-winit"]

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -35,6 +35,7 @@
     "artifacts": "napi artifacts",
     "compile": "tsc --build",
     "build": "napi build --platform --release --js rust-module.cjs --dts rust-module.d.cts -c binaries.json",
+    "build:minimal": "napi build --platform --js rust-module.cjs --dts rust-module.d.cts -c binaries.json --no-default-features",
     "build:debug": "napi build --platform --js rust-module.cjs --dts rust-module.d.cts -c binaries.json && pnpm compile",
     "build:testing": "napi build --platform --js rust-module.cjs --dts rust-module.d.cts -c binaries.json --features testing && pnpm compile",
     "install": "node build-on-demand.mjs",

--- a/api/python/slint/Cargo.toml
+++ b/api/python/slint/Cargo.toml
@@ -22,9 +22,8 @@ name = "stub-gen"
 path = "stub-gen/main.rs"
 
 [features]
-default = ["backend-winit", "renderer-femtovg", "renderer-software", "accessibility"]
 # Keep in sync with features in nightly_snapshot.yaml, cpp_package.yaml, slint_tool_binary.yaml, and api/node/Cargo.toml
-# binaries: default = ["backend-linuxkms-noseat", "backend-winit", "renderer-femtovg", "renderer-skia", "accessibility"]
+default = ["backend-linuxkms-noseat", "backend-winit", "renderer-femtovg", "renderer-skia", "accessibility"]
 
 backend-qt = ["slint-interpreter/backend-qt"]
 backend-winit = ["slint-interpreter/backend-winit"]


### PR DESCRIPTION
The node and python bindings had different default features for dev builds vs release builds. A Perl-based CI hack swapped the defaults at publish time. Make the defaults match the binary features directly so that building from the monorepo produces the same result.

Fixes: #11222
