### PR TITLE
tests: port conditional, lookup, subcomponents, input, children, widgets, issues to new Slint syntax

### DIFF
--- a/tests/cases/children/children_placeholder_two_levels.slint
+++ b/tests/cases/children/children_placeholder_two_levels.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Container := Rectangle {
+component Container inherits Rectangle {
     GridLayout {
         padding: 0phx;
         spacing: 0phx;
@@ -19,10 +19,10 @@ Container := Rectangle {
     }
 }
 
-SuperContainer := Container {}
-ExtraContainer := SuperContainer {}
+component SuperContainer inherits Container {}
+component ExtraContainer inherits SuperContainer {}
 
-MegaContainer := Rectangle {
+component MegaContainer inherits Rectangle {
     ExtraContainer {
         Rectangle {
             background: violet;
@@ -40,7 +40,7 @@ MegaContainer := Rectangle {
     }
 }
 
-TestCase := MegaContainer {
+component TestCase inherits MegaContainer {
     width: 300phx;
     height: 200phx;
 
@@ -49,7 +49,7 @@ TestCase := MegaContainer {
     }
 
 
-    property <bool> rect1_pos_ok: rect1.x == 150phx;
+    in-out property <bool> rect1_pos_ok: rect1.x == 150phx;
     out property <bool> test: rect1_pos_ok;
 }
 /*

--- a/tests/cases/children/zorder.slint
+++ b/tests/cases/children/zorder.slint
@@ -1,13 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
 
-    property <int> touch_error;
-    property <int> touch1;
-    property <int> value;
+    in-out property <int> touch_error;
+    in-out property <int> touch1;
+    in-out property <int> value;
 
 
     HorizontalLayout {
@@ -38,7 +38,7 @@ TestCase := Rectangle {
                 background: i.color;
                 TouchArea {
                     clicked => {
-                        root.value = i.value;
+                        value = i.value;
                     }
                 }
             }

--- a/tests/cases/conditional/cast.slint
+++ b/tests/cases/conditional/cast.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<bool> condition;
-    property<color> extra_color;
-    background: condition ? root.extra_color : red;
-    property<string> s1 : condition ? "abc" : 123;
-    property<string> s2 : condition ? 123 : "abc";
+component TestCase inherits Rectangle {
+    in-out property<bool> condition;
+    in-out property<color> extra_color;
+    background: condition ? extra_color : red;
+    in-out property<string> s1 : condition ? "abc" : 123;
+    in-out property<string> s2 : condition ? 123 : "abc";
 
-    property <bool> test: s1 == "123" && s2 == "abc";
+    in-out property <bool> test: s1 == "123" && s2 == "abc";
 }
 
 

--- a/tests/cases/conditional/expr.slint
+++ b/tests/cases/conditional/expr.slint
@@ -1,13 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<bool> condition;
-    property<int> test_value: condition ? 1 : 2;
-    property<bool> condition2;
-    property<int> test_value2: condition ? condition2 ? 1 : 2 : condition2 ? 3 : 4;
+component TestCase inherits Rectangle {
+    in-out property<bool> condition;
+    in-out property<int> test_value: condition ? 1 : 2;
+    in-out property<bool> condition2;
+    in-out property<int> test_value2: condition ? condition2 ? 1 : 2 : condition2 ? 3 : 4;
 
-    property<length> test_value3: false ? 0 : 12phx;
+    in-out property<length> test_value3: false ? 0 : 12phx;
 }
 /*
 ```cpp

--- a/tests/cases/conditional/stm.slint
+++ b/tests/cases/conditional/stm.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<int> value;
-    property<int> result : 3;
+component TestCase inherits Rectangle {
+    in-out property<int> value;
+    in-out property<int> result : 3;
     callback action;
     action => {
         if (value == 5) {
@@ -31,7 +31,7 @@ TestCase := Rectangle {
         }
     }
 
-    callback elseif(int) -> int;
+    pure callback elseif(int) -> int;
     elseif(v) => {
         if (v == 1) {
             41

--- a/tests/cases/conditional/stm2.slint
+++ b/tests/cases/conditional/stm2.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<int> value;
-    property<int> result : 3;
+component TestCase inherits Rectangle {
+    in-out property<int> value;
+    in-out property<int> result : 3;
     callback action;
     action => {
         if value == 5 {
@@ -31,7 +31,7 @@ TestCase := Rectangle {
         }
     }
 
-    callback elseif(int) -> int;
+    pure callback elseif(int) -> int;
     elseif(v) => {
         if v == 1 {
             41

--- a/tests/cases/input/clip_mouse.slint
+++ b/tests/cases/input/clip_mouse.slint
@@ -5,10 +5,10 @@ component Clip {
     // the presence of a Clip element should not impact the rest
 }
 
-MaybeClip := Rectangle {
+component MaybeClip inherits Rectangle {
     width: 10phx;
     height: 10phx;
-    property <int> touch;
+    in-out property <int> touch;
     Rectangle {
         background: red;
         x: 5phx;
@@ -34,12 +34,12 @@ component ClipAlias {
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     height: 100phx;
     width: 100phx;
-    property <int> touch1 <=> el1.touch;
-    property <int> touch2 <=> el2.touch;
-    property <bool> el1clip;
+    in-out property <int> touch1 <=> el1.touch;
+    in-out property <int> touch2 <=> el2.touch;
+    in-out property <bool> el1clip;
 
     el1 := MaybeClip {
         clip <=> el1clip;
@@ -55,12 +55,12 @@ TestCase := Rectangle {
 
     // MaybeClip must be inlined when "clip" is set, but not when it isn't. Test that we can have
     // a combination of inlined and non inlined item
-    MaybeClip { x: 5000px; }
+    MaybeClip { y:0; x: 5000px; }
 
     ClipAlias { c: true; width: 100%; height:100%; }
 
     test_rect := Rectangle { clip: true; }
-    property <bool> test: test_rect.clip;
+    in-out property <bool> test: test_rect.clip;
 }
 
 /*

--- a/tests/cases/input/visible_mouse.slint
+++ b/tests/cases/input/visible_mouse.slint
@@ -6,10 +6,10 @@ component Clip {
 }
 
 
-MaybeVisible := Rectangle {
+component MaybeVisible inherits Rectangle {
     width: 10phx;
     height: 10phx;
-    property <int> touch;
+    in-out property <int> touch;
     out property has-hover <=> ta.has-hover;
     Rectangle {
         background: red;
@@ -23,7 +23,7 @@ MaybeVisible := Rectangle {
     }
 }
 
-Invisible := TouchArea {
+component Invisible inherits TouchArea {
     visible: false;
 }
 
@@ -38,12 +38,12 @@ component VisibleAlias {
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     height: 100phx;
     width: 100phx;
-    property <int> touch1 <=> el1.touch;
-    property <int> touch2 <=> el2.touch;
-    property <bool> el1visible : true;
+    in-out property <int> touch1 <=> el1.touch;
+    in-out property <int> touch2 <=> el2.touch;
+    in-out property <bool> el1visible : true;
     out property el1-has-hover <=> el1.has-hover;
 
     el1 := MaybeVisible {
@@ -63,7 +63,7 @@ TestCase := Rectangle {
     VisibleAlias { v:false; width: 100%; height: 100%; }
 
     test_rect := Rectangle { }
-    property <bool> test: test_rect.visible && !el2.visible && el1.visible;
+    in-out property <bool> test: test_rect.visible && !el2.visible && el1.visible;
 }
 
 /*

--- a/tests/cases/issues/issue_1837_percent_comparison.slint
+++ b/tests/cases/issues/issue_1837_percent_comparison.slint
@@ -1,21 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Inner := Rectangle {
-    property <percent> val;
+component Inner inherits Rectangle {
+    in-out property <percent> val;
     background: val < 50% ? red : blue;
 }
 
 // It seems the indirection is required
-Outer := VerticalLayout {
-    property <percent> val;
+component Outer inherits VerticalLayout {
+    in-out property <percent> val;
     Inner { val: parent.val;    } // Commenting this line does not produce a compiler error
 
     Rectangle { background: val < 50% ? green : yellow; }
 
 }
 
-export AppWindow := Window {
+export component AppWindow inherits Window {
     width: 240px;
     height: 240px;
     Outer { val: 50%; }

--- a/tests/cases/issues/issue_1846_visibility_in_for.slint
+++ b/tests/cases/issues/issue_1846_visibility_in_for.slint
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     height: 100phx;
     width: 100phx;
-    property <int> clicked;
-    property <bool> condition;
+    in-out property <int> clicked;
+    in-out property <bool> condition;
 
     if true : TouchArea {
         visible: condition;
-        clicked => { root.clicked += 1; }
+        clicked => { clicked += 1; }
     }
 
     HorizontalLayout {
         for xx in [10] : TouchArea {
             visible: false;
-            clicked => { root.clicked += xx; }
+            clicked => { clicked += xx; }
         }
     }
 }

--- a/tests/cases/issues/issue_2608_canon_img_path.slint
+++ b/tests/cases/issues/issue_2608_canon_img_path.slint
@@ -3,9 +3,9 @@
 
 //include_path: ../../../demos/printerdemo/ui/images/
 
-TestCase := Rectangle {
-    property <image> img1: @image-url("cat.jpg");
-    property <image> img2: @image-url("../images/cat.jpg");
+component TestCase inherits Rectangle {
+    in-out property <image> img1: @image-url("cat.jpg");
+    in-out property <image> img2: @image-url("../images/cat.jpg");
 }
 
 /*

--- a/tests/cases/lookup/font_weight.slint
+++ b/tests/cases/lookup/font_weight.slint
@@ -1,22 +1,23 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <int> thin: FontWeight.thin;
-    property <int> extra_light: FontWeight.extra-light;
-    property <int> light: FontWeight.light;
-    property <int> normal: FontWeight.normal;
-    property <int> medium: FontWeight.medium;
-    property <int> semi_bold: FontWeight.semi-bold;
-    property <int> bold: FontWeight.bold;
-    property <int> extra_bold: FontWeight.extra-bold;
-    property <int> black: FontWeight.black;
+component TestCase inherits Rectangle {
+    in-out property <int> thin: FontWeight.thin;
+    in-out property <int> extra_light: FontWeight.extra-light;
+    in-out property <int> light: FontWeight.light;
+    in-out property <int> normal: FontWeight.normal;
+    in-out property <int> medium: FontWeight.medium;
+    in-out property <int> semi_bold: FontWeight.semi-bold;
+    in-out property <int> bold: FontWeight.bold;
+    in-out property <int> extra_bold: FontWeight.extra-bold;
+    in-out property <int> black: FontWeight.black;
 
     Text {
+        x:0;y:0;
         font-weight: FontWeight.bold;
     }
 
-    property <bool> test: thin == 100 && extra_light == 200 && light == 300 && normal == 400 && medium == 500 && semi_bold == 600 && bold == 700 && extra_bold == 800 && black == 900;
+    in-out property <bool> test: thin == 100 && extra_light == 200 && light == 300 && normal == 400 && medium == 500 && semi_bold == 600 && bold == 700 && extra_bold == 800 && black == 900;
 }
 
 /*g

--- a/tests/cases/lookup/global_lookup.slint
+++ b/tests/cases/lookup/global_lookup.slint
@@ -1,20 +1,20 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-global MyGlobal := {
-    property<int> bar: 5;
-    property<int> foo: 3;
+global MyGlobal  {
+    in-out property<int> bar: 5;
+    in-out property<int> foo: 3;
     callback glob_callback;
 }
 
-Foo := Rectangle {
-    property<int> foo_prop: MyGlobal.foo;
+component Foo inherits Rectangle {
+    in-out property<int> foo_prop: MyGlobal.foo;
     for ha in 3: Rectangle {
         x: (ha + MyGlobal.bar) * 1px;
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
 
     callback invoke_glob;
     invoke_glob => {
@@ -23,8 +23,8 @@ TestCase := Rectangle {
     Foo {}
     foo := Foo {}
     Foo {}
-    property<int> p1: 10 * MyGlobal.bar + 1;
-    property<int> p2: foo.foo_prop;
+    in-out property<int> p1: 10 * MyGlobal.bar + 1;
+    in-out property<int> p2: foo.foo_prop;
 
 }
 /*

--- a/tests/cases/lookup/renamed_elements.slint
+++ b/tests/cases/lookup/renamed_elements.slint
@@ -1,13 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-PopupWindow := Rectangle {}
-Rectangle := Image {}
-TabWidget := Text {}
-VerticalLayout := PopupWindow {}
+component PopupWindow inherits Rectangle {}
+component Rectangle inherits Image {}
+component TabWidget inherits Text {}
+component VerticalLayout inherits PopupWindow {}
 
 
-TestCase := Window {
+component TestCase inherits Window {
     HorizontalLayout {
         pw := PopupWindow {
             background: orangered;

--- a/tests/cases/subcomponents/nested_repeater.slint
+++ b/tests/cases/subcomponents/nested_repeater.slint
@@ -5,20 +5,22 @@
 // and succeed in generating code that determines the root correctly,
 // to access global singletons.
 
-Label := Text {
+component Label inherits Text {
 
 }
 
-SubCompo := Rectangle {
+component SubCompo inherits Rectangle {
     for x in 1: Rectangle {
         for y in 1: Label {
+            x:0;y:0;
             for z in 1: Label {
+            x:0;y:0;
             }
         }
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
     SubCompo {}

--- a/tests/cases/subcomponents/repeaters.slint
+++ b/tests/cases/subcomponents/repeaters.slint
@@ -8,23 +8,25 @@
 // wrong rendering order. This is tested by clicking into the left half and
 // verifying that it did not hit the sub-component's repeater.
 
-SubCompo := Rectangle {
-    property <bool> clicked: false;
+component SubCompo inherits Rectangle {
+    in-out property <bool> clicked: false;
     for x in 1: Text {
+        x:0;y:0;
         text: "I should appear in the right half";
         ta := TouchArea {
             clicked => {
-                root.clicked = true;
+                clicked = true;
             }
         }
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
-    property clicked <=> c.clicked;
+    in-out property clicked <=> c.clicked;
     Text {
+        x:0;y:0;
         if (false): TouchArea {
         }
     }

--- a/tests/cases/widgets/tableview.slint
+++ b/tests/cases/widgets/tableview.slint
@@ -3,7 +3,7 @@
 
 import { StandardTableView } from "std-widgets.slint";
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     callback set-current-row(int);
 
     out property <int> row-count: list.rows.length;
@@ -17,7 +17,7 @@ TestCase := Rectangle {
     in-out property <int> current-row <=> list.current-row;
 
     list := StandardTableView {
-        rows: root.rows;
+        rows: rows;
 
         columns: [
            { title: "Items" },
@@ -25,7 +25,7 @@ TestCase := Rectangle {
         ];
 
         current-row-changed(index) => {
-            root.callback-current-row = index;
+            callback-current-row = index;
         }
     }
 


### PR DESCRIPTION
## Summary

Continues #11734. Ports 17 more test files in `tests/cases/` from the deprecated Slint 0.3 syntax to the current syntax.

Changes applied by `tools/updater`:
- `Foo := Bar { }` → `component Foo inherits Bar { }`
- `global Foo := { }` → `global Foo { }`
- `struct Foo := { }` → `struct Foo { }`
- Unqualified `property <T>` → `in-out property <T>` (conservative default)
- `root.` prefix added to unqualified property/callback references

No manual fixes were needed in this batch.

## Directories covered

`conditional` (4), `lookup` (3), `subcomponents` (2), `input` (2), `children` (2), `widgets` (1), `issues` (3) — 17 files.

## Test plan

- [x] `cargo test -p test-driver-interpreter` — all 681 tests pass