### PR TITLE
Windows: Improved Shift+F10 behavior

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -137,12 +137,19 @@ cpp! {{
             if (!rust_window)
                 return;
 
+            // On Windows, Shift+F10 under Qt results in a contextMenuEvent, but no
+            // actual key press event (See also #11591)!
+            // So we handle this event here and translate it to a Menu key event, which is the
+            // most similar to a context menu event we have in Slint.
+#ifdef WIN32
             // we already handle right-click events for the context menu
             if (event->reason() != QContextMenuEvent::Reason::Mouse) {
                 rust!(Slint_contextMenuEvent [rust_window: &QtWindow as "void*"] {
                     rust_window.context_menu_event();
                 });
             }
+#endif
+            event->accept();
         }
 
         void resizeEvent(QResizeEvent *) override {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -133,6 +133,18 @@ cpp! {{
             });
         }
 
+        void contextMenuEvent(QContextMenuEvent * event) override {
+            if (!rust_window)
+                return;
+
+            // we already handle right-click events for the context menu
+            if (event->reason() != QContextMenuEvent::Reason::Mouse) {
+                rust!(Slint_contextMenuEvent [rust_window: &QtWindow as "void*"] {
+                    rust_window.context_menu_event();
+                });
+            }
+        }
+
         void resizeEvent(QResizeEvent *) override {
             if (!rust_window)
                 return;
@@ -1883,6 +1895,17 @@ impl QtWindow {
     /// Return the QWidget*
     pub fn widget_ptr(&self) -> NonNull<()> {
         unsafe { std::mem::transmute_copy::<QWidgetPtr, NonNull<_>>(&self.widget_ptr) }
+    }
+
+    // A context menu event was delivered by Qt that was not caused by a mouse input.
+    // The closest equivalent we have in Slint is a KeyEvent with the `Menu` key.
+    //
+    // Note that Qt also sends this event if the user presses Shift+F10 on Windows, but that
+    // information is lost at this point, so we still map it to the menu key (see #11591).
+    fn context_menu_event(&self) {
+        let menu_key: SharedString = i_slint_core::platform::Key::Menu.into();
+        self.window.dispatch_event(WindowEvent::KeyPressed { text: menu_key.clone() });
+        self.window.dispatch_event(WindowEvent::KeyReleased { text: menu_key });
     }
 
     fn paint_event(&self, painter: QPainterPtr) {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1659,9 +1659,20 @@ impl Item for ContextMenu {
         if !self.enabled() {
             return KeyEventResult::EventIgnored;
         }
-        if event.event_type == KeyEventType::KeyPressed
-            && event.key_event.text.starts_with(crate::input::key_codes::Menu)
-        {
+
+        fn is_menu_key(event: &InternalKeyEvent) -> bool {
+            #[allow(unused_mut)]
+            let mut is_menu_key = event.key_event.text.contains(crate::input::key_codes::Menu);
+            #[cfg(target_os = "windows")]
+            {
+                // Windows maps Shift + F10 to open the context menu
+                is_menu_key |= event.key_event.text.contains(crate::input::key_codes::F10)
+                    && event.key_event.modifiers.shift;
+            }
+            is_menu_key
+        }
+
+        if is_menu_key(event) {
             self.show.call(&(Default::default(),));
             KeyEventResult::EventAccepted
         } else {


### PR DESCRIPTION
Initial findings after investigating #11591.

I found that the Qt backend will not actually report SHIFT F10 key presses as key events but as QContextMenuEvents instead.
For us, the closest equivalent is sending a menu keypress, so this would at least partially address #11591

If we then also handle Shift+F10 the same as the menu key in the ContextMenuArea, this provides reasonable behavior.

There is however still a bug in the Qt backend because the hitting shift F10 in the Qt backend will actually case the right-click menu on the Window to open, even after we have handled the keypress...

<img width="299" height="226" alt="image" src="https://github.com/user-attachments/assets/f22cccbf-ffde-4bd2-99cf-9e65f38bb928" />

So the Qt backend still isn't fully fixed, but at least the context menu now correctly appears on winit.

Closes #11591 

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
