### PR TITLE
tests: port bindings to new Slint syntax

### DIFF
--- a/tests/cases/bindings/animated_default_geometry.slint
+++ b/tests/cases/bindings/animated_default_geometry.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
 
     width: 100px;
     height: 200px;
@@ -13,7 +13,7 @@ TestCase := Rectangle {
         animate width { duration: 1s; }
     }
 
-    property<bool> test: r.width == 100px && r.height == 200px;
+    in-out property<bool> test: r.width == 100px && r.height == 200px;
 }
 
 /*

--- a/tests/cases/bindings/change_sub_property.slint
+++ b/tests/cases/bindings/change_sub_property.slint
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-SubElem := Rectangle {
-    property <int> value: sub.value;
+component SubElem inherits Rectangle {
+    in-out property <int> value: sub.value;
     callback change();
     change => { sub.value += 44; }
     sub := Rectangle {
@@ -10,10 +10,10 @@ SubElem := Rectangle {
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     callback change();
     change => sub.change();
-    property <int> toplevel: sub.value + 1;
+    in-out property <int> toplevel: sub.value + 1;
     sub := SubElem { }
 }
 

--- a/tests/cases/bindings/change_sub_property2.slint
+++ b/tests/cases/bindings/change_sub_property2.slint
@@ -1,16 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-SubElem := Rectangle {
-    property <int> value: 55;
+component SubElem inherits Rectangle {
+    in-out property <int> value: 55;
     callback change();
     change => { value += 44; }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     callback change();
     change => { sub.change(); sub2.change(); }
-    property <int> toplevel: sub.value + sub2.value;
+    in-out property <int> toplevel: sub.value + sub2.value;
     sub := SubElem { }
     sub2 := SubElem { value : 1; }
 }

--- a/tests/cases/bindings/change_sub_property_indirection.slint
+++ b/tests/cases/bindings/change_sub_property_indirection.slint
@@ -2,27 +2,28 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // hello, hello2 and alias are aliases
-SubElem := Rectangle {
-    property <string> hello <=> hello2;
-    property <string> hello2;
+component SubElem inherits Rectangle {
+    in-out property <string> hello <=> hello2;
+    in-out property <string> hello2;
     t := Text {
+        x:0;y:0;
         text <=> hello;
     }
-    property <string> alias <=> t.text;
+    in-out property <string> alias <=> t.text;
 
-    property <string> binding: hello2;
+    in-out property <string> binding: hello2;
 }
 
-TestCase := Rectangle {
-    property <string> public_alias: "ABC";
+component TestCase inherits Rectangle {
+    in-out property <string> public_alias: "ABC";
 
     sub_alias := SubElem {
         hello <=> public_alias;
-        property <string> indirection: binding;
+        property <string> indirection: self.binding;
     }
 
-    property <string> sub_text <=> sub_alias.indirection;
-    property <bool> test: sub_text == "ABC";
+    in-out property <string> sub_text <=> sub_alias.indirection;
+    in-out property <bool> test: sub_text == "ABC";
 }
 
 

--- a/tests/cases/bindings/issue_1026_opacity_alias.slint
+++ b/tests/cases/bindings/issue_1026_opacity_alias.slint
@@ -2,36 +2,36 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-RoundedIcon := Rectangle {
-    property <float> background-opacity <=> background-fill.opacity;
+component RoundedIcon inherits Rectangle {
+    in-out property <float> background-opacity <=> background-fill.opacity;
     background-fill := Rectangle {
         background:  #ff7d34;
         opacity: 1.0;
     }
-    property <float> o: background-fill.opacity;
+    in-out property <float> o: background-fill.opacity;
 }
 
-Device := VerticalLayout {
+component Device inherits VerticalLayout {
     spacing: 5px;
     ri := RoundedIcon {
         background-opacity: 0.15;
     }
 
-    property<float> o: ri.o;
+    in-out property<float> o: ri.o;
 }
 
-Sub := Rectangle {
-    property o <=> d.o;
+component Sub inherits Rectangle {
+    in-out property o <=> d.o;
     d := Device {}
 }
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     s := Sub {}
     d := Device {}
-    property o1 <=> s.o;
-    property o2 <=> d.o;
-    property <bool> test: abs(o1 - 0.15) < 0.001 && abs(o2 - 0.15) < 0.001;
+    in-out property o1 <=> s.o;
+    in-out property o2 <=> d.o;
+    in-out property <bool> test: abs(root.o1 - 0.15) < 0.001 && abs(root.o2 - 0.15) < 0.001;
 }
 
 /*

--- a/tests/cases/bindings/issue_345_opacity_animation.slint
+++ b/tests/cases/bindings/issue_345_opacity_animation.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Sub := Rectangle {
-    property <bool> cond;
-    property <float> child_opacity: inner.opacity;
+component Sub inherits Rectangle {
+    in-out property <bool> cond;
+    in-out property <float> child_opacity: inner.opacity;
     inner := Rectangle {
         opacity: cond ? 0 : 1;
         animate opacity { duration: 1s; }
@@ -11,9 +11,9 @@ Sub := Rectangle {
     }
 }
 
-TestCase := Rectangle {
-    property cond <=> s.cond;
-    property val <=> s.child_opacity;
+component TestCase inherits Rectangle {
+    in-out property cond <=> s.cond;
+    in-out property val <=> s.child_opacity;
     s := Sub {}
 }
 

--- a/tests/cases/bindings/issue_385_default_geom.slint
+++ b/tests/cases/bindings/issue_385_default_geom.slint
@@ -2,16 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100px;
     height: 200px;
 
     r := Rectangle {
+        x:0;y:0;
         width <=> root.width;
         height <=> root.height;
     }
 
-    property<bool> test: r.width == 100px && r.height == 200px;
+    in-out property<bool> test: r.width == 100px && r.height == 200px;
 }
 
 /*

--- a/tests/cases/bindings/multiple_two_way.slint
+++ b/tests/cases/bindings/multiple_two_way.slint
@@ -1,24 +1,24 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-O := Text {
-    property <int> val;
+component O inherits Text {
+    in-out property <int> val;
     text: val;
-    property <int> a: val + 1;
+    in-out property <int> a: val + 1;
 }
 
-TestCase := Window {
-    property <int> val: condition ? 2 : 4;
-    property <bool> condition : false;
+component TestCase inherits Window {
+    in-out property <int> val: condition ? 2 : 4;
+    in-out property <bool> condition : false;
     HorizontalLayout {
-        o1 := O { val <=> root.val; }
-        o2 := O { val <=> root.val; }
-        o3 := O { val <=> root.val; }
-        o4 := O { val <=> root.val; }
-        o5 := O { val <=> root.val; }
+        o1 := O { val <=> val; }
+        o2 := O { val <=> val; }
+        o3 := O { val <=> val; }
+        o4 := O { val <=> val; }
+        o5 := O { val <=> val; }
     }
-    property <int> checksum: 10000 * o1.a + 1000 * o2.a + 100 * o3.a + 10 * o4.a + 1 * o5.a;
-    property <bool> test: checksum == 55555;
+    in-out property <int> checksum: 10000 * o1.a + 1000 * o2.a + 100 * o3.a + 10 * o4.a + 1 * o5.a;
+    in-out property <bool> test: checksum == 55555;
 }
 
 

--- a/tests/cases/bindings/override.slint
+++ b/tests/cases/bindings/override.slint
@@ -1,26 +1,27 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Compo := Text {
-    property <int> prop_a: 10;
-    property <int> prop_b;
+component Compo inherits Text {
+    in-out property <int> prop_a: 10;
+    in-out property <int> prop_b;
     prop_b: 20;
     text: "hello";
 }
 
-TestCase := Rectangle {
-    property <string> text: "ignore_me";
+component TestCase inherits Rectangle {
+    in-out property <string> text: "ignore_me";
     c := Compo {
+        x:0;y:0;
         prop_a: 1;
         prop_b: 2;
         text: "world";
     }
 
-    property<int> prop_a: c.prop_a;
-    property<int> prop_b: c.prop_b;
-    property<string> prop_text: c.text;
+    in-out property<int> prop_a: c.prop_a;
+    in-out property<int> prop_b: c.prop_b;
+    in-out property<string> prop_text: c.text;
 
-    property<bool> test: prop_a == 1 && prop_b == 2 && prop_text == "world";
+    in-out property<bool> test: prop_a == 1 && prop_b == 2 && prop_text == "world";
 }
 
 /*

--- a/tests/cases/bindings/two_way_binding.slint
+++ b/tests/cases/bindings/two_way_binding.slint
@@ -1,28 +1,29 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-OtherComp := Rectangle {
-    property <string> t <=> text.text;
-    property <string> get_text <=> text.text;
+component OtherComp inherits Rectangle {
+    in-out property <string> t <=> text.text;
+    in-out property <string> get_text <=> text.text;
     text := Text {
+        x:0;y:0;
         text: "to be overridden";
     }
-    property <int> some_value: 42;
-    property <int> some_value_alias <=> some_value;
+    in-out property <int> some_value: 42;
+    in-out property <int> some_value_alias <=> some_value;
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
 
-    property <string> text1: "Hello";
-    property <string> text2: "Blah";
-    property <string> ti1_text: ti1.text;
-    property <string> ti2_text: ti2.text;
-    property <string> text_item_text: text_item.text;
-    property <string> othercomp_t: "real value";
-    property <string> othercomp_get_text: other_comp.get_text;
-    property <int> othercomp_some_value;
-    property <int> othercomp_some_value_alias <=> other_comp.some_value_alias;
-    property <int> othercomp_some_value_alias2;
+    in-out property <string> text1: "Hello";
+    in-out property <string> text2: "Blah";
+    in-out property <string> ti1_text: ti1.text;
+    in-out property <string> ti2_text: ti2.text;
+    in-out property <string> text_item_text: text_item.text;
+    in-out property <string> othercomp_t: "real value";
+    in-out property <string> othercomp_get_text: other_comp.get_text;
+    in-out property <int> othercomp_some_value;
+    in-out property <int> othercomp_some_value_alias <=> other_comp.some_value_alias;
+    in-out property <int> othercomp_some_value_alias2;
 
     ti1 := TextInput {
         text <=> text1;
@@ -33,15 +34,17 @@ TestCase := Rectangle {
     }
 
     text_item := Text {
+        x:0;y:0;
         text: text2;
     }
 
     Text {
+        x:0;y:0;
         text <=> text1;
     }
 
     other_comp := OtherComp {
-        t <=> root.othercomp_t;
+        t <=> othercomp_t;
         some_value <=> othercomp_some_value;
         some_value_alias <=> othercomp_some_value_alias2;
     }

--- a/tests/cases/bindings/two_way_binding2.slint
+++ b/tests/cases/bindings/two_way_binding2.slint
@@ -1,50 +1,53 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-OtherComp := Rectangle {
-    property t <=> text.text;
-    property get_text <=> text.text;
+component OtherComp inherits Rectangle {
+    in-out property t <=> text.text;
+    in-out property get_text <=> text.text;
     text := Text {
+        x:0;y:0;
         text: "to be overridden";
     }
-    property <int> some_value: 42;
-    property some_value_alias <=> some_value;
+    in-out property <int> some_value: 42;
+    in-out property some_value_alias <=> some_value;
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
 
-    property <string> text1: "Hello";
-    property <string> text2: "Blah";
-    property ti1_text <=> ti1.text_alias;
-    property ti2_text <=> ti2.text_alias;
-    property text_item_text <=> text_item.text;
-    property <string> othercomp_t: "real value";
-    property othercomp_get_text <=> other_comp.get_text;
-    property <int> othercomp_some_value;
-    property othercomp_some_value_alias <=> other_comp.some_value_alias;
-    property <int> othercomp_some_value_alias2;
+    in-out property <string> text1: "Hello";
+    in-out property <string> text2: "Blah";
+    in-out property ti1_text <=> ti1.text_alias;
+    in-out property ti2_text <=> ti2.text_alias;
+    in-out property text_item_text <=> text_item.text;
+    in-out property <string> othercomp_t: "real value";
+    in-out property othercomp_get_text <=> other_comp.get_text;
+    in-out property <int> othercomp_some_value;
+    in-out property othercomp_some_value_alias <=> other_comp.some_value_alias;
+    in-out property <int> othercomp_some_value_alias2;
 
     ti1 := TextInput {
-        property text_alias <=> text;
+        property text_alias <=> self.text;
         text <=> text1;
     }
 
     ti2 := TextInput {
-        property text_alias <=> text_alias_indirection;
-        property text_alias_indirection <=> text;
+        property text_alias <=> self.text_alias_indirection;
+        property text_alias_indirection <=> self.text;
         text <=> text_item.text;
     }
 
     text_item := Text {
+        x:0;y:0;
         text: text2;
     }
 
     Text {
+        x:0;y:0;
         text <=> text1;
     }
 
     other_comp := OtherComp {
-        t <=> root.othercomp_t;
+        t <=> othercomp_t;
         some_value <=> othercomp_some_value;
         some_value_alias <=> othercomp_some_value_alias2;
     }

--- a/tests/cases/bindings/two_way_binding_animation.slint
+++ b/tests/cases/bindings/two_way_binding_animation.slint
@@ -1,30 +1,31 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <int> xx : 1000;
+component TestCase inherits Rectangle {
+    in-out property <int> xx : 1000;
 
     animate x {
         duration: xx * 1ms;
         easing: ease;
     }
 
-    property<int> hello: 40;
+    in-out property<int> hello: 40;
     animate hello {
         duration: 1200ms;
     }
 
-    property<bool> condition: true;
-    property<int> binding_dep: condition ? 100 : 150;
+    in-out property<bool> condition: true;
+    in-out property<int> binding_dep: condition ? 100 : 150;
     animate binding_dep {
         duration: 1200ms;
     }
 
     t:= Text {
-        font_weight <=> root.binding_dep;
+        x:0;y:0;
+        font_weight <=> binding_dep;
     }
-    property <int> t1_font: t.font_weight;
-    property alias_hello <=> hello;
+    in-out property <int> t1_font: t.font_weight;
+    in-out property alias_hello <=> hello;
 }
 
 /*

--- a/tests/cases/bindings/two_way_binding_extra.slint
+++ b/tests/cases/bindings/two_way_binding_extra.slint
@@ -4,14 +4,15 @@
 
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
 
-    property<length> xx: 50phx;
-    property<length> ww <=> first.width;
+    in-out property<length> xx: 50phx;
+    in-out property<length> ww <=> first.width;
 
     first := TouchArea {
+        y:0;
         x <=> parent.xx;
         width: 50phx;
         enabled <=> second.enabled;
@@ -21,13 +22,13 @@ TestCase := Rectangle {
 
     second := TouchArea {
         x <=> parent.xx;
-        width <=> root.ww;
+        width <=> ww;
         height <=> first.height;
         clicked => { result += 300; }
         y: 50phx;
     }
 
-    property <int> result: 5;
+    in-out property <int> result: 5;
 }
 
 

--- a/tests/cases/bindings/two_way_bug.slint
+++ b/tests/cases/bindings/two_way_bug.slint
@@ -3,16 +3,16 @@
 
 // There used to be a bug in the deduplicate_property_read pass that would mess up aliases
 
-BoxWithButtons := Window {
-    property <string> value <=> val.text;
-    val := Text {}
+component BoxWithButtons inherits Window {
+    in-out property <string> value <=> val.text;
+    val := Text {x:0;y:0;}
 }
 
-export TestCase := BoxWithButtons {
-    property <int> temperature: 24;
+export component TestCase inherits BoxWithButtons {
+    in-out property <int> temperature: 24;
     value: {
         (temperature < 0 ? "" : "+") + temperature;
     }
 
-    property <bool> test: value == "+24";
+    in-out property <bool> test: root.value == "+24";
 }

--- a/tests/cases/bindings/two_way_deep.slint
+++ b/tests/cases/bindings/two_way_deep.slint
@@ -1,24 +1,24 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-LineEdit := Rectangle {
-    property <string> text <=> ti.text;
+component LineEdit inherits Rectangle {
+    in-out property <string> text <=> ti.text;
     ti := TextInput {  }
 }
 
-LiTest := Rectangle {
+component LiTest inherits Rectangle {
     li1 := LineEdit { text: "li1"; }
     li2 := LineEdit { text <=> li1.text; }
     li3 := LineEdit { text <=> li4.text; }
     li4 := LineEdit { text: "li4"; }
-    property <bool> test_li: li1.text == "li1" && li3.text == "li4";
+    in-out property <bool> test_li: li1.text == "li1" && li3.text == "li4";
 }
 
-export TestCase := Window {
+export component TestCase inherits Window {
 
     li := LiTest {  }
 
-    property <bool> test: li.test_li;
+    in-out property <bool> test: li.test_li;
 }
 
 /*

--- a/tests/cases/bindings/two_way_model.slint
+++ b/tests/cases/bindings/two_way_model.slint
@@ -4,13 +4,13 @@
 // Regression test for a bug in which an alias to a model property was not
 // properly set because it was thought as constant
 
-MenuItem := Rectangle {
-    property <length> h <=> root.val;
+component MenuItem inherits Rectangle {
+    in-out property <length> h <=> val;
     height: val;
-    property <length> val;
+    in-out property <length> val;
 }
 
-export TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     VerticalLayout {
         for entry[idx] in [
             { val: 12px },
@@ -19,7 +19,7 @@ export TestCase := Rectangle {
         }
         Rectangle {}
     }
-    property <bool> test: root.preferred_height == 12px;
+    in-out property <bool> test: root.preferred_height == 12px;
 }
 
 /*

--- a/tests/cases/bindings/two_way_priority.slint
+++ b/tests/cases/bindings/two_way_priority.slint
@@ -1,20 +1,20 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-OpacityTwoWay := Rectangle {
-    property <float> sub_opacity <=> rect.opacity;
+component OpacityTwoWay inherits Rectangle {
+    in-out property <float> sub_opacity <=> rect.opacity;
     rect := Rectangle {
         opacity: 0.75;
     }
 }
 
-Compo := Rectangle {
+component Compo inherits Rectangle {
     preferred-height: 10px;
-    property<int> foo <=> self.bar;
-    property<int> bar: 120;
+    in-out property<int> foo <=> self.bar;
+    in-out property<int> bar: 120;
 }
 
-export TestCase := Window {
+export component TestCase inherits Window {
     compo0 := Compo { foo: compo1.foo + 20; }
     compo1 := Compo {}
     compo2 := Compo { foo: compo1.foo + 10; }
@@ -24,18 +24,18 @@ export TestCase := Window {
         otw2 := OpacityTwoWay { sub_opacity: 0.5; }
     }
 
-    property <int> override_bar: 22;
+    in-out property <int> override_bar: 22;
     force_instance := VerticalLayout {
         if true : Compo { bar <=> override_bar; }
     }
 
-    property <int> compo0_foo: compo0.foo;
-    property <int> compo2_foo: compo2.foo;
-    property <float> otw_opacity <=> otw.sub_opacity;
+    in-out property <int> compo0_foo: compo0.foo;
+    in-out property <int> compo2_foo: compo2.foo;
+    in-out property <float> otw_opacity <=> otw.sub_opacity;
 
-    property <bool> test_override_bar: force_instance.preferred-height == 10px && override_bar == 22;
+    in-out property <bool> test_override_bar: force_instance.preferred-height == 10px && override_bar == 22;
 
-    property <bool> test: compo0_foo == 140 && compo2_foo == 130 && otw_opacity == 0.5 && otw2.sub_opacity == 0.5 && test_override_bar;
+    in-out property <bool> test: compo0_foo == 140 && compo2_foo == 130 && otw_opacity == 0.5 && otw2.sub_opacity == 0.5 && test_override_bar;
 }
 
 /*

--- a/tests/cases/bindings/two_way_simple.slint
+++ b/tests/cases/bindings/two_way_simple.slint
@@ -1,21 +1,22 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<brush> extra_background <=> background;
-    property<length> sub_width1 <=> sub.width;
-    property<length> sub_width2: sub.width;
+component TestCase inherits Rectangle {
+    in-out property<brush> extra_background <=> root.background;
+    in-out property<length> sub_width1 <=> sub.width;
+    in-out property<length> sub_width2: sub.width;
 
-    property<int> sub_foo1: 44;
-    property<int> sub_foo2: sub.foo;
+    in-out property<int> sub_foo1: 44;
+    in-out property<int> sub_foo2: sub.foo;
 
 
     sub := Rectangle {
+        x:0;
         width: 80phx;
-        property<int> foo <=> root.sub_foo1;
+        property<int> foo <=> sub_foo1;
     }
 
-    if (true) : Rectangle { background: root.extra_background; }
+    if (true) : Rectangle { background: extra_background; }
 }
 
 


### PR DESCRIPTION
## Summary

Continues #11734 / #11848 / #11849. Ports 18 test files in `tests/cases/bindings/` from the deprecated Slint 0.3 syntax to the current syntax.

Changes applied by `tools/updater` (same five rules as #11734).

No manual fixes were needed in this batch despite the high density of `<=>` two-way aliases — none target an `out property` (the pattern that needed the manual fix in #11734).

## Test plan

- [x] \`cargo test -p test-driver-interpreter\` — all 681 tests pass