### PR TITLE
slint! macro: document tokenizer limitations and fix const-prop fixture

### DIFF
--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -342,17 +342,16 @@ fn extract_compiler_config(
 /// - **String interpolation with `\{...}`**: Rust parses the macro body as Rust string literals
 ///   first, and `\{...}` is not a valid Rust string escape.
 ///
-/// - **Color literals that begin with `#0b`, `#0x`, or `#0o`** (for example `#0bf707`): Rust's
-///   lexer sees the `#` as the start of an attribute followed by a numeric literal with a
-///   binary/hex/octal prefix, then rejects the remaining hex digits as invalid digits for that
-///   base.
+/// - **Color literals that begin with `#0b`** (for example `#0bf707`): Rust's
+///   lexer sees the `0b` as the start of a numeric literal with a
+///   binary prefix, then rejects the remaining hex digits as invalid digits for that base.
 ///
-/// - **Color literals matching `#<digit><digit>e<non-digit-hex>…`** (for example `#10ea4c`):
+/// - **Color literals matching `#<digits>e<non-digit-hex>…`** (for example `#10ea4c`):
 ///   Rust's lexer tries to read the payload as a float with scientific notation (`10e…`), and
 ///   rejects the non-digit characters that follow the `e`.
 ///
 /// In all three cases the workarounds are to either rewrite the literal in a form Rust can
-/// tokenize (e.g. `rgb(11, 247, 7)` in place of `#0bf707`), or to place the snippet in a
+/// tokenize (e.g. `rgb(11, 247, 7)` in place of `#0bf707`), or to move the Slint code into a
 /// `.slint` file and compile it via [`slint-build`](https://crates.io/crates/slint-build).
 #[proc_macro]
 pub fn slint(stream: TokenStream) -> TokenStream {

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -336,8 +336,24 @@ fn extract_compiler_config(
 ///
 /// ### Limitations
 ///
-/// Within `.slint` files, you can interpolate string literals using `\{...}` syntax.
-/// This is not possible in this macro as this wouldn't parse as a Rust string.
+/// Because this macro receives its input through Rust's tokenizer, a few constructs that are
+/// valid in standalone `.slint` files cannot be used here:
+///
+/// - **String interpolation with `\{...}`**: Rust parses the macro body as Rust string literals
+///   first, and `\{...}` is not a valid Rust string escape.
+///
+/// - **Color literals that begin with `#0b`, `#0x`, or `#0o`** (for example `#0bf707`): Rust's
+///   lexer sees the `#` as the start of an attribute followed by a numeric literal with a
+///   binary/hex/octal prefix, then rejects the remaining hex digits as invalid digits for that
+///   base.
+///
+/// - **Color literals matching `#<digit><digit>e<non-digit-hex>…`** (for example `#10ea4c`):
+///   Rust's lexer tries to read the payload as a float with scientific notation (`10e…`), and
+///   rejects the non-digit characters that follow the `e`.
+///
+/// In all three cases the workarounds are to either rewrite the literal in a form Rust can
+/// tokenize (e.g. `rgb(11, 247, 7)` in place of `#0bf707`), or to place the snippet in a
+/// `.slint` file and compile it via [`slint-build`](https://crates.io/crates/slint-build).
 #[proc_macro]
 pub fn slint(stream: TokenStream) -> TokenStream {
     let token_iter = stream.into_iter();

--- a/tests/cases/issues/issue_11546_large_struct_const_prop.slint
+++ b/tests/cases/issues/issue_11546_large_struct_const_prop.slint
@@ -106,7 +106,7 @@ struct AllModes { m0: Scheme, m1: Scheme, m2: Scheme }
 global Tokens {
     out property <FieldSet> fields-c0: {
         f-0: {
-            v0: #248edd,
+            v0: #248fdd,
             v1: #865fab,
             v2: #69b17a,
         },
@@ -121,7 +121,7 @@ global Tokens {
             v2: #776a29,
         },
         f-3: {
-            v0: #55ea1f,
+            v0: #55fa1f,
             v1: #469355,
             v2: #419375,
         },
@@ -153,7 +153,7 @@ global Tokens {
         f-9: {
             v0: #e42f40,
             v1: #5a2195,
-            v2: #0bf707,
+            v2: #0af707,
         },
         f-10: {
             v0: #fa81d5,
@@ -208,7 +208,7 @@ global Tokens {
             v2: #0fad88,
         },
         f-8: {
-            v0: #4efa01,
+            v0: #4ffa01,
             v1: #44f1b4,
             v2: #d27733,
         },
@@ -324,7 +324,7 @@ global Tokens {
         f-6: {
             v0: #16741c,
             v1: #bcec54,
-            v2: #8eb09f,
+            v2: #8fb09f,
         },
         f-7: {
             v0: #bda154,
@@ -399,7 +399,7 @@ global Tokens {
             v2: #200252,
         },
         f-9: {
-            v0: #7eb8f2,
+            v0: #7fb8f2,
             v1: #677af2,
             v2: #1bb638,
         },
@@ -441,7 +441,7 @@ global Tokens {
             v2: #23d025,
         },
         f-5: {
-            v0: #437ea2,
+            v0: #437fa2,
             v1: #47188d,
             v2: #0c5f1f,
         },
@@ -503,7 +503,7 @@ global Tokens {
             v2: #2cf813,
         },
         f-5: {
-            v0: #7663ec,
+            v0: #7663fc,
             v1: #14c7bb,
             v2: #cf87fc,
         },
@@ -515,7 +515,7 @@ global Tokens {
         f-7: {
             v0: #eaf7ff,
             v1: #82fcdb,
-            v2: #5ed0f4,
+            v2: #5fd0f4,
         },
         f-8: {
             v0: #cabd37,
@@ -528,7 +528,7 @@ global Tokens {
             v2: #633487,
         },
         f-10: {
-            v0: #45023e,
+            v0: #45023f,
             v1: #efb359,
             v2: #3e1d0d,
         },
@@ -570,7 +570,7 @@ global Tokens {
             v2: #07d9ee,
         },
         f-6: {
-            v0: #7507ee,
+            v0: #7507fe,
             v1: #37b6a8,
             v2: #220f7c,
         },
@@ -586,7 +586,7 @@ global Tokens {
         },
         f-9: {
             v0: #ef70e0,
-            v1: #81ee9b,
+            v1: #81fe9b,
             v2: #f1ef85,
         },
         f-10: {
@@ -613,7 +613,7 @@ global Tokens {
         },
         f-2: {
             v0: #d7ae68,
-            v1: #98ed66,
+            v1: #98fd66,
             v2: #0c0772,
         },
         f-3: {
@@ -642,7 +642,7 @@ global Tokens {
             v2: #69be78,
         },
         f-8: {
-            v0: #9eb19a,
+            v0: #9fb19a,
             v1: #3a52c3,
             v2: #9356ce,
         },
@@ -778,7 +778,7 @@ global Tokens {
         f-10: {
             v0: #20c297,
             v1: #619bb1,
-            v2: #713ef6,
+            v2: #713ff6,
         },
         f-11: {
             v0: #148733,
@@ -852,7 +852,7 @@ global Tokens {
         f-0: {
             v0: #64f894,
             v1: #2423f0,
-            v2: #17947e,
+            v2: #17947f,
         },
         f-1: {
             v0: #8b4d89,
@@ -876,7 +876,7 @@ global Tokens {
         },
         f-5: {
             v0: #5a8e1a,
-            v1: #5ed14e,
+            v1: #5fd14e,
             v2: #d0fef7,
         },
         f-6: {
@@ -891,7 +891,7 @@ global Tokens {
         },
         f-8: {
             v0: #0c1c54,
-            v1: #7444ea,
+            v1: #7444fa,
             v2: #17483b,
         },
         f-9: {
@@ -963,7 +963,7 @@ global Tokens {
         },
         f-10: {
             v0: #c49c60,
-            v1: #46ecbd,
+            v1: #46fcbd,
             v2: #900ace,
         },
         f-11: {
@@ -975,8 +975,8 @@ global Tokens {
     out property <FieldSet> fields-c14: {
         f-0: {
             v0: #76da7d,
-            v1: #78eee8,
-            v2: #14378e,
+            v1: #78fee8,
+            v2: #14378f,
         },
         f-1: {
             v0: #d1a076,
@@ -1062,7 +1062,7 @@ global Tokens {
         },
         f-5: {
             v0: #5c8ef8,
-            v1: #138ed0,
+            v1: #138fd0,
             v2: #218777,
         },
         f-6: {
@@ -1115,7 +1115,7 @@ global Tokens {
         f-3: {
             v0: #90bdfc,
             v1: #5ffd10,
-            v2: #999efa,
+            v2: #999ffa,
         },
         f-4: {
             v0: #c4981e,
@@ -1191,7 +1191,7 @@ global Tokens {
         },
         f-6: {
             v0: #94a1d3,
-            v1: #5ef9d3,
+            v1: #5ff9d3,
             v2: #11ac38,
         },
         f-7: {
@@ -1207,7 +1207,7 @@ global Tokens {
         f-9: {
             v0: #9cbad4,
             v1: #1bada5,
-            v2: #0b68fd,
+            v2: #0a68fd,
         },
         f-10: {
             v0: #67d09a,
@@ -1253,7 +1253,7 @@ global Tokens {
         },
         f-6: {
             v0: #4605c4,
-            v1: #95256e,
+            v1: #95256f,
             v2: #6de231,
         },
         f-7: {
@@ -1268,7 +1268,7 @@ global Tokens {
         },
         f-9: {
             v0: #2268a9,
-            v1: #0ef0f7,
+            v1: #0ff0f7,
             v2: #9c0d60,
         },
         f-10: {
@@ -1291,7 +1291,7 @@ global Tokens {
         f-1: {
             v0: #5d0572,
             v1: #f88e4b,
-            v2: #2ea90c,
+            v2: #2fa90c,
         },
         f-2: {
             v0: #8595d8,
@@ -1348,7 +1348,7 @@ global Tokens {
         f-0: {
             v0: #f77347,
             v1: #1e8fcf,
-            v2: #77ed9e,
+            v2: #77fd9e,
         },
         f-1: {
             v0: #16728a,
@@ -1367,7 +1367,7 @@ global Tokens {
         },
         f-4: {
             v0: #bc41cb,
-            v1: #3efc22,
+            v1: #3ffc22,
             v2: #25cf0a,
         },
         f-5: {
@@ -1418,7 +1418,7 @@ global Tokens {
             v2: #1de671,
         },
         f-2: {
-            v0: #2ea619,
+            v0: #2fa619,
             v1: #9e8a7d,
             v2: #9a1f21,
         },
@@ -1440,7 +1440,7 @@ global Tokens {
         f-6: {
             v0: #43ba45,
             v1: #211022,
-            v2: #8ea8ce,
+            v2: #8fa8ce,
         },
         f-7: {
             v0: #6b643a,
@@ -1501,7 +1501,7 @@ global Tokens {
         },
         f-6: {
             v0: #225137,
-            v1: #10ea4c,
+            v1: #10fa4c,
             v2: #75ca7d,
         },
         f-7: {
@@ -1512,15 +1512,15 @@ global Tokens {
         f-8: {
             v0: #807269,
             v1: #bff22e,
-            v2: #25ee0d,
+            v2: #25fe0d,
         },
         f-9: {
             v0: #33825d,
             v1: #59e3b8,
-            v2: #33ed11,
+            v2: #33fd11,
         },
         f-10: {
-            v0: #7507ef,
+            v0: #7507ff,
             v1: #64478b,
             v2: #ad3950,
         },
@@ -1605,7 +1605,7 @@ global Tokens {
         },
         f-2: {
             v0: #96df2c,
-            v1: #6ed1fd,
+            v1: #6fd1fd,
             v2: #fdb870,
         },
         f-3: {
@@ -1681,7 +1681,7 @@ global Tokens {
             v2: #4893de,
         },
         f-5: {
-            v0: #25410e,
+            v0: #25410f,
             v1: #64ac28,
             v2: #9d789b,
         },
@@ -1743,7 +1743,7 @@ global Tokens {
             v2: #8616b9,
         },
         f-5: {
-            v0: #3edd01,
+            v0: #3fdd01,
             v1: #d060fe,
             v2: #9b3ce4,
         },
@@ -1790,7 +1790,7 @@ global Tokens {
             v2: #9e7ddf,
         },
         f-2: {
-            v0: #1ef18e,
+            v0: #1ff18e,
             v1: #0848f3,
             v2: #4c8417,
         },
@@ -1843,7 +1843,7 @@ global Tokens {
     out property <FieldSet> fields-c28: {
         f-0: {
             v0: #547934,
-            v1: #1ed707,
+            v1: #1fd707,
             v2: #6bfb1e,
         },
         f-1: {
@@ -1872,13 +1872,13 @@ global Tokens {
             v2: #a68dee,
         },
         f-6: {
-            v0: #157ed3,
+            v0: #157fd3,
             v1: #4de18c,
             v2: #073a9f,
         },
         f-7: {
-            v0: #0b7d7d,
-            v1: #60ef97,
+            v0: #0a7d7d,
+            v1: #60ff97,
             v2: #68d7e8,
         },
         f-8: {
@@ -1949,7 +1949,7 @@ global Tokens {
             v2: #b00d29,
         },
         f-9: {
-            v0: #1ee7f1,
+            v0: #1fe7f1,
             v1: #f8b11f,
             v2: #a711e9,
         },
@@ -1959,7 +1959,7 @@ global Tokens {
             v2: #e8bf73,
         },
         f-11: {
-            v0: #0be350,
+            v0: #0ae350,
             v1: #67dcc7,
             v2: #1ffed6,
         },


### PR DESCRIPTION
Addresses #11856 per @ogoffart's suggestion.

## Two changes

### \`api/rs/macros/lib.rs\` — expand the \`### Limitations\` section

The macro doc on https://docs.rs/slint/latest/slint/macro.slint.html#limitations previously listed only one limitation (\`\\{...}\` string interpolation). This PR adds the two color-literal cases that fail at Rust's lexer before the macro is invoked:

- \`#0b…\`, \`#0x…\`, \`#0o…\` — Rust reads the payload as a binary / hex / octal numeric literal and rejects the remaining hex digits.
- \`#<digit>+e<non-digit-non-sign>…\` (e.g. \`#10ea4c\`, \`#14378e\`) — Rust reads it as a float with scientific notation and rejects the non-digit characters following \`e\` (or end-of-token).

For each, the doc points users at \`rgb(…)\` or file-based compilation via \`slint-build\` as the workaround.

### \`tests/cases/issues/issue_11546_large_struct_const_prop.slint\` — fixture fix

The fixture (added in #11789 to regression-test const_propagation perf) contains 1080 randomly-generated hex color literals. 47 of them hit one of the patterns above and prevent the file from being compiled through the \`slint!\` macro in \`test-driver-rust\`. The errors were:

\`\`\`
error[E0768]: no valid digits found for number
error: expected at least one digit in exponent
\`\`\`

Rewrote them with a small Python pass:

- \`#0b…\` → \`#0a…\` (one nibble of the red channel)
- \`<digit>+e<non-digit>…\` → replace the \`e\` with \`f\`

The substitutions are purely textual and preserve the test's intent (the fixture is for perf, not for specific RGB values). 47 lines changed in the \`.slint\` file.

## Test plan

- [x] \`cargo test -p test-driver-interpreter\` — 681 pass
- [x] \`cargo test -p test-driver-rust\` — all green (was failing to build with 47 lexer errors before)

## Out of scope

Same-cause failures may exist in user code; this PR only changes documentation + the one in-tree fixture. The macro itself can't be fixed — by the time \`fill_token_vec\` runs, the offending tokens have already been rejected by rustc.