### PR TITLE
slint-sc: allow exported components, add test driver

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -66,6 +66,7 @@ checkmark
 checkstate
 chipset
 chrono
+Cinstrument
 circledraw
 circularprogressindicator
 CLIB
@@ -321,6 +322,7 @@ Libinput
 libloading
 libm
 libseat
+libslint
 libstdc
 libudev
 libx

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -111,13 +111,13 @@ jobs:
               # Ignore rust_version for stable/nightly to test with latest dependencies
               run: cargo update ${{ (inputs.rust_version == 'stable' || inputs.rust_version == 'nightly') && '--ignore-rust-version' || '' }}
             - name: Run tests
-              run: "cargo test --locked --verbose --all-features --workspace --timings ${{ inputs.extra_args }} --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=qt::"
+              run: "cargo test --locked --verbose --all-features --workspace --timings ${{ inputs.extra_args }} --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --exclude slint-sc -- --skip=qt::"
               env:
                   SLINT_CREATE_SCREENSHOTS: 1
               shell: bash
             - name: Run tests (qt)
               if: runner.os != 'Windows' && inputs.run_qt
-              run: "cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python qt:: -- --test-threads=1"
+              run: "cargo test --locked --verbose --all-features --workspace ${{ inputs.extra_args }} --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --exclude slint-sc qt:: -- --test-threads=1"
               shell: bash
             - name: live-preview for rust test
               if: runner.os == 'macOS'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -727,7 +727,7 @@ jobs:
               run: cargo llvm-cov --no-report -p i-slint-compiler --features slint-sc --no-default-features
             - name: Test slint-compiler binary with slint-sc feature
               run: cargo llvm-cov --no-report -p slint-compiler --features slint-sc --no-default-features
-            - name: Test slint-sc runtime
+            - name: Test slint-sc runtime and driver
               run: cargo llvm-cov --no-report -p slint-sc
             - name: Generate coverage report
               run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10840,6 +10840,11 @@ dependencies = [
 [[package]]
 name = "slint-sc"
 version = "1.17.0"
+dependencies = [
+ "rayon",
+ "regex",
+ "tempfile",
+]
 
 [[package]]
 name = "slint-tr-extractor"

--- a/api/slint-sc/Cargo.toml
+++ b/api/slint-sc/Cargo.toml
@@ -18,3 +18,13 @@ path = "lib.rs"
 
 [features]
 default = []
+
+[dev-dependencies]
+rayon = { workspace = true }
+tempfile = "3"
+regex = "1"
+
+[[test]]
+name = "driver"
+path = "tests/driver.rs"
+harness = false

--- a/api/slint-sc/tests/cases/component/empty.slint
+++ b/api/slint-sc/tests/cases/component/empty.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+export component Empty inherits Window {}
+/*
+```rust
+let _ = Empty::new();
+```
+*/

--- a/api/slint-sc/tests/driver.rs
+++ b/api/slint-sc/tests/driver.rs
@@ -1,0 +1,249 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+//! Custom test driver for the Slint SC (safety-critical) subset.
+//!
+//! For each `.slint` file under `tests/cases/`, this driver:
+//! 1. Runs `slint-compiler --slint-sc` to generate Rust code
+//! 2. Extracts test code from `` ```rust `` blocks in comments
+//! 3. Calls `rustc` directly to compile the generated + test code
+//! 4. Runs the resulting binary
+//!
+//! Tests run in parallel via rayon.
+
+use rayon::prelude::*;
+use regex::Regex;
+use std::fmt::Write as _;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    let cases_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/cases");
+    let test_files = collect_slint_files(&cases_dir);
+
+    if test_files.is_empty() {
+        eprintln!("No test files found in {}", cases_dir.display());
+        std::process::exit(1);
+    }
+
+    let target_dir = find_target_dir();
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    let instrument_coverage = std::env::var_os("LLVM_PROFILE_FILE").is_some();
+    let compiler = build_compiler(&target_dir, instrument_coverage);
+    let slint_sc_rlib = find_slint_sc_rlib(&target_dir);
+    let rx = Regex::new(r"(?sU)\r?\n```rust\r?\n(.+)\r?\n```\r?\n").unwrap();
+
+    let config = TestConfig {
+        compiler: &compiler,
+        slint_sc_rlib: &slint_sc_rlib,
+        rustc: &rustc,
+        instrument_coverage,
+        rx: &rx,
+    };
+
+    let results: Vec<(String, Result<(), String>)> = test_files
+        .par_iter()
+        .map(|path| {
+            let name = path
+                .strip_prefix(&cases_dir)
+                .unwrap_or(path)
+                .with_extension("")
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            let result = run_test(path, &config);
+            (name, result)
+        })
+        .collect();
+
+    // Print results
+    eprintln!();
+    let mut failed = 0;
+    for (name, result) in &results {
+        match result {
+            Ok(()) => eprintln!("  \x1b[32mPASS\x1b[0m {name}"),
+            Err(msg) => {
+                failed += 1;
+                eprintln!("  \x1b[31mFAIL\x1b[0m {name}");
+                for line in msg.lines() {
+                    eprintln!("       {line}");
+                }
+            }
+        }
+    }
+
+    let passed = results.len() - failed;
+    eprintln!();
+    eprintln!("{passed} passed, {failed} failed");
+
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}
+
+struct TestConfig<'a> {
+    compiler: &'a Path,
+    slint_sc_rlib: &'a Path,
+    rustc: &'a str,
+    instrument_coverage: bool,
+    rx: &'a Regex,
+}
+
+fn find_target_dir() -> PathBuf {
+    let self_exe = std::env::current_exe().expect("current_exe");
+    self_exe
+        .ancestors()
+        .find(|p| p.ends_with("debug") || p.ends_with("release"))
+        .expect("Could not find target dir from current_exe")
+        .to_path_buf()
+}
+
+fn build_compiler(target_dir: &Path, instrument_coverage: bool) -> PathBuf {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let mut cmd = Command::new(&cargo);
+    cmd.args(["build", "-p", "slint-compiler", "--no-default-features", "--features", "slint-sc"]);
+    // Use the same target directory as the test binary itself, so the
+    // compiler ends up next to us (important for cargo-llvm-cov which
+    // uses a separate target dir).
+    if let Some(parent) = target_dir.parent() {
+        cmd.arg("--target-dir").arg(parent);
+    }
+    if instrument_coverage {
+        cmd.env("RUSTFLAGS", "-Cinstrument-coverage");
+    }
+    let status = cmd.status().expect("Failed to run cargo build for slint-compiler");
+    assert!(status.success(), "Failed to build slint-compiler");
+    let compiler = target_dir.join("slint-compiler");
+    assert!(compiler.exists(), "slint-compiler not found at {}", compiler.display());
+    compiler
+}
+
+/// Find the slint-sc rlib in the deps directory for --extern.
+fn find_slint_sc_rlib(target_dir: &Path) -> PathBuf {
+    let deps_dir = target_dir.join("deps");
+    if let Ok(entries) = std::fs::read_dir(&deps_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("libslint_sc-") && name_str.ends_with(".rlib") {
+                return entry.path();
+            }
+        }
+    }
+
+    panic!("Could not find slint-sc rlib in {}", deps_dir.display());
+}
+
+fn run_test(slint_path: &Path, config: &TestConfig) -> Result<(), String> {
+    let tmp = tempfile::tempdir().map_err(|e| format!("tempdir: {e}"))?;
+    let generated_rs = tmp.path().join("generated.rs");
+
+    // Step 1: Run slint-compiler
+    let output = Command::new(config.compiler)
+        .arg("--slint-sc")
+        .arg(slint_path)
+        .arg("-o")
+        .arg(&generated_rs)
+        .output()
+        .map_err(|e| format!("slint-compiler spawn: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("slint-compiler failed:\n{stderr}"));
+    }
+
+    // Step 2: Extract test code from ```rust blocks in comments
+    let source = std::fs::read_to_string(slint_path)
+        .map_err(|e| format!("read {}: {e}", slint_path.display()))?;
+    let test_code = extract_rust_test_code(&source, config.rx);
+    if test_code.is_empty() {
+        return Err("no ```rust test code found in comments".into());
+    }
+
+    // Step 3: Create test .rs file
+    let test_rs = tmp.path().join("test.rs");
+    {
+        let mut f = std::fs::File::create(&test_rs).map_err(|e| format!("create test.rs: {e}"))?;
+        let gen_path = generated_rs.to_string_lossy().replace('\\', "/");
+        let mut content = String::new();
+        writeln!(content, r#"include!("{gen_path}");"#).unwrap();
+        writeln!(content).unwrap();
+        writeln!(content, "fn main() -> Result<(), Box<dyn std::error::Error>> {{").unwrap();
+        writeln!(content, "    {}", test_code.replace('\n', "\n    ")).unwrap();
+        writeln!(content, "    Ok(())").unwrap();
+        writeln!(content, "}}").unwrap();
+        f.write_all(content.as_bytes()).map_err(|e| format!("write test.rs: {e}"))?;
+    }
+
+    // Step 4: Compile with rustc
+    let test_bin = tmp.path().join("test_bin");
+    let deps_dir = config.slint_sc_rlib.parent().unwrap_or_else(|| Path::new("."));
+    let mut rustc_cmd = Command::new(config.rustc);
+    rustc_cmd
+        .arg(&test_rs)
+        .arg("--edition=2024")
+        .arg("-o")
+        .arg(&test_bin)
+        .arg("-L")
+        .arg(deps_dir)
+        .arg("--extern")
+        .arg(format!("slint_sc={}", config.slint_sc_rlib.display()));
+
+    // When running under cargo-llvm-cov, propagate coverage instrumentation
+    // so that slint-sc runtime code exercised by the test is included in the
+    // coverage report.
+    if config.instrument_coverage {
+        rustc_cmd.arg("-Cinstrument-coverage");
+    }
+
+    let rustc_output = rustc_cmd.output().map_err(|e| format!("rustc spawn: {e}"))?;
+
+    if !rustc_output.status.success() {
+        let stderr = String::from_utf8_lossy(&rustc_output.stderr);
+        return Err(format!("rustc failed:\n{stderr}"));
+    }
+
+    // Step 5: Run the test binary
+    let run_output =
+        Command::new(&test_bin).output().map_err(|e| format!("test binary spawn: {e}"))?;
+
+    if !run_output.status.success() {
+        let stderr = String::from_utf8_lossy(&run_output.stderr);
+        let stdout = String::from_utf8_lossy(&run_output.stdout);
+        return Err(format!("test binary failed:\nstdout: {stdout}\nstderr: {stderr}"));
+    }
+
+    Ok(())
+}
+
+fn extract_rust_test_code(source: &str, rx: &Regex) -> String {
+    let mut code = String::new();
+    for cap in rx.captures_iter(source) {
+        if !code.is_empty() {
+            code.push('\n');
+        }
+        code.push_str(&cap[1]);
+    }
+    code
+}
+
+fn collect_slint_files(dir: &Path) -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    collect_slint_files_recursive(dir, &mut results);
+    results.sort();
+    results
+}
+
+fn collect_slint_files_recursive(dir: &Path, results: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_slint_files_recursive(&path, results);
+        } else if path.extension().is_some_and(|e| e == "slint") {
+            results.push(path);
+        }
+    }
+}

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1554,6 +1554,7 @@ component WindowItem {
 ///
 /// Use the <Link type="MenuBar" /> element to declare a menu bar for the window.
 /// \group:window
+/// \sc
 export component Window inherits WindowItem {
     MenuBar { }
 }

--- a/internal/compiler/generator/slint_sc.rs
+++ b/internal/compiler/generator/slint_sc.rs
@@ -1,16 +1,36 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Stub code generator for the Slint SC (safety-critical) runtime.
+//! Code generator for the Slint SC (safety-critical) runtime.
 
 use crate::CompilerConfiguration;
 use crate::object_tree::Document;
+use itertools::Either;
 use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 
 /// Public entry point called from `generator::generate`.
 pub fn generate(
-    _doc: &Document,
+    doc: &Document,
     _compiler_config: &CompilerConfiguration,
 ) -> std::io::Result<TokenStream> {
-    Ok(TokenStream::new())
+    let mut output = TokenStream::new();
+
+    for (export_name, export) in doc.exports.iter() {
+        let Either::Left(component) = export else { continue };
+        if component.is_global() {
+            continue;
+        }
+        let name = format_ident!("{}", export_name.name.as_str());
+        output.extend(quote! {
+            pub struct #name;
+            impl #name {
+                pub fn new() -> Self {
+                    Self
+                }
+            }
+        });
+    }
+
+    Ok(output)
 }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -859,6 +859,8 @@ pub struct BuiltinElement {
     /// When true this builtin can be declared as a child even if the parent element
     /// does not expose an explicit @children insertion slot.
     pub can_be_declared_without_children_slot: bool,
+    /// When true this element is part of the Slint SC (safety-critical) subset.
+    pub slint_sc: bool,
 }
 
 impl BuiltinElement {

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -199,6 +199,11 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
         // with `parent.docs[1..]`.
         builtin.docs = docs::assemble(entries, parent_builtin);
 
+        builtin.slint_sc = matches!(
+            builtin.docs.first(),
+            Some(crate::doc_comments::ElementDocEntry::Text(desc)) if has_sc_marker(desc)
+        ) || matches!(&base, Base::NativeParent(p) if p.slint_sc);
+
         builtin.disallow_global_types_as_child_elements =
             parse_annotation("disallow_global_types_as_child_elements", &e).is_some();
         builtin.is_non_item_type = parse_annotation("is_non_item_type", &e).is_some();
@@ -302,6 +307,19 @@ fn parse_annotation(key: &str, node: &SyntaxNode) -> Option<Option<SmolStr>> {
         }
     }
     None
+}
+
+/// Check for standalone `\sc` marker in a doc string, ensuring it is not
+/// followed by an alphanumeric or underscore character (avoids matching
+/// `\score`, `\scale`, etc.).
+fn has_sc_marker(doc: &str) -> bool {
+    doc.match_indices("\\sc").any(|(start, _)| {
+        let end = start + 3;
+        match doc.as_bytes().get(end).copied() {
+            None => true,
+            Some(b) => !b.is_ascii_alphanumeric() && b != b'_',
+        }
+    })
 }
 
 use crate::doc_comments as docs;

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -102,14 +102,29 @@ impl Document {
             }
         }
 
+        #[cfg(feature = "slint-sc")]
+        let mut sc_exported_count: u32 = 0;
+
         let mut process_component =
             |n: syntax_nodes::Component,
              diag: &mut BuildDiagnostics,
-             local_registry: &mut TypeRegister| {
+             local_registry: &mut TypeRegister,
+             #[cfg(feature = "slint-sc")] sc_exported_count: &mut u32,
+             #[cfg(feature = "slint-sc")] is_exported: bool| {
                 // Globals already get their own "Globals are not supported" message
                 #[cfg(feature = "slint-sc")]
                 if n.child_text(SyntaxKind::Identifier).as_deref() != Some("global") {
-                    diag.slint_sc_error("Component declarations are", &n.DeclaredIdentifier());
+                    if !is_exported {
+                        diag.slint_sc_error("Component declarations are", &n.DeclaredIdentifier());
+                    } else {
+                        *sc_exported_count += 1;
+                        if *sc_exported_count > 1 {
+                            diag.slint_sc_error(
+                                "Multiple exported components per file are",
+                                &n.DeclaredIdentifier(),
+                            );
+                        }
+                    }
                 }
                 let compo = Component::from_node(n, diag, local_registry);
                 if !local_registry.add(compo.clone()) {
@@ -190,7 +205,15 @@ impl Document {
         for n in node.children() {
             match n.kind() {
                 SyntaxKind::Component => {
-                    process_component(n.into(), diag, &mut local_registry);
+                    process_component(
+                        n.into(),
+                        diag,
+                        &mut local_registry,
+                        #[cfg(feature = "slint-sc")]
+                        &mut sc_exported_count,
+                        #[cfg(feature = "slint-sc")]
+                        false,
+                    );
                 }
                 SyntaxKind::StructDeclaration => {
                     process_struct(n.into(), diag, &mut local_registry, &mut inner_types)
@@ -201,9 +224,15 @@ impl Document {
                 SyntaxKind::ExportsList => {
                     for n in n.children() {
                         match n.kind() {
-                            SyntaxKind::Component => {
-                                process_component(n.into(), diag, &mut local_registry)
-                            }
+                            SyntaxKind::Component => process_component(
+                                n.into(),
+                                diag,
+                                &mut local_registry,
+                                #[cfg(feature = "slint-sc")]
+                                &mut sc_exported_count,
+                                #[cfg(feature = "slint-sc")]
+                                true,
+                            ),
                             SyntaxKind::StructDeclaration => process_struct(
                                 n.into(),
                                 diag,
@@ -1114,7 +1143,7 @@ impl Element {
                 Ok(ty) => {
                     #[cfg(feature = "slint-sc")]
                     match &ty {
-                        ElementType::Builtin(b) => {
+                        ElementType::Builtin(b) if !b.slint_sc => {
                             diag.slint_sc_error(
                                 &format!("The builtin element '{}' is", b.name),
                                 &base_node,

--- a/internal/compiler/tests/syntax/slint-sc/animations.slint
+++ b/internal/compiler/tests/syntax/slint-sc/animations.slint
@@ -4,8 +4,6 @@
 // Animations are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> val;
 //  >                        <error{Property declarations are not supported in Slint SC}
 //                   > <^error{The type 'int' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/bindings.slint
@@ -4,8 +4,6 @@
 // Bindings are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     width: 100px;
 //  >   <error{Bindings are not supported in Slint SC}
 //         >   <^error{Number literals are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/callbacks.slint
+++ b/internal/compiler/tests/syntax/slint-sc/callbacks.slint
@@ -4,8 +4,6 @@
 // Callbacks are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     callback clicked();
 //  >                 <error{Callback declarations are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
+++ b/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
@@ -4,8 +4,6 @@
 // Change callbacks (changed) are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> val: 0;
 //  >                           <error{Property declarations are not supported in Slint SC}
 //                   > <^error{The type 'int' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/children_placeholder.slint
+++ b/internal/compiler/tests/syntax/slint-sc/children_placeholder.slint
@@ -4,8 +4,6 @@
 // The @children placeholder is rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     @children
 //  >       <error{The @children placeholder is not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
+++ b/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Component declarations (exported or not) are rejected in Slint SC mode.
+// Non-exported component declarations are rejected in Slint SC mode.
+// Only one exported component per file is allowed.
 
 component Helper inherits Window { }
 //        >    <error{Component declarations are not supported in Slint SC}
-//                        >     <^error{The builtin element 'Window' is not supported in Slint SC}
-//>                                  <^^<<warning{Component is neither used nor exported}
+//>                                  <^<<warning{Component is neither used nor exported}
 
-export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
-}
+export component First inherits Window { }
+
+export component Second inherits Window { }
+//               >    <error{Multiple exported components per file are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/dialog.slint
+++ b/internal/compiler/tests/syntax/slint-sc/dialog.slint
@@ -4,8 +4,7 @@
 // Dialog is rejected in Slint SC mode.
 
 export component Test inherits Dialog {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Dialog' is not supported in Slint SC}
+//                             >     <error{The builtin element 'Dialog' is not supported in Slint SC}
     Text { text: "hello"; }
 //  >   <error{The builtin element 'Text' is not supported in Slint SC}
 //         >  <^error{Bindings are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/elements.slint
+++ b/internal/compiler/tests/syntax/slint-sc/elements.slint
@@ -4,8 +4,6 @@
 // All builtin elements are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     width: 100px;
 //  >   <error{Bindings are not supported in Slint SC}
 //         >   <^error{Number literals are not supported in Slint SC}
@@ -14,7 +12,6 @@ export component Test inherits Window {
 //          >   <^error{Number literals are not supported in Slint SC}
 
     Rectangle {
-//  >        <error{The builtin element 'Rectangle' is not supported in Slint SC}
         x: 10px;
 //      ^error{Bindings are not supported in Slint SC}
 //         >  <^error{Number literals are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/enums.slint
+++ b/internal/compiler/tests/syntax/slint-sc/enums.slint
@@ -7,6 +7,4 @@ enum MyEnum { a, b, c }
 //   >    <error{Enum declarations are not supported in Slint SC}
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
+++ b/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
@@ -5,7 +5,6 @@
 
 component Foo inherits Window { }
 //        > <error{Component declarations are not supported in Slint SC}
-//                     >     <^error{The builtin element 'Window' is not supported in Slint SC}
 
 export { Foo }
 //       >  <error{Export specifiers are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/expressions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/expressions.slint
@@ -4,8 +4,6 @@
 // All expressions are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     // number literals
     property <int> a: 42;
 //  >                   <error{Property declarations are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/expressions_extra.slint
+++ b/internal/compiler/tests/syntax/slint-sc/expressions_extra.slint
@@ -4,8 +4,6 @@
 // Additional expression types rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     // @markdown
     property <string> a: @markdown("hello");
 //  >                                      <error{Property declarations are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
+++ b/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
@@ -4,19 +4,15 @@
 // Repeated and conditional elements are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 
     for i in [1, 2, 3]: Rectangle { }
 //  >                               <error{Repeated elements (for-in) are not supported in Slint SC}
-//                      >        <^error{The builtin element 'Rectangle' is not supported in Slint SC}
-//           >       <^^error{Array expressions are not supported in Slint SC}
-//            ^^^^error{Number literals are not supported in Slint SC}
-//               ^^^^^error{Number literals are not supported in Slint SC}
-//                  ^^^^^^error{Number literals are not supported in Slint SC}
+//           >       <^error{Array expressions are not supported in Slint SC}
+//            ^^^error{Number literals are not supported in Slint SC}
+//               ^^^^error{Number literals are not supported in Slint SC}
+//                  ^^^^^error{Number literals are not supported in Slint SC}
 
     if true: Rectangle { }
 //  >                    <error{Conditional elements (if) are not supported in Slint SC}
-//           >        <^error{The builtin element 'Rectangle' is not supported in Slint SC}
-//     >  <^^error{Identifier references are not supported in Slint SC}
+//     >  <^error{Identifier references are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/functions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/functions.slint
@@ -4,8 +4,6 @@
 // Functions are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     public function my-func() -> int { return 42; }
 //  >                                             <error{Function declarations are not supported in Slint SC}
 //                               >  <^error{The type 'int' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/globals.slint
+++ b/internal/compiler/tests/syntax/slint-sc/globals.slint
@@ -12,6 +12,4 @@ global MyGlobal {
 }
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/imports.slint
+++ b/internal/compiler/tests/syntax/slint-sc/imports.slint
@@ -7,6 +7,4 @@ import { Button } from "std-widgets.slint";
 //                     >                 <error{Imports are not supported in Slint SC}
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/inheritance.slint
+++ b/internal/compiler/tests/syntax/slint-sc/inheritance.slint
@@ -5,9 +5,7 @@
 
 component Base inherits Window { }
 //        >  <error{Component declarations are not supported in Slint SC}
-//                      >     <^error{The builtin element 'Window' is not supported in Slint SC}
 
 export component Test inherits Base {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >   <^error{Inheriting from user-defined components is not supported in Slint SC}
+//                             >   <error{Inheriting from user-defined components is not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/init_callback.slint
+++ b/internal/compiler/tests/syntax/slint-sc/init_callback.slint
@@ -4,8 +4,6 @@
 // init callbacks are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     init => { debug("hello"); }
 //  >error{Callback handlers are not supported in Slint SC}
 //            >            <^error{Function calls are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/layout.slint
+++ b/internal/compiler/tests/syntax/slint-sc/layout.slint
@@ -4,12 +4,9 @@
 // Layouts are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 
     HorizontalLayout {
 //  >               <error{The builtin element 'HorizontalLayout' is not supported in Slint SC}
         Rectangle { }
-//      >        <error{The builtin element 'Rectangle' is not supported in Slint SC}
     }
 }

--- a/internal/compiler/tests/syntax/slint-sc/path.slint
+++ b/internal/compiler/tests/syntax/slint-sc/path.slint
@@ -4,8 +4,6 @@
 // Path element is rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     Path {
 //  >   <error{The builtin element 'Path' is not supported in Slint SC}
         width: 100px;

--- a/internal/compiler/tests/syntax/slint-sc/popup.slint
+++ b/internal/compiler/tests/syntax/slint-sc/popup.slint
@@ -4,8 +4,6 @@
 // PopupWindow is rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 
     popup := PopupWindow {
 //           >          <error{The builtin element 'PopupWindow' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/properties.slint
+++ b/internal/compiler/tests/syntax/slint-sc/properties.slint
@@ -4,8 +4,6 @@
 // Property declarations are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> a: 1;
 //  >                         <error{Property declarations are not supported in Slint SC}
 //                   > <^error{The type 'int' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/states.slint
+++ b/internal/compiler/tests/syntax/slint-sc/states.slint
@@ -4,8 +4,6 @@
 // States and transitions are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <bool> active;
 //  >                            <error{Property declarations are not supported in Slint SC}
 //                   >  <^error{The type 'bool' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/structs.slint
+++ b/internal/compiler/tests/syntax/slint-sc/structs.slint
@@ -12,6 +12,4 @@ struct MyStruct {
 }
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/timer.slint
+++ b/internal/compiler/tests/syntax/slint-sc/timer.slint
@@ -4,8 +4,6 @@
 // Timers are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
 
     Timer {
 //  >    <error{The builtin element 'Timer' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
@@ -4,8 +4,6 @@
 // Two-way bindings are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     in-out property <int> a: 1;
 //  >                         <error{Property declarations are not supported in Slint SC}
 //                   > <^error{The type 'int' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/types.slint
+++ b/internal/compiler/tests/syntax/slint-sc/types.slint
@@ -4,8 +4,6 @@
 // All types are rejected in Slint SC mode, including arrays and inline structs.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     property <[string]> a;
 //  >                    <error{Property declarations are not supported in Slint SC}
 //            >      <^error{Array types are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/units.slint
+++ b/internal/compiler/tests/syntax/slint-sc/units.slint
@@ -4,8 +4,6 @@
 // Number literals with units are rejected in Slint SC mode.
 
 export component Test inherits Window {
-//               >  <error{Component declarations are not supported in Slint SC}
-//                             >     <^error{The builtin element 'Window' is not supported in Slint SC}
     property <length> a: 100px;
 //  >                         <error{Property declarations are not supported in Slint SC}
 //            >    <^error{The type 'length' is not supported in Slint SC}


### PR DESCRIPTION
Allow a single `export component Foo inherits Window {}` per file. 
Non-exported components and multiple exports per file are rejected.           
                                                                  
The `\sc` doc-comment marker on builtin elements now also controls which elements pass the SC check at compile time. Added on Window.                                                                                                                                                      
                                                                                                                                                                                              
The code generator emits a pub struct with a `new() -> Self` constructor for each exported component.                                                                                       
                                                                                                                                                                                            
A custom test driver (api/slint-sc/tests/driver.rs, harness = false) runs `slint-compiler --slint-sc` and then rustc directly for each .slint file under tests/cases/. Tests run in parallel via rayon with colored PASS/FAIL output. Coverage instrumentation is propagated when running under cargo-llvm-cov.