### PR TITLE
layout: Fix percentage size in children impacting parent layout

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1361,6 +1361,10 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
     fold.min += extra_w;
     fold.max = Saturating::add(fold.max, extra_w);
     fold.preferred += extra_w;
+    // Don't propagate children's percentage constraints to the parent.
+    // Percentages are relative to the layout's own size, not the grandparent's.
+    fold.min_percent = 0 as _;
+    fold.max_percent = 100 as _;
     fold
 }
 

--- a/tests/cases/layout/box_percent_no_bubble.slint
+++ b/tests/cases/layout/box_percent_no_bubble.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test that percentage sizes in children don't propagate upward
+// and override parent layout constraints (issue #3346).
+
+component Foo {
+    min-height: 20phx;
+    max-height: 40phx;
+    preferred-height: 30phx;
+    HorizontalLayout {
+        alignment: start;
+        rect := Rectangle {
+            background: pink;
+            height: 100%;
+            width: 50phx;
+        }
+    }
+}
+
+export component TestCase inherits Rectangle {
+    width: 200phx;
+    height: 200phx;
+    VerticalLayout {
+        alignment: start;
+        padding: 0phx;
+        spacing: 0phx;
+        foo := Foo {}
+        text := Text {
+            text: "Hello World!";
+            font-size: 24px;
+        }
+    }
+
+    // Foo should respect its own max-height constraint (40phx),
+    // not expand to fill the available space.
+    out property <bool> test: foo.height <= 40phx && foo.height >= 20phx;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
Don't propagate children's min_percent/max_percent in box_layout_info_ortho. These percentages are relative to the layout's own size and should not bubble up to the parent's layout info.

Fixes: #3346
