### PR TITLE
Safety docs missing Slint syntax colors

### DIFF
--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -37,7 +37,11 @@ export default defineConfig({
         mermaid(),
         starlight({
             title: "Slint SC Safety Manual",
-            customCss: ["./src/styles/sls-ids.css"],
+            customCss: [
+                "@slint/common-files/src/styles/starlight-slint-custom.css",
+                "@slint/common-files/src/styles/starlight-slint-theme.css",
+                "./src/styles/sls-ids.css",
+            ],
             components: {
                 Footer: "@slint/common-files/src/components/Footer.astro",
                 Header: "@slint/common-files/src/components/Header.astro",

--- a/docs/safety/ec.config.mjs
+++ b/docs/safety/ec.config.mjs
@@ -1,0 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+import starlightExpressiveCode from "@slint/common-files/src/utils/starlight-expressive-code.mjs";
+
+export default starlightExpressiveCode();


### PR DESCRIPTION
This also allows examples to be opened in Slintpad

Before:
<img width="847" height="738" alt="Screenshot 2026-05-24 at 17 48 52" src="https://github.com/user-attachments/assets/e8417682-7c6d-4704-8371-88c1463784fd" />

After:
<img width="888" height="796" alt="Screenshot 2026-05-24 at 17 49 23" src="https://github.com/user-attachments/assets/a60b2034-638a-439b-9f0f-142f8fd74dd3" />
