### PR TITLE
Qt: Add support for drop events

### DIFF
--- a/examples/dnd-kanban/kanban.cpp
+++ b/examples/dnd-kanban/kanban.cpp
@@ -55,16 +55,20 @@ int main()
         return payload ? payload->source_column : -1;
     });
 
+    api.on_has_plaintext([](slint::DataTransfer data) { return data.has_plaintext(); });
+
     api.on_add_task([columns](slint::DataTransfer data, int target, int target_index) {
-        auto user_data = data.user_data();
-        auto *payload = std::any_cast<DragPayload>(&user_data);
-        if (!payload) {
-            return;
-        }
         if (target < 0 || target >= static_cast<int>(columns.size())) {
             return;
         }
-        columns[target]->insert(static_cast<size_t>(target_index), payload->task);
+        auto user_data = data.user_data();
+        if (auto *payload = std::any_cast<DragPayload>(&user_data)) {
+            columns[target]->insert(static_cast<size_t>(target_index), payload->task);
+            return;
+        }
+        if (auto text = data.fetch_plaintext()) {
+            columns[target]->insert(static_cast<size_t>(target_index), TaskData { *text });
+        }
     });
 
     api.on_move_task([columns](slint::DataTransfer data, int target, int target_index) {

--- a/examples/dnd-kanban/kanban.cpp
+++ b/examples/dnd-kanban/kanban.cpp
@@ -23,16 +23,16 @@ int main()
     auto window = MainWindow::create();
 
     auto todo = std::make_shared<slint::VectorModel<TaskData>>(std::vector<TaskData> {
-            { 1, "Write release notes" },
-            { 2, "Reply to mailing list" },
-            { 3, "Triage open issues" },
+            { "Write release notes" },
+            { "Reply to mailing list" },
+            { "Triage open issues" },
     });
     auto doing = std::make_shared<slint::VectorModel<TaskData>>(std::vector<TaskData> {
-            { 4, "Polish drag-and-drop example" },
-            { 5, "Review kanban PR" },
+            { "Polish drag-and-drop example" },
+            { "Review kanban PR" },
     });
     auto done = std::make_shared<slint::VectorModel<TaskData>>(std::vector<TaskData> {
-            { 6, "Set up project skeleton" },
+            { "Set up project skeleton" },
     });
 
     window->set_todo(todo);

--- a/examples/dnd-kanban/kanban.slint
+++ b/examples/dnd-kanban/kanban.slint
@@ -4,7 +4,6 @@
 import { Palette } from "std-widgets.slint";
 
 export struct TaskData {
-    id: int,
     title: string,
 }
 

--- a/examples/dnd-kanban/kanban.slint
+++ b/examples/dnd-kanban/kanban.slint
@@ -14,6 +14,8 @@ export global Api {
     pure callback make-data(task: TaskData, source-column: int, source-index: int) -> data-transfer;
     // Returns the source column for a payload produced by `make-data`, or -1 for foreign payloads.
     pure callback source-column-of(data: data-transfer) -> int;
+    // Whether the payload carries plaintext we can turn into a new task title.
+    pure callback has-plaintext(data: data-transfer) -> bool;
     // Copy the payload's task into `target-column` at `target-index` (clamped to [0, len]).
     callback add-task(data: data-transfer, target-column: int, target-index: int);
     // Move the payload's task to `target-column` at `target-index`. Handles same-column
@@ -137,8 +139,8 @@ component KanbanColumn inherits Rectangle {
         drop-area := DropArea {
             vertical-stretch: 1;
             can-drop(event) => {
-                // Reject payloads from outside this app.
-                if Api.source-column-of(event.data) < 0 {
+                // Reject foreign payloads that aren't our own card and aren't plaintext.
+                if Api.source-column-of(event.data) < 0 && !Api.has-plaintext(event.data) {
                     return DragAction.none;
                 }
                 // Track the cursor so the drop indicator can follow it.
@@ -194,7 +196,7 @@ export component MainWindow inherits Window {
         spacing: 12px;
 
         Text {
-            text: "Drag a card between columns — hold the copy modifier to duplicate";
+            text: "Drag a card between columns — hold the copy modifier to duplicate. Drop plain text from another app to add a new card.";
             font-size: 18px;
             font-weight: 700;
             color: Theme.text-primary;

--- a/examples/dnd-kanban/main.js
+++ b/examples/dnd-kanban/main.js
@@ -48,11 +48,18 @@ appWindow.Api.source_column_of = (data) => {
     return payload instanceof DragPayload ? payload.sourceColumn : -1;
 };
 
+appWindow.Api.has_plaintext = (data) => data.hasPlaintext;
+
 appWindow.Api.add_task = (data, targetColumn, targetIndex) => {
-    const payload = data.userData;
-    if (!(payload instanceof DragPayload)) return;
     if (targetColumn < 0 || targetColumn >= columns.length) return;
-    columns[targetColumn].insert(targetIndex, payload.task);
+    const payload = data.userData;
+    if (payload instanceof DragPayload) {
+        columns[targetColumn].insert(targetIndex, payload.task);
+        return;
+    }
+    if (data.hasPlaintext) {
+        columns[targetColumn].insert(targetIndex, { title: data.fetchPlaintext() });
+    }
 };
 
 appWindow.Api.move_task = (data, targetColumn, targetIndex) => {

--- a/examples/dnd-kanban/main.js
+++ b/examples/dnd-kanban/main.js
@@ -19,16 +19,16 @@ class DragPayload {
 }
 
 const todo = new slint.ArrayModel([
-    { id: 1, title: "Write release notes" },
-    { id: 2, title: "Reply to mailing list" },
-    { id: 3, title: "Triage open issues" },
+    { title: "Write release notes" },
+    { title: "Reply to mailing list" },
+    { title: "Triage open issues" },
 ]);
 const doing = new slint.ArrayModel([
-    { id: 4, title: "Polish drag-and-drop example" },
-    { id: 5, title: "Review kanban PR" },
+    { title: "Polish drag-and-drop example" },
+    { title: "Review kanban PR" },
 ]);
 const done = new slint.ArrayModel([
-    { id: 6, title: "Set up project skeleton" },
+    { title: "Set up project skeleton" },
 ]);
 
 appWindow.todo = todo;

--- a/examples/dnd-kanban/main.py
+++ b/examples/dnd-kanban/main.py
@@ -24,20 +24,20 @@ class MainWindow(slint.loader.kanban.MainWindow):
         super().__init__()
         self.todo = ListModel(
             [
-                TaskData(id=1, title="Write release notes"),
-                TaskData(id=2, title="Reply to mailing list"),
-                TaskData(id=3, title="Triage open issues"),
+                TaskData(title="Write release notes"),
+                TaskData(title="Reply to mailing list"),
+                TaskData(title="Triage open issues"),
             ]
         )
         self.doing = ListModel(
             [
-                TaskData(id=4, title="Polish drag-and-drop example"),
-                TaskData(id=5, title="Review kanban PR"),
+                TaskData(title="Polish drag-and-drop example"),
+                TaskData(title="Review kanban PR"),
             ]
         )
         self.done = ListModel(
             [
-                TaskData(id=6, title="Set up project skeleton"),
+                TaskData(title="Set up project skeleton"),
             ]
         )
         self._columns = [self.todo, self.doing, self.done]

--- a/examples/dnd-kanban/main.py
+++ b/examples/dnd-kanban/main.py
@@ -55,16 +55,23 @@ class MainWindow(slint.loader.kanban.MainWindow):
         payload = data.user_data
         return payload.source_column if isinstance(payload, DragPayload) else -1
 
+    @slint.callback(global_name="Api", name="has-plaintext")
+    def has_plaintext(self, data: DataTransfer) -> bool:
+        return data.has_plaintext
+
     @slint.callback(global_name="Api", name="add-task")
     def add_task(
         self, data: DataTransfer, target_column: int, target_index: int
     ) -> None:
-        payload = data.user_data
-        if not isinstance(payload, DragPayload):
-            return
         if not 0 <= target_column < len(self._columns):
             return
-        self._columns[target_column].insert(target_index, payload.task)
+        payload = data.user_data
+        if isinstance(payload, DragPayload):
+            self._columns[target_column].insert(target_index, payload.task)
+            return
+        text = data.fetch_plaintext()
+        if text is not None:
+            self._columns[target_column].insert(target_index, TaskData(title=text))
 
     @slint.callback(global_name="Api", name="move-task")
     def move_task(

--- a/examples/dnd-kanban/main.rs
+++ b/examples/dnd-kanban/main.rs
@@ -21,16 +21,15 @@ fn main() -> Result<(), slint::PlatformError> {
     let window = MainWindow::new()?;
 
     let todo = Rc::new(VecModel::from(vec![
-        TaskData { id: 1, title: "Write release notes".into() },
-        TaskData { id: 2, title: "Reply to mailing list".into() },
-        TaskData { id: 3, title: "Triage open issues".into() },
+        TaskData { title: "Write release notes".into() },
+        TaskData { title: "Reply to mailing list".into() },
+        TaskData { title: "Triage open issues".into() },
     ]));
     let doing = Rc::new(VecModel::from(vec![
-        TaskData { id: 4, title: "Polish drag-and-drop example".into() },
-        TaskData { id: 5, title: "Review kanban PR".into() },
+        TaskData { title: "Polish drag-and-drop example".into() },
+        TaskData { title: "Review kanban PR".into() },
     ]));
-    let done =
-        Rc::new(VecModel::from(vec![TaskData { id: 6, title: "Set up project skeleton".into() }]));
+    let done = Rc::new(VecModel::from(vec![TaskData { title: "Set up project skeleton".into() }]));
 
     window.set_todo(todo.clone().into());
     window.set_doing(doing.clone().into());

--- a/examples/dnd-kanban/main.rs
+++ b/examples/dnd-kanban/main.rs
@@ -54,17 +54,25 @@ fn main() -> Result<(), slint::PlatformError> {
             .map_or(-1, |p| p.source_column as i32)
     });
 
+    api.on_has_plaintext(|data| data.fetch_plaintext().is_ok());
+
     api.on_add_task({
         let columns = columns.clone();
         move |data, target, target_index| {
             let target = target as usize;
-            let Some(payload) = data.user_data().and_then(|rc| rc.downcast::<DragPayload>().ok())
-            else {
+            if target >= columns.len() {
+                return;
+            }
+            let task = if let Some(payload) =
+                data.user_data().and_then(|rc| rc.downcast::<DragPayload>().ok())
+            {
+                payload.task.clone()
+            } else if let Ok(text) = data.fetch_plaintext() {
+                TaskData { title: text }
+            } else {
                 return;
             };
-            if target < columns.len() {
-                columns[target].insert(target_index as usize, payload.task.clone());
-            }
+            columns[target].insert(target_index as usize, task);
         }
     });
 

--- a/internal/backends/qt/key_generated.rs
+++ b/internal/backends/qt/key_generated.rs
@@ -6,7 +6,7 @@
 ```sh
 cargo install bindgen-cli
 export QT_INCLUDE_PATH="/usr/include/x86_64-linux-gnu/qt6"
-bindgen $QT_INCLUDE_PATH/QtCore/qnamespace.h --allowlist-type Qt::Key --allowlist-type Qt::KeyboardModifier --allowlist-type Qt::AlignmentFlag --allowlist-type Qt::TextFlag --allowlist-type Qt::FillRule --allowlist-type Qt::CursorShape --allowlist-type Qt::ScrollPhase -o internal/backends/qt/key_generated.rs -- -I $QT_INCLUDE_PATH -xc++
+bindgen $QT_INCLUDE_PATH/QtCore/qnamespace.h --allowlist-type Qt::Key --allowlist-type Qt::KeyboardModifier --allowlist-type Qt::AlignmentFlag --allowlist-type Qt::TextFlag --allowlist-type Qt::FillRule --allowlist-type Qt::CursorShape --allowlist-type Qt::ScrollPhase --allowlist-type Qt::DropAction -o internal/backends/qt/key_generated.rs -- -I $QT_INCLUDE_PATH -xc++
 ```
 then add license header and this doc
 */
@@ -554,6 +554,13 @@ pub type Qt_CursorShape = ::std::os::raw::c_uint;
 pub const Qt_FillRule_OddEvenFill: Qt_FillRule = 0;
 pub const Qt_FillRule_WindingFill: Qt_FillRule = 1;
 pub type Qt_FillRule = ::std::os::raw::c_uint;
+pub const Qt_DropAction_CopyAction: Qt_DropAction = 1;
+pub const Qt_DropAction_MoveAction: Qt_DropAction = 2;
+pub const Qt_DropAction_LinkAction: Qt_DropAction = 4;
+pub const Qt_DropAction_ActionMask: Qt_DropAction = 255;
+pub const Qt_DropAction_TargetMoveAction: Qt_DropAction = 32770;
+pub const Qt_DropAction_IgnoreAction: Qt_DropAction = 0;
+pub type Qt_DropAction = ::std::os::raw::c_uint;
 pub const Qt_ScrollPhase_NoScrollPhase: Qt_ScrollPhase = 0;
 pub const Qt_ScrollPhase_ScrollBegin: Qt_ScrollPhase = 1;
 pub const Qt_ScrollPhase_ScrollUpdate: Qt_ScrollPhase = 2;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1,10 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore frameless qbrush qpointf qreal qwidgetsize svgz Nesw qsize qstring
+// cSpell: ignore frameless qbrush qpointf qreal qvariant qwidgetsize svgz Nesw qsize qstring
 
 use cpp::*;
 use i_slint_common::sharedfontique::HashedBlob;
+use i_slint_core::DataTransfer;
 use i_slint_core::graphics::rendering_metrics_collector::{
     RenderingMetrics, RenderingMetricsCollector,
 };
@@ -21,8 +22,8 @@ use i_slint_core::item_tree::{
     ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeWeak, ParentItemTraversalMode,
 };
 use i_slint_core::items::{
-    self, FillRule, ImageRendering, ItemRc, ItemRef, Layer, LineCap, LineJoin, MouseCursor,
-    Opacity, PointerEventButton, RenderingResult, TextWrap,
+    self, DragAction, DropEvent, FillRule, ImageRendering, ItemRc, ItemRef, Layer, LineCap,
+    LineJoin, MouseCursor, Opacity, PointerEventButton, RenderingResult, TextWrap,
 };
 use i_slint_core::layout::Orientation;
 use i_slint_core::lengths::{
@@ -53,9 +54,14 @@ cpp! {{
     #include <QtCore/QPointer>
     #include <QtCore/QThread>
     #include <QtCore/QTimer>
+    #include <QtCore/QMimeData>
     #include <QtGui/QAccessible>
     #include <QtGui/QCursor>
     #include <QtGui/QDesktopServices>
+    #include <QtGui/QDragEnterEvent>
+    #include <QtGui/QDragLeaveEvent>
+    #include <QtGui/QDragMoveEvent>
+    #include <QtGui/QDropEvent>
     #include <QtGui/QIconEngine>
     #include <QtGui/QImageReader>
     #include <QtGui/QPaintEngine>
@@ -118,6 +124,7 @@ cpp! {{
             // to draw the window background which is set on the palette.
             // (But the window background might not be opaque)
             setAttribute(Qt::WA_NoSystemBackground, false);
+            setAcceptDrops(true);
             grabGesture(Qt::PinchGesture);
         }
 
@@ -249,6 +256,91 @@ cpp! {{
             rust!(Slint_mouseLeaveEvent [rust_window: &QtWindow as "void*"] {
                 rust_window.mouse_event(MouseEvent::Exit)
             });
+        }
+
+        // Translates a QDragMoveEvent (DragEnter is a subclass) into Slint's MouseEvent::DragMove
+        // and reports the negotiated drop action back to Qt. `is_drop` switches to MouseEvent::Drop.
+        Qt::DropAction dispatchDragEvent(QDropEvent *event, bool is_drop) {
+            if (!rust_window)
+                return Qt::IgnoreAction;
+            const QMimeData *mime = event->mimeData();
+            QString text = mime->hasText() ? mime->text() : QString();
+            QSize image_size;
+            QByteArray image_bytes;
+            if (mime->hasImage()) {
+                QImage image = qvariant_cast<QImage>(mime->imageData());
+                if (!image.isNull()) {
+                    image.convertTo(QImage::Format_RGBA8888);
+                    image_size = image.size();
+                    const int row_bytes = image.width() * 4;
+                    image_bytes.resize(row_bytes * image.height());
+                    // QImage may pad scan lines for alignment, so we can't just copy
+                    // sizeInBytes() — pack row-by-row into a tight width*height*4 buffer.
+                    for (int y = 0; y < image.height(); ++y) {
+                        memcpy(image_bytes.data() + y * row_bytes,
+                               image.constScanLine(y), row_bytes);
+                    }
+                }
+            }
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QPoint pos = event->position().toPoint();
+    #else
+            QPoint pos = event->pos();
+    #endif
+            int allowed = int(event->possibleActions());
+            int proposed = int(event->proposedAction());
+            int chosen = rust!(Slint_dragEvent [
+                rust_window: &QtWindow as "void*",
+                pos: qttypes::QPoint as "QPoint",
+                text: qttypes::QString as "QString",
+                image_bytes: qttypes::QByteArray as "QByteArray",
+                image_size: qttypes::QSize as "QSize",
+                allowed: u32 as "int",
+                proposed: u32 as "int",
+                is_drop: bool as "bool"
+            ] -> u32 as "int" {
+                rust_window.drag_event(
+                    pos,
+                    text.clone(),
+                    image_bytes.clone(),
+                    image_size,
+                    allowed,
+                    proposed,
+                    is_drop,
+                )
+            });
+            return Qt::DropAction(chosen);
+        }
+
+        void dragEnterEvent(QDragEnterEvent *event) override {
+            // Accept unconditionally: ignoring here kills the whole gesture for this widget,
+            // so a DropArea further along the cursor's path would never see the drag. Per-
+            // position feedback is carried by setDropAction (Qt::IgnoreAction = no-drop cursor).
+            event->setDropAction(dispatchDragEvent(event, false));
+            event->accept();
+        }
+
+        void dragMoveEvent(QDragMoveEvent *event) override {
+            event->setDropAction(dispatchDragEvent(event, false));
+            event->accept();
+        }
+
+        void dragLeaveEvent(QDragLeaveEvent *) override {
+            if (!rust_window)
+                return;
+            rust!(Slint_dragLeaveEvent [rust_window: &QtWindow as "void*"] {
+                rust_window.mouse_event(MouseEvent::Exit)
+            });
+        }
+
+        void dropEvent(QDropEvent *event) override {
+            Qt::DropAction chosen = dispatchDragEvent(event, true);
+            if (chosen != Qt::IgnoreAction) {
+                event->setDropAction(chosen);
+                event->accept();
+            } else {
+                event->ignore();
+            }
         }
 
         void keyPressEvent(QKeyEvent *event) override {
@@ -672,6 +764,27 @@ fn from_qt_button(qt_button: u32) -> PointerEventButton {
         8 => PointerEventButton::Back,
         16 => PointerEventButton::Forward,
         _ => PointerEventButton::Other,
+    }
+}
+
+fn qt_drop_action_to_slint(qt_action: u32) -> DragAction {
+    match qt_action {
+        key_generated::Qt_DropAction_CopyAction => DragAction::Copy,
+        // Qt's TargetMoveAction is a Move variant on internal moves.
+        key_generated::Qt_DropAction_MoveAction | key_generated::Qt_DropAction_TargetMoveAction => {
+            DragAction::Move
+        }
+        key_generated::Qt_DropAction_LinkAction => DragAction::Link,
+        _ => DragAction::None,
+    }
+}
+
+fn slint_drag_action_to_qt(action: DragAction) -> u32 {
+    match action {
+        DragAction::Copy => key_generated::Qt_DropAction_CopyAction,
+        DragAction::Move => key_generated::Qt_DropAction_MoveAction,
+        DragAction::Link => key_generated::Qt_DropAction_LinkAction,
+        _ => key_generated::Qt_DropAction_IgnoreAction,
     }
 }
 
@@ -1944,6 +2057,60 @@ impl QtWindow {
     fn mouse_event(&self, event: MouseEvent) {
         WindowInner::from_pub(&self.window).process_mouse_input(event);
         timer_event();
+    }
+
+    /// Dispatch a Qt drag/drop event. `allowed` is `event->possibleActions()` and
+    /// `proposed` is `event->proposedAction()` as `Qt::DropAction` bitmask values
+    /// (see `key_generated::Qt_DropAction_*`). `image_bytes` must be in
+    /// `QImage::Format_RGBA8888` layout (row-major, 4 bytes per pixel, straight
+    /// alpha) so they map directly onto `SharedPixelBuffer<Rgba8Pixel>`; an empty
+    /// buffer means no image is offered. Returns the negotiated `Qt::DropAction`
+    /// (`Qt_DropAction_IgnoreAction` when no `DropArea` accepted) for the caller
+    /// to feed back into `QDropEvent::setDropAction` + `accept()`.
+    fn drag_event(
+        &self,
+        pos: qttypes::QPoint,
+        text: qttypes::QString,
+        image_bytes: qttypes::QByteArray,
+        image_size: qttypes::QSize,
+        allowed: u32,
+        proposed: u32,
+        is_drop: bool,
+    ) -> u32 {
+        let position = i_slint_core::api::LogicalPosition::new(pos.x as f32, pos.y as f32);
+        let allow_copy = allowed & key_generated::Qt_DropAction_CopyAction != 0;
+        let allow_move = allowed
+            & (key_generated::Qt_DropAction_MoveAction
+                | key_generated::Qt_DropAction_TargetMoveAction)
+            != 0;
+        let allow_link = allowed & key_generated::Qt_DropAction_LinkAction != 0;
+        let mut data = DataTransfer::default();
+        let text: String = text.into();
+        if !text.is_empty() {
+            data.set_plaintext(text.into());
+        }
+        let image_bytes = image_bytes.to_slice();
+        if image_size.width > 0 && image_size.height > 0 && !image_bytes.is_empty() {
+            let buffer = SharedPixelBuffer::<Rgba8Pixel>::clone_from_slice(
+                image_bytes,
+                image_size.width,
+                image_size.height,
+            );
+            data.set_image(i_slint_core::graphics::Image::from_rgba8(buffer).into());
+        }
+        let drop_event = DropEvent {
+            data,
+            position,
+            allow_copy,
+            allow_move,
+            allow_link,
+            proposed_action: qt_drop_action_to_slint(proposed),
+        };
+        let mouse_event =
+            if is_drop { MouseEvent::Drop(drop_event) } else { MouseEvent::DragMove(drop_event) };
+        let chosen = WindowInner::from_pub(&self.window).process_mouse_input(mouse_event);
+        timer_event();
+        chosen.map(slint_drag_action_to_qt).unwrap_or(key_generated::Qt_DropAction_IgnoreAction)
     }
 
     fn key_event(&self, key: i32, text: qttypes::QString, released: bool, repeat: bool) {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -31,6 +31,7 @@ use i_slint_core::lengths::{
     PhysicalPx, ScaleFactor, logical_size_from_api,
 };
 use i_slint_core::platform::{PlatformError, WindowEvent};
+use i_slint_core::string::ToSharedString;
 use i_slint_core::textlayout::sharedparley::{self, GlyphRenderer, fontique, parley};
 use i_slint_core::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
 use i_slint_core::{ImageInner, SharedString};
@@ -2085,9 +2086,9 @@ impl QtWindow {
             != 0;
         let allow_link = allowed & key_generated::Qt_DropAction_LinkAction != 0;
         let mut data = DataTransfer::default();
-        let text: String = text.into();
+        let text = text.to_shared_string();
         if !text.is_empty() {
-            data.set_plaintext(text.into());
+            data.set_plaintext(text);
         }
         let image_bytes = image_bytes.to_slice();
         if image_size.width > 0 && image_size.height > 0 && !image_bytes.is_empty() {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore frameless qbrush qpointf qreal qvariant qwidgetsize svgz Nesw qsize qstring
+// cSpell: ignore frameless qbrush qimage qpointf qreal qvariant qwidgetsize svgz Nesw qsize qstring
 
 use cpp::*;
 use i_slint_common::sharedfontique::HashedBlob;
@@ -266,23 +266,7 @@ cpp! {{
                 return Qt::IgnoreAction;
             const QMimeData *mime = event->mimeData();
             QString text = mime->hasText() ? mime->text() : QString();
-            QSize image_size;
-            QByteArray image_bytes;
-            if (mime->hasImage()) {
-                QImage image = qvariant_cast<QImage>(mime->imageData());
-                if (!image.isNull()) {
-                    image.convertTo(QImage::Format_RGBA8888);
-                    image_size = image.size();
-                    const int row_bytes = image.width() * 4;
-                    image_bytes.resize(row_bytes * image.height());
-                    // QImage may pad scan lines for alignment, so we can't just copy
-                    // sizeInBytes() — pack row-by-row into a tight width*height*4 buffer.
-                    for (int y = 0; y < image.height(); ++y) {
-                        memcpy(image_bytes.data() + y * row_bytes,
-                               image.constScanLine(y), row_bytes);
-                    }
-                }
-            }
+            QImage image = mime->hasImage() ? qvariant_cast<QImage>(mime->imageData()) : QImage();
     #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             QPoint pos = event->position().toPoint();
     #else
@@ -294,21 +278,12 @@ cpp! {{
                 rust_window: &QtWindow as "void*",
                 pos: qttypes::QPoint as "QPoint",
                 text: qttypes::QString as "QString",
-                image_bytes: qttypes::QByteArray as "QByteArray",
-                image_size: qttypes::QSize as "QSize",
+                image: qttypes::QImage as "QImage",
                 allowed: u32 as "int",
                 proposed: u32 as "int",
                 is_drop: bool as "bool"
             ] -> u32 as "int" {
-                rust_window.drag_event(
-                    pos,
-                    text.clone(),
-                    image_bytes.clone(),
-                    image_size,
-                    allowed,
-                    proposed,
-                    is_drop,
-                )
+                rust_window.drag_event(pos, text.clone(), image.clone(), allowed, proposed, is_drop)
             });
             return Qt::DropAction(chosen);
         }
@@ -1587,6 +1562,34 @@ pub(crate) fn image_to_pixmap(
     shared_image_buffer_to_pixmap(&image.render_to_buffer(source_size)?)
 }
 
+/// Converts a Qt image to a Slint `SharedPixelBuffer<Rgba8Pixel>`, repacking each
+/// scan line so the result has no row padding. Returns `None` for empty images.
+pub(crate) fn qimage_to_shared_pixel_buffer(
+    mut image: qttypes::QImage,
+) -> Option<SharedPixelBuffer<Rgba8Pixel>> {
+    let size = image.size();
+    if size.width == 0 || size.height == 0 {
+        return None;
+    }
+    let bytes = cpp!(unsafe [mut image as "QImage"] -> qttypes::QByteArray as "QByteArray" {
+        image.convertTo(QImage::Format_RGBA8888);
+        const int row_bytes = image.width() * 4;
+        QByteArray packed;
+        packed.resize(row_bytes * image.height());
+        // QImage may pad scan lines for alignment, so we can't just copy sizeInBytes()
+        // — pack row-by-row into a tight width*height*4 buffer.
+        for (int y = 0; y < image.height(); ++y) {
+            memcpy(packed.data() + y * row_bytes, image.constScanLine(y), row_bytes);
+        }
+        return packed;
+    });
+    Some(SharedPixelBuffer::<Rgba8Pixel>::clone_from_slice(
+        bytes.to_slice(),
+        size.width,
+        size.height,
+    ))
+}
+
 impl QtItemRenderer<'_> {
     fn draw_image_impl(
         &mut self,
@@ -2062,18 +2065,16 @@ impl QtWindow {
 
     /// Dispatch a Qt drag/drop event. `allowed` is `event->possibleActions()` and
     /// `proposed` is `event->proposedAction()` as `Qt::DropAction` bitmask values
-    /// (see `key_generated::Qt_DropAction_*`). `image_bytes` must be in
-    /// `QImage::Format_RGBA8888` layout (row-major, 4 bytes per pixel, straight
-    /// alpha) so they map directly onto `SharedPixelBuffer<Rgba8Pixel>`; an empty
-    /// buffer means no image is offered. Returns the negotiated `Qt::DropAction`
-    /// (`Qt_DropAction_IgnoreAction` when no `DropArea` accepted) for the caller
-    /// to feed back into `QDropEvent::setDropAction` + `accept()`.
+    /// (see `key_generated::Qt_DropAction_*`). `image` is the source's image payload
+    /// when one is offered, or a default (null) `QImage` otherwise. Returns the
+    /// negotiated `Qt::DropAction` (`Qt_DropAction_IgnoreAction` when no `DropArea`
+    /// accepted) for the caller to feed back into `QDropEvent::setDropAction` +
+    /// `accept()`.
     fn drag_event(
         &self,
         pos: qttypes::QPoint,
         text: qttypes::QString,
-        image_bytes: qttypes::QByteArray,
-        image_size: qttypes::QSize,
+        image: qttypes::QImage,
         allowed: u32,
         proposed: u32,
         is_drop: bool,
@@ -2090,13 +2091,7 @@ impl QtWindow {
         if !text.is_empty() {
             data.set_plaintext(text);
         }
-        let image_bytes = image_bytes.to_slice();
-        if image_size.width > 0 && image_size.height > 0 && !image_bytes.is_empty() {
-            let buffer = SharedPixelBuffer::<Rgba8Pixel>::clone_from_slice(
-                image_bytes,
-                image_size.width,
-                image_size.height,
-            );
+        if let Some(buffer) = qimage_to_shared_pixel_buffer(image) {
             data.set_image(i_slint_core::graphics::Image::from_rgba8(buffer).into());
         }
         let drop_event = DropEvent {
@@ -2663,24 +2658,10 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
 
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         let widget_ptr = self.widget_ptr();
-
-        let size = cpp! {unsafe [widget_ptr as "QWidget*"] -> qttypes::QSize as "QSize" {
-            return widget_ptr->size();
+        let image = cpp! {unsafe [widget_ptr as "QWidget*"] -> qttypes::QImage as "QImage" {
+            return widget_ptr->grab().toImage();
         }};
-
-        let rgba8_data = cpp! {unsafe [widget_ptr as "QWidget*"] -> qttypes::QByteArray as "QByteArray" {
-            QPixmap pixmap = widget_ptr->grab();
-            QImage image = pixmap.toImage();
-            image.convertTo(QImage::Format_ARGB32);
-            return QByteArray(reinterpret_cast<const char *>(image.constBits()), image.sizeInBytes());
-        }};
-
-        let buffer = i_slint_core::graphics::SharedPixelBuffer::<i_slint_core::graphics::Rgba8Pixel>::clone_from_slice(
-            rgba8_data.to_slice(),
-            size.width,
-            size.height,
-        );
-        Ok(buffer)
+        qimage_to_shared_pixel_buffer(image).ok_or_else(|| "widget has zero size".into())
     }
 
     fn supports_transformations(&self) -> bool {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -674,7 +674,7 @@ impl Window {
                 });
             }
             crate::platform::WindowEvent::PointerExited => {
-                self.0.process_mouse_input(MouseEvent::Exit)
+                self.0.process_mouse_input(MouseEvent::Exit);
             }
 
             crate::platform::WindowEvent::KeyPressed { text } => {

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1022,6 +1022,18 @@ impl MouseInputState {
     pub fn has_delayed_event(&self) -> bool {
         self.delayed.is_some()
     }
+
+    /// The action negotiated with the `DropArea` that accepted the most recent
+    /// `DragMove`/`Drop`, or `None` if none accepted.
+    pub fn drop_target_action(&self) -> Option<crate::items::DragAction> {
+        let action = self
+            .drop_target
+            .as_ref()
+            .and_then(|t| t.upgrade())
+            .and_then(|i| i.downcast::<crate::items::DropArea>())
+            .map(|d| d.as_pin_ref().current_action())?;
+        (action != crate::items::DragAction::None).then_some(action)
+    }
 }
 
 /// Try to handle the mouse grabber. Return None if the event has been handled, otherwise

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -630,11 +630,12 @@ impl WindowInner {
     }
 
     /// Receive a mouse event and pass it to the items of the component to
-    /// change their state.
-    pub fn process_mouse_input(&self, mut event: MouseEvent) {
+    /// change their state. For `DragMove`/`Drop`, returns the negotiated
+    /// [`DragAction`](crate::items::DragAction), or `None` if no `DropArea` accepted.
+    pub fn process_mouse_input(&self, mut event: MouseEvent) -> Option<crate::items::DragAction> {
         crate::animations::update_animations();
 
-        let Some(item_tree) = self.try_component() else { return };
+        let item_tree = self.try_component()?;
         self.ensure_tree_instantiated();
 
         // handle multiple press release
@@ -877,6 +878,7 @@ impl WindowInner {
         }
 
         let is_dragging = mouse_input_state.drag_data.is_some();
+        let drop_target_action = mouse_input_state.drop_target_action();
         self.mouse_input_state.set(mouse_input_state);
 
         // The drag-image overlay follows the cursor and lives outside any item tree, so
@@ -918,6 +920,8 @@ impl WindowInner {
         }
 
         self.ensure_tree_instantiated();
+
+        drop_target_action
     }
 
     /// Receive a raw touch event from a backend and either forward it as a mouse


### PR DESCRIPTION
This permits dropping plain text from other apps with the Qt backend.

The interface isn't super great, but I'd say let's try this and see how well it works with the other backends and then design something better. I'm thinking - in particular - of process_mouse_input and the feedback from the dnd events to the backend.