### PR TITLE
linuxkms: Fix build warnings about unused functions

### DIFF
--- a/internal/backends/linuxkms/build.rs
+++ b/internal/backends/linuxkms/build.rs
@@ -28,5 +28,10 @@ fn main() {
             any(feature = "renderer-skia-vulkan", feature = "unstable-wgpu-28"),
             not(feature = "unstable-wgpu-27")
         ) },
+        wgpu_surface: { any(
+            feature = "unstable-wgpu-28",
+            feature = "renderer-femtovg-wgpu",
+            feature = "unstable-wgpu-27"
+        ) },
     }
 }

--- a/internal/backends/linuxkms/drmoutput.rs
+++ b/internal/backends/linuxkms/drmoutput.rs
@@ -297,6 +297,7 @@ impl DrmOutput {
     /// Returns the refresh rate in millihertz, computed from the mode's pixel clock
     /// and timing parameters. This matches the precision used by Vulkan's
     /// VkDisplayModeParametersKHR::refreshRate.
+    #[cfg(wgpu_surface)]
     pub fn refresh_rate_millihertz(&self) -> u32 {
         let clock = self.mode.clock() as u64; // in kHz
         let (_, _, htotal) = self.mode.hsync();
@@ -360,6 +361,7 @@ impl DrmOutput {
     }
 
     // Iterate through all planes and collect formats from compatible ones
+    #[cfg(wgpu_surface)]
     pub fn find_compatible_plane(&self) -> Result<drm::control::plane::Info, PlatformError> {
         let _ = self.drm_device.set_client_capability(drm::ClientCapability::UniversalPlanes, true);
         let plane_handles = self


### PR DESCRIPTION
Guard them with a cfg only when they're needed

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
