### PR TITLE
compiler: Simplify builtin struct handling

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -184,12 +184,7 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
             $(#[derive(Copy, Eq)])?
             struct $Name:ident {
                 @name = $NameTy:ident :: $NameVariant:ident,
-                export {
-                    $( $(#[doc = $pub_doc:literal])* $pub_field:ident : $pub_type:ty, )*
-                }
-                private {
-                    $( $(#[doc = $pri_doc:literal])* $pri_field:ident : $pri_type:ty, )*
-                }
+                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty, )*
             }
         )*) => {
             $(
@@ -197,25 +192,13 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
                 $(writeln!(file, "///{}", $struct_doc)?;)*
                 writeln!(file, "struct {} {{", stringify!($Name))?;
                 $(
-                    $(writeln!(file, "    ///{}", $pub_doc)?;)*
-                    let pub_type = match stringify!($pub_type) {
+                    $(writeln!(file, "    ///{}", $field_doc)?;)*
+                    let field_type = match stringify!($field_type) {
                         "i32" => "int32_t",
                         "f32" | "Coord" => "float",
                         other => other,
                     };
-                    writeln!(file, "    {} {};", pub_type, stringify!($pub_field))?;
-                )*
-                $(
-                    $(writeln!(file, "    ///{}", $pri_doc)?;)*
-                    let pri_type = stringify!($pri_type).replace(' ', "");
-                    let pri_type = match pri_type.as_str() {
-                        "usize" => "uintptr_t",
-                        // This shouldn't be accessed by the C++ anyway, just need to have the same ABI in a struct
-                        "Option<i32>" => "std::pair<int32_t, int32_t>",
-                        "Option<core::ops::Range<i32>>" => "std::tuple<int32_t, int32_t, int32_t>",
-                        other => other,
-                    };
-                    writeln!(file, "    {} {};", pri_type, stringify!($pri_field))?;
+                    writeln!(file, "    {} {};", field_type, stringify!($field))?;
                 )*
                 writeln!(file, "    /// \\private")?;
                 writeln!(file, "    {}", format!("friend bool operator==(const {name}&, const {name}&) = default;", name = stringify!($Name)))?;

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -168,27 +168,22 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
     writeln!(structs_priv, "#include \"private/slint_keys.h\"")?;
     writeln!(structs_priv, "namespace slint::cbindgen_private {{")?;
     writeln!(structs_priv, "enum class KeyEventType : uint8_t;")?;
-    macro_rules! struct_file {
-        (BuiltinPublicStruct, $Name:ident) => {{
-            writeln!(structs_priv, "using slint::language::{};", stringify!($Name))?;
-            &mut structs_pub
-        }};
-        (BuiltinPrivateStruct, $_:ident) => {
-            &mut structs_priv
-        };
-    }
     macro_rules! print_structs {
         ($(
             $(#[doc = $struct_doc:literal])*
             $(#[non_exhaustive])?
             $(#[derive(Copy, Eq)])?
-            struct $Name:ident {
-                @name = $NameTy:ident :: $NameVariant:ident,
+            $vis:vis struct $Name:ident {
                 $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty, )*
             }
         )*) => {
             $(
-                let file = struct_file!($NameTy, $Name);
+                let file: &mut dyn Write = if stringify!($vis) == "pub" {
+                    writeln!(structs_priv, "using slint::language::{};", stringify!($Name))?;
+                    &mut structs_pub
+                } else {
+                    &mut structs_priv
+                };
                 $(writeln!(file, "///{}", $struct_doc)?;)*
                 writeln!(file, "struct {} {{", stringify!($Name))?;
                 $(

--- a/api/node/build.rs
+++ b/api/node/build.rs
@@ -55,12 +55,7 @@ fn generate_language_module() {
             $(#[derive(Copy, Eq)])?
             struct $Name:ident {
                 @name = $NameTy:ident :: $NameVariant:ident,
-                export {
-                    $( $(#[doc = $pub_doc:literal])* $pub_field:ident : $pub_type:ty, )*
-                }
-                private {
-                    $( $(#[doc = $pri_doc:literal])* $pri_field:ident : $pri_type:ty, )*
-                }
+                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty, )*
             }
         )*) => {
             $(
@@ -69,7 +64,7 @@ fn generate_language_module() {
                         name: stringify!($Name),
                         docs: vec![$($struct_doc),*],
                         fields: vec![$(
-                            (stringify!($pub_field), stringify!($pub_type), vec![$($pub_doc),*])
+                            (stringify!($field), stringify!($field_type), vec![$($field_doc),*])
                         ),*],
                     });
                 }

--- a/api/node/build.rs
+++ b/api/node/build.rs
@@ -53,13 +53,12 @@ fn generate_language_module() {
             $(#[doc = $struct_doc:literal])*
             $(#[non_exhaustive])?
             $(#[derive(Copy, Eq)])?
-            struct $Name:ident {
-                @name = $NameTy:ident :: $NameVariant:ident,
+            $vis:vis struct $Name:ident {
                 $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty, )*
             }
         )*) => {
             $(
-                if stringify!($NameTy) == "BuiltinPublicStruct" {
+                if stringify!($vis) == "pub" {
                     structs.push(StructEntry {
                         name: stringify!($Name),
                         docs: vec![$($struct_doc),*],

--- a/api/node/build.rs
+++ b/api/node/build.rs
@@ -13,7 +13,7 @@ fn main() {
     generate_language_module();
 }
 
-/// Collect the public language types (`pub enum` enums and `BuiltinPublicStruct` structs)
+/// Collect the public language types (`pub enum` enums and `pub struct` structs)
 /// and emit `typescript/generated/language.ts`. Enums become `as const` maps from the Rust
 /// variant identifier to the kebab-case string the Slint runtime accepts; structs become
 /// TS type aliases. A type-only `namespace language { … }` declaration provides the named

--- a/api/python/slint/build.rs
+++ b/api/python/slint/build.rs
@@ -35,8 +35,7 @@ macro_rules! generate_builtin_structs_pyi {
         $(#[doc = $struct_doc:literal])*
         $(#[non_exhaustive])?
         $(#[derive(Copy, Eq)])?
-        struct $Name:ident {
-            @name = $NameTy:ident :: $Variant:ident,
+        $vis:vis struct $Name:ident {
             $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
         }
     )*) => {
@@ -51,51 +50,40 @@ macro_rules! generate_builtin_structs_pyi {
             writeln!(writer, "from slint import DataTransfer, LogicalPosition").unwrap();
 
             $(
-                generate_builtin_structs_pyi!(@check writer, $NameTy, $Name,
-                    [$($struct_doc),*],
-                    [$([$($field_doc),*] $field : $field_type),*]
-                );
+                if stringify!($vis) == "pub" {
+                    writeln!(writer, "\nclass {}(typing.NamedTuple):", stringify!($Name)).unwrap();
+                    let struct_doc = vec![$($struct_doc),*].join("\n").trim().to_string();
+                    if !struct_doc.is_empty() {
+                        writeln!(writer, "    \"\"\"").unwrap();
+                        for line in struct_doc.lines() {
+                            if line.is_empty() {
+                                writeln!(writer).unwrap();
+                            } else {
+                                writeln!(writer, "    {}", line).unwrap();
+                            }
+                        }
+                        writeln!(writer, "    \"\"\"").unwrap();
+                    }
+                    writeln!(writer, "").unwrap();
+                    $(
+                        writeln!(writer, "    {}: {} = {}", stringify!($field), map_type(stringify!($field_type)), map_default(stringify!($field_type))).unwrap();
+                        let field_doc_str = vec![$($field_doc),*].join("\n").trim().to_string();
+                        if !field_doc_str.is_empty() {
+                            writeln!(writer, "    \"\"\"").unwrap();
+                            for line in field_doc_str.lines() {
+                                if line.is_empty() {
+                                    writeln!(writer).unwrap();
+                                } else {
+                                    writeln!(writer, "    {}", line).unwrap();
+                                }
+                            }
+                            writeln!(writer, "    \"\"\"").unwrap();
+                        }
+                    )*
+                }
             )*
         }
     };
-    (@check $writer:expr, BuiltinPublicStruct, $Name:ident,
-        [$($struct_doc:literal),*],
-        [$([$($field_doc:literal),*] $field:ident : $field_type:ident),*]
-    ) => {
-        writeln!($writer, "\nclass {}(typing.NamedTuple):", stringify!($Name)).unwrap();
-        let struct_doc = vec![$($struct_doc),*].join("\n").trim().to_string();
-        if !struct_doc.is_empty() {
-            writeln!($writer, "    \"\"\"").unwrap();
-            for line in struct_doc.lines() {
-                if line.is_empty() {
-                    writeln!($writer).unwrap();
-                } else {
-                    writeln!($writer, "    {}", line).unwrap();
-                }
-            }
-            writeln!($writer, "    \"\"\"").unwrap();
-        }
-        writeln!($writer, "").unwrap();
-        $(
-            writeln!($writer, "    {}: {} = {}", stringify!($field), map_type(stringify!($field_type)), map_default(stringify!($field_type))).unwrap();
-            let fd = vec![$($field_doc),*].join("\n").trim().to_string();
-            if !fd.is_empty() {
-                writeln!($writer, "    \"\"\"").unwrap();
-                for line in fd.lines() {
-                    if line.is_empty() {
-                        writeln!($writer).unwrap();
-                    } else {
-                        writeln!($writer, "    {}", line).unwrap();
-                    }
-                }
-                writeln!($writer, "    \"\"\"").unwrap();
-            }
-        )*
-    };
-    (@check $writer:expr, BuiltinPrivateStruct, $Name:ident,
-        [$($struct_doc:literal),*],
-        [$([$($field_doc:literal),*] $field:ident : $field_type:ident),*]
-    ) => {};
 }
 
 i_slint_common::for_each_builtin_structs!(generate_builtin_structs_pyi);

--- a/api/python/slint/build.rs
+++ b/api/python/slint/build.rs
@@ -37,12 +37,7 @@ macro_rules! generate_builtin_structs_pyi {
         $(#[derive(Copy, Eq)])?
         struct $Name:ident {
             @name = $NameTy:ident :: $Variant:ident,
-            export {
-                $( $(#[doc = $pub_doc:literal])* $pub_field:ident : $pub_type:ident, )*
-            }
-            private {
-                $($private:tt)*
-            }
+            $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
         }
     )*) => {
         fn generate_pyi(writer: &mut impl Write) {
@@ -58,14 +53,14 @@ macro_rules! generate_builtin_structs_pyi {
             $(
                 generate_builtin_structs_pyi!(@check writer, $NameTy, $Name,
                     [$($struct_doc),*],
-                    [$([$($pub_doc),*] $pub_field : $pub_type),*]
+                    [$([$($field_doc),*] $field : $field_type),*]
                 );
             )*
         }
     };
     (@check $writer:expr, BuiltinPublicStruct, $Name:ident,
         [$($struct_doc:literal),*],
-        [$([$($pub_doc:literal),*] $pub_field:ident : $pub_type:ident),*]
+        [$([$($field_doc:literal),*] $field:ident : $field_type:ident),*]
     ) => {
         writeln!($writer, "\nclass {}(typing.NamedTuple):", stringify!($Name)).unwrap();
         let struct_doc = vec![$($struct_doc),*].join("\n").trim().to_string();
@@ -82,11 +77,11 @@ macro_rules! generate_builtin_structs_pyi {
         }
         writeln!($writer, "").unwrap();
         $(
-            writeln!($writer, "    {}: {} = {}", stringify!($pub_field), map_type(stringify!($pub_type)), map_default(stringify!($pub_type))).unwrap();
-            let field_doc = vec![$($pub_doc),*].join("\n").trim().to_string();
-            if !field_doc.is_empty() {
+            writeln!($writer, "    {}: {} = {}", stringify!($field), map_type(stringify!($field_type)), map_default(stringify!($field_type))).unwrap();
+            let fd = vec![$($field_doc),*].join("\n").trim().to_string();
+            if !fd.is_empty() {
                 writeln!($writer, "    \"\"\"").unwrap();
-                for line in field_doc.lines() {
+                for line in fd.lines() {
                     if line.is_empty() {
                         writeln!($writer).unwrap();
                     } else {
@@ -99,7 +94,7 @@ macro_rules! generate_builtin_structs_pyi {
     };
     (@check $writer:expr, BuiltinPrivateStruct, $Name:ident,
         [$($struct_doc:literal),*],
-        [$([$($pub_doc:literal),*] $pub_field:ident : $pub_type:ident),*]
+        [$([$($field_doc:literal),*] $field:ident : $field_type:ident),*]
     ) => {};
 }
 

--- a/api/python/slint/language.rs
+++ b/api/python/slint/language.rs
@@ -4,7 +4,7 @@
 // cSpell: ignore kwargs namedtuple
 //! This module generates Python bindings for the public Slint language types:
 //!
-//! * `BuiltinPublicStruct` structs (via `for_each_builtin_structs!`) become
+//! * `pub struct` declarations (via `for_each_builtin_structs!`) become
 //!   `collections.namedtuple` classes with documented defaults.
 //! * `pub enum` declarations (via `for_each_enums!`) become `enum.Enum`
 //!   subclasses whose member name and value are the kebab-case strings the

--- a/api/python/slint/language.rs
+++ b/api/python/slint/language.rs
@@ -126,44 +126,25 @@ macro_rules! declare_python_public_structs {
         $(#[doc = $struct_doc:literal])*
         $(#[non_exhaustive])?
         $(#[derive(Copy, Eq)])?
-        struct $Name:ident {
-            @name = $NameTy:ident :: $NameVariant:ident,
+        $vis:vis struct $Name:ident {
             $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
         }
     )*) => {
         fn register_structs(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
             $(
-                declare_python_public_structs!(@register $NameTy, $Name, py, m;
-                    docs: [$(#[doc = $struct_doc])*],
-                    fields: [$( $(#[doc = $field_doc])* $field : $field_type ,)*],
-                );
+                if stringify!($vis) == "pub" {
+                    let class_doc = [ $($struct_doc),* ].join("\n");
+                    let fields = vec![
+                        $(
+                            (stringify!($field), stringify!($field_type), [ $($field_doc),* ].join("\n")),
+                        )*
+                    ];
+                    register_named_tuple(py, m, stringify!($Name), &class_doc, &fields)?;
+                }
             )*
             Ok(())
         }
     };
-
-    // Public struct arm: collects doc comments and field metadata, then calls
-    // `register_named_tuple` to create and register the NamedTuple class.
-    (@register BuiltinPublicStruct, $Name:ident, $py:ident, $m:ident;
-        docs: [$(#[doc = $struct_doc:literal])*],
-        fields: [$( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident ,)*],
-    ) => {
-        {
-            let class_doc = [ $($struct_doc),* ].join("\n");
-            let fields = vec![
-                $(
-                    (stringify!($field), stringify!($field_type), [ $($field_doc),* ].join("\n")),
-                )*
-            ];
-            register_named_tuple($py, $m, stringify!($Name), &class_doc, &fields)?;
-        }
-    };
-
-    // Private struct arm: intentionally empty — private structs are not exposed to Python.
-    (@register BuiltinPrivateStruct, $_Name:ident, $py:ident, $m:ident;
-        docs: [$(#[$struct_meta:meta])*],
-        fields: [$( $(#[$field_meta:meta])* $field:ident : $field_type:ty ,)*],
-    ) => {};
 }
 
 i_slint_common::for_each_builtin_structs!(declare_python_public_structs);

--- a/api/python/slint/language.rs
+++ b/api/python/slint/language.rs
@@ -122,29 +122,20 @@ fn register_enum_class(
 /// This macro processes `for_each_builtin_structs` and generates a `register_structs`
 /// function that registers all public structs as NamedTuples in the `slint.language` submodule.
 macro_rules! declare_python_public_structs {
-    // Top-level arm: matches the full list of struct definitions emitted by
-    // `for_each_builtin_structs!`. For each struct, it delegates to the
-    // `@register` arm which decides whether to register or skip it based
-    // on whether it's a BuiltinPublicStruct or BuiltinPrivateStruct.
     ($(
         $(#[doc = $struct_doc:literal])*
         $(#[non_exhaustive])?
         $(#[derive(Copy, Eq)])?
         struct $Name:ident {
             @name = $NameTy:ident :: $NameVariant:ident,
-            export {
-                $( $(#[doc = $pub_doc:literal])* $pub_field:ident : $pub_type:ident, )*
-            }
-            private {
-                $( $(#[doc = $pri_doc:literal])* $pri_field:ident : $pri_type:ty, )*
-            }
+            $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
         }
     )*) => {
         fn register_structs(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
             $(
                 declare_python_public_structs!(@register $NameTy, $Name, py, m;
                     docs: [$(#[doc = $struct_doc])*],
-                    fields: [$( $(#[doc = $pub_doc])* $pub_field : $pub_type ,)*],
+                    fields: [$( $(#[doc = $field_doc])* $field : $field_type ,)*],
                 );
             )*
             Ok(())
@@ -155,13 +146,13 @@ macro_rules! declare_python_public_structs {
     // `register_named_tuple` to create and register the NamedTuple class.
     (@register BuiltinPublicStruct, $Name:ident, $py:ident, $m:ident;
         docs: [$(#[doc = $struct_doc:literal])*],
-        fields: [$( $(#[doc = $field_doc:literal])* $pub_field:ident : $pub_type:ident ,)*],
+        fields: [$( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident ,)*],
     ) => {
         {
             let class_doc = [ $($struct_doc),* ].join("\n");
             let fields = vec![
                 $(
-                    (stringify!($pub_field), stringify!($pub_type), [ $($field_doc),* ].join("\n")),
+                    (stringify!($field), stringify!($field_type), [ $($field_doc),* ].join("\n")),
                 )*
             ];
             register_named_tuple($py, $m, stringify!($Name), &class_doc, &fields)?;
@@ -171,7 +162,7 @@ macro_rules! declare_python_public_structs {
     // Private struct arm: intentionally empty — private structs are not exposed to Python.
     (@register BuiltinPrivateStruct, $_Name:ident, $py:ident, $m:ident;
         docs: [$(#[$struct_meta:meta])*],
-        fields: [$( $(#[$field_meta:meta])* $pub_field:ident : $pub_type:ty ,)*],
+        fields: [$( $(#[$field_meta:meta])* $field:ident : $field_type:ty ,)*],
     ) => {};
 }
 

--- a/api/python/slint/value.rs
+++ b/api/python/slint/value.rs
@@ -12,7 +12,7 @@ use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use i_slint_compiler::langtype::{BuiltinPublicStruct, StructName, Type};
+use i_slint_compiler::langtype::{BuiltinStruct, StructName, Type};
 
 use i_slint_core::model::{Model, ModelRc};
 
@@ -64,13 +64,13 @@ impl<'py> IntoPyObject<'py> for SlintToPyValue {
                 let struct_type = expected_type.filter(|t| matches!(t, Type::Struct(_)));
                 if let Some(Type::Struct(s)) = struct_type.as_ref() {
                     match &s.name {
-                        StructName::BuiltinPublic(BuiltinPublicStruct::LogicalPosition) => {
+                        StructName::Builtin(BuiltinStruct::LogicalPosition) => {
                             let x = struct_field_as_f32(&structval, "x");
                             let y = struct_field_as_f32(&structval, "y");
                             return crate::geometry::PyLogicalPosition { x, y }
                                 .into_bound_py_any(py);
                         }
-                        StructName::BuiltinPublic(BuiltinPublicStruct::LogicalSize) => {
+                        StructName::Builtin(BuiltinStruct::LogicalSize) => {
                             let width = struct_field_as_f32(&structval, "width");
                             let height = struct_field_as_f32(&structval, "height");
                             return crate::geometry::PyLogicalSize { width, height }

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -462,19 +462,12 @@ pub mod language {
     macro_rules! export_builtin_structs {
         ($(
             $(#[$attr:meta])*
-            struct $Name:ident {
-                @name = $NameTy:ident :: $NameVariant:ident,
+            $vis:vis struct $Name:ident {
                 $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
             }
         )*) => {
-            $(
-                export_builtin_structs!(@export $NameTy $Name);
-            )*
+            $( #[allow(unused_imports)] $vis use i_slint_core::items::$Name; )*
         };
-        (@export BuiltinPublicStruct $Name:ident) => {
-            pub use i_slint_core::items::$Name;
-        };
-        (@export BuiltinPrivateStruct $Name:ident) => {};
     }
 
     i_slint_common::for_each_builtin_structs!(export_builtin_structs);

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -464,12 +464,7 @@ pub mod language {
             $(#[$attr:meta])*
             struct $Name:ident {
                 @name = $NameTy:ident :: $NameVariant:ident,
-                export {
-                    $( $(#[$pub_attr:meta])* $pub_field:ident : $pub_type:ty, )*
-                }
-                private {
-                    $( $(#[$pri_attr:meta])* $pri_field:ident : $pri_type:ty, )*
-                }
+                $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
             }
         )*) => {
             $(

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -296,8 +296,7 @@ pub fn extract_builtin_structs(
             $(#[doc = $struct_doc:literal])*
             $(#[non_exhaustive])?
             $(#[derive(Copy, Eq)])?
-            struct $Name:ident {
-                @name = $inner_name:expr,
+            $vis:vis struct $Name:ident {
                 $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
             }
         )*) => {

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -298,12 +298,7 @@ pub fn extract_builtin_structs(
             $(#[derive(Copy, Eq)])?
             struct $Name:ident {
                 @name = $inner_name:expr,
-                export {
-                    $( $(#[doc = $pub_doc:literal])* $pub_field:ident : $pub_type:ident, )*
-                }
-                private {
-                    $( $(#[doc = $pri_doc:literal])* $pri_field:ident : $pri_type:ty, )*
-                }
+                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
             }
         )*) => {
             $(
@@ -313,11 +308,11 @@ pub fn extract_builtin_structs(
 
                 let mut fields = Vec::new();
                 $(
-                    let key = stringify!($pub_field).to_string();
-                    let type_name = map_type!($pub_type).to_string();
+                    let key = stringify!($field).to_string();
+                    let type_name = map_type!($field_type).to_string();
                     let mut f_description = String::new();
                     $(
-                        f_description += &format!("{}", $pub_doc);
+                        f_description += &format!("{}", $field_doc);
                     )*
                     fields.push(StructFieldDoc { key, description: f_description, type_name });
                 )*

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -12,15 +12,10 @@
 ///         $(#[$struct_attr:meta])*
 ///         struct $Name:ident {
 ///             @name = $inner_name:expr,
-///             export {
-///                 $( $(#[$pub_attr:meta])* $pub_field:ident : $pub_type:ty, )*
-///             }
-///             private {
-///                 $( $(#[$pri_attr:meta])* $pri_field:ident : $pri_type:ty, )*
-///             }
+///             $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
 ///         }
 ///     )*) => {
-///         $(println!("{} => export:[{}] private:[{}]", stringify!($Name), stringify!($($pub_field),*), stringify!($($pri_field),*));)*
+///         $(println!("{} => [{}]", stringify!($Name), stringify!($($field),*));)*
 ///     };
 /// }
 /// i_slint_common::for_each_builtin_structs!(print_builtin_structs);
@@ -41,18 +36,14 @@ macro_rules! for_each_builtin_structs {
             #[derive(Copy, Eq)]
             struct KeyboardModifiers {
                 @name = BuiltinPublicStruct::KeyboardModifiers,
-                export {
-                    /// Indicates the Alt key on a keyboard.
-                    alt: bool,
-                    /// Indicates the Control key on a keyboard, except on macOS, where it is the Command key (⌘).
-                    control: bool,
-                    /// Indicates the Shift key on a keyboard.
-                    shift: bool,
-                    /// Indicates the Control key on macos, and the Windows key on Windows.
-                    meta: bool,
-                }
-                private {
-                }
+                /// Indicates the Alt key on a keyboard.
+                alt: bool,
+                /// Indicates the Control key on a keyboard, except on macOS, where it is the Command key (⌘).
+                control: bool,
+                /// Indicates the Shift key on a keyboard.
+                shift: bool,
+                /// Indicates the Control key on macos, and the Windows key on Windows.
+                meta: bool,
             }
 
             /// Represents a Pointer event sent by the windowing system.
@@ -60,18 +51,14 @@ macro_rules! for_each_builtin_structs {
             #[non_exhaustive]
             struct PointerEvent {
                 @name = BuiltinPublicStruct::PointerEvent,
-                export {
-                    /// The button that was pressed or released
-                    button: PointerEventButton,
-                    /// The kind of the event
-                    kind: PointerEventKind,
-                    /// The keyboard modifiers pressed during the event
-                    modifiers: KeyboardModifiers,
-                    /// The unique ID of the touch point, indicating the finger ID. 0 means it's not a touch event (e.g., mouse).
-                    touch_finger_id: i32,
-                }
-                private {
-                }
+                /// The button that was pressed or released
+                button: PointerEventButton,
+                /// The kind of the event
+                kind: PointerEventKind,
+                /// The keyboard modifiers pressed during the event
+                modifiers: KeyboardModifiers,
+                /// The unique ID of the touch point, indicating the finger ID. 0 means it's not a touch event (e.g., mouse).
+                touch_finger_id: i32,
             }
 
             /// Represents a Pointer scroll (or wheel) event sent by the windowing system.
@@ -79,171 +66,137 @@ macro_rules! for_each_builtin_structs {
             #[non_exhaustive]
             struct PointerScrollEvent {
                 @name = BuiltinPublicStruct::PointerScrollEvent,
-                export {
-                    /// The amount of pixel in the horizontal direction
-                    delta_x: Coord,
-                    /// The amount of pixel in the vertical direction
-                    delta_y: Coord,
-                    /// The keyboard modifiers pressed during the event
-                    modifiers: KeyboardModifiers,
-                }
-                private {
-                }
+                /// The amount of pixel in the horizontal direction
+                delta_x: Coord,
+                /// The amount of pixel in the vertical direction
+                delta_y: Coord,
+                /// The keyboard modifiers pressed during the event
+                modifiers: KeyboardModifiers,
             }
 
             /// This structure is generated and passed to the key press and release callbacks of the `FocusScope` element.
             #[non_exhaustive]
             struct KeyEvent {
                 @name = BuiltinPublicStruct::KeyEvent,
-                export {
-                    /// The unicode representation of the key pressed.
-                    text: SharedString,
-                    /// The keyboard modifiers active at the time of the key press event.
-                    modifiers: KeyboardModifiers,
-                    /// This field is set to true for key press events that are repeated,
-                    /// i.e. the key is held down. It's always false for key release events.
-                    repeat: bool,
-                }
-                private {
-                }
+                /// The unicode representation of the key pressed.
+                text: SharedString,
+                /// The keyboard modifiers active at the time of the key press event.
+                modifiers: KeyboardModifiers,
+                /// This field is set to true for key press events that are repeated,
+                /// i.e. the key is held down. It's always false for key release events.
+                repeat: bool,
             }
 
             /// This structure is passed to the callbacks of the `DropArea` element
             struct DropEvent {
                 @name = BuiltinPublicStruct::DropEvent,
-                export {
-                    /// The payload set on the source `DragArea`.
-                    data: DataTransfer,
+                /// The payload set on the source `DragArea`.
+                data: DataTransfer,
 
-                    /// The cursor position in the `DropArea`'s local coordinates.
-                    position: LogicalPosition,
+                /// The cursor position in the `DropArea`'s local coordinates.
+                position: LogicalPosition,
 
-                    /// Mirrors `DragArea.allow-copy`: true if the source allows the drop to copy the data.
-                    allow_copy: bool,
+                /// Mirrors `DragArea.allow-copy`: true if the source allows the drop to copy the data.
+                allow_copy: bool,
 
-                    /// Mirrors `DragArea.allow-move`: true if the source allows the drop to move the data.
-                    allow_move: bool,
+                /// Mirrors `DragArea.allow-move`: true if the source allows the drop to move the data.
+                allow_move: bool,
 
-                    /// Mirrors `DragArea.allow-link`: true if the source allows the drop to link to the data.
-                    allow_link: bool,
+                /// Mirrors `DragArea.allow-link`: true if the source allows the drop to link to the data.
+                allow_link: bool,
 
-                    /// The action negotiated from current modifier state and the source's `preferred-action`,
-                    /// clamped to the allowed set. Updated on every `DragMove`. The target's `can-drop`
-                    /// callback can return this to honor the user's modifier choice, or override with
-                    /// any other allowed action.
-                    proposed_action: DragAction,
-                }
-                private {
-                }
+                /// The action negotiated from current modifier state and the source's `preferred-action`,
+                /// clamped to the allowed set. Updated on every `DragMove`. The target's `can-drop`
+                /// callback can return this to honor the user's modifier choice, or override with
+                /// any other allowed action.
+                proposed_action: DragAction,
             }
 
             /// Represents an item in a StandardListView and a StandardTableView.
             #[non_exhaustive]
             struct StandardListViewItem {
                 @name = BuiltinPublicStruct::StandardListViewItem,
-                export {
-                    /// The text content of the item
-                    text: SharedString,
-                }
-                private {
-                }
+                /// The text content of the item
+                text: SharedString,
             }
 
             /// Represents one option in a `RadioGroup`.
             #[non_exhaustive]
             struct RadioEntry {
                 @name = BuiltinPublicStruct::RadioEntry,
-                export {
-                    /// Label shown next to the radio button.
-                    text: SharedString,
-                    /// When `true`, this option is visible but not selectable.
-                    disabled: bool,
-                }
-                private {
-                }
+                /// Label shown next to the radio button.
+                text: SharedString,
+                /// When `true`, this option is visible but not selectable.
+                disabled: bool,
             }
 
             /// This is used to define the column and the column header of a TableView
             #[non_exhaustive]
             struct TableColumn {
                 @name = BuiltinPrivateStruct::TableColumn,
-                export {
-                    /// The title of the column header
-                    title: SharedString,
-                    /// The minimum column width (logical length)
-                    min_width: Coord,
-                    /// The horizontal column stretch
-                    horizontal_stretch: f32,
-                    /// Sorts the column
-                    sort_order: SortOrder,
-                    /// the actual width of the column (logical length)
-                    width: Coord,
-                }
-                private {
-                }
+                /// The title of the column header
+                title: SharedString,
+                /// The minimum column width (logical length)
+                min_width: Coord,
+                /// The horizontal column stretch
+                horizontal_stretch: f32,
+                /// Sorts the column
+                sort_order: SortOrder,
+                /// the actual width of the column (logical length)
+                width: Coord,
             }
 
             /// A structure to hold metrics of a font for a specified pixel size.
             struct FontMetrics {
                 @name = BuiltinPrivateStruct::FontMetrics,
-                export {
-                    /// The distance between the baseline and the top of the tallest glyph in the font.
-                    ascent: Coord,
-                    /// The distance between the baseline and the bottom of the tallest glyph in the font.
-                    /// This is usually negative.
-                    descent: Coord,
-                    /// The distance between the baseline and the horizontal midpoint of the tallest glyph in the font,
-                    /// or zero if not specified by the font.
-                    x_height: Coord,
-                    /// The distance between the baseline and the top of a regular upper-case glyph in the font,
-                    /// or zero if not specified by the font.
-                    cap_height: Coord,
-                }
-                private {
-                }
+                /// The distance between the baseline and the top of the tallest glyph in the font.
+                ascent: Coord,
+                /// The distance between the baseline and the bottom of the tallest glyph in the font.
+                /// This is usually negative.
+                descent: Coord,
+                /// The distance between the baseline and the horizontal midpoint of the tallest glyph in the font,
+                /// or zero if not specified by the font.
+                x_height: Coord,
+                /// The distance between the baseline and the top of a regular upper-case glyph in the font,
+                /// or zero if not specified by the font.
+                cap_height: Coord,
             }
 
             /// An item in the menu of a menu bar or context menu
             struct MenuEntry {
                 @name = BuiltinPrivateStruct::MenuEntry,
-                export {
-                    /// The text of the menu entry
-                    title: SharedString,
-                    /// the icon associated with the menu entry
-                    icon: Image,
-                    /// an opaque id that can be used to identify the menu entry
-                    id: SharedString,
-                    // keys: KeySequence,
-                    /// whether the menu entry is enabled
-                    enabled: bool,
-                    /// whether the menu entry is checkable
-                    checkable: bool,
-                    /// whether the menu entry is checked
-                    checked: bool,
-                    /// Sub menu
-                    has_sub_menu: bool,
-                    /// The menu entry is a separator
-                    is_separator: bool,
-                    /// The shortcut keys
-                    shortcut: Keys,
-                }
-                private {}
+                /// The text of the menu entry
+                title: SharedString,
+                /// the icon associated with the menu entry
+                icon: Image,
+                /// an opaque id that can be used to identify the menu entry
+                id: SharedString,
+                // keys: KeySequence,
+                /// whether the menu entry is enabled
+                enabled: bool,
+                /// whether the menu entry is checkable
+                checkable: bool,
+                /// whether the menu entry is checked
+                checked: bool,
+                /// Sub menu
+                has_sub_menu: bool,
+                /// The menu entry is a separator
+                is_separator: bool,
+                /// The shortcut keys
+                shortcut: Keys,
             }
 
             /// A structure representing the four edges of an axis-aligned rectangle
             struct Edges {
                 @name = BuiltinPrivateStruct::Edges,
-                export {
-                    /// The left edge value
-                    left: Coord,
-                    /// The top edge value
-                    top: Coord,
-                    /// The right edge value
-                    right: Coord,
-                    /// The bottom edge value
-                    bottom: Coord,
-                }
-                private {}
+                /// The left edge value
+                left: Coord,
+                /// The top edge value
+                top: Coord,
+                /// The right edge value
+                right: Coord,
+                /// The bottom edge value
+                bottom: Coord,
             }
         ];
     };

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -5,17 +5,20 @@
 
 /// Call a macro with every builtin structures exposed in the .slint language
 ///
+/// Each struct is declared with `pub struct` if it should be re-exported in a public
+/// language-binding module (e.g. `slint::language` in the Rust crate), or plain `struct`
+/// to stay private. Consumers can dispatch on `$vis:vis`.
+///
 /// ## Example
 /// ```rust
 /// macro_rules! print_builtin_structs {
 ///     ($(
 ///         $(#[$struct_attr:meta])*
-///         struct $Name:ident {
-///             @name = $inner_name:expr,
+///         $vis:vis struct $Name:ident {
 ///             $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
 ///         }
 ///     )*) => {
-///         $(println!("{} => [{}]", stringify!($Name), stringify!($($field),*));)*
+///         $(println!("{} ({}) => [{}]", stringify!($Name), stringify!($vis), stringify!($($field),*));)*
 ///     };
 /// }
 /// i_slint_common::for_each_builtin_structs!(print_builtin_structs);
@@ -34,8 +37,7 @@ macro_rules! for_each_builtin_structs {
             /// On Windows, the Windows key is mapped to the meta modifier.
             #[non_exhaustive]
             #[derive(Copy, Eq)]
-            struct KeyboardModifiers {
-                @name = BuiltinPublicStruct::KeyboardModifiers,
+            pub struct KeyboardModifiers {
                 /// Indicates the Alt key on a keyboard.
                 alt: bool,
                 /// Indicates the Control key on a keyboard, except on macOS, where it is the Command key (⌘).
@@ -49,8 +51,7 @@ macro_rules! for_each_builtin_structs {
             /// Represents a Pointer event sent by the windowing system.
             /// This structure is passed to the `pointer-event` callback of the `TouchArea` element.
             #[non_exhaustive]
-            struct PointerEvent {
-                @name = BuiltinPublicStruct::PointerEvent,
+            pub struct PointerEvent {
                 /// The button that was pressed or released
                 button: PointerEventButton,
                 /// The kind of the event
@@ -64,8 +65,7 @@ macro_rules! for_each_builtin_structs {
             /// Represents a Pointer scroll (or wheel) event sent by the windowing system.
             /// This structure is passed to the `scroll-event` callback of the `TouchArea` element.
             #[non_exhaustive]
-            struct PointerScrollEvent {
-                @name = BuiltinPublicStruct::PointerScrollEvent,
+            pub struct PointerScrollEvent {
                 /// The amount of pixel in the horizontal direction
                 delta_x: Coord,
                 /// The amount of pixel in the vertical direction
@@ -76,8 +76,7 @@ macro_rules! for_each_builtin_structs {
 
             /// This structure is generated and passed to the key press and release callbacks of the `FocusScope` element.
             #[non_exhaustive]
-            struct KeyEvent {
-                @name = BuiltinPublicStruct::KeyEvent,
+            pub struct KeyEvent {
                 /// The unicode representation of the key pressed.
                 text: SharedString,
                 /// The keyboard modifiers active at the time of the key press event.
@@ -88,8 +87,7 @@ macro_rules! for_each_builtin_structs {
             }
 
             /// This structure is passed to the callbacks of the `DropArea` element
-            struct DropEvent {
-                @name = BuiltinPublicStruct::DropEvent,
+            pub struct DropEvent {
                 /// The payload set on the source `DragArea`.
                 data: DataTransfer,
 
@@ -114,16 +112,14 @@ macro_rules! for_each_builtin_structs {
 
             /// Represents an item in a StandardListView and a StandardTableView.
             #[non_exhaustive]
-            struct StandardListViewItem {
-                @name = BuiltinPublicStruct::StandardListViewItem,
+            pub struct StandardListViewItem {
                 /// The text content of the item
                 text: SharedString,
             }
 
             /// Represents one option in a `RadioGroup`.
             #[non_exhaustive]
-            struct RadioEntry {
-                @name = BuiltinPublicStruct::RadioEntry,
+            pub struct RadioEntry {
                 /// Label shown next to the radio button.
                 text: SharedString,
                 /// When `true`, this option is visible but not selectable.
@@ -133,7 +129,6 @@ macro_rules! for_each_builtin_structs {
             /// This is used to define the column and the column header of a TableView
             #[non_exhaustive]
             struct TableColumn {
-                @name = BuiltinPrivateStruct::TableColumn,
                 /// The title of the column header
                 title: SharedString,
                 /// The minimum column width (logical length)
@@ -148,7 +143,6 @@ macro_rules! for_each_builtin_structs {
 
             /// A structure to hold metrics of a font for a specified pixel size.
             struct FontMetrics {
-                @name = BuiltinPrivateStruct::FontMetrics,
                 /// The distance between the baseline and the top of the tallest glyph in the font.
                 ascent: Coord,
                 /// The distance between the baseline and the bottom of the tallest glyph in the font.
@@ -164,7 +158,6 @@ macro_rules! for_each_builtin_structs {
 
             /// An item in the menu of a menu bar or context menu
             struct MenuEntry {
-                @name = BuiltinPrivateStruct::MenuEntry,
                 /// The text of the menu entry
                 title: SharedString,
                 /// the icon associated with the menu entry
@@ -188,7 +181,6 @@ macro_rules! for_each_builtin_structs {
 
             /// A structure representing the four edges of an axis-aligned rectangle
             struct Edges {
-                @name = BuiltinPrivateStruct::Edges,
                 /// The left edge value
                 left: Coord,
                 /// The top edge value

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -3,7 +3,7 @@
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::langtype::{
-    BuiltinElement, BuiltinPublicStruct, EnumerationValue, Function, Keys, Struct, Type,
+    BuiltinElement, BuiltinStruct, EnumerationValue, Function, Keys, Struct, Type,
 };
 use crate::layout::Orientation;
 use crate::lookup::LookupCtx;
@@ -237,7 +237,7 @@ declare_builtin_function_types!(
             (SmolStr::new_static("alpha"), Type::Int32),
         ])
         .collect(),
-        name: BuiltinPublicStruct::Color.into(),
+        name: BuiltinStruct::Color.into(),
     })),
     ColorHsvaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
         fields: IntoIterator::into_iter([
@@ -247,7 +247,7 @@ declare_builtin_function_types!(
             (SmolStr::new_static("alpha"), Type::Float32),
         ])
         .collect(),
-        name: BuiltinPublicStruct::Color.into(),
+        name: BuiltinStruct::Color.into(),
     })),
     ColorOklchStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
         fields: IntoIterator::into_iter([
@@ -257,7 +257,7 @@ declare_builtin_function_types!(
             (SmolStr::new_static("alpha"), Type::Float32),
         ])
         .collect(),
-        name: BuiltinPublicStruct::Color.into(),
+        name: BuiltinStruct::Color.into(),
     })),
     ColorBrighter: (Type::Brush, Type::Float32) -> Type::Brush,
     ColorDarker: (Type::Brush, Type::Float32) -> Type::Brush,
@@ -270,7 +270,7 @@ declare_builtin_function_types!(
             (SmolStr::new_static("height"), Type::Int32),
         ])
         .collect(),
-        name: crate::langtype::BuiltinPrivateStruct::Size.into(),
+        name: crate::langtype::BuiltinStruct::Size.into(),
     })),
     ArrayLength: (Type::Model) -> Type::Int32,
     Rgb: (Type::Int32, Type::Int32, Type::Int32, Type::Float32) -> Type::Color,

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -15,7 +15,7 @@ use std::rc::{Rc, Weak};
 
 use crate::CompilerConfiguration;
 use crate::expression_tree::{BindingExpression, Expression};
-use crate::langtype::{BuiltinPrivateStruct, ElementType, StructName};
+use crate::langtype::{BuiltinStruct, ElementType, StructName};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, Document, ElementRc};
 
@@ -443,7 +443,7 @@ pub fn for_each_const_properties(
                     .iter()
                     .filter(|(_, x)| {
                         x.property_type.is_property_type() &&
-                            !matches!( &x.property_type, crate::langtype::Type::Struct(s) if matches!(s.name, StructName::BuiltinPrivate(BuiltinPrivateStruct::StateInfo)))
+                            !matches!( &x.property_type, crate::langtype::Type::Struct(s) if matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo)))
                     })
                     .map(|(k, _)| k.clone()),
             );

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -460,8 +460,7 @@ pub mod cpp_ast {
 use crate::CompilerConfiguration;
 use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp};
 use crate::langtype::{
-    BuiltinPrivateStruct, BuiltinPublicStruct, Enumeration, EnumerationValue, NativeClass,
-    StructName, Type,
+    BuiltinStruct, Enumeration, EnumerationValue, NativeClass, StructName, Type,
 };
 use crate::layout::Orientation;
 use crate::llr::{
@@ -496,35 +495,26 @@ impl CppType for StructName {
         match self {
             StructName::None => None,
             StructName::User { name, .. } => Some(ident(name)),
-            StructName::BuiltinPrivate(builtin_private) => builtin_private.cpp_type(),
-            StructName::BuiltinPublic(builtin_public) => builtin_public.cpp_type(),
+            StructName::Builtin(builtin) => builtin.cpp_type(),
         }
     }
 }
 
-impl CppType for BuiltinPrivateStruct {
-    fn cpp_type(&self) -> Option<SmolStr> {
-        let name: &'static str = self.into();
-        match self {
-            Self::PathMoveTo
-            | Self::PathLineTo
-            | Self::PathArcTo
-            | Self::PathCubicTo
-            | Self::PathQuadraticTo
-            | Self::PathClose => Some(format_smolstr!("slint::private_api::{}", name)),
-            _ => Some(format_smolstr!("slint::cbindgen_private::{}", name)),
-        }
-    }
-}
-
-impl CppType for BuiltinPublicStruct {
+impl CppType for BuiltinStruct {
     fn cpp_type(&self) -> Option<SmolStr> {
         let name: &'static str = self.into();
         match self {
             Self::Color | Self::LogicalPosition | Self::LogicalSize => {
                 Some(format_smolstr!("slint::{}", name))
             }
-            _ => Some(format_smolstr!("slint::language::{}", name)),
+            Self::PathMoveTo
+            | Self::PathLineTo
+            | Self::PathArcTo
+            | Self::PathCubicTo
+            | Self::PathQuadraticTo
+            | Self::PathClose => Some(format_smolstr!("slint::private_api::{}", name)),
+            s if s.is_public() => Some(format_smolstr!("slint::language::{}", name)),
+            _ => Some(format_smolstr!("slint::cbindgen_private::{}", name)),
         }
     }
 }

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -673,20 +673,20 @@ fn python_type_name(ty: &Type) -> SmolStr {
         Type::Array(elem_type) => format_smolstr!("slint.Model[{}]", python_type_name(elem_type)),
         Type::Struct(s) => match &s.name {
             StructName::User { name, .. } => ident(name),
-            StructName::BuiltinPrivate(_) => SmolStr::new_static("None"),
-            StructName::BuiltinPublic(
-                crate::langtype::BuiltinPublicStruct::Color
-                | crate::langtype::BuiltinPublicStruct::LogicalPosition
-                | crate::langtype::BuiltinPublicStruct::LogicalSize,
+            StructName::Builtin(
+                crate::langtype::BuiltinStruct::Color
+                | crate::langtype::BuiltinStruct::LogicalPosition
+                | crate::langtype::BuiltinStruct::LogicalSize,
             )
             | StructName::None => {
                 let tuple_types = s.fields.values().map(python_type_name).collect::<Vec<_>>();
                 format_smolstr!("typing.Tuple[{}]", tuple_types.join(", "))
             }
-            StructName::BuiltinPublic(builtin_public_struct) => {
-                let name: &'static str = builtin_public_struct.into();
+            StructName::Builtin(builtin_struct) if builtin_struct.is_public() => {
+                let name: &'static str = builtin_struct.into();
                 format_smolstr!("slint.language.{}", name)
             }
+            StructName::Builtin(_) => SmolStr::new_static("None"),
         },
         Type::Enumeration(enumeration) => {
             if enumeration.node.is_some() {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3292,7 +3292,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             if ty.name.is_some() {
                 let name_tokens = struct_name_to_tokens(&ty.name).unwrap();
                 let keys = ty.fields.keys().map(|k| ident(k));
-                if matches!(&ty.name, StructName::BuiltinPrivate(private_type) if private_type.is_layout_data())
+                if matches!(&ty.name, StructName::Builtin(b) if b.is_layout_data())
                 {
                     quote!(#name_tokens{#(#keys: #elem as _,)*})
                 } else {
@@ -4287,23 +4287,15 @@ fn struct_name_to_tokens(name: &StructName) -> Option<proc_macro2::TokenStream> 
     match name {
         StructName::None => None,
         StructName::User { name, .. } => Some(proc_macro2::TokenTree::from(ident(name)).into()),
-        StructName::BuiltinPrivate(builtin_private_struct) => {
-            let name: &'static str = builtin_private_struct.into();
+        StructName::Builtin(builtin_struct) => {
+            let name: &'static str = builtin_struct.into();
             let name = format_ident!("{}", name);
-            Some(quote!(sp::#name))
-        }
-        StructName::BuiltinPublic(builtin_public_struct) => {
-            let name: &'static str = builtin_public_struct.into();
-            let name = format_ident!("{}", name);
-            if matches!(
-                builtin_public_struct,
-                crate::langtype::BuiltinPublicStruct::Color
-                    | crate::langtype::BuiltinPublicStruct::LogicalPosition
-                    | crate::langtype::BuiltinPublicStruct::LogicalSize
-            ) {
-                Some(quote!(slint::#name))
-            } else {
-                Some(quote!(slint::language::#name))
+            match builtin_struct {
+                crate::langtype::BuiltinStruct::Color
+                | crate::langtype::BuiltinStruct::LogicalPosition
+                | crate::langtype::BuiltinStruct::LogicalSize => Some(quote!(slint::#name)),
+                s if s.is_public() => Some(quote!(slint::language::#name)),
+                _ => Some(quote!(sp::#name)),
             }
         }
     }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -673,7 +673,19 @@ impl Display for ElementType {
 }
 
 #[derive(Debug, Clone, PartialEq, strum::EnumString, strum::IntoStaticStr)]
-pub enum BuiltinPrivateStruct {
+pub enum BuiltinStruct {
+    // Public structs (exported to language bindings)
+    Color,
+    LogicalPosition,
+    LogicalSize,
+    StandardListViewItem,
+    RadioEntry,
+    Keys,
+    KeyEvent,
+    KeyboardModifiers,
+    PointerEvent,
+    PointerScrollEvent,
+    // Private structs (internal to the compiler/runtime)
     PathMoveTo,
     PathLineTo,
     PathArcTo,
@@ -697,11 +709,29 @@ pub enum BuiltinPrivateStruct {
     PathElement,
     TableColumn,
     MenuEntry,
+    DropEvent,
     Edges,
     InternalKeyEvent,
 }
 
-impl BuiltinPrivateStruct {
+impl BuiltinStruct {
+    pub fn is_public(&self) -> bool {
+        matches!(
+            self,
+            Self::Color
+                | Self::LogicalPosition
+                | Self::LogicalSize
+                | Self::StandardListViewItem
+                | Self::RadioEntry
+                | Self::Keys
+                | Self::KeyEvent
+                | Self::KeyboardModifiers
+                | Self::PointerEvent
+                | Self::PointerScrollEvent
+                | Self::DropEvent
+        )
+    }
+
     pub fn is_layout_data(&self) -> bool {
         matches!(
             self,
@@ -712,39 +742,7 @@ impl BuiltinPrivateStruct {
                 | Self::FlexboxLayoutData
         )
     }
-    pub fn slint_name(&self) -> Option<SmolStr> {
-        match self {
-            // These are public types in the Slint language
-            Self::Point
-            | Self::FontMetrics
-            | Self::TableColumn
-            | Self::MenuEntry
-            | Self::InternalKeyEvent
-            | Self::Edges => {
-                let name: &'static str = self.into();
-                Some(SmolStr::new_static(name))
-            }
-            _ => None,
-        }
-    }
-}
 
-#[derive(Debug, Clone, PartialEq, strum::EnumString, strum::IntoStaticStr)]
-pub enum BuiltinPublicStruct {
-    Color,
-    LogicalPosition,
-    LogicalSize,
-    StandardListViewItem,
-    RadioEntry,
-    Keys,
-    KeyEvent,
-    KeyboardModifiers,
-    PointerEvent,
-    PointerScrollEvent,
-    DropEvent,
-}
-
-impl BuiltinPublicStruct {
     pub fn slint_name(&self) -> Option<SmolStr> {
         match self {
             Self::Color => Some(SmolStr::new_static("color")),
@@ -757,7 +755,17 @@ impl BuiltinPublicStruct {
             Self::KeyboardModifiers => Some(SmolStr::new_static("KeyboardModifiers")),
             Self::PointerEvent => Some(SmolStr::new_static("PointerEvent")),
             Self::PointerScrollEvent => Some(SmolStr::new_static("PointerScrollEvent")),
-            Self::DropEvent => Some(SmolStr::new_static("DropEvent")),
+            Self::Point
+            | Self::FontMetrics
+            | Self::TableColumn
+            | Self::MenuEntry
+            | Self::InternalKeyEvent
+            | Self::Edges
+            | Self::DropEvent => {
+                let name: &'static str = self.into();
+                Some(SmolStr::new_static(name))
+            }
+            _ => None,
         }
     }
 }
@@ -771,7 +779,7 @@ pub struct NativeClass {
     pub deprecated_aliases: HashMap<SmolStr, SmolStr>,
     /// Type override if class_name is not equal to the name to be used in the
     /// target language API.
-    pub builtin_struct: Option<BuiltinPrivateStruct>,
+    pub builtin_struct: Option<BuiltinStruct>,
 }
 
 impl NativeClass {
@@ -926,8 +934,7 @@ pub enum StructName {
         /// When declared in .slint, this is the node of the declaration.
         node: syntax_nodes::ObjectType,
     },
-    BuiltinPublic(BuiltinPublicStruct),
-    BuiltinPrivate(BuiltinPrivateStruct),
+    Builtin(BuiltinStruct),
 }
 
 impl PartialEq for StructName {
@@ -937,8 +944,7 @@ impl PartialEq for StructName {
                 Self::User { name: l_user_name, node: _ },
                 Self::User { name: r_user_name, node: _ },
             ) => l_user_name == r_user_name,
-            (Self::BuiltinPublic(l0), Self::BuiltinPublic(r0)) => l0 == r0,
-            (Self::BuiltinPrivate(l0), Self::BuiltinPrivate(r0)) => l0 == r0,
+            (Self::Builtin(l0), Self::Builtin(r0)) => l0 == r0,
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
     }
@@ -949,8 +955,7 @@ impl StructName {
         match self {
             StructName::None => None,
             StructName::User { name, .. } => Some(name.clone()),
-            StructName::BuiltinPublic(builtin_public) => builtin_public.slint_name(),
-            StructName::BuiltinPrivate(builtin_private) => builtin_private.slint_name(),
+            StructName::Builtin(builtin) => builtin.slint_name(),
         }
     }
 
@@ -970,15 +975,9 @@ impl StructName {
     }
 }
 
-impl From<BuiltinPrivateStruct> for StructName {
-    fn from(value: BuiltinPrivateStruct) -> Self {
-        Self::BuiltinPrivate(value)
-    }
-}
-
-impl From<BuiltinPublicStruct> for StructName {
-    fn from(value: BuiltinPublicStruct) -> Self {
-        Self::BuiltinPublic(value)
+impl From<BuiltinStruct> for StructName {
+    fn from(value: BuiltinStruct) -> Self {
+        Self::Builtin(value)
     }
 }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -672,66 +672,83 @@ impl Display for ElementType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, strum::EnumString, strum::IntoStaticStr)]
-pub enum BuiltinStruct {
-    // Public structs (exported to language bindings)
-    Color,
-    LogicalPosition,
-    LogicalSize,
-    StandardListViewItem,
-    RadioEntry,
-    Keys,
-    KeyEvent,
-    KeyboardModifiers,
-    PointerEvent,
-    PointerScrollEvent,
-    // Private structs (internal to the compiler/runtime)
-    PathMoveTo,
-    PathLineTo,
-    PathArcTo,
-    PathCubicTo,
-    PathQuadraticTo,
-    PathClose,
-    Size,
-    StateInfo,
-    Point,
-    PropertyAnimation,
-    GridLayoutData,
-    GridLayoutInputData,
-    BoxLayoutData,
-    BoxLayoutOrthoData,
-    FlexboxLayoutData,
-    LayoutItemInfo,
-    FlexboxLayoutItemInfo,
-    Padding,
-    LayoutInfo,
-    FontMetrics,
-    PathElement,
-    TableColumn,
-    MenuEntry,
-    DropEvent,
-    Edges,
-    InternalKeyEvent,
+macro_rules! define_builtin_struct_enum {
+    ($(
+        $(#[$attr:meta])*
+        $vis:vis struct $Name:ident {
+            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
+        }
+    )*) => {
+        #[derive(Debug, Clone, PartialEq, strum::EnumString, strum::IntoStaticStr)]
+        pub enum BuiltinStruct {
+            // Generated from for_each_builtin_structs
+            $($Name,)*
+            // Not in the macro (registered separately in typeregister.rs)
+            Color,
+            LogicalPosition,
+            LogicalSize,
+            Keys,
+            PathMoveTo,
+            PathLineTo,
+            PathArcTo,
+            PathCubicTo,
+            PathQuadraticTo,
+            PathClose,
+            Size,
+            StateInfo,
+            Point,
+            PropertyAnimation,
+            GridLayoutData,
+            GridLayoutInputData,
+            BoxLayoutData,
+            BoxLayoutOrthoData,
+            FlexboxLayoutData,
+            LayoutItemInfo,
+            FlexboxLayoutItemInfo,
+            Padding,
+            LayoutInfo,
+            PathElement,
+            InternalKeyEvent,
+        }
+
+        impl BuiltinStruct {
+            pub fn is_public(&self) -> bool {
+                match self {
+                    // Macro-defined structs: derived from the `pub` visibility keyword
+                    $(Self::$Name => stringify!($vis) == "pub",)*
+                    // Non-macro public structs
+                    Self::Color | Self::LogicalPosition | Self::LogicalSize | Self::Keys => true,
+                    _ => false,
+                }
+            }
+
+            /// The name of this struct in the Slint language, or None if it is
+            /// purely internal and not visible in .slint files.
+            pub fn slint_name(&self) -> Option<SmolStr> {
+                match self {
+                    // Macro-defined structs all have a slint name matching their Rust name
+                    $(Self::$Name => {
+                        Some(SmolStr::new_static(stringify!($Name)))
+                    })*
+                    // Non-macro structs with custom slint names
+                    Self::Color => Some(SmolStr::new_static("color")),
+                    Self::LogicalPosition => Some(SmolStr::new_static("Point")),
+                    Self::LogicalSize => Some(SmolStr::new_static("Size")),
+                    Self::Keys => Some(SmolStr::new_static("Keys")),
+                    Self::Point
+                    | Self::InternalKeyEvent => {
+                        let name: &'static str = self.into();
+                        Some(SmolStr::new_static(name))
+                    }
+                    _ => None,
+                }
+            }
+        }
+    };
 }
+i_slint_common::for_each_builtin_structs!(define_builtin_struct_enum);
 
 impl BuiltinStruct {
-    pub fn is_public(&self) -> bool {
-        matches!(
-            self,
-            Self::Color
-                | Self::LogicalPosition
-                | Self::LogicalSize
-                | Self::StandardListViewItem
-                | Self::RadioEntry
-                | Self::Keys
-                | Self::KeyEvent
-                | Self::KeyboardModifiers
-                | Self::PointerEvent
-                | Self::PointerScrollEvent
-                | Self::DropEvent
-        )
-    }
-
     pub fn is_layout_data(&self) -> bool {
         matches!(
             self,
@@ -741,32 +758,6 @@ impl BuiltinStruct {
                 | Self::BoxLayoutOrthoData
                 | Self::FlexboxLayoutData
         )
-    }
-
-    pub fn slint_name(&self) -> Option<SmolStr> {
-        match self {
-            Self::Color => Some(SmolStr::new_static("color")),
-            Self::LogicalPosition => Some(SmolStr::new_static("Point")),
-            Self::LogicalSize => Some(SmolStr::new_static("Size")),
-            Self::StandardListViewItem => Some(SmolStr::new_static("StandardListViewItem")),
-            Self::RadioEntry => Some(SmolStr::new_static("RadioEntry")),
-            Self::Keys => Some(SmolStr::new_static("Keys")),
-            Self::KeyEvent => Some(SmolStr::new_static("KeyEvent")),
-            Self::KeyboardModifiers => Some(SmolStr::new_static("KeyboardModifiers")),
-            Self::PointerEvent => Some(SmolStr::new_static("PointerEvent")),
-            Self::PointerScrollEvent => Some(SmolStr::new_static("PointerScrollEvent")),
-            Self::Point
-            | Self::FontMetrics
-            | Self::TableColumn
-            | Self::MenuEntry
-            | Self::InternalKeyEvent
-            | Self::Edges
-            | Self::DropEvent => {
-                let name: &'static str = self.into();
-                Some(SmolStr::new_static(name))
-            }
-            _ => None,
-        }
     }
 }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -762,21 +762,6 @@ impl BuiltinPublicStruct {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, derive_more::From)]
-pub enum BuiltinStruct {
-    Private(BuiltinPrivateStruct),
-    Public(BuiltinPublicStruct),
-}
-
-impl BuiltinStruct {
-    pub fn slint_name(&self) -> Option<SmolStr> {
-        match self {
-            Self::Private(native_private_type) => native_private_type.slint_name(),
-            Self::Public(native_public_type) => native_public_type.slint_name(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct NativeClass {
     pub parent: Option<Rc<NativeClass>>,

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -729,7 +729,7 @@ impl BuiltinPrivateStruct {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, strum::IntoStaticStr)]
+#[derive(Debug, Clone, PartialEq, strum::EnumString, strum::IntoStaticStr)]
 pub enum BuiltinPublicStruct {
     Color,
     LogicalPosition,

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -14,7 +14,7 @@ use super::lower_layout_expression::{
 use super::lower_to_item_tree::{LoweredSubComponentMapping, LoweringState};
 use super::{Animation, LocalMemberReference, MemberReference, PropertyIdx};
 use crate::expression_tree::{BuiltinFunction, Callable, Expression as tree_Expression};
-use crate::langtype::{BuiltinPrivateStruct, Struct, StructName, Type};
+use crate::langtype::{BuiltinStruct, Struct, StructName, Type};
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
 use crate::namedreference::NamedReference;
@@ -570,7 +570,7 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
     fn animation_ty() -> Rc<Struct> {
         Rc::new(Struct {
             fields: animation_fields().collect(),
-            name: BuiltinPrivateStruct::PropertyAnimation.into(),
+            name: BuiltinStruct::PropertyAnimation.into(),
         })
     }
 
@@ -657,7 +657,7 @@ fn compile_path(
                             .iter()
                             .map(|(k, v)| (k.clone(), v.ty.clone()))
                             .collect(),
-                        name: StructName::BuiltinPrivate(
+                        name: StructName::Builtin(
                             element
                                 .element_type
                                 .native_class

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -9,7 +9,7 @@ use smol_str::SmolStr;
 
 use super::lower_to_item_tree::LoweredElement;
 use super::{GridLayoutRepeatedElement, LayoutRepeatedElement};
-use crate::langtype::{BuiltinPrivateStruct, EnumerationValue, Struct, Type};
+use crate::langtype::{BuiltinStruct, EnumerationValue, Struct, Type};
 use crate::layout::{GridLayoutCell, Orientation, RowColExpr};
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
@@ -194,7 +194,7 @@ pub(super) fn solve_grid_layout(
         enumeration: crate::typeregister::BUILTIN.with(|b| b.enums.Orientation.clone()),
     });
     let data = make_struct(
-        BuiltinPrivateStruct::GridLayoutData,
+        BuiltinStruct::GridLayoutData,
         [
             ("size", Type::Float32, size),
             ("spacing", Type::Float32, spacing),
@@ -256,7 +256,7 @@ pub(super) fn solve_box_layout(
     let size = layout_geometry_size(&layout.geometry.rect, o, ctx);
     let (data, function) = if o == layout.orientation {
         let data = make_struct(
-            BuiltinPrivateStruct::BoxLayoutData,
+            BuiltinStruct::BoxLayoutData,
             [
                 ("size", Type::Float32, size),
                 ("spacing", Type::Float32, spacing),
@@ -284,7 +284,7 @@ pub(super) fn solve_box_layout(
             })
         };
         let data = make_struct(
-            BuiltinPrivateStruct::BoxLayoutOrthoData,
+            BuiltinStruct::BoxLayoutOrthoData,
             [
                 ("size", Type::Float32, size),
                 ("padding", padding.ty(ctx), padding),
@@ -350,7 +350,7 @@ pub(super) fn solve_flexbox_layout(
     let width = layout_geometry_size(&layout.geometry.rect, Orientation::Horizontal, ctx);
     let height = layout_geometry_size(&layout.geometry.rect, Orientation::Vertical, ctx);
     let data = make_struct(
-        BuiltinPrivateStruct::FlexboxLayoutData,
+        BuiltinStruct::FlexboxLayoutData,
         [
             ("width", Type::Float32, width),
             ("height", Type::Float32, height),
@@ -847,7 +847,7 @@ fn default_align_self() -> (Type, llr_Expression) {
 
 fn make_layout_cell_data_struct(layout_info: llr_Expression) -> llr_Expression {
     make_struct(
-        BuiltinPrivateStruct::LayoutItemInfo,
+        BuiltinStruct::LayoutItemInfo,
         [("constraint", crate::typeregister::layout_info_type().into(), layout_info)],
     )
 }
@@ -864,7 +864,7 @@ struct FlexItemProps {
 fn make_flexbox_cell_data_struct(layout_info: llr_Expression, fp: FlexItemProps) -> llr_Expression {
     let (align_self_ty, _) = default_align_self();
     make_struct(
-        BuiltinPrivateStruct::FlexboxLayoutItemInfo,
+        BuiltinStruct::FlexboxLayoutItemInfo,
         [
             ("constraint", crate::typeregister::layout_info_type().into(), layout_info),
             ("flex-grow", Type::Float32, fp.grow),
@@ -1062,7 +1062,7 @@ fn grid_layout_input_data(
         let colspan_expr = propref(&elem.cell.borrow().colspan_expr);
 
         make_struct(
-            BuiltinPrivateStruct::GridLayoutInputData,
+            BuiltinStruct::GridLayoutInputData,
             [
                 ("new_row", Type::Bool, new_row_expr),
                 ("row", Type::Float32, row_expr),
@@ -1146,7 +1146,7 @@ pub(super) fn grid_layout_input_data_ty() -> Type {
             (SmolStr::new_static("colspan"), Type::Int32),
         ])
         .collect(),
-        name: BuiltinPrivateStruct::GridLayoutInputData.into(),
+        name: BuiltinStruct::GridLayoutInputData.into(),
     }))
 }
 
@@ -1166,7 +1166,7 @@ fn generate_layout_padding_and_spacing(
     let (begin, end) = layout_geometry.padding.begin_end(orientation);
 
     let padding = make_struct(
-        BuiltinPrivateStruct::Padding,
+        BuiltinStruct::Padding,
         [("begin", Type::Float32, padding_prop(begin)), ("end", Type::Float32, padding_prop(end))],
     );
 
@@ -1362,7 +1362,7 @@ pub fn get_grid_layout_input_for_repeated(
             let rowspan = convert_row_col_expr(&grid_cell.rowspan_expr, &*ctx);
             let colspan = convert_row_col_expr(&grid_cell.colspan_expr, &*ctx);
             let value = make_struct(
-                BuiltinPrivateStruct::GridLayoutInputData,
+                BuiltinStruct::GridLayoutInputData,
                 [
                     ("new_row", Type::Bool, new_row_expr.clone()),
                     ("row", Type::Float32, row),
@@ -1449,7 +1449,7 @@ pub fn get_flexbox_layout_item_info_for_repeated(
     let order = prop_ref("flex-order").unwrap_or(llr_Expression::NumberLiteral(0.0));
 
     make_struct(
-        BuiltinPrivateStruct::FlexboxLayoutItemInfo,
+        BuiltinStruct::FlexboxLayoutItemInfo,
         [
             (
                 "constraint",

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -6,9 +6,7 @@ use by_address::ByAddress;
 use super::lower_expression::{ExpressionLoweringCtx, ExpressionLoweringCtxInner};
 use crate::CompilerConfiguration;
 use crate::expression_tree::Expression as tree_Expression;
-use crate::langtype::{
-    BuiltinPrivateStruct, BuiltinPublicStruct, ElementType, Struct, StructName, Type,
-};
+use crate::langtype::{BuiltinStruct, ElementType, Struct, StructName, Type};
 use crate::llr::item_tree::*;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{self, Component, ElementRc, PropertyAnalysis, PropertyVisibility};
@@ -528,7 +526,7 @@ fn lower_sub_component(
 
             let is_state_info = matches!(
                 e.borrow().lookup_property(p).property_type,
-                Type::Struct(s) if matches!(s.name, StructName::BuiltinPrivate(BuiltinPrivateStruct::StateInfo))
+                Type::Struct(s) if matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo))
             );
 
             sub_component.property_init.push((
@@ -852,7 +850,7 @@ fn lower_popup_component(
     let sc = lower_sub_component(&popup.component, ctx.state, Some(&ctx.inner), compiler_config);
     use super::Expression::PropertyReference as PR;
     let position = super::lower_expression::make_struct(
-        BuiltinPublicStruct::LogicalPosition,
+        BuiltinStruct::LogicalPosition,
         [
             ("x", Type::LogicalLength, PR(sc.mapping.map_property_reference(&popup.x, ctx.state))),
             ("y", Type::LogicalLength, PR(sc.mapping.map_property_reference(&popup.y, ctx.state))),

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -12,8 +12,8 @@ use std::rc::Rc;
 
 use crate::expression_tree::Expression;
 use crate::langtype::{
-    BuiltinElement, BuiltinPrivateStruct, BuiltinPropertyDefault, BuiltinPropertyInfo,
-    DefaultSizeBinding, ElementType, Function, NativeClass, Type,
+    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, BuiltinStruct, DefaultSizeBinding,
+    ElementType, Function, NativeClass, Type,
 };
 use crate::object_tree::{self, *};
 use crate::parser::{SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
@@ -142,7 +142,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
             })
             .collect();
         n.builtin_struct = parse_annotation("builtin_struct", &e)
-            .map(|x| x.unwrap().parse::<BuiltinPrivateStruct>().unwrap());
+            .map(|x| x.unwrap().parse::<BuiltinStruct>().unwrap());
         enum Base {
             None,
             Global,

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -12,7 +12,7 @@
 use crate::EmbedResourcesKind;
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
-use crate::langtype::{BuiltinPrivateStruct, Struct, Type};
+use crate::langtype::{BuiltinStruct, Struct, Type};
 use crate::object_tree::*;
 use smol_str::SmolStr;
 use std::cell::RefCell;
@@ -165,7 +165,7 @@ fn compile_path_from_string_literal(
             (SmolStr::new_static("y"), Type::Float32),
         ])
         .collect(),
-        name: BuiltinPrivateStruct::Point.into(),
+        name: BuiltinStruct::Point.into(),
     });
 
     let mut points = Vec::new();

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use super::GlobalAnalysis;
 use crate::expression_tree::*;
-use crate::langtype::{BuiltinPrivateStruct, ElementType, StructName, Type};
+use crate::langtype::{BuiltinStruct, ElementType, StructName, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
 use smol_str::{ToSmolStr, format_smolstr};
@@ -35,10 +35,7 @@ fn simplify_expression(
             if nr.is_constant()
                 && !match nr.ty() {
                     Type::Struct(s) => {
-                        matches!(
-                            s.name,
-                            StructName::BuiltinPrivate(BuiltinPrivateStruct::StateInfo)
-                        )
+                        matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo))
                     }
                     _ => false,
                 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -11,7 +11,8 @@ use std::rc::Rc;
 use crate::expression_tree::BuiltinFunction;
 use crate::langtype::{
     BuiltinElement, BuiltinPrivateStruct, BuiltinPropertyDefault, BuiltinPropertyInfo,
-    BuiltinPublicStruct, ElementType, Enumeration, Function, PropertyLookupResult, Struct, Type,
+    BuiltinPublicStruct, ElementType, Enumeration, Function, PropertyLookupResult, Struct,
+    StructName, Type,
 };
 use crate::object_tree::{Component, PropertyVisibility};
 use crate::typeloader;
@@ -501,8 +502,7 @@ impl TypeRegister {
         macro_rules! register_builtin_structs {
             ($(
                 $(#[$attr:meta])*
-                struct $Name:ident {
-                    @name = $inner_name:expr,
+                $vis:vis struct $Name:ident {
                     $( $(#[$field_attr:meta])* $field:ident : $field_type:ident, )*
                 }
             )*) => { $(
@@ -832,11 +832,18 @@ pub mod builtin_structs {
         };
     }
 
+    fn struct_name_for(vis: &str, name: &str) -> StructName {
+        if vis == "pub" {
+            name.parse::<BuiltinPublicStruct>().unwrap().into()
+        } else {
+            name.parse::<BuiltinPrivateStruct>().unwrap().into()
+        }
+    }
+
     macro_rules! declare_builtin_structs {
         ($(
             $(#[$attr:meta])*
-            struct $Name:ident {
-                @name = $inner_name:expr,
+            $vis:vis struct $Name:ident {
                 $( $(#[$field_attr:meta])* $field:ident : $field_type:ident, )*
             }
         )*) => {
@@ -854,7 +861,7 @@ pub mod builtin_structs {
                         fields: BTreeMap::from([
                             $((stringify!($field).replace_smolstr("_", "-"), map_type!($field_type, $field_type))),*
                         ]),
-                        name: $inner_name.into(),
+                        name: struct_name_for(stringify!($vis), stringify!($Name)),
                     });
                     )*
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -503,12 +503,7 @@ impl TypeRegister {
                 $(#[$attr:meta])*
                 struct $Name:ident {
                     @name = $inner_name:expr,
-                    export {
-                        $( $(#[$pub_attr:meta])* $pub_field:ident : $pub_type:ident, )*
-                    }
-                    private {
-                        $( $(#[$pri_attr:meta])* $pri_field:ident : $pri_type:ty, )*
-                    }
+                    $( $(#[$field_attr:meta])* $field:ident : $field_type:ident, )*
                 }
             )*) => { $(
                 register.insert_type_with_name(Type::Struct(builtin_structs::$Name()), SmolStr::new(stringify!($Name)));
@@ -842,12 +837,7 @@ pub mod builtin_structs {
             $(#[$attr:meta])*
             struct $Name:ident {
                 @name = $inner_name:expr,
-                export {
-                    $( $(#[$pub_attr:meta])* $pub_field:ident : $pub_type:ident, )*
-                }
-                private {
-                    $( $(#[$pri_attr:meta])* $pri_field:ident : $pri_type:ty, )*
-                }
+                $( $(#[$field_attr:meta])* $field:ident : $field_type:ident, )*
             }
         )*) => {
             pub struct BuiltinStructs {
@@ -862,7 +852,7 @@ pub mod builtin_structs {
                     #[allow(non_snake_case)]
                     let $Name = Rc::new(Struct{
                         fields: BTreeMap::from([
-                            $((stringify!($pub_field).replace_smolstr("_", "-"), map_type!($pub_type, $pub_type))),*
+                            $((stringify!($field).replace_smolstr("_", "-"), map_type!($field_type, $field_type))),*
                         ]),
                         name: $inner_name.into(),
                     });

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use crate::expression_tree::BuiltinFunction;
 use crate::langtype::{
     BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, BuiltinStruct, ElementType,
-    Enumeration, Function, PropertyLookupResult, Struct, StructName, Type,
+    Enumeration, Function, PropertyLookupResult, Struct, Type,
 };
 use crate::object_tree::{Component, PropertyVisibility};
 use crate::typeloader;
@@ -831,10 +831,6 @@ pub mod builtin_structs {
         };
     }
 
-    fn struct_name_for(name: &str) -> StructName {
-        name.parse::<BuiltinStruct>().unwrap().into()
-    }
-
     macro_rules! declare_builtin_structs {
         ($(
             $(#[$attr:meta])*
@@ -856,7 +852,7 @@ pub mod builtin_structs {
                         fields: BTreeMap::from([
                             $((stringify!($field).replace_smolstr("_", "-"), map_type!($field_type, $field_type))),*
                         ]),
-                        name: struct_name_for(stringify!($Name)),
+                        name: BuiltinStruct::$Name.into(),
                     });
                     )*
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -10,9 +10,8 @@ use std::rc::Rc;
 
 use crate::expression_tree::BuiltinFunction;
 use crate::langtype::{
-    BuiltinElement, BuiltinPrivateStruct, BuiltinPropertyDefault, BuiltinPropertyInfo,
-    BuiltinPublicStruct, ElementType, Enumeration, Function, PropertyLookupResult, Struct,
-    StructName, Type,
+    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, BuiltinStruct, ElementType,
+    Enumeration, Function, PropertyLookupResult, Struct, StructName, Type,
 };
 use crate::object_tree::{Component, PropertyVisibility};
 use crate::typeloader;
@@ -115,7 +114,7 @@ impl BuiltinTypes {
                         .map(|s| (SmolStr::new_static(s), Type::Float32)),
                 )
                 .collect(),
-            name: BuiltinPrivateStruct::LayoutInfo.into(),
+            name: BuiltinStruct::LayoutInfo.into(),
         });
         let enums = BuiltinEnums::new();
         let flex_align_self_type = Type::Enumeration(enums.FlexboxLayoutAlignSelf.clone());
@@ -127,7 +126,7 @@ impl BuiltinTypes {
                     (SmolStr::new_static("y"), Type::LogicalLength),
                 ])
                 .collect(),
-                name: BuiltinPublicStruct::LogicalPosition.into(),
+                name: BuiltinStruct::LogicalPosition.into(),
             }),
             logical_size_type: Rc::new(Struct {
                 fields: IntoIterator::into_iter([
@@ -135,7 +134,7 @@ impl BuiltinTypes {
                     (SmolStr::new_static("height"), Type::LogicalLength),
                 ])
                 .collect(),
-                name: BuiltinPublicStruct::LogicalSize.into(),
+                name: BuiltinStruct::LogicalSize.into(),
             }),
             font_metrics_type: Type::Struct(Rc::new(Struct {
                 fields: IntoIterator::into_iter([
@@ -145,7 +144,7 @@ impl BuiltinTypes {
                     (SmolStr::new_static("cap-height"), Type::LogicalLength),
                 ])
                 .collect(),
-                name: BuiltinPrivateStruct::FontMetrics.into(),
+                name: BuiltinStruct::FontMetrics.into(),
             })),
             noarg_callback_type: Type::Callback(Rc::new(Function {
                 return_type: Type::Void,
@@ -165,11 +164,11 @@ impl BuiltinTypes {
                     (SmolStr::new_static("change-time"), Type::Duration),
                 ])
                 .collect(),
-                name: BuiltinPrivateStruct::StateInfo.into(),
+                name: BuiltinStruct::StateInfo.into(),
             }),
             path_element_type: Type::Struct(Rc::new(Struct {
                 fields: Default::default(),
-                name: BuiltinPrivateStruct::PathElement.into(),
+                name: BuiltinStruct::PathElement.into(),
             })),
             layout_item_info_type: Type::Struct(Rc::new(Struct {
                 fields: IntoIterator::into_iter([(
@@ -177,7 +176,7 @@ impl BuiltinTypes {
                     layout_info_type.clone().into(),
                 )])
                 .collect(),
-                name: BuiltinPrivateStruct::LayoutItemInfo.into(),
+                name: BuiltinStruct::LayoutItemInfo.into(),
             })),
             flexbox_layout_item_info_type: Type::Struct(Rc::new(Struct {
                 fields: IntoIterator::into_iter([
@@ -189,7 +188,7 @@ impl BuiltinTypes {
                     ("flex-order".into(), Type::Int32),
                 ])
                 .collect(),
-                name: BuiltinPrivateStruct::FlexboxLayoutItemInfo.into(),
+                name: BuiltinStruct::FlexboxLayoutItemInfo.into(),
             })),
             gridlayout_input_data_type: Type::Struct(Rc::new(Struct {
                 fields: IntoIterator::into_iter([
@@ -199,7 +198,7 @@ impl BuiltinTypes {
                     ("colspan".into(), Type::Int32),
                 ])
                 .collect(),
-                name: BuiltinPrivateStruct::GridLayoutInputData.into(),
+                name: BuiltinStruct::GridLayoutInputData.into(),
             })),
         }
     }
@@ -832,12 +831,8 @@ pub mod builtin_structs {
         };
     }
 
-    fn struct_name_for(vis: &str, name: &str) -> StructName {
-        if vis == "pub" {
-            name.parse::<BuiltinPublicStruct>().unwrap().into()
-        } else {
-            name.parse::<BuiltinPrivateStruct>().unwrap().into()
-        }
+    fn struct_name_for(name: &str) -> StructName {
+        name.parse::<BuiltinStruct>().unwrap().into()
     }
 
     macro_rules! declare_builtin_structs {
@@ -861,7 +856,7 @@ pub mod builtin_structs {
                         fields: BTreeMap::from([
                             $((stringify!($field).replace_smolstr("_", "-"), map_type!($field_type, $field_type))),*
                         ]),
-                        name: struct_name_for(stringify!($vis), stringify!($Name)),
+                        name: struct_name_for(stringify!($Name)),
                     });
                     )*
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2135,8 +2135,7 @@ declare_item_vtable! {
 macro_rules! declare_builtin_structs {
     ($(
         $(#[$struct_attr:meta])*
-        struct $Name:ident {
-            @name = $inner_name:expr,
+        $vis:vis struct $Name:ident {
             $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
         }
     )*) => {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2137,12 +2137,7 @@ macro_rules! declare_builtin_structs {
         $(#[$struct_attr:meta])*
         struct $Name:ident {
             @name = $inner_name:expr,
-            export {
-                $( $(#[$pub_attr:meta])* $pub_field:ident : $pub_type:ty, )*
-            }
-            private {
-                $( $(#[$pri_attr:meta])* $pri_field:ident : $pri_type:ty, )*
-            }
+            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
         }
     )*) => {
         $(
@@ -2151,12 +2146,8 @@ macro_rules! declare_builtin_structs {
             $(#[$struct_attr])*
             pub struct $Name {
                 $(
-                    $(#[$pub_attr])*
-                    pub $pub_field : $pub_type,
-                )*
-                $(
-                    $(#[$pri_attr])*
-                    pub $pri_field : $pri_type,
+                    $(#[$field_attr])*
+                    pub $field : $field_type,
                 )*
             }
         )*

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -302,17 +302,14 @@ macro_rules! declare_value_struct_conversion {
         $(#[$struct_attr:meta])*
         struct $Name:ident {
             @name = $inner_name:expr,
-            export {
-                $( $(#[$pub_attr:meta])* $pub_field:ident : $pub_type:ty, )*
-            }
-            private { $($pri:tt)* }
+            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
         }
     )*) => {
         $(
             impl From<$Name> for Value {
                 fn from(item: $Name) -> Self {
                     let mut struct_ = Struct::default();
-                    $(struct_.set_field(stringify!($pub_field).into(), item.$pub_field.into());)*
+                    $(struct_.set_field(stringify!($field).into(), item.$field.into());)*
                     Value::Struct(struct_)
                 }
             }
@@ -325,7 +322,7 @@ macro_rules! declare_value_struct_conversion {
                             type Ty = $Name;
                             #[allow(unused)]
                             let mut res: Ty = Ty::default();
-                            $(res.$pub_field = x.get_field(stringify!($pub_field)).ok_or(())?.clone().try_into().map_err(|_|())?;)*
+                            $(res.$field = x.get_field(stringify!($field)).ok_or(())?.clone().try_into().map_err(|_|())?;)*
                             Ok(res)
                         }
                         _ => Err(()),

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -300,8 +300,7 @@ macro_rules! declare_value_struct_conversion {
     };
     ($(
         $(#[$struct_attr:meta])*
-        struct $Name:ident {
-            @name = $inner_name:expr,
+        $vis:vis struct $Name:ident {
             $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
         }
     )*) => {

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -8,7 +8,7 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 use dynamic_type::{Instance, InstanceBox};
 use i_slint_compiler::expression_tree::{Expression, NamedReference, TwoWayBinding};
-use i_slint_compiler::langtype::{BuiltinPrivateStruct, StructName, Type};
+use i_slint_compiler::langtype::{BuiltinStruct, StructName, Type};
 use i_slint_compiler::object_tree::{ElementRc, ElementWeak, TransitionDirection};
 use i_slint_compiler::{CompilerConfiguration, generator, object_tree, parser};
 use i_slint_compiler::{diagnostics::BuildDiagnostics, object_tree::PropertyDeclaration};
@@ -1282,12 +1282,7 @@ pub(crate) fn generate_item_tree<'id>(
             Type::Image => property_info::<i_slint_core::graphics::Image>(),
             Type::Bool => property_info::<bool>(),
             Type::ComponentFactory => property_info::<ComponentFactory>(),
-            Type::Struct(s)
-                if matches!(
-                    s.name,
-                    StructName::BuiltinPrivate(BuiltinPrivateStruct::StateInfo)
-                ) =>
-            {
+            Type::Struct(s) if matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo)) => {
                 property_info::<i_slint_core::properties::StateInfo>()
             }
             Type::Struct(_) => property_info::<Value>(),
@@ -1721,7 +1716,7 @@ pub fn instantiate(
             } else if let Some(PropertiesWithinComponent { offset, prop: prop_info, .. }) =
                 description.custom_properties.get(prop_name).filter(|_| is_root)
             {
-                let is_state_info = matches!(&property_type, Type::Struct (s) if matches!(s.name, StructName::BuiltinPrivate(BuiltinPrivateStruct::StateInfo)));
+                let is_state_info = matches!(&property_type, Type::Struct (s) if matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo)));
                 if is_state_info {
                     let prop = Pin::new_unchecked(
                         &*(instance_ref.as_ptr().add(*offset)


### PR DESCRIPTION
Remove redundant layers from for_each_builtin_structs! and the compiler's struct type system:                                                                                               
                                                                  
  - Remove the empty `export{}/private{}` field wrappers (no struct has private fields anymore)                                                                                                 
  - Replace `@name = BuiltinPublicStruct::X` with pub struct/struct visibility, matching the pattern already used by for_each_enums!                                                          
  - Merge BuiltinPublicStruct and BuiltinPrivateStruct into a single BuiltinStruct enum with an is_public() method, simplifying StructName to one Builtin variant                             
  - Generate the macro-defined enum variants automatically so adding a struct to the macro no longer requires a manual edit in langtype.rs                                                    
                                                                                                                                                                                              