### PR TITLE
tests: port crashes, elements, layout to new Slint syntax

### DIFF
--- a/tests/cases/crashes/access_moved_propdecl.slint
+++ b/tests/cases/crashes/access_moved_propdecl.slint
@@ -4,7 +4,7 @@
 // Test case that accesses a declared property ("property<bool> pressed") from within a binding for "text".
 // The property will be moved to the root as part of the move declarations pass and therefore the named reference
 // to "gallery_button.pressed" needs to be fixed up.
-App := Rectangle {
+component App inherits Rectangle {
     gallery_button := Rectangle {
         property<string> text: gallery_button.pressed ? "Button pressed" : "Button not pressed";
         property<bool> pressed: touch_area.pressed;

--- a/tests/cases/crashes/alias_in_if.slint
+++ b/tests/cases/crashes/alias_in_if.slint
@@ -1,17 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-App := Rectangle {
-    property <string> hello: "ooo";
-    if (hello != "") : Text { text <=> hello; }
+component App inherits Rectangle {
+    in-out property <string> hello: "ooo";
+    if (hello != "") : Text { x:0;y:0; text <=> hello; }
 
-    property<bool> test1: hello == "ooo";
+    in-out property<bool> test1: hello == "ooo";
 
     // Another crash:
-    property <string> directory: "hello";
+    in-out property <string> directory: "hello";
     vl := VerticalLayout {
         if true: pp:= Rectangle {
-            property <string> text <=> root.directory;
+            property <string> text <=> directory;
             HorizontalLayout {
                 inner := Text {
                     text: pp.text;
@@ -19,8 +19,8 @@ App := Rectangle {
             }
         }
     }
-    ref := Text { text: "hello"; }
-    property<bool> test2: vl.preferred-width == ref.preferred-width;
+    ref := Text { x:0;y:0; text: "hello"; }
+    in-out property<bool> test2: vl.preferred-width == ref.preferred-width;
 
-    property<bool> test: test1 && test2;
+    in-out property<bool> test: test1 && test2;
 }

--- a/tests/cases/crashes/issue1113_popup_in_repeater.slint
+++ b/tests/cases/crashes/issue1113_popup_in_repeater.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-App := Window {
+component App inherits Window {
     for menu-item in [{children: ["hello"]}] : VerticalLayout {
         Rectangle {
             popup := PopupWindow {

--- a/tests/cases/crashes/issue1267_opacity_in_layout.slint
+++ b/tests/cases/crashes/issue1267_opacity_in_layout.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-MainWindow := Window {
+component MainWindow inherits Window {
     VerticalLayout {
         Rectangle {
             opacity: 0.5;

--- a/tests/cases/crashes/issue173_uninitialized_globals.slint
+++ b/tests/cases/crashes/issue173_uninitialized_globals.slint
@@ -3,15 +3,15 @@
 
 // This is a test for a crash with the interpreter when evaluating properties
 
-global Settings := {
-    property <bool> test;
-    property <color> some_color;
-    property <string> some_string;
-    property <int> count;
-    property <{aa: bool, bb: int, cc: string}> object;
+global Settings  {
+    in-out property <bool> test;
+    in-out property <color> some_color;
+    in-out property <string> some_string;
+    in-out property <int> count;
+    in-out property <{aa: bool, bb: int, cc: string}> object;
 }
 
-export Demo := Window {
+export component Demo inherits Window {
     width: 300px;
     height: 300px;
 
@@ -23,8 +23,8 @@ export Demo := Window {
 
     for foo in Settings.count: Rectangle {}
 
-    property <bool> obj: !Settings.object.aa && Settings.object.bb == 0 && Settings.object.cc == "";
+    in-out property <bool> obj: !Settings.object.aa && Settings.object.bb == 0 && Settings.object.cc == "";
 
-    property <bool> test: title == "" && r.background == Settings.some_color && Settings.count == 0 && obj;
+    in-out property <bool> test: root.title == "" && r.background == Settings.some_color && Settings.count == 0 && obj;
 
 }

--- a/tests/cases/crashes/issue_1009_const_alias.slint
+++ b/tests/cases/crashes/issue_1009_const_alias.slint
@@ -1,17 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-Button := Text { }
+component Button inherits Text { }
 
-PanelButton := HorizontalLayout {
-    property<string> button-text <=> button.text;
+component PanelButton inherits HorizontalLayout {
+    in-out property<string> button-text <=> button.text;
     button := Button { }
 }
 
-TestCase := Window {
-    property <bool> test: pb.preferred-height == control.preferred-height;
+component TestCase inherits Window {
+    in-out property <bool> test: pb.preferred-height == control.preferred-height;
     pb := PanelButton {  button-text: "button1";  }
-    control := Text { text: "button1"; }
+    control := Text { x:0;y:0; text: "button1"; }
 }
 
 

--- a/tests/cases/crashes/issue_1233_listview_const_shadow.slint
+++ b/tests/cases/crashes/issue_1233_listview_const_shadow.slint
@@ -4,7 +4,7 @@
 
 import { ListView } from "std-widgets.slint";
 
-App := Window {
+component App inherits Window {
     width: 100px;
     height: 600px;
 

--- a/tests/cases/crashes/issue_983_listview_const_width.slint
+++ b/tests/cases/crashes/issue_983_listview_const_width.slint
@@ -3,21 +3,21 @@
 
 import { ListView } from "std-widgets.slint";
 
-FileLine := Rectangle {
-    property <string> filename;
+component FileLine inherits Rectangle {
+    in-out property <string> filename;
     HorizontalLayout {
         t_filename := Text {
-            text: root.filename;
+            text: filename;
         }
     }
 }
 
-export struct FileItem := {
+export struct FileItem  {
     filename: string,
 }
 
-MainWindow := Window {
-    property <[FileItem]> file-model: [ ];
+component MainWindow inherits Window {
+    in-out property <[FileItem]> file-model: [ ];
     height: 500px;
     width: 500px;
 

--- a/tests/cases/crashes/optimized_popup_parent.slint
+++ b/tests/cases/crashes/optimized_popup_parent.slint
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-Foo := Rectangle {
+component Foo inherits Rectangle {
     public function show() { x.show(); }
     x := PopupWindow {  }
 }
 
-Bar := Rectangle {
+component Bar inherits Rectangle {
 
     TouchArea {
         clicked => { x.show();  f.show(); }

--- a/tests/cases/crashes/subsubcomponent.slint
+++ b/tests/cases/crashes/subsubcomponent.slint
@@ -1,10 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-SubSubCompo := Rectangle { }
-SubCompo := SubSubCompo {}
+component SubSubCompo inherits Rectangle { }
+component SubCompo inherits SubSubCompo {}
 
-export TestCase := Window {
+export component TestCase inherits Window {
     SubCompo {}
 }
 

--- a/tests/cases/crashes/subsubcomponent2.slint
+++ b/tests/cases/crashes/subsubcomponent2.slint
@@ -3,19 +3,19 @@
 
 // Test for issue #781
 
-global Glop := {
-    property <int> r;
+global Glop  {
+    in-out property <int> r;
 }
 
-SubSubCompo := Rectangle {
-    property <int> val;
+component SubSubCompo inherits Rectangle {
+    in-out property <int> val;
     TouchArea {
         clicked => { Glop.r = val; }
     }
 }
-SubCompo := SubSubCompo { }
+component SubCompo inherits SubSubCompo { }
 
-export TestCase := Window {
+export component TestCase inherits Window {
     width: 300px;
     height: 300px;
     HorizontalLayout {
@@ -23,7 +23,7 @@ export TestCase := Window {
         SubCompo { val: 99; }
     }
 
-    property <int> result: Glop.r;
+    in-out property <int> result: Glop.r;
 }
 
 /*

--- a/tests/cases/elements/flickable2.slint
+++ b/tests/cases/elements/flickable2.slint
@@ -1,23 +1,24 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-InheritFlickable := Flickable {}
+component InheritFlickable inherits Flickable {}
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 500phx;
     height: 500phx;
 
     Flickable {
         r1 := Rectangle {
-            property<bool> ok: height == root.height && width == root.width;
+            property<bool> ok: self.height == root.height && self.width == root.width;
         }
     }
 
     InheritFlickable {
+        x:0;
         width: 123phx;
         viewport_height: 456phx;
         r2 := Rectangle {
-            property<bool> ok: height == 456phx && width == 123phx;
+            property<bool> ok: self.height == 456phx && self.width == 123phx;
         }
     }
 
@@ -26,7 +27,7 @@ TestCase := Window {
             spacing: 0phx;
             padding: 0phx;
             r3 := Rectangle {
-                property<bool> ok: height == root.height/2 && width == 888phx && f3.viewport_width == 888phx && f3.min-width == 0phx;
+                property<bool> ok: self.height == root.height/2 && self.width == 888phx && f3.viewport_width == 888phx && f3.min-width == 0phx;
             }
             Rectangle {
                 min-width: 888phx;
@@ -49,8 +50,8 @@ TestCase := Window {
 
     Flickable { for i in 5: Rectangle {} }
 
-    property<bool> all_ok: r1.ok && r2.ok && r3.ok && r4.ok;
-    property<bool> test: all_ok;
+    in-out property<bool> all_ok: r1.ok && r2.ok && r3.ok && r4.ok;
+    in-out property<bool> test: all_ok;
 }
 
 /*

--- a/tests/cases/elements/flickable3.slint
+++ b/tests/cases/elements/flickable3.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-TestCase := Window {
+component TestCase inherits Window {
   width: 500phx;
   height: 500phx;
 
@@ -31,17 +31,18 @@ TestCase := Window {
     height: 300phx;
 
     t2 := TouchArea {
+      x:0;
       width: 50phx;
       Rectangle { background: parent.has-hover ? green: yellow; }
       pointer-event(event) => {
         if event.kind == PointerEventKind.cancel {
-            root.pointer-events += "C";
+            pointer-events += "C";
         } else if event.kind == PointerEventKind.down {
-            root.pointer-events += "D(" + self.mouse-y/1px + ")";
+            pointer-events += "D(" + self.mouse-y/1px + ")";
         } else if event.kind == PointerEventKind.up {
-            root.pointer-events += "U(" + self.mouse-y/1px + ")";
+            pointer-events += "U(" + self.mouse-y/1px + ")";
         } else if event.kind == PointerEventKind.move {
-            root.pointer-events += "M(" + self.mouse-y/1px + ")";
+            pointer-events += "M(" + self.mouse-y/1px + ")";
         }
         }
     }

--- a/tests/cases/elements/flickable_focus.slint
+++ b/tests/cases/elements/flickable_focus.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     preferred-width: 500px;
     preferred-height: 500px;
     no-frame: false;
@@ -45,8 +45,8 @@ TestCase := Window {
         fs.clear-focus();
     }
 
-    property <length> offset_x: -f.viewport_x;
-    property <length> offset_y: -f.viewport_y;
+    in-out property <length> offset_x: -f.viewport_x;
+    in-out property <length> offset_y: -f.viewport_y;
 }
 
 /*

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -3,43 +3,50 @@
 
 //include_path: ../../../demos/printerdemo/ui/images/
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     img := Image {
+        x:0;y:0;
         source: @image-url("cat.jpg");
     }
 
     img2 := Image {
+        x:0;y:0;
         source: @image-url("cat.jpg");
         source-clip-x: 20;
     }
 
     img3 := Image {
+        x:0;y:0;
         source: @image-url("image.slint");
     }
 
     img4 := Image {
+        x:0;y:0;
         source: @image-url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
     }
 
     img5 := Image {
+        x:0;y:0;
         source: @image-url("data:image/svg+xml,%3Csvg%20width%3D%22100%22%20height%3D%2295%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpolygon%20fill%3D%22%23231815%22%20points%3D%2250%2C0%2065.451%2C31.271%20100%2C36.287%2075%2C60.729%2081.902%2C95%2050%2C78.361%2018.098%2C95%2025%2C60.729%200%2C36.287%2034.549%2C31.271%22%2F%3E%3C%2Fsvg%3E");
     }
 
     img6 := Image {
+        x:0;y:0;
         source: @image-url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAiIGhlaWdodD0iNDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iMjUiIGN5PSIyMCIgcj0iMTUiIGZpbGw9InJlZCIvPjwvc3ZnPg==");
     }
 
     // same data URI as img4, tests deduplication
     img7 := Image {
+        x:0;y:0;
         source: @image-url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
     }
 
     out property <image> with-border: @image-url("dog.jpg", nine-slice(12 13 14 15));
 
-    property <length> img_width: img.width;
-    property <length> img_height: img.height;
+    in-out property <length> img_width: img.width;
+    in-out property <length> img_height: img.height;
     in-out property <float> test_no_overflow: (21 - img.source.width) / 2; // (21 - 320)/2 = -149.5
-    property <bool> test: img2.source-clip-height * 1px == img2.height && img2.source-clip-width * 1px == img2.width &&
+    in-out property <bool> test: img2.source-clip-height * 1px == img2.height && img2.source-clip-width * 1px == img2.width &&
          img2.width/1px == img2.source.width - 20 && img3.source.width == 0 && img3.source.height == 0 && test_no_overflow == -149.5 &&
          img4.source.width == 1 && img4.source.height == 1 &&
          img5.source.width > 0 && img5.source.height > 0 &&

--- a/tests/cases/elements/image_geometry.slint
+++ b/tests/cases/elements/image_geometry.slint
@@ -3,17 +3,19 @@
 
 //include_path: ../../../demos/printerdemo/ui/images/
 
-FixedWidthImage := Image {
+component FixedWidthImage inherits Image {
     source: @image-url("cat.jpg");
     width: 500phx;
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     fixed_image := Image {
+        x:0;y:0;
         width: 50phx;
         height: 50phx;
     }
     fixed_image_contain := Image {
+        x:0;y:0;
         width: 50phx;
         height: 50phx;
         image-fit: contain;
@@ -28,16 +30,19 @@ TestCase := Rectangle {
     }
 
     image_with_missing_height := FixedWidthImage {
+        x:0;y:0;
         property <bool> expected_height_ok: self.height == 750phx;
     }
 
     image_with_missing_width := Image {
+        x:0;y:0;
         source: @image-url("cat.jpg");
         height: 600phx;
         property <bool> expected_width_ok: self.width == 400phx;
     }
 
     image_with_missing_width_clipped := Image {
+        x:0;y:0;
         source: @image-url("cat.jpg");
         height: 600phx;
         source-clip-width: 20;
@@ -45,15 +50,15 @@ TestCase := Rectangle {
         property <bool> expected_width_ok: self.width == 600phx;
     }
 
-    property <bool> fixed_image_default_image_fit_ok: fixed_image.image-fit == ImageFit.fill;
-    property <bool> fixed_image_image_fit_override_ok: fixed_image_contain.image-fit == ImageFit.contain;
-    property <bool> image_in_layout_fit_ok: image_in_layout.image-fit == ImageFit.contain;
-    property <bool> image_in_layout_custom_fit_ok: image_in_layout_with_explicit_fit.image-fit == ImageFit.fill;
-    property <bool> image_with_missing_height_ok <=> image_with_missing_height.expected_height_ok;
-    property <bool> image_with_missing_width_ok <=> image_with_missing_width.expected_width_ok;
-    property <bool> image_with_missing_width_clipped_ok <=> image_with_missing_width.expected_width_ok;
+    in-out property <bool> fixed_image_default_image_fit_ok: fixed_image.image-fit == ImageFit.fill;
+    in-out property <bool> fixed_image_image_fit_override_ok: fixed_image_contain.image-fit == ImageFit.contain;
+    in-out property <bool> image_in_layout_fit_ok: image_in_layout.image-fit == ImageFit.contain;
+    in-out property <bool> image_in_layout_custom_fit_ok: image_in_layout_with_explicit_fit.image-fit == ImageFit.fill;
+    in-out property <bool> image_with_missing_height_ok <=> image_with_missing_height.expected_height_ok;
+    in-out property <bool> image_with_missing_width_ok <=> image_with_missing_width.expected_width_ok;
+    in-out property <bool> image_with_missing_width_clipped_ok <=> image_with_missing_width.expected_width_ok;
 
-    property <bool> test: fixed_image_default_image_fit_ok && fixed_image_image_fit_override_ok && image_in_layout_fit_ok && image_in_layout_custom_fit_ok && image_with_missing_height_ok && image_with_missing_width_ok && image_with_missing_width_clipped_ok;
+    in-out property <bool> test: fixed_image_default_image_fit_ok && fixed_image_image_fit_override_ok && image_in_layout_fit_ok && image_in_layout_custom_fit_ok && image_with_missing_height_ok && image_with_missing_width_ok && image_with_missing_width_clipped_ok;
 }
 
 /*

--- a/tests/cases/elements/listview.slint
+++ b/tests/cases/elements/listview.slint
@@ -3,7 +3,7 @@
 
 import { ListView  } from "std-widgets.slint";
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 400px;
     height: 540px;
 

--- a/tests/cases/elements/listview_click_open.slint
+++ b/tests/cases/elements/listview_click_open.slint
@@ -3,8 +3,8 @@
 
 import { ListView } from "std-widgets.slint";
 
-Item := Text {
-    property <int> index;
+component Item inherits Text {
+    in-out property <int> index;
     text: "I'm item #" + index;
     Rectangle {
         border-width: 1px;
@@ -12,14 +12,14 @@ Item := Text {
     }
 }
 
-export TestCase := Window {
+export component TestCase inherits Window {
     width:  300phx;
     height: 300phx;
 
-    property <int> last_clicked: -1;
+    in-out property <int> last_clicked: -1;
 
-    property <length> item-height: 25phx;
-    property <length> listview-y <=> lv.viewport_y;
+    in-out property <length> item-height: 25phx;
+    in-out property <length> listview-y <=> lv.viewport_y;
 
     lv := ListView {
         for i in 200: r := Item {
@@ -41,7 +41,7 @@ export TestCase := Window {
                 }
                 TouchArea {
                     clicked => {
-                        last-clicked = i;
+                        root.last-clicked = i;
                     }
                 }
             }

--- a/tests/cases/elements/path_fit.slint
+++ b/tests/cases/elements/path_fit.slint
@@ -1,9 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
 
     Text {
+        x:0;y:0;
         text: "The path should fit into the red rectangle";
         color: black;
     }

--- a/tests/cases/elements/path_fit.slint
+++ b/tests/cases/elements/path_fit.slint
@@ -1,10 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-component TestCase inherits Rectangle {
+TestCase := Rectangle {
 
     Text {
-        x:0;y:0;
         text: "The path should fit into the red rectangle";
         color: black;
     }

--- a/tests/cases/elements/popupwindow.slint
+++ b/tests/cases/elements/popupwindow.slint
@@ -7,11 +7,11 @@ component Window {}
 
 component InheritsPopup inherits PopupWindow {}
 
-Combo := Rectangle {
-    property <color> inner_color;
+component Combo inherits Rectangle {
+    in-out property <color> inner_color;
     my_popup := PopupWindow {
         Rectangle {
-            background: root.inner_color;
+            background: inner_color;
             insidelayout := VerticalLayout {
                 spacing: 3px;
                 for aa in [1, 2]: Text { text: aa; }
@@ -23,11 +23,11 @@ Combo := Rectangle {
     }
 }
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     for x in [1, 2] :  Combo { }
 }
 
-ComplexTestCase := Rectangle {
+component ComplexTestCase inherits Rectangle {
     TestCase {
         cob := Combo {
             PopupWindow {
@@ -40,7 +40,7 @@ ComplexTestCase := Rectangle {
     TestCase {  }
 }
 
-TypeConversionTestCase := Rectangle {
+component TypeConversionTestCase inherits Rectangle {
     height: 400px;
     popup := PopupWindow {
         y: root.height / 2;

--- a/tests/cases/elements/tabwidget.slint
+++ b/tests/cases/elements/tabwidget.slint
@@ -3,11 +3,11 @@
 
 import { TabWidget } from "std-widgets.slint";
 
-TestCase := Window {
+component TestCase inherits Window {
     preferred_height: 500px;
     preferred_width: 500px;
 
-    property <int> current_tab: tw.current-index;
+    in-out property <int> current_tab: tw.current-index;
 
     VerticalLayout {
         padding: 20px;
@@ -22,7 +22,7 @@ TestCase := Window {
             }
             Tab {
                 title: "World";
-                Text { text: "This is the second widget"; }
+                Text { x:0;y:0; text: "This is the second widget"; }
             }
             Tab {
                 title: "Third";
@@ -34,5 +34,5 @@ TestCase := Window {
         }
     }
 
-    property <bool> test: tw.vertical_stretch == 1 && tw.horizontal_stretch == 1 && tw.min_height > 200px && current-tab == 1;
+    in-out property <bool> test: tw.vertical_stretch == 1 && tw.horizontal_stretch == 1 && tw.min_height > 200px && root.current-tab == 1;
 }

--- a/tests/cases/elements/togglebutton.slint
+++ b/tests/cases/elements/togglebutton.slint
@@ -3,10 +3,11 @@
 
 import { Button } from "std-widgets.slint";
 
-TestCase := Rectangle {
-    property <bool> checked <=> tb.checked;
+component TestCase inherits Rectangle {
+    in-out property <bool> checked <=> tb.checked;
 
     tb := Button {
+        x:0;y:0;
         width: 100px;
         height: 100px;
 

--- a/tests/cases/layout/box_alignment.slint
+++ b/tests/cases/layout/box_alignment.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-MyWid := Rectangle {
+component MyWid inherits Rectangle {
     min-width: 20phx;
     min-height: 20phx;
     horizontal-stretch:0;

--- a/tests/cases/layout/geometry_center_by_default.slint
+++ b/tests/cases/layout/geometry_center_by_default.slint
@@ -19,10 +19,10 @@ component Foo {
         && G.is-center(t1.x, t1.width, self.width) && G.is-center(t1.y, t1.height, self.height);
 }
 
-Old := Rectangle {
-    r1 := Rectangle { width: 20px; }
+component Old inherits Rectangle {
+    r1 := Rectangle { x:0; width: 20px; }
     r2 := Rectangle { height: 20px; y: 20px; }
-    t1 := Text { text: "Foobar"; }
+    t1 := Text { x:0;y:0; text: "Foobar"; }
 
     out property <bool> test:
         r1.x == 0 && r1.y == 0

--- a/tests/cases/layout/geometry_center_by_default.slint
+++ b/tests/cases/layout/geometry_center_by_default.slint
@@ -19,10 +19,10 @@ component Foo {
         && G.is-center(t1.x, t1.width, self.width) && G.is-center(t1.y, t1.height, self.height);
 }
 
-component Old inherits Rectangle {
-    r1 := Rectangle { x:0; width: 20px; }
+Old := Rectangle {
+    r1 := Rectangle { width: 20px; }
     r2 := Rectangle { height: 20px; y: 20px; }
-    t1 := Text { x:0;y:0; text: "Foobar"; }
+    t1 := Text { text: "Foobar"; }
 
     out property <bool> test:
         r1.x == 0 && r1.y == 0

--- a/tests/cases/layout/grid_fixed_size.slint
+++ b/tests/cases/layout/grid_fixed_size.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 
-SubWithConstraints := Rectangle {
+component SubWithConstraints inherits Rectangle {
     min-height: 20px;
 }
 
@@ -43,9 +43,9 @@ export component TestCase inherits Rectangle {
 
     }
 
-    property <length> expected_y1: 300phx*0.3;
-    property <length> expected_y2: 300phx*0.3 + 20phx;
-    property <length> expected_x1: 30phx;
+    in-out property <length> expected_y1: 300phx*0.3;
+    in-out property <length> expected_y2: 300phx*0.3 + 20phx;
+    in-out property <length> expected_x1: 30phx;
 
     out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == expected_x1 && rect1.height == expected_y1;
     out property <bool> rect2_pos_ok: rect2.x == expected_x1 && rect2.y == 0phx && rect2.width == 270phx && rect2.height == expected_y1;

--- a/tests/cases/layout/grid_within_for.slint
+++ b/tests/cases/layout/grid_within_for.slint
@@ -3,13 +3,13 @@
 
 // Regression test for a panic in the compiler
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
-    property<int> value: 1;
+    in-out property<int> value: 1;
 
     for c[index] in [#f00, #00f, #0a0]: Rectangle {
-        y: index * height;
+        y: index * self.height;
         width: parent.width;
         height: 100phx;
         GridLayout {

--- a/tests/cases/layout/issue_1057_listview_subcomponent_height.slint
+++ b/tests/cases/layout/issue_1057_listview_subcomponent_height.slint
@@ -3,24 +3,25 @@
 
 import { ListView  } from "std-widgets.slint";
 
-MyListItem := Rectangle {
+component MyListItem inherits Rectangle {
     callback clicked <=> ta.clicked;
-    property <string> string;
+    in-out property <string> string;
 
     height: 100px;
 
     Text {
+        x:0;y:0;
         text: string;
     }
 
     ta := TouchArea {  }
 }
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 300px;
     height: 500px;
 
-    property <string> value;
+    in-out property <string> value;
 
     HorizontalLayout {
         lv := ListView {
@@ -30,7 +31,7 @@ TestCase := Window {
             }
         }
     }
-    property <int> viewport-height: lv.viewport-height / 1px;
+    in-out property <int> viewport-height: lv.viewport-height / 1px;
 }
 
 /*

--- a/tests/cases/layout/issue_140.slint
+++ b/tests/cases/layout/issue_140.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-HelloWorld := Window {
+component HelloWorld inherits Window {
     HorizontalLayout {
         VerticalLayout {
             HorizontalLayout {

--- a/tests/cases/layout/issue_147_for_explicit_size.slint
+++ b/tests/cases/layout/issue_147_for_explicit_size.slint
@@ -1,12 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 500px;
     height: 550px;
     background: #ecedeb;
 
-    property<[int]> xs: [1, 2, 3];
+    in-out property<[int]> xs: [1, 2, 3];
 
     VerticalLayout {
         padding: 0px;
@@ -30,7 +30,7 @@ TestCase := Window {
         }
     }
 
-    property<int> last_clicked;
+    in-out property<int> last_clicked;
 }
 /*
 ```cpp

--- a/tests/cases/layout/issue_147_for_explicit_size_merge.slint
+++ b/tests/cases/layout/issue_147_for_explicit_size_merge.slint
@@ -1,12 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 500px;
     height: 550px;
     background: #ecedeb;
 
-    property<[int]> xs: [1, 2, 3];
+    in-out property<[int]> xs: [1, 2, 3];
 
     VerticalLayout {
         padding: 0px;
@@ -36,7 +36,7 @@ TestCase := Window {
         }
     }
 
-    property<int> last_clicked;
+    in-out property<int> last_clicked;
 }
 /*
 ```cpp

--- a/tests/cases/layout/issue_149_nested_for.slint
+++ b/tests/cases/layout/issue_149_nested_for.slint
@@ -1,12 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 300phx;
     height: 300phx;
 
-    property<[int]> xs: [1, 2, 3];
-    property<[int]> ys: [10, 20, 30];
+    in-out property<[int]> xs: [1, 2, 3];
+    in-out property<[int]> ys: [10, 20, 30];
 
     VerticalLayout {
         padding: 0px;
@@ -20,12 +20,12 @@ TestCase := Window {
                         last_clicked = x_ + y_;
                     }
                 }
-                Text { text: (x_ + y_);  }
+                Text { x:0;y:0; text: (x_ + y_);  }
             }
         }
     }
 
-    property<int> last_clicked;
+    in-out property<int> last_clicked;
 }
 /*
 ```cpp

--- a/tests/cases/layout/issue_167_if_relayout.slint
+++ b/tests/cases/layout/issue_167_if_relayout.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width:  300px;
     height: 300px;
     if (true) : Rectangle {
@@ -17,7 +17,7 @@ TestCase := Window {
             }
         }
     }
-    property<int> last_clicked;
+    in-out property<int> last_clicked;
 }
 /*
 ```cpp

--- a/tests/cases/layout/issue_553_materialized_init.slint
+++ b/tests/cases/layout/issue_553_materialized_init.slint
@@ -3,16 +3,16 @@
 
 // Test the propagation of maximum and minimum size through nested grid layouts
 
-TestCase := Rectangle {
+component TestCase inherits Rectangle {
     min-width: 500px;
-    max-width: min-width;
+    max-width: root.min-width;
 
-    property xxx <=> preferred-height;
+    in-out property xxx <=> root.preferred-height;
     HorizontalLayout {
         Rectangle { height: 88px; }
     }
 
-    property <bool> test: min-width == 500px && max-width == 500px && xxx == 88px;
+    in-out property <bool> test: root.min-width == 500px && root.max-width == 500px && root.xxx == 88px;
 }
 
 /*

--- a/tests/cases/layout/nested_boxes.slint
+++ b/tests/cases/layout/nested_boxes.slint
@@ -3,7 +3,7 @@
 
 // cSpell:ignore redblue
 
-RectRed := Rectangle {
+component RectRed inherits Rectangle {
     background: red;
     min_width: 200phx;
     horizontal-stretch: 0;
@@ -32,7 +32,7 @@ RectRed := Rectangle {
         rect_pink.height == 50phx;
 }
 
-RedBlue := HorizontalLayout {
+component RedBlue inherits HorizontalLayout {
     spacing: 0phx;
     padding: 0phx;
 
@@ -141,7 +141,7 @@ export component TestCase inherits Rectangle {
     out property rect_green_ok <=> hl_redblue.rect_green_ok;
     out property rect_pink_ok <=> hl_redblue.rect_pink_ok;
 
-    out property <bool> test: rect_orange_ok && rect_blue_ok && rect_red_ok && rect_green_ok && rect_pink_ok && rect_yellow_ok && rect_black1_ok && rect_black2_ok;
+    out property <bool> test: rect_orange_ok && rect_blue_ok && rect_red_ok && root.rect_green_ok && root.rect_pink_ok && rect_yellow_ok && rect_black1_ok && rect_black2_ok;
 }
 
 /*

--- a/tests/cases/layout/override_from_parent.slint
+++ b/tests/cases/layout/override_from_parent.slint
@@ -1,11 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-ComboBox := Rectangle {
+component ComboBox inherits Rectangle {
     min-width: 60px;
 }
 
-SubComp1 := Rectangle {
+component SubComp1 inherits Rectangle {
     HorizontalLayout {
         ComboBox {
             width: 200px;
@@ -13,18 +13,18 @@ SubComp1 := Rectangle {
     }
 }
 
-SubComp2 := HorizontalLayout {
+component SubComp2 inherits HorizontalLayout {
     ComboBox {
         width: 200px;
     }
 }
 
-SubComp3 := HorizontalLayout {
+component SubComp3 inherits HorizontalLayout {
     max-width: 500px;
     Rectangle { }
 }
 
-SubComp4 := SubComp1 {}
+component SubComp4 inherits SubComp1 {}
 
 
 export component TestCase inherits Rectangle {


### PR DESCRIPTION
## Summary

Continues #11734 series. Ports 35 test files in `tests/cases/` from the deprecated Slint 0.3 syntax to the current syntax.

Changes applied by `tools/updater` (same five rules as #11734).

**One file skipped:** `crashes/issue1271_set_in_if.slint`. The regression's whole point is that assignments inside an `if` inside a property binding (`background`) used to crash. Under new-syntax parsing those assignments are rejected as "Assignment in a pure context", which would defeat the test. Needs a small structural workaround in a follow-up.

## Directories covered

`crashes` (11 of 12), `elements` (11), `layout` (13) — 35 files.

## Test plan

- [x] \`cargo test -p test-driver-interpreter\` — all 681 tests pass