### PR TITLE
Use cSpell github action

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -50,6 +50,10 @@ jobs:
               run: rustup toolchain install stable-x86_64-unknown-linux-gnu --profile default
             - name: Run lints
               run: mise run --force --jobs=1 'ci:autofix:lint'
+            - name: Spell check
+              uses: streetsidesoftware/cspell-action@v8
+              with:
+                incremental_files_only: true
 
     ci:
         needs: [format_fix, lint_typecheck]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -97,13 +97,6 @@ description = "Run knip"
 run = "pnpm knip"
 depends = ["prepare:pnpm-install"]
 
-["lint:cspell"]
-description = "Run cSpell on the repository (respects .gitignore)"
-# cspell can hang on exit with Node 24 (worker threads); use Node 22 in CI.
-tools.node = "22"
-run = "pnpm exec cspell lint --no-progress --gitignore ."
-depends = ["prepare:pnpm-install"]
-
 ### Build
 
 ["build:lsp:wasm"]
@@ -151,4 +144,4 @@ depends = [
 
 ["ci:autofix:lint"]
 description = "CI autofix job -- lint steps"
-depends = ["lint:legal:reuse", "lint:ts:typecheck", "lint:ts:knip", "lint:cspell"]
+depends = ["lint:legal:reuse", "lint:ts:typecheck", "lint:ts:knip"]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 # Use https://mise.jdx.dev/schema/mise-task.json for validation.
+# cspell:ignore pipx taplo dedupe
 
 ### fixes
 
@@ -12,13 +13,13 @@ tools = { "pipx:clang-format" = "20.1.3" }
 
 ["fix:rust:lockfile:root"]
 description = "Update the main lockfile (if absolutely necessary)"
-# Use cargo build -p xtask to test if the lockfile needs upating.
+# Use cargo build -p xtask to test if the lockfile needs updating.
 # The fix:legal:copyright task needs the xtask anyhow, so this has a double use.
 run = "cargo build --locked -p xtask || (echo \"### Updating Main Lockfile! ###\" && cargo update)"
 
 ["fix:rust:lockfile:bevy"]
 description = "Update the bevy example lockfile (if absolutely necessary)"
-# Use cargo metadata to test if the lockfile needs upating.
+# Use cargo metadata to test if the lockfile needs updating.
 # --format-version suppresses "warning: please specify `--format-version` flag explicitly to avoid compatibility problems"
 run = "cargo metadata --locked --format-version=1 > /dev/null || (echo \"### Updating Main Lockfile! ###\" && cargo update)"
 dir = "examples/bevy"
@@ -115,7 +116,7 @@ tools = { "ubi:wasm-bindgen/wasm-pack" = "0.13.1" }
 depends = ["prepare:pnpm-install"]
 
 ["build:interpreter:wasm"]
-description = "Build the Slint interpreteer (WASM)"
+description = "Build the Slint interpreter (WASM)"
 dir = "tools/slintpad"
 sources = ["api/wasm-interpreter/Cargo.toml", "api/wasm-interpreter/src/**/*.rs"]
 outputs = ["api/wasm-interpreter/pkg/*"]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -98,7 +98,9 @@ depends = ["prepare:pnpm-install"]
 
 ["lint:cspell"]
 description = "Run cSpell on the repository (respects .gitignore)"
-run = "pnpm exec cspell --no-progress --gitignore ."
+# cspell can hang on exit with Node 24 (worker threads); use Node 22 in CI.
+tools.node = "22"
+run = "pnpm exec cspell lint --no-progress --gitignore ."
 depends = ["prepare:pnpm-install"]
 
 ### Build

--- a/cspell.json
+++ b/cspell.json
@@ -308,7 +308,6 @@
     ],
     "ignorePaths": [
         ".github/**",
-        ".mise/**",
         "api/cpp/docs/conf.py",
         "CHANGELOG.md",
         "cspell.json",

--- a/cspell.json
+++ b/cspell.json
@@ -308,6 +308,7 @@
     ],
     "ignorePaths": [
         ".github/**",
+        ".mise/**",
         "api/cpp/docs/conf.py",
         "CHANGELOG.md",
         "cspell.json",

--- a/cspell.json
+++ b/cspell.json
@@ -307,6 +307,7 @@
         "yellowgreen"
     ],
     "ignorePaths": [
+        ".github/**",
         "api/cpp/docs/conf.py",
         "CHANGELOG.md",
         "cspell.json",


### PR DESCRIPTION
The previous MISE way doesn't exit correctly on a typo and is left
hanging till the action timeout cancels everything. This action might be
a few seconds slower, but should be more reliable.