### PR TITLE
Allow using Skia renderer on Android again

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -308,12 +308,12 @@ wgpu-28 = { workspace = true, optional = true }
 wgpu-29 = { workspace = true, optional = true }
 
 i-slint-backend-winit = { workspace = true, optional = true }
+i-slint-renderer-skia = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # FemtoVG is disabled on android because it doesn't compile without setting RUST_FONTCONFIG_DLOPEN=on
 # end even then wouldn't work because it can't load fonts
 i-slint-renderer-femtovg = { workspace = true, optional = true }
-i-slint-renderer-skia = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-backend-android-activity = { workspace = true, optional = true }

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -88,10 +88,10 @@ cfg-if = "1"
 i-slint-core = { workspace = true }
 i-slint-backend-testing = { workspace = true, optional = true }
 i-slint-core-macros = { workspace = true }
+i-slint-renderer-skia = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 i-slint-backend-winit = { workspace = true, features = ["default", "muda"], optional = true }
-i-slint-renderer-skia = { workspace = true, optional = true }
 i-slint-renderer-femtovg = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
This fixes an issue where if you enabled the renderer-skia feature for the Rust API crate, it would stop building because the internal i-slint-renderer-skia crate wasn't in the dependencies list. I think this was erroneously put under the not(android) block.

I only needed to modify the rs api crate, but I did the same for the backend selector for consistency I guess.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
