### PR TITLE
winit/muda: fix needless_borrow clippy lint in MenuBar::visible check

### DIFF
--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -215,8 +215,8 @@ impl MudaAdapter {
         if let Some(menu_tree) = menu_tree {
             let mut build_menu = || {
                 let mut menu_entries = Default::default();
-                if vtable::VRc::borrow(&menu_tree).visible() {
-                    vtable::VRc::borrow(&menu_tree).sub_menu(None, &mut menu_entries);
+                if vtable::VRc::borrow(menu_tree).visible() {
+                    vtable::VRc::borrow(menu_tree).sub_menu(None, &mut menu_entries);
                 }
 
                 if menu_entries.is_empty() && muda_type == MudaType::Menubar {


### PR DESCRIPTION
`VRc::borrow` already takes a reference internally; the `&` added in #11272 (efcff40bc) is redundant and triggers `clippy::needless_borrow` as a hard error under `-D warnings`.

Remove the spurious `&` on both call sites in `generate_menu_entry`.