### PR TITLE
Enable textlayout shaping tests under Miri

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1078,4 +1078,4 @@ jobs:
             - name: Run Miri on i-slint-core
               env:
                   MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-tree-borrows
-              run: cargo miri test -p i-slint-core --lib -- --skip textlayout --skip item_tree
+              run: cargo miri test -p i-slint-core --lib -- --skip item_tree

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -312,7 +312,10 @@ impl FontMetrics<f32> for &rustybuzz::Face<'_> {
 
 #[cfg(test)]
 fn with_default_font<R>(mut callback: impl FnMut(&rustybuzz::Face<'_>) -> R) -> R {
-    let mut collection = fontique::Collection::default();
+    let mut collection = fontique::Collection::new(fontique::CollectionOptions {
+        system_fonts: false,
+        ..Default::default()
+    });
     let font_path: std::path::PathBuf =
         [env!("CARGO_MANIFEST_DIR"), "..", "common", "sharedfontique", "Inter-VariableFont.ttf"]
             .iter()


### PR DESCRIPTION
Skip loading system fonts in the test helper since the tests only use a bundled font file. This avoids the fontconfig FFI call that Miri cannot handle.
