### PR TITLE
CI: Reduce PR job load

### DIFF
--- a/.github/actions/install-linux-dependencies/action.yaml
+++ b/.github/actions/install-linux-dependencies/action.yaml
@@ -15,10 +15,6 @@ inputs:
         description: 'Force GCC version 10 (default: "no")'
         required: false
         default: "no"
-    old-ubuntu:
-        description: "This is running on an older version of Ubuntu"
-        required: false
-        default: "no"
 
 runs:
     using: composite
@@ -27,13 +23,7 @@ runs:
           if: runner.os == 'Linux'
           run: |
               sudo apt-get update
-              sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev libinput-dev libgbm-dev libfontconfig-dev ${{ inputs.extra-packages }}
-          shell: bash
-        - name: Install Linux dependencies
-          if: ${{ runner.os == 'Linux' && (inputs.old-ubuntu != 'true')}}
-          run: |
-              sudo apt-get update
-              sudo apt-get install libseat-dev libsystemd-dev
+              sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev libinput-dev libgbm-dev libfontconfig-dev libseat-dev libsystemd-dev ${{ inputs.extra-packages }}
           shell: bash
         - name: Install C++ compiler
           if: ${{ (runner.os == 'Linux') && (inputs.force-gcc-10 == 'true') }}

--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -136,11 +136,11 @@ updater_test:
 
 servo_example:
  - 'examples/servo/**'
- - *ci_config
+ - '.github/workflows/servo_example.yaml'
 
 bevy_examples:
  - 'examples/bevy/**'
- - *ci_config
+ - '.github/workflows/bevy_examples.yaml'
 
 slint_sc:
  - 'internal/compiler/**'

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -94,12 +94,9 @@ jobs:
                   version: "6.2.2"
                   setup-python: false
                   cache: true
-            - name: Install ffmpeg and alsa (Linux)
+            - name: Install ffmpeg, alsa, gstreamer and libunwind (Linux)
               if: runner.os == 'Linux'
-              run: sudo apt-get install clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config
-            - name: Install gstreamer and libunwind (Linux)
-              if: runner.os == 'Linux'
-              run: sudo apt-get install libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+              run: sudo apt-get install clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
             - name: Setup headless display
               if: runner.os != 'macOS'
               uses: pyvista/setup-headless-display-action@v4

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -123,7 +123,7 @@ jobs:
               run: "cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python qt:: -- --test-threads=1"
               shell: bash
             - name: live-preview for rust test
-              if: runner.os == 'Linux'
+              if: runner.os == 'macOS'
               env:
                 SLINT_LIVE_PREVIEW: 1
               run: cargo test --locked --verbose --all-features --features slint/live-preview -p test-driver-rust -- --skip=_qt::t

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -357,7 +357,7 @@ jobs:
               working-directory: editors/vscode
               run: pnpm test_grammar
 
-    # test to compile the mcu backend for the arm target (no_std)
+    # test to compile the mcu backend for no_std targets (ARM and ESP32)
     mcu:
         needs: files-changed
         if: ${{ needs.files-changed.outputs.internal == 'true' || needs.files-changed.outputs.examples_mcu == 'true' || needs.files-changed.outputs.api_rs == 'true' }}
@@ -367,59 +367,33 @@ jobs:
             CARGO_PROFILE_DEV_DEBUG: 0
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
         runs-on: ubuntu-22.04
-        strategy:
-            matrix:
-                include:
-                    - feature: pico-st7789
-                      target: thumbv6m-none-eabi
-                    - feature: pico2-st7789
-                      target: thumbv8m.main-none-eabihf
-                    - feature: pico2-touch-lcd-2-8
-                      target: thumbv8m.main-none-eabihf
-                    - feature: stm32h735g
-                      target: thumbv7em-none-eabihf
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/setup-rust
               with:
-                  target: ${{matrix.target}}
-            - name: Check
-              run: cargo check --target=${{matrix.target}} -p printerdemo_mcu --no-default-features --features=mcu-board-support/${{matrix.feature}} --release
-
-    # test to compile the mcu backend for the arm target (no_std) using embassy
-    mcu-embassy:
-        needs: files-changed
-        if: ${{ needs.files-changed.outputs.internal == 'true' || needs.files-changed.outputs.examples_mcu == 'true' || needs.files-changed.outputs.api_rs == 'true' }}
-        env:
-            SLINT_FONT_SIZES: 8,11,10,12,13,14,15,16,18,20,22,24,32
-            RUSTFLAGS: --cfg slint_int_coord -D warnings
-            CARGO_PROFILE_DEV_DEBUG: 0
-            CARGO_PROFILE_RELEASE_OPT_LEVEL: s
-        runs-on: ubuntu-22.04
-        steps:
-            - uses: actions/checkout@v6
-            - uses: ./.github/actions/setup-rust
+                  target: thumbv6m-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabihf
+            - uses: esp-rs/xtensa-toolchain@v1.7
+              if: ${{ needs.files-changed.outputs.examples_mcu == 'true' }}
               with:
-                  target: thumbv8m.main-none-eabihf
-            - name: Check
-              working-directory: examples/mcu-embassy
+                  buildtargets: esp32
+                  ldproxy: false
+            - name: Check pico-st7789
+              run: cargo check --target=thumbv6m-none-eabi -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --release
+            - name: Check mcu-embassy
               run: cargo check --bin ui_mcu --target=thumbv8m.main-none-eabihf --no-default-features --features="mcu-embassy/mcu" --release
-
-#    mcu_esp:
-#        env:
-#            RUSTFLAGS: -D warnings
-#        runs-on: ubuntu-22.04
-#        steps:
-#            - uses: actions/checkout@v6
-#            - uses: dtolnay/rust-toolchain@stable
-#            - uses: esp-rs/xtensa-toolchain@v1.7
-#              with:
-#                  default: true
-#                  buildtargets: esp32
-#                  ldproxy: false
-#            - uses: Swatinem/rust-cache@v2
-#            - name: S3Box
-#              run: cargo +esp check -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box  --config examples/mcu-board-support/esp32_s3_box/cargo-config.toml --release
+              working-directory: examples/mcu-embassy
+            - name: Check all boards
+              if: ${{ needs.files-changed.outputs.examples_mcu == 'true' }}
+              run: |
+                  cargo check --target=thumbv8m.main-none-eabihf -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico2-st7789 --release
+                  cargo check --target=thumbv8m.main-none-eabihf -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico2-touch-lcd-2-8 --release
+                  cargo check --target=thumbv7em-none-eabihf -p printerdemo_mcu --no-default-features --features=mcu-board-support/stm32h735g --release
+                  cargo check --target=thumbv8m.main-none-eabihf -p printerdemo_mcu --no-default-features --features=mcu-board-support/stm32u5g9j-dk2 --release
+                  cargo +esp check -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box-3 --config examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml --release
+                  cargo +esp check -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-lcd-ev-board --config examples/mcu-board-support/esp32_s3_lcd_ev_board/cargo-config.toml --release
+                  cargo +esp check -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esope-sld-c-w-s3 --config examples/mcu-board-support/esope_sld_c_w_s3/cargo-config.toml --release
+                  cargo +esp check -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/waveshare-esp32-s3-touch-amoled-1-8 --config examples/mcu-board-support/waveshare_esp32_s3_touch_amoled_1_8/cargo-config.toml --release
+                  cargo +esp check -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/m5stack-cores3 --config examples/mcu-board-support/m5stack_cores3/cargo-config.toml --release
 
     ffi_32bit_build:
         needs: files-changed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,17 +79,13 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: ubuntu-22.04
-                      name: "Ubuntu 22.04 beta"
-                      rust_version: "beta"
-                      extra_args: "--exclude plotter --exclude material-gallery"
                     - os: windows-2022
                       name: "Windows 2022 1.92"
                       rust_version: "1.92"
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player --exclude material-gallery"
                     - os: macos-14
-                      name: "MacOS 14 stable"
-                      rust_version: "stable"
+                      name: "MacOS 14 beta"
+                      rust_version: "beta"
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player --exclude material-gallery"
         uses: ./.github/workflows/build_and_test_reusable.yaml
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
 
     node_test_macos:
         needs: files-changed
-        if: ${{ needs.files-changed.outputs.api_node == 'true' || needs.files-changed.outputs.tests == 'true' }}
+        if: ${{ needs.files-changed.outputs.api_node == 'true' }}
         uses: ./.github/workflows/node_test_reusable.yaml
         with:
           name: "Node.js macOS"
@@ -119,7 +119,7 @@ jobs:
 
     node_test_windows:
         needs: files-changed
-        if: ${{ needs.files-changed.outputs.api_node == 'true' || needs.files-changed.outputs.tests == 'true' }}
+        if: ${{ needs.files-changed.outputs.api_node == 'true' }}
         uses: ./.github/workflows/node_test_reusable.yaml
         with:
           name: "Node.js Windows"
@@ -135,14 +135,14 @@ jobs:
           os: "ubuntu-22.04"
     python_test_macos:
         needs: files-changed
-        if: ${{ needs.files-changed.outputs.api_python == 'true' || needs.files-changed.outputs.tests == 'true' }}
+        if: ${{ needs.files-changed.outputs.api_python == 'true' }}
         uses: ./.github/workflows/python_test_reusable.yaml
         with:
           name: "Python macOS"
           os: "macos-14"
     python_test_windows:
         needs: files-changed
-        if: ${{ needs.files-changed.outputs.api_python == 'true' || needs.files-changed.outputs.tests == 'true' }}
+        if: ${{ needs.files-changed.outputs.api_python == 'true' }}
         uses: ./.github/workflows/python_test_reusable.yaml
         with:
           name: "Python Windows"
@@ -551,7 +551,7 @@ jobs:
     # Test that the formater don't introduce slint compilation error
     fmt_test:
         needs: files-changed
-        if: ${{ needs.files-changed.outputs.slintpad == 'true' || needs.files-changed.outputs.tests == 'true' }}
+        if: ${{ needs.files-changed.outputs.slintpad == 'true' }}
         env:
             SLINT_NO_QT: 1
             CARGO_INCREMENTAL: false

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -45,8 +45,6 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/install-linux-dependencies
-              with:
-                  old-ubuntu: true
             - name: Install Qt (Ubuntu)
               uses: jurplel/install-qt-action@v4
               if: matrix.os == 'ubuntu-22.04'
@@ -98,8 +96,6 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/install-linux-dependencies
-              with:
-                  old-ubuntu: true
             - uses: ./.github/actions/setup-rust
               with:
                   target: ${{ matrix.target }}
@@ -149,8 +145,6 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/install-linux-dependencies
-              with:
-                  old-ubuntu: true
             - uses: dtolnay/rust-toolchain@stable
             - uses: cargo-bins/cargo-binstall@main
             - name: install espup
@@ -257,8 +251,6 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/install-linux-dependencies
-              with:
-                  old-ubuntu: true
             - uses: ./.github/actions/setup-rust
             - uses: ilammy/msvc-dev-cmd@v1
               with:

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -96,8 +96,6 @@ jobs:
               with:
                   target: ${{ matrix.toolchain }}
             - uses: ./.github/actions/install-linux-dependencies
-              with:
-                  old-ubuntu: true
             - name: Build LSP
               run: cargo build --target ${{ matrix.toolchain }} --features ${{ env.SLINT_BINARY_FEATURES }} --release -p slint-lsp
             - name: Create artifact directory

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -81,8 +81,6 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/install-linux-dependencies
-              with:
-                  old-ubuntu: true
             - uses: ./.github/actions/install-skia-dependencies
             - uses: ilammy/msvc-dev-cmd@v1
               if: runner.os == 'Windows'

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -106,8 +106,6 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/install-linux-dependencies
-              with:
-                  old-ubuntu: true
             - uses: ./.github/actions/setup-rust
               with:
                   target: x86_64-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ![Slint](./logo/slint-logo-full-light.svg#gh-light-mode-only) ![Slint](./logo/slint-logo-full-dark.svg#gh-dark-mode-only)
 
-[![Build Status](https://github.com/slint-ui/slint/workflows/CI/badge.svg)](https://github.com/slint-ui/slint/actions)
+[![Build Status](https://github.com/slint-ui/slint/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/slint-ui/slint/actions/workflows/ci.yaml)
 [![REUSE status](https://api.reuse.software/badge/github.com/slint-ui/slint)](https://api.reuse.software/info/github.com/slint-ui/slint)
 [![Discussions](https://img.shields.io/github/discussions/slint-ui/slint)](https://github.com/slint-ui/slint/discussions)
 

--- a/api/cpp/docs/index.rst
+++ b/api/cpp/docs/index.rst
@@ -56,13 +56,6 @@ Slint C++ documentation
 
    thirdparty.md
 
-.. image:: https://github.com/slint-ui/slint/workflows/CI/badge.svg
-   :target: https://github.com/slint-ui/slint/actions
-   :alt: GitHub CI Build Status
-
-.. image:: https://img.shields.io/github/discussions/slint-ui/slint
-   :target: https://github.com/slint-ui/slint/discussions
-   :alt: GitHub Discussions
 
 `Slint <https://slint.dev/>`_ is a toolkit to efficiently develop fluid graphical user interfaces for any display: embedded devices and desktop applications.
 Slint C++ is the C++ API to interact with a Slint UI from C++.

--- a/examples/mcu-board-support/esp32_s3_lcd_ev_board/esp32_s3_lcd_ev_board.rs
+++ b/examples/mcu-board-support/esp32_s3_lcd_ev_board/esp32_s3_lcd_ev_board.rs
@@ -79,7 +79,7 @@ const FRAME_BYTES: usize = (LCD_H_RES as usize * LCD_V_RES as usize) * 2;
 const NUM_DMA_DESC: usize = (FRAME_BYTES + CHUNK_SIZE - 1) / CHUNK_SIZE;
 
 // Place DMA descriptors in DMA-capable RAM
-#[link_section = ".dma"]
+#[unsafe(link_section = ".dma")]
 static mut TX_DESCRIPTORS: [DmaDescriptor; NUM_DMA_DESC] = [DmaDescriptor::EMPTY; NUM_DMA_DESC];
 
 #[panic_handler]


### PR DESCRIPTION
  - Tighten path filters: servo/bevy examples only run on their own file changes, not on CI config or Cargo.lock changes. macOS/Windows Node/Python tests only trigger on binding changes.
  - Drop Ubuntu from the build_and_test matrix
  - Merge separate apt-get calls                                  
                                                                                                                                                        