### PR TITLE
slint-compiler: avoid duplicate codegen for library-exported enums/st…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6030,6 +6030,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "issue-11836-test-app"
+version = "1.17.0"
+dependencies = [
+ "issue-11836-test-library",
+ "slint",
+ "slint-build",
+]
+
+[[package]]
+name = "issue-11836-test-library"
+version = "1.17.0"
+dependencies = [
+ "slint",
+ "slint-build",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ members = [
   'tests/manual/module-builds/blogica',
   'tests/manual/module-builds/blogicb',
   'tests/manual/module-builds/app',
+  'tests/issues/test-11836-project/test-app',
+  'tests/issues/test-11836-project/test-library',
   'tests/backends/',
   'tools/compiler',
   'docs/slint-doc-generator',

--- a/internal/compiler/passes/collect_structs_and_enums.rs
+++ b/internal/compiler/passes/collect_structs_and_enums.rs
@@ -26,16 +26,18 @@ pub fn collect_structs_and_enums(doc: &Document) {
     used_types.structs_and_enums = Vec::with_capacity(hash.len());
     while let Some(next) = hash.iter().next() {
         let key = next.0.clone();
-        if let Some(library_info) = doc.library_exports.get(key.as_str()) {
-            // This is a type imported from an external library, just skip it for code generation
-            hash.remove(&key);
-            used_types.library_types_imports.push((key, library_info.clone()));
-            continue;
-        }
 
-        // Here, using BTreeMap::pop_first would be great when it is stable
-        let used_struct_and_enums = &mut used_types.structs_and_enums;
-        sort_types(&mut hash, used_struct_and_enums, &key);
+        sort_types(&mut hash, &key, &mut |key, ty| {
+            // Here, using BTreeMap::pop_first would be great when it is stable
+            let used_struct_and_enums = &mut used_types.structs_and_enums;
+
+            if let Some(library_info) = doc.library_exports.get(key.as_str()) {
+                // This is a type imported from an external library, just skip it for code generation
+                used_types.library_types_imports.push((key.clone(), library_info.clone()));
+            } else {
+                used_struct_and_enums.push(ty.clone());
+            }
+        });
     }
 }
 
@@ -66,16 +68,20 @@ fn collect_types_in_component(root_component: &Rc<Component>, hash: &mut BTreeMa
 
 /// Move the object named `key` from hash to vector, making sure that all object used by
 /// it are placed before in the vector
-fn sort_types(hash: &mut BTreeMap<SmolStr, Type>, vec: &mut Vec<Type>, key: &str) {
+fn sort_types(
+    hash: &mut BTreeMap<SmolStr, Type>,
+    key: &SmolStr,
+    visitor: &mut impl FnMut(&SmolStr, &Type),
+) {
     let ty = if let Some(ty) = hash.remove(key) { ty } else { return };
     if let Type::Struct(s) = &ty
         && let StructName::User { .. } = &s.name
     {
         for sub_ty in s.fields.values() {
-            visit_declared_type(sub_ty, &mut |name, _| sort_types(hash, vec, name));
+            visit_declared_type(sub_ty, &mut |name, _| sort_types(hash, name, visitor));
         }
     }
-    vec.push(ty)
+    visitor(key, &ty)
 }
 
 /// Will call the `visitor` for every named struct or enum that is not builtin

--- a/tests/issues/test-11836-project/test-app/Cargo.toml
+++ b/tests/issues/test-11836-project/test-app/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+[package]
+name = "issue-11836-test-app"
+version.workspace = true
+edition.workspace = true
+authors = ["Slint Developers <info@slint.dev>"]
+publish = false
+license = "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0"
+
+[dependencies]
+slint = { path = "../../../../api/rs/slint" }
+issue-11836-test-library = { path = "../test-library" }
+
+[build-dependencies]
+slint-build = { path = "../../../../api/rs/build", features = ["experimental-module-builds"] }

--- a/tests/issues/test-11836-project/test-app/build.rs
+++ b/tests/issues/test-11836-project/test-app/build.rs
@@ -1,0 +1,7 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+fn main() {
+    let config = slint_build::CompilerConfiguration::new();
+    slint_build::compile_with_config("ui/app-window.slint", config).expect("Slint build failed");
+}

--- a/tests/issues/test-11836-project/test-app/src/main.rs
+++ b/tests/issues/test-11836-project/test-app/src/main.rs
@@ -1,0 +1,14 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use issue_11836_test_library::test_library;
+use slint::ComponentHandle;
+
+slint::include_modules!();
+
+fn main() {
+    let ui = AppWindow::new().unwrap();
+
+    test_library::init(&ui);
+    ui.run().unwrap();
+}

--- a/tests/issues/test-11836-project/test-app/ui/app-window.slint
+++ b/tests/issues/test-11836-project/test-app/ui/app-window.slint
@@ -1,0 +1,12 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import {
+    TestComponent,
+    TestGlobal,
+} from "@test_library";
+export { TestGlobal }
+
+export component AppWindow inherits Window {
+    TestComponent { }
+}

--- a/tests/issues/test-11836-project/test-library/Cargo.toml
+++ b/tests/issues/test-11836-project/test-library/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+[package]
+name = "issue-11836-test-library"
+version.workspace = true
+edition.workspace = true
+authors = ["Slint Developers <info@slint.dev>"]
+publish = false
+license = "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0"
+links = "test_library"
+
+[dependencies]
+slint = { path = "../../../../api/rs/slint" }
+
+[build-dependencies]
+slint-build = { path = "../../../../api/rs/build", features = ["experimental-module-builds"] }

--- a/tests/issues/test-11836-project/test-library/build.rs
+++ b/tests/issues/test-11836-project/test-library/build.rs
@@ -1,0 +1,12 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+fn main() -> Result<(), slint_build::CompileError> {
+    let config = slint_build::CompilerConfiguration::new()
+        .as_library("test_library")
+        .rust_module("test_library");
+
+    slint_build::compile_with_config("ui/test-library.slint", config)?;
+
+    Ok(())
+}

--- a/tests/issues/test-11836-project/test-library/src/lib.rs
+++ b/tests/issues/test-11836-project/test-library/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+pub mod test_library {
+    slint::include_modules!();
+    use slint::ComponentHandle;
+
+    pub fn init<T>(_ui: &T)
+    where
+        T: ComponentHandle + 'static,
+        for<'a> TestGlobal<'a>: slint::Global<'a, T>,
+    {
+    }
+}

--- a/tests/issues/test-11836-project/test-library/ui/test-library.slint
+++ b/tests/issues/test-11836-project/test-library/ui/test-library.slint
@@ -1,0 +1,75 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Button } from "std-widgets.slint";
+
+export enum TestType {
+    test1,
+    test2,
+    test3,
+    test4,
+}
+
+export enum TestAction {
+    test1,
+    test2,
+    test3,
+    test4,
+}
+
+export enum TestType2 {
+    test1,
+    test2,
+    test3,
+    test4,
+}
+
+export struct TestActions {
+    test1: TestAction,
+    test2: TestAction,
+}
+
+export struct TestStruct {
+    test1: TestType,
+    test2: bool,
+}
+
+export global TestGlobal {
+    in-out property <[TestStruct]> test-in-out;
+    callback test-callback(i1: int, s1: TestStruct);
+}
+
+export component TestSubComponent inherits Rectangle {
+    out property <TestType> demo-prop-out: TestType.test1;
+    in-out property <[TestStruct]> test-in-out <=> TestGlobal.test-in-out;
+
+    for btn-config[index] in test-in-out: Rectangle {
+        Button {
+            property <TestType> test-prop: btn-config.test1;
+
+            checked: (demo-prop-out == self.test-prop);
+            clicked => {
+                root.demo-prop-out = self.test-prop;
+            }
+        }
+    }
+}
+
+struct TestStruct1 {
+    test1: TestType,
+    test2-actions: TestActions,
+}
+
+struct TestStruct2 {
+    test-map: [[TestStruct1]],
+}
+
+export component TestComponent {
+    in-out property <TestStruct2> test-configs;
+
+    function do-test-test(test1: TestType) {
+        test-configs.test-map[0][0].test1 = test1;
+    }
+
+    TestSubComponent { }
+}


### PR DESCRIPTION
…ructs

Depending on usage and component structure, enums/structs originating from an external library could be missed by collection. In that case, the compiler generated those types again locally, which produced conflicting duplicate definitions.
Ensure all used struct/enum types are checked against library exports before generating code.

Fixes #11836

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
