### PR TITLE
use make_d3d() instead of new_d3d()

### DIFF
--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -190,7 +190,7 @@ impl SwapChain {
                 protected: skia_safe::gpu::Protected::No,
             };
             let backend_texture =
-                skia_safe::gpu::BackendRenderTarget::new_d3d((width, height), &texture_info);
+                skia_safe::gpu::backend_render_targets::make_d3d((width, height), &texture_info);
 
             skia_safe::gpu::surfaces::wrap_backend_render_target(
                 gr_context,
@@ -380,7 +380,7 @@ impl super::Surface for D3DSurface {
             protected_context: skia_safe::gpu::Protected::No,
         };
 
-        let gr_context = unsafe { skia_safe::gpu::DirectContext::new_d3d(&backend_context, None) }
+        let gr_context = unsafe { skia_safe::gpu::direct_contexts::make_d3d(&backend_context, None) }
             .ok_or_else(|| format!("unable to create Skia D3D DirectContext"))?;
 
         let window_handle = window_handle

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -380,8 +380,9 @@ impl super::Surface for D3DSurface {
             protected_context: skia_safe::gpu::Protected::No,
         };
 
-        let gr_context = unsafe { skia_safe::gpu::direct_contexts::make_d3d(&backend_context, None) }
-            .ok_or_else(|| format!("unable to create Skia D3D DirectContext"))?;
+        let gr_context =
+            unsafe { skia_safe::gpu::direct_contexts::make_d3d(&backend_context, None) }
+                .ok_or_else(|| format!("unable to create Skia D3D DirectContext"))?;
 
         let window_handle = window_handle
             .window_handle()


### PR DESCRIPTION
The `new_d3d()` method has been deprecated since version 0.95.0