### PR TITLE
Fix RefCell reentrancy panic in text_size and char_size

### DIFF
--- a/api/rs/slint/tests/issue_11765_text_size_reentrant_borrow.rs
+++ b/api/rs/slint/tests/issue_11765_text_size_reentrant_borrow.rs
@@ -1,0 +1,83 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Regression test for https://github.com/slint-ui/slint/issues/11765
+//!
+//! `sharedparley::text_size` borrows `font_context()` at the start, then calls
+//! `text_item.text()` which evaluates a property binding. If that binding reads
+//! a layout property of a container with other text elements (e.g.
+//! `header.min-width / 1px`), computing that layout recurses into `text_size`
+//! for those inner text elements, hitting a double `borrow_mut()` panic on the
+//! shared `FontContext` `RefCell`.
+
+mod common;
+
+use slint::platform::software_renderer::{PremultipliedRgbaColor, SoftwareRenderer, TargetPixel};
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Default)]
+struct TestPixel(bool);
+
+impl TargetPixel for TestPixel {
+    fn blend(&mut self, _color: PremultipliedRgbaColor) {
+        *self = Self(true);
+    }
+    fn from_rgb(_red: u8, _green: u8, _blue: u8) -> Self {
+        Self(true)
+    }
+}
+
+const WIDTH: usize = 640;
+const HEIGHT: usize = 480;
+
+fn render(renderer: &SoftwareRenderer) {
+    let mut buf = vec![TestPixel(false); WIDTH * HEIGHT];
+    renderer.render(buf.as_mut_slice(), WIDTH);
+}
+
+#[test]
+fn text_size_does_not_double_borrow_font_context() {
+    let window = common::setup(WIDTH as u32, HEIGHT as u32);
+
+    // Reproduces the pattern from issue #11765: a Text element whose `text`
+    // property is bound to the min-width of a container that itself contains
+    // text elements. When the layout system calls `text_size` for the outer
+    // Text, evaluating the `text` binding forces layout of the inner container,
+    // which calls `text_size` for the inner Text elements — all while the
+    // outer `text_size` still holds `font_context().borrow_mut()`.
+    slint::slint! {
+        component Header {
+            HorizontalLayout {
+                Text {
+                    text: "Hello World";
+                    font-size: 16px;
+                }
+                Text {
+                    text: "Some details";
+                    font-size: 12px;
+                }
+            }
+        }
+
+        export component TestCase inherits Window {
+            width: 640px;
+            height: 480px;
+
+            VerticalLayout {
+                header := Header {}
+
+                // This text's content depends on header's layout, creating
+                // the re-entrant text_size call chain.
+                Text {
+                    text: header.min-width / 1px;
+                }
+            }
+        }
+    }
+
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+
+    // Trigger layout + render — this is where the double borrow would panic.
+    window.draw_if_needed(render);
+}

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1330,17 +1330,17 @@ pub fn text_size(
 ) -> Option<LogicalSize> {
     let scale_factor = renderer.scale_factor()?;
 
+    // Evaluate properties before borrowing font_context: both font_request()
+    // and text() can trigger property bindings that re-enter text_size for
+    // other elements, which would panic on a second borrow_mut().
+    let font_request = text_item.font_request(item_rc);
+    let text = text_item.text();
+
     let ctx = renderer.slint_context()?;
     let mut font_ctx = ctx.font_context().borrow_mut();
 
-    let layout_builder = LayoutWithoutLineBreaksBuilder::new(
-        Some(text_item.font_request(item_rc)),
-        text_wrap,
-        None,
-        scale_factor,
-    );
-
-    let text = text_item.text();
+    let layout_builder =
+        LayoutWithoutLineBreaksBuilder::new(Some(font_request), text_wrap, None, scale_factor);
 
     let paragraphs_without_linebreaks =
         create_text_paragraphs(&layout_builder, &mut font_ctx, text, None, Color::default());
@@ -1443,19 +1443,19 @@ pub fn text_input_byte_offset_for_position(
         return 0;
     }
 
-    let Some(ctx) = renderer.slint_context() else {
-        return 0;
-    };
-    let mut font_ctx = ctx.font_context().borrow_mut();
-
     let layout_builder = LayoutWithoutLineBreaksBuilder::new(
         Some(text_input.font_request(item_rc)),
         text_input.wrap(),
         None,
         scale_factor,
     );
-
     let visual_representation = text_input.visual_representation(None);
+
+    let Some(ctx) = renderer.slint_context() else {
+        return 0;
+    };
+    let mut font_ctx = ctx.font_context().borrow_mut();
+
     let paragraphs_without_linebreaks = create_text_paragraphs(
         &layout_builder,
         &mut font_ctx,
@@ -1501,13 +1501,15 @@ pub fn text_input_cursor_rect_for_byte_offset(
         );
     }
 
+    let visual_representation = text_input.visual_representation(None);
+    let cursor_width = text_input.text_cursor_width() * scale_factor;
+
     let Some(ctx) = renderer.slint_context() else {
         return LogicalRect::default();
     };
 
     let mut font_ctx = ctx.font_context().borrow_mut();
 
-    let visual_representation = text_input.visual_representation(None);
     let byte_offset = visual_representation.map_byte_offset_from_actual_to_visual_text(byte_offset);
 
     let paragraphs_without_linebreaks = create_text_paragraphs(
@@ -1525,7 +1527,6 @@ pub fn text_input_cursor_rect_for_byte_offset(
         scale_factor,
         LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
     );
-    let cursor_rect = layout
-        .cursor_rect_for_byte_offset(byte_offset, text_input.text_cursor_width() * scale_factor);
+    let cursor_rect = layout.cursor_rect_for_byte_offset(byte_offset, cursor_width);
     cursor_rect / scale_factor
 }

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -793,22 +793,27 @@ impl RendererSealed for SoftwareRenderer {
             return LogicalSize::default();
         };
         let font_request = text_item.font_request(item_rc);
+        // Evaluate text() before borrowing font_context: the binding can
+        // re-enter text_size for other elements and would panic on a second
+        // borrow_mut().
+        let content = text_item.text();
         #[cfg(feature = "systemfonts")]
         let Some(slint_ctx) = self.slint_context() else {
             return Default::default();
         };
-        #[cfg(feature = "systemfonts")]
-        let mut font_ctx = slint_ctx.font_context().borrow_mut();
-        let font = fonts::match_font(
-            &font_request,
-            scale_factor,
+        let font = {
             #[cfg(feature = "systemfonts")]
-            &mut font_ctx,
-        );
+            let mut font_ctx = slint_ctx.font_context().borrow_mut();
+            fonts::match_font(
+                &font_request,
+                scale_factor,
+                #[cfg(feature = "systemfonts")]
+                &mut font_ctx,
+            )
+        };
 
         #[cfg(feature = "systemfonts")]
         if matches!(font, fonts::Font::VectorFont(_)) && !parley_disabled() {
-            drop(font_ctx);
             return sharedparley::text_size(
                 self,
                 text_item,
@@ -820,7 +825,6 @@ impl RendererSealed for SoftwareRenderer {
             .unwrap_or_default();
         }
 
-        let content = text_item.text();
         let string = match &content {
             PlainOrStyledText::Plain(string) => alloc::borrow::Cow::Borrowed(string.as_str()),
             PlainOrStyledText::Styled(styled_text) => {
@@ -863,18 +867,21 @@ impl RendererSealed for SoftwareRenderer {
         let Some(slint_ctx) = self.slint_context() else {
             return Default::default();
         };
-        #[cfg(feature = "systemfonts")]
-        let mut font_ctx = slint_ctx.font_context().borrow_mut();
-        let font = fonts::match_font(
-            &font_request,
-            scale_factor,
+        let font = {
             #[cfg(feature = "systemfonts")]
-            &mut font_ctx,
-        );
+            let mut font_ctx = slint_ctx.font_context().borrow_mut();
+            fonts::match_font(
+                &font_request,
+                scale_factor,
+                #[cfg(feature = "systemfonts")]
+                &mut font_ctx,
+            )
+        };
 
         match (font, parley_disabled()) {
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
+                let mut font_ctx = slint_ctx.font_context().borrow_mut();
                 sharedparley::char_size(&mut font_ctx, text_item, item_rc, ch).unwrap_or_default()
             }
             #[cfg(feature = "systemfonts")]


### PR DESCRIPTION
text_size and char_size held font_context().borrow_mut() across property reads on the text item (text(), font_request(), visual_representation(), text_cursor_width()). A dirty binding can re-enter the same code path through a layout dependency — e.g. another Text's preferred-width or a container's min-width — and panic on a second borrow_mut.

Hoist all such property reads above the borrow, scope font_ctx to the narrowest necessary region, and document the invariant inline so the pattern isn't re-introduced.

- sharedparley.rs: text_size, text_input_byte_offset_for_position, text_input_cursor_rect_for_byte_offset
- software/lib.rs: text_size (hoist text()) and char_size (scope font_ctx to the match_font call)

Includes a regression test reproducing the original report.

Fixes #11765.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
