### PR TITLE
Fix generated Rust code to be compatible with edition 2021

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3517,19 +3517,24 @@ fn compile_builtin_function_call(
                 let is_tooltip = popup.is_tooltip;
                 let close_policy = compile_expression(close_policy, ctx);
                 let popup_id_name = internal_popup_id(*popup_index as usize);
+                let globals_init = if !is_tooltip {
+                    quote! {
+                        if let Some(popup_window_adapter) = window.create_popup_window_adapter() {
+                            shared_global.clone_with_window_adapter(popup_window_adapter)
+                        } else {
+                            shared_global.clone()
+                        }
+                    }
+                } else {
+                    quote! { shared_global.clone() }
+                };
                 component_access_tokens.then(|component_access_tokens| quote!({
                     let parent_item = #parent_item;
                     // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one
                     let shared_global = #component_access_tokens.globals.get().unwrap();
                     let window_adapter = shared_global.window_adapter_impl();
                     let window = sp::WindowInner::from_pub(window_adapter.window());
-                    let globals = if !#is_tooltip
-                        && let Some(popup_window_adapter) = window.create_popup_window_adapter()
-                    {
-                        shared_global.clone_with_window_adapter(popup_window_adapter)
-                    } else {
-                        shared_global.clone()
-                    };
+                    let globals = #globals_init;
 
                     let popup_instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone(), globals).unwrap();
                     let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);

--- a/tests/cases/elements/popupwindow_position.slint
+++ b/tests/cases/elements/popupwindow_position.slint
@@ -135,7 +135,8 @@ for i in 1..11 {
     assert_eq!(instance.global::<Properties<'_>>().get_popup_y(), i as f32 * 20., "Iteration: {}", i);
 
     assert_eq!(inner.active_popups.borrow().len(), 1);
-    if let slint_testing::PopupWindowLocation::ChildWindow(position) = inner.active_popups.borrow().first().unwrap().location {
+    let popups = inner.active_popups.borrow();
+    if let slint_testing::PopupWindowLocation::ChildWindow(position) = popups.first().unwrap().location {
         assert_eq!(position, slint_testing::LogicalPoint::new(i as f32 * 10., i as f32 * 20.))
     } else {
         assert!(false);

--- a/tests/driver/rust/Cargo.toml
+++ b/tests/driver/rust/Cargo.toml
@@ -5,7 +5,8 @@
 name = "test-driver-rust"
 description = "Driver for the rust-based tests in Slint"
 authors.workspace = true
-edition.workspace = true
+# Keep an older edition to ensure the generated code is compatible with users that don't use the latest edition
+edition = "2021"
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -66,10 +66,10 @@ fn generated_file_for_test<'a>(
     // parallelizing the compilation.
     if base.map(|path| case_root_dir.join(path).is_dir()).unwrap_or_default() {
         let mut base = base.unwrap().to_owned();
-        if base.starts_with("widgets")
-            && let Some(style) = testcase.requested_style
-        {
-            base = PathBuf::from(format!("{}-{}", base.display(), style));
+        if base.starts_with("widgets") {
+            if let Some(style) = testcase.requested_style {
+                base = PathBuf::from(format!("{}-{}", base.display(), style));
+            }
         }
 
         let base = base.into_os_string();


### PR DESCRIPTION
The code generator was emitting let chains which require edition 2024. Since some of our users are still using older editions, change the rust test driver to build with edition 2021 so we catch such issues in CI.

Also resolve the `is_tooltip` condition at codegen time instead of emitting a runtime check.
