### PR TITLE
tests: port callbacks, focus to new Slint syntax

### DIFF
--- a/tests/cases/callbacks/callback_alias.slint
+++ b/tests/cases/callbacks/callback_alias.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Foo := Rectangle {
+component Foo inherits Rectangle {
     pure callback hallo_alias <=> xxx.hallo;
     callback clicked <=> are.clicked;
     xxx := Rectangle {
@@ -12,14 +12,14 @@ Foo := Rectangle {
     are := TouchArea { }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
 
     pure callback foo1_alias <=> foo1.hallo_alias;
     pure callback foo2_alias <=> foo2.hallo_alias;
 
     callback foo1_clicked <=> foo1.clicked;
 
-    callback call_foo2(int) -> int;
+    pure callback call_foo2(int) -> int;
     call_foo2(a) => { return foo2.hallo_alias(a); }
 
     foo1 := Foo {
@@ -30,7 +30,7 @@ TestCase := Rectangle {
         clicked => { debug(42) }
     }
 
-    property <bool> test: foo1_alias(100) == 122 && foo2_alias(100) == 188;
+    in-out property <bool> test: foo1_alias(100) == 122 && foo2_alias(100) == 188;
 }
 
 /*

--- a/tests/cases/callbacks/callback_conn.slint
+++ b/tests/cases/callbacks/callback_conn.slint
@@ -1,16 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    callback test_func(int) -> int;
+component TestCase inherits Rectangle {
+    pure callback test_func(int) -> int;
     test_func(val) => val ;
 
-    callback test_func2(int, string) -> string ;
+    pure callback test_func2(int, string) -> string ;
     test_func2(val, str) => {str + "=" + val} ;
 
-    property <int> test_prop: 4 + test_func(2);
-    property <string> test_prop2 : test_func2(54, "hello");
-    property <bool> test: test_prop == 6 && test_prop2 == "hello=54";
+    in-out property <int> test_prop: 4 + test_func(2);
+    in-out property <string> test_prop2 : test_func2(54, "hello");
+    in-out property <bool> test: test_prop == 6 && test_prop2 == "hello=54";
 
 }
 

--- a/tests/cases/callbacks/callback_name_conflicts.slint
+++ b/tests/cases/callbacks/callback_name_conflicts.slint
@@ -1,10 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
-    property <int> value;
+    in-out property <int> value;
     callback clicked; // this callback shouldn't conflict with the other callback
 
     TouchArea {

--- a/tests/cases/callbacks/functions.slint
+++ b/tests/cases/callbacks/functions.slint
@@ -1,25 +1,25 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-global G := {
-    property <string> hello: "hello";
+global G  {
+    in-out property <string> hello: "hello";
     function meh(w: string) -> string {
-        return hello + " " + w;
+        return root.hello + " " + w;
     }
 }
 
-SubCompo := Rectangle {
+component SubCompo inherits Rectangle {
     public pure function hello() -> color { red }
 }
 
-export global PubGlob := {
-    public function beh(a: int, b: int) -> int { a + b + 10 }
+export global PubGlob  {
+    pure public function beh(a: int, b: int) -> int { a + b + 10 }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
 
-    property <int> c: 100000;
-    private property <int> one: 1 + Math.round((x / 1px) - (y / 1px));
+    in-out property <int> c: 100000;
+    private property <int> one: 1 + Math.round((root.x / 1px) - (root.y / 1px));
 
     function foo() {}
     function the_function(a: int, b: int) -> int { foo(); a + b + c + one }
@@ -32,12 +32,12 @@ TestCase := Rectangle {
 
     }
 
-    public function pub(a: int, b: int) -> int { a + b + c }
+    pure public function pub(a: int, b: int) -> int { a + b + c }
 
     public function set_c(p: int) { c = p }
 
 
-    property <bool> test: the_function(4500, 20) == 104521 && G.meh("world") == "hello world" && sc.hello() == Colors.red;
+    in-out property <bool> test: the_function(4500, 20) == 104521 && G.meh("world") == "hello world" && sc.hello() == Colors.red;
 }
 
 /*

--- a/tests/cases/callbacks/handler.slint
+++ b/tests/cases/callbacks/handler.slint
@@ -1,11 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     callback test_callback;
     callback test_callback2;
     callback test_callback3;
-    property<int> callback_emission_count;
+    in-out property<int> callback_emission_count;
     test_callback => {
         callback_emission_count += 1;
         // This returns something despite the callback isn't supposed to return anything.
@@ -13,7 +13,7 @@ TestCase := Rectangle {
         // result in compilation error in the generated code
         callback_emission_count
     }
-    test_callback2 => {  callback_emission_count = 88; root.test_callback3(); }
+    test_callback2 => {  callback_emission_count = 88; test_callback3(); }
 }
 /*
 ```cpp

--- a/tests/cases/callbacks/handler_with_arg.slint
+++ b/tests/cases/callbacks/handler_with_arg.slint
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore salùt
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     callback test_callback(int);
     callback test_callback2(string);
     callback test_callback3(int, string);
-    property<int> callback_emission_count;
+    in-out property<int> callback_emission_count;
     test_callback => { callback_emission_count += 1; }
-    test_callback2(xx) => { callback_emission_count = 88; root.test_callback3(55, xx); }
+    test_callback2(xx) => { callback_emission_count = 88; test_callback3(55, xx); }
 }
 
 /*

--- a/tests/cases/callbacks/init.slint
+++ b/tests/cases/callbacks/init.slint
@@ -6,37 +6,37 @@
 
 import { ExportedGlobal } from "../../helper_components/export_globals.slint";
 
-export global InitOrder := {
-    property <string> observed-order: "start";
+export global InitOrder  {
+    in-out property <string> observed-order: "start";
 }
 
-Sub1 := Rectangle {
+component Sub1 inherits Rectangle {
     init => {
         InitOrder.observed-order += "|sub1";
     }
 }
 
-Sub2 := Rectangle {
+component Sub2 inherits Rectangle {
     init => {
         InitOrder.observed-order += "|sub2";
     }
 }
 
-SubSub := Rectangle {
+component SubSub inherits Rectangle {
     init => {
         InitOrder.observed-order += "|subsub";
     }
 }
 
-Sub3 := Rectangle {
-    property <string> some-value: "should-not-show-up";
+component Sub3 inherits Rectangle {
+    in-out property <string> some-value: "should-not-show-up";
     init => {
         InitOrder.observed-order += some-value;
     }
     SubSub {}
 }
 
-Container := Rectangle {
+component Container inherits Rectangle {
     in property <string> name-inside: "container";
     init => {
         InitOrder.observed-order += "|" + self.name-inside;
@@ -44,15 +44,15 @@ Container := Rectangle {
     @children
 }
 
-InsideRepeater := Rectangle {
-    property <int> index;
+component InsideRepeater inherits Rectangle {
+    in-out property <int> index;
     init => {
         InitOrder.observed-order += "(i" + self.index + ")";
     }
     @children
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
     init => {
@@ -98,10 +98,10 @@ TestCase := Rectangle {
         Rectangle {}
     }
 
-    property <string> test_global_prop_value: InitOrder.observed-order;
+    in-out property <string> test_global_prop_value: InitOrder.observed-order;
 
-    property <string> expected_static_order: "start|sub1|sub2|subsub|sub3|container|root|sub1-use-site|container-instantiation|element";
-    property <string> expected_full_order: expected_static_order + "|repeater0(i0)|repeater1(i1)";
+    in-out property <string> expected_static_order: "start|sub1|sub2|subsub|sub3|container|root|sub1-use-site|container-instantiation|element";
+    in-out property <string> expected_full_order: expected_static_order + "|repeater0(i0)|repeater1(i1)";
 
     out property <bool> test: InitOrder.observed-order == expected_full_order;
 }

--- a/tests/cases/callbacks/init_layout.slint
+++ b/tests/cases/callbacks/init_layout.slint
@@ -3,12 +3,12 @@
 
 // Verify that the init callback is invoked in the correct order
 
-export global InitOrder := {
-    property <string> observed-order: "start";
+export global InitOrder  {
+    in-out property <string> observed-order: "start";
 }
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
     init => {
@@ -25,9 +25,9 @@ TestCase := Rectangle {
         }
     }
 
-    property <string> expected_order: "start|root|hello|world";
+    in-out property <string> expected_order: "start|root|hello|world";
 
-    property <bool> test: root.preferred-width == 20px && InitOrder.observed-order == expected_order;
+    in-out property <bool> test: root.preferred-width == 20px && InitOrder.observed-order == expected_order;
 }
 
 /*

--- a/tests/cases/callbacks/init_popup.slint
+++ b/tests/cases/callbacks/init_popup.slint
@@ -3,7 +3,7 @@
 
 // Verify that the init callback is invoked in the correct order
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -11,7 +11,7 @@ TestCase := Rectangle {
 
     popup := PopupWindow {
         init => {
-            root.popup-created += 1;
+            popup-created += 1;
         }
     }
 

--- a/tests/cases/callbacks/return_value.slint
+++ b/tests/cases/callbacks/return_value.slint
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore haha
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     pure callback test_func(int) -> int;
     pure callback test_func2(string, int) -> string;
     test_func2(str, val) => { str + "=" + (val + some_value) }
 
-    property <int> test_prop: 4 + test_func(2);
-    property <string> test_prop2: test_func2("hello", 42);
-    property <int> some_value: 8;
+    in-out property <int> test_prop: 4 + test_func(2);
+    in-out property <string> test_prop2: test_func2("hello", 42);
+    in-out property <int> some_value: 8;
 
-    callback dummy() -> int;
+    pure callback dummy() -> int;
     dummy => { 4.4 }
     callback returns_void;
     returns_void => { test_func2("haha", 8) }
 
-    property <bool> test: test_prop == 4 && test_prop2 == "hello=50";
+    in-out property <bool> test: test_prop == 4 && test_prop2 == "hello=50";
 }
 
 /*

--- a/tests/cases/focus/event_propagation.slint
+++ b/tests/cases/focus/event_propagation.slint
@@ -1,16 +1,18 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
     forward-focus: input2;
 
     input1 := TextInput {
+        y:0;
         width: parent.width;
         height: 200phx;
         Rectangle {
             FocusScope {
+                x:0;
                 width: 75%;
                 key-pressed(event) => {
                     if (event.text != Key.Shift && event.text != Key.Control) {
@@ -22,22 +24,24 @@ TestCase := Rectangle {
                 if (false) : Rectangle { FocusScope {} }
 
                 input2 := TextInput {
+                    x:0;
                     width: 75%;
                     height: 100%;
                 }
             }
         }
         Rectangle {
+            x:0;
             width: 0%;
             FocusScope {  }
         }
     }
 
-    property<bool> input1_focused: input1.has_focus;
-    property<string> input1_text: input1.text;
-    property<bool> input2_focused: input2.has_focus;
-    property<string> input2_text: input2.text;
-    property<string> received;
+    in-out property<bool> input1_focused: input1.has_focus;
+    in-out property<string> input1_text: input1.text;
+    in-out property<bool> input2_focused: input2.has_focus;
+    in-out property<string> input2_text: input2.text;
+    in-out property<string> received;
 }
 
 /*

--- a/tests/cases/focus/event_propagation_2.slint
+++ b/tests/cases/focus/event_propagation_2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     FocusScope {
@@ -44,12 +44,12 @@ TestCase := Window {
         }
     }
 
-    property<bool> toggle: true;
-    property<string> r1;
-    property<string> r2;
-    property<string> r3;
-    property<string> r4;
-    property<string> r5;
+    in-out property<bool> toggle: true;
+    in-out property<string> r1;
+    in-out property<string> r2;
+    in-out property<string> r3;
+    in-out property<string> r4;
+    in-out property<string> r5;
 }
 
 // cSpell:disable

--- a/tests/cases/focus/focus_change_subcompo.slint
+++ b/tests/cases/focus/focus_change_subcompo.slint
@@ -6,8 +6,8 @@
 // Test that the correct item indices are computed when focusing
 // children of sub-components or their roots.
 
-SubComponentWithFocusableChild := Rectangle {
-    property <bool> has-focus: input.has-focus;
+component SubComponentWithFocusableChild inherits Rectangle {
+    in-out property <bool> has-focus: input.has-focus;
 
     callback activate();
     activate => {
@@ -20,15 +20,15 @@ SubComponentWithFocusableChild := Rectangle {
     }
 }
 
-SubComponentWithRootFocusable := TextInput {
+component SubComponentWithRootFocusable inherits TextInput {
     callback activate();
     activate => {
         root.focus();
     }
 }
 
-FocusInNestedSubComponent := Rectangle {
-    property <bool> has-focus: compo.has-focus;
+component FocusInNestedSubComponent inherits Rectangle {
+    in-out property <bool> has-focus: compo.has-focus;
     callback activate();
     activate => {
         compo.activate();
@@ -38,7 +38,7 @@ FocusInNestedSubComponent := Rectangle {
 }
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
 
@@ -64,9 +64,9 @@ TestCase := Rectangle {
         height: 150px;
     }
 
-    property<bool> input1_focused: input1.has_focus;
-    property<bool> input2_focused: input2.has_focus;
-    property<bool> input3_focused: input3.has_focus;
+    in-out property<bool> input1_focused: input1.has_focus;
+    in-out property<bool> input2_focused: input2.has_focus;
+    in-out property<bool> input3_focused: input3.has_focus;
 
 }
 

--- a/tests/cases/focus/focus_change_through_signal.slint
+++ b/tests/cases/focus/focus_change_through_signal.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-SubElement := Rectangle {
-    property text <=> input.text;
-    property <bool> has-focus: input.has-focus;
+component SubElement inherits Rectangle {
+    in-out property text <=> input.text;
+    in-out property <bool> has-focus: input.has-focus;
     forward_focus: input;
     input := TextInput {
         width: 100%;
@@ -11,7 +11,7 @@ SubElement := Rectangle {
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
 
@@ -23,6 +23,7 @@ TestCase := Rectangle {
 
     Rectangle {
         input1 := TextInput {
+            y:0;
             width: parent.width;
             height: 200phx;
         }
@@ -36,10 +37,10 @@ TestCase := Rectangle {
 
     if (false) : SubElement {  }
 
-    property<bool> input1_focused: input1.has_focus;
-    property<string> input1_text: input1.text;
-    property<bool> input2_focused: input2.has_focus;
-    property<string> input2_text: input2.text;
+    in-out property<bool> input1_focused: input1.has_focus;
+    in-out property<string> input1_text: input1.text;
+    in-out property<bool> input2_focused: input2.has_focus;
+    in-out property<string> input2_text: input2.text;
 }
 
 /*

--- a/tests/cases/focus/forward.slint
+++ b/tests/cases/focus/forward.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
 
@@ -9,6 +9,7 @@ TestCase := Rectangle {
     focus_rectangle => { rectangle.focus(); }
 
     rectangle := Rectangle {
+        y:0;
         width: parent.width;
         height: 200phx;
         forward-focus: input;
@@ -20,7 +21,7 @@ TestCase := Rectangle {
         height: 200phx;
     }
 
-    property<bool> input_focused: input.has_focus;
+    in-out property<bool> input_focused: input.has_focus;
 }
 
 /*

--- a/tests/cases/focus/initial_focus.slint
+++ b/tests/cases/focus/initial_focus.slint
@@ -1,12 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
     forward-focus: input1;
 
     input1 := TextInput {
+        y:0;
         width: parent.width;
         height: 200phx;
     }
@@ -16,10 +17,10 @@ TestCase := Rectangle {
         height: 200phx;
     }
 
-    property<bool> input1_focused: input1.has_focus;
-    property<string> input1_text: input1.text;
-    property<bool> input2_focused: input2.has_focus;
-    property<string> input2_text: input2.text;
+    in-out property<bool> input1_focused: input1.has_focus;
+    in-out property<string> input1_text: input1.text;
+    in-out property<bool> input2_focused: input2.has_focus;
+    in-out property<string> input2_text: input2.text;
 }
 
 /*

--- a/tests/cases/focus/initial_focus_through_component.slint
+++ b/tests/cases/focus/initial_focus_through_component.slint
@@ -1,10 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-MyTextInput := TextInput { }
+component MyTextInput inherits TextInput { }
 
-TextComponent := Rectangle {
-    property<bool> has_focus: my_text_input.has_focus;
+component TextComponent inherits Rectangle {
+    in-out property<bool> has_focus: my_text_input.has_focus;
     forward-focus: my_text_input;
     my_text_input := MyTextInput { }
 
@@ -16,7 +16,7 @@ TextComponent := Rectangle {
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
     forward-focus: input2;
@@ -31,8 +31,8 @@ TestCase := Rectangle {
       input1.focus();
     }
 
-    property<bool> input1_focused: input1.has_focus;
-    property<bool> input2_focused: input2.has_focus;
+    in-out property<bool> input1_focused: input1.has_focus;
+    in-out property<bool> input2_focused: input2.has_focus;
 }
 
 /*

--- a/tests/cases/focus/initial_focus_through_layout.slint
+++ b/tests/cases/focus/initial_focus_through_layout.slint
@@ -1,15 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TextComponent := GridLayout {
-    property<bool> has_focus: my_text_input.has_focus;
+component TextComponent inherits GridLayout {
+    in-out property<bool> has_focus: my_text_input.has_focus;
     forward-focus: my_text_input;
     Row {
         my_text_input := TextInput { }
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
     forward-focus: input2;
@@ -19,8 +19,8 @@ TestCase := Rectangle {
     input2 := TextComponent {
     }
 
-    property<bool> input1_focused: input1.has_focus;
-    property<bool> input2_focused: input2.has_focus;
+    in-out property<bool> input1_focused: input1.has_focus;
+    in-out property<bool> input2_focused: input2.has_focus;
 }
 
 /*

--- a/tests/cases/focus/keyboard_focus.slint
+++ b/tests/cases/focus/keyboard_focus.slint
@@ -3,11 +3,11 @@
 
 import { SpinBox, LineEdit, HorizontalBox, VerticalBox, TabWidget } from "std-widgets.slint";
 
-TestCase := Window {
+component TestCase inherits Window {
     preferred-width: 500px;
     preferred-height: 400px;
 
-    property<[{name: string, account: string, score: float}]> model: [
+    in-out property<[{name: string, account: string, score: float}]> model: [
         {
             name: "Olivier",
             account: "ogoffart",
@@ -20,7 +20,7 @@ TestCase := Window {
         }
     ];
 
-    property<string> result;
+    in-out property<string> result;
 
     VerticalBox {
         FocusScope {

--- a/tests/cases/focus/keyboard_focus2.slint
+++ b/tests/cases/focus/keyboard_focus2.slint
@@ -5,12 +5,12 @@
 
 import { VerticalBox, ListView } from "std-widgets.slint";
 
-TestCase := Window {
+component TestCase inherits Window {
   width: 500px;
   height: 400px;
 
-  property <[string]> features : [ "f" ];
-  property <string> result;
+  in-out property <[string]> features : [ "f" ];
+  in-out property <string> result;
 
   VerticalBox {
     VerticalBox {


### PR DESCRIPTION
## Summary

Continues #11734 series. Ports 20 test files in `tests/cases/` from the deprecated Slint 0.3 syntax to the current syntax.

Changes applied by `tools/updater` (same five rules as #11734). No manual fixes were needed.

## Directories covered

`callbacks` (10), `focus` (10) — 20 files.

## Test plan

- [x] \`cargo test -p test-driver-interpreter\` — all 681 tests pass