### PR TITLE
Python generator: annotate Point/Size with slint.LogicalPosition / sl…

### DIFF
--- a/api/python/slint/tests/test_api_match.py
+++ b/api/python/slint/tests/test_api_match.py
@@ -28,7 +28,7 @@ def test_no_change() -> None:
         base_dir() / "api-match.slint",
         expected_api_base64_compressed=compress_and_encode(r"""
         {
-            "version":"2.0",
+            "version":"2.1",
             "globals":[],
             "components":[
                 {
@@ -54,7 +54,7 @@ def test_incompatible_changes() -> None:
             base_dir() / "api-match.slint",
             expected_api_base64_compressed=compress_and_encode(r"""
             {
-                "version":"2.0",
+                "version":"2.1",
                 "globals":[],
                 "components":[
                     {

--- a/api/python/slint/tests/test_logical_position.py
+++ b/api/python/slint/tests/test_logical_position.py
@@ -3,8 +3,10 @@
 
 """Tests for the LogicalPosition and LogicalSize value classes."""
 
+import typing
 from pathlib import Path
 
+import pytest
 import slint
 
 
@@ -73,3 +75,26 @@ def test_round_trip_through_slint_property(tmp_path: Path) -> None:
 
     app.s = slint.LogicalSize(100.0, 50.0)
     assert app.s == slint.LogicalSize(100.0, 50.0)
+
+    # Dict writes round-trip into the pyclass on read.
+    app.p = {"x": 11.0, "y": 12.0}
+    assert app.p == slint.LogicalPosition(11.0, 12.0)
+    app.s = {"width": 13.0, "height": 14.0}
+    assert app.s == slint.LogicalSize(13.0, 14.0)
+
+    # NamedTuple writes (with matching field names) round-trip too.
+    PointNT = typing.NamedTuple("PointNT", [("x", float), ("y", float)])
+    SizeNT = typing.NamedTuple("SizeNT", [("width", float), ("height", float)])
+    app.p = PointNT(21.0, 22.0)
+    assert app.p == slint.LogicalPosition(21.0, 22.0)
+    app.s = SizeNT(23.0, 24.0)
+    assert app.s == slint.LogicalSize(23.0, 24.0)
+
+    # Plain tuples are not accepted: the runtime requires a typed value,
+    # dict, or NamedTuple. The generated `.py` annotation reflects this
+    # (slint.LogicalPosition / slint.LogicalSize), so a static type checker
+    # also flags such assignments.
+    with pytest.raises(TypeError):
+        app.p = (31.0, 32.0)  # type: ignore[assignment]
+    with pytest.raises(TypeError):
+        app.s = (33.0, 34.0)  # type: ignore[assignment]

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -319,7 +319,7 @@ impl Default for PyModule {
             // `python_type_name` changes (e.g. Type::Int32 → "int" in 2.0).
             // A previously-generated wrapper that carries an older version
             // is treated as incompatible by `changed_version`.
-            version: SmolStr::new_static("2.0"),
+            version: SmolStr::new_static("2.1"),
             globals: Default::default(),
             components: Default::default(),
             structs_and_enums: Default::default(),
@@ -673,12 +673,13 @@ fn python_type_name(ty: &Type) -> SmolStr {
         Type::Array(elem_type) => format_smolstr!("slint.Model[{}]", python_type_name(elem_type)),
         Type::Struct(s) => match &s.name {
             StructName::User { name, .. } => ident(name),
-            StructName::Builtin(
-                crate::langtype::BuiltinStruct::Color
-                | crate::langtype::BuiltinStruct::LogicalPosition
-                | crate::langtype::BuiltinStruct::LogicalSize,
-            )
-            | StructName::None => {
+            StructName::Builtin(crate::langtype::BuiltinStruct::LogicalPosition) => {
+                SmolStr::new_static("slint.LogicalPosition")
+            }
+            StructName::Builtin(crate::langtype::BuiltinStruct::LogicalSize) => {
+                SmolStr::new_static("slint.LogicalSize")
+            }
+            StructName::Builtin(crate::langtype::BuiltinStruct::Color) | StructName::None => {
                 let tuple_types = s.fields.values().map(python_type_name).collect::<Vec<_>>();
                 format_smolstr!("typing.Tuple[{}]", tuple_types.join(", "))
             }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -335,6 +335,7 @@ macro_rules! declare_value_struct_conversion {
 declare_value_struct_conversion!(struct i_slint_core::layout::LayoutInfo { min, max, min_percent, max_percent, preferred, stretch });
 declare_value_struct_conversion!(struct i_slint_core::graphics::Point { x, y, ..Default::default()});
 declare_value_struct_conversion!(struct i_slint_core::api::LogicalPosition { x, y });
+declare_value_struct_conversion!(struct i_slint_core::api::LogicalSize { width, height });
 declare_value_struct_conversion!(struct i_slint_core::properties::StateInfo { current_state, previous_state, change_time });
 
 i_slint_common::for_each_builtin_structs!(declare_value_struct_conversion);

--- a/tests/cases/types/logical_geometry.slint
+++ b/tests/cases/types/logical_geometry.slint
@@ -7,6 +7,39 @@ export component TestCase inherits Window {
 }
 
 /*
+```rust
+let instance = TestCase::new().unwrap();
+let p: slint::LogicalPosition = instance.get_p();
+assert_eq!(p.x, 1.);
+assert_eq!(p.y, 2.);
+let s: slint::LogicalSize = instance.get_s();
+assert_eq!(s.width, 3.);
+assert_eq!(s.height, 4.);
+
+instance.set_p(slint::LogicalPosition::new(10., 20.));
+assert_eq!(instance.get_p(), slint::LogicalPosition::new(10., 20.));
+instance.set_s(slint::LogicalSize::new(30., 40.));
+assert_eq!(instance.get_s(), slint::LogicalSize::new(30., 40.));
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint::LogicalPosition p = instance.get_p();
+assert_eq(p.x, 1);
+assert_eq(p.y, 2);
+slint::LogicalSize s = instance.get_s();
+assert_eq(s.width, 3);
+assert_eq(s.height, 4);
+
+instance.set_p(slint::LogicalPosition({10, 20}));
+assert_eq(instance.get_p().x, 10);
+assert_eq(instance.get_p().y, 20);
+instance.set_s(slint::LogicalSize({30, 40}));
+assert_eq(instance.get_s().width, 30);
+assert_eq(instance.get_s().height, 40);
+```
+
 ```pyi
 class TestCase(slint.Component):
     p: slint.LogicalPosition

--- a/tests/cases/types/logical_geometry.slint
+++ b/tests/cases/types/logical_geometry.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    in-out property <Point> p: { x: 1px, y: 2px };
+    in-out property <Size> s: { width: 3px, height: 4px };
+}
+
+/*
+```pyi
+class TestCase(slint.Component):
+    p: slint.LogicalPosition
+    s: slint.LogicalSize
+```
+*/


### PR DESCRIPTION
…int.LogicalSize

The previous typing.Tuple[float, float] annotation was misleading: the runtime never accepted plain tuples, only the pyclasses, dicts, or NamedTuples. Type checkers blessed code that would fail at runtime; the new annotation lets static and dynamic agree.

PyModule version bumped so stale wrappers report as incompatible rather than as a confusing per-property type-change diff.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
