### PR TITLE
CI: Run doc tests to verify slint snippets in markdown as part of the…

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -50,6 +50,7 @@ docs_build:
  - 'internal/**'
  - 'helper_crates/**'
  - 'tools/lsp/**'
+ - 'tests/doctests/**'
  - *ci_config
 
 # Tree-sitter grammar

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -114,13 +114,13 @@ jobs:
               # Ignore rust_version for stable/nightly to test with latest dependencies
               run: cargo update ${{ (inputs.rust_version == 'stable' || inputs.rust_version == 'nightly') && '--ignore-rust-version' || '' }}
             - name: Run tests
-              run: "cargo test --locked --verbose --all-features --workspace --timings ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=qt::"
+              run: "cargo test --locked --verbose --all-features --workspace --timings ${{ inputs.extra_args }} --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=qt::"
               env:
                   SLINT_CREATE_SCREENSHOTS: 1
               shell: bash
             - name: Run tests (qt)
               if: runner.os != 'Windows' && inputs.run_qt
-              run: "cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python qt:: -- --test-threads=1"
+              run: "cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python qt:: -- --test-threads=1"
               shell: bash
             - name: live-preview for rust test
               if: runner.os == 'Linux'

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -154,6 +154,8 @@ jobs:
                 cargo run --release -p slint-doc-generator -- $EXTRA_FLAGS
             - name: "Generate SC API reference"
               run: cargo run --release -p slint-doc-generator -- --slint-sc generate-mdx
+            - name: "Compile Slint snippets in Markdown (doctests)"
+              run: cargo test -p doctests
             - name: "Build Safety Manual"
               working-directory: docs/safety
               run: pnpm build

--- a/tests/doctests/build.rs
+++ b/tests/doctests/build.rs
@@ -10,10 +10,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut tests_file = BufWriter::new(std::fs::File::create(&tests_file_path)?);
 
     let prefix = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").canonicalize()?;
-    for entry in walkdir::WalkDir::new(&prefix)
-        .follow_links(false)
-        .into_iter()
-        .filter_entry(|entry| entry.file_name() != "target")
+    for entry in
+        walkdir::WalkDir::new(&prefix).follow_links(false).into_iter().filter_entry(|entry| {
+            !matches!(entry.file_name().to_str(), Some("target" | "dist" | "node_modules"))
+        })
     {
         let entry = entry?;
         let path = entry.path();


### PR DESCRIPTION
… docs build

The CI path filters won't run the full rust tests when making a change for example to to the safety manual, thus skipping the docests. Instead, run those as part of the docs build.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
