### PR TITLE
Re-evaluate property bindings when a callback handler is changed

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2258,6 +2258,17 @@ fn generate_sub_component(
             field_access,
             Declaration::Var(Var { ty, name: cpp_name, ..Default::default() }),
         ));
+        if callback.needs_tracker {
+            let tracker_name = callback_tracker_name(&callback.name);
+            target_struct.members.push((
+                field_access,
+                Declaration::Var(Var {
+                    ty: "slint::private_api::Property<uint8_t>".into(),
+                    name: tracker_name,
+                    ..Default::default()
+                }),
+            ));
+        }
     }
 
     for (i, _) in component.change_callbacks.iter().enumerate() {
@@ -3140,6 +3151,17 @@ fn generate_global(
             Access::Public,
             Declaration::Var(Var { ty, name: cpp_name, ..Default::default() }),
         ));
+        if callback.needs_tracker {
+            let tracker_name = callback_tracker_name(&callback.name);
+            global_struct.members.push((
+                Access::Public,
+                Declaration::Var(Var {
+                    ty: "slint::private_api::Property<uint8_t>".into(),
+                    name: tracker_name,
+                    ..Default::default()
+                }),
+            ));
+        }
     }
 
     let mut init = vec!["(void)this->globals;".into()];
@@ -3344,6 +3366,15 @@ fn generate_public_api_for_properties(
                     ..Default::default()
                 }),
             ));
+            let tracker = access_callback_tracker_cpp(&p.prop, ctx);
+            let mut on_stmts = vec![
+                "slint::private_api::assert_main_thread();".into(),
+                "[[maybe_unused]] auto self = this;".into(),
+                format!("{}.set_handler(std::forward<Functor>(callback_handler));", access),
+            ];
+            if let Some(t) = &tracker {
+                on_stmts.push(format!("{t}.mark_dirty();"));
+            }
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
@@ -3353,11 +3384,7 @@ fn generate_public_api_for_properties(
                         param_types.join(", "),
                     )),
                     signature: "(Functor && callback_handler) const".into(),
-                    statements: Some(vec![
-                        "slint::private_api::assert_main_thread();".into(),
-                        "[[maybe_unused]] auto self = this;".into(),
-                        format!("{}.set_handler(std::forward<Functor>(callback_handler));", access),
-                    ]),
+                    statements: Some(on_stmts),
                     ..Default::default()
                 }),
             ));
@@ -3593,6 +3620,64 @@ fn access_local_member(reference: &llr::LocalMemberReference, ctx: &EvaluationCo
     access_member(&reference.clone().into(), ctx).unwrap()
 }
 
+/// Returns the C++ field name for the change-tracker property of a callback.
+fn callback_tracker_name(callback_name: &str) -> SmolStr {
+    format_smolstr!("callback_tracker_{}", callback_name.replace('-', "_"))
+}
+
+/// Returns the C++ code to access the change-tracker `Property<uint8_t>` for an exported callback.
+/// Returns `None` if the callback doesn't have a tracker.
+fn access_callback_tracker_cpp(
+    reference: &llr::MemberReference,
+    ctx: &EvaluationContext,
+) -> Option<String> {
+    fn in_global(
+        g: &llr::GlobalComponent,
+        callback_idx: &llr::CallbackIdx,
+        self_: &str,
+    ) -> Option<String> {
+        if !g.callbacks[*callback_idx].needs_tracker {
+            return None;
+        }
+        let tracker_name = callback_tracker_name(&g.callbacks[*callback_idx].name);
+        Some(format!("{self_}{tracker_name}"))
+    }
+
+    match reference {
+        llr::MemberReference::Global {
+            global_index,
+            member: llr::LocalMemberIndex::Callback(callback_idx),
+        } => {
+            let global = &ctx.compilation_unit.globals[*global_index];
+            if matches!(ctx.current_scope, EvaluationScope::Global(i) if i == *global_index) {
+                in_global(global, callback_idx, "this->")
+            } else {
+                let global_access = &ctx.generator_state.global_access;
+                let global_id = format!("global_{}", concatenate_ident(&global.name));
+                in_global(global, callback_idx, &format!("{global_access}->{global_id}->"))
+            }
+        }
+        llr::MemberReference::Relative { parent_level: 0, local_reference } => {
+            if let llr::LocalMemberIndex::Callback(callback_idx) = &local_reference.reference {
+                if let Some(current_global) = ctx.current_global() {
+                    return in_global(current_global, callback_idx, "this->");
+                }
+                if local_reference.sub_component_path.is_empty()
+                    && let Some(sc_idx) = ctx.parent_sub_component_idx(0)
+                {
+                    let sc = &ctx.compilation_unit.sub_components[sc_idx];
+                    if sc.callbacks[*callback_idx].needs_tracker {
+                        let tracker_name = callback_tracker_name(&sc.callbacks[*callback_idx].name);
+                        return Some(format!("self->{tracker_name}"));
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 /// Helper to access a member property/callback of a component.
 ///
 /// Because the parent can be deleted (issue #3464), this might be an option when accessing the parent
@@ -3745,11 +3830,14 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         }
         Expression::CallBackCall { callback, arguments } => {
             let f = access_member(callback, ctx);
+            let tracker_get = access_callback_tracker_cpp(callback, ctx)
+                .map(|t| format!("(void){t}.get(), "))
+                .unwrap_or_default();
             let mut a = arguments.iter().map(|a| compile_expression(a, ctx));
             if expr.ty(ctx) == Type::Void {
-                f.then(|f| format!("{f}.call({})", a.join(",")))
+                f.then(|f| format!("{tracker_get}{f}.call({})", a.join(",")))
             } else {
-                f.map_or_default(|f| format!("{f}.call({})", a.join(",")))
+                f.map_or_default(|f| format!("({tracker_get}{f}.call({}))", a.join(",")))
             }
         }
         Expression::FunctionCall { function, arguments } => {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -45,6 +45,12 @@ pub fn ident(ident: &str) -> proc_macro2::Ident {
     }
 }
 
+/// Returns the identifier used for the Property<()> that tracks when a
+/// callback handler is changed from native code.
+fn callback_tracker_ident(callback_name: &str) -> proc_macro2::Ident {
+    format_ident!("callback_tracker_{}", callback_name.replace('-', "_"))
+}
+
 impl quote::ToTokens for Orientation {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let tks = match self {
@@ -898,6 +904,67 @@ fn handle_property_init(
     }
 }
 
+/// Returns the code to access the change-tracker `Property<()>` for an exported callback.
+/// Returns `None` if the callback doesn't have a tracker.
+fn access_callback_tracker(
+    reference: &llr::MemberReference,
+    ctx: &EvaluationContext,
+) -> Option<TokenStream> {
+    fn in_global(
+        g: &llr::GlobalComponent,
+        callback_idx: &llr::CallbackIdx,
+        _self: TokenStream,
+    ) -> Option<TokenStream> {
+        if !g.callbacks[*callback_idx].needs_tracker {
+            return None;
+        }
+        let tracker_name = callback_tracker_ident(&g.callbacks[*callback_idx].name);
+        let global_name = global_inner_name(g);
+        let tracker_field = quote!({ *&#global_name::FIELD_OFFSETS.#tracker_name() });
+        Some(quote!(#tracker_field.apply_pin(#_self)))
+    }
+
+    match reference {
+        llr::MemberReference::Global {
+            global_index,
+            member: llr::LocalMemberIndex::Callback(callback_idx),
+        } => {
+            let global = &ctx.compilation_unit.globals[*global_index];
+            let s = if matches!(ctx.current_scope, EvaluationScope::Global(i) if i == *global_index)
+            {
+                quote!(_self)
+            } else {
+                let global_access = &ctx.generator_state.global_access;
+                let global_id = format_ident!("global_{}", ident(&global.name));
+                quote!(#global_access.#global_id.as_ref())
+            };
+            in_global(global, callback_idx, s)
+        }
+        llr::MemberReference::Relative { parent_level: 0, local_reference } => {
+            if let llr::LocalMemberIndex::Callback(callback_idx) = &local_reference.reference {
+                if let Some(current_global) = ctx.current_global() {
+                    return in_global(current_global, callback_idx, quote!(_self));
+                }
+                if local_reference.sub_component_path.is_empty()
+                    && let Some(sc_idx) = ctx.parent_sub_component_idx(0)
+                {
+                    let sc = &ctx.compilation_unit.sub_components[sc_idx];
+                    if sc.callbacks[*callback_idx].needs_tracker {
+                        let tracker_name =
+                            callback_tracker_ident(&sc.callbacks[*callback_idx].name);
+                        let component_id = inner_component_id(sc);
+                        let tracker_field =
+                            access_component_field_offset(&component_id, &tracker_name);
+                        return Some(quote!((#tracker_field).apply_pin(_self)));
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 /// Public API for Global and root component
 fn public_api(
     public_properties: &llr::PublicProperties,
@@ -926,6 +993,8 @@ fn public_api(
             ));
             let on_ident = format_ident!("on_{}", prop_ident);
             let args_index = (0..callback_args.len()).map(proc_macro2::Literal::usize_unsuffixed);
+            let tracker_access = access_callback_tracker(&p.prop, ctx);
+            let set_dirty = tracker_access.map(|t| quote!(#t.mark_dirty();));
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #on_ident(&self, mut f: impl FnMut(#(#callback_args),*) -> #return_type + 'static) {
@@ -934,7 +1003,8 @@ fn public_api(
                     #prop.set_handler(
                         // FIXME: why do i need to clone here?
                         move |args| f(#(args.#args_index.clone()),*)
-                    )
+                    );
+                    #set_dirty
                 }
             ));
         } else if let Type::Function(function) = &p.ty {
@@ -1052,6 +1122,8 @@ fn generate_sub_component(
         declared_property_vars.push(prop_ident.clone());
         declared_property_types.push(rust_property_type.clone());
     }
+    let mut callback_tracker_names = Vec::new();
+
     for callback in component.callbacks.iter() {
         let cb_ident = ident(&callback.name);
         let callback_args =
@@ -1060,6 +1132,9 @@ fn generate_sub_component(
         declared_callbacks.push(cb_ident.clone());
         declared_callbacks_types.push(callback_args);
         declared_callbacks_ret.push(return_type);
+        if callback.needs_tracker {
+            callback_tracker_names.push(callback_tracker_ident(&callback.name));
+        }
     }
 
     let change_tracker_names = component
@@ -1519,6 +1594,7 @@ fn generate_sub_component(
             #(#popup_id_names : ::core::cell::Cell<sp::Option<::core::num::NonZeroU32>>,)*
             #(#declared_property_vars : sp::Property<#declared_property_types>,)*
             #(#declared_callbacks : sp::Callback<(#(#declared_callbacks_types,)*), #declared_callbacks_ret>,)*
+            #(#callback_tracker_names : sp::Property<()>,)*
             #(#repeated_element_components,)*
             #(#change_tracker_names : sp::ChangeTracker,)*
             #(#timer_names : sp::Timer,)*
@@ -1730,12 +1806,17 @@ fn generate_global(
         declared_property_vars.push(ident(&property.name));
         declared_property_types.push(rust_property_type(&property.ty).unwrap());
     }
+    let mut callback_tracker_names = Vec::new();
+
     for callback in &global.callbacks {
         let callback_args =
             callback.args.iter().map(|a| rust_primitive_type(a).unwrap()).collect::<Vec<_>>();
         declared_callbacks.push(ident(&callback.name));
         declared_callbacks_types.push(callback_args);
         declared_callbacks_ret.push(rust_primitive_type(&callback.ret_ty));
+        if callback.needs_tracker {
+            callback_tracker_names.push(callback_tracker_ident(&callback.name));
+        }
     }
 
     let mut init = Vec::new();
@@ -1852,6 +1933,7 @@ fn generate_global(
             pub struct #inner_component_id {
                 #(#pub_token  #declared_property_vars: sp::Property<#declared_property_types>,)*
                 #(#pub_token  #declared_callbacks: sp::Callback<(#(#declared_callbacks_types,)*), #declared_callbacks_ret>,)*
+                #(#pub_token  #callback_tracker_names : sp::Property<()>,)*
                 #(#pub_token  #change_tracker_names : sp::ChangeTracker,)*
                 globals : sp::OnceCell<sp::Weak<SharedGlobals>>,
             }
@@ -2984,11 +3066,15 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         }
         Expression::CallBackCall { callback, arguments } => {
             let f = access_member(callback, ctx);
+            let tracker = access_callback_tracker(callback, ctx);
+            let register_dep = tracker.map(|t| {
+                quote!(#t.get();)
+            });
             let a = arguments.iter().map(|a| compile_expression_to_value(a, ctx));
             if expr.ty(ctx) == Type::Void {
-                f.then(|f| quote!(#f.call(&(#(#a as _,)*))))
+                f.then(|f| quote!({ #register_dep #f.call(&(#(#a as _,)*)); }))
             } else {
-                f.map_or_default(|f| quote!(#f.call(&(#(#a as _,)*))))
+                f.map_or_default(|f| quote!({ #register_dep #f.call(&(#(#a as _,)*)) }))
             }
         }
         Expression::FunctionCall { function, arguments } => {

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -317,6 +317,11 @@ pub struct Callback {
 
     /// Same as for Property::use_count
     pub use_count: Cell<usize>,
+
+    /// Whether this callback needs a change tracker `Property<()>` so that
+    /// setting a new handler from native code triggers re-evaluation of
+    /// property bindings that invoke this callback.
+    pub needs_tracker: bool,
 }
 
 #[derive(Debug)]

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -357,6 +357,7 @@ fn lower_sub_component(
                     args: callback.args.clone(),
                     ty: Type::Callback(callback.clone()),
                     use_count: 0.into(),
+                    needs_tracker: x.expose_in_public_api,
                 });
                 index.into()
             } else {
@@ -915,6 +916,7 @@ fn lower_global(
                 args: cb.args.clone(),
                 ty: x.property_type.clone(),
                 use_count: 0.into(),
+                needs_tracker: x.expose_in_public_api,
             });
             state.global_properties.insert(
                 nr.clone(),

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -462,6 +462,10 @@ pub struct ItemTreeDescription<'id> {
     pub(crate) items: HashMap<SmolStr, ItemWithinItemTree>,
     pub(crate) custom_properties: HashMap<SmolStr, PropertiesWithinComponent>,
     pub(crate) custom_callbacks: HashMap<SmolStr, FieldOffset<Instance<'id>, Callback>>,
+    /// For each exported callback, a `Property<()>` that tracks when the handler changes.
+    /// Calling `get()` before invoking a callback registers a dependency; calling `mark_dirty()`
+    /// after setting a handler triggers re-evaluation of dependent bindings.
+    pub(crate) callback_trackers: HashMap<SmolStr, FieldOffset<Instance<'id>, Property<()>>>,
     repeater: Vec<ErasedRepeaterWithinComponent<'id>>,
     /// Map the Element::id of the repeater to the index in the `repeater` vec
     pub repeater_names: HashMap<SmolStr, usize>,
@@ -733,8 +737,12 @@ impl ItemTreeDescription<'_> {
             eval::set_callback_handler(&inst, &alias.element(), alias.name(), handler)?
         } else {
             let x = self.custom_callbacks.get(name).ok_or(())?;
-            let sig = x.apply(unsafe { &*(component.as_ptr() as *const dynamic_type::Instance) });
+            let inst = unsafe { &*(component.as_ptr() as *const dynamic_type::Instance) };
+            let sig = x.apply(inst);
             sig.set_handler(handler);
+            if let Some(tracker_offset) = self.callback_trackers.get(name) {
+                tracker_offset.apply_pin(unsafe { Pin::new_unchecked(inst) }).mark_dirty();
+            }
         }
         Ok(())
     }
@@ -1225,6 +1233,7 @@ pub(crate) fn generate_item_tree<'id>(
 
     let mut custom_properties = HashMap::new();
     let mut custom_callbacks = HashMap::new();
+    let mut callback_trackers = HashMap::new();
     fn property_info<T>() -> (Box<dyn PropertyInfo<u8, Value>>, dynamic_type::StaticTypeInfo)
     where
         T: PartialEq + Clone + Default + std::convert::TryInto<Value> + 'static,
@@ -1328,6 +1337,10 @@ pub(crate) fn generate_item_tree<'id>(
         if matches!(&decl.property_type, Type::Callback { .. }) {
             custom_callbacks
                 .insert(name.clone(), builder.type_builder.add_field_type::<Callback>());
+            if decl.expose_in_public_api {
+                callback_trackers
+                    .insert(name.clone(), builder.type_builder.add_field_type::<Property<()>>());
+            }
             continue;
         }
         let Some((prop, type_info)) = property_info_for_type(&decl.property_type, name) else {
@@ -1418,6 +1431,7 @@ pub(crate) fn generate_item_tree<'id>(
         items: builder.items_types,
         custom_properties,
         custom_callbacks,
+        callback_trackers,
         original: component.clone(),
         original_elements: builder.original_elements,
         repeater: builder.repeater,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -2108,6 +2108,9 @@ pub(crate) fn invoke_callback(
             if element.id == element.enclosing_component.upgrade().unwrap().root_element.borrow().id
             {
                 if let Some(callback_offset) = description.custom_callbacks.get(callback_name) {
+                    if let Some(tracker_offset) = description.callback_trackers.get(callback_name) {
+                        tracker_offset.apply_pin(enclosing_component.instance).get();
+                    }
                     let callback = callback_offset.apply(&*enclosing_component.instance);
                     let res = callback.call(args);
                     return Some(if res != Value::Void {
@@ -2161,6 +2164,9 @@ pub(crate) fn set_callback_handler(
                 if let Some(callback_offset) = description.custom_callbacks.get(callback_name) {
                     let callback = callback_offset.apply(&*enclosing_component.instance);
                     callback.set_handler(handler);
+                    if let Some(tracker_offset) = description.callback_trackers.get(callback_name) {
+                        tracker_offset.apply_pin(enclosing_component.instance).mark_dirty();
+                    }
                     return Ok(());
                 } else if enclosing_component.description.original.is_global() {
                     return Err(());

--- a/tests/cases/callbacks/callback_change_reevaluation.slint
+++ b/tests/cases/callbacks/callback_change_reevaluation.slint
@@ -1,0 +1,202 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test that setting a callback handler from native code triggers
+// re-evaluation of properties that depend on that callback's return value.
+// Regression test for https://github.com/slint-ui/slint/issues/11673
+// and https://github.com/slint-ui/slint/issues/9551
+
+export global Logic {
+    pure callback should-show() -> bool;
+    pure callback compute-value() -> int;
+}
+
+export component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+
+    // --- Global callback tests ---
+    out property <bool> show-it: Logic.should-show();
+    out property <int> out-value: Logic.compute-value();
+
+    // Test from #11673: conditional element whose visibility depends on a callback
+    if show-it: Rectangle {
+        width: 100phx;
+        height: 100phx;
+        background: red;
+        TouchArea {
+            width: 100%;
+            height: 100%;
+            clicked => { click-count += 1; }
+        }
+    }
+    in-out property <int> click-count: 0;
+
+    // --- Root-level callback tests ---
+    pure callback root-flag() -> bool;
+    pure callback root-compute(int) -> int;
+
+    out property <bool> root-flag-value: root.root-flag();
+    out property <int> root-computed: root.root-compute(7);
+
+    out property <bool> test: !show-it && out-value == 0 && !root-flag-value && root-computed == 0;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+// --- Global callbacks ---
+assert_eq(instance.get_show_it(), false);
+assert_eq(instance.get_out_value(), 0);
+
+instance.global<Logic>().on_should_show([] { return true; });
+assert_eq(instance.get_show_it(), true);
+
+instance.global<Logic>().on_compute_value([] { return 42; });
+assert_eq(instance.get_out_value(), 42);
+
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq(instance.get_click_count(), 1);
+
+instance.global<Logic>().on_should_show([] { return false; });
+assert_eq(instance.get_show_it(), false);
+
+instance.global<Logic>().on_compute_value([] { return 100; });
+assert_eq(instance.get_out_value(), 100);
+
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq(instance.get_click_count(), 1);
+
+// --- Root-level callbacks ---
+assert_eq(instance.get_root_flag_value(), false);
+assert_eq(instance.get_root_computed(), 0);
+
+instance.on_root_flag([] { return true; });
+assert_eq(instance.get_root_flag_value(), true);
+
+instance.on_root_compute([](int x) { return x * 3; });
+assert_eq(instance.get_root_computed(), 21);
+
+instance.on_root_flag([] { return false; });
+assert_eq(instance.get_root_flag_value(), false);
+
+instance.on_root_compute([](int x) { return x + 1; });
+assert_eq(instance.get_root_computed(), 8);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+
+// --- Global callbacks ---
+assert_eq!(instance.get_show_it(), false);
+assert_eq!(instance.get_out_value(), 0);
+
+instance.global::<Logic<'_>>().on_should_show(|| true);
+assert_eq!(instance.get_show_it(), true);
+
+instance.global::<Logic<'_>>().on_compute_value(|| 42);
+assert_eq!(instance.get_out_value(), 42);
+
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq!(instance.get_click_count(), 1);
+
+instance.global::<Logic<'_>>().on_should_show(|| false);
+assert_eq!(instance.get_show_it(), false);
+
+instance.global::<Logic<'_>>().on_compute_value(|| 100);
+assert_eq!(instance.get_out_value(), 100);
+
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq!(instance.get_click_count(), 1);
+
+// --- Root-level callbacks ---
+assert_eq!(instance.get_root_flag_value(), false);
+assert_eq!(instance.get_root_computed(), 0);
+
+instance.on_root_flag(|| true);
+assert_eq!(instance.get_root_flag_value(), true);
+
+instance.on_root_compute(|x| x * 3);
+assert_eq!(instance.get_root_computed(), 21);
+
+instance.on_root_flag(|| false);
+assert_eq!(instance.get_root_flag_value(), false);
+
+instance.on_root_compute(|x| x + 1);
+assert_eq!(instance.get_root_computed(), 8);
+```
+
+```js
+var instance = new slint.TestCase({});
+
+// --- Global callbacks ---
+assert.equal(instance.show_it, false);
+assert.equal(instance.out_value, 0);
+
+instance.Logic.should_show = function() { return true; };
+assert.equal(instance.show_it, true);
+
+instance.Logic.compute_value = function() { return 42; };
+assert.equal(instance.out_value, 42);
+
+instance.Logic.should_show = function() { return false; };
+assert.equal(instance.show_it, false);
+
+instance.Logic.compute_value = function() { return 100; };
+assert.equal(instance.out_value, 100);
+
+// --- Root-level callbacks ---
+assert.equal(instance.root_flag_value, false);
+assert.equal(instance.root_computed, 0);
+
+instance.root_flag = function() { return true; };
+assert.equal(instance.root_flag_value, true);
+
+instance.root_compute = function(x) { return x * 3; };
+assert.equal(instance.root_computed, 21);
+
+instance.root_flag = function() { return false; };
+assert.equal(instance.root_flag_value, false);
+
+instance.root_compute = function(x) { return x + 1; };
+assert.equal(instance.root_computed, 8);
+```
+
+```python
+instance = TestCase()
+
+# --- Global callbacks ---
+assert instance.show_it == False
+assert instance.out_value == 0
+
+instance.Logic.should_show = lambda: True
+assert instance.show_it == True
+
+instance.Logic.compute_value = lambda: 42
+assert instance.out_value == 42
+
+instance.Logic.should_show = lambda: False
+assert instance.show_it == False
+
+instance.Logic.compute_value = lambda: 100
+assert instance.out_value == 100
+
+# --- Root-level callbacks ---
+assert instance.root_flag_value == False
+assert instance.root_computed == 0
+
+instance.root_flag = lambda: True
+assert instance.root_flag_value == True
+
+instance.root_compute = lambda x: x * 3
+assert instance.root_computed == 21
+
+instance.root_flag = lambda: False
+assert instance.root_flag_value == False
+
+instance.root_compute = lambda x: x + 1
+assert instance.root_computed == 8
+```
+*/


### PR DESCRIPTION
For each exported callback, the code generators now emit a Property<()> (Rust) / Property<uint8_t> (C++) tracker field. When a binding invokes the callback, it reads the tracker to register a dependency. When on_xxx() sets a new handler, it calls mark_dirty() on the tracker, causing dependent bindings to re-evaluate.

Fixes: #11673
Fixes: #9551
