### PR TITLE
Don't presume Docs always have been built and deploy if lock file changes

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -51,6 +51,7 @@ docs_build:
  - 'helper_crates/**'
  - 'tools/lsp/**'
  - 'tests/doctests/**'
+ - *js_config
  - *ci_config
 
 # Tree-sitter grammar
@@ -128,6 +129,7 @@ slintpad:
  - 'tools/lsp/**'
  - 'api/rs/**'
  - 'docs/common/src/utils/slint.tmLanguage.json'
+ - *js_config
 
 updater_test:
  - *internal

--- a/.github/workflows/deploy_preview.yaml
+++ b/.github/workflows/deploy_preview.yaml
@@ -102,7 +102,6 @@ jobs:
               id: assemble
               env:
                 PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-                DL_DOCS: ${{ steps.dl-docs.outcome }}
                 DL_SLINTPAD: ${{ steps.dl-slintpad.outcome }}
                 DL_MATERIAL: ${{ steps.dl-material.outcome }}
               run: |
@@ -119,7 +118,7 @@ jobs:
                 LINKS=""
 
                 # Assemble docs from sub-artifacts into master/docs/
-                if [ "$DL_DOCS" = "success" ]; then
+                if [ -d artifacts/docs-parts/docs ]; then
                   mkdir -p "$DIST/master/docs"
                   cp -R artifacts/docs-parts/docs/. "$DIST/master/docs/"
                   LINKS="$LINKS<li>Documentation: "


### PR DESCRIPTION
1. Fixes an issue where if the docs are not built deploy_preview will
   fail as the check it used always thinks the docs have been built and
   then fails to find them. It now just checks to see if a docs
   artifact exisit.
2. Items such as Astro only change in the root PNPM
   workspace file and so won't be detected as a docs change with the
   previous system. Anything that changes the lock file will now build
   the docs and slintpad. The correct behaviour as lock file changes
   could break these items.