### PR TITLE
slint-viewer: Implement iOS builds and fix various issues with App Store validation

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -15,6 +15,8 @@ amdgpu
 amet
 Amoled
 Appbar
+appicon
+appiconset
 appkit
 appmain
 appsink
@@ -22,6 +24,7 @@ appview
 ARCHS
 armhf
 arrayvec
+assetcatalog
 astrolib
 astrowind
 asyncio
@@ -322,6 +325,7 @@ libgstrtspserver
 Libinput
 libloading
 libm
+librsvg
 libseat
 libslint
 libstdc
@@ -536,6 +540,7 @@ spinboxes
 SPIRAM
 SPRINTF
 Spyrosoft
+srcroot
 SRCS
 SRGBA
 standardbutton
@@ -669,6 +674,7 @@ writeback
 WRONLY
 xbuild
 xcarchive
+xcassets
 xcent
 xchg
 xcrun

--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -668,8 +668,10 @@ WQXGA
 writeback
 WRONLY
 xbuild
+xcarchive
 xcent
 xchg
+xcrun
 xfer
 xfixes
 xlib

--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -155,6 +155,8 @@ driverlib
 droparea
 dropevent
 DSHIELD
+dsym
+dsymutil
 dustygold
 Dxgi
 DYLD

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -228,7 +228,8 @@ jobs:
             - uses: ./.github/actions/setup-rust
               with:
                   target: aarch64-apple-ios
-            - run: brew install xcodegen
+            # librsvg provides rsvg-convert, used to render the app icon.
+            - run: brew install xcodegen librsvg
             - name: Compute version numbers
               run: |
                   # Marketing version from the workspace, build number from the

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -21,6 +21,10 @@ on:
                 type: boolean
                 description: Sign binaries on macOS (false for manual builds)
                 default: false
+            ios:
+                type: boolean
+                description: Also build an unsigned iOS archive (.xcarchive) of the viewer
+                default: false
 
     workflow_call:
         inputs:
@@ -36,6 +40,10 @@ on:
                 type: boolean
                 description: Sign binaries on macOS
                 default: true
+            ios:
+                type: boolean
+                description: Also build an unsigned iOS archive (.xcarchive) of the viewer
+                default: false
         secrets:
             certificate:
                 description: "certificate secret"
@@ -206,3 +214,43 @@ jobs:
               with:
                   name: slint-${{ github.event.inputs.program || inputs.program }}-macos
                   path: slint-${{ github.event.inputs.program || inputs.program }}-macos.tar.gz
+
+    # Opt-in: build an unsigned iOS archive of the viewer that can be signed and
+    # exported into an .ipa locally, e.g. for upload to TestFlight.
+    build_ios:
+        if: ${{ github.event.inputs.ios == 'true' || inputs.ios }}
+        runs-on: macos-26
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  # Full history so the build number (commit count) is accurate.
+                  fetch-depth: 0
+            - uses: ./.github/actions/setup-rust
+              with:
+                  target: aarch64-apple-ios
+            - run: brew install xcodegen
+            - name: Compute version numbers
+              run: |
+                  # Marketing version from the workspace, build number from the
+                  # git history (monotonic), short SHA for artifact traceability.
+                  MARKETING_VERSION=$(sed -n '/\[workspace.package\]/,/^\[/{s/^version = "\(.*\)"/\1/p;}' Cargo.toml)
+                  echo "MARKETING_VERSION=$MARKETING_VERSION" >> "$GITHUB_ENV"
+                  echo "CURRENT_PROJECT_VERSION=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
+                  echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+            - run: xcodegen generate --spec ios-project.yml
+              working-directory: tools/viewer
+            - name: Archive (unsigned)
+              working-directory: tools/viewer
+              run: |
+                  xcodebuild -scheme "slint-viewer" \
+                    -destination "generic/platform=iOS" \
+                    -archivePath "$RUNNER_TEMP/slint-viewer.xcarchive" \
+                    archive \
+                    CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
+                    MARKETING_VERSION="$MARKETING_VERSION" \
+                    CURRENT_PROJECT_VERSION="$CURRENT_PROJECT_VERSION"
+            - name: Upload artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: slint-viewer-ios-${{ env.MARKETING_VERSION }}-${{ env.SHORT_SHA }}
+                  path: ${{ runner.temp }}/slint-viewer.xcarchive

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -1,0 +1,73 @@
+# Building slint-viewer for iOS
+
+Producing an iOS build of `slint-viewer` for TestFlight happens in two stages: CI builds an
+**unsigned** archive, and you **sign, export and upload** it locally. Keeping the signing local
+means no Apple distribution credentials need to live in the CI secrets.
+
+## Building the archive in CI
+
+The [`slint_tool_binary.yaml`](../.github/workflows/slint_tool_binary.yaml) workflow has an opt-in
+`ios` input (default `false`). Enable it to build the `build_ios` job, which produces an unsigned
+`.xcarchive` and uploads it as a workflow artifact named `slint-viewer-ios-<version>-<short-sha>`.
+
+Trigger it from the Actions tab ("Build slint-viewer or -lsp binary" → "Run workflow") with **ios**
+checked, or:
+
+```bash
+gh workflow run slint_tool_binary.yaml -f program=viewer -f ios=true
+```
+
+The archive carries the workspace version as its marketing version and the commit count as its build
+number. App Store Connect requires the build number to grow with every upload, so always archive
+from a newer commit than the last upload.
+
+## Signing, exporting and uploading locally
+
+### Prerequisites
+
+ * An Apple Developer account that is a member of the team owning the `dev.slint.slint-viewer`
+   App ID, with a matching **App Store Connect** app record.
+ * An **Apple Distribution** signing certificate and an **App Store** provisioning profile for
+   `dev.slint.slint-viewer` installed in your keychain.
+ * An **App Store Connect API key** (`.p8` plus its Key ID and Issuer ID) for uploading.
+
+### Sign and upload
+
+Download and unzip the CI artifact, then create an `ExportOptions.plist`. The `upload` destination
+makes `xcodebuild` upload to App Store Connect directly, so no separate upload tool is needed:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+</dict>
+</plist>
+```
+
+(Older Xcode versions use `app-store` instead of `app-store-connect` for the `method`.)
+
+A single `xcodebuild -exportArchive` then signs the archive with your distribution certificate and
+provisioning profile and uploads it using an App Store Connect API key (`.p8`):
+
+```bash
+xcodebuild -exportArchive \
+    -archivePath slint-viewer.xcarchive \
+    -exportPath export \
+    -exportOptionsPlist ExportOptions.plist \
+    -authenticationKeyPath ~/private_keys/AuthKey_<KEY_ID>.p8 \
+    -authenticationKeyID <KEY_ID> \
+    -authenticationKeyIssuerID <ISSUER_ID>
+```
+
+After processing, the build appears under TestFlight in App Store Connect.
+
+To upload through a GUI instead, set `destination` to `export` so the signed
+`export/slint-viewer.ipa` is written to disk, then drag it into the
+[Transporter](https://apps.apple.com/app/transporter/id1450874784) app.

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -21,6 +21,9 @@ The archive carries the workspace version as its marketing version and the commi
 number. App Store Connect requires the build number to grow with every upload, so always archive
 from a newer commit than the last upload.
 
+The app icon is rendered from `logo/slint-logo-square-light-whitebg.svg` into the asset catalog at
+build time by `scripts/render_ios_app_icon.bash` using `rsvg-convert`, so it is not checked in.
+
 ## Signing, exporting and uploading locally
 
 ### Prerequisites

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -8,6 +8,7 @@ docs/
 ├── building.md     # How to build Slint
 ├── development.md  # How to develop Slint
 ├── embedded-tutorials.md       # Embedded tutorials template
+├── ios.md          # How to build slint-viewer for iOS / TestFlight
 ├── install_qt.md   # How to install Qt
 ├── nightly-release-notes.md    # Release note template
 ├── release-artifacts.md

--- a/scripts/build_for_ios_with_cargo.bash
+++ b/scripts/build_for_ios_with_cargo.bash
@@ -17,6 +17,11 @@ else
     MAYBE_RELEASE=
 fi
 
+# Build with debug info so a dSYM can be produced below. Release builds carry no
+# debug info by default, which makes the archive fail validation with a missing
+# dSYM for the (cargo-built) executable.
+export CARGO_PROFILE_RELEASE_DEBUG="${CARGO_PROFILE_RELEASE_DEBUG:-1}"
+
 # Make Cargo output cache files in Xcode's directories
 export CARGO_TARGET_DIR="$DERIVED_FILE_DIR/cargo"
 
@@ -48,6 +53,14 @@ done
 
 # Combine executables, and place them at the output path excepted by Xcode
 lipo -create -output "$TARGET_BUILD_DIR/$EXECUTABLE_PATH" "${executables[@]}"
+
+# Generate a dSYM for the executable into the folder Xcode collects dSYMs from
+# for the archive. Xcode only produces dSYMs for what it compiles, not for this
+# cargo-built binary, so without this the archive has no dSYM matching its UUID.
+if [ -n "${DWARF_DSYM_FOLDER_PATH:-}" ] && [ -n "${DWARF_DSYM_FILE_NAME:-}" ]; then
+    mkdir -p "$DWARF_DSYM_FOLDER_PATH"
+    dsymutil "$TARGET_BUILD_DIR/$EXECUTABLE_PATH" -o "$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME"
+fi
 
 # Force code signing every run for device builds (non-simulator), unless code
 # signing is disabled (e.g. unsigned archive builds with CODE_SIGNING_ALLOWED=NO).

--- a/scripts/build_for_ios_with_cargo.bash
+++ b/scripts/build_for_ios_with_cargo.bash
@@ -49,8 +49,9 @@ done
 # Combine executables, and place them at the output path excepted by Xcode
 lipo -create -output "$TARGET_BUILD_DIR/$EXECUTABLE_PATH" "${executables[@]}"
 
-# Force code signing every run for device builds (non-simulator)
-if [ $IS_SIMULATOR -eq 0 ]; then
+# Force code signing every run for device builds (non-simulator), unless code
+# signing is disabled (e.g. unsigned archive builds with CODE_SIGNING_ALLOWED=NO).
+if [ $IS_SIMULATOR -eq 0 ] && [ "${CODE_SIGNING_ALLOWED:-YES}" != "NO" ] && [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]; then
     codesign --force --sign "${EXPANDED_CODE_SIGN_IDENTITY}" \
              --entitlements "${TARGET_TEMP_DIR}/${PRODUCT_NAME}.app.xcent" \
              "${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"

--- a/scripts/render_ios_app_icon.bash
+++ b/scripts/render_ios_app_icon.bash
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+# Generate the slint-viewer iOS app icon asset catalog from the Slint logo SVG.
+# This creates the whole Assets.xcassets/AppIcon.appiconset (so none of it is
+# checked in) and runs as an Xcode pre-build script, before the catalog is
+# compiled. Can also be invoked standalone. Requires rsvg-convert from librsvg.
+
+set -euo pipefail
+
+# Homebrew locations, so this works from Xcode's stripped-down PATH too.
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SVG="$REPO_ROOT/logo/slint-logo-square-light-whitebg.svg"
+CATALOG="$REPO_ROOT/tools/viewer/Assets.xcassets"
+ICON_SET="$CATALOG/AppIcon.appiconset"
+
+if ! command -v rsvg-convert >/dev/null 2>&1; then
+    echo "error: rsvg-convert not found. Install it with 'brew install librsvg'." >&2
+    exit 1
+fi
+
+mkdir -p "$ICON_SET"
+
+cat > "$CATALOG/Contents.json" <<'JSON'
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+JSON
+
+cat > "$ICON_SET/Contents.json" <<'JSON'
+{
+  "images" : [
+    {
+      "filename" : "icon-1024.png",
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+JSON
+
+# --background-color=white flattens onto an opaque background, so the result has
+# no alpha channel (required for App Store icons).
+rsvg-convert --background-color=white -w 1024 -h 1024 "$SVG" -o "$ICON_SET/icon-1024.png"
+echo "Generated iOS app icon catalog at $CATALOG"

--- a/tools/viewer/.gitignore
+++ b/tools/viewer/.gitignore
@@ -4,3 +4,6 @@
 
 # Xcode build output (xcodebuild -derivedDataPath build)
 /build/
+
+# App icon asset catalog generated at build time by scripts/render_ios_app_icon.bash
+/Assets.xcassets/

--- a/tools/viewer/ios-project.yml
+++ b/tools/viewer/ios-project.yml
@@ -28,7 +28,7 @@ targets:
           [
             UIInterfaceOrientationPortrait,
             UIInterfaceOrientationPortraitUpsideDown,
-            UIInterfaceOrientationPortraitLandscapeLeft,
+            UIInterfaceOrientationLandscapeLeft,
             UIInterfaceOrientationLandscapeRight,
           ]
     sources: []

--- a/tools/viewer/ios-project.yml
+++ b/tools/viewer/ios-project.yml
@@ -5,6 +5,10 @@ options:
   bundleIdPrefix: dev.slint
 settings:
   ENABLE_USER_SCRIPT_SANDBOXING: NO
+  # Defaults for local builds; CI overrides these via xcodebuild to inject the
+  # Slint version and a monotonic, git-derived build number (commit count).
+  MARKETING_VERSION: "1.0"
+  CURRENT_PROJECT_VERSION: "1"
 targets:
   slint-viewer:
     type: application
@@ -13,6 +17,8 @@ targets:
     info:
       path: Info.plist
       properties:
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchScreen:
           - ImageRespectSafeAreaInsets: false
         NSLocalNetworkUsageDescription: "We need to talk to editors on the local network."

--- a/tools/viewer/ios-project.yml
+++ b/tools/viewer/ios-project.yml
@@ -5,6 +5,7 @@ options:
   bundleIdPrefix: dev.slint
 settings:
   ENABLE_USER_SCRIPT_SANDBOXING: NO
+  ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
   # Defaults for local builds; CI overrides these via xcodebuild to inject the
   # Slint version and a monotonic, git-derived build number (commit count).
   MARKETING_VERSION: "1.0"
@@ -31,7 +32,17 @@ targets:
             UIInterfaceOrientationLandscapeLeft,
             UIInterfaceOrientationLandscapeRight,
           ]
-    sources: []
+    sources:
+      # Generated at build time by the pre-build script below, so it may be
+      # absent when the project is generated.
+      - path: Assets.xcassets
+        optional: true
+    preBuildScripts:
+      - name: Generate app icon
+        script: |
+          ../../scripts/render_ios_app_icon.bash
+        outputFiles:
+          - $(SRCROOT)/Assets.xcassets/AppIcon.appiconset/icon-1024.png
     postCompileScripts:
       - script: |
           ../../scripts/build_for_ios_with_cargo.bash slint-viewer --features remote

--- a/tools/viewer/ios-project.yml
+++ b/tools/viewer/ios-project.yml
@@ -20,8 +20,9 @@ targets:
       properties:
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
-        UILaunchScreen:
-          - ImageRespectSafeAreaInsets: false
+        # Must be a dictionary (an empty one yields the default launch screen);
+        # iPad multitasking requires a valid UILaunchScreen.
+        UILaunchScreen: {}
         NSLocalNetworkUsageDescription: "We need to talk to editors on the local network."
         NSBonjourServices:
           - "_slint-preview._tcp"


### PR DESCRIPTION
This PR includes various fixes to pass App Store validation, such as invalid plist keys as well as the missing icon, and it also adds a way of building the xcarchive in the CI.

We can later switch to Xcode cloud with automatic submissions, but for now this gets us going slowly.