### PR TITLE
Fix context menu activating on right-click release after repositioning

### DIFF
--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -103,6 +103,11 @@ export component MenuItemBase {
     in property <int> font-weight <=> label.font-weight;
     in property <length> border-radius <=> background-layer.border-radius;
     in property <bool> is-current;
+    // Time at which the item was created, used to suppress accidental
+    // activation from the mouse-up that opened the menu.
+    property <duration> open-time;
+    property <bool> had-press;
+    init => { open-time = animation-tick(); }
     in property <MenuEntry> entry;
     in property <image> sub-menu-icon;
     in property <length> spacing <=> layout.spacing;
@@ -173,7 +178,11 @@ export component MenuItemBase {
                     root.set-current()
                 } else if event.kind == PointerEventKind.down && entry.has-sub-menu && entry.enabled {
                     activate(entry, self.absolute-position.y);
+                } else if event.kind == PointerEventKind.down {
+                    // A deliberate press always enables activation
+                    root.had-press = true;
                 } else if event.kind == PointerEventKind.up
+                        && (root.had-press || animation-tick() - root.open-time > 300ms)
                         && self.mouse-y > 0 && self.mouse-y < self.height
                         && self.mouse-x > 0 && self.mouse-x < self.width
                         && entry.enabled {

--- a/tests/cases/widgets/contextmenu.slint
+++ b/tests/cases/widgets/contextmenu.slint
@@ -94,6 +94,33 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
 // verify that the checked menu item is not checked
 assert!(!instance.get_checkable_menu_item_checked());
+
+// Test that right-click release immediately after opening does not activate (issue #11824).
+// Advance mock time so animation-tick() is not zero.
+slint_testing::mock_elapsed_time(500);
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+// Move to entry and release right button without delay — must NOT activate.
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(25.0, 25.0) });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(25.0, 25.0), button: PointerEventButton::Right });
+assert_eq!(instance.get_result(), "");
+
+// Re-open and verify left-click still activates immediately.
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(25.0, 25.0), button: PointerEventButton::Left });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(25.0, 25.0), button: PointerEventButton::Left });
+assert_eq!(instance.get_result(), "Entry1");
+
+// Re-open, wait 300ms, then right-click should activate.
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+slint_testing::mock_elapsed_time(300);
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(25.0, 25.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(25.0, 25.0), button: PointerEventButton::Right });
+assert_eq!(instance.get_result(), "Entry1");
 ```
 
 ```cpp
@@ -121,6 +148,31 @@ slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_cod
 slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::UpArrow);
 slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::Return);
 assert_eq(instance.get_result(), "Open2");
+
+// Test that right-click release immediately after opening does not activate (issue #11824).
+slint_testing::mock_elapsed_time(500);
+instance.set_result("");
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({25.0, 25.0}));
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({25.0, 25.0}), slint::PointerEventButton::Right);
+assert_eq(instance.get_result(), "");
+
+// Re-open and verify left-click still activates immediately.
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({25.0, 25.0}), slint::PointerEventButton::Left);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({25.0, 25.0}), slint::PointerEventButton::Left);
+assert_eq(instance.get_result(), "Entry1");
+
+// Re-open, wait 300ms, then right-click should activate.
+instance.set_result("");
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+slint_testing::mock_elapsed_time(300);
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({25.0, 25.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({25.0, 25.0}), slint::PointerEventButton::Right);
+assert_eq(instance.get_result(), "Entry1");
 
 ```
 */


### PR DESCRIPTION
When a context menu is repositioned (e.g. near screen edges), a menu item can end up under the cursor. The right-button release then immediately activates it. Suppress activation for 300ms after the menu opens unless a deliberate press happened first.

Fixes: #11824
