### PR TITLE
listview: Ensure sub-components are instantiated in listview_layout 

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -1036,7 +1036,9 @@ class Repeater
                     }(),
             .init =
                     [](void *ud, uintptr_t instance_idx) {
-                        (*static_cast<Ctx *>(ud)->inner->data[instance_idx].ptr)->init();
+                        auto &c = static_cast<Ctx *>(ud)->inner->data[instance_idx];
+                        (*c.ptr)->init();
+                        (*c.ptr)->ensure_instantiated();
                     },
         };
     }
@@ -1175,6 +1177,8 @@ public:
         track_model_changes();
         for (std::size_t i = 0; i < inner->data.size(); ++i) {
             auto index = order == TraversalOrder::BackToFront ? i : inner->data.size() - 1 - i;
+            if (!inner->data[index].ptr)
+                continue;
             auto ref = item_at(index);
             if (ref.vtable->visit_children_item(ref, -1, order, visitor)
                 != std::numeric_limits<uint64_t>::max()) {
@@ -1191,6 +1195,8 @@ public:
             return {};
         }
         const auto &x = inner->data.at(i - offset);
+        if (!x.ptr)
+            return {};
         return vtable::VWeak<private_api::ItemTreeVTable> { x.ptr->into_dyn() };
     }
 
@@ -1232,7 +1238,8 @@ public:
     {
         if (inner) {
             for (auto &&x : inner->data) {
-                f(*x.ptr);
+                if (x.ptr)
+                    f(*x.ptr);
             }
         }
     }

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -717,10 +717,7 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
     /// The index should be within [`Self::range()`]
     pub fn instance_at(&self, index: usize) -> Option<ItemTreeRc<C>> {
         let inner = self.0.inner.borrow();
-        inner
-            .instances
-            .get(index.checked_sub(inner.layout_state.offset)?)
-            .and_then(|c| c.1.clone())
+        inner.instances.get(index.checked_sub(inner.layout_state.offset)?).and_then(|c| c.1.clone())
     }
 
     /// Return true if the Repeater as empty
@@ -899,8 +896,7 @@ mod ffi {
             unsafe { (self.splice)(self.user_data, position, remove, add) }
         }
         fn ensure_updated(&mut self, instance_idx: usize, row: usize) -> bool {
-            let created =
-                unsafe { (self.ensure_updated)(self.user_data, instance_idx, row) };
+            let created = unsafe { (self.ensure_updated)(self.user_data, instance_idx, row) };
             if created {
                 unsafe { (self.init)(self.user_data, instance_idx) };
             }

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -128,8 +128,8 @@ trait RepeaterInstanceOps {
     /// Replace the range `position..position+remove` with `add` new empty/dirty slots.
     fn splice(&mut self, position: usize, remove: usize, add: usize);
 
-    /// If dirty, ensure the instance is created and updated for `row`.
-    /// Returns `true` if freshly created (needs init later).
+    /// If dirty, ensure the instance is created, initialized, and updated
+    /// for `row`. Returns `true` if freshly created.
     fn ensure_updated(&mut self, instance_idx: usize, row: usize) -> bool;
 
     /// Height of the instance, or `None` if not yet created.
@@ -141,32 +141,23 @@ trait RepeaterInstanceOps {
 }
 
 /// Update all instances in the repeater, creating any that are missing.
-/// Returns indices of newly created instances (that need `init()` called).
-fn update_all_instances(
-    ops: &mut impl RepeaterInstanceOps,
-    offset: usize,
-    count: usize,
-) -> Vec<usize> {
+fn update_all_instances(ops: &mut impl RepeaterInstanceOps, offset: usize, count: usize) {
     let cur = ops.len();
     if count > cur {
         ops.splice(cur, 0, count - cur);
     } else if count < cur {
         ops.splice(count, cur - count, 0);
     }
-    let mut indices_to_init = Vec::new();
     for i in 0..count {
-        if ops.ensure_updated(i, i + offset) {
-            indices_to_init.push(i);
-        }
+        ops.ensure_updated(i, i + offset);
     }
-    indices_to_init
 }
 
 /// Update only the instances visible in the ListView viewport.
 ///
 /// This is the core virtualization algorithm: it estimates which model rows
 /// are visible, instantiates/updates those, lays them out, and cleans up
-/// off-screen instances. Returns indices of newly created instances.
+/// off-screen instances. Returns whether any instance was created.
 fn update_visible_instances(
     ops: &mut impl RepeaterInstanceOps,
     state: &mut RepeaterLayoutState,
@@ -176,7 +167,7 @@ fn update_visible_instances(
     viewport_y: Pin<&Property<LogicalLength>>,
     listview_width: LogicalLength,
     listview_height: LogicalLength,
-) -> Vec<usize> {
+) -> bool {
     let zero = LogicalLength::default();
     let mut vp_width = listview_width.get();
     let listview_height = listview_height.get();
@@ -186,7 +177,7 @@ fn update_visible_instances(
         viewport_height.set(zero);
         viewport_y.set(zero);
         viewport_width.set(listview_width);
-        return Vec::new();
+        return false;
     }
 
     let mut vp_y = viewport_y.get().get();
@@ -194,7 +185,7 @@ fn update_visible_instances(
         vp_y = vp_y.min(0 as Coord);
     }
 
-    let mut indices_to_init = Vec::new();
+    let mut changed = false;
 
     // Estimate element height from cached value or by measuring existing instances.
     let element_height = if state.cached_item_height > 0 as Coord {
@@ -215,9 +206,7 @@ fn update_visible_instances(
             // No items exist yet. Create one to measure.
             state.offset = state.offset.min(row_count - 1);
             ops.splice(0, ops.len(), 1);
-            if ops.ensure_updated(0, state.offset) {
-                indices_to_init.push(0);
-            }
+            changed |= ops.ensure_updated(0, state.offset);
             ops.height(0).unwrap_or(0 as Coord)
         }
     };
@@ -242,9 +231,7 @@ fn update_visible_instances(
         let mut it_y = first_item_y + vp_y;
         let mut new_off = state.offset;
         for i in 0..ops.len() {
-            if ops.ensure_updated(i, new_off) {
-                indices_to_init.push(i);
-            }
+            changed |= ops.ensure_updated(i, new_off);
             let h = ops.height(i).unwrap_or(0 as Coord);
             if it_y + h > 0 as Coord || new_off + 1 >= row_count {
                 break;
@@ -270,15 +257,11 @@ fn update_visible_instances(
         while new_offset > 0 && new_offset_y > 0 as Coord {
             new_offset -= 1;
             ops.splice(0, 0, 1);
-            ops.ensure_updated(0, new_offset);
+            changed |= ops.ensure_updated(0, new_offset);
             new_offset_y -= ops.height(0).unwrap_or(0 as Coord);
             prepend_count += 1;
         }
         if prepend_count > 0 {
-            for x in &mut indices_to_init {
-                *x += prepend_count;
-            }
-            indices_to_init.extend(0..prepend_count);
             state.offset = new_offset;
         }
         debug_assert!(new_offset >= state.offset && new_offset <= state.offset + ops.len());
@@ -291,9 +274,7 @@ fn update_visible_instances(
             if idx >= row_count {
                 break;
             }
-            if ops.ensure_updated(i, idx) {
-                indices_to_init.push(i);
-            }
+            changed |= ops.ensure_updated(i, idx);
             vp_width = vp_width.max(ops.listview_layout(i, &mut y));
             idx += 1;
             if y >= listview_height {
@@ -305,8 +286,7 @@ fn update_visible_instances(
         while y < listview_height && idx < row_count {
             let i = ops.len();
             ops.splice(i, 0, 1);
-            ops.ensure_updated(i, idx);
-            indices_to_init.push(i);
+            changed |= ops.ensure_updated(i, idx);
             vp_width = vp_width.max(ops.listview_layout(i, &mut y));
             idx += 1;
         }
@@ -323,20 +303,11 @@ fn update_visible_instances(
         if new_offset != state.offset {
             let remove_count = new_offset - state.offset;
             ops.splice(0, remove_count, 0);
-            indices_to_init.retain_mut(|i| {
-                if *i < remove_count {
-                    false
-                } else {
-                    *i -= remove_count;
-                    true
-                }
-            });
             state.offset = new_offset;
         }
         let keep = idx - new_offset;
         if ops.len() > keep {
             ops.splice(keep, ops.len() - keep, 0);
-            indices_to_init.retain(|x| *x < keep);
         }
 
         if ops.len() == 0 {
@@ -361,53 +332,61 @@ fn update_visible_instances(
         break;
     }
 
-    indices_to_init
+    changed
 }
 
 /// Adapter implementing [`RepeaterInstanceOps`] for the native Rust repeater.
 struct RustRepeaterOps<'a, C: RepeatedItemTree> {
-    instances: &'a mut Vec<(RepeatedInstanceState, Option<ItemTreeRc<C>>)>,
+    inner: &'a RefCell<RepeaterInner<C>>,
     init: &'a dyn Fn() -> ItemTreeRc<C>,
     model: &'a ModelRc<C::Data>,
 }
 
 impl<C: RepeatedItemTree> RepeaterInstanceOps for RustRepeaterOps<'_, C> {
     fn len(&self) -> usize {
-        self.instances.len()
+        self.inner.borrow().instances.len()
     }
 
     fn splice(&mut self, position: usize, remove: usize, add: usize) {
-        self.instances.splice(
+        self.inner.borrow_mut().instances.splice(
             position..position + remove,
             core::iter::repeat_with(|| (RepeatedInstanceState::Dirty, None)).take(add),
         );
     }
 
     fn ensure_updated(&mut self, instance_idx: usize, row: usize) -> bool {
-        let c = &mut self.instances[instance_idx];
-        if c.0 == RepeatedInstanceState::Dirty {
+        let (created, instance) = {
+            let mut inner = self.inner.borrow_mut();
+            let c = &mut inner.instances[instance_idx];
+            if c.0 != RepeatedInstanceState::Dirty {
+                return false;
+            }
             let created = c.1.is_none();
             if created {
                 c.1 = Some((self.init)());
             }
             c.1.as_ref().unwrap().update(row, self.model.row_data(row).unwrap_or_default());
             c.0 = RepeatedInstanceState::Clean;
-            created
-        } else {
-            false
+            (created, c.1.as_ref().unwrap().clone())
+        };
+        if created {
+            crate::properties::evaluate_no_tracking(|| instance.init());
         }
+        crate::item_tree::ensure_item_tree_instantiated(&vtable::VRc::into_dyn(instance));
+        created
     }
 
     fn height(&self, instance_idx: usize) -> Option<Coord> {
-        self.instances[instance_idx]
+        self.inner.borrow().instances[instance_idx]
             .1
             .as_ref()
             .map(|x| x.as_pin_ref().item_geometry(0).height_length().get())
     }
 
     fn listview_layout(&self, instance_idx: usize, y: &mut Coord) -> Coord {
+        let inner = self.inner.borrow();
         let mut y_len = LogicalLength::new(*y);
-        let w = self.instances[instance_idx]
+        let w = inner.instances[instance_idx]
             .1
             .as_ref()
             .unwrap()
@@ -597,18 +576,10 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
         let model = self.model();
         let changed = if self.data().project_ref().is_dirty.get() {
             let count = model.row_count();
-            let mut inner = self.0.inner.borrow_mut();
-            let offset = inner.layout_state.offset;
-            let mut ops =
-                RustRepeaterOps { instances: &mut inner.instances, init: &init, model: &model };
+            let offset = self.0.inner.borrow().layout_state.offset;
+            let mut ops = RustRepeaterOps { inner: &self.0.inner, init: &init, model: &model };
             self.data().is_dirty.set(false);
-            let indices_to_init = update_all_instances(&mut ops, offset, count);
-
-            drop(inner);
-            // Run init callbacks without tracking so that property reads from
-            // init code do not attach to the current evaluation context (e.g.
-            // the redraw tracker or a layout binding).
-            crate::properties::evaluate_no_tracking(|| self.init_instances(indices_to_init));
+            update_all_instances(&mut ops, offset, count);
             self.data().instance_generation.mark_dirty();
             true
         } else {
@@ -618,8 +589,6 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
     }
 
     /// Recurse into child instances to ensure they are instantiated.
-    /// Called from the generated `ensure_instantiated` method, separately
-    /// from `ensure_updated`, to avoid property recursion.
     fn ensure_children_instantiated(&self) -> bool {
         let mut changed = false;
         for instance in self.instances_vec() {
@@ -627,15 +596,6 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
                 crate::item_tree::ensure_item_tree_instantiated(&vtable::VRc::into_dyn(instance));
         }
         changed
-    }
-
-    fn init_instances(&self, indices: Vec<usize>) {
-        let inner = self.0.inner.borrow();
-        for index in indices {
-            if let Some((_, Some(comp))) = inner.instances.get(index) {
-                comp.init();
-            }
-        }
     }
 
     /// Register the ListView viewport properties as dependencies so that
@@ -676,13 +636,11 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
         let row_count = model.row_count();
 
         let data = self.data();
-        let mut inner = data.inner.borrow_mut();
-
-        let RepeaterInner { ref mut instances, ref mut layout_state } = *inner;
-        let mut ops = RustRepeaterOps { instances, init: &init, model: &model };
-        let indices_to_init = update_visible_instances(
+        let mut layout_state = data.inner.borrow().layout_state.clone();
+        let mut ops = RustRepeaterOps { inner: &data.inner, init: &init, model: &model };
+        let changed = update_visible_instances(
             &mut ops,
-            layout_state,
+            &mut layout_state,
             row_count,
             viewport_width,
             viewport_height,
@@ -690,10 +648,8 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
             listview_width,
             listview_height.get(),
         );
+        data.inner.borrow_mut().layout_state = layout_state;
 
-        let changed = !indices_to_init.is_empty();
-        drop(inner);
-        crate::properties::evaluate_no_tracking(|| self.init_instances(indices_to_init));
         if changed {
             self.data().instance_generation.mark_dirty();
         }
@@ -764,7 +720,7 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
         inner
             .instances
             .get(index.checked_sub(inner.layout_state.offset)?)
-            .map(|c| c.1.clone().expect("That was updated before!"))
+            .and_then(|c| c.1.clone())
     }
 
     /// Return true if the Repeater as empty
@@ -935,14 +891,6 @@ mod ffi {
         pub init: unsafe extern "C" fn(user_data: *mut core::ffi::c_void, instance_idx: usize),
     }
 
-    impl RepeaterInstanceOpsVTable {
-        fn init_instances(&self, indices: Vec<usize>) {
-            for idx in indices {
-                unsafe { (self.init)(self.user_data, idx) };
-            }
-        }
-    }
-
     impl RepeaterInstanceOps for RepeaterInstanceOpsVTable {
         fn len(&self) -> usize {
             unsafe { (self.len)(self.user_data) }
@@ -951,7 +899,12 @@ mod ffi {
             unsafe { (self.splice)(self.user_data, position, remove, add) }
         }
         fn ensure_updated(&mut self, instance_idx: usize, row: usize) -> bool {
-            unsafe { (self.ensure_updated)(self.user_data, instance_idx, row) }
+            let created =
+                unsafe { (self.ensure_updated)(self.user_data, instance_idx, row) };
+            if created {
+                unsafe { (self.init)(self.user_data, instance_idx) };
+            }
+            created
         }
         fn height(&self, instance_idx: usize) -> Option<Coord> {
             let h = unsafe { (self.height)(self.user_data, instance_idx) };
@@ -969,8 +922,7 @@ mod ffi {
         offset: usize,
         count: usize,
     ) {
-        let indices_to_init = update_all_instances(ops, offset, count);
-        ops.init_instances(indices_to_init);
+        update_all_instances(ops, offset, count);
     }
 
     #[unsafe(no_mangle)]
@@ -984,7 +936,7 @@ mod ffi {
         listview_width: LogicalLength,
         listview_height: LogicalLength,
     ) -> bool {
-        let indices_to_init = update_visible_instances(
+        update_visible_instances(
             ops,
             state,
             row_count,
@@ -993,9 +945,6 @@ mod ffi {
             viewport_y,
             listview_width,
             listview_height,
-        );
-        let changed = !indices_to_init.is_empty();
-        ops.init_instances(indices_to_init);
-        changed
+        )
     }
 }

--- a/tests/cases/callbacks/init_listview.slint
+++ b/tests/cases/callbacks/init_listview.slint
@@ -35,7 +35,7 @@ assert_eq!(instance.get_result(), "(10)(11)(12)");
 instance.set_result("".into());
 instance.set_scroll(-850.);
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert_eq!(instance.get_result(), "(8)(9)");
+assert_eq!(instance.get_result(), "(9)(8)");
 
 
 ```
@@ -57,7 +57,7 @@ assert_eq(instance.get_result(), "(10)(11)(12)");
 instance.set_result("");
 instance.set_scroll(-850.);
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert_eq(instance.get_result(), "(8)(9)");
+assert_eq(instance.get_result(), "(9)(8)");
 ```
 
 
@@ -77,7 +77,7 @@ assert.equal(instance.result, "(10)(11)(12)");
 instance.result = "";
 instance.scroll = -850.;
 slintlib.private_api.send_mouse_click(instance, 5., 5.);
-assert.equal(instance.result, "(8)(9)");
+assert.equal(instance.result, "(9)(8)");
 ```
 
 

--- a/tests/cases/callbacks/init_order.slint
+++ b/tests/cases/callbacks/init_order.slint
@@ -1,0 +1,63 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Verify that a parent's init callback always fires before its children
+// are instantiated, for both `if` (conditional) and `for` (repeater).
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    out property <string> log;
+
+    // A conditional whose init must fire before its for-children.
+    if true: Rectangle {
+        init => { log += "if1,"; }
+        for i in [1, 2]: Rectangle {
+            init => { log += "for1." + i + ","; }
+        }
+    }
+
+    // A for-repeater whose children each contain a conditional.
+    for i in [1, 2]: Rectangle {
+        init => { log += "for2." + i + ","; }
+        if true: Rectangle {
+            init => { log += "if2." + i + ","; }
+        }
+    }
+
+    // Nested: for inside if inside for.
+    for i in [1]: Rectangle {
+        init => { log += "outer." + i + ","; }
+        if true: Rectangle {
+            init => { log += "mid." + i + ","; }
+            for j in [1, 2]: Rectangle {
+                init => { log += "inner." + i + "." + j + ","; }
+            }
+        }
+    }
+
+    out property <bool> test: true;
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_log(), "if1,for1.1,for1.2,for2.1,if2.1,for2.2,if2.2,outer.1,mid.1,inner.1.1,inner.1.2,");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_log(), "if1,for1.1,for1.2,for2.1,if2.1,for2.2,if2.2,outer.1,mid.1,inner.1.1,inner.1.2,");
+```
+
+```js
+var instance = new slint.TestCase({});
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.log, "if1,for1.1,for1.2,for2.1,if2.1,for2.2,if2.2,outer.1,mid.1,inner.1.1,inner.1.2,");
+```
+
+*/

--- a/tests/cases/elements/listview-millions.slint
+++ b/tests/cases/elements/listview-millions.slint
@@ -11,13 +11,15 @@ export component TestCase inherits Window {
     in-out property <length> viewport-y <=> lv.viewport-y;
 
     lv := ListView {
-        for _[num] in 2130000000: Rectangle {
-            height: 20px;
-            border-width: 1px;
-            border-color: red;
-            Text { text: num; }
-            TouchArea {
-                clicked => { result = "|"+num; root.clicked(num) }
+        for _[num] in 2130000000: HorizontalLayout {
+            if true: Rectangle {
+                height: 20px;
+                border-width: 1px;
+                border-color: red;
+                Text { text: num; }
+                TouchArea {
+                    clicked => { result = "|"+num; root.clicked(num) }
+                }
             }
         }
     }

--- a/tests/cases/elements/listview-millions.slint
+++ b/tests/cases/elements/listview-millions.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// As of now, the C++ optimization doesn't optimize hidden item of Listview so this test would take forever
-//ignore:cpp
-
 import { ListView } from "std-widgets.slint";
 export component TestCase inherits Window {
     preferred-width: 300px;
@@ -84,7 +81,46 @@ const TestCase &instance = *handle;
 auto clicked = std::make_shared<std::vector<int>>();
 instance.on_clicked([clicked](int x) { clicked->push_back(x); });
 slint_testing::send_mouse_click(&instance, 5., 250.);
-assert(*clicked == std::vector<int>{12});
+assert((*clicked == std::vector<int>{12}));
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert((*clicked == std::vector<int>{12, 13, 11}));
+
+instance.set_viewport_y(-20. * 1000.);
+clicked->clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert((*clicked == std::vector<int>{1012}));
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert((*clicked == std::vector<int>{1012, 1013, 1011}));
+
+instance.set_viewport_y(-20. * 100000.);
+clicked->clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert((*clicked == std::vector<int>{100012}));
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert((*clicked == std::vector<int>{100012, 100013, 100011}));
+
+instance.set_viewport_y(-20. * 10000000.);
+clicked->clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert((*clicked == std::vector<int>{10000012}));
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert((*clicked == std::vector<int>{10000012, 10000013, 10000011}));
+
+instance.set_viewport_y(-20. * 210000000.);
+clicked->clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert((*clicked == std::vector<int>{210000012}));
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert((*clicked == std::vector<int>{210000012, 210000013, 210000011}));
+
+// go all the way to the end, it shouldn't crash or loop forever
+instance.set_viewport_y(-20. * (2130000000. - 5.));
+slint_testing::send_mouse_click(&instance, 5., 250.);
 ```
 
 ```js


### PR DESCRIPTION
When a ListView repeater delegate contains conditional children (e.g.
`if true: Rectangle { ... }`), newly created instances report zero
height because the conditional sub-components have not been instantiated
yet. This causes update_visible_instances to loop forever since y never
advances.

Call ensure_instantiated() at the start of listview_layout in all three
backends (Rust codegen, C++ codegen, interpreter) so that conditionals
and nested repeaters are materialized before the height is read.

Fixes: https://github.com/slint-ui/slint/issues/11736