### PR TITLE
Fix LSP diagnostics on folder rename

### DIFF
--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -213,6 +213,7 @@ impl Snapshotter {
             global_type_registry: self.snapshot_type_register(&type_loader.global_type_registry),
             compiler_config: type_loader.compiler_config.clone(),
             resolved_style: type_loader.resolved_style.clone(),
+            revision: type_loader.revision,
         })
     }
 
@@ -918,6 +919,9 @@ pub struct TypeLoader {
     /// The style that was specified in the compiler configuration, but resolved. So "native" for example is resolved to the concrete
     /// style.
     pub resolved_style: String,
+    /// The revision in the TypeLoader marks changes to the TypeLoader.
+    /// Any changes should increase the revision number via [Self::bump_revision]
+    revision: u64,
     all_documents: LoadedDocuments,
 }
 
@@ -942,6 +946,7 @@ impl TypeLoader {
             },
             compiler_config,
             resolved_style: style.clone(),
+            revision: 0,
             all_documents: Default::default(),
         };
 
@@ -966,6 +971,14 @@ impl TypeLoader {
         myself
     }
 
+    fn bump_revision(&mut self) {
+        self.revision = self.revision.wrapping_add(1);
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
     /// Drop a document from the TypeLoader and invalidate all of its dependencies.
     /// Returns the list of all (transitive) dependencies.
     ///
@@ -974,6 +987,7 @@ impl TypeLoader {
     pub fn drop_document(&mut self, path: &Path) -> Result<HashSet<PathBuf>, std::io::Error> {
         let dependencies = self.invalidate_document(path);
         self.all_documents.docs.remove(path);
+        self.bump_revision();
 
         if self.all_documents.currently_loading.contains_key(path) {
             Err(std::io::Error::new(ErrorKind::InvalidInput, format!("{path:?} is still loading")))
@@ -1021,6 +1035,7 @@ impl TypeLoader {
             extra_deps.extend(self.invalidate_document(dep));
         }
         extra_deps.extend(deps);
+        self.bump_revision();
         extra_deps
     }
 
@@ -1524,6 +1539,7 @@ impl TypeLoader {
                 .insert(path.clone());
         }
         state.tl.all_documents.docs.insert(path, (LoadedDocument::Document(doc), parse_errors));
+        state.tl.bump_revision();
     }
 
     async fn load_file_impl<'a>(
@@ -2417,10 +2433,42 @@ fn test_snapshotting() {
     assert_eq!(root_element.borrow().base_type.to_string(), "Rectangle");
 
     let copy = snapshot(&type_loader).unwrap();
+    assert_eq!(copy.revision(), type_loader.revision());
 
     let doc = copy.get_document(&path).unwrap();
     let c = doc.inner_components.first().unwrap();
     assert_eq!(c.id, "Foobar");
     let root_element = c.root_element.clone();
     assert_eq!(root_element.borrow().base_type.to_string(), "Rectangle");
+}
+
+#[test]
+fn test_watch_paths_revision_bumps_on_mutations() {
+    let mut type_loader = TypeLoader::new(
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter),
+        &mut BuildDiagnostics::default(),
+    );
+
+    assert_eq!(type_loader.revision(), 0);
+
+    let path = PathBuf::from("/tmp/test-revision.slint");
+    let mut diag = BuildDiagnostics::default();
+    spin_on::spin_on(type_loader.load_file(
+        &path,
+        &path,
+        "export component Foobar inherits Rectangle { }".to_string(),
+        false,
+        &mut diag,
+    ));
+    assert!(!diag.has_errors());
+    let after_load = type_loader.revision();
+    assert_ne!(after_load, 0);
+
+    type_loader.invalidate_document(&path);
+    let after_invalidate = type_loader.revision();
+    assert_ne!(after_invalidate, after_load);
+
+    type_loader.drop_document(&path).unwrap();
+    let after_drop = type_loader.revision();
+    assert_ne!(after_drop, after_invalidate);
 }

--- a/internal/live-preview/file_watcher.rs
+++ b/internal/live-preview/file_watcher.rs
@@ -7,8 +7,6 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 
-use notify::Watcher as _;
-
 /// A normalized file-system change emitted by [`FileWatcher`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FileChangeKind {
@@ -29,9 +27,78 @@ pub struct WatchEvent {
     pub kind: FileChangeKind,
 }
 
+/// The underlying file system watcher implementation (based on notify::RecommendedWatcher by
+/// default)
+pub trait FileWatcherImpl: Sized + 'static {
+    /// The error type used by the [`FileWatcher`].
+    type Error: Send;
+
+    /// Add the given path to the watch set.
+    ///
+    /// Note that the reconcile loop expects to receive events for this path after a successful
+    /// call, so implementations should not return until the watch is fully active and events
+    /// will be received.
+    fn watch(&mut self, path: &Path) -> Result<(), Self::Error>;
+
+    /// Remove the given path from the watch set.
+    fn unwatch(&mut self, path: &Path) -> Result<(), Self::Error>;
+
+    /// The error to return when the worker thread has stopped and can no longer process messages.
+    fn worker_stopped_error() -> Self::Error;
+
+    /// Whether the error is transient and should not be reported to the user, for example
+    /// because it may occur during normal operation when files or probe directories are removed.
+    fn is_transient_watch_error(err: &Self::Error) -> bool;
+
+    /// Whether the implementation needs to watch target files directly in order to receive change
+    /// events, or if watching parent directories is sufficient.
+    fn needs_direct_file_watches() -> bool;
+}
+
+impl FileWatcherImpl for notify::RecommendedWatcher {
+    type Error = notify::Error;
+
+    fn worker_stopped_error() -> Self::Error {
+        notify::Error::generic("file watcher worker thread stopped")
+    }
+
+    fn is_transient_watch_error(err: &Self::Error) -> bool {
+        match &err.kind {
+            notify::ErrorKind::PathNotFound
+            | notify::ErrorKind::WatchNotFound
+            | notify::ErrorKind::Generic(_) => true,
+            notify::ErrorKind::Io(e) => e.kind() == std::io::ErrorKind::NotFound,
+            _ => false,
+        }
+    }
+
+    fn watch(&mut self, path: &Path) -> Result<(), Self::Error> {
+        notify::Watcher::watch(self, path, notify::RecursiveMode::NonRecursive)
+    }
+
+    fn unwatch(&mut self, path: &Path) -> Result<(), Self::Error> {
+        notify::Watcher::unwatch(self, path)
+    }
+
+    fn needs_direct_file_watches() -> bool {
+        // On macOS, notify does not report file changed events, if we only watch the parent
+        // directory, so we need to add a direct file watch as well.
+        cfg!(target_os = "macos")
+    }
+}
+
 /// A file watcher for a set of source or resource paths.
-pub struct FileWatcher {
-    tx: mpsc::Sender<WorkerMessage>,
+///
+/// Given a set of existing and/or non-existing paths, the file watcher will try to minimize the
+/// number of actual OS file watches needed to receive events for all the given paths.
+/// It reconciles the events with the file state and disk and synthesizes  file change events if
+/// e.g. a file in a new directory is created before the OS watch could be set up.
+///
+/// Communication with the OS is abstracted behind a low-level trait ([`FileWatcherImpl`]) which is responsible for
+/// delivering the original file watcher events.
+/// This allows the file watcher to be used with the OS APIs (i.e. notify) or the LSP file watcher.
+pub struct FileWatcher<Impl: FileWatcherImpl = notify::RecommendedWatcher> {
+    tx: mpsc::Sender<WorkerMessage<Impl>>,
 
     /// Use a worker thread for processing file events and updating watches.
     ///
@@ -44,19 +111,43 @@ pub struct FileWatcher {
     worker: Option<JoinHandle<()>>,
 }
 
-impl FileWatcher {
-    /// Creates a watcher and invokes `on_event` for matching watched-path changes.
+impl FileWatcher<notify::RecommendedWatcher> {
+    /// Creates a watcher based on the notify crate and invokes `on_event` for matching watched-path changes.
     ///
     /// Runtime watcher errors are forwarded to `on_error`.
     pub fn start(
         on_event: impl FnMut(WatchEvent) + Send + 'static,
         on_error: impl FnMut(notify::Error) + Send + 'static,
-    ) -> notify::Result<Self> {
+    ) -> Result<Self, notify::Error> {
+        Self::start_with_impl(on_event, on_error, |event_handler| {
+            notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+                // Keep the backend callback lightweight and forward the real work to the worker.
+                //
+                // This is especially needed on inotify backends, where calling watch/unwatch within
+                // the callback can cause a deadlock.
+                let events = event.map(classify_event);
+                event_handler.send(events).ok();
+            })
+        })
+    }
+}
+
+impl<Impl: FileWatcherImpl> FileWatcher<Impl> {
+    /// Creates a watcher and invokes `on_event` for matching watched-path changes.
+    ///
+    /// Runtime watcher errors are forwarded to `on_error`.
+    pub fn start_with_impl(
+        on_event: impl FnMut(WatchEvent) + Send + 'static,
+        on_error: impl FnMut(Impl::Error) + Send + 'static,
+        create_impl: impl FnOnce(FileWatcherEventSink<Impl>) -> Result<Impl, Impl::Error>
+        + Send
+        + 'static,
+    ) -> Result<Self, Impl::Error> {
         let (tx, rx) = mpsc::channel();
         let (startup_tx, startup_rx) = mpsc::sync_channel(1);
         let worker_tx = tx.clone();
         let worker = thread::spawn(move || {
-            worker_loop(rx, worker_tx, startup_tx, on_event, on_error);
+            worker_loop(create_impl, rx, worker_tx, startup_tx, on_event, on_error);
         });
 
         match startup_rx.recv() {
@@ -67,13 +158,13 @@ impl FileWatcher {
             }
             Err(_) => {
                 let _ = worker.join();
-                Err(worker_stopped_error())
+                Err(Impl::worker_stopped_error())
             }
         }
     }
 
     /// Replaces the watched path set with `paths`.
-    pub fn update_watched_paths<I>(&mut self, paths: I) -> notify::Result<()>
+    pub fn update_watched_paths<I>(&mut self, paths: I) -> Result<(), Impl::Error>
     where
         I: IntoIterator<Item = PathBuf>,
     {
@@ -85,12 +176,22 @@ impl FileWatcher {
         let (response_tx, response_rx) = mpsc::sync_channel(1);
         self.tx
             .send(WorkerMessage::UpdateWatchedPaths { watched_files, response: response_tx })
-            .map_err(|_| worker_stopped_error())?;
-        response_rx.recv().map_err(|_| worker_stopped_error())?
+            .map_err(|_| Impl::worker_stopped_error())?;
+        response_rx.recv().map_err(|_| Impl::worker_stopped_error())?
+    }
+
+    /// The [`FileWatcherImpl`] receives a [`FileWatcherEventSink`] on creation.
+    /// However, it is created on the reconcile worker thread, so the caller may not have access to
+    /// it anymore.
+    ///
+    /// This method can be used to get a new sink at any time, for example to send events
+    /// from the main thread.
+    pub fn event_sink(&mut self) -> FileWatcherEventSink<Impl> {
+        FileWatcherEventSink { tx: self.tx.clone() }
     }
 }
 
-impl Drop for FileWatcher {
+impl<Impl: FileWatcherImpl> Drop for FileWatcher<Impl> {
     fn drop(&mut self) {
         let _ = self.tx.send(WorkerMessage::Shutdown);
         if let Some(worker) = self.worker.take() {
@@ -139,12 +240,12 @@ fn classify_event(event: notify::Event) -> Vec<(PathBuf, FileChangeKind)> {
     }
 }
 
-enum WorkerMessage {
+enum WorkerMessage<Impl: FileWatcherImpl> {
     UpdateWatchedPaths {
         watched_files: HashSet<PathBuf>,
-        response: mpsc::SyncSender<notify::Result<()>>,
+        response: mpsc::SyncSender<Result<(), Impl::Error>>,
     },
-    RawEvent(notify::Result<notify::Event>),
+    FileSystemEvents(Result<Vec<(PathBuf, FileChangeKind)>, Impl::Error>),
     Shutdown,
 }
 
@@ -176,12 +277,12 @@ struct WorkerState {
 }
 
 impl WorkerState {
-    fn update_watched_paths(
+    fn update_watched_paths<Impl: FileWatcherImpl>(
         &mut self,
-        watcher: &mut notify::RecommendedWatcher,
+        watcher: &mut Impl,
         watched_files: HashSet<PathBuf>,
         on_event: &mut impl FnMut(WatchEvent),
-    ) -> notify::Result<()> {
+    ) -> Result<(), Impl::Error> {
         let previous_states = watched_files
             .iter()
             .map(|path| {
@@ -199,18 +300,18 @@ impl WorkerState {
         self.reconcile(watcher, previous_states, HashSet::new(), on_event)
     }
 
-    fn handle_raw_event(
+    fn handle_events<Impl: FileWatcherImpl>(
         &mut self,
-        watcher: &mut notify::RecommendedWatcher,
-        event: notify::Event,
+        watcher: &mut Impl,
+        events: Vec<(PathBuf, FileChangeKind)>,
         on_event: &mut impl FnMut(WatchEvent),
-    ) -> notify::Result<()> {
+    ) -> Result<(), Impl::Error> {
         if self.watched_files.is_empty() {
             return Ok(());
         }
 
         let previous_states = self.target_states.clone();
-        let changed_paths = classify_event(event)
+        let changed_paths = events
             .into_iter()
             .filter_map(|(path, kind)| {
                 (kind == FileChangeKind::Changed && self.watched_files.contains(&path))
@@ -221,19 +322,19 @@ impl WorkerState {
         self.reconcile(watcher, previous_states, changed_paths, on_event)
     }
 
-    fn reconcile(
+    fn reconcile<Impl: FileWatcherImpl>(
         &mut self,
-        watcher: &mut notify::RecommendedWatcher,
+        watcher: &mut Impl,
         previous_states: HashMap<PathBuf, TargetState>,
         changed_paths: HashSet<PathBuf>,
         on_event: &mut impl FnMut(WatchEvent),
-    ) -> notify::Result<()> {
+    ) -> Result<(), Impl::Error> {
         const MAX_RECONCILE_PASSES: usize = 8;
 
         let mut target_states = scan_target_states(&self.watched_files);
 
         for _ in 0..MAX_RECONCILE_PASSES {
-            let desired_watches = desired_watches_for_states(&target_states);
+            let desired_watches = desired_watches_for_states::<Impl>(&target_states);
             if desired_watches == self.registered_watches {
                 break;
             }
@@ -275,19 +376,19 @@ impl WorkerState {
         Ok(())
     }
 
-    fn apply_watch_plan(
+    fn apply_watch_plan<Impl: FileWatcherImpl>(
         &mut self,
-        watcher: &mut notify::RecommendedWatcher,
+        watcher: &mut Impl,
         desired_registrations: &HashSet<PathBuf>,
-    ) -> notify::Result<()> {
+    ) -> Result<(), Impl::Error> {
         let current_watches = self.registered_watches.clone();
 
         for registration in desired_registrations.difference(&current_watches) {
-            match watcher.watch(registration, notify::RecursiveMode::NonRecursive) {
+            match watcher.watch(registration) {
                 Ok(()) => {
                     self.registered_watches.insert(registration.clone());
                 }
-                Err(err) if is_transient_watch_error(&err) => {}
+                Err(err) if Impl::is_transient_watch_error(&err) => {}
                 Err(err) => return Err(err),
             }
         }
@@ -295,7 +396,7 @@ impl WorkerState {
         for registration in current_watches.difference(desired_registrations) {
             match watcher.unwatch(registration) {
                 Ok(()) => {}
-                Err(err) if is_transient_watch_error(&err) => {}
+                Err(err) if Impl::is_transient_watch_error(&err) => {}
                 Err(err) => return Err(err),
             }
             self.registered_watches.remove(registration);
@@ -305,20 +406,33 @@ impl WorkerState {
     }
 }
 
-fn worker_loop(
-    rx: mpsc::Receiver<WorkerMessage>,
-    tx: mpsc::Sender<WorkerMessage>,
-    startup_tx: mpsc::SyncSender<notify::Result<()>>,
+/// A handle to the file watcher worker, allowing it to receive file system events and
+/// update watches from the [`FileWatcherImpl`].
+pub struct FileWatcherEventSink<Impl: FileWatcherImpl> {
+    tx: mpsc::Sender<WorkerMessage<Impl>>,
+}
+
+impl<Impl: FileWatcherImpl> FileWatcherEventSink<Impl> {
+    /// Send a file system event to the worker from the [`FileWatcherImpl`].
+    pub fn send(
+        &self,
+        events: Result<Vec<(PathBuf, FileChangeKind)>, Impl::Error>,
+    ) -> Result<(), Impl::Error> {
+        self.tx
+            .send(WorkerMessage::FileSystemEvents(events))
+            .map_err(|_| Impl::worker_stopped_error())
+    }
+}
+
+fn worker_loop<Impl: FileWatcherImpl>(
+    create_impl: impl FnOnce(FileWatcherEventSink<Impl>) -> Result<Impl, Impl::Error> + Send + 'static,
+    rx: mpsc::Receiver<WorkerMessage<Impl>>,
+    tx: mpsc::Sender<WorkerMessage<Impl>>,
+    startup_tx: mpsc::SyncSender<Result<(), Impl::Error>>,
     mut on_event: impl FnMut(WatchEvent) + Send + 'static,
-    mut on_error: impl FnMut(notify::Error) + Send + 'static,
+    mut on_error: impl FnMut(Impl::Error) + Send + 'static,
 ) {
-    let watcher = notify::recommended_watcher(move |event| {
-        // Keep the backend callback lightweight and forward the real work to the worker.
-        //
-        // This is especially needed on inotify backends, where calling watch/unwatch within
-        // the callback can cause a deadlock.
-        let _ = tx.send(WorkerMessage::RawEvent(event));
-    });
+    let watcher = create_impl(FileWatcherEventSink { tx });
 
     let mut watcher = match watcher {
         Ok(watcher) => {
@@ -342,13 +456,13 @@ fn worker_loop(
                     &mut on_event,
                 ));
             }
-            WorkerMessage::RawEvent(Ok(event)) => {
-                if let Err(err) = state.handle_raw_event(&mut watcher, event, &mut on_event) {
+            WorkerMessage::FileSystemEvents(Ok(event)) => {
+                if let Err(err) = state.handle_events(&mut watcher, event, &mut on_event) {
                     on_error(err);
                 }
             }
-            WorkerMessage::RawEvent(Err(err)) => {
-                if !is_transient_watch_error(&err) {
+            WorkerMessage::FileSystemEvents(Err(err)) => {
+                if !Impl::is_transient_watch_error(&err) {
                     on_error(err);
                 }
             }
@@ -370,13 +484,15 @@ fn scan_target_state(path: &Path) -> TargetState {
     }
 }
 
-fn desired_watches_for_states(target_states: &HashMap<PathBuf, TargetState>) -> HashSet<PathBuf> {
+fn desired_watches_for_states<Impl: FileWatcherImpl>(
+    target_states: &HashMap<PathBuf, TargetState>,
+) -> HashSet<PathBuf> {
     let mut watches = target_states
         .values()
         .filter_map(|state| state.probe_dir().cloned())
         .collect::<HashSet<_>>();
 
-    if needs_direct_file_watches() {
+    if Impl::needs_direct_file_watches() {
         watches.extend(
             target_states
                 .iter()
@@ -404,26 +520,6 @@ fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
     }
 
     Some(i_slint_compiler::pathutils::clean_path(current))
-}
-
-fn is_transient_watch_error(err: &notify::Error) -> bool {
-    match &err.kind {
-        notify::ErrorKind::PathNotFound
-        | notify::ErrorKind::WatchNotFound
-        | notify::ErrorKind::Generic(_) => true,
-        notify::ErrorKind::Io(e) => e.kind() == std::io::ErrorKind::NotFound,
-        _ => false,
-    }
-}
-
-fn worker_stopped_error() -> notify::Error {
-    notify::Error::generic("file watcher worker thread stopped")
-}
-
-fn needs_direct_file_watches() -> bool {
-    // On macOS, notify does not report file changed events, if we only watch the parent
-    // directory, so we need to add a direct file watch as well.
-    cfg!(target_os = "macos")
 }
 
 #[cfg(test)]

--- a/internal/live-preview/file_watcher.rs
+++ b/internal/live-preview/file_watcher.rs
@@ -18,10 +18,14 @@ pub enum FileChangeKind {
     Deleted,
 }
 
-/// A file-system event for one watched path.
+/// A file-system event for one path.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WatchEvent {
-    /// The affected watched path.
+    /// The affected path.
+    ///
+    /// Most file watchers only emit watched paths.
+    /// Optionally a FileWatcher can be created with pass_through_unwatched_events = true, in which
+    /// case the path may not be on the list of watched paths.
     pub path: PathBuf,
     /// The normalized change kind for this path.
     pub kind: FileChangeKind,
@@ -119,7 +123,7 @@ impl FileWatcher<notify::RecommendedWatcher> {
         on_event: impl FnMut(WatchEvent) + Send + 'static,
         on_error: impl FnMut(notify::Error) + Send + 'static,
     ) -> Result<Self, notify::Error> {
-        Self::start_with_impl(on_event, on_error, |event_handler| {
+        Self::start_with_impl(on_event, on_error, false, |event_handler| {
             notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
                 // Keep the backend callback lightweight and forward the real work to the worker.
                 //
@@ -135,10 +139,14 @@ impl FileWatcher<notify::RecommendedWatcher> {
 impl<Impl: FileWatcherImpl> FileWatcher<Impl> {
     /// Creates a watcher and invokes `on_event` for matching watched-path changes.
     ///
+    /// If `pass_through_unwatched_events` is `true`, raw file-system events for paths outside the
+    /// current watched set are forwarded as-is.
+    ///
     /// Runtime watcher errors are forwarded to `on_error`.
     pub fn start_with_impl(
         on_event: impl FnMut(WatchEvent) + Send + 'static,
         on_error: impl FnMut(Impl::Error) + Send + 'static,
+        pass_through_unwatched_events: bool,
         create_impl: impl FnOnce(FileWatcherEventSink<Impl>) -> Result<Impl, Impl::Error>
         + Send
         + 'static,
@@ -147,7 +155,15 @@ impl<Impl: FileWatcherImpl> FileWatcher<Impl> {
         let (startup_tx, startup_rx) = mpsc::sync_channel(1);
         let worker_tx = tx.clone();
         let worker = thread::spawn(move || {
-            worker_loop(create_impl, rx, worker_tx, startup_tx, on_event, on_error);
+            worker_loop(
+                create_impl,
+                rx,
+                worker_tx,
+                startup_tx,
+                on_event,
+                on_error,
+                pass_through_unwatched_events,
+            );
         });
 
         match startup_rx.recv() {
@@ -304,8 +320,19 @@ impl WorkerState {
         &mut self,
         watcher: &mut Impl,
         events: Vec<(PathBuf, FileChangeKind)>,
+        pass_through_unwatched_events: bool,
         on_event: &mut impl FnMut(WatchEvent),
     ) -> Result<(), Impl::Error> {
+        if pass_through_unwatched_events {
+            let passthrough_events = events
+                .iter()
+                .filter(|(path, _kind)| !self.watched_files.contains(path))
+                .map(|(path, kind)| WatchEvent { path: path.clone(), kind: *kind });
+            for event in passthrough_events {
+                on_event(event);
+            }
+        }
+
         if self.watched_files.is_empty() {
             return Ok(());
         }
@@ -431,6 +458,7 @@ fn worker_loop<Impl: FileWatcherImpl>(
     startup_tx: mpsc::SyncSender<Result<(), Impl::Error>>,
     mut on_event: impl FnMut(WatchEvent) + Send + 'static,
     mut on_error: impl FnMut(Impl::Error) + Send + 'static,
+    pass_through_unwatched_events: bool,
 ) {
     let watcher = create_impl(FileWatcherEventSink { tx });
 
@@ -457,7 +485,12 @@ fn worker_loop<Impl: FileWatcherImpl>(
                 ));
             }
             WorkerMessage::FileSystemEvents(Ok(event)) => {
-                if let Err(err) = state.handle_events(&mut watcher, event, &mut on_event) {
+                if let Err(err) = state.handle_events(
+                    &mut watcher,
+                    event,
+                    pass_through_unwatched_events,
+                    &mut on_event,
+                ) {
                     on_error(err);
                 }
             }
@@ -535,6 +568,17 @@ mod tests {
     const EVENT_TIMEOUT: Duration = Duration::from_millis(100);
     const QUIET_TIMEOUT: Duration = Duration::from_millis(50);
 
+    fn new_test_root() -> PathBuf {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+        let unique_id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let root = std::env::temp_dir()
+            .join(format!("slint-file-watcher-{timestamp}-{unique_id}-{}", std::process::id()));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
     struct TestContext {
         root: PathBuf,
         watcher: FileWatcher,
@@ -544,22 +588,27 @@ mod tests {
 
     impl TestContext {
         fn new() -> Self {
-            static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+            Self::new_with_passthrough(false)
+        }
 
-            let unique_id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-            let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-            let root = std::env::temp_dir()
-                .join(format!("slint-file-watcher-{timestamp}-{unique_id}-{}", std::process::id()));
-            fs::create_dir_all(&root).unwrap();
+        fn new_with_passthrough(pass_through_unwatched_events: bool) -> Self {
+            let root = new_test_root();
             let (event_tx, events) = mpsc::channel();
             let (error_tx, errors) = mpsc::channel();
 
-            let watcher = FileWatcher::start(
+            let watcher = FileWatcher::start_with_impl(
                 move |event| {
                     event_tx.send(event).unwrap();
                 },
                 move |error| {
                     error_tx.send(error).unwrap();
+                },
+                pass_through_unwatched_events,
+                |event_handler| {
+                    notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+                        let events = event.map(classify_event);
+                        event_handler.send(events).ok();
+                    })
                 },
             )
             .unwrap();
@@ -609,6 +658,10 @@ mod tests {
             self.settle();
             self.drain_events();
             self.assert_no_errors();
+        }
+
+        fn send_raw(&mut self, events: Vec<(PathBuf, FileChangeKind)>) {
+            self.watcher.event_sink().send(Ok(events)).unwrap();
         }
 
         fn settle(&self) {
@@ -684,6 +737,86 @@ mod tests {
         ctx.write("ui/main.slint", "second");
 
         ctx.expect_event(&watched, FileChangeKind::Changed);
+    }
+
+    #[test]
+    fn passthrough_can_emit_unwatched_paths() {
+        let mut ctx = TestContext::new_with_passthrough(true);
+        let unwatched = ctx.path("ui/unwatched.slint");
+
+        ctx.send_raw(vec![(unwatched.clone(), FileChangeKind::Changed)]);
+
+        ctx.expect_event(&unwatched, FileChangeKind::Changed);
+        ctx.expect_quiet();
+    }
+
+    #[test]
+    fn passthrough_works_without_watched_paths() {
+        let mut ctx = TestContext::new_with_passthrough(true);
+        let unwatched = ctx.path("ui/unwatched.slint");
+
+        ctx.send_raw(vec![(unwatched.clone(), FileChangeKind::Created)]);
+
+        ctx.expect_event(&unwatched, FileChangeKind::Created);
+        ctx.expect_quiet();
+    }
+
+    #[test]
+    fn passthrough_does_not_leak_without_opt_in() {
+        let mut ctx = TestContext::new();
+        let unwatched = ctx.path("ui/unwatched.slint");
+
+        ctx.send_raw(vec![(unwatched, FileChangeKind::Changed)]);
+
+        ctx.expect_quiet();
+    }
+
+    #[test]
+    fn passthrough_still_reconciles_watched_paths() {
+        let mut ctx = TestContext::new_with_passthrough(true);
+        let watched = ctx.path("ui/missing.slint");
+
+        ctx.create_dir_all("ui");
+        let sibling = ctx.write("ui/sibling.slint", "first");
+        ctx.watch(&["ui/missing.slint"]);
+        ctx.write("ui/missing.slint", "created later");
+        ctx.expect_event(&watched, FileChangeKind::Created);
+
+        ctx.send_raw(vec![(sibling.clone(), FileChangeKind::Changed)]);
+        ctx.expect_event(&sibling, FileChangeKind::Changed);
+        ctx.settle();
+
+        for event in ctx.drain_events() {
+            assert_eq!(
+                event,
+                WatchEvent { path: watched.clone(), kind: FileChangeKind::Changed },
+                "unexpected trailing event after reconcile",
+            );
+        }
+    }
+
+    #[test]
+    fn passthrough_does_not_duplicate_watched_events() {
+        let mut ctx = TestContext::new_with_passthrough(true);
+        let watched = ctx.write("ui/main.slint", "first");
+
+        ctx.watch(&["ui/main.slint"]);
+        ctx.remove_file("ui/main.slint");
+        ctx.send_raw(vec![(watched.clone(), FileChangeKind::Deleted)]);
+
+        ctx.expect_event(&watched, FileChangeKind::Deleted);
+        let folder_path = ctx.path("ui");
+
+        ctx.settle();
+        // On some platforms, removing a file creates a file change event on the folder (e.g. on macOS)
+        // Only allow this, but no other event to occur
+        for event in ctx.drain_events() {
+            assert_eq!(
+                event,
+                WatchEvent { path: folder_path.clone(), kind: FileChangeKind::Changed },
+            )
+        }
+        ctx.expect_quiet();
     }
 
     #[test]

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -465,6 +465,10 @@ impl DocumentCache {
         let (doc, offset) = self.get_document_and_offset(text_document_uri, pos)?;
         self.element_at_document_and_offset(doc, offset)
     }
+
+    pub fn all_paths_to_watch(&self) -> HashSet<PathBuf> {
+        self.type_loader.all_files_to_watch()
+    }
 }
 
 #[cfg(test)]

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -280,6 +280,10 @@ impl DocumentCache {
         self.type_loader.global_type_registry.borrow()
     }
 
+    pub fn revision(&self) -> u64 {
+        self.type_loader.revision()
+    }
+
     fn invalidate_everything(&mut self) {
         let all_files = self.type_loader.all_files().cloned().collect::<Vec<_>>();
 

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -295,7 +295,6 @@ async fn lsp_main(
     let root_path = full_path.clone();
     let url = Url::from_file_path(full_path)
         .map_err(|_| format!("Failed to convert {} to URL!", cli.file))?;
-    file_watcher.update_watched_paths(std::iter::once(root_path.clone()))?;
     language::show_preview(
         PreviewComponent { url: url.clone(), component: cli.component },
         &mut ctx,
@@ -306,7 +305,8 @@ async fn lsp_main(
     language::reload_document(&mut ctx, url)
         .await
         .map_err(|err| format!("Failed to load file: {}: {err}", cli.file))?;
-    sync_file_watcher(&mut file_watcher, &ctx, &root_path)?;
+    let mut watch_paths_revision = None;
+    sync_file_watcher_if_needed(&mut file_watcher, &ctx, &root_path, &mut watch_paths_revision)?;
 
     const RECOMPILE_IDLE_TIMEOUT: Duration = Duration::from_millis(50);
     loop {
@@ -337,9 +337,15 @@ async fn lsp_main(
                         tracing::error!("Failed document reload: {err}");
                     }
                 }
-                sync_file_watcher(&mut file_watcher, &ctx, &root_path)?;
             }
         }
+
+        sync_file_watcher_if_needed(
+            &mut file_watcher,
+            &ctx,
+            &root_path,
+            &mut watch_paths_revision,
+        )?;
     }
 }
 
@@ -355,11 +361,17 @@ async fn trigger_editor_file_watcher(
     language::trigger_file_watcher(ctx, url, kind).await
 }
 
-fn sync_file_watcher(
+fn sync_file_watcher_if_needed(
     watcher: &mut FileWatcher,
     ctx: &language::Context,
     root_path: &std::path::Path,
+    watch_paths_revision: &mut Option<u64>,
 ) -> Result<()> {
+    let current_revision = ctx.document_cache.revision();
+    if watch_paths_revision.is_some_and(|rev| rev == current_revision) {
+        return Ok(());
+    }
+
     watcher.update_watched_paths(
         std::iter::once(root_path.to_path_buf()).chain(
             ctx.document_cache
@@ -370,6 +382,7 @@ fn sync_file_watcher(
                 .filter_map(|url| common::uri_to_file(&url)),
         ),
     )?;
+    *watch_paths_revision = Some(current_revision);
     Ok(())
 }
 

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -1,5 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+//
+// cspell:ignore unwatch
 use std::{
     pin::Pin,
     rc::Rc,
@@ -8,12 +10,12 @@ use std::{
     time::Duration,
 };
 
-use i_slint_live_preview::file_watcher::{FileChangeKind, FileWatcher, WatchEvent};
+use i_slint_live_preview::file_watcher::{FileWatcher, WatchEvent};
 use i_slint_live_preview::protocol::{
     LspToPreviewMessage, PreviewComponent, PreviewToLspMessage, SourceFileVersion, VersionedUrl,
 };
 use lsp_server::{Message, RequestId};
-use lsp_types::{FileChangeType, MessageType, Url, notification::Notification};
+use lsp_types::{MessageType, Url, notification::Notification};
 
 use crate::{
     common::{self, LspToPreviews, Result, document_cache::OpenImportCallback},
@@ -350,15 +352,7 @@ async fn trigger_editor_file_watcher(
         return Ok(());
     };
 
-    language::trigger_file_watcher(ctx, url, lsp_file_change_type(kind)).await
-}
-
-fn lsp_file_change_type(kind: FileChangeKind) -> FileChangeType {
-    match kind {
-        FileChangeKind::Created => FileChangeType::CREATED,
-        FileChangeKind::Changed => FileChangeType::CHANGED,
-        FileChangeKind::Deleted => FileChangeType::DELETED,
-    }
+    language::trigger_file_watcher(ctx, url, kind).await
 }
 
 fn sync_file_watcher(

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -172,6 +172,9 @@ async fn register_file_watcher(ctx: &Context) -> common::Result<()> {
         .and_then(|wf| wf.dynamic_registration)
         .unwrap_or(false)
     {
+        tracing::trace!(
+            "Client supports dynamic file watcher registration, registering for all files"
+        );
         let fs_watcher = lsp_types::DidChangeWatchedFilesRegistrationOptions {
             watchers: vec![lsp_types::FileSystemWatcher {
                 glob_pattern: lsp_types::GlobPattern::String("**/*".to_string()),
@@ -974,7 +977,19 @@ pub async fn delete_document(ctx: &mut Context, url: lsp_types::Url) -> common::
     // The preview cares about resources and slint files, so forward everything
     ctx.to_preview.send(&LspToPreviewMessage::ForgetFile { url: url.clone() });
 
-    drop_document_impl(ctx, url)
+    #[cfg(feature = "preview-engine")]
+    let version = ctx.document_cache.document_version(&url);
+
+    let result = drop_document_impl(ctx, url.clone());
+
+    // make sure to clear the diagnostics on this file.
+    // This is especially important for deleted files, but also for renamed files to clear the diagnostics on the old file.
+    // Otherwise they will stick around forever (e.g. in VS Code).
+    #[cfg(feature = "preview-engine")]
+    let _ =
+        common::lsp_to_editor::notify_lsp_diagnostics(&ctx.server_notifier, url, version, vec![]);
+
+    result
 }
 
 pub async fn trigger_file_watcher(

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -25,18 +25,22 @@ use i_slint_compiler::parser::{
 use i_slint_compiler::{diagnostics::BuildDiagnostics, langtype::Type};
 #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
 use i_slint_live_preview::protocol::PreviewComponent;
-use i_slint_live_preview::protocol::{
-    LspToPreviewMessage, PreviewConfig, PreviewToLspMessage, SourceFileVersion, VersionedUrl,
+use i_slint_live_preview::{
+    file_watcher::FileChangeKind,
+    protocol::{
+        LspToPreviewMessage, PreviewConfig, PreviewToLspMessage, SourceFileVersion, VersionedUrl,
+    },
 };
+
 use itertools::Itertools;
 use lsp_types::TextDocumentPositionParams;
 use lsp_types::{
     ClientCapabilities, CodeActionOrCommand, CodeActionProviderCapability, CodeLens,
     CodeLensOptions, Color, ColorInformation, ColorPresentation, Command, CompletionOptions,
-    DocumentSymbol, DocumentSymbolResponse, FileChangeType, InitializeParams, InitializeResult,
-    OneOf, Position, PrepareRenameResponse, RenameOptions, SemanticTokensFullOptions,
-    SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, ServerInfo,
-    TextDocumentSyncCapability, TextEdit, Url, WorkDoneProgressOptions,
+    DocumentSymbol, DocumentSymbolResponse, InitializeParams, InitializeResult, OneOf, Position,
+    PrepareRenameResponse, RenameOptions, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, ServerCapabilities, ServerInfo, TextDocumentSyncCapability, TextEdit,
+    Url, WorkDoneProgressOptions,
     request::{
         CodeActionRequest, CodeLensRequest, ColorPresentationRequest, Completion, DocumentColor,
         DocumentHighlightRequest, DocumentSymbolRequest, ExecuteCommand, Formatting,
@@ -976,18 +980,17 @@ pub async fn delete_document(ctx: &mut Context, url: lsp_types::Url) -> common::
 pub async fn trigger_file_watcher(
     ctx: &mut Context,
     url: lsp_types::Url,
-    typ: lsp_types::FileChangeType,
+    typ: FileChangeKind,
 ) -> common::Result<()> {
     if !ctx.open_urls.contains(&url) {
         tracing::debug!("File watcher triggered for {url} (type: {:?})", typ);
         match typ {
-            FileChangeType::DELETED => delete_document(ctx, url).await?,
+            FileChangeKind::Deleted => delete_document(ctx, url).await?,
             // If the file was newly created, we still need to drop it as another file may
             // already depend on it by trying to import it before it exists.
             // This is especially common on file renames.
             // See also #11304
-            FileChangeType::CHANGED | FileChangeType::CREATED => drop_document(ctx, url).await?,
-            _ => tracing::warn!("Unknown file change type: {:?} for {url}", typ),
+            FileChangeKind::Changed | FileChangeKind::Created => drop_document(ctx, url).await?,
         }
     } else {
         tracing::trace!("Ignoring file watcher event for open document: {url}");

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -5,6 +5,8 @@
 
 use lsp_types::{Diagnostic, Url};
 
+use i_slint_live_preview::file_watcher::FileChangeKind;
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -305,7 +307,7 @@ fn preview_file_recompiled_when_dependency_changes() {
     spin_on::spin_on(crate::language::trigger_file_watcher(
         &mut ctx,
         dep_url.clone(),
-        lsp_types::FileChangeType::CHANGED,
+        FileChangeKind::Changed,
     ))
     .unwrap();
 
@@ -368,7 +370,7 @@ mod missing_imports {
         spin_on::spin_on(crate::language::trigger_file_watcher(
             &mut ctx,
             dep_url,
-            lsp_types::FileChangeType::CREATED,
+            FileChangeKind::Created,
         ))
         .unwrap();
 

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -571,6 +571,9 @@ async fn run_main_loop(
     )
     .unwrap();
 
+    let mut watch_paths_revision = None;
+    sync_file_watcher_if_needed(&mut file_watcher, &ctx, &mut watch_paths_revision)?;
+
     loop {
         let recompile_idle_timeout =
             if ctx.pending_recompile.is_empty() { Duration::MAX } else { RECOMPILE_IDLE_TIMEOUT };
@@ -624,10 +627,25 @@ async fn run_main_loop(
             }
         }
 
-        // make sure to always update the watched paths
-        let paths_to_watch = ctx.document_cache.all_paths_to_watch();
-        file_watcher.update_watched_paths(paths_to_watch).ok();
+        sync_file_watcher_if_needed(&mut file_watcher, &ctx, &mut watch_paths_revision)?;
     }
+}
+
+fn sync_file_watcher_if_needed(
+    watcher: &mut FileWatcher<LspFileWatcherImpl>,
+    ctx: &Context,
+    watch_paths_revision: &mut Option<u64>,
+) -> Result<()> {
+    let current_revision = ctx.document_cache.revision();
+    if watch_paths_revision.is_some_and(|rev| rev == current_revision) {
+        return Ok(());
+    }
+
+    watcher
+        .update_watched_paths(ctx.document_cache.all_paths_to_watch())
+        .map_err(|err| std::io::Error::other(format!("Failed to update watched paths: {err:?}")))?;
+    *watch_paths_revision = Some(current_revision);
+    Ok(())
 }
 
 async fn handle_lsp_message(

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -558,6 +558,13 @@ async fn run_main_loop(
         |err| {
             tracing::error!("File watcher error: {err:?}");
         },
+        // Pass through events from files that are not in the watch list.
+        // This ensures the LSP will still manage to detect file changed events in the majority of
+        // cases, even if the file is missing from the watch list for any reason.
+        //
+        // This ensures that adding our own FileWatcher reconciliation on top of the file change
+        // events doesn't regress the LSP.
+        true,
         // We don't need the event_sink in the worker thread, we just send the events directly
         // from the main thread to the file watchers worker thread.
         move |_event_sink| Ok(LspFileWatcherImpl {}),

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -1,5 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+//
+// cspell:ignore unwatch
 
 #![cfg(not(target_arch = "wasm32"))]
 #![allow(clippy::await_holding_refcell_ref)]
@@ -22,7 +24,7 @@ use language::*;
 
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, InitializeParams, Url,
+    DidOpenTextDocumentParams, FileChangeType, InitializeParams, Url,
     notification::{
         DidChangeConfiguration, DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument,
         DidOpenTextDocument, Notification,
@@ -41,7 +43,10 @@ use std::task::{Poll, Waker};
 use std::time::Duration;
 
 use crate::common::{LspToPreviews, document_cache::CompilerConfiguration};
-use i_slint_live_preview::protocol::{LspToPreviewMessage, PreviewToLspMessage, VersionedUrl};
+use i_slint_live_preview::{
+    file_watcher::{self, FileChangeKind, FileWatcher},
+    protocol::{LspToPreviewMessage, PreviewToLspMessage, VersionedUrl},
+};
 
 #[cfg(not(any(
     target_os = "openbsd",
@@ -384,6 +389,83 @@ async fn main_loop(
     result
 }
 
+#[derive(Debug)]
+enum FileWatcherError {
+    WorkerStopped,
+}
+
+// A file watcher implementation that receives file change events from the LSP's DidChangeWatchedFiles notifications
+//
+// It uses the slint_interpreter::FileWatcher to reconcile events.
+//
+// E.g. if a directory is renamed, VS Code will just send a delete event for the old path, and a create event for the new path.
+// The slint_interpreter::FileWatcher will reconcile this and send a delete event for all files in the renamed directory,
+// and create events for all relevant files in the new directory.
+struct LspFileWatcherImpl {}
+
+impl LspFileWatcherImpl {
+    fn process_file_watcher_event(
+        watcher: &mut FileWatcher<Self>,
+        event: DidChangeWatchedFilesParams,
+    ) {
+        let events: Vec<_> = event
+            .changes
+            .into_iter()
+            .filter_map(|event| {
+                tracing::debug!("Watched file changed: {} (type: {:?})", event.uri, event.typ);
+                common::uri_to_file(&event.uri).and_then(|path| {
+                    let ty = match event.typ {
+                        FileChangeType::DELETED => FileChangeKind::Deleted,
+                        FileChangeType::CREATED => FileChangeKind::Created,
+                        FileChangeType::CHANGED => FileChangeKind::Changed,
+                        _ => {
+                            tracing::debug!("Unknown FileChangeType: {:?}", event.typ);
+                            return None;
+                        }
+                    };
+                    Some((path, ty))
+                })
+            })
+            .collect();
+
+        if let Err(err) = watcher.event_sink().send(Ok(events)) {
+            tracing::error!("Failed to process file change event: {err:?}");
+        }
+    }
+}
+
+impl file_watcher::FileWatcherImpl for LspFileWatcherImpl {
+    type Error = FileWatcherError;
+
+    fn watch(&mut self, _path: &std::path::Path) -> std::result::Result<(), Self::Error> {
+        // noop, we're already watching everything 👀
+        // TODO: Change watch path registration of the language client
+        Ok(())
+    }
+
+    fn unwatch(&mut self, _path: &std::path::Path) -> std::result::Result<(), Self::Error> {
+        // noop, we're already watching everything 👀
+        // TODO: Change watch path registration of the language client
+        Ok(())
+    }
+
+    fn worker_stopped_error() -> Self::Error {
+        FileWatcherError::WorkerStopped
+    }
+
+    fn is_transient_watch_error(_err: &Self::Error) -> bool {
+        false
+    }
+
+    fn needs_direct_file_watches() -> bool {
+        // noop, we're already watching everything 👀
+        //
+        // TODO: It's unclear from the LSP specification if direct file watches are needed.
+        // So likely this needs to be `true` if we switch to minimizing the LSP watch paths.
+        false
+    }
+}
+
 async fn run_main_loop(
     connection: Connection,
     init_param: InitializeParams,
@@ -467,6 +549,21 @@ async fn run_main_loop(
 
     startup_lsp(&mut ctx).await?;
 
+    let (file_watcher_sender, mut file_watcher_receiver) = mpsc::unbounded_channel();
+
+    let mut file_watcher = FileWatcher::<LspFileWatcherImpl>::start_with_impl(
+        move |fs_event| {
+            file_watcher_sender.send(fs_event).unwrap();
+        },
+        |err| {
+            tracing::error!("File watcher error: {err:?}");
+        },
+        // We don't need the event_sink in the worker thread, we just send the events directly
+        // from the main thread to the file watchers worker thread.
+        move |_event_sink| Ok(LspFileWatcherImpl {}),
+    )
+    .unwrap();
+
     loop {
         let recompile_idle_timeout =
             if ctx.pending_recompile.is_empty() { Duration::MAX } else { RECOMPILE_IDLE_TIMEOUT };
@@ -478,6 +575,7 @@ async fn run_main_loop(
                         &connection,
                         &mut rh,
                         &mut ctx,
+                        &mut file_watcher
                     ).await
                     {
                         Ok(true) => {
@@ -502,6 +600,11 @@ async fn run_main_loop(
                     }
                 }
             }
+            file_event = file_watcher_receiver.recv() => {
+                if let Some(file_event) = file_event {
+                    trigger_file_watcher(&mut ctx, common::file_to_uri(&file_event.path).unwrap(), file_event.kind).await.ok();
+                }
+            }
             _ = tokio::time::sleep(recompile_idle_timeout) => {
                 tracing::debug!("LSP recompiling");
                 let pending_recompile = std::mem::take(&mut ctx.pending_recompile);
@@ -513,6 +616,10 @@ async fn run_main_loop(
                 }
             }
         }
+
+        // make sure to always update the watched paths
+        let paths_to_watch = ctx.document_cache.all_paths_to_watch();
+        file_watcher.update_watched_paths(paths_to_watch).ok();
     }
 }
 
@@ -521,6 +628,7 @@ async fn handle_lsp_message(
     connection: &Arc<Connection>,
     rh: &mut RequestHandler,
     ctx: &mut Context,
+    file_watcher: &mut FileWatcher<LspFileWatcherImpl>,
 ) -> Result<bool> {
     tracing::trace!("Handling LSP message: {msg:?}");
     match msg {
@@ -535,7 +643,7 @@ async fn handle_lsp_message(
             // should not be receiving responses, since they're handled in the dedicated thread
         }
         Message::Notification(notification) => {
-            handle_notification(notification, ctx).await?;
+            handle_notification(notification, ctx, file_watcher).await?;
         }
     }
     Ok(false)
@@ -576,7 +684,11 @@ fn crossbeam_tokio_adapter(
     }
 }
 
-async fn handle_notification(req: lsp_server::Notification, ctx: &mut Context) -> Result<()> {
+async fn handle_notification(
+    req: lsp_server::Notification,
+    ctx: &mut Context,
+    file_watcher: &mut FileWatcher<LspFileWatcherImpl>,
+) -> Result<()> {
     match &*req.method {
         DidOpenTextDocument::METHOD => {
             let params: DidOpenTextDocumentParams = serde_json::from_value(req.params)?;
@@ -610,10 +722,7 @@ async fn handle_notification(req: lsp_server::Notification, ctx: &mut Context) -
         DidChangeConfiguration::METHOD => load_configuration(ctx).await,
         DidChangeWatchedFiles::METHOD => {
             let params: DidChangeWatchedFilesParams = serde_json::from_value(req.params)?;
-            for fe in params.changes {
-                tracing::debug!("Watched file changed: {} (type: {:?})", fe.uri, fe.typ);
-                trigger_file_watcher(ctx, fe.uri, fe.typ).await?;
-            }
+            LspFileWatcherImpl::process_file_watcher_event(file_watcher, params);
             Ok(())
         }
 

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -13,7 +13,10 @@ pub mod util;
 
 use common::LspToPreviews;
 use common::{DocumentCache, Result};
-use i_slint_live_preview::protocol::{LspToPreviewMessage, PreviewToLspMessage, VersionedUrl};
+use i_slint_live_preview::{
+    file_watcher::FileChangeKind,
+    protocol::{LspToPreviewMessage, PreviewToLspMessage, VersionedUrl},
+};
 use js_sys::Function;
 pub use language::{Context, RequestHandler};
 use lsp_types::Url;
@@ -411,6 +414,12 @@ impl SlintServer {
         let mut ctx = self.ctx.lock().await;
         let url: Url = serde_wasm_bindgen::from_value(url)?;
         let typ: lsp_types::FileChangeType = serde_wasm_bindgen::from_value(typ)?;
+        let typ = match typ {
+            lsp_types::FileChangeType::CREATED => FileChangeKind::Created,
+            lsp_types::FileChangeType::CHANGED => FileChangeKind::Changed,
+            lsp_types::FileChangeType::DELETED => FileChangeKind::Deleted,
+            _ => return Err(JsError::new("Unknown FileChangeType")),
+        };
         language::trigger_file_watcher(&mut ctx, url, typ)
             .await
             .map_err(|e| JsError::new(&e.to_string()))?;


### PR DESCRIPTION
As outlined in #11778, this wires up the file system watcher to the LSP so that we can benefit from the reconcile logic in the file system watcher.

Closes #11778 

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
