### PR TITLE
fonts: Skip redundant registration of embedded fonts

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2612,7 +2612,7 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         let ctx = self.slint_context().ok_or("slint platform not initialized")?;
-        ctx.font_context().borrow_mut().collection.register_fonts(data.to_vec().into(), None);
+        ctx.font_context().borrow_mut().register_static_font(data);
         Ok(())
     }
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -92,11 +92,14 @@ pub fn configure_test_fonts() {
                 system_fonts: false,
             });
             font_context.source_cache = fontique::SourceCache::new_shared();
+            font_context.clear_registered_static_fonts();
             for file in
                 FONTS_DIR.files().filter(|f| f.path().extension().is_some_and(|ext| ext == "ttf"))
             {
-                let fonts =
-                    font_context.collection.register_fonts(file.contents().to_vec().into(), None);
+                let fonts = font_context.collection.register_fonts(
+                    fontique::Blob::new(std::sync::Arc::new(file.contents())),
+                    None,
+                );
                 for generic_family in FALLBACK_FAMILIES {
                     font_context.collection.set_generic_families(
                         generic_family,

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -474,7 +474,7 @@ impl RendererSealed for TestingWindow {
         data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         let ctx = self.slint_context().ok_or("slint platform not initialized")?;
-        ctx.font_context().borrow_mut().collection.register_fonts(data.to_vec().into(), None);
+        ctx.font_context().borrow_mut().register_static_font(data);
         Ok(())
     }
 

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -96,7 +96,7 @@ vtable = { workspace = true }
 portable-atomic = { version = "1", features = ["critical-section"] }
 auto_enums = { version = "0.8.0", optional = true }
 cfg-if = "1"
-derive_more = { workspace = true, features = ["error"] }
+derive_more = { workspace = true, features = ["error", "deref", "deref_mut"] }
 euclid = { workspace = true }
 lyon_algorithms = { version = "1.0", optional = true, default-features = false }
 lyon_geom = { version = "1.0", optional = true, default-features = false }

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -50,7 +50,7 @@ pub(crate) struct SlintContextInner {
     #[cfg(all(unix, not(target_os = "macos")))]
     xdg_app_id: core::cell::RefCell<Option<crate::SharedString>>,
     #[cfg(feature = "shared-parley")]
-    pub(crate) font_context: core::cell::RefCell<parley::FontContext>,
+    pub(crate) font_context: core::cell::RefCell<crate::textlayout::sharedparley::FontContext>,
     #[cfg(feature = "shared-swash")]
     pub(crate) swash_scale_context: core::cell::RefCell<swash::scale::ScaleContext>,
     pub(crate) modifiers: Cell<InternalKeyboardModifierState>,
@@ -93,7 +93,9 @@ impl SlintContext {
                     collection: collection.inner,
                     source_cache: collection.source_cache,
                 };
-                core::cell::RefCell::new(font_context)
+                core::cell::RefCell::new(crate::textlayout::sharedparley::FontContext::new(
+                    font_context,
+                ))
             },
             #[cfg(feature = "shared-swash")]
             swash_scale_context: core::cell::RefCell::new(swash::scale::ScaleContext::new()),
@@ -108,7 +110,9 @@ impl SlintContext {
 
     /// Return a reference to the font context
     #[cfg(feature = "shared-parley")]
-    pub fn font_context(&self) -> &core::cell::RefCell<parley::FontContext> {
+    pub fn font_context(
+        &self,
+    ) -> &core::cell::RefCell<crate::textlayout::sharedparley::FontContext> {
         &self.0.font_context
     }
 

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -22,8 +22,48 @@ use alloc::vec::Vec;
 use core::ops::Range;
 use core::pin::Pin;
 use euclid::num::Zero;
+use i_slint_common::sharedfontique;
 use skrifa::MetadataProvider as _;
 use std::cell::RefCell;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+pub struct FontContext {
+    pub inner: parley::FontContext,
+    /// `(ptr, len)` of each `&'static [u8]` already handed to fontique, so repeat
+    /// `register_static_font` calls for the same embedded font are skipped.
+    registered_static_fonts: HashSet<(usize, usize)>,
+}
+
+impl FontContext {
+    pub fn new(inner: parley::FontContext) -> Self {
+        Self { inner, registered_static_fonts: HashSet::default() }
+    }
+
+    pub fn register_static_font(&mut self, data: &'static [u8]) {
+        let key = (data.as_ptr() as usize, data.len());
+        if self.registered_static_fonts.insert(key) {
+            self.inner.collection.register_fonts(fontique::Blob::new(Arc::new(data)), None);
+        }
+    }
+
+    pub fn clear_registered_static_fonts(&mut self) {
+        self.registered_static_fonts.clear();
+    }
+}
+
+impl core::ops::Deref for FontContext {
+    type Target = parley::FontContext;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl core::ops::DerefMut for FontContext {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
 
 type InnerTextLayoutCache = crate::item_rendering::ItemCache<Vec<TextParagraph>>;
 
@@ -71,8 +111,6 @@ pub type PhysicalLength = euclid::Length<f32, PhysicalPx>;
 pub type PhysicalRect = euclid::Rect<f32, PhysicalPx>;
 type PhysicalSize = euclid::Size2D<f32, PhysicalPx>;
 type PhysicalPoint = euclid::Point2D<f32, PhysicalPx>;
-
-use i_slint_common::sharedfontique;
 
 /// Trait used for drawing text and text input elements with parley, where parley does the
 /// shaping and positioning, and the renderer is responsible for drawing just the glyphs.

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -28,7 +28,10 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+#[derive(derive_more::Deref, derive_more::DerefMut)]
 pub struct FontContext {
+    #[deref]
+    #[deref_mut]
     pub inner: parley::FontContext,
     /// `(ptr, len)` of each `&'static [u8]` already handed to fontique, so repeat
     /// `register_static_font` calls for the same embedded font are skipped.
@@ -49,19 +52,6 @@ impl FontContext {
 
     pub fn clear_registered_static_fonts(&mut self) {
         self.registered_static_fonts.clear();
-    }
-}
-
-impl core::ops::Deref for FontContext {
-    type Target = parley::FontContext;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl core::ops::DerefMut for FontContext {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
     }
 }
 

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -400,7 +400,7 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         let ctx = self.slint_context().ok_or("slint platform not initialized")?;
-        ctx.font_context().borrow_mut().collection.register_fonts(data.to_vec().into(), None);
+        ctx.font_context().borrow_mut().register_static_font(data);
         Ok(())
     }
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -928,7 +928,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         let ctx = self.slint_context().ok_or("slint platform not initialized")?;
-        ctx.font_context().borrow_mut().collection.register_fonts(data.to_vec().into(), None);
+        ctx.font_context().borrow_mut().register_static_font(data);
         Ok(())
     }
 

--- a/internal/renderers/software/fonts/systemfonts.rs
+++ b/internal/renderers/software/fonts/systemfonts.rs
@@ -74,14 +74,6 @@ pub fn fallbackfont(
     VectorFont::new(font, swash_key, swash_offset, requested_pixel_size)
 }
 
-pub fn register_font_from_memory(
-    collection: &mut fontique::Collection,
-    data: &'static [u8],
-) -> Result<(), Box<dyn std::error::Error>> {
-    collection.register_fonts(data.to_vec().into(), None);
-    Ok(())
-}
-
 #[cfg(not(target_family = "wasm"))]
 pub fn register_font_from_path(
     collection: &mut fontique::Collection,

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -1181,10 +1181,8 @@ impl RendererSealed for SoftwareRenderer {
         data: &'static [u8],
     ) -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         let ctx = self.slint_context().ok_or("slint platform not initialized")?;
-        self::fonts::systemfonts::register_font_from_memory(
-            &mut ctx.font_context().borrow_mut().collection,
-            data,
-        )
+        ctx.font_context().borrow_mut().register_static_font(data);
+        Ok(())
     }
 
     #[cfg(all(feature = "systemfonts", not(target_arch = "wasm32")))]


### PR DESCRIPTION
Each component instantiation calls `register_font_from_memory` for every embedded `import "foo.ttf"`. Fontique has no built-in dedup, so every new window appended a fresh `FontInfo` to the family — and the bytes were `to_vec()`'d on the way in. That's ~4 MB leaked per window per font.

Dedup at the Slint layer, keyed on the static slice's pointer and length (unique per `include_bytes!`). Pass the slice as `Arc<&'static [u8]>` so the first registration also avoids the copy.

Fixes #11266

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
