### PR TITLE
docs: Auto-derive links for builtin structs and enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,6 +5432,7 @@ dependencies = [
 name = "i-slint-core-macros"
 version = "1.17.0"
 dependencies = [
+ "i-slint-common",
  "quote",
  "serde_json",
  "syn 2.0.117",

--- a/api/cpp/docs/conf.py
+++ b/api/cpp/docs/conf.py
@@ -18,6 +18,7 @@
 import textwrap
 import os
 import json
+import re
 
 
 # -- Project information -----------------------------------------------------
@@ -145,6 +146,24 @@ with open(
 for key in links.keys():
     href = links[key]["href"]
     url = f"https://slint.dev/releases/{version}/docs/slint/{href}"
+    myst_substitutions[f"slint_href_{key}"] = url
+    rst_epilog += f".. |{key}| replace:: :code:`{key}`\n"
+    rst_epilog += f".. _{key}: {url}\n"
+
+# Auto-derive substitutions for builtin structs and enums. The names live in
+# i_slint_common's `for_each_builtin_structs!` and `for_each_enums!` macros;
+# all their entries render on the same anchor-style page. Kept here so writing
+# `|Edges|` etc. in C++ docs works without manual link-data.json upkeep.
+_common_dir = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "internal", "common"
+)
+_name_re = re.compile(r"^\s*(?:pub\s+)?(?:struct|enum)\s+(\w+)\s*\{", re.MULTILINE)
+_builtin_names = ["Point", "Size"]
+for _fname in ("builtin_structs.rs", "enums.rs"):
+    with open(os.path.join(_common_dir, _fname)) as _f:
+        _builtin_names.extend(_name_re.findall(_f.read()))
+for key in _builtin_names:
+    url = f"https://slint.dev/releases/{version}/docs/slint/reference/global-structs-enums/#{key.lower()}"
     myst_substitutions[f"slint_href_{key}"] = url
     rst_epilog += f".. |{key}| replace:: :code:`{key}`\n"
     rst_epilog += f".. _{key}: {url}\n"

--- a/docs/common/src/utils/utils.ts
+++ b/docs/common/src/utils/utils.ts
@@ -91,7 +91,7 @@ export function getTypeInfo(typeName: KnownType): TypeInfo {
             };
         case "Edges":
             return {
-                href: linkMap.Edges.href,
+                href: "reference/global-structs-enums/#edges",
                 defaultValue: "0px",
             };
         case "float":
@@ -131,12 +131,12 @@ export function getTypeInfo(typeName: KnownType): TypeInfo {
             };
         case "Point":
             return {
-                href: linkMap.Point.href,
+                href: "reference/global-structs-enums/#point",
                 defaultValue: "(0px, 0px)",
             };
         case "Size":
             return {
-                href: linkMap.Size.href,
+                href: "reference/global-structs-enums/#size",
                 defaultValue: "(0px, 0px)",
             };
         case "relative-font-size":

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -5602,6 +5602,7 @@ dependencies = [
 name = "i-slint-core-macros"
 version = "1.17.0"
 dependencies = [
+ "i-slint-common",
  "quote",
  "serde_json",
  "syn",
@@ -6277,14 +6278,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -7970,9 +7971,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]

--- a/internal/core-macros/Cargo.toml
+++ b/internal/core-macros/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro = true
 path = "lib.rs"
 
 [dependencies]
+i-slint-common = { workspace = true }
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "visit-mut"] }
 serde_json = { workspace = true }

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -35,17 +35,11 @@
     "data_transfer": {
         "href": "reference/primitive-types/#data-transfer"
     },
-    "DragAction": {
-        "href": "reference/global-structs-enums/#dragaction"
-    },
     "DragArea": {
         "href": "reference/drag-and-drop/dragarea/"
     },
     "DropArea": {
         "href": "reference/drag-and-drop/droparea/"
-    },
-    "DropEvent": {
-        "href": "reference/global-structs-enums/#dropevent"
     },
     "ComponentLibraries": {
         "href": "guide/language/coding/file/#component-libraries"
@@ -62,23 +56,14 @@
     "easing": {
         "href": "reference/primitive-types/#easing"
     },
-    "Edges": {
-        "href": "reference/global-structs-enums/#edges"
-    },
     "EnumType": {
         "href": "reference/global-structs-enums/"
-    },
-    "EventResult": {
-        "href": "reference/global-structs-enums/#eventresult"
     },
     "Expressions": {
         "href": "guide/language/coding/expressions-and-statements/"
     },
     "float": {
         "href": "reference/primitive-types/#float"
-    },
-    "FocusReason": {
-        "href": "reference/global-structs-enums/#focusreason"
     },
     "FocusHandling": {
         "href": "guide/development/focus/"
@@ -167,9 +152,6 @@
     "PopupWindow": {
         "href": "reference/window/popupwindow/"
     },
-    "Point": {
-        "href": "reference/global-structs-enums/#point"
-    },
     "ProgressIndicator": {
         "href": "reference/std-widgets/basic-widgets/progressindicator/"
     },
@@ -181,9 +163,6 @@
     },
     "relativeFontSize": {
         "href": "reference/primitive-types/#relative-font-size"
-    },
-    "Size": {
-        "href": "reference/global-structs-enums/#size"
     },
     "slintFile": {
         "href": "guide/language/coding/file/"

--- a/internal/core-macros/slint_doc.rs
+++ b/internal/core-macros/slint_doc.rs
@@ -21,6 +21,35 @@ impl syn::visit_mut::VisitMut for Visitor {
     }
 }
 
+/// Names of builtin structs and enums that have an entry on the
+/// `reference/global-structs-enums/` page. Derived from the macros in
+/// `i_slint_common` so adding a new struct or enum makes `slint:Name` links
+/// work without editing `link-data.json`.
+fn builtin_struct_and_enum_names() -> &'static std::collections::HashSet<&'static str> {
+    macro_rules! collect_struct_names {
+        ($( $(#[$_:meta])* $vis:vis struct $Name:ident { $($body:tt)* } )*) => {
+            &[$( stringify!($Name), )* "Point", "Size"]
+        };
+    }
+    macro_rules! collect_enum_names {
+        ($( $(#[$_:meta])* $vis:vis enum $Name:ident { $($body:tt)* } )*) => {
+            &[$( stringify!($Name), )*]
+        };
+    }
+    const STRUCTS: &[&str] = i_slint_common::for_each_builtin_structs!(collect_struct_names);
+    const ENUMS: &[&str] = i_slint_common::for_each_enums!(collect_enum_names);
+    static ALL: std::sync::OnceLock<std::collections::HashSet<&'static str>> =
+        std::sync::OnceLock::new();
+    ALL.get_or_init(|| STRUCTS.iter().chain(ENUMS.iter()).copied().collect())
+}
+
+/// Build the anchor for a struct/enum name on the `global-structs-enums`
+/// page. The page renders headings like `### PointerEvent`, which the Astro
+/// slugger lowercases without splitting camelCase, e.g. `#pointerevent`.
+fn anchor_for(name: &str) -> String {
+    name.to_ascii_lowercase()
+}
+
 impl Visitor {
     pub fn new() -> Self {
         let link_data: serde_json::Value = serde_json::from_str(include_str!(concat!(
@@ -56,6 +85,12 @@ impl Visitor {
                     .as_str()
                     .expect("invalid string in link-data.json");
                 format!("https://releases.slint.dev/{}/docs/slint/{dst}", env!("CARGO_PKG_VERSION"),)
+            } else if builtin_struct_and_enum_names().contains(link) {
+                format!(
+                    "https://releases.slint.dev/{}/docs/slint/reference/global-structs-enums/#{}",
+                    env!("CARGO_PKG_VERSION"),
+                    anchor_for(link),
+                )
             } else {
                 panic!("Unknown link {link}");
             };
@@ -76,6 +111,9 @@ fn test_slint_doc() {
     slint::index is not a link
     slint:index is a link
     rust link: slint:rust:foobar
+    auto struct: slint:Edges
+    auto enum: slint:EventResult
+    auto struct point: slint:Point
      "
     .to_owned();
 
@@ -90,6 +128,9 @@ fn test_slint_doc() {
     slint::index is not a link
     https://releases.slint.dev/{0}/docs/slint/ is a link
     rust link: https://releases.slint.dev/{0}/docs/rust/foobar
+    auto struct: https://releases.slint.dev/{0}/docs/slint/reference/global-structs-enums/#edges
+    auto enum: https://releases.slint.dev/{0}/docs/slint/reference/global-structs-enums/#eventresult
+    auto struct point: https://releases.slint.dev/{0}/docs/slint/reference/global-structs-enums/#point
      ",
             env!("CARGO_PKG_VERSION")
         )


### PR DESCRIPTION
Names from i_slint_common's for_each_builtin_structs! and for_each_enums! macros now produce slint:Name -> global-structs-enums anchor URLs without needing entries in link-data.json. C++ Sphinx and Astro consumers carry the same URL pattern locally.

Replaces and closes #10698

