### PR TITLE
tests: port properties, imports, expr to new Slint syntax

### DIFF
--- a/tests/cases/expr/animation_tick.slint
+++ b/tests/cases/expr/animation_tick.slint
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <int> xx: animation-tick() / 1ms;
+component TestCase inherits Rectangle {
+    in-out property <int> xx: animation-tick() / 1ms;
 }
 
 /*

--- a/tests/cases/expr/comparison.slint
+++ b/tests/cases/expr/comparison.slint
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore fooa foob
-TestCase := Rectangle {
-    property<int> hello: 44;
+component TestCase inherits Rectangle {
+    in-out property<int> hello: 44;
 
-    property<bool> t1: hello == 44 || hello == 45;
-    property<bool> t2: hello > 44 && hello < 46;
-    property<bool> t3: hello >= 44 && hello <= 46;
-    property<bool> t4: t1 || (t2 && t3);
-    property<bool> t5: t2 || hello + 3 != 4*10+4;
-    property<bool> t6: !t1 || 1 == 0;
+    in-out property<bool> t1: hello == 44 || hello == 45;
+    in-out property<bool> t2: hello > 44 && hello < 46;
+    in-out property<bool> t3: hello >= 44 && hello <= 46;
+    in-out property<bool> t4: t1 || (t2 && t3);
+    in-out property<bool> t5: t2 || hello + 3 != 4*10+4;
+    in-out property<bool> t6: !t1 || 1 == 0;
 
-    property<string> my_str: "hello";
-    property<bool> t7: my_str == "hello";
+    in-out property<string> my_str: "hello";
+    in-out property<bool> t7: my_str == "hello";
 
-    property<bool> string-cmp: "fooa" < "foob";
+    in-out property<bool> string-cmp: "fooa" < "foob";
 
     out property <bool> test: t1 && !t2 && t3 && t4 && t5 && !t6 && t7 && string-cmp;
 }

--- a/tests/cases/expr/debug.slint
+++ b/tests/cases/expr/debug.slint
@@ -1,20 +1,20 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<string> text: "init";
-    property<string> text2: { debug(text); text }
+component TestCase inherits Rectangle {
+    in-out property<string> text: "init";
+    in-out property<string> text2: { debug(text); text }
     callback foo;
     foo => {
         debug("callback");
     }
     background: { test; text2; blue  }
 
-    im := Image {}
+    im := Image {x:0;y:0;}
 
-    property <bool> test: {
+    in-out property <bool> test: {
         debug();
-        debug(42, 42px, width / 5s, { x: 42, y: im.image_fit, z: { d: im.opacity } }, root.background, im.source, Orientation.horizontal);
+        debug(42, 42px, root.width / 5s, { x: 42, y: im.image_fit, z: { d: im.opacity } }, root.background, im.source, Orientation.horizontal);
         true;
     }
 }

--- a/tests/cases/expr/to-fixed.slint
+++ b/tests/cases/expr/to-fixed.slint
@@ -1,17 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<string> t1: 12345.6789.to-fixed(0);
-    property<string> t2: 12345.6789.to-fixed(1.0);
-    property<string> t3: 12345.6789.to-fixed(6);
-    property<string> t4: (-12345.6789).to-fixed(0);
-    property<string> t5: (-12345.6789).to-fixed(1);
-    property<string> t6: (-12345.6789).to-fixed(6.0);
-    property<string> t7: 2.34.to-fixed(1);
-    property<string> t8: 2.35.to-fixed(1.0);
-    property<string> t9: 2.55.to-fixed(1);
-    property<string> t10: 12345.6789.to-fixed(-1);
+component TestCase inherits Rectangle {
+    in-out property<string> t1: 12345.6789.to-fixed(0);
+    in-out property<string> t2: 12345.6789.to-fixed(1.0);
+    in-out property<string> t3: 12345.6789.to-fixed(6);
+    in-out property<string> t4: (-12345.6789).to-fixed(0);
+    in-out property<string> t5: (-12345.6789).to-fixed(1);
+    in-out property<string> t6: (-12345.6789).to-fixed(6.0);
+    in-out property<string> t7: 2.34.to-fixed(1);
+    in-out property<string> t8: 2.35.to-fixed(1.0);
+    in-out property<string> t9: 2.55.to-fixed(1);
+    in-out property<string> t10: 12345.6789.to-fixed(-1);
 }
 /*
 ```cpp

--- a/tests/cases/expr/to-precision.slint
+++ b/tests/cases/expr/to-precision.slint
@@ -1,21 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<string> t1: 5.123456.to-precision(0.0);
-    property<string> t2: 5.123456.to-precision(5);
-    property<string> t3: 5.123456.to-precision(2);
-    property<string> t4: 5.123456.to-precision(1);
-    property<string> t5: 0.000123.to-precision(0);
-    property<string> t6: 0.000123.to-precision(5.0);
-    property<string> t7: 0.000123.to-precision(2);
-    property<string> t8: 0.000123.to-precision(1);
-    property<string> t9: (-1234.5).to-precision(1);
-    property<string> t10: (-1234.5).to-precision(2);
-    property<string> t11: (-1234.5).to-precision(6.0);
-    property<string> t12: 0.00000012345.to-precision(1);
-    property<string> t13: 0.00000012345.to-precision(10.0);
-    property<string> t14: 5.123456.to-precision(-1);
+component TestCase inherits Rectangle {
+    in-out property<string> t1: 5.123456.to-precision(0.0);
+    in-out property<string> t2: 5.123456.to-precision(5);
+    in-out property<string> t3: 5.123456.to-precision(2);
+    in-out property<string> t4: 5.123456.to-precision(1);
+    in-out property<string> t5: 0.000123.to-precision(0);
+    in-out property<string> t6: 0.000123.to-precision(5.0);
+    in-out property<string> t7: 0.000123.to-precision(2);
+    in-out property<string> t8: 0.000123.to-precision(1);
+    in-out property<string> t9: (-1234.5).to-precision(1);
+    in-out property<string> t10: (-1234.5).to-precision(2);
+    in-out property<string> t11: (-1234.5).to-precision(6.0);
+    in-out property<string> t12: 0.00000012345.to-precision(1);
+    in-out property<string> t13: 0.00000012345.to-precision(10.0);
+    in-out property<string> t14: 5.123456.to-precision(-1);
 }
 /*
 ```cpp

--- a/tests/cases/imports/duplicated_name.slint
+++ b/tests/cases/imports/duplicated_name.slint
@@ -10,16 +10,16 @@ import { ColorButton } from "test_button.slint";
 import { TestButton as TheRealTestButton  } from "re_export.slint";
 
 // ColorButton uses TestButtonImpl
-TestButtonImpl := Rectangle {
-    property <int> abc: 12;
+component TestButtonImpl inherits Rectangle {
+    in-out property <int> abc: 12;
 }
 
 // Testbutton is another name for TestButtonImpl
-TestButton := Rectangle {
-    property <string> abc: "hello";
+component TestButton inherits Rectangle {
+    in-out property <string> abc: "hello";
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     ColorButton { button_color: red; }
     TestButtonImpl { abc: 4; }
     TestButton { abc: "world"; }

--- a/tests/cases/imports/external_globals.slint
+++ b/tests/cases/imports/external_globals.slint
@@ -6,10 +6,10 @@
 
 //include_path: ../../helper_components
 import { UseGlobal } from "export_globals.slint";
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     ug := UseGlobal {}
-    property<int> p1: ug.used42;
-    property<int> p2: ug.used44;
+    in-out property<int> p1: ug.used42;
+    in-out property<int> p2: ug.used44;
 }
 /*
 

--- a/tests/cases/imports/external_globals_nameclash.slint
+++ b/tests/cases/imports/external_globals_nameclash.slint
@@ -10,22 +10,22 @@ import {
     ExportedGlobal as FromExport,
 } from "export_globals.slint";
 
-global NotExported := {
-    property<int> abc: 1000;
-    property<string> prop: "_";
+global NotExported  {
+    in-out property<int> abc: 1000;
+    in-out property<string> prop: "_";
 }
 
-global ExportedGlobal := {
-    property<int> abc: 1001;
+global ExportedGlobal  {
+    in-out property<int> abc: 1001;
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     ug := UseGlobal {}
-    property<int> p1: ug.used42;
-    property<int> p2: ug.used44;
-    property<int> p3: NotExported.abc + ExportedGlobal.abc;
+    in-out property<int> p1: ug.used42;
+    in-out property<int> p2: ug.used44;
+    in-out property<int> p3: NotExported.abc + ExportedGlobal.abc;
 
-    property <bool> test: p1 == 42 && p2 == 44 && p3 == 2001 ;//&& NotExported.prop == "_";
+    in-out property <bool> test: p1 == 42 && p2 == 44 && p3 == 2001 ;//&& NotExported.prop == "_";
 }
 /*
 

--- a/tests/cases/imports/external_structs.slint
+++ b/tests/cases/imports/external_structs.slint
@@ -6,14 +6,14 @@
 
 //include_path: ../../helper_components
 import { UseStruct , ExportedStruct, ExportEnum , } from "export_structs.slint";
-TestCase := Rectangle {
-    property <ExportedStruct> exp: { d: 3001, e: {a: 2001} };
+component TestCase inherits Rectangle {
+    in-out property <ExportedStruct> exp: { d: 3001, e: {a: 2001} };
     u := UseStruct {
         exp: { d: 3002, e: {a: 2002} };
         nexp: { b: 3003, c: {a: 2003} };
     }
     out property<bool> xx: ExportEnum.Hello != ExportEnum.Bonjour;
-    property<int> p1: u.nexp.c.a;
+    in-out property<int> p1: u.nexp.c.a;
 }
 /*
 

--- a/tests/cases/imports/external_type.slint
+++ b/tests/cases/imports/external_type.slint
@@ -10,7 +10,7 @@ import { ColorButton } from "../helper_components/test_button.slint";
 import { Button } from "std-widgets.slint";
 import { TestButton as ReExportedButton } from "re_export.slint";
 import { Main_Window } from "main_window.slint";
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     RealButton {} // aliased from external file
     ColorButton {} // from external file
     ReExportedButton {} // from external file re-exported

--- a/tests/cases/imports/import_multi.slint
+++ b/tests/cases/imports/import_multi.slint
@@ -4,7 +4,7 @@
 import { ExportedA } from "./exported_component.slint";
 import { ExportedB } from "./exported_component.slint";
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     ExportedA {}
     ExportedB {}
 }

--- a/tests/cases/imports/reexport.slint
+++ b/tests/cases/imports/reexport.slint
@@ -6,7 +6,7 @@
 
 //include_path: ../../helper_components
 import { TestButton, ColorButton } from "re_export_all.slint";
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     TestButton {}
     ColorButton {}
 }

--- a/tests/cases/properties/animation_from_click.slint
+++ b/tests/cases/properties/animation_from_click.slint
@@ -1,13 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 120px;
     height: 120px;
 
-    property <int> hello: a.hello;
-    property <int> binding_dep: a.binding_dep;
-    property <int> unset_property;
+    in-out property <int> hello: a.hello;
+    in-out property <int> binding_dep: a.binding_dep;
+    in-out property <int> unset_property;
     animate unset_property {
         duration: 1200ms;
     }
@@ -18,7 +18,7 @@ TestCase := Rectangle {
             duration: 1200ms;
         }
         property<bool> condition: true;
-        property<int> binding_dep: condition ? 100 : 150;
+        property<int> binding_dep: self.condition ? 100 : 150;
         animate binding_dep {
             duration: 1200ms;
         }

--- a/tests/cases/properties/animation_merging.slint
+++ b/tests/cases/properties/animation_merging.slint
@@ -2,23 +2,23 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-AnimatedObject := Rectangle {
-    property <int> animated_prop;
+component AnimatedObject inherits Rectangle {
+    in-out property <int> animated_prop;
     animate animated_prop { duration: aa_duration; }
-    property <duration> aa_duration: 1s;
+    in-out property <duration> aa_duration: 1s;
 }
 
-NotAnimatedObject := Rectangle {
-    property <int> value;
-    property <int> animated_prop: value;
+component NotAnimatedObject inherits Rectangle {
+    in-out property <int> value;
+    in-out property <int> animated_prop: value;
 }
 
-TestCase := Rectangle {
-    property <int> value : 1000;
-    property <int> o1_val: o1.animated_prop;
-    property <int> o2_val: o2.animated_prop;
-    property <int> o3_val: o3.animated_prop;
-    property <int> o4_val: o4.animated_prop;
+component TestCase inherits Rectangle {
+    in-out property <int> value : 1000;
+    in-out property <int> o1_val: o1.animated_prop;
+    in-out property <int> o2_val: o2.animated_prop;
+    in-out property <int> o3_val: o3.animated_prop;
+    in-out property <int> o4_val: o4.animated_prop;
     o1 := AnimatedObject {
         animated_prop: value;
     }
@@ -31,7 +31,7 @@ TestCase := Rectangle {
         animated_prop: value;
     }
     o4 := NotAnimatedObject {
-        value: root.value;
+        value: value;
         animate animated_prop { duration: 4s; }
     }
 }

--- a/tests/cases/properties/issue1237_states_visible.slint
+++ b/tests/cases/properties/issue1237_states_visible.slint
@@ -1,23 +1,24 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
    width: 100px;
    height: 100px;
-   property<int> niceness: 33;
+   in-out property<int> niceness: 33;
    greeting := TouchArea {
-       clicked => { root.niceness += 1; }
+       clicked => { niceness += 1; }
        t:= Text {
+           x:0;y:0;
            text: "Hello world";
        }
 
        states [
-            rude when root.niceness <= 0: {visible: false;}
-            mannered when root.niceness > 100: {t.text: "Hello, dearest world"; t.font-size: 32px;}
+            rude when niceness <= 0: {visible: false;}
+            mannered when niceness > 100: {t.text: "Hello, dearest world"; t.font-size: 32px;}
        ]
    }
 
-   property <bool> test: greeting.visible;
+   in-out property <bool> test: greeting.visible;
 }
 
 

--- a/tests/cases/properties/property_animation.slint
+++ b/tests/cases/properties/property_animation.slint
@@ -1,28 +1,28 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <int> xx : 1000;
+component TestCase inherits Rectangle {
+    in-out property <int> xx : 1000;
 
-    property <easing> ea: ease;
+    in-out property <easing> ea: ease;
 
     animate x {
         duration: xx * 1ms;
         easing: ea;
     }
 
-    property<int> hello: 40;
+    in-out property<int> hello: 40;
     animate hello {
         duration: 1200ms;
     }
 
-    property<bool> condition: true;
-    property<int> binding_dep: condition ? 100 : 150;
+    in-out property<bool> condition: true;
+    in-out property<int> binding_dep: condition ? 100 : 150;
     animate binding_dep {
         duration: 1200ms;
     }
 
-    property<int> direction: 100;
+    in-out property<int> direction: 100;
     animate direction {
         duration: 600ms;
         direction: alternate-reverse;

--- a/tests/cases/properties/states.slint
+++ b/tests/cases/properties/states.slint
@@ -3,9 +3,9 @@
 
 // cSpell:ignore subcomp
 
-SubSubComp := Rectangle {
-    property <bool> active;
-    property <int> value: 10;
+component SubSubComp inherits Rectangle {
+    in-out property <bool> active;
+    in-out property <int> value: 10;
     states [
         active when active : {
             value: 150;
@@ -13,9 +13,9 @@ SubSubComp := Rectangle {
     ]
 }
 
-SubComp := SubSubComp {
+component SubComp inherits SubSubComp {
     states [
-        foobar when active : {
+        foobar when root.active : {
             r.background: red;
         }
     ]
@@ -23,11 +23,12 @@ SubComp := SubSubComp {
     r := Rectangle {}
 }
 
-TestCase := Rectangle {
-    property<int> top_level: 4;
-    property<int> active_index: 0;
-    property<int> some_prop: 5;
+component TestCase inherits Rectangle {
+    in-out property<int> top_level: 4;
+    in-out property<int> active_index: 0;
+    in-out property<int> some_prop: 5;
     text1 := Text {
+        x:0;y:0;
         text: "hello";
         property<int> foo: 85 + top_level;
     }
@@ -43,7 +44,7 @@ TestCase := Rectangle {
         }
     ]
 
-    property<int> text1_foo: text1.foo;
+    in-out property<int> text1_foo: text1.foo;
 
     for xx in [1, 2] : Rectangle {
         states [
@@ -57,7 +58,7 @@ TestCase := Rectangle {
     sc := SubComp {
         active: active_index == 1;
     }
-    property <int> subcomp: sc.value;
+    in-out property <int> subcomp: sc.value;
 
 }
 

--- a/tests/cases/properties/transitions2.slint
+++ b/tests/cases/properties/transitions2.slint
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-TestCase := Rectangle {
-    property<int> top_level: 4;
-    property<int> active_index: 0;
-    property<int> some_prop: 5;
-    property<int> another_prop: 100;
+component TestCase inherits Rectangle {
+    in-out property<int> top_level: 4;
+    in-out property<int> active_index: 0;
+    in-out property<int> some_prop: 5;
+    in-out property<int> another_prop: 100;
     text1 := Text {
+        x:0;y:0;
         property<int> foo: 85 + top_level;
     }
 
@@ -31,7 +32,7 @@ TestCase := Rectangle {
         }
     ]
 
-    property<int> text1_foo: text1.foo;
+    in-out property<int> text1_foo: text1.foo;
 
 }
 


### PR DESCRIPTION
## Summary

Continues #11734 / #11848. Ports 18 test files in `tests/cases/` from the deprecated Slint 0.3 syntax to the current syntax.

Changes applied by `tools/updater` (same five rules as #11734).

**Manual fix:** `imports/external_globals.slint` was emptied by the updater because the helper-component import path could not be resolved without test-driver search paths. The file was restored from master and ported by hand.

## Directories covered

`properties` (6), `imports` (7), `expr` (5) — 18 files.

## Test plan

- [x] \`cargo test -p test-driver-interpreter\` — all 681 tests pass