### PR TITLE
revert using extra_data.globals to get the window adapter.

### DIFF
--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1625,7 +1625,7 @@ pub fn instantiate(
             if let Some(WindowOptions::UseExistingWindow(adapter)) = window_options.as_ref() {
                 Some(adapter.clone())
             } else {
-                extra_data.globals.get().unwrap().window_adapter().and_then(|wa| wa.get().cloned())
+                instance_ref.maybe_window_adapter()
             };
 
         let component_rc = vtable::VRc::into_dyn(self_rc.clone());
@@ -2742,14 +2742,11 @@ impl<'a, 'id> InstanceRef<'a, 'id> {
 
     pub fn maybe_window_adapter(&self) -> Option<WindowAdapterRc> {
         let root_weak = vtable::VWeak::into_dyn(self.root_weak().clone());
-        let root = self.root_weak().upgrade()?;
-        generativity::make_guard!(guard);
-        let comp = root.unerase(guard);
         Self::get_or_init_window_adapter_ref(
-            &comp.description,
+            &self.description,
             root_weak,
             false,
-            comp.instance.as_pin_ref().get_ref(),
+            self.instance.get_ref(),
         )
         .ok()
         .cloned()


### PR DESCRIPTION
Reason: We can directly use in maybe_window_adapter self to determine the window adapter, since we pas the globals from the parent to the childrens. So all have the same global and so also the same window adapter

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
