### PR TITLE
tests: port examples, models to new Slint syntax

### DIFF
--- a/tests/cases/examples/box_shadow_use.slint
+++ b/tests/cases/examples/box_shadow_use.slint
@@ -11,7 +11,7 @@
 // Additionally, there are three green rectangles at the bottom placed diagonally
 // using equal spacing and manual calculation, using a repeater.
 
-BlueRect := Rectangle {
+component BlueRect inherits Rectangle {
     background: blue;
     border-radius: 10px;
     drop-shadow-offset-x: 10px;
@@ -22,7 +22,7 @@ BlueRect := Rectangle {
     clip: true;
 }
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 800px;
     height: 600px;
 

--- a/tests/cases/examples/color.slint
+++ b/tests/cases/examples/color.slint
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Win := Window {
-    property <color> base: #00007F;
+component Win inherits Window {
+    in-out property <color> base: #00007F;
     GridLayout {
         r := Rectangle {
             background: base;

--- a/tests/cases/examples/colored_image.slint
+++ b/tests/cases/examples/colored_image.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Win := Window {
+component Win inherits Window {
     GridLayout {
         Image {
             source: @image-url("../../../examples/memory/icons/tile_logo.png");

--- a/tests/cases/examples/hello.slint
+++ b/tests/cases/examples/hello.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TwoRectangle := Rectangle {
+component TwoRectangle inherits Rectangle {
 
     callback clicked;
 
@@ -13,15 +13,16 @@ TwoRectangle := Rectangle {
         background: red;
 
         my_area := TouchArea {
+            x:0;y:0;
             width: 25phx;
             height: 25phx;
-            clicked => { root.clicked() }
+            clicked => { clicked() }
         }
     }
 }
 
-ButtonRectangle := Rectangle {
-    property<string> button_text;
+component ButtonRectangle inherits Rectangle {
+    in-out property<string> button_text;
     callback clicked;
     width: 100phx;
     height: 75phx;
@@ -30,9 +31,10 @@ ButtonRectangle := Rectangle {
         background: { area.pressed ? green : root.background };
         animate background { duration: 500ms; }
         area := TouchArea {
+            x:0;y:0;
             width: inner.width;
             height: inner.height;
-            clicked => { root.clicked() }
+            clicked => { clicked() }
         }
         Text {
             animate x { duration: 500ms; }
@@ -56,7 +58,7 @@ ButtonRectangle := Rectangle {
     }
 }
 
-Hello := Rectangle {
+component Hello inherits Rectangle {
 
     callback foobar;
     callback plus_clicked;
@@ -65,6 +67,7 @@ Hello := Rectangle {
     background: white;
 
     TwoRectangle {
+        x:0;y:0;
         width: 100phx;
         height: 100phx;
         background: blue;
@@ -97,7 +100,7 @@ Hello := Rectangle {
         clicked => { counter += 1 }
         button_text: "+";
     }
-    property<int> counter;
+    in-out property<int> counter;
     counter_label := Text { x: 100phx; y: 300phx; text: counter; color: black; }
     ButtonRectangle {
         background: #888;
@@ -156,7 +159,7 @@ Hello := Rectangle {
     }
 
     Path {
-        commands: ta.pressed ? root.arrow_down_commands : root.funky-shape-commands;
+        commands: ta.pressed ? arrow_down_commands : root.funky-shape-commands;
         x: 100phx;
         y: 500phx;
         stroke: black;
@@ -167,9 +170,9 @@ Hello := Rectangle {
 
     }
 
-    property <string> arrow_down_commands: "M21.8,311.1l84.2-82.1c15.7-15.2,41-15.2,56.7,0l341.1,304.1l333.7-297.5c15.5-15.2,41-15.2,56.6,0l84.3,82.1c15.6,15.2,15.6,40,0,55.2L531.7,771c-15.7,15.3-41,15.3-56.7,0l-6.9-6.7L21.8,366.3C6.1,351,6.1,326.3,21.8,311.1z";
-    property <string> funky_shape_commands: "M 100 300 Q 150 50 250 150 C 250 300 300 300 300 450 A 50 50 0 1 0 450 450 L 550 300";
-    property <length> width2 <=> root.width;
+    in-out property <string> arrow_down_commands: "M21.8,311.1l84.2-82.1c15.7-15.2,41-15.2,56.7,0l341.1,304.1l333.7-297.5c15.5-15.2,41-15.2,56.6,0l84.3,82.1c15.6,15.2,15.6,40,0,55.2L531.7,771c-15.7,15.3-41,15.3-56.7,0l-6.9-6.7L21.8,366.3C6.1,351,6.1,326.3,21.8,311.1z";
+    in-out property <string> funky_shape_commands: "M 100 300 Q 150 50 250 150 C 250 300 300 300 300 450 A 50 50 0 1 0 450 450 L 550 300";
+    in-out property <length> width2 <=> root.width;
 }
 
 /*

--- a/tests/cases/examples/image_fit.slint
+++ b/tests/cases/examples/image_fit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Win := Window {
+component Win inherits Window {
     GridLayout {
         Image {
             source: @image-url("../../../demos/printerdemo/ui/images/cat.jpg");

--- a/tests/cases/examples/key_press.slint
+++ b/tests/cases/examples/key_press.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-W := Window {
+component W inherits Window {
     VerticalLayout {
         Rectangle { background: field.has_focus ? blue: red;  }
         field := FocusScope {

--- a/tests/cases/examples/layer.slint
+++ b/tests/cases/examples/layer.slint
@@ -8,7 +8,7 @@ import { Button } from "std-widgets.slint";
 // output, and to have a compile-time verification that the lowering to the Layer
 // element compiles.
 
-MyLayer := Rectangle {
+component MyLayer inherits Rectangle {
     cache-rendering-hint: true;
     background: red;
     for i in 1000: Rectangle {
@@ -19,12 +19,13 @@ MyLayer := Rectangle {
         drop-shadow-offset-y: 5px;
         drop-shadow-color: green;
         Text {
+            x:0;y:0;
             text: "Many text items over each other";
         }
     }
 }
 
-export TestCase := Window {
+export component TestCase inherits Window {
     preferred-width: 800px;
     preferred-height: 600px;
     background: white;
@@ -42,15 +43,16 @@ export TestCase := Window {
 
             // This will be a layer
             layered := MyLayer {
+                x:0;y:0;
                 width: 200px;
                 height: 100px;
 
                 property <bool> place_to_the_right;
                 states [
-                    right when place_to_the_right: {
+                    right when self.place_to_the_right: {
                         x: 200px;
                     }
-                    left when !place_to_the_right: {
+                    left when !self.place_to_the_right: {
                         x: 10px;
                     }
                 ]

--- a/tests/cases/examples/opacity.slint
+++ b/tests/cases/examples/opacity.slint
@@ -1,8 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Comp := Rectangle {
+component Comp inherits Rectangle {
     Rectangle {
+        x:0;y:0;
         width: 5%;
         height: 5%;
         background: white;
@@ -11,12 +12,13 @@ Comp := Rectangle {
 }
 
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 800px;
     height: 600px;
     background: green;
 
     Rectangle {
+        x:0;y:0;
         background: red;
         width: 50%;
         height: 50%;
@@ -31,6 +33,7 @@ TestCase := Window {
         height: 50%;
         opacity: 0.5;
         Rectangle {
+            x:0;y:0;
             width: 10%;
             height: 10%;
             background: yellow;

--- a/tests/cases/examples/path_fill_rule.slint
+++ b/tests/cases/examples/path_fill_rule.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-PathFillRule := Window {
+component PathFillRule inherits Window {
     GridLayout {
         Row {
             Text {

--- a/tests/cases/examples/path_line_join.slint
+++ b/tests/cases/examples/path_line_join.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-PathLineJoin := Window {
+component PathLineJoin inherits Window {
     GridLayout {
         Row {
             Text {

--- a/tests/cases/examples/path_viewbox.slint
+++ b/tests/cases/examples/path_viewbox.slint
@@ -3,7 +3,7 @@
 
 // cSpell: ignore unclipped
 
-RectPath := Path {
+component RectPath inherits Path {
     MoveTo {
         x: 0;
         y: 0;
@@ -27,7 +27,7 @@ RectPath := Path {
     Close {}
 }
 
-PathViewBox := Window {
+component PathViewBox inherits Window {
     preferred-width: 600px;
     preferred-height: 600px;
 
@@ -52,6 +52,7 @@ PathViewBox := Window {
         height: 100px;
 
         RectPath {
+            x:0;y:0;
             width: 100px;
             height: 100px;
 
@@ -75,6 +76,7 @@ PathViewBox := Window {
         height: 100px;
 
         RectPath {
+            x:0;y:0;
             width: 100px;
             height: 100px;
 

--- a/tests/cases/examples/plusminus.slint
+++ b/tests/cases/examples/plusminus.slint
@@ -1,15 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Btn := Rectangle {
-    property<string> button_text;
+component Btn inherits Rectangle {
+    in-out property<string> button_text;
     callback clicked;
     width: 100phx;
     height: 75phx;
     TouchArea {
+        x:0;y:0;
         width: 100phx;
         height: 75phx;
-        clicked => { root.clicked() }
+        clicked => { clicked() }
     }
     Text {
         x: 50phx;
@@ -19,12 +20,12 @@ Btn := Rectangle {
     }
 }
 
-PlusMinus := Rectangle {
+component PlusMinus inherits Rectangle {
     width: 100phx;
     height: 300phx;
     background: white;
 
-    property<int> counter;
+    in-out property<int> counter;
 
     GridLayout {
         Row {

--- a/tests/cases/examples/rotate.slint
+++ b/tests/cases/examples/rotate.slint
@@ -8,7 +8,7 @@
 // The rectangle with the linear gradient should be rotated by 315 degrees
 // inside the other black rectangle
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 800px;
     height: 600px;
 
@@ -51,6 +51,7 @@ TestCase := Window {
         height: i2.height;
 
         i2 := Image {
+            x:0;y:0;
             rotation-angle: 315deg;
             source: @image-url("../../../logo/slint-logo-square-light-128x128.png");
         }

--- a/tests/cases/examples/window_default_font.slint
+++ b/tests/cases/examples/window_default_font.slint
@@ -4,7 +4,7 @@
 // Test for manual visual verification of default font properties of Window
 //
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 800px;
     height: 600px;
 

--- a/tests/cases/models/for.slint
+++ b/tests/cases/models/for.slint
@@ -1,16 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-ExtraComponent := Rectangle {
-    for x in [{a: "0"}, {a: "1"}] : Text { text: x.a; }
+component ExtraComponent inherits Rectangle {
+    for x in [{a: "0"}, {a: "1"}] : Text { x:0;y:0; text: x.a; }
 }
 
 
-Extra2 := Rectangle {
-    property<int> top_level;
-    property<int> value;
+component Extra2 inherits Rectangle {
+    in-out property<int> top_level;
+    in-out property<int> value;
     callback update_value;
     for aaa[r] in [[10, top_level], [2, 3]] : blah := Rectangle {
+        y:0;
         width: parent.width;
         height: root.height;
         property <int> some_value: 1000;
@@ -21,19 +22,19 @@ Extra2 := Rectangle {
             x: r*10phx;
             y: l*10phx;
             clicked => {
-                root.value += bb + blah.some_value;
+                value += bb + blah.some_value;
                 update_value();
             }
         }
     }
 }
 
-export TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
     background: white;
-    property<float> top_level: 42;
-    property<int> value: 0;
+    in-out property<float> top_level: 42;
+    in-out property<int> value: 0;
 
    for pp[idx] in 5: Rectangle {
         s := Rectangle {
@@ -41,9 +42,9 @@ export TestCase := Rectangle {
             x: 2phx * idx;
             y: 200phx * pp;
             width: s.within;
-            height: root.top_level * 1phx;
+            height: top_level * 1phx;
             for nested in [1phx] : Rectangle {
-                x : s.width + root.top_level * 1phx + nested;
+                x : s.width + top_level * 1phx + nested;
             }
         }
     }
@@ -55,10 +56,11 @@ export TestCase := Rectangle {
 
     for pp[idx] in ["1","3","2"]: Rectangle {
         x: idx * 1phx;
-        Text { text: pp; }
+        Text { x:0;y:0; text: pp; }
     }
 
     for pp in [{a: 12, b: "aa", c: {a: #00f}}, {a: 13, b: "cc", c: { a: #f00}}]: Text {
+        y:0;
         x: pp.a * 1phx;
         text: pp.b;
         color: pp.c.a;
@@ -66,25 +68,27 @@ export TestCase := Rectangle {
         }
     }
     Extra2 {
+        y:0;
         width: parent.width;
         height: root.height;
-        top_level: root.top_level;
+        top_level: top_level;
         update_value => {
-            root.value = self.value;
+            value = self.value;
         }
     }
 
-    property<[{a: int}]> m;
+    in-out property<[{a: int}]> m;
     for x in m : TouchArea {
+        y:0;
         width: parent.width;
         height: root.height;
         clicked => {
-            root.value = x.a;
+            value = x.a;
         }
     }
 
     // issue #2977
-    for v in value + value : Text { text: v; }
+    for v in value + value : Text { x:0;y:0; text: v; }
 }
 
 

--- a/tests/cases/models/if.slint
+++ b/tests/cases/models/if.slint
@@ -1,22 +1,23 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
     background: white;
-    property<int> top_level: 42;
+    in-out property<int> top_level: 42;
 
-    property<bool> cond1;
-    property<bool> cond2;
-    property<bool> cond3;
+    in-out property<bool> cond1;
+    in-out property<bool> cond2;
+    in-out property<bool> cond3;
 
     if (cond1) : TouchArea {
+        y:0;
         width: parent.width;
         height: root.height;
-        property<int> xx: root.top_level;
+        property<int> xx: top_level;
         clicked => {
-            root.top_level += self.xx + 8;
+            top_level += self.xx + 8;
         }
     }
 

--- a/tests/cases/models/if_cond_property.slint
+++ b/tests/cases/models/if_cond_property.slint
@@ -4,7 +4,7 @@
 // Test that the condition of an if can access the properties of native items
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
 

--- a/tests/cases/models/if_lookup.slint
+++ b/tests/cases/models/if_lookup.slint
@@ -3,23 +3,23 @@
 
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
     background: white;
-    property<int> top_level: 42;
+    in-out property<int> top_level: 42;
 
-    property<bool> cond1;
+    in-out property<bool> cond1;
 
     Rectangle {
         property <string> blah: "ddd";
         Rectangle {
             property <bool> cc <=> cond1;
             property <bool> blah: false;
-            if (cc || self.blah) : TouchArea {
+            if (self.cc || self.blah) : TouchArea {
                 property <int> cc: 0;
                 clicked => {
-                    root.top_level += 50;
+                    top_level += 50;
                 }
             }
         }

--- a/tests/cases/models/init_recursion.slint
+++ b/tests/cases/models/init_recursion.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <length> test-height: layout.preferred-height;
-    property <bool> test: self.test-height != 0;
+component TestCase inherits Rectangle {
+    in-out property <length> test-height: layout.preferred-height;
+    in-out property <bool> test: self.test-height != 0;
 
     layout := VerticalLayout {
         if true: TextInput {

--- a/tests/cases/models/listview_model_change.slint
+++ b/tests/cases/models/listview_model_change.slint
@@ -11,12 +11,12 @@
 
 import { ListView } from "std-widgets.slint";
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 300px;
     height: 300px;
 
-    property<length> viewport-height: lv.viewport-height;
-    property<[length]> fixed-height-model: [100px, 0px];
+    in-out property<length> viewport-height: lv.viewport-height;
+    in-out property<[length]> fixed-height-model: [100px, 0px];
 
     lv := ListView {
         for fixed-height in fixed-height-model: Rectangle {

--- a/tests/cases/models/model_in_struct.slint
+++ b/tests/cases/models/model_in_struct.slint
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore foos
-struct Foo := {
+struct Foo  {
     ok: bool,
 }
 
 // Make sure that the generated code for this compiles, as we emit
 // #[derive(Debug)] for structures and in this case the field of the
 // struct contains a model handle.
-struct Bar := {
+struct Bar  {
     foos: [Foo],
 }
 
-TestCase := Rectangle {
-    property <[Bar]> bars: [];
+component TestCase inherits Rectangle {
+    in-out property <[Bar]> bars: [];
 
     // make sure the generated code compiles (that we generate .clone() properly)
-    property <Foo> foo: {ok: true};
-    property <Bar> bar: {foos: [foo, foo]};
-    property <[Bar]> bars2: [bar, bar];
+    in-out property <Foo> foo: {ok: true};
+    in-out property <Bar> bar: {foos: [foo, foo]};
+    in-out property <[Bar]> bars2: [bar, bar];
 }

--- a/tests/cases/models/negative_intmodel.slint
+++ b/tests/cases/models/negative_intmodel.slint
@@ -3,15 +3,15 @@
 
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
 
-    property <int> creation-count: 0;
+    in-out property <int> creation-count: 0;
 
-    property <length> test-height: preferred-height;
+    in-out property <length> test-height: root.preferred-height;
 
-    property <int> repeater-count: -10;
+    in-out property <int> repeater-count: -10;
 
     VerticalLayout {
         for _ in repeater-count: Rectangle {

--- a/tests/cases/models/scrolled_model.slint
+++ b/tests/cases/models/scrolled_model.slint
@@ -3,11 +3,11 @@
 
 import { Button, ListView } from "std-widgets.slint";
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 50phx;
 
-    property<[{name: string}]> model: [
+    in-out property<[{name: string}]> model: [
         { name: "1Olivier", },
         { name: "1Simon", },
         { name: "2Olivier", },

--- a/tests/cases/models/write_to_model.slint
+++ b/tests/cases/models/write_to_model.slint
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
-    property<[{name: string, account: string, score: float}]> model: [
+    in-out property<[{name: string, account: string, score: float}]> model: [
         {
             name: "Olivier",
             account: "ogoffart",
@@ -18,9 +18,10 @@ TestCase := Rectangle {
         }
     ];
 
-    property <int> clicked_score;
+    in-out property <int> clicked_score;
 
     for person[i] in model: TouchArea {
+        y:0;
         x: i*10phx;
         width: 10phx;
         height: 10phx;
@@ -29,7 +30,7 @@ TestCase := Rectangle {
             person.score += 1;
             person.score = person.score + 1;
             person.score += 1;
-            clicked_score = score;
+            clicked_score = self.score;
         }
     }
 

--- a/tests/cases/models/write_to_model_sub_component.slint
+++ b/tests/cases/models/write_to_model_sub_component.slint
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-SubComponent := Rectangle {
-    property <[int]> m;
+component SubComponent inherits Rectangle {
+    in-out property <[int]> m;
     HorizontalLayout {
         for foo in m: Rectangle {
             if foo < 100 : TouchArea {
@@ -13,10 +13,10 @@ SubComponent := Rectangle {
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 100px;
     height: 100px;
-    property <[int]> mod;
+    in-out property <[int]> mod;
     SubComponent {
         m: mod;
     }


### PR DESCRIPTION
## Summary

Continues #11734 series. Ports 25 test files in `tests/cases/` from the deprecated Slint 0.3 syntax to the current syntax.

Changes applied by `tools/updater` (same five rules as #11734).

**One file skipped:** `models/assign_equal_model.slint` is intentionally left in old syntax in this batch. Porting it produces:

\`\`\`
in-out property <bool> test: root.do();  // error: Call of impure callback 'do'
\`\`\`

\`do\` cannot be \`pure\` because its body has assignments. Under old-syntax parsing, calling a non-pure callback from a property binding was tolerated. To port this file we'd need to drop the \`test\` property (which is never read by the harness, only used to force \`do()\` evaluation at component-creation time) or restructure the test. Leaving as follow-up discussion.

## Directories covered

`examples` (14), `models` (11 of 12) — 25 files.

## Test plan

- [x] \`cargo test -p test-driver-interpreter\` — all 681 tests pass