### PR TITLE
android: Fix panic, compilation warning, and build issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -609,6 +609,8 @@ jobs:
         needs: files-changed
         if: ${{ needs.files-changed.outputs.internal == 'true' || needs.files-changed.outputs.api_rs == 'true' || needs.files-changed.outputs.examples == 'true' }}
         runs-on: ubuntu-latest
+        env:
+            RUSTFLAGS: -D warnings
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/install-linux-dependencies

--- a/api/rs/slint/android.rs
+++ b/api/rs/slint/android.rs
@@ -118,7 +118,7 @@ pub fn init(app: android_activity::AndroidApp) -> Result<(), SetPlatformError> {
     unreachable!();
     #[cfg(target_os = "android")]
     {
-        crate::platform::set_platform(Box::new(
+        crate::platform::set_platform(alloc::boxed::Box::new(
             i_slint_backend_android_activity::AndroidPlatform::new(app),
         ))
     }
@@ -155,7 +155,7 @@ pub fn init_with_event_listener(
     unreachable!();
     #[cfg(target_os = "android")]
     {
-        crate::platform::set_platform(Box::new(
+        crate::platform::set_platform(alloc::boxed::Box::new(
             i_slint_backend_android_activity::AndroidPlatform::new_with_event_listener(
                 app, listener,
             ),

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -199,10 +199,12 @@ each instance will have their own instance of associated globals singletons.
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![allow(clippy::needless_doctest_main)] // We document how to write a main function
 
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(not(feature = "compat-1-2"))]
 compile_error!(

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -13,14 +13,13 @@ use i_slint_core::api::{
     LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, PlatformError, Window,
 };
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventResult, KeyEventType, TouchPhase};
-use i_slint_core::items::ColorScheme;
 use i_slint_core::lengths::PhysicalEdges;
 use i_slint_core::platform::{
     Key, PointerEventButton, WindowAdapter, WindowEvent, WindowProperties,
 };
 use i_slint_core::timers::{Timer, TimerMode};
 use i_slint_core::window::{InputMethodRequest, WindowInner};
-use i_slint_core::{Property, SharedString};
+use i_slint_core::SharedString;
 use i_slint_renderer_skia::{SkiaRenderer, SkiaSharedContext};
 use std::cell::Cell;
 use std::rc::Rc;
@@ -176,16 +175,7 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
 impl AndroidWindowAdapter {
     pub fn new(app: AndroidApp) -> Rc<Self> {
         let java_helper = JavaHelper::new(&app).unwrap_or_else(|e| print_jni_error(&app, e));
-        let initial_scheme =
-            match java_helper.color_scheme().unwrap_or_else(|e| print_jni_error(&app, e)) {
-                0x10 => ColorScheme::Light,  // UI_MODE_NIGHT_NO(0x10)
-                0x20 => ColorScheme::Dark,   // UI_MODE_NIGHT_YES(0x20)
-                0x0 => ColorScheme::Unknown, // UI_MODE_NIGHT_UNDEFINED
-                _ => ColorScheme::Unknown,
-            };
-        let initial_accent =
-            java_helper.accent_color().unwrap_or_else(|e| print_jni_error(&app, e));
-        let rc = Rc::<Self>::new_cyclic(|w| Self {
+        Rc::<Self>::new_cyclic(|w| Self {
             app,
             window: Window::new(w.clone()),
             #[cfg(not(any(feature = "unstable-wgpu-28", feature = "unstable-wgpu-29")))]
@@ -203,11 +193,7 @@ impl AndroidWindowAdapter {
             show_cursor_handles: Cell::new(false),
             long_press: RefCell::default(),
             last_pressed_state: Cell::new(ButtonState(0)),
-        });
-        let ctx = i_slint_core::window::WindowInner::from_pub(&rc.window).context();
-        ctx.set_color_scheme(initial_scheme);
-        ctx.set_accent_color(initial_accent);
-        rc
+        })
     }
 
     pub fn process_event(&self, event: &PollEvent<'_>) -> Result<ControlFlow<()>, PlatformError> {
@@ -540,7 +526,7 @@ impl AndroidWindowAdapter {
     pub fn do_render(&self) -> Result<(), PlatformError> {
         if let Some(win) = self.app.native_window() {
             let o = self.offset.get();
-            self.renderer.render_transformed_with_post_callback(
+            let _ = self.renderer.render_transformed_with_post_callback(
                 0.,
                 (o.x as f32, o.y as f32),
                 PhysicalSize { width: win.width() as _, height: win.height() as _ },

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -9,6 +9,7 @@ use android_activity::input::{
     ButtonState, InputEvent, KeyAction, Keycode, MotionAction, MotionEvent,
 };
 use android_activity::{InputStatus, MainEvent, PollEvent};
+use i_slint_core::SharedString;
 use i_slint_core::api::{
     LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, PlatformError, Window,
 };
@@ -19,7 +20,6 @@ use i_slint_core::platform::{
 };
 use i_slint_core::timers::{Timer, TimerMode};
 use i_slint_core::window::{InputMethodRequest, WindowInner};
-use i_slint_core::SharedString;
 use i_slint_renderer_skia::{SkiaRenderer, SkiaSharedContext};
 use std::cell::Cell;
 use std::rc::Rc;

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -157,6 +157,24 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
         }
     }
 
+    fn bind_context(&self, ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
+        let ctx = ctx.upgrade().expect("bind_context called while the SlintContext is still alive");
+        let color_scheme = match self
+            .window
+            .java_helper
+            .color_scheme()
+            .unwrap_or_else(|e| javahelper::print_jni_error(&self.app, e))
+        {
+            0x10 => i_slint_core::items::ColorScheme::Light, // UI_MODE_NIGHT_NO
+            0x20 => i_slint_core::items::ColorScheme::Dark,  // UI_MODE_NIGHT_YES
+            _ => i_slint_core::items::ColorScheme::Unknown,
+        };
+        ctx.set_color_scheme(color_scheme);
+        if let Ok(accent) = self.window.java_helper.accent_color() {
+            ctx.set_accent_color(accent);
+        }
+    }
+
     fn long_press_interval(&self, _: i_slint_core::InternalToken) -> Duration {
         self.window.java_helper.long_press_timeout().unwrap_or(Duration::from_millis(500))
     }

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -436,11 +436,14 @@ impl BackendSelector {
             return Err(format!("Only the Skia renderer is supported on Android").into());
         }
 
-        if cfg!(feature = "backend-android-activity") {
+        #[cfg(feature = "backend-android-activity")]
+        {
             i_slint_backend_android_activity::set_requested_graphics_api(
                 self.requested_graphics_api.clone(),
             )
-        } else {
+        }
+        #[cfg(not(feature = "backend-android-activity"))]
+        {
             Err(format!(
                 "The BackendSelector is only supported with the backend-android-activity backend"
             )


### PR DESCRIPTION
AndroidPlatform::new() creates an AndroidWindowAdapter which called WindowInner::context() to set the color scheme and accent color. But the SlintContext is only initialized by set_platform(), which runs after AndroidPlatform::new() returns. Move the color scheme and accent color initialization into bind_context(), which is called by set_platform() after the context is ready.

Fix cfg!() vs #[cfg()] in backend-selector: cfg!() is a runtime macro that still compiles both branches

Fix warnings: unused import and must_use.
Deny warnings in the Android CI job so these don't regress.
