### PR TITLE
node: Fix overflow panic in event loop integration

### DIFF
--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -57,7 +57,9 @@ pub enum ProcessEventsResult {
     Exited,
 }
 
-fn process_events_with_timeout(timeout: std::time::Duration) -> napi::Result<ProcessEventsResult> {
+fn process_events_with_timeout(
+    timeout: Option<std::time::Duration>,
+) -> napi::Result<ProcessEventsResult> {
     i_slint_backend_selector::with_platform(|b| {
         b.process_events(timeout, i_slint_core::InternalToken)
     })
@@ -70,7 +72,7 @@ fn process_events_with_timeout(timeout: std::time::Duration) -> napi::Result<Pro
 
 #[napi]
 pub fn process_events() -> napi::Result<ProcessEventsResult> {
-    process_events_with_timeout(std::time::Duration::ZERO)
+    process_events_with_timeout(Some(std::time::Duration::ZERO))
 }
 
 #[napi]

--- a/api/node/rust/uv_event_loop.rs
+++ b/api/node/rust/uv_event_loop.rs
@@ -323,9 +323,9 @@ mod platform {
         loop {
             let uv_timeout = state.prepare_handle.backend_timeout_ms();
             let timeout = if uv_timeout < 0 {
-                Duration::MAX
+                None
             } else {
-                Duration::from_millis(uv_timeout as u64)
+                Some(Duration::from_millis(uv_timeout as u64))
             };
 
             match crate::process_events_with_timeout(timeout) {
@@ -362,7 +362,7 @@ mod platform {
 
         // Check that the backend supports process_events
         // (the testing backend doesn't).
-        crate::process_events_with_timeout(Duration::ZERO)?;
+        crate::process_events_with_timeout(Some(Duration::ZERO))?;
 
         let fd_ready = ensure_watcher_spawned(&uv)?;
         let on_exit = on_exit.create_ref()?;

--- a/api/node/rust/uv_event_loop.rs
+++ b/api/node/rust/uv_event_loop.rs
@@ -322,11 +322,8 @@ mod platform {
     fn process_slint_events(state: &PrepareState) -> ProcessEventsResult {
         loop {
             let uv_timeout = state.prepare_handle.backend_timeout_ms();
-            let timeout = if uv_timeout < 0 {
-                None
-            } else {
-                Some(Duration::from_millis(uv_timeout as u64))
-            };
+            let timeout =
+                if uv_timeout < 0 { None } else { Some(Duration::from_millis(uv_timeout as u64)) };
 
             match crate::process_events_with_timeout(timeout) {
                 Ok(ProcessEventsResult::Exited) | Err(_) => return ProcessEventsResult::Exited,

--- a/docs/development/ffi-language-bindings.md
+++ b/docs/development/ffi-language-bindings.md
@@ -208,7 +208,7 @@ pub enum ProcessEventsResult {
 #[napi]
 pub fn process_events() -> napi::Result<ProcessEventsResult> {
     i_slint_backend_selector::with_platform(|b| {
-        b.process_events(std::time::Duration::ZERO, i_slint_core::InternalToken)
+        b.process_events(Some(std::time::Duration::ZERO), i_slint_core::InternalToken)
     })
     .map_err(|e| napi::Error::from_reason(e.to_string()))
     .map(|result| match result {

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -220,7 +220,7 @@ impl i_slint_core::platform::Platform for Backend {
 
     fn process_events(
         &self,
-        _timeout: core::time::Duration,
+        _timeout: Option<core::time::Duration>,
         _: i_slint_core::InternalToken,
     ) -> Result<core::ops::ControlFlow<()>, PlatformError> {
         #[cfg(not(no_qt))]
@@ -228,7 +228,7 @@ impl i_slint_core::platform::Platform for Backend {
             // Schedule any timers with Qt that were set up before this event loop start.
             crate::qt_window::timer_event();
             use cpp::cpp;
-            let timeout_ms: i32 = _timeout.as_millis() as _;
+            let timeout_ms: i32 = _timeout.map_or(-1, |d| d.as_millis() as i32);
             let loop_was_quit = cpp! {unsafe [timeout_ms as "int"] -> bool as "bool" {
                 ensure_initialized(true);
                 qApp->processEvents(QEventLoop::AllEvents, timeout_ms);

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -756,13 +756,13 @@ impl i_slint_core::platform::Platform for Backend {
     #[cfg(all(not(target_arch = "wasm32"), not(ios_and_friends)))]
     fn process_events(
         &self,
-        timeout: core::time::Duration,
+        timeout: Option<core::time::Duration>,
         _: i_slint_core::InternalToken,
     ) -> Result<core::ops::ControlFlow<()>, PlatformError> {
         let loop_state = self.event_loop_state.borrow_mut().take().unwrap_or_else(|| {
             EventLoopState::new(self.shared_data.clone(), self.custom_application_handler.take())
         });
-        let (new_state, status) = loop_state.pump_events(Some(timeout))?;
+        let (new_state, status) = loop_state.pump_events(timeout)?;
         *self.event_loop_state.borrow_mut() = Some(new_state);
         match status {
             winit::platform::pump_events::PumpStatus::Continue => {

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -43,7 +43,9 @@ pub trait Platform {
     ///   if the loop was terminated via `quit_event_loop()`,
     ///   or through a last-window-closed mechanism.
     ///   Callers shouldn't assume the full timeout has elapsed when the function returns.
-    /// * If the timeout is zero,
+    /// * If the timeout is `None`, the implementation should wait
+    ///   indefinitely for events.
+    /// * If the timeout is `Some(Duration::ZERO)`,
     ///   the implementation should merely peek and process any pending events,
     ///   then return immediately.
     ///
@@ -57,7 +59,7 @@ pub trait Platform {
     #[doc(hidden)]
     fn process_events(
         &self,
-        _timeout: core::time::Duration,
+        _timeout: Option<core::time::Duration>,
         _: crate::InternalToken,
     ) -> Result<core::ops::ControlFlow<()>, PlatformError> {
         Err(PlatformError::NoEventLoopProvider)


### PR DESCRIPTION
Change Platform::process_events timeout from Duration to Option<Duration> so that None means "wait indefinitely". Previously the Node.js event loop passed Duration::MAX when libuv had no pending timers, which caused std::time::Instant overflow in winit's pump_app_events.