### PR TITLE
FlexboxLayout: generate a measure callback for flexbox cross-axis sizing

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -218,6 +218,34 @@ inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexboxL
     return result;
 }
 
+// Like `solve_flexbox_layout`, but with a measure callback used for
+// height-for-width: `measure(index, known_w, known_h)` returns `{width,
+// height}`; an absent optional means "compute it". A negative value over the C
+// ABI denotes an absent dimension.
+template<typename MeasureFn>
+inline SharedVector<float>
+solve_flexbox_layout_with_measure(const cbindgen_private::FlexboxLayoutData &data,
+                                  cbindgen_private::Slice<int> repeater_indices, MeasureFn measure)
+{
+    SharedVector<float> result;
+    cbindgen_private::Slice<uint32_t> ri =
+            make_slice(reinterpret_cast<uint32_t *>(repeater_indices.ptr), repeater_indices.len);
+    auto thunk = [](void *user_data, uintptr_t child_index, float known_width, float known_height,
+                    float *out_width, float *out_height) {
+        auto *f = reinterpret_cast<MeasureFn *>(user_data);
+        auto wh = (*f)(
+                child_index,
+                known_width < 0 ? std::optional<float> {} : std::optional<float> { known_width },
+                known_height < 0 ? std::optional<float> {} : std::optional<float> { known_height });
+        *out_width = wh.first;
+        *out_height = wh.second;
+    };
+    cbindgen_private::slint_solve_flexbox_layout(&data, ri, &result,
+                                                 reinterpret_cast<const void *>(+thunk),
+                                                 reinterpret_cast<void *>(&measure));
+    return result;
+}
+
 inline cbindgen_private::LayoutInfo flexbox_layout_info_main_axis(
         cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells, float spacing,
         const cbindgen_private::Padding &padding, cbindgen_private::FlexboxLayoutWrap flex_wrap)

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4362,6 +4362,71 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             sub_expression,
             ctx,
         ),
+        Expression::SolveFlexboxLayoutWithMeasure {
+            data,
+            repeater_indices,
+            measure_cells,
+            default_cells,
+        } => {
+            let data = compile_expression(data, ctx);
+            let repeater_indices = compile_expression(repeater_indices, ctx);
+            // cbindgen does not expose `LayoutInfo::preferred_bounded()`, so
+            // inline it: preferred_bounded = max(min(preferred, max), min).
+            let mut v_cases = String::new();
+            let mut h_cases = String::new();
+            for (i, item) in measure_cells.iter().enumerate() {
+                if let Either::Left((h_info, v_info)) = item {
+                    let v = compile_expression(v_info, ctx);
+                    let h = compile_expression(h_info, ctx);
+                    v_cases.push_str(&format!(
+                        "case {i}: {{ auto li = {v}; nh = std::max(std::min(li.preferred, li.max), li.min); break; }}\n"
+                    ));
+                    h_cases.push_str(&format!(
+                        "case {i}: {{ auto li = {h}; nw = std::max(std::min(li.preferred, li.max), li.min); break; }}\n"
+                    ));
+                }
+            }
+            // Preferred (default-constraint) size per cell, returned when taffy
+            // asks for a dimension without a known cross-axis size.
+            let mut pref_w = String::new();
+            let mut pref_h = String::new();
+            for item in default_cells {
+                if let Either::Left((h_info, v_info)) = item {
+                    let h = compile_expression(h_info, ctx);
+                    let v = compile_expression(v_info, ctx);
+                    pref_w.push_str(&format!(
+                        "[&]{{ auto li = {h}; return std::max(std::min(li.preferred, li.max), li.min); }}(),\n"
+                    ));
+                    pref_h.push_str(&format!(
+                        "[&]{{ auto li = {v}; return std::max(std::min(li.preferred, li.max), li.min); }}(),\n"
+                    ));
+                }
+            }
+            format!(
+                "slint::private_api::solve_flexbox_layout_with_measure({data}, {repeater_indices}, \
+                 [&](uintptr_t index, std::optional<float> known_w, std::optional<float> known_h) \
+                 -> std::pair<float, float> {{\n\
+                    const float pref_w[] = {{ {pref_w} }};\n\
+                    const float pref_h[] = {{ {pref_h} }};\n\
+                    const size_t cell_count = sizeof(pref_w) / sizeof(float);\n\
+                    float w = known_w.value_or(index < cell_count ? pref_w[index] : 0.0f);\n\
+                    float h = known_h.value_or(index < cell_count ? pref_h[index] : 0.0f);\n\
+                    if (known_w.has_value() && !known_h.has_value()) {{\n\
+                        [[maybe_unused]] float measure_known_w = w;\n\
+                        float nh = h;\n\
+                        switch (index) {{\n{v_cases}default: break;\n}}\n\
+                        return {{ w, nh }};\n\
+                    }}\n\
+                    if (known_h.has_value() && !known_w.has_value()) {{\n\
+                        [[maybe_unused]] float measure_known_h = h;\n\
+                        float nw = w;\n\
+                        switch (index) {{\n{h_cases}default: break;\n}}\n\
+                        return {{ nw, h }};\n\
+                    }}\n\
+                    return {{ w, h }};\n\
+                 }})"
+            )
+        }
         Expression::WithGridInputData {
             cells_variable,
             repeater_indices_var_name,

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3461,6 +3461,19 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             ctx,
         ),
 
+        Expression::SolveFlexboxLayoutWithMeasure {
+            data,
+            repeater_indices,
+            measure_cells,
+            default_cells,
+        } => generate_solve_flexbox_layout_with_measure(
+            data,
+            repeater_indices,
+            measure_cells,
+            default_cells,
+            ctx,
+        ),
+
         Expression::WithGridInputData {
             cells_variable,
             repeater_indices_var_name,
@@ -4738,6 +4751,78 @@ fn generate_with_flexbox_layout_item_info(
         let #cells_v_variable = sp::Slice::from_slice(&items_vec_v);
         #ri_from_slice
         #sub_expression
+    } }
+}
+
+/// Emit a `solve_flexbox_layout_with_measure` call with a generated measure
+/// callback. For each static cell, `measure_cells[i]` is
+/// `(h_info_given_known_h, v_info_given_known_w)` — `LayoutInfo` expressions
+/// that read the `__measure_known_w` / `__measure_known_h` locals. taffy calls
+/// the callback with exactly one of width/height known (the cross axis), so we
+/// recompute that cell's perpendicular info at the assigned dimension.
+fn generate_solve_flexbox_layout_with_measure(
+    data: &Expression,
+    repeater_indices: &Expression,
+    measure_cells: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
+    default_cells: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
+    ctx: &EvaluationContext,
+) -> TokenStream {
+    let data = compile_expression(data, ctx);
+    let repeater_indices = compile_expression(repeater_indices, ctx);
+    let known_w_ident = ident("measure_known_w");
+    let known_h_ident = ident("measure_known_h");
+
+    // Height-for-width / width-for-height: recompute the perpendicular info at
+    // the dimension taffy assigned.
+    let mut v_arms = Vec::new();
+    let mut h_arms = Vec::new();
+    for (i, item) in measure_cells.iter().enumerate() {
+        if let Either::Left((h_info, v_info)) = item {
+            let idx = proc_macro2::Literal::usize_unsuffixed(i);
+            let v = compile_expression(v_info, ctx);
+            let h = compile_expression(h_info, ctx);
+            v_arms.push(quote!(#idx => ({ #v }).preferred_bounded(),));
+            h_arms.push(quote!(#idx => ({ #h }).preferred_bounded(),));
+        }
+        // Repeater cells (the `Right` case) are not emitted; they fall through
+        // to the preferred default below.
+    }
+
+    // Preferred (default-constraint) size per cell, returned when taffy asks
+    // for a dimension without a known cross-axis size (mirrors the plain
+    // `solve_flexbox_layout` measure).
+    let mut def_w = Vec::new();
+    let mut def_h = Vec::new();
+    for item in default_cells {
+        if let Either::Left((h_info, v_info)) = item {
+            let h = compile_expression(h_info, ctx);
+            let v = compile_expression(v_info, ctx);
+            def_w.push(quote!(({ #h }).preferred_bounded(),));
+            def_h.push(quote!(({ #v }).preferred_bounded(),));
+        }
+    }
+
+    quote! { {
+        let pref_w: &[f32] = &[#(#def_w)*];
+        let pref_h: &[f32] = &[#(#def_h)*];
+        let mut measure = |index: usize, known_w: Option<f32>, known_h: Option<f32>| -> (f32, f32) {
+            let w = known_w.unwrap_or_else(|| pref_w.get(index).copied().unwrap_or(0f32));
+            let h = known_h.unwrap_or_else(|| pref_h.get(index).copied().unwrap_or(0f32));
+            if known_w.is_some() && known_h.is_none() {
+                let #known_w_ident = w;
+                let _ = #known_w_ident;
+                let nh = match index { #(#v_arms)* _ => h };
+                return (w, nh);
+            }
+            if known_h.is_some() && known_w.is_none() {
+                let #known_h_ident = h;
+                let _ = #known_h_ident;
+                let nw = match index { #(#h_arms)* _ => w };
+                return (nw, h);
+            }
+            (w, h)
+        };
+        sp::solve_flexbox_layout_with_measure(&#data, #repeater_indices, Some(&mut measure))
     } }
 }
 

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -232,6 +232,27 @@ pub enum Expression {
         elements: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
         sub_expression: Box<Expression>,
     },
+    /// Calls `solve_flexbox_layout_with_measure` with a generated measure
+    /// callback so the cross-axis size of height-for-width cells is recomputed
+    /// at the width/height taffy actually assigns (rather than the cell's
+    /// preferred size). `data` is the `FlexboxLayoutData`. For each static cell,
+    /// `measure_cells[i]` is `(h_info_given_known_h, v_info_given_known_w)`,
+    /// each a `LayoutInfo`-typed expression that reads
+    /// `ReadLocalVariable("measure_known_w" / "measure_known_h")` (a `Float32`)
+    /// as its cross-axis constraint. `default_cells[i]` is the cell's
+    /// `(h_info, v_info)` at the default constraint (matching `data`'s cells);
+    /// it provides the preferred size returned when taffy asks for a dimension
+    /// without a known cross-axis size (mirroring the plain `solve_flexbox_layout`
+    /// measure). Repeater cells (the `Right` case) are not routed through the
+    /// callback yet.
+    SolveFlexboxLayoutWithMeasure {
+        /// The `FlexboxLayoutData` (built inline with the cell arrays, so its
+        /// temporaries live for the duration of the solve call).
+        data: Box<Expression>,
+        repeater_indices: Box<Expression>,
+        measure_cells: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
+        default_cells: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
+    },
     /// Will call the sub_expression, with the cells variable set to the
     /// array of GridLayoutInputData from the elements
     WithGridInputData {
@@ -386,6 +407,7 @@ impl Expression {
             Self::GridRepeaterCacheAccess { .. } => Type::LogicalLength,
             Self::WithLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
             Self::WithFlexboxLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
+            Self::SolveFlexboxLayoutWithMeasure { .. } => Type::LayoutCache,
             Self::WithGridInputData { sub_expression, .. } => sub_expression.ty(ctx),
             Self::MinMax { ty, .. } => ty.clone(),
             Self::EmptyComponentFactory => Type::ComponentFactory,
@@ -491,6 +513,23 @@ macro_rules! visit_impl {
             Expression::WithFlexboxLayoutItemInfo { elements, sub_expression, .. } => {
                 $visitor(sub_expression);
                 elements.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
+                    $visitor(h);
+                    $visitor(v);
+                });
+            }
+            Expression::SolveFlexboxLayoutWithMeasure {
+                data,
+                repeater_indices,
+                measure_cells,
+                default_cells,
+            } => {
+                $visitor(data);
+                $visitor(repeater_indices);
+                measure_cells.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
+                    $visitor(h);
+                    $visitor(v);
+                });
+                default_cells.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
                     $visitor(h);
                     $visitor(v);
                 });

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -410,11 +410,107 @@ pub(super) fn solve_flexbox_layout(
                 return_ty: Type::LayoutCache,
             }),
         },
-        None => llr_Expression::ExtraBuiltinFunctionCall {
-            function: "solve_flexbox_layout".into(),
-            arguments: vec![data, empty_int32_slice()],
-            return_ty: Type::LayoutCache,
-        },
+        None => {
+            // Only height-for-width-capable cells benefit from re-measuring;
+            // a flexbox without any keeps the cheaper plain solve.
+            let needs_measure = layout.elems.iter().any(|li| {
+                let elem = &li.item.element;
+                is_height_for_width_cell(elem)
+                    || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
+            });
+            if !needs_measure {
+                return llr_Expression::ExtraBuiltinFunctionCall {
+                    function: "solve_flexbox_layout".into(),
+                    arguments: vec![data, empty_int32_slice()],
+                    return_ty: Type::LayoutCache,
+                };
+            }
+            // Static cells only: emit a generated measure callback so the
+            // cross-axis size of height-for-width cells is recomputed at the
+            // width/height taffy assigns, instead of the cell's preferred
+            // size (parity with the interpreter).
+            let measure_cells = layout
+                .elems
+                .iter()
+                .map(|li| {
+                    let elem = &li.item.element;
+                    let v_constraint = is_height_for_width_cell(elem).then(|| {
+                        crate::expression_tree::Expression::ReadLocalVariable {
+                            name: "measure_known_w".into(),
+                            ty: Type::LogicalLength,
+                        }
+                    });
+                    let v_info = get_layout_info(
+                        elem,
+                        ctx,
+                        &li.item.constraints,
+                        Orientation::Vertical,
+                        v_constraint,
+                    );
+                    let h_constraint =
+                        elem.borrow().inherited_layout_info_h_with_constraint().is_some().then(
+                            || crate::expression_tree::Expression::ReadLocalVariable {
+                                name: "measure_known_h".into(),
+                                ty: Type::LogicalLength,
+                            },
+                        );
+                    let h_info = get_layout_info(
+                        elem,
+                        ctx,
+                        &li.item.constraints,
+                        Orientation::Horizontal,
+                        h_constraint,
+                    );
+                    Either::Left((h_info, v_info))
+                })
+                .collect();
+            // Preferred (default-constraint) info per cell, matching the cells
+            // carried by `data`. Returned by the measure callback when taffy
+            // asks for a dimension without a known cross-axis size, so the
+            // both-unknown case mirrors the plain `solve_flexbox_layout`.
+            let default_cells = layout
+                .elems
+                .iter()
+                .map(|li| {
+                    let elem = &li.item.element;
+                    let v_constraint = if is_height_for_width_cell(elem) {
+                        default_cross_axis_constraint(elem)
+                    } else {
+                        None
+                    };
+                    let v_info = get_layout_info(
+                        elem,
+                        ctx,
+                        &li.item.constraints,
+                        Orientation::Vertical,
+                        v_constraint,
+                    );
+                    let h_constraint =
+                        elem.borrow().inherited_layout_info_h_with_constraint().is_some().then(
+                            || {
+                                crate::expression_tree::Expression::NumberLiteral(
+                                    f32::MAX as f64,
+                                    crate::expression_tree::Unit::Px,
+                                )
+                            },
+                        );
+                    let h_info = get_layout_info(
+                        elem,
+                        ctx,
+                        &li.item.constraints,
+                        Orientation::Horizontal,
+                        h_constraint,
+                    );
+                    Either::Left((h_info, v_info))
+                })
+                .collect();
+            llr_Expression::SolveFlexboxLayoutWithMeasure {
+                data: Box::new(data),
+                repeater_indices: Box::new(empty_int32_slice()),
+                measure_cells,
+                default_cells,
+            }
+        }
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -71,6 +71,7 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::GridRepeaterCacheAccess { .. } => PROPERTY_ACCESS_COST,
         Expression::WithLayoutItemInfo { .. } => return isize::MAX,
         Expression::WithFlexboxLayoutItemInfo { .. } => return isize::MAX,
+        Expression::SolveFlexboxLayoutWithMeasure { .. } => return isize::MAX,
         Expression::WithGridInputData { .. } => return isize::MAX,
         Expression::MinMax { .. } => 10,
         Expression::EmptyComponentFactory => 10,

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -458,6 +458,9 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             Expression::WithFlexboxLayoutItemInfo { .. } => {
                 write!(f, "WithFlexboxLayoutItemInfo(TODO)",)
             }
+            Expression::SolveFlexboxLayoutWithMeasure { .. } => {
+                write!(f, "SolveFlexboxLayoutWithMeasure(TODO)",)
+            }
             Expression::WithGridInputData { .. } => write!(f, "WithGridInputData(TODO)",),
             Expression::MinMax { ty: _, op, lhs, rhs } => match op {
                 MinMaxOp::Min => write!(f, "min({}, {})", e(lhs), e(rhs)),

--- a/tests/cases/layout/flexbox_component_with_wrap.slint
+++ b/tests/cases/layout/flexbox_component_with_wrap.slint
@@ -11,7 +11,7 @@ component Card inherits Rectangle {
     background: #e0e0e0;
     VerticalLayout {
         padding: 5px;
-        Text {
+        t := Text {
             text: "A card component with text that should word-wrap when the card is narrow enough";
             wrap: word-wrap;
             horizontal-alignment: left;
@@ -21,6 +21,7 @@ component Card inherits Rectangle {
             background: #ccc;
         }
     }
+    out property <length> text_h: t.height;
 }
 
 export component TestCase inherits Window {
@@ -41,11 +42,19 @@ export component TestCase inherits Window {
         }
     }
 
-    // The card should be beside the rectangle with non-zero dimensions.
-    // No recursion panic means the cross-axis constraint propagates
-    // through the component boundary correctly.
+    // Single-line reference Text in the same font, so the check doesn't
+    // depend on the renderer's font metrics (some drivers, e.g. nodejs,
+    // don't install the deterministic test fonts).
+    ref := Text {
+        text: "Reference";
+    }
+
+    // The wrapping Text must actually wrap to several lines (height above a
+    // single line). Before the height-for-width fix the generated code
+    // computed the card height at the Text's preferred (single-line) width,
+    // so the Text came out ~1 line tall.
     out property <bool> test_r: r.x == 0px && r.width == 50px;
-    out property <bool> test_c: c.width > 0px && c.height > 0px;
+    out property <bool> test_c: c.width > 0px && c.text_h > ref.height * 1.5;
 
     out property <bool> test: test_r && test_c;
 }

--- a/tests/cases/layout/flexbox_nested_component_with_wrap.slint
+++ b/tests/cases/layout/flexbox_nested_component_with_wrap.slint
@@ -12,23 +12,25 @@ component Inner inherits Rectangle {
     background: #ccc;
     VerticalLayout {
         padding: 3px;
-        Text {
+        t := Text {
             text: "Innermost text that should word-wrap when narrow";
             wrap: word-wrap;
         }
     }
+    out property <length> text_h: t.height;
 }
 
 component Outer inherits Rectangle {
     background: #e0e0e0;
     VerticalLayout {
         padding: 5px;
-        Inner { }
+        inner := Inner { }
         Rectangle {
             height: 20px;
             background: #999;
         }
     }
+    out property <length> text_h: inner.text_h;
 }
 
 export component TestCase inherits Window {
@@ -49,8 +51,17 @@ export component TestCase inherits Window {
         }
     }
 
+    // Single-line reference Text in the same font, so the check doesn't
+    // depend on the renderer's font metrics.
+    ref := Text {
+        text: "Reference";
+    }
+
+    // The innermost wrapping Text must wrap to several lines (height well
+    // above a single line), proving the width constraint propagates through
+    // both component boundaries down to the Text.
     out property <bool> test_r: r.x == 0px && r.width == 50px;
-    out property <bool> test_o: o.width > 0px && o.height > 0px;
+    out property <bool> test_o: o.width > 0px && o.text_h > ref.height * 1.5;
 
     out property <bool> test: test_r && test_o;
 }

--- a/tests/cases/layout/flexbox_shrunk_wrap_height.slint
+++ b/tests/cases/layout/flexbox_shrunk_wrap_height.slint
@@ -1,0 +1,70 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A wrapping Text inside a component used as a flex-shrunk cell. The card is
+// squeezed well below the text's preferred (single-line) width, so the text
+// must wrap to several lines and the card needs a tall height.
+//
+// This exercises height-for-width re-measurement at the actual assigned
+// width. The interpreter re-measures via a measure callback; the generated
+// (rust/C++) code must do the same, otherwise it computes the height at the
+// preferred (single-line) width and the card comes out far too short.
+
+component Card inherits Rectangle {
+    HorizontalLayout {
+        padding: 4px;
+        t := Text {
+            text: "A fairly long sentence that has to word-wrap into several lines once the card is squeezed narrow by the flexbox";
+            wrap: word-wrap;
+        }
+    }
+    out property <length> text_h: t.height;
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 400px;
+
+    VerticalLayout {
+        spacing: 5px;
+        FlexboxLayout {
+            spacing: 10px;
+            padding: 6px;
+            flex-wrap: no-wrap;
+            align-items: start;
+            vertical-stretch: 0;
+            Rectangle { width: 60px; height: 60px; flex-shrink: 0; }
+            card := Card { flex-shrink: 1; }
+        }
+        Rectangle { vertical-stretch: 1; }
+    }
+
+    // Single-line reference Text in the same font, so the check is
+    // independent of the renderer's font metrics (some test drivers, e.g.
+    // nodejs, don't install the deterministic test fonts).
+    ref := Text {
+        text: "Reference";
+    }
+
+    // Squeezed narrow, the sentence wraps to many lines: its laid-out height
+    // is well above a single line. Computed at the preferred (single-line)
+    // width — the bug — it would be ~1 line.
+    out property <bool> test: card.text_h > ref.height * 1.5;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_three_level_component_with_wrap.slint
+++ b/tests/cases/layout/flexbox_three_level_component_with_wrap.slint
@@ -12,12 +12,13 @@ component Inner inherits Rectangle {
     background: #e0e0e0;
     VerticalLayout {
         padding: 5px;
-        Text {
+        t := Text {
             text: "Text that should word-wrap when the card is narrow enough";
             wrap: word-wrap;
             horizontal-alignment: left;
         }
     }
+    out property <length> text_h: t.height;
 }
 
 component Mid inherits Inner { }
@@ -42,8 +43,16 @@ export component TestCase inherits Window {
         }
     }
 
+    // Single-line reference Text in the same font, so the check doesn't
+    // depend on the renderer's font metrics.
+    ref := Text {
+        text: "Reference";
+    }
+
+    // The wrapping Text reached through three levels of `inherits` must
+    // wrap to several lines (height well above a single line).
     out property <bool> test_r: r.x == 0px && r.width == 50px;
-    out property <bool> test_c: c.width > 0px && c.height > 20px;
+    out property <bool> test_c: c.width > 0px && c.text_h > ref.height * 1.5;
 
     out property <bool> test: test_r && test_c;
 }


### PR DESCRIPTION
compiler: re-measure flexbox cells at the assigned cross-axis size

The rust and C++ generators used the plain `solve_flexbox_layout`, which
sizes cells at their preferred cross-axis dimension — so a flex-shrunk
cell (e.g. a wrapping Text) came out wrong, unlike the interpreter which
re-measures. Generate a measure callback instead, recomputing a cell's
perpendicular layoutinfo at the dimension taffy assigns, for both axes
(height-for-width and width-for-height). Flexboxes with no
cross-axis-dependent cell keep the plain solve.

Test: flexbox_shrunk_wrap_height.slint (rust/cpp/interpreter).
and this allows to make the other tests stricter (they were only passing before
because they were only checking `width > 0 && height > 0` to ensure no recursion panic)