### PR TITLE
TextInput: accessible set value

### DIFF
--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -4,8 +4,8 @@
 //! Pass that lowers synthetic `accessible-*` properties
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{Expression, NamedReference};
-use crate::langtype::EnumerationValue;
+use crate::expression_tree::{Callable, Expression, NamedReference};
+use crate::langtype::{EnumerationValue, Type};
 use crate::object_tree::{Component, ElementRc};
 
 use smol_str::SmolStr;
@@ -96,6 +96,29 @@ fn apply_builtin(e: &ElementRc) {
         e.borrow_mut().set_binding_if_not_set("accessible-read-only".into(), || {
             Expression::PropertyReference(read_only_prop)
         });
+        {
+            // Setup callback for accessible-action-set-value
+            let text_prop = NamedReference::new(e, SmolStr::new_static("text"));
+            let edited_callback = NamedReference::new(e, SmolStr::new_static("edited"));
+            e.borrow_mut().set_binding_if_not_set("accessible-action-set-value".into(), || {
+                Expression::CodeBlock(vec![
+                    Expression::SelfAssignment {
+                        lhs: Box::new(Expression::PropertyReference(text_prop.clone())),
+                        rhs: Box::new(Expression::FunctionParameterReference {
+                            index: 0,
+                            ty: Type::String,
+                        }),
+                        op: '=',
+                        node: None,
+                    },
+                    Expression::FunctionCall {
+                        function: Callable::Callback(edited_callback),
+                        arguments: vec![],
+                        source_location: None,
+                    },
+                ])
+            });
+        }
     } else if bty.name == "Image" {
         e.borrow_mut().set_binding_if_not_set("accessible-role".into(), || {
             let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone());

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -411,8 +411,11 @@ impl<Unit> Property<Length<crate::Coord, Unit>> {
         // Safety: the BindingCallable will cast its argument to T
         unsafe {
             self.handle.set_binding::<Length<crate::Coord, Unit>, core::cell::RefCell<PropertyPhysicsAnimationData<S>>>(RefCell::new(PropertyPhysicsAnimationData::new(
-                simulation_data.simulation(self.get_internal().0 as f32, limit_value),
-            )));
+                    simulation_data.simulation(self.get_internal().0 as f32, limit_value),
+                )),
+                #[cfg(slint_debug_property)]
+                self.debug_name.borrow().as_str()
+            );
         }
         self.handle.mark_dirty(
             #[cfg(slint_debug_property)]

--- a/tests/cases/accessibility/textinput.slint
+++ b/tests/cases/accessibility/textinput.slint
@@ -10,16 +10,6 @@ export component TestCase inherits Window {
     out property <string> text_input_text: ti.text;
     out property <string> line_edit_text: le.text;
 
-    callback set_text_input_text_using_accessible();
-    set_text_input_text_using_accessible => {
-        ti.accessible-action-set-value("Hello");
-    }
-
-    callback set_line_edit_text_using_accessible();
-    set_line_edit_text_using_accessible => {
-        le.accessible-action-set-value("World");
-    }
-
     ti := TextInput {
         text: "123";
     }
@@ -30,21 +20,6 @@ export component TestCase inherits Window {
 }
 
 /*
-
-```rust
-// Test that when setting the value of the TextInput using the accessible, the value is preserved
-
-let instance = TestCase::new().unwrap();
-
-assert_eq!(instance.get_text_input_text(), "123");
-instance.invoke_set_text_input_text_using_accessible();
-assert_eq!(instance.get_text_input_text(), "Hello");
-
-assert_eq!(instance.get_line_edit_text(), "456");
-instance.invoke_set_line_edit_text_using_accessible();
-assert_eq!(instance.get_line_edit_text(), "World");
-```
-
 ```rust
 // Test that when setting the value of the TextInput using the accessible, the value is preserved
 

--- a/tests/cases/accessibility/textinput.slint
+++ b/tests/cases/accessibility/textinput.slint
@@ -1,0 +1,73 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { LineEdit } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 400px;
+
+    out property <string> text_input_text: ti.text;
+    out property <string> line_edit_text: le.text;
+
+    callback set_text_input_text_using_accessible();
+    set_text_input_text_using_accessible => {
+        ti.accessible-action-set-value("Hello");
+    }
+
+    callback set_line_edit_text_using_accessible();
+    set_line_edit_text_using_accessible => {
+        le.accessible-action-set-value("World");
+    }
+
+    ti := TextInput {
+        text: "123";
+    }
+
+    le := LineEdit {
+        text: "456";
+    }
+}
+
+/*
+
+```rust
+// Test that when setting the value of the TextInput using the accessible, the value is preserved
+
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_text_input_text(), "123");
+instance.invoke_set_text_input_text_using_accessible();
+assert_eq!(instance.get_text_input_text(), "Hello");
+
+assert_eq!(instance.get_line_edit_text(), "456");
+instance.invoke_set_line_edit_text_using_accessible();
+assert_eq!(instance.get_line_edit_text(), "World");
+```
+
+```rust
+// Test that when setting the value of the TextInput using the accessible, the value is preserved
+
+let instance = TestCase::new().unwrap();
+
+{
+    let text_input = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::ti").next().unwrap();
+    assert_eq!(text_input.accessible_value(), Some("123".into()));
+    assert_eq!(instance.get_text_input_text(), "123");
+    text_input.set_accessible_value("Hello");
+    assert_eq!(text_input.accessible_value(), Some("Hello".into()));
+    assert_eq!(instance.get_text_input_text(), "Hello", "Test component was not notified");
+}
+
+{
+    let line_edit = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::le").next().unwrap();
+    assert_eq!(line_edit.accessible_value(), Some("456".into()));
+    assert_eq!(instance.get_line_edit_text(), "456");
+    line_edit.set_accessible_value("World");
+    assert_eq!(line_edit.accessible_value(), Some("World".into()));
+    assert_eq!(instance.get_line_edit_text(), "World", "Test component was not notified");
+}
+```
+
+
+*/


### PR DESCRIPTION
- [] ~~If the change modifies a visible behavior, it changes the documentation accordingly~~
- [x] If possible, the change is auto-tested
- [ ] ~~If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`~~
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
