### PR TITLE
api: Move StandardListViewItem and TableColumn to slint::language

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -373,7 +373,6 @@ fn gen_corelib(
         "PointerEvent",
         "PointerScrollEvent",
         "Rect",
-        "SortOrder",
         "BitmapFont",
         "DataTransferOpaque",
     ]

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -220,7 +220,12 @@ pub use i_slint_core::component_factory::ComponentFactory;
 #[cfg(not(target_arch = "wasm32"))]
 pub use i_slint_core::graphics::{BorrowedOpenGLTextureBuilder, BorrowedOpenGLTextureOrigin};
 pub use i_slint_core::input::{Keys, KeysParseError};
-pub use i_slint_core::items::{StandardListViewItem, TableColumn};
+#[doc(hidden)]
+#[deprecated(note = "Use slint::language::StandardListViewItem instead")]
+pub use i_slint_core::items::StandardListViewItem;
+#[doc(hidden)]
+#[deprecated(note = "Use slint::language::TableColumn instead")]
+pub use i_slint_core::items::TableColumn;
 pub use i_slint_core::model::{
     FilterModel, MapModel, Model, ModelExt, ModelNotify, ModelPeer, ModelRc, ModelTracker,
     ReverseModel, SortModel, VecModel,

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -128,7 +128,7 @@ macro_rules! for_each_builtin_structs {
 
             /// This is used to define the column and the column header of a TableView
             #[non_exhaustive]
-            struct TableColumn {
+            pub struct TableColumn {
                 /// The title of the column header
                 title: SharedString,
                 /// The minimum column width (logical length)

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -522,7 +522,7 @@ macro_rules! for_each_enums {
             /// This enum represents the different values of the `sort-order` property.
             /// It's used to sort a `StandardTableView` by a column.
             #[non_exhaustive]
-            enum SortOrder {
+            pub enum SortOrder {
                 /// The column is unsorted.
                 Unsorted,
 


### PR DESCRIPTION
Make TableColumn and SortOrder public so they are exported in the slint::language module across all language bindings. Deprecate the old slint::StandardListViewItem and slint::TableColumn re-exports.
