### PR TITLE
tests: port types, text to new Slint syntax

### DIFF
--- a/tests/cases/text/control_keys_input.slint
+++ b/tests/cases/text/control_keys_input.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     ti := TextInput {
     }
 
-    property <bool> input_focused: ti.has_focus;
-    property <string> text <=> ti.text;
+    in-out property <bool> input_focused: ti.has_focus;
+    in-out property <string> text <=> ti.text;
 }
 
 /*

--- a/tests/cases/text/cursor_move.slint
+++ b/tests/cases/text/cursor_move.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
-    property<string> test_text: self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/text/cursor_move_grapheme.slint
+++ b/tests/cases/text/cursor_move_grapheme.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
-    property<string> test_text: self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/text/custom_font.slint
+++ b/tests/cases/text/custom_font.slint
@@ -8,7 +8,7 @@ import "../../../demos/printerdemo/ui/fonts/Inter-24pt-Regular.ttf";
 import "../../../demos/printerdemo/ui/fonts/Inter-24pt-Medium.ttf";
 
 
-TestCase := Window {
+component TestCase inherits Window {
     preferred-width: 100phx;
     preferred-height: 100phx;
     default-font-family: "Inter 24pt";

--- a/tests/cases/text/cut.slint
+++ b/tests/cases/text/cut.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
-    property<string> test_text: self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/text/default_color.slint
+++ b/tests/cases/text/default_color.slint
@@ -3,31 +3,32 @@
 
 import { Palette } from "std-widgets.slint";
 
-SubElement := Rectangle {
-    property sub_color <=> sub.color;
-    sub := Text { text: "sub"; }
+component SubElement inherits Rectangle {
+    in-out property sub_color <=> sub.color;
+    sub := Text { x:0;y:0; text: "sub"; }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     // This binding allow the test to set the style's default color so that we can compare it
-    property<color> binding_to_default_text_color: Palette.foreground;
+    in-out property<color> binding_to_default_text_color: Palette.foreground;
 
-    default_text := Text { text: "default"; }
+    default_text := Text { x:0;y:0; text: "default"; }
     text_with_color := Text {
+        x:0;y:0;
         text: "yellow";
         color: #ffff00ff;
     }
     text_in_sub_element := SubElement { sub_color: #ff0000; }
-    text_in_state := Text { }
+    text_in_state := Text { x:0;y:0; }
     states [ xx when false: { text_in_state.color: #abc; } ]
 
-    property <color> default_text_color: default_text.color;
-    property <color> color_of_initialized_text: text_with_color.color;
-    property <color> color_of_sub_element_text: text_in_sub_element.sub_color;
-    property <color> color_in_state: text-in-state.color;
+    in-out property <color> default_text_color: default_text.color;
+    in-out property <color> color_of_initialized_text: text_with_color.color;
+    in-out property <color> color_of_sub_element_text: text_in_sub_element.sub_color;
+    in-out property <color> color_in_state: text-in-state.color;
 
-    property <bool> test: default_text_color == Palette.foreground && color-of-initialized-text == #ffff00ff
-        && color_of_sub_element_text == #ff0000 && color-in-state == Palette.foreground;
+    in-out property <bool> test: default_text_color == Palette.foreground && root.color-of-initialized-text == #ffff00ff
+        && color_of_sub_element_text == #ff0000 && root.color-in-state == Palette.foreground;
 }
 
 

--- a/tests/cases/text/input_type_number.slint
+++ b/tests/cases/text/input_type_number.slint
@@ -1,15 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     ti := TextInput {
         input-type: number;
     }
 
-    property <bool> input_focused: ti.has_focus;
-    property <string> text <=> ti.text;
+    in-out property <bool> input_focused: ti.has_focus;
+    in-out property <string> text <=> ti.text;
 }
 
 /*

--- a/tests/cases/text/key_repeat.slint
+++ b/tests/cases/text/key_repeat.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     ti := FocusScope {
@@ -17,9 +17,9 @@ TestCase := Window {
         }
     }
 
-    property <bool> input_focused: ti.has_focus;
-    property <bool> pressed;
-    property <bool> repeat;
+    in-out property <bool> input_focused: ti.has_focus;
+    in-out property <bool> pressed;
+    in-out property <bool> repeat;
 }
 
 /*

--- a/tests/cases/text/keyboard_modifiers.slint
+++ b/tests/cases/text/keyboard_modifiers.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     ti := FocusScope {
@@ -21,11 +21,11 @@ TestCase := Window {
         }
     }
 
-    property <bool> input_focused: ti.has_focus;
-    property <bool> shift_modifier;
-    property <bool> alt_modifier;
-    property <bool> control_modifier;
-    property <bool> meta_modifier;
+    in-out property <bool> input_focused: ti.has_focus;
+    in-out property <bool> shift_modifier;
+    in-out property <bool> alt_modifier;
+    in-out property <bool> control_modifier;
+    in-out property <bool> meta_modifier;
 }
 
 /*

--- a/tests/cases/text/select_all.slint
+++ b/tests/cases/text/select_all.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
-    property<string> test_text: self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/text/select_double_click.slint
+++ b/tests/cases/text/select_double_click.slint
@@ -1,16 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     font-family: "FixedTestFont";
     font-size: 10px;
     width: 120phx;
     height: 100phx;
-    property<string> test_text <=> self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text <=> self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/text/select_dribble_click.slint
+++ b/tests/cases/text/select_dribble_click.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
-    property<string> test_text: self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/text/surrogate_cursor.slint
+++ b/tests/cases/text/surrogate_cursor.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
-    property<string> test_text: self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/text/text_change.slint
+++ b/tests/cases/text/text_change.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     VerticalLayout {
@@ -11,9 +11,9 @@ TestCase := Window {
         Rectangle { }
     }
 
-    property <string> text <=> ti.text;
-    property <bool> input_focused: ti.has_focus;
-    property<int> test_cursor_pos: ti.cursor_position_byte_offset;
+    in-out property <string> text <=> ti.text;
+    in-out property <bool> input_focused: ti.has_focus;
+    in-out property<int> test_cursor_pos: ti.cursor_position_byte_offset;
 }
 
 /*

--- a/tests/cases/text/text_property_change.slint
+++ b/tests/cases/text/text_property_change.slint
@@ -3,13 +3,13 @@
 
 // Test that the
 
-global SomeGlobal := {
-    property <string> intermediate_alias <=> intermediate_prop;
-    property <string> intermediate_prop;
-    property <string> text: intermediate_prop;
+global SomeGlobal  {
+    in-out property <string> intermediate_alias <=> root.intermediate_prop;
+    in-out property <string> intermediate_prop;
+    in-out property <string> text: root.intermediate_prop;
 }
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     VerticalLayout {
@@ -17,8 +17,8 @@ TestCase := Window {
         spacing: 0;
         ti := TextInput {
             property <string> foo <=> SomeGlobal.intermediate_alias;
-            text <=> foo;
-            property <bool> bar <=> has_focus;
+            text <=> self.foo;
+            property <bool> bar <=> self.has_focus;
 
         }
         t := Text {
@@ -27,8 +27,8 @@ TestCase := Window {
         Rectangle { }
     }
 
-    property <string> text <=> t.text;
-    property <bool> input_focused: ti.bar;
+    in-out property <string> text <=> t.text;
+    in-out property <bool> input_focused: ti.bar;
 }
 
 /*

--- a/tests/cases/text/undo_redo.slint
+++ b/tests/cases/text/undo_redo.slint
@@ -1,15 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := TextInput {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
     single-line: false;
-    property<string> test_text: self.text;
-    property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    property<int> test_anchor_pos: self.anchor_position_byte_offset;
-    property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    property<bool> input_focused: self.has_focus;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+    in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
+    in-out property<bool> input_focused: self.has_focus;
 }
 
 /*

--- a/tests/cases/types/angles.slint
+++ b/tests/cases/types/angles.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Test := Rectangle {
-    property<angle> angle: 0.25turn;
-    property<bool> test: abs((angle - 0.5rad * 3.1415926535)/1grad) < 0.00001;
+component Test inherits Rectangle {
+    in-out property<angle> angle: 0.25turn;
+    in-out property<bool> test: abs((angle - 0.5rad * 3.1415926535)/1grad) < 0.00001;
 }
 
 /*

--- a/tests/cases/types/bool.slint
+++ b/tests/cases/types/bool.slint
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore falsevar truevar
-TestCase := Rectangle {
-    property<bool> truevar: true;
-    property<bool> falsevar: false;
+component TestCase inherits Rectangle {
+    in-out property<bool> truevar: true;
+    in-out property<bool> falsevar: false;
 }
 /*
 ```cpp

--- a/tests/cases/types/brush.slint
+++ b/tests/cases/types/brush.slint
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore seethru
-Test := Rectangle {
+component Test inherits Rectangle {
     // allow declaring brush properties and assigning colors
-    property<brush> color_brush: blue;
+    in-out property<brush> color_brush: blue;
     // allow to use brighter and darker on a brush
-    property<brush> lighter: true ? color_brush.brighter(50%) : color_brush.darker(50%);
+    in-out property<brush> lighter: true ? color_brush.brighter(50%) : color_brush.darker(50%);
     // allow to use `transparentize`
-    property<brush> seethru: color_brush.transparentize(30%);
+    in-out property<brush> seethru: color_brush.transparentize(30%);
 
     VerticalLayout {
         r1 := Rectangle {
@@ -18,15 +18,15 @@ Test := Rectangle {
             background: r1.background.darker(50%);
         }
     }
-    property <color> r2_col: r2.background;
-    property <brush> conditional: false ? Colors.white : true ? r2.background : Colors.green;
+    in-out property <color> r2_col: r2.background;
+    in-out property <brush> conditional: false ? Colors.white : true ? r2.background : Colors.green;
 
     test_circle := Rectangle {
         background: @radial_gradient(circle, #abc, #123 10%, #fed);
-        property <color> colo: background;
-        property <bool> test: colo == #abc
-            && background.brighter(10%) == @radial_gradient(circle, (#abc).brighter(10%), (#123).brighter(10%) 10%, (#fed).brighter(10%))
-            && background != colo;
+        property <color> colo: self.background;
+        property <bool> test: self.colo == #abc
+            && self.background.brighter(10%) == @radial_gradient(circle, (#abc).brighter(10%), (#123).brighter(10%) 10%, (#fed).brighter(10%))
+            && self.background != self.colo;
     }
 
     out property <bool> test_rgb: rgb(color_brush.red, color_brush.green, color_brush.blue) == color_brush;

--- a/tests/cases/types/color.slint
+++ b/tests/cases/types/color.slint
@@ -3,72 +3,72 @@
 
 // cspell:ignore bwood
 
-Test := Rectangle {
-    property<color> b1: blue;
-    property<color> b2: #00f;
-    property<color> b3: #0000ff;
-    property<color> b4: #00ff;
-    property<color> b5: #0000ffff;
-    property<color> r1: red;
-    property<color> r2: #f00;
-    property<color> r3: #ff0000;
-    property<color> r4: #f00f;
-    property<color> r5: #ff0000ff;
+component Test inherits Rectangle {
+    in-out property<color> b1: blue;
+    in-out property<color> b2: #00f;
+    in-out property<color> b3: #0000ff;
+    in-out property<color> b4: #00ff;
+    in-out property<color> b5: #0000ffff;
+    in-out property<color> r1: red;
+    in-out property<color> r2: #f00;
+    in-out property<color> r3: #ff0000;
+    in-out property<color> r4: #f00f;
+    in-out property<color> r5: #ff0000ff;
 
-    property<color> y1: yellow;
-    property<color> y2: #ff0;
+    in-out property<color> y1: yellow;
+    in-out property<color> y2: #ff0;
 
-    property<color> g1: #999;
+    in-out property<color> g1: #999;
 
-    property<color> c1: #ff335588;
-    property<color> c2: rgb(100, 23, 42);
-    property<color> c3: rgba(39%, 50%, 16%, 81%);
+    in-out property<color> c1: #ff335588;
+    in-out property<color> c2: rgb(100, 23, 42);
+    in-out property<color> c3: rgba(39%, 50%, 16%, 81%);
 
-    property<color> i1: rgb(0, 666, -85);
+    in-out property<color> i1: rgb(0, 666, -85);
 
     // allow to use `mix` on colors
-    property<color> p1: true ? b1.mix(r1, 30%) : y1.mix(c1, 70%);
+    in-out property<color> p1: true ? b1.mix(r1, 30%) : y1.mix(c1, 70%);
     // allow to use `with_alpha` on colors
-    property<brush> invisible: b1.with-alpha(0%);
+    in-out property<brush> invisible: b1.with-alpha(0%);
 
-    property<float> b1hue: 240.0;
-    property<float> b1sat: 1.0;
-    property<float> b1bri: 1.0;
+    in-out property<float> b1hue: 240.0;
+    in-out property<float> b1sat: 1.0;
+    in-out property<float> b1bri: 1.0;
 
-    property<float> r1hue: 0.0;
-    property<float> r1sat: 1.0;
-    property<float> r1bri: 1.0;
+    in-out property<float> r1hue: 0.0;
+    in-out property<float> r1sat: 1.0;
+    in-out property<float> r1bri: 1.0;
 
-    property<float> y1hue: 60.0;
-    property<float> y1sat: 1.0;
-    property<float> y1bri: 1.0;
+    in-out property<float> y1hue: 60.0;
+    in-out property<float> y1sat: 1.0;
+    in-out property<float> y1bri: 1.0;
 
-    property <color> gr1: green;
-    property<float> gr1hue: 120.0;
-    property<float> gr1sat: 1.0;
-    property<float> gr1bri: 0.501960813999176;
-    property <color> new_green: hsv(120.0, 1.0, 0.501960813999176);
+    in-out property <color> gr1: green;
+    in-out property<float> gr1hue: 120.0;
+    in-out property<float> gr1sat: 1.0;
+    in-out property<float> gr1bri: 0.501960813999176;
+    in-out property <color> new_green: hsv(120.0, 1.0, 0.501960813999176);
 
     // burlywood
-    property<color> bwood: Colors.burlywood;
-    property<float> bwood_hue: 33.79310607910156;
-    property<float> bwood_sat: 0.39189186692237854;
-    property<float> bwood_bri: 0.8705882430076599;
+    in-out property<color> bwood: Colors.burlywood;
+    in-out property<float> bwood_hue: 33.79310607910156;
+    in-out property<float> bwood_sat: 0.39189186692237854;
+    in-out property<float> bwood_bri: 0.8705882430076599;
 
     // hsv with angle hue
-    property<color> hsv_angle1: hsv(240deg, 1, 1);
-    property<color> hsv_angle2: hsv(240, 1, 1);
+    in-out property<color> hsv_angle1: hsv(240deg, 1, 1);
+    in-out property<color> hsv_angle2: hsv(240, 1, 1);
 
     // oklch color creation
-    property<color> oklch1: oklch(0.5, 0.1, 180);
-    property<color> oklch2: oklch(0.7, 0.15, 90, 0.8);
+    in-out property<color> oklch1: oklch(0.5, 0.1, 180);
+    in-out property<color> oklch2: oklch(0.7, 0.15, 90, 0.8);
     // oklch with percentage - 100% chroma equals 0.4
-    property<color> oklch_pct1: oklch(50%, 100%, 180);
-    property<color> oklch_pct2: oklch(0.5, 0.4, 180);
+    in-out property<color> oklch_pct1: oklch(50%, 100%, 180);
+    in-out property<color> oklch_pct2: oklch(0.5, 0.4, 180);
     // oklch with angle hue
-    property<color> oklch_angle1: oklch(0.5, 0.1, 180deg);
-    property<color> oklch_angle2: oklch(0.5, 0.1, 180);
-    property<color> oklch_angle3: oklch(0.5, 0.1, 0.5turn);
+    in-out property<color> oklch_angle1: oklch(0.5, 0.1, 180deg);
+    in-out property<color> oklch_angle2: oklch(0.5, 0.1, 180);
+    in-out property<color> oklch_angle3: oklch(0.5, 0.1, 0.5turn);
 
     // oklch conversion - approximate values for known colors
     // Red in oklch: L≈0.63, C≈0.26, H≈29
@@ -104,7 +104,7 @@ Test := Rectangle {
     // Test oklch angle hue: 180deg == 180 == 0.5turn
     out property <bool> test_oklch_angle: oklch_angle1 == oklch_angle2 && oklch_angle1 == oklch_angle3;
 
-    property<bool> test: b1 == b2 && b2 == b5 && b3 == Colors.blue && Colors.red == r4 && y1 == Colors.rgba(255, 100%, 0, 100%)
+    in-out property<bool> test: b1 == b2 && b2 == b5 && b3 == Colors.blue && Colors.red == r4 && y1 == Colors.rgba(255, 100%, 0, 100%)
         && test_rgb && test_hsv && test_hsv_hue && test_hsv_sat && test_hsv_bri && test_hsv_wrap && test_hsv_angle
         && test_oklch_red && test_oklch_blue && test_oklch_white && test_oklch_create && test_oklch_percent && test_oklch_angle;
 }

--- a/tests/cases/types/cubic-bezier.slint
+++ b/tests/cases/types/cubic-bezier.slint
@@ -3,7 +3,7 @@
 
 // Test that cubic-bezier() can accept negative numbers
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     animate background {
       easing: cubic-bezier(0.600, -0.280, 0.735, 0.045); // ease-in-back
     }

--- a/tests/cases/types/duration.slint
+++ b/tests/cases/types/duration.slint
@@ -1,26 +1,26 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<duration> d1: 100ms;
-    property<duration> d2: 3s;
-    property<duration> d3: 1.5s;
-    property<duration> d4: 30 * 1ms;
-    property<duration> d5: 8ms + 3s;
-    property<duration> d6: d1 - d2;
-    property<duration> d7: -0.5s;
-    property<duration> d8: -0.5s / 2 * 1px / 1px;
-    property<int> i1: d1 / 1ms;
-    property<int> i2: d1 / (2ms + 0);
+component TestCase inherits Rectangle {
+    in-out property<duration> d1: 100ms;
+    in-out property<duration> d2: 3s;
+    in-out property<duration> d3: 1.5s;
+    in-out property<duration> d4: 30 * 1ms;
+    in-out property<duration> d5: 8ms + 3s;
+    in-out property<duration> d6: d1 - d2;
+    in-out property<duration> d7: -0.5s;
+    in-out property<duration> d8: -0.5s / 2 * 1px / 1px;
+    in-out property<int> i1: d1 / 1ms;
+    in-out property<int> i2: d1 / (2ms + 0);
 
-    property<int> untyped_d1: self.d1 / 1ms;
-    property<int> untyped_d2: self.d2 / 1ms;
-    property<int> untyped_d3: self.d3 / 1ms;
-    property<int> untyped_d4: self.d4 / 1ms;
-    property<int> untyped_d5: self.d5 / 1ms;
-    property<int> untyped_d6: self.d6 / 1ms;
-    property<int> untyped_d7: self.d7 / 1ms;
-    property<int> untyped_d8: self.d8 / 1ms;
+    in-out property<int> untyped_d1: self.d1 / 1ms;
+    in-out property<int> untyped_d2: self.d2 / 1ms;
+    in-out property<int> untyped_d3: self.d3 / 1ms;
+    in-out property<int> untyped_d4: self.d4 / 1ms;
+    in-out property<int> untyped_d5: self.d5 / 1ms;
+    in-out property<int> untyped_d6: self.d6 / 1ms;
+    in-out property<int> untyped_d7: self.d7 / 1ms;
+    in-out property<int> untyped_d8: self.d8 / 1ms;
 }
 
 

--- a/tests/cases/types/enum_compare.slint
+++ b/tests/cases/types/enum_compare.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <TextWrap> hello: word-wrap;
-    property <bool> test: hello == TextWrap.word-wrap && hello != TextWrap.no-wrap && !(hello == TextWrap.no-wrap);
+component TestCase inherits Rectangle {
+    in-out property <TextWrap> hello: word-wrap;
+    in-out property <bool> test: hello == TextWrap.word-wrap && hello != TextWrap.no-wrap && !(hello == TextWrap.no-wrap);
 }
 
 /*

--- a/tests/cases/types/functions.slint
+++ b/tests/cases/types/functions.slint
@@ -7,9 +7,9 @@ struct Foo1 { member: int, }
 struct Foo2 { a: Foo1 }
 struct Foo3 { b: int }
 
-TestCase := TouchArea {
+component TestCase inherits TouchArea {
     // Based on Issue #2655
-    public function fn1(foo2: Foo2) -> Foo3 {
+    pure public function fn1(foo2: Foo2) -> Foo3 {
       return { b: foo2.a.member+1 };
     }
     public function fn2() { fn1({a:{member:456}}); }

--- a/tests/cases/types/gradients.slint
+++ b/tests/cases/types/gradients.slint
@@ -3,16 +3,16 @@
 
 // Verify that this compiles with all generators
 
-Test := Rectangle {
+component Test inherits Rectangle {
     background: @linear-gradient(45deg, #ff9a9e 0%, #fad0c4 99%, #fad0c4 100%);
-    property <color> foo: #a23;
-    property <brush> bar: @linear-gradient(1.2rad, foo.darker(0.5), foo.brighter(0.5), );
+    in-out property <color> foo: #a23;
+    in-out property <brush> bar: @linear-gradient(1.2rad, foo.darker(0.5), foo.brighter(0.5), );
 
     for data in [{xx: #b56}] : Rectangle {
         background: @linear-gradient(1.2rad, data.xx, blue);
     }
 
-    property <color> c: @linear-gradient(90deg,#e2e1e1,#c5c5c5);
+    in-out property <color> c: @linear-gradient(90deg,#e2e1e1,#c5c5c5);
 
 
     Rectangle {

--- a/tests/cases/types/length.slint
+++ b/tests/cases/types/length.slint
@@ -1,26 +1,26 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<physical_length> l1: 12phx;
-    property<physical_length> l2: 12px;
-    property<physical_length> l3: 100phx + 12px;
-    property<physical_length> l4: 120 * 1phx;
+component TestCase inherits Rectangle {
+    in-out property<physical_length> l1: 12phx;
+    in-out property<physical_length> l2: 12px;
+    in-out property<physical_length> l3: 100phx + 12px;
+    in-out property<physical_length> l4: 120 * 1phx;
 
-    property<length> ll1: 12phx;
-    property<length> ll2: 12px;
-    property<length> ll3: 100phx + 12px;
-    property<length> ll4: 120 * 1phx;
+    in-out property<length> ll1: 12phx;
+    in-out property<length> ll2: 12px;
+    in-out property<length> ll3: 100phx + 12px;
+    in-out property<length> ll4: 120 * 1phx;
 
-    property<bool> value: l1 == 10phx + 2phx;
+    in-out property<bool> value: l1 == 10phx + 2phx;
 
-    property<length> zero1: 0;
-    property<length> zero2: 0 + 1phx - 0 - 1phx;
-    property<bool> test_zero: zero2 == 0;
+    in-out property<length> zero1: 0;
+    in-out property<length> zero2: 0 + 1phx - 0 - 1phx;
+    in-out property<bool> test_zero: zero2 == 0;
 
-    property <float> ratio: 1px / 1phx;
+    in-out property <float> ratio: 1px / 1phx;
 
-    property<bool> test: (8phx * 5px * 3ms / 2phx)  == (8px * (3ms / 2phx) * 5px) / ratio
+    in-out property<bool> test: (8phx * 5px * 3ms / 2phx)  == (8px * (3ms / 2phx) * 5px) / ratio
         && l1*l2 - ll1*ll2 == 0cm*0phx && value;
 
 }

--- a/tests/cases/types/nested_struct.slint
+++ b/tests/cases/types/nested_struct.slint
@@ -4,14 +4,14 @@
 // This test case verifies that we do emit the code for the `Nested` struct,
 // when it's only indirectly referenced through the `Item` struct.
 
-struct Nested := {
+struct Nested  {
     ok: bool
 }
 
-struct Item := {
+struct Item  {
     nested: Nested
 }
 
-export TestCase := Rectangle {
-    property <Item> fob;
+export component TestCase inherits Rectangle {
+    in-out property <Item> fob;
 }

--- a/tests/cases/types/object.slint
+++ b/tests/cases/types/object.slint
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore binop
-TestCase := Rectangle {
-    property<{a: string, b: int}> foo: {a : "444", b: 12 };
-    property<{a: string, b: int}> obj_conversion: { b: 12, a : 444, c: "nothing" };
-    property<{a: string, b: int}> obj_conversion2: { a: "hello" };
-    property<{a: string, b: int}> obj_cond: true ? { b: 12, a : "ddd" } :  { a: 12, b : 444, c: "nothing" };
-    property<{a: int, b: int}> obj_cond_merge : true ? { a: 1 } : { b: 10 };
-    property<bool> obj_binop_merge : { foo: 0, x: 1 } == { bar: 0, x: 1 };
+component TestCase inherits Rectangle {
+    in-out property<{a: string, b: int}> foo: {a : "444", b: 12 };
+    in-out property<{a: string, b: int}> obj_conversion: { b: 12, a : 444, c: "nothing" };
+    in-out property<{a: string, b: int}> obj_conversion2: { a: "hello" };
+    in-out property<{a: string, b: int}> obj_cond: true ? { b: 12, a : "ddd" } :  { a: 12, b : 444, c: "nothing" };
+    in-out property<{a: int, b: int}> obj_cond_merge : true ? { a: 1 } : { b: 10 };
+    in-out property<bool> obj_binop_merge : { foo: 0, x: 1 } == { bar: 0, x: 1 };
 
-    property<string> foo_a : foo.a;
-    property<int> foo_b : foo.b;
-    property<int> obj_cond_merge_b : obj_cond_merge.b;
+    in-out property<string> foo_a : foo.a;
+    in-out property<int> foo_b : foo.b;
+    in-out property<int> obj_cond_merge_b : obj_cond_merge.b;
     callback change_foo;
     change_foo => {
         foo.a = obj_conversion2.a;
@@ -21,7 +21,7 @@ TestCase := Rectangle {
 
     function return_object() -> { aa: { bb: int } }
     { return { aa: { bb: { cc: 42 }.cc } }; }
-    property <bool> test: return_object().aa.bb == 42 && obj_binop_merge;
+    in-out property <bool> test: return_object().aa.bb == 42 && obj_binop_merge;
 
 }
 

--- a/tests/cases/types/percent.slint
+++ b/tests/cases/types/percent.slint
@@ -1,17 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property<float> p1: 100%;
-    property<float> p2: 1%;
-    property<float> p3: 5.5%;
-    property<float> p4: 10 + 50%;
+component TestCase inherits Rectangle {
+    in-out property<float> p1: 100%;
+    in-out property<float> p2: 1%;
+    in-out property<float> p3: 5.5%;
+    in-out property<float> p4: 10 + 50%;
 
-    property <percent> p_min: min(50%, 100%);
-    property <percent> p_max: max(50%, 0%);
-    property <percent> p_clamp: clamp(50%, 0%, 100%);
+    in-out property <percent> p_min: min(50%, 100%);
+    in-out property <percent> p_max: max(50%, 0%);
+    in-out property <percent> p_clamp: clamp(50%, 0%, 100%);
 
-    property <bool> test: p_min == 50% && p_max == 50% && p_clamp == 50%;
+    in-out property <bool> test: p_min == 50% && p_max == 50% && p_clamp == 50%;
 }
 
 

--- a/tests/cases/types/relative_lengths.slint
+++ b/tests/cases/types/relative_lengths.slint
@@ -1,27 +1,29 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Sub := Rectangle {
+component Sub inherits Rectangle {
     width: 25%;
     height: 35%;
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 600phx;
     inner_rect := Rectangle {
+        x:0;
         width: 50%;
-        inner_inner := Sub { }
+        inner_inner := Sub { x:0;y:0; }
     }
-    property<length> test_length: inner_rect.width;
-    property<length> test_inner_inner_length: inner_inner.width;
+    in-out property<length> test_length: inner_rect.width;
+    in-out property<length> test_inner_inner_length: inner_inner.width;
 
 
     height: 200phx;
-    property<percent> controller: 10%;
+    in-out property<percent> controller: 10%;
     inner_rect_2 := Rectangle {
+        y:0;
         height: parent.controller;
     }
-    property<length> controlled_test_length: inner_rect_2.height;
+    in-out property<length> controlled_test_length: inner_rect_2.height;
 }
 
 

--- a/tests/cases/types/resource.slint
+++ b/tests/cases/types/resource.slint
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 //include_path: ../../../demos/printerdemo/ui/images/
-TestCase := Rectangle {
-    property <image> empty_image: @image-url("");
-    property <image> cat: @image-url("cat.jpg");
+component TestCase inherits Rectangle {
+    in-out property <image> empty_image: @image-url("");
+    in-out property <image> cat: @image-url("cat.jpg");
 
-    property <int> empty_width: empty_image.width;
-    property <int> empty_height: empty_image.height;
-    property <int> cat_width: cat.width;
-    property <int> cat_height: cat.height;
+    in-out property <int> empty_width: empty_image.width;
+    in-out property <int> empty_height: empty_image.height;
+    in-out property <int> cat_width: cat.width;
+    in-out property <int> cat_height: cat.height;
 
-    property <bool> test: empty_width == 0 && empty_height == 0 && cat_width == 320 && cat_height == 480;
+    in-out property <bool> test: empty_width == 0 && empty_height == 0 && cat_width == 320 && cat_height == 480;
 }
 
 /*

--- a/tests/cases/types/structs.slint
+++ b/tests/cases/types/structs.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export struct Player := {
+export struct Player  {
     name: string,
     score: int,
     energy_level: float,
@@ -15,23 +15,23 @@ export struct With-Dash_And-underscore {
     foo-bar: int,
 }
 
-TestCase := Rectangle {
-    property<Player> player_1: {name : "Player1", score: 12, energy_level: 80% };
-    property<Player> player_2: {name : "Player2", score: 24, energy_level: 40% };
+component TestCase inherits Rectangle {
+    in-out property<Player> player_1: {name : "Player1", score: 12, energy_level: 80% };
+    in-out property<Player> player_2: {name : "Player2", score: 24, energy_level: 40% };
 
-    property<[Player]> players: [player_1, player_2];
-    property<[Player]> player_list: [
+    in-out property<[Player]> players: [player_1, player_2];
+    in-out property<[Player]> player_list: [
         {name : "Simon", score: 1, energy_level: 50% },
         {name : "Olivier", score: 10 },
         {name : "NoScore", }
     ];
 
-    property player_2_alias <=> player_2;
-    property<int> player_2_score: player_2_alias.score;
+    in-out property player_2_alias <=> player_2;
+    in-out property<int> player_2_score: root.player_2_alias.score;
 
     in-out property <With-Dash_And-underscore> underscore;
 
-    property <bool> test: player_2_score == 24;
+    in-out property <bool> test: player_2_score == 24;
 
 }
 


### PR DESCRIPTION
## Summary

Continues #11734 series. Ports 32 test files in `tests/cases/` from the deprecated Slint 0.3 syntax to the current syntax.

Changes applied by `tools/updater` (same five rules as #11734). No manual fixes were needed.

## Directories covered

`types` (16), `text` (16) — 32 files.

## Test plan

- [x] \`cargo test -p test-driver-interpreter\` — all 681 tests pass