### PR TITLE
remote viewer: rebuild remote preview on every editor keystroke

### DIFF
--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -29,7 +29,7 @@ slint-interpreter = { workspace = true, optional = true, default-features = fals
 # remote
 dashmap = { version = "6.1.0", optional = true }
 tokio-tungstenite = { version = "0.28.0", features = ["rustls"], optional = true }
-tokio = { version = "1.48.0", features = ["rt", "net", "sync", "macros"], optional = true }
+tokio = { version = "1.48.0", features = ["rt", "net", "sync", "macros", "time"], optional = true }
 futures-util = { version = "0.3.31", features = ["sink"], optional = true }
 postcard = { version = "1.1.3", features = ["alloc"], optional = true }
 base64 = { version = "0.22.1", optional = true }

--- a/internal/live-preview/lib.rs
+++ b/internal/live-preview/lib.rs
@@ -3,6 +3,11 @@
 
 #![doc = include_str!("README.md")]
 
+/// Window over which a burst of keystrokes from the editor is coalesced into a single
+/// preview rebuild. Used by both the in-process LSP preview and the remote viewer so a
+/// single value governs how reactive the preview feels.
+pub const REBUILD_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(50);
+
 #[cfg(feature = "protocol")]
 pub mod protocol;
 

--- a/internal/live-preview/live_component.rs
+++ b/internal/live-preview/live_component.rs
@@ -297,7 +297,7 @@ impl Watcher {
                     std::mem::replace(&mut watcher.lock().unwrap().state, WatcherState::Changed)
                 {
                     // Wait a bit to let the time to write multiple files
-                    std::thread::sleep(std::time::Duration::from_millis(15));
+                    std::thread::sleep(crate::REBUILD_DEBOUNCE);
                     waker.wake();
                 }
             },

--- a/internal/live-preview/remote.rs
+++ b/internal/live-preview/remote.rs
@@ -5,4 +5,4 @@ mod compilation;
 mod connection;
 
 pub use compilation::init_compiler;
-pub use connection::{CacheEntry, Connection, ConnectionMessage};
+pub use connection::{CacheEntry, Connection, ConnectionMessage, FileCache};

--- a/internal/live-preview/remote/compilation.rs
+++ b/internal/live-preview/remote/compilation.rs
@@ -30,10 +30,9 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
                 )));
             };
             Some(
-                connection
-                    .request_file(url)
-                    .await
-                    .map(|file_content| String::from_utf8_lossy(&file_content.contents).to_string()),
+                connection.request_file(url).await.map(|file_content| {
+                    String::from_utf8_lossy(&file_content.contents).to_string()
+                }),
             )
         })
     });

--- a/internal/live-preview/remote/compilation.rs
+++ b/internal/live-preview/remote/compilation.rs
@@ -1,9 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{path::PathBuf, rc::Weak};
+use std::rc::Weak;
 
 use i_slint_core::InternalToken;
+use lsp_types::Url;
 
 use super::connection::Connection;
 
@@ -12,21 +13,28 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
 
     let file_loader_connection = connection.clone();
     compiler.set_file_loader(move |path: &std::path::Path| {
-        // make path absolute in our virtual file system
-        let path = PathBuf::from("/").join(path);
+        let url = Url::from_file_path(path);
+        let path_display = path.display().to_string();
         let connection = file_loader_connection.clone();
         Box::pin(async move {
-            Some(if let Some(connection) = connection.upgrade() {
-                connection
-                    .request_file(path.as_os_str().to_str().unwrap().to_owned())
-                    .await
-                    .map(|file_content| String::from_utf8_lossy(&file_content.contents).to_string())
-            } else {
-                Err(std::io::Error::new(
+            let Some(connection) = connection.upgrade() else {
+                return Some(Err(std::io::Error::new(
                     std::io::ErrorKind::BrokenPipe,
                     "Connection is no longer available",
-                ))
-            })
+                )));
+            };
+            let Ok(url) = url else {
+                return Some(Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Not an absolute file path: {path_display}"),
+                )));
+            };
+            Some(
+                connection
+                    .request_file(url)
+                    .await
+                    .map(|file_content| String::from_utf8_lossy(&file_content.contents).to_string()),
+            )
         })
     });
 
@@ -34,15 +42,16 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
     compiler.compiler_configuration(InternalToken).resource_url_mapper =
         Some(std::rc::Rc::new(move |url: &str| {
             let connection = mapper_connection.clone();
-            let path = url.to_owned();
+            let url_str = url.to_owned();
             Box::pin(async move {
-                if path.starts_with("builtin:/") {
+                if url_str.starts_with("builtin:/") {
                     return None;
                 }
                 let connection = connection.upgrade()?;
-                let file_content = connection.request_file(path.clone()).await.ok()?;
+                let parsed = Url::parse(&url_str).ok()?;
+                let file_content = connection.request_file(parsed).await.ok()?;
 
-                let extension = std::path::Path::new(&path)
+                let extension = std::path::Path::new(&url_str)
                     .extension()
                     .and_then(|e| e.to_str())
                     .unwrap_or("png");

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -4,21 +4,10 @@
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
-    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
-/// The compiler stores file paths in URL form (e.g. `/C:/foo.slint` on Windows, with percent
-/// encoding preserved). The LSP sends `SetContents` with the same `Url`. Comparing the path
-/// from `Url::to_file_path()` against the path from `compilation_result.watch_paths()` is
-/// platform-dependent and unreliable on Windows or for paths with spaces, so the dependency
-/// set is keyed on the URL's path component, which is the form both sides natively produce.
-type DependencyKey = String;
-
-/// Window over which a burst of keystrokes is coalesced into a single `ContentsChanged`
-/// notification, matching the in-process preview's `preview_loading_delay_timer`.
-const REBUILD_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(150);
-
+use crate::REBUILD_DEBOUNCE;
 use crate::protocol::{
     LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PreviewComponent, PreviewConfig,
     PreviewToLspMessage, SLINT_PROTOCOLS_HEADER, SLINT_VERSION, SLINT_VERSION_HEADER,
@@ -104,8 +93,10 @@ pub enum CacheEntry {
     Ready(VersionedFileContent),
 }
 
-/// Shared cache of file contents pushed by the LSP, keyed by absolute file path.
-pub type FileCache = Arc<DashMap<String, CacheEntry>>;
+/// Shared cache of file contents pushed by the LSP, keyed by the `Url` the LSP sent. Using
+/// the URL verbatim avoids platform-dependent path normalization (Windows backslashes,
+/// percent-encoding) — equality is structural.
+pub type FileCache = Arc<DashMap<Url, CacheEntry>>;
 
 #[derive(Debug)]
 pub enum ConnectionMessage {
@@ -135,29 +126,22 @@ pub struct Connection {
     local_addr: SocketAddr,
     thread_handle: Option<(std::thread::JoinHandle<()>, sync::oneshot::Sender<()>)>,
     message_sender: sync::mpsc::UnboundedSender<Message>,
-    file_cache: Arc<DashMap<String, CacheEntry>>,
-    /// Files the currently shown component depends on, keyed by `Url::path()`. `SetContents`
-    /// notifications for paths outside this set are ignored, so unrelated edits in the user's
-    /// editor don't trigger a rebuild. Updated by the viewer after each compile.
-    dependencies: Arc<Mutex<HashSet<DependencyKey>>>,
+    file_cache: FileCache,
+    /// Files the currently shown component depends on. `SetContents` notifications for URLs
+    /// outside this set are ignored, so unrelated edits in the user's editor don't trigger a
+    /// rebuild. Updated by the viewer after each compile.
+    dependencies: Arc<Mutex<HashSet<Url>>>,
 }
 
-/// Compute the `file_cache` key for an incoming LSP URL. Returns `None` (with a warning) for
-/// schemes that aren't `file://` or for paths the host OS represents non-UTF-8 — both cases
-/// the remote preview protocol can't handle. We log and skip rather than panic the connection
-/// task, since the LSP can legitimately produce URLs like `vscode-remote://`.
-fn cache_key_for_url(url: &Url) -> Option<String> {
-    let Ok(path) = url.to_file_path() else {
+/// Whether the connection can act on this URL. The remote preview protocol only handles
+/// `file://` URLs; the LSP can legitimately produce others (e.g. `vscode-remote://`), but
+/// they're silently ignored on this side.
+fn is_supported(url: &Url) -> bool {
+    if url.scheme() != "file" {
         tracing::warn!("Ignoring message for unsupported URL scheme: {url}");
-        return None;
-    };
-    match path.into_os_string().into_string() {
-        Ok(s) => Some(s),
-        Err(_) => {
-            tracing::warn!("Ignoring message for non-UTF-8 file path: {url}");
-            None
-        }
+        return false;
     }
+    true
 }
 
 impl Connection {
@@ -165,8 +149,8 @@ impl Connection {
         address: Option<SocketAddr>,
         message_handler: impl Fn(ConnectionMessage) + 'static + Send + Sync,
     ) -> anyhow::Result<Self> {
-        let file_cache = Arc::new(DashMap::<String, CacheEntry>::new());
-        let dependencies = Arc::new(Mutex::new(HashSet::<DependencyKey>::new()));
+        let file_cache = Arc::new(DashMap::<Url, CacheEntry>::new());
+        let dependencies = Arc::new(Mutex::new(HashSet::<Url>::new()));
         let (message_sender, mut message_receiver) = sync::mpsc::unbounded_channel();
 
         let inner_file_cache = file_cache.clone();
@@ -266,13 +250,10 @@ impl Connection {
         })
     }
 
-    /// Replace the set of files the connection treats as relevant. A subsequent `SetContents`
-    /// for a path in `paths` produces a `ContentsChanged` message; anything outside is dropped.
-    /// `paths` is expected to be the `watch_paths` returned by the compiler — they are stored
-    /// in URL-path form (the same form the LSP sends in `SetContents`).
-    pub fn set_dependencies(&self, paths: Vec<PathBuf>) {
-        *self.dependencies.lock().unwrap() =
-            paths.into_iter().filter_map(|p| p.into_os_string().into_string().ok()).collect();
+    /// Replace the set of URLs the connection treats as relevant. A subsequent `SetContents`
+    /// for a URL in `urls` produces a `ContentsChanged` message; anything outside is dropped.
+    pub fn set_dependencies(&self, urls: Vec<Url>) {
+        *self.dependencies.lock().unwrap() = urls.into_iter().collect();
     }
 
     /// Shared cache of files pushed by the LSP. The viewer reads this to feed
@@ -285,7 +266,7 @@ impl Connection {
         mut receiver: SplitStream<WebSocketStream<TcpStream>>,
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
         file_cache: FileCache,
-        dependencies: Arc<Mutex<HashSet<DependencyKey>>>,
+        dependencies: Arc<Mutex<HashSet<Url>>>,
         message_sender: UnboundedSender<Message>,
         remote_addr: SocketAddr,
     ) {
@@ -318,22 +299,22 @@ impl Connection {
                                     tracing::debug!("Received message {message:?}");
                                     match message {
                                         LspToPreviewMessage::InvalidateContents { url } => {
-                                            let Some(key) = cache_key_for_url(&url) else {
+                                            if !is_supported(&url) {
                                                 continue;
-                                            };
-                                            file_cache.remove(&key);
-                                            if dependencies.lock().unwrap().contains(url.path()) {
+                                            }
+                                            file_cache.remove(&url);
+                                            if dependencies.lock().unwrap().contains(&url) {
                                                 debounce_deadline = Some(
                                                     tokio::time::Instant::now() + REBUILD_DEBOUNCE,
                                                 );
                                             }
                                         }
                                         LspToPreviewMessage::ForgetFile { url } => {
-                                            let Some(key) = cache_key_for_url(&url) else {
+                                            if !is_supported(&url) {
                                                 continue;
-                                            };
+                                            }
                                             if let Some((_, CacheEntry::Loading(senders))) =
-                                                file_cache.remove(&key)
+                                                file_cache.remove(&url)
                                             {
                                                 for sender in senders {
                                                     let _ = sender.send(Err(std::io::Error::new(
@@ -342,7 +323,7 @@ impl Connection {
                                                     )));
                                                 }
                                             }
-                                            if dependencies.lock().unwrap().contains(url.path()) {
+                                            if dependencies.lock().unwrap().contains(&url) {
                                                 debounce_deadline = Some(
                                                     tokio::time::Instant::now() + REBUILD_DEBOUNCE,
                                                 );
@@ -354,15 +335,19 @@ impl Connection {
                                                 url.url(),
                                                 contents.len()
                                             );
-                                            let Some(key) = cache_key_for_url(url.url()) else {
+                                            if !is_supported(url.url()) {
                                                 continue;
-                                            };
+                                            }
                                             let versioned_content = VersionedFileContent {
                                                 version: *url.version(),
                                                 contents: contents.into(),
                                             };
+                                            let triggers_rebuild = dependencies
+                                                .lock()
+                                                .unwrap()
+                                                .contains(url.url());
                                             file_cache
-                                                .entry(key)
+                                                .entry(url.url().clone())
                                                 .and_modify(|entry| {
                                                     if let CacheEntry::Loading(senders) = entry {
                                                         for sender in senders.drain(..) {
@@ -373,11 +358,7 @@ impl Connection {
                                                     }
                                                 })
                                                 .insert(CacheEntry::Ready(versioned_content));
-                                            if dependencies
-                                                .lock()
-                                                .unwrap()
-                                                .contains(url.url().path())
-                                            {
+                                            if triggers_rebuild {
                                                 debounce_deadline = Some(
                                                     tokio::time::Instant::now() + REBUILD_DEBOUNCE,
                                                 );
@@ -442,15 +423,15 @@ impl Connection {
         Ok(())
     }
 
-    pub async fn request_file(&self, file: String) -> std::io::Result<VersionedFileContent> {
-        if let Some(entry) = self.file_cache.get(&file)
+    pub async fn request_file(&self, url: Url) -> std::io::Result<VersionedFileContent> {
+        if let Some(entry) = self.file_cache.get(&url)
             && let CacheEntry::Ready(entry) = entry.value()
         {
             return Ok(entry.clone());
         }
         let (sender, receiver) = oneshot::channel();
-        let request_file; // do not hold the lock on requested_files across await
-        match self.file_cache.entry(file.clone()) {
+        let request_file; // do not hold the lock across await
+        match self.file_cache.entry(url.clone()) {
             Entry::Occupied(mut occupied) => match occupied.get_mut() {
                 CacheEntry::Ready(entry) => {
                     return Ok(entry.clone());
@@ -465,16 +446,15 @@ impl Connection {
                 request_file = true;
             }
         }
-        if request_file {
-            self.send(PreviewToLspMessage::RequestState {
-                files: vec![Url::from_file_path(&file).map_err(|()| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        format!("Invalid file path: {file}"),
-                    )
-                })?],
-            })
-            .map_err(std::io::Error::other)?;
+        if request_file
+            && let Err(err) =
+                self.send(PreviewToLspMessage::RequestState { files: vec![url.clone()] })
+        {
+            // The Loading entry we just inserted will never be resolved by the
+            // websocket task — remove it so the senders inside (including ours)
+            // drop and a later request_file for the same key doesn't deadlock.
+            self.file_cache.remove(&url);
+            return Err(std::io::Error::other(err));
         }
         receiver.await.map_err(std::io::Error::other)?
     }

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -91,6 +91,9 @@ pub enum CacheEntry {
     Ready(VersionedFileContent),
 }
 
+/// Shared cache of file contents pushed by the LSP, keyed by absolute file path.
+pub type FileCache = Arc<DashMap<String, CacheEntry>>;
+
 #[derive(Debug)]
 pub enum ConnectionMessage {
     Connected {
@@ -104,7 +107,13 @@ pub enum ConnectionMessage {
     },
     ShowPreview {
         preview_component: PreviewComponent,
-        file_cache: Arc<DashMap<String, CacheEntry>>,
+        file_cache: FileCache,
+    },
+    /// The contents of a file changed in the editor. The viewer should rebuild the currently
+    /// shown component if the file is one of its dependencies.
+    ContentsChanged {
+        url: Url,
+        file_cache: FileCache,
     },
     #[allow(dead_code)]
     HighlightFromEditor {
@@ -215,7 +224,7 @@ impl Connection {
     async fn handle_connection(
         mut receiver: SplitStream<WebSocketStream<TcpStream>>,
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
-        file_cache: Arc<DashMap<String, CacheEntry>>,
+        file_cache: FileCache,
         message_sender: UnboundedSender<Message>,
         remote_addr: SocketAddr,
     ) {
@@ -284,6 +293,10 @@ impl Connection {
                                             }
                                         })
                                         .insert(CacheEntry::Ready(versioned_content));
+                                    message_handler(ConnectionMessage::ContentsChanged {
+                                        url: url.url().clone(),
+                                        file_cache: file_cache.clone(),
+                                    });
                                 }
                                 LspToPreviewMessage::SetConfiguration { config } => {
                                     message_handler(ConnectionMessage::SetConfiguration { config });

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -2,9 +2,22 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::{
+    collections::HashSet,
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
-    sync::Arc,
+    path::PathBuf,
+    sync::{Arc, Mutex},
 };
+
+/// The compiler stores file paths in URL form (e.g. `/C:/foo.slint` on Windows, with percent
+/// encoding preserved). The LSP sends `SetContents` with the same `Url`. Comparing the path
+/// from `Url::to_file_path()` against the path from `compilation_result.watch_paths()` is
+/// platform-dependent and unreliable on Windows or for paths with spaces, so the dependency
+/// set is keyed on the URL's path component, which is the form both sides natively produce.
+type DependencyKey = String;
+
+/// Window over which a burst of keystrokes is coalesced into a single `ContentsChanged`
+/// notification, matching the in-process preview's `preview_loading_delay_timer`.
+const REBUILD_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(150);
 
 use crate::protocol::{
     LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PreviewComponent, PreviewConfig,
@@ -107,14 +120,10 @@ pub enum ConnectionMessage {
     },
     ShowPreview {
         preview_component: PreviewComponent,
-        file_cache: FileCache,
     },
-    /// The contents of a file changed in the editor. The viewer should rebuild the currently
-    /// shown component if the file is one of its dependencies.
-    ContentsChanged {
-        url: Url,
-        file_cache: FileCache,
-    },
+    /// A dependency of the currently shown component changed. The viewer should rebuild.
+    /// The connection has already filtered unrelated edits and debounced bursts of keystrokes.
+    ContentsChanged,
     #[allow(dead_code)]
     HighlightFromEditor {
         url: Option<Url>,
@@ -127,6 +136,28 @@ pub struct Connection {
     thread_handle: Option<(std::thread::JoinHandle<()>, sync::oneshot::Sender<()>)>,
     message_sender: sync::mpsc::UnboundedSender<Message>,
     file_cache: Arc<DashMap<String, CacheEntry>>,
+    /// Files the currently shown component depends on, keyed by `Url::path()`. `SetContents`
+    /// notifications for paths outside this set are ignored, so unrelated edits in the user's
+    /// editor don't trigger a rebuild. Updated by the viewer after each compile.
+    dependencies: Arc<Mutex<HashSet<DependencyKey>>>,
+}
+
+/// Compute the `file_cache` key for an incoming LSP URL. Returns `None` (with a warning) for
+/// schemes that aren't `file://` or for paths the host OS represents non-UTF-8 — both cases
+/// the remote preview protocol can't handle. We log and skip rather than panic the connection
+/// task, since the LSP can legitimately produce URLs like `vscode-remote://`.
+fn cache_key_for_url(url: &Url) -> Option<String> {
+    let Ok(path) = url.to_file_path() else {
+        tracing::warn!("Ignoring message for unsupported URL scheme: {url}");
+        return None;
+    };
+    match path.into_os_string().into_string() {
+        Ok(s) => Some(s),
+        Err(_) => {
+            tracing::warn!("Ignoring message for non-UTF-8 file path: {url}");
+            None
+        }
+    }
 }
 
 impl Connection {
@@ -135,9 +166,11 @@ impl Connection {
         message_handler: impl Fn(ConnectionMessage) + 'static + Send + Sync,
     ) -> anyhow::Result<Self> {
         let file_cache = Arc::new(DashMap::<String, CacheEntry>::new());
+        let dependencies = Arc::new(Mutex::new(HashSet::<DependencyKey>::new()));
         let (message_sender, mut message_receiver) = sync::mpsc::unbounded_channel();
 
         let inner_file_cache = file_cache.clone();
+        let inner_dependencies = dependencies.clone();
         let inner_message_sender = message_sender.clone();
 
         let (local_addr_sender, local_addr_receiver) =
@@ -160,7 +193,10 @@ impl Connection {
                 local_addr_sender.send(listener.local_addr()).ok();
 
                 let message_handler = Arc::new(message_handler);
-                let mut current_sink = None;
+                // The sink is the write half; the JoinHandle is the read-half task. We keep
+                // both so the next accept can abort the in-flight task and reset shared state
+                // before its messages race with the new client's.
+                let mut current_session: Option<(_, tokio::task::JoinHandle<()>)> = None;
                 loop {
                     tokio::select! {
                         accept = listener.accept() => {
@@ -177,19 +213,27 @@ impl Connection {
                                         }
                                         Ok(stream) => {
                                             tracing::info!("Websocket established with {addr:?}");
-                                            let (sink, receiver) = stream.split();
-                                            tokio::spawn(Self::handle_connection(
-                                                receiver,
-                                                message_handler.clone(),
-                                                inner_file_cache.clone(),
-                                                inner_message_sender.clone(),
-                                                addr,
-                                            ));
-                                            if let Some(_old_sink) = current_sink.replace(sink) {
+                                            if let Some((_old_sink, old_handle)) = current_session.take() {
                                                 tracing::error!(
                                                     "Second connection while we were already connected, dropping old connection"
                                                 );
+                                                old_handle.abort();
+                                                // The aborted task can't run its end-of-loop
+                                                // cleanup, so reset the shared state here so
+                                                // the new client starts from a clean cache.
+                                                inner_file_cache.clear();
+                                                inner_dependencies.lock().unwrap().clear();
                                             }
+                                            let (sink, receiver) = stream.split();
+                                            let handle = tokio::spawn(Self::handle_connection(
+                                                receiver,
+                                                message_handler.clone(),
+                                                inner_file_cache.clone(),
+                                                inner_dependencies.clone(),
+                                                inner_message_sender.clone(),
+                                                addr,
+                                            ));
+                                            current_session = Some((sink, handle));
                                         }
                                     }
                                 }
@@ -200,8 +244,8 @@ impl Connection {
                             break;
                         }
                         message = message_receiver.recv() => {
-                            if let (Some(message), Some(current_sink)) = (message, &mut current_sink)
-                                && let Err(err) = current_sink.send(message).await {
+                            if let (Some(message), Some((sink, _))) = (message, current_session.as_mut())
+                                && let Err(err) = sink.send(message).await {
                                 tracing::error!("Failed sending message to Websocket: {err}");
                             }
                         }
@@ -218,126 +262,176 @@ impl Connection {
             thread_handle: Some((thread_handle, quit_sender)),
             message_sender,
             file_cache,
+            dependencies,
         })
+    }
+
+    /// Replace the set of files the connection treats as relevant. A subsequent `SetContents`
+    /// for a path in `paths` produces a `ContentsChanged` message; anything outside is dropped.
+    /// `paths` is expected to be the `watch_paths` returned by the compiler — they are stored
+    /// in URL-path form (the same form the LSP sends in `SetContents`).
+    pub fn set_dependencies(&self, paths: Vec<PathBuf>) {
+        *self.dependencies.lock().unwrap() =
+            paths.into_iter().filter_map(|p| p.into_os_string().into_string().ok()).collect();
+    }
+
+    /// Shared cache of files pushed by the LSP. The viewer reads this to feed
+    /// `Compiler::build_from_source`.
+    pub fn file_cache(&self) -> FileCache {
+        self.file_cache.clone()
     }
 
     async fn handle_connection(
         mut receiver: SplitStream<WebSocketStream<TcpStream>>,
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
         file_cache: FileCache,
+        dependencies: Arc<Mutex<HashSet<DependencyKey>>>,
         message_sender: UnboundedSender<Message>,
         remote_addr: SocketAddr,
     ) {
         message_handler(ConnectionMessage::Connected { remote_addr });
-        while let Some(msg) = receiver.next().await {
-            match msg {
-                Ok(Message::Text(text)) => {
-                    // Handle incoming text messages
-                    tracing::warn!("Received text message: {text}");
+        // `Some(deadline)` while a `SetContents`-driven rebuild is pending. The sleep_until
+        // arm of the select fires `ContentsChanged` once the burst of keystrokes settles.
+        let mut debounce_deadline: Option<tokio::time::Instant> = None;
+        'outer: loop {
+            let debounce_fut = async {
+                match debounce_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending::<()>().await,
                 }
-                Ok(Message::Binary(bin)) => {
-                    // Handle incoming binary messages
-                    match postcard::from_bytes::<LspToPreviewMessage>(&bin) {
-                        Ok(message) => {
-                            tracing::debug!("Received message {message:?}");
-                            // Process the data
-                            match message {
-                                LspToPreviewMessage::InvalidateContents { url } => {
-                                    file_cache.remove(
-                                        url.to_file_path().unwrap().as_os_str().to_str().unwrap(),
-                                    );
-                                }
-                                LspToPreviewMessage::ForgetFile { url } => {
-                                    if let Some((_, CacheEntry::Loading(senders))) = file_cache
-                                        .remove(
-                                            url.to_file_path()
+            };
+            tokio::select! {
+                biased;
+                _ = debounce_fut => {
+                    debounce_deadline = None;
+                    message_handler(ConnectionMessage::ContentsChanged);
+                }
+                msg = receiver.next() => {
+                    let Some(msg) = msg else { break };
+                    match msg {
+                        Ok(Message::Text(text)) => {
+                            tracing::warn!("Received text message: {text}");
+                        }
+                        Ok(Message::Binary(bin)) => {
+                            match postcard::from_bytes::<LspToPreviewMessage>(&bin) {
+                                Ok(message) => {
+                                    tracing::debug!("Received message {message:?}");
+                                    match message {
+                                        LspToPreviewMessage::InvalidateContents { url } => {
+                                            let Some(key) = cache_key_for_url(&url) else {
+                                                continue;
+                                            };
+                                            file_cache.remove(&key);
+                                            if dependencies.lock().unwrap().contains(url.path()) {
+                                                debounce_deadline = Some(
+                                                    tokio::time::Instant::now() + REBUILD_DEBOUNCE,
+                                                );
+                                            }
+                                        }
+                                        LspToPreviewMessage::ForgetFile { url } => {
+                                            let Some(key) = cache_key_for_url(&url) else {
+                                                continue;
+                                            };
+                                            if let Some((_, CacheEntry::Loading(senders))) =
+                                                file_cache.remove(&key)
+                                            {
+                                                for sender in senders {
+                                                    let _ = sender.send(Err(std::io::Error::new(
+                                                        std::io::ErrorKind::NotFound,
+                                                        "File not found",
+                                                    )));
+                                                }
+                                            }
+                                            if dependencies.lock().unwrap().contains(url.path()) {
+                                                debounce_deadline = Some(
+                                                    tokio::time::Instant::now() + REBUILD_DEBOUNCE,
+                                                );
+                                            }
+                                        }
+                                        LspToPreviewMessage::SetContents { url, contents } => {
+                                            tracing::debug!(
+                                                "Inserting file {} with {} bytes.",
+                                                url.url(),
+                                                contents.len()
+                                            );
+                                            let Some(key) = cache_key_for_url(url.url()) else {
+                                                continue;
+                                            };
+                                            let versioned_content = VersionedFileContent {
+                                                version: *url.version(),
+                                                contents: contents.into(),
+                                            };
+                                            file_cache
+                                                .entry(key)
+                                                .and_modify(|entry| {
+                                                    if let CacheEntry::Loading(senders) = entry {
+                                                        for sender in senders.drain(..) {
+                                                            let _ = sender.send(Ok(
+                                                                versioned_content.clone(),
+                                                            ));
+                                                        }
+                                                    }
+                                                })
+                                                .insert(CacheEntry::Ready(versioned_content));
+                                            if dependencies
+                                                .lock()
                                                 .unwrap()
-                                                .as_os_str()
-                                                .to_str()
-                                                .unwrap(),
-                                        )
-                                    {
-                                        for sender in senders {
-                                            let _ = sender.send(Err(std::io::Error::new(
-                                                std::io::ErrorKind::NotFound,
-                                                "File not found",
-                                            )));
+                                                .contains(url.url().path())
+                                            {
+                                                debounce_deadline = Some(
+                                                    tokio::time::Instant::now() + REBUILD_DEBOUNCE,
+                                                );
+                                            }
+                                        }
+                                        LspToPreviewMessage::SetConfiguration { config } => {
+                                            message_handler(ConnectionMessage::SetConfiguration {
+                                                config,
+                                            });
+                                        }
+                                        LspToPreviewMessage::ShowPreview(preview_component) => {
+                                            // ShowPreview rebuilds unconditionally; cancel any
+                                            // queued debounce so the viewer only rebuilds once.
+                                            debounce_deadline = None;
+                                            message_handler(ConnectionMessage::ShowPreview {
+                                                preview_component,
+                                            });
+                                        }
+                                        LspToPreviewMessage::HighlightFromEditor { url, offset } => {
+                                            message_handler(ConnectionMessage::HighlightFromEditor {
+                                                url,
+                                                offset,
+                                            });
+                                        }
+                                        LspToPreviewMessage::Quit => {
+                                            break 'outer;
                                         }
                                     }
                                 }
-                                LspToPreviewMessage::SetContents { url, contents } => {
-                                    tracing::debug!(
-                                        "Inserting file {} with {} bytes.",
-                                        url.url(),
-                                        contents.len()
-                                    );
-                                    let versioned_content = VersionedFileContent {
-                                        version: *url.version(),
-                                        contents: contents.into(),
-                                    };
-                                    file_cache
-                                        .entry(
-                                            url.url()
-                                                .to_file_path()
-                                                .unwrap()
-                                                .to_str()
-                                                .unwrap()
-                                                .to_owned(),
-                                        )
-                                        .and_modify(|entry| {
-                                            if let CacheEntry::Loading(senders) = entry {
-                                                for sender in senders.drain(..) {
-                                                    let _ =
-                                                        sender.send(Ok(versioned_content.clone()));
-                                                }
-                                            }
-                                        })
-                                        .insert(CacheEntry::Ready(versioned_content));
-                                    message_handler(ConnectionMessage::ContentsChanged {
-                                        url: url.url().clone(),
-                                        file_cache: file_cache.clone(),
-                                    });
-                                }
-                                LspToPreviewMessage::SetConfiguration { config } => {
-                                    message_handler(ConnectionMessage::SetConfiguration { config });
-                                }
-                                LspToPreviewMessage::ShowPreview(preview_component) => {
-                                    message_handler(ConnectionMessage::ShowPreview {
-                                        preview_component,
-                                        file_cache: file_cache.clone(),
-                                    });
-                                }
-                                LspToPreviewMessage::HighlightFromEditor { url, offset } => {
-                                    message_handler(ConnectionMessage::HighlightFromEditor {
-                                        url,
-                                        offset,
-                                    });
-                                }
-                                LspToPreviewMessage::Quit => {
-                                    break;
+                                Err(err) => {
+                                    tracing::error!("Failed to deserialize message: {err}");
                                 }
                             }
                         }
+                        Ok(Message::Ping(data)) => {
+                            message_sender.send(Message::Pong(data)).ok();
+                        }
+                        Ok(Message::Pong(_)) => {}
+                        Ok(Message::Close(_)) => {
+                            break;
+                        }
+                        Ok(Message::Frame(_)) => unreachable!(),
                         Err(err) => {
-                            tracing::error!("Failed to deserialize message: {err}");
+                            tracing::error!("WebSocket error: {err}");
+                            break;
                         }
                     }
                 }
-                Ok(Message::Ping(data)) => {
-                    message_sender.send(Message::Pong(data)).ok();
-                }
-                Ok(Message::Pong(_)) => {}
-                Ok(Message::Close(_)) => {
-                    // Handle connection close
-                    break;
-                }
-                Ok(Message::Frame(_)) => unreachable!(),
-                Err(err) => {
-                    tracing::error!("WebSocket error: {err}");
-                    break;
-                }
             }
         }
+        // Drop cached contents so a reconnecting peer doesn't see stale buffers from the prior
+        // session (the next peer only pushes files currently dirty in its editor and would
+        // otherwise inherit our cache for everything else).
+        file_cache.clear();
         message_handler(ConnectionMessage::Disconnected { remote_addr });
     }
 

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1415,7 +1415,7 @@ pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior)
                 let timer = slint::Timer::default();
                 timer.start(
                     slint::TimerMode::SingleShot,
-                    core::time::Duration::from_millis(50),
+                    i_slint_live_preview::REBUILD_DEBOUNCE,
                     || {
                         let _ = slint::spawn_local(reload_timer_function());
                     },

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -238,9 +238,7 @@ async fn build_and_show(
             .map(|d| d.to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        if let Err(err) =
-            inner_window.set_property("message", SharedString::from(message).into())
-        {
+        if let Err(err) = inner_window.set_property("message", SharedString::from(message).into()) {
             tracing::error!("Failed setting property: {err}");
         }
         return Ok(None);

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -6,7 +6,7 @@ use std::{net::SocketAddr, rc::Rc};
 use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_core::InternalToken;
 use i_slint_core::SharedString;
-use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage};
+use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage, lsp_types};
 use i_slint_live_preview::remote::{Connection, ConnectionMessage, init_compiler};
 use slint_interpreter::ComponentHandle as _;
 

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -1,13 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{net::SocketAddr, rc::Rc};
+use std::{collections::HashSet, net::SocketAddr, path::PathBuf, rc::Rc};
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_core::InternalToken;
 use i_slint_core::SharedString;
-use i_slint_live_preview::protocol::PreviewToLspMessage;
-use i_slint_live_preview::remote::{CacheEntry, Connection, ConnectionMessage, init_compiler};
+use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage};
+use i_slint_live_preview::remote::{
+    CacheEntry, Connection, ConnectionMessage, FileCache, init_compiler,
+};
 use slint_interpreter::ComponentHandle as _;
 
 const MAIN_SLINT: &str = include_str!("remote/main.slint");
@@ -121,6 +123,8 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
 
     let mut last_connection = None;
     let mut instance = inner_window.clone_strong();
+    let mut current_preview: Option<PreviewComponent> = None;
+    let mut dependencies: HashSet<PathBuf> = HashSet::new();
     while let Some(msg) = message_receiver.recv().await {
         match msg {
             ConnectionMessage::SetConfiguration { config } => {
@@ -129,98 +133,47 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     config.enable_experimental;
             }
             ConnectionMessage::ShowPreview { preview_component, file_cache } => {
-                tracing::debug!(
-                    "Cached files: {:#?}",
-                    file_cache.iter().map(|entry| entry.key().to_string()).collect::<Vec<_>>()
-                );
-                let compilation_result = if let Some(entry) = file_cache.get(
-                    preview_component.url.to_file_path().unwrap().as_os_str().to_str().unwrap(),
-                ) && let CacheEntry::Ready(file) = &*entry
+                if let Some(BuildOutcome { new_instance, watch_paths }) = build_and_show(
+                    &compiler,
+                    &preview_component,
+                    &file_cache,
+                    &inner_window,
+                    &instance,
+                    &connection,
+                )
+                .await
                 {
-                    tracing::debug!("Fetched file {} from cache.", preview_component.url);
-                    compiler
-                        .build_from_source(
-                            str::from_utf8(&file.contents).unwrap().to_owned(),
-                            preview_component.url.path().into(),
-                        )
-                        .await
-                } else {
-                    tracing::debug!("Failed fetching file {} from cache.", preview_component.url);
-                    compiler.build_from_path(preview_component.url.path()).await
-                };
-                if compilation_result.has_errors() {
-                    let mut build_diagnostics = BuildDiagnostics::default();
-                    for d in compilation_result.diagnostics() {
-                        tracing::warn!("Compiler error: {d}");
-                        build_diagnostics.push_compiler_error(d);
+                    if let Some(new_instance) = new_instance {
+                        instance = new_instance;
                     }
-
-                    if let Err(err) = inner_window.set_property(
-                        "message",
-                        SharedString::from(build_diagnostics.to_string_vec().join("\n")).into(),
-                    ) {
-                        tracing::error!("Failed setting property: {err}");
+                    if let Some(watch_paths) = watch_paths {
+                        dependencies = watch_paths.into_iter().collect();
                     }
-
-                    let message = PreviewToLspMessage::Diagnostics {
-                        uri: preview_component.url,
-                        version: None,
-                        diagnostics: compilation_result
-                            .diagnostics()
-                            .map(|diagnostic| {
-                                i_slint_live_preview::protocol::to_lsp_diagnostic(
-                                    &diagnostic,
-                                    i_slint_compiler::diagnostics::ByteFormat::Utf8,
-                                )
-                            })
-                            .collect(),
-                    };
-
-                    connection.send(message).ok();
-
+                }
+                current_preview = Some(preview_component);
+            }
+            ConnectionMessage::ContentsChanged { url, file_cache } => {
+                let Some(preview_component) = current_preview.clone() else { continue };
+                let Ok(path) = url.to_file_path() else { continue };
+                if !dependencies.contains(&path) {
                     continue;
                 }
-                if let Err(err) = inner_window.set_property("message", SharedString::new().into()) {
-                    tracing::error!("Failed setting property: {err}");
-                }
-
-                let Some(component) = preview_component
-                    .component
-                    .as_deref()
-                    .or_else(|| compilation_result.component_names().next())
-                    .and_then(|name| compilation_result.component(name))
-                else {
-                    if let Err(err) = inner_window
-                        .set_property("message", SharedString::from("Component not found").into())
-                    {
-                        tracing::error!("Failed setting property: {err}");
+                if let Some(BuildOutcome { new_instance, watch_paths }) = build_and_show(
+                    &compiler,
+                    &preview_component,
+                    &file_cache,
+                    &inner_window,
+                    &instance,
+                    &connection,
+                )
+                .await
+                {
+                    if let Some(new_instance) = new_instance {
+                        instance = new_instance;
                     }
-                    tracing::error!("Component not found");
-                    continue;
-                };
-
-                let Ok(new_instance) =
-                    component.create_with_existing_window(instance.window()).inspect_err(|err| {
-                        if let Err(err) = inner_window
-                            .set_property("message", SharedString::from(format!("{err}")).into())
-                        {
-                            tracing::error!("Failed setting property: {err}");
-                        }
-                        tracing::warn!("Platform error: {err}");
-                    })
-                else {
-                    return Ok(());
-                };
-
-                if let Err(err) = new_instance.show() {
-                    if let Err(err) = inner_window
-                        .set_property("message", SharedString::from(format!("{err}")).into())
-                    {
-                        tracing::error!("Failed setting property: {err}");
+                    if let Some(watch_paths) = watch_paths {
+                        dependencies = watch_paths.into_iter().collect();
                     }
-                    tracing::warn!("Platform error: {err}");
-                } else {
-                    instance = new_instance;
                 }
             }
             ConnectionMessage::HighlightFromEditor { .. } => {}
@@ -236,6 +189,8 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
             ConnectionMessage::Disconnected { remote_addr } => {
                 if last_connection == Some(remote_addr) {
                     last_connection = None;
+                    current_preview = None;
+                    dependencies.clear();
                     inner_window = main_ui
                         .create_with_existing_window(instance.window())
                         .unwrap_or_else(|_| main_ui.create().unwrap());
@@ -257,4 +212,122 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
         .inspect_err(|err| tracing::error!("mdns shutdown: {err}"))?;
 
     Ok(())
+}
+
+struct BuildOutcome {
+    /// `Some` if a new component instance was successfully created and shown. The caller should
+    /// replace its tracked instance with it.
+    new_instance: Option<slint_interpreter::ComponentInstance>,
+    /// Files the compiled component depends on. `None` means the build failed too early to
+    /// produce a meaningful dependency list, and the caller should keep its previous one.
+    watch_paths: Option<Vec<PathBuf>>,
+}
+
+/// Compile `preview_component` (using `file_cache` for the in-memory editor buffer if available)
+/// and replace the visible instance with it. Returns `None` only when the host window cannot be
+/// reused, which is a fatal condition for the caller.
+async fn build_and_show(
+    compiler: &slint_interpreter::Compiler,
+    preview_component: &PreviewComponent,
+    file_cache: &FileCache,
+    inner_window: &slint_interpreter::ComponentInstance,
+    instance: &slint_interpreter::ComponentInstance,
+    connection: &Connection,
+) -> Option<BuildOutcome> {
+    tracing::debug!(
+        "Cached files: {:#?}",
+        file_cache.iter().map(|entry| entry.key().to_string()).collect::<Vec<_>>()
+    );
+    let compilation_result = if let Some(entry) = file_cache
+        .get(preview_component.url.to_file_path().unwrap().as_os_str().to_str().unwrap())
+        && let CacheEntry::Ready(file) = &*entry
+    {
+        tracing::debug!("Fetched file {} from cache.", preview_component.url);
+        compiler
+            .build_from_source(
+                str::from_utf8(&file.contents).unwrap().to_owned(),
+                preview_component.url.path().into(),
+            )
+            .await
+    } else {
+        tracing::debug!("Failed fetching file {} from cache.", preview_component.url);
+        compiler.build_from_path(preview_component.url.path()).await
+    };
+    if compilation_result.has_errors() {
+        let mut build_diagnostics = BuildDiagnostics::default();
+        for d in compilation_result.diagnostics() {
+            tracing::warn!("Compiler error: {d}");
+            build_diagnostics.push_compiler_error(d);
+        }
+
+        if let Err(err) = inner_window.set_property(
+            "message",
+            SharedString::from(build_diagnostics.to_string_vec().join("\n")).into(),
+        ) {
+            tracing::error!("Failed setting property: {err}");
+        }
+
+        let message = PreviewToLspMessage::Diagnostics {
+            uri: preview_component.url.clone(),
+            version: None,
+            diagnostics: compilation_result
+                .diagnostics()
+                .map(|diagnostic| {
+                    i_slint_live_preview::protocol::to_lsp_diagnostic(
+                        &diagnostic,
+                        i_slint_compiler::diagnostics::ByteFormat::Utf8,
+                    )
+                })
+                .collect(),
+        };
+
+        connection.send(message).ok();
+
+        return Some(BuildOutcome { new_instance: None, watch_paths: None });
+    }
+    if let Err(err) = inner_window.set_property("message", SharedString::new().into()) {
+        tracing::error!("Failed setting property: {err}");
+    }
+
+    let watch_paths = Some(compilation_result.watch_paths(InternalToken).to_vec());
+
+    let Some(component) = preview_component
+        .component
+        .as_deref()
+        .or_else(|| compilation_result.component_names().next())
+        .and_then(|name| compilation_result.component(name))
+    else {
+        if let Err(err) =
+            inner_window.set_property("message", SharedString::from("Component not found").into())
+        {
+            tracing::error!("Failed setting property: {err}");
+        }
+        tracing::error!("Component not found");
+        return Some(BuildOutcome { new_instance: None, watch_paths });
+    };
+
+    let Ok(new_instance) =
+        component.create_with_existing_window(instance.window()).inspect_err(|err| {
+            if let Err(err) =
+                inner_window.set_property("message", SharedString::from(format!("{err}")).into())
+            {
+                tracing::error!("Failed setting property: {err}");
+            }
+            tracing::warn!("Platform error: {err}");
+        })
+    else {
+        return None;
+    };
+
+    if let Err(err) = new_instance.show() {
+        if let Err(err) =
+            inner_window.set_property("message", SharedString::from(format!("{err}")).into())
+        {
+            tracing::error!("Failed setting property: {err}");
+        }
+        tracing::warn!("Platform error: {err}");
+        return Some(BuildOutcome { new_instance: None, watch_paths });
+    }
+
+    Some(BuildOutcome { new_instance: Some(new_instance), watch_paths })
 }

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{collections::HashSet, net::SocketAddr, path::PathBuf, rc::Rc};
+use std::{net::SocketAddr, path::PathBuf, rc::Rc};
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_core::InternalToken;
@@ -124,7 +124,6 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     let mut last_connection = None;
     let mut instance = inner_window.clone_strong();
     let mut current_preview: Option<PreviewComponent> = None;
-    let mut dependencies: HashSet<PathBuf> = HashSet::new();
     while let Some(msg) = message_receiver.recv().await {
         match msg {
             ConnectionMessage::SetConfiguration { config } => {
@@ -132,8 +131,9 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                 compiler.compiler_configuration(InternalToken).enable_experimental =
                     config.enable_experimental;
             }
-            ConnectionMessage::ShowPreview { preview_component, file_cache } => {
-                if let Some(BuildOutcome { new_instance, watch_paths }) = build_and_show(
+            ConnectionMessage::ShowPreview { preview_component } => {
+                let file_cache = connection.file_cache();
+                let BuildOutcome { new_instance, watch_paths } = build_and_show(
                     &compiler,
                     &preview_component,
                     &file_cache,
@@ -141,24 +141,17 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     &instance,
                     &connection,
                 )
-                .await
-                {
-                    if let Some(new_instance) = new_instance {
-                        instance = new_instance;
-                    }
-                    if let Some(watch_paths) = watch_paths {
-                        dependencies = watch_paths.into_iter().collect();
-                    }
+                .await?;
+                if let Some(new_instance) = new_instance {
+                    instance = new_instance;
                 }
+                connection.set_dependencies(watch_paths);
                 current_preview = Some(preview_component);
             }
-            ConnectionMessage::ContentsChanged { url, file_cache } => {
+            ConnectionMessage::ContentsChanged => {
                 let Some(preview_component) = current_preview.clone() else { continue };
-                let Ok(path) = url.to_file_path() else { continue };
-                if !dependencies.contains(&path) {
-                    continue;
-                }
-                if let Some(BuildOutcome { new_instance, watch_paths }) = build_and_show(
+                let file_cache = connection.file_cache();
+                let BuildOutcome { new_instance, watch_paths } = build_and_show(
                     &compiler,
                     &preview_component,
                     &file_cache,
@@ -166,15 +159,11 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     &instance,
                     &connection,
                 )
-                .await
-                {
-                    if let Some(new_instance) = new_instance {
-                        instance = new_instance;
-                    }
-                    if let Some(watch_paths) = watch_paths {
-                        dependencies = watch_paths.into_iter().collect();
-                    }
+                .await?;
+                if let Some(new_instance) = new_instance {
+                    instance = new_instance;
                 }
+                connection.set_dependencies(watch_paths);
             }
             ConnectionMessage::HighlightFromEditor { .. } => {}
             ConnectionMessage::Connected { remote_addr } => {
@@ -190,7 +179,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                 if last_connection == Some(remote_addr) {
                     last_connection = None;
                     current_preview = None;
-                    dependencies.clear();
+                    connection.set_dependencies(Vec::new());
                     inner_window = main_ui
                         .create_with_existing_window(instance.window())
                         .unwrap_or_else(|_| main_ui.create().unwrap());
@@ -218,14 +207,16 @@ struct BuildOutcome {
     /// `Some` if a new component instance was successfully created and shown. The caller should
     /// replace its tracked instance with it.
     new_instance: Option<slint_interpreter::ComponentInstance>,
-    /// Files the compiled component depends on. `None` means the build failed too early to
-    /// produce a meaningful dependency list, and the caller should keep its previous one.
-    watch_paths: Option<Vec<PathBuf>>,
+    /// Files the compiled component depends on. The type loader populates this list even when
+    /// compilation has errors, so the caller can keep watching the right files while the user
+    /// types a fix.
+    watch_paths: Vec<PathBuf>,
 }
 
 /// Compile `preview_component` (using `file_cache` for the in-memory editor buffer if available)
-/// and replace the visible instance with it. Returns `None` only when the host window cannot be
-/// reused, which is a fatal condition for the caller.
+/// and replace the visible instance with it. Returns `Err` only when the platform can no longer
+/// host a Slint window — the caller should propagate it and exit, since retrying on every
+/// keystroke would only repeat the underlying failure.
 async fn build_and_show(
     compiler: &slint_interpreter::Compiler,
     preview_component: &PreviewComponent,
@@ -233,13 +224,13 @@ async fn build_and_show(
     inner_window: &slint_interpreter::ComponentInstance,
     instance: &slint_interpreter::ComponentInstance,
     connection: &Connection,
-) -> Option<BuildOutcome> {
+) -> anyhow::Result<BuildOutcome> {
     tracing::debug!(
         "Cached files: {:#?}",
         file_cache.iter().map(|entry| entry.key().to_string()).collect::<Vec<_>>()
     );
-    let compilation_result = if let Some(entry) = file_cache
-        .get(preview_component.url.to_file_path().unwrap().as_os_str().to_str().unwrap())
+    let compilation_result = if let Some(entry) =
+        file_cache.get(preview_component.url.to_file_path().unwrap().as_os_str().to_str().unwrap())
         && let CacheEntry::Ready(file) = &*entry
     {
         tracing::debug!("Fetched file {} from cache.", preview_component.url);
@@ -253,6 +244,7 @@ async fn build_and_show(
         tracing::debug!("Failed fetching file {} from cache.", preview_component.url);
         compiler.build_from_path(preview_component.url.path()).await
     };
+    let watch_paths = compilation_result.watch_paths(InternalToken).to_vec();
     if compilation_result.has_errors() {
         let mut build_diagnostics = BuildDiagnostics::default();
         for d in compilation_result.diagnostics() {
@@ -283,13 +275,11 @@ async fn build_and_show(
 
         connection.send(message).ok();
 
-        return Some(BuildOutcome { new_instance: None, watch_paths: None });
+        return Ok(BuildOutcome { new_instance: None, watch_paths });
     }
     if let Err(err) = inner_window.set_property("message", SharedString::new().into()) {
         tracing::error!("Failed setting property: {err}");
     }
-
-    let watch_paths = Some(compilation_result.watch_paths(InternalToken).to_vec());
 
     let Some(component) = preview_component
         .component
@@ -303,31 +293,14 @@ async fn build_and_show(
             tracing::error!("Failed setting property: {err}");
         }
         tracing::error!("Component not found");
-        return Some(BuildOutcome { new_instance: None, watch_paths });
+        return Ok(BuildOutcome { new_instance: None, watch_paths });
     };
 
-    let Ok(new_instance) =
-        component.create_with_existing_window(instance.window()).inspect_err(|err| {
-            if let Err(err) =
-                inner_window.set_property("message", SharedString::from(format!("{err}")).into())
-            {
-                tracing::error!("Failed setting property: {err}");
-            }
-            tracing::warn!("Platform error: {err}");
-        })
-    else {
-        return None;
-    };
+    let new_instance = component
+        .create_with_existing_window(instance.window())
+        .map_err(|err| anyhow::anyhow!("Cannot create component instance: {err}"))?;
 
-    if let Err(err) = new_instance.show() {
-        if let Err(err) =
-            inner_window.set_property("message", SharedString::from(format!("{err}")).into())
-        {
-            tracing::error!("Failed setting property: {err}");
-        }
-        tracing::warn!("Platform error: {err}");
-        return Some(BuildOutcome { new_instance: None, watch_paths });
-    }
+    new_instance.show().map_err(|err| anyhow::anyhow!("Cannot show component: {err}"))?;
 
-    Some(BuildOutcome { new_instance: Some(new_instance), watch_paths })
+    Ok(BuildOutcome { new_instance: Some(new_instance), watch_paths })
 }

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -1,15 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{net::SocketAddr, path::PathBuf, rc::Rc};
+use std::{net::SocketAddr, rc::Rc};
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_core::InternalToken;
 use i_slint_core::SharedString;
 use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage};
-use i_slint_live_preview::remote::{
-    CacheEntry, Connection, ConnectionMessage, FileCache, init_compiler,
-};
+use i_slint_live_preview::remote::{Connection, ConnectionMessage, init_compiler};
 use slint_interpreter::ComponentHandle as _;
 
 const MAIN_SLINT: &str = include_str!("remote/main.slint");
@@ -132,38 +130,32 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     config.enable_experimental;
             }
             ConnectionMessage::ShowPreview { preview_component } => {
-                let file_cache = connection.file_cache();
-                let BuildOutcome { new_instance, watch_paths } = build_and_show(
+                if let Some(new_instance) = build_and_show(
                     &compiler,
                     &preview_component,
-                    &file_cache,
                     &inner_window,
                     &instance,
                     &connection,
                 )
-                .await?;
-                if let Some(new_instance) = new_instance {
+                .await?
+                {
                     instance = new_instance;
                 }
-                connection.set_dependencies(watch_paths);
                 current_preview = Some(preview_component);
             }
             ConnectionMessage::ContentsChanged => {
                 let Some(preview_component) = current_preview.clone() else { continue };
-                let file_cache = connection.file_cache();
-                let BuildOutcome { new_instance, watch_paths } = build_and_show(
+                if let Some(new_instance) = build_and_show(
                     &compiler,
                     &preview_component,
-                    &file_cache,
                     &inner_window,
                     &instance,
                     &connection,
                 )
-                .await?;
-                if let Some(new_instance) = new_instance {
+                .await?
+                {
                     instance = new_instance;
                 }
-                connection.set_dependencies(watch_paths);
             }
             ConnectionMessage::HighlightFromEditor { .. } => {}
             ConnectionMessage::Connected { remote_addr } => {
@@ -203,82 +195,55 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     Ok(())
 }
 
-struct BuildOutcome {
-    /// `Some` if a new component instance was successfully created and shown. The caller should
-    /// replace its tracked instance with it.
-    new_instance: Option<slint_interpreter::ComponentInstance>,
-    /// Files the compiled component depends on. The type loader populates this list even when
-    /// compilation has errors, so the caller can keep watching the right files while the user
-    /// types a fix.
-    watch_paths: Vec<PathBuf>,
-}
-
-/// Compile `preview_component` (using `file_cache` for the in-memory editor buffer if available)
-/// and replace the visible instance with it. Returns `Err` only when the platform can no longer
-/// host a Slint window — the caller should propagate it and exit, since retrying on every
-/// keystroke would only repeat the underlying failure.
+/// Compile `preview_component` from the connection's file cache and replace the visible
+/// instance with it. Returns `Ok(Some(new))` after a successful build, `Ok(None)` if the
+/// build failed or the component wasn't found, and `Err` only when the platform can no
+/// longer host a Slint window — the caller should propagate it and exit, since retrying
+/// on every keystroke would only repeat the underlying failure.
 async fn build_and_show(
     compiler: &slint_interpreter::Compiler,
     preview_component: &PreviewComponent,
-    file_cache: &FileCache,
     inner_window: &slint_interpreter::ComponentInstance,
     instance: &slint_interpreter::ComponentInstance,
     connection: &Connection,
-) -> anyhow::Result<BuildOutcome> {
-    tracing::debug!(
-        "Cached files: {:#?}",
-        file_cache.iter().map(|entry| entry.key().to_string()).collect::<Vec<_>>()
-    );
-    let compilation_result = if let Some(entry) =
-        file_cache.get(preview_component.url.to_file_path().unwrap().as_os_str().to_str().unwrap())
-        && let CacheEntry::Ready(file) = &*entry
-    {
-        tracing::debug!("Fetched file {} from cache.", preview_component.url);
-        compiler
-            .build_from_source(
-                str::from_utf8(&file.contents).unwrap().to_owned(),
-                preview_component.url.path().into(),
-            )
-            .await
-    } else {
-        tracing::debug!("Failed fetching file {} from cache.", preview_component.url);
-        compiler.build_from_path(preview_component.url.path()).await
+) -> anyhow::Result<Option<slint_interpreter::ComponentInstance>> {
+    let Ok(path) = preview_component.url.to_file_path() else {
+        tracing::error!("Not a file URL: {}", preview_component.url);
+        return Ok(None);
     };
-    let watch_paths = compilation_result.watch_paths(InternalToken).to_vec();
-    if compilation_result.has_errors() {
-        let mut build_diagnostics = BuildDiagnostics::default();
-        for d in compilation_result.diagnostics() {
-            tracing::warn!("Compiler error: {d}");
-            build_diagnostics.push_compiler_error(d);
+    let file = match connection.request_file(preview_component.url.clone()).await {
+        Ok(file) => file,
+        Err(err) => {
+            tracing::error!("Failed fetching {}: {err}", preview_component.url);
+            return Ok(None);
         }
+    };
+    let compilation_result = compiler
+        .build_from_source(String::from_utf8_lossy(&file.contents).into_owned(), path)
+        .await;
+    // Watch paths come from the type loader and are populated even on errors, so the
+    // connection keeps reacting to edits in the right files while the user types a fix.
+    let watch_urls: Vec<lsp_types::Url> = compilation_result
+        .watch_paths(InternalToken)
+        .iter()
+        .filter_map(|p| lsp_types::Url::from_file_path(p).ok())
+        .collect();
+    connection.set_dependencies(watch_urls);
 
-        if let Err(err) = inner_window.set_property(
-            "message",
-            SharedString::from(build_diagnostics.to_string_vec().join("\n")).into(),
-        ) {
+    if compilation_result.has_errors() {
+        send_diagnostics(&compilation_result, &preview_component.url, connection);
+        let message = compilation_result
+            .diagnostics()
+            .inspect(|d| tracing::warn!("Compiler diagnostic: {d}"))
+            .map(|d| d.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        if let Err(err) =
+            inner_window.set_property("message", SharedString::from(message).into())
+        {
             tracing::error!("Failed setting property: {err}");
         }
-
-        let message = PreviewToLspMessage::Diagnostics {
-            uri: preview_component.url.clone(),
-            version: None,
-            diagnostics: compilation_result
-                .diagnostics()
-                .map(|diagnostic| {
-                    i_slint_live_preview::protocol::to_lsp_diagnostic(
-                        &diagnostic,
-                        i_slint_compiler::diagnostics::ByteFormat::Utf8,
-                    )
-                })
-                .collect(),
-        };
-
-        connection.send(message).ok();
-
-        return Ok(BuildOutcome { new_instance: None, watch_paths });
-    }
-    if let Err(err) = inner_window.set_property("message", SharedString::new().into()) {
-        tracing::error!("Failed setting property: {err}");
+        return Ok(None);
     }
 
     let Some(component) = preview_component
@@ -287,14 +252,25 @@ async fn build_and_show(
         .or_else(|| compilation_result.component_names().next())
         .and_then(|name| compilation_result.component(name))
     else {
+        // Compilation produced no errors but the requested component is missing.
+        // Don't publish a Diagnostics message: that would clobber whatever the LSP
+        // (or a previous compile) was showing in the editor for this URI, while
+        // the only signal we have to surface is local to the viewer window.
         if let Err(err) =
             inner_window.set_property("message", SharedString::from("Component not found").into())
         {
             tracing::error!("Failed setting property: {err}");
         }
         tracing::error!("Component not found");
-        return Ok(BuildOutcome { new_instance: None, watch_paths });
+        return Ok(None);
     };
+
+    // Clean build: publish the (possibly empty) diagnostic list so the editor
+    // clears any errors we surfaced from the previous build.
+    send_diagnostics(&compilation_result, &preview_component.url, connection);
+    if let Err(err) = inner_window.set_property("message", SharedString::new().into()) {
+        tracing::error!("Failed setting property: {err}");
+    }
 
     let new_instance = component
         .create_with_existing_window(instance.window())
@@ -302,5 +278,26 @@ async fn build_and_show(
 
     new_instance.show().map_err(|err| anyhow::anyhow!("Cannot show component: {err}"))?;
 
-    Ok(BuildOutcome { new_instance: Some(new_instance), watch_paths })
+    Ok(Some(new_instance))
+}
+
+fn send_diagnostics(
+    compilation_result: &slint_interpreter::CompilationResult,
+    uri: &lsp_types::Url,
+    connection: &Connection,
+) {
+    let message = PreviewToLspMessage::Diagnostics {
+        uri: uri.clone(),
+        version: None,
+        diagnostics: compilation_result
+            .diagnostics()
+            .map(|diagnostic| {
+                i_slint_live_preview::protocol::to_lsp_diagnostic(
+                    &diagnostic,
+                    i_slint_compiler::diagnostics::ByteFormat::Utf8,
+                )
+            })
+            .collect(),
+    };
+    connection.send(message).ok();
 }


### PR DESCRIPTION
Previously the remote viewer only recompiled when the LSP sent ShowPreview. SetContents from intermediate keystrokes was cached but never triggered a rebuild. Emit a new ContentsChanged message from the cache update, and have the viewer re-run build_and_show when the changed file is a dependency of the currently shown component (mirroring tools/lsp/preview.rs:set_contents).
