### PR TITLE
Don't suppress pointer events from a ToolTip's TooltipArea

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -243,6 +243,18 @@ pub enum InputEventFilterResult {
     /// If any other component is handling the event it will be not handled by the component returned this result
     //(Can't use core::time::Duration because it is not repr(c))
     DelayForwarding(u64),
+    /// Passive observer (e.g. tooltip hover tracker): like `ForwardAndIgnore` for
+    /// routing (children are visited, `input_event` is skipped), but the item is migrated
+    /// from the path stack to the `MouseInputState` observers side-list when it would
+    /// otherwise be popped. A later [`MouseEvent::Exit`] is delivered directly by
+    /// [`send_exit_events`] when the item no longer appears in either list.
+    ///
+    /// If a descendant aborts traversal before the observer's input handling completes,
+    /// the entry stays on the path stack with this filter result rather than migrating —
+    /// that path expects the observer to have zero origin, no transform, and
+    /// `clips_children == false`, so the path-stack walk can treat it like any other
+    /// item.
+    ForwardAndObserve,
 }
 
 /// This module contains the constant character code used to represent the keys.
@@ -1217,6 +1229,11 @@ pub struct MouseInputState {
     /// The stack of item which contain the mouse cursor (or grab),
     /// along with the last result from the input function
     item_stack: Vec<(ItemWeak, InputEventFilterResult)>,
+    /// Passive trackers that saw the last event without claiming it (see
+    /// [`InputEventResult::ObserveEvent`]). Held outside `item_stack` so the stack
+    /// stays a single root-to-leaf path; entries here receive a synthesized
+    /// [`MouseEvent::Exit`] when they no longer appear after a new event.
+    observers: Vec<ItemWeak>,
     /// Offset to apply to the first item of the stack (used if there is a popup)
     pub(crate) offset: LogicalPoint,
     /// true if the top item of the stack has the mouse grab
@@ -1413,6 +1430,21 @@ pub(crate) fn send_exit_events(
             }
         }
     }
+
+    // Observers live outside the path-stack and are tracked by identity. Exit fires
+    // only when the item is missing from BOTH the new observer set and the new path
+    // stack: an item whose ForwardAndObserve filter never ran (because a child aborted
+    // before reaching it) is still on the path stack with another filter result, and
+    // should not receive Exit.
+    for obs in &old_input_state.observers {
+        if new_input_state.observers.iter().any(|x| x == obs)
+            || new_input_state.item_stack.iter().any(|(x, _)| x == obs)
+        {
+            continue;
+        }
+        let Some(item) = obs.upgrade() else { continue };
+        item.borrow().as_ref().input_event(&MouseEvent::Exit, window_adapter, &item, cursor);
+    }
 }
 
 /// Process the `mouse_event` on the `component`, the `mouse_grabber_stack` is the previous stack
@@ -1568,6 +1600,10 @@ fn send_mouse_event_to_item(
                 .push((item_rc.downgrade(), InputEventFilterResult::DelayForwarding(duration)));
             return VisitChildrenResult::abort(item_rc.index(), 0);
         }
+        // Like ForwardAndIgnore: forward to children, skip input_event. The
+        // EventIgnored arm below moves our entry from the path stack to the observers
+        // side list instead of dropping it.
+        InputEventFilterResult::ForwardAndObserve => (true, true),
     };
 
     result.item_stack.push((item_rc.downgrade(), filter_result));
@@ -1607,11 +1643,19 @@ fn send_mouse_event_to_item(
     match r {
         InputEventResult::EventAccepted => VisitChildrenResult::abort(item_rc.index(), 0),
         InputEventResult::EventIgnored => {
-            let _pop = result.item_stack.pop();
+            let popped = result.item_stack.pop();
             debug_assert_eq!(
-                _pop.map(|x| (x.0.upgrade().unwrap().index(), x.1)).unwrap(),
+                popped.as_ref().map(|x| (x.0.upgrade().unwrap().index(), x.1)).unwrap(),
                 (item_rc.index(), filter_result)
             );
+            // For ForwardAndObserve, migrate the entry to the observers side list (dedup)
+            // so a later Exit can still reach it.
+            if filter_result == InputEventFilterResult::ForwardAndObserve
+                && let Some((weak, _)) = popped
+                && !result.observers.iter().any(|x| *x == weak)
+            {
+                result.observers.push(weak);
+            }
             VisitChildrenResult::CONTINUE
         }
         InputEventResult::GrabMouse => {

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -243,17 +243,8 @@ pub enum InputEventFilterResult {
     /// If any other component is handling the event it will be not handled by the component returned this result
     //(Can't use core::time::Duration because it is not repr(c))
     DelayForwarding(u64),
-    /// Passive observer (e.g. tooltip hover tracker): like `ForwardAndIgnore` for
-    /// routing (children are visited, `input_event` is skipped), but the item is migrated
-    /// from the path stack to the `MouseInputState` observers side-list when it would
-    /// otherwise be popped. A later [`MouseEvent::Exit`] is delivered directly by
-    /// [`send_exit_events`] when the item no longer appears in either list.
-    ///
-    /// If a descendant aborts traversal before the observer's input handling completes,
-    /// the entry stays on the path stack with this filter result rather than migrating —
-    /// that path expects the observer to have zero origin, no transform, and
-    /// `clips_children == false`, so the path-stack walk can treat it like any other
-    /// item.
+    /// Like `ForwardAndIgnore`, but the item still receives a [`MouseEvent::Exit`]
+    /// when the pointer leaves, even if a sibling handles the event in between.
     ForwardAndObserve,
 }
 
@@ -1652,7 +1643,7 @@ fn send_mouse_event_to_item(
             // so a later Exit can still reach it.
             if filter_result == InputEventFilterResult::ForwardAndObserve
                 && let Some((weak, _)) = popped
-                && !result.observers.iter().any(|x| *x == weak)
+                && !result.observers.contains(&weak)
             {
                 result.observers.push(weak);
             }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2000,7 +2000,9 @@ impl Item for TooltipArea {
             self.schedule_show(self_rc);
         }
 
-        InputEventFilterResult::ForwardAndInterceptGrab
+        // Observe without claiming: siblings still receive the event; the routing tracks
+        // this item on its observers side-list and delivers Exit when the pointer leaves.
+        InputEventFilterResult::ForwardAndObserve
     }
 
     fn input_event(
@@ -2010,16 +2012,10 @@ impl Item for TooltipArea {
         _self_rc: &ItemRc,
         _: &mut MouseCursor,
     ) -> InputEventResult {
-        match event {
-            // Accept move/exit so this passive tracker stays in the routing lifecycle and
-            // continues receiving leave transitions, but ignore other interaction semantics.
-            MouseEvent::Moved { .. } => InputEventResult::EventAccepted,
-            MouseEvent::Exit => {
-                self.set_hover_state(false, _self_rc);
-                InputEventResult::EventAccepted
-            }
-            _ => InputEventResult::EventIgnored,
+        if matches!(event, MouseEvent::Exit) {
+            self.set_hover_state(false, _self_rc);
         }
+        InputEventResult::EventIgnored
     }
 
     fn capture_key_event(

--- a/tests/cases/elements/tooltip_inside_toucharea.slint
+++ b/tests/cases/elements/tooltip_inside_toucharea.slint
@@ -1,0 +1,109 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `ToolTip` nested directly inside a `TouchArea` keeps the TouchArea hoverable and
+// shows the tooltip after the delay. The TouchArea sits at a non-zero offset under
+// two containers, exercising cumulative geometry translation through the routing
+// path on both enter and leave.
+
+export component TestCase {
+    width: 300px;
+    height: 200px;
+
+    in-out property <int> init-count;
+    in-out property <int> move-count;
+    out property <bool> touch-hover <=> ta.has-hover;
+
+    Rectangle {
+        x: 20px;
+        y: 30px;
+        width: 240px;
+        height: 140px;
+
+        Rectangle {
+            x: 15px;
+            y: 25px;
+            width: 200px;
+            height: 90px;
+
+            ta := TouchArea {
+                x: 10px;
+                y: 5px;
+                width: 150px;
+                height: 60px;
+                pointer-event(event) => {
+                    if (event.kind == PointerEventKind.move) {
+                        root.move-count += 1;
+                    }
+                }
+
+                ToolTip {
+                    placement: above-element;
+                    Rectangle {
+                        init => { root.init-count += 1; }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*
+
+```rust
+use slint::{platform::WindowEvent, LogicalPosition};
+
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_touch_hover());
+assert_eq!(instance.get_init_count(), 0);
+assert_eq!(instance.get_move_count(), 0);
+
+// TouchArea absolute geometry: x = 20 + 15 + 10 = 45, y = 30 + 25 + 5 = 60,
+// w = 150, h = 60 — spans (45,60) to (195,120). Pointer dispatch is in window
+// coords; the routing has to translate through both Rectangles before TouchArea
+// hit-tests.
+
+// Inside the TouchArea: hover flips on, pointer-event(move) fires.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(50.0, 70.0),
+});
+assert!(instance.get_touch_hover());
+assert_eq!(instance.get_move_count(), 1);
+assert_eq!(instance.get_init_count(), 0);
+
+// After the delay, the tooltip popup is shown and init fires.
+slint_testing::mock_elapsed_time(600);
+assert_eq!(instance.get_init_count(), 1);
+
+// (40, 80) is inside both Rectangles but outside the TouchArea — exercises the
+// cumulative-translation Exit path: the outer Rectangle still contains the pointer,
+// the inner Rectangle still contains it, but the TouchArea (in inner-local coords
+// (10..160, 5..65)) no longer does.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(40.0, 80.0),
+});
+assert!(!instance.get_touch_hover());
+
+// Re-enter the TouchArea from inside the same parent Rectangle. The routing
+// goes through the two ancestor Rectangles again before reaching the TouchArea.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(60.0, 80.0),
+});
+assert!(instance.get_touch_hover());
+assert_eq!(instance.get_move_count(), 2);
+
+// (250, 100) is inside the outer Rectangle but outside the inner one — the
+// cumulative-translation walk drops both the inner Rectangle and the TouchArea.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(250.0, 100.0),
+});
+assert!(!instance.get_touch_hover());
+
+// Fully outside the test area — clears everything.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(280.0, 190.0),
+});
+assert!(!instance.get_touch_hover());
+```
+
+*/

--- a/tests/cases/elements/tooltip_inside_toucharea.slint
+++ b/tests/cases/elements/tooltip_inside_toucharea.slint
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// A `ToolTip` nested directly inside a `TouchArea` keeps the TouchArea hoverable and
-// shows the tooltip after the delay. The TouchArea sits at a non-zero offset under
+// A `ToolTip` nested directly inside a `TouchArea` keeps the TouchArea receiving
+// hover and shows the tooltip after the delay. The TouchArea sits at a non-zero offset under
 // two containers, exercising cumulative geometry translation through the routing
 // path on both enter and leave.
 

--- a/tests/cases/elements/tooltip_toucharea_hover_coexist.slint
+++ b/tests/cases/elements/tooltip_toucharea_hover_coexist.slint
@@ -1,17 +1,40 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// A `ToolTip` on a sibling element doesn't suppress pointer-event(move) on the
+// `TouchArea`, and the tooltip still shows on hover. Both items are placed at
+// non-trivial offsets so the routing has to translate cumulatively before the
+// hit-test resolves.
+
 export component TestCase {
-    width: 200px;
-    height: 120px;
+    width: 300px;
+    height: 200px;
 
     in-out property <int> init-count;
+    in-out property <int> move-count;
     out property <bool> touch-hover <=> ta.has-hover;
 
+    // TouchArea covers the upper-left portion of the window.
     ta := TouchArea {
-        width: parent.width;
-        height: parent.height;
+        x: 10px;
+        y: 20px;
+        width: 200px;
+        height: 140px;
+        pointer-event(event) => {
+            if (event.kind == PointerEventKind.move) {
+                root.move-count += 1;
+            }
+        }
+    }
 
+    // Sibling Rectangle with the ToolTip overlaps only the bottom-right corner of
+    // the TouchArea, leaving a TouchArea-only region (top strip and left strip) where
+    // the pointer hits only the TouchArea path.
+    Rectangle {
+        x: 100px;
+        y: 80px;
+        width: 150px;
+        height: 100px;
         ToolTip {
             placement: above-element;
             Rectangle {
@@ -29,21 +52,41 @@ use slint::{platform::WindowEvent, LogicalPosition};
 let instance = TestCase::new().unwrap();
 assert!(!instance.get_touch_hover());
 assert_eq!(instance.get_init_count(), 0);
+assert_eq!(instance.get_move_count(), 0);
 
-// Hover enters: TouchArea gets hover, but tooltip init has not fired yet (delay pending).
+// TouchArea spans (10,20)-(210,160). Sibling Rectangle (with ToolTip) spans
+// (100,80)-(250,180). Overlap region: (100,80)-(210,160).
+
+// Move into the overlap: pointer-event fires AND the observer is registered.
 instance.window().dispatch_event(WindowEvent::PointerMoved {
-    position: LogicalPosition::new(20.0, 20.0),
+    position: LogicalPosition::new(150.0, 100.0),
 });
 assert!(instance.get_touch_hover());
+assert_eq!(instance.get_move_count(), 1);
 assert_eq!(instance.get_init_count(), 0);
 
-// After the delay, the tooltip popup is shown and init fires.
+// Another move in the overlap.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(170.0, 120.0),
+});
+assert_eq!(instance.get_move_count(), 2);
+
+// After the delay, the tooltip popup is shown.
 slint_testing::mock_elapsed_time(600);
 assert_eq!(instance.get_init_count(), 1);
 
-// Moving out hides the tooltip and clears hover.
+// Move into a TouchArea-only region: the cursor is still inside TouchArea
+// (so pointer-event fires) but outside the Rectangle/ToolTip — the observer
+// drops out of the new state and Exit fires on the TooltipArea.
 instance.window().dispatch_event(WindowEvent::PointerMoved {
-    position: LogicalPosition::new(250.0, 250.0),
+    position: LogicalPosition::new(50.0, 40.0),
+});
+assert!(instance.get_touch_hover());
+assert_eq!(instance.get_move_count(), 3);
+
+// Fully outside: TouchArea hover clears.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(280.0, 30.0),
 });
 assert!(!instance.get_touch_hover());
 ```


### PR DESCRIPTION
Add an InputEventFilterResult::ForwardAndObserve variant for items that need to track hover without claiming the event. TooltipArea returns it from its filter; the routing migrates the entry from the path stack to a `MouseInputState.observers` side list when it would otherwise be popped on EventIgnored. A trailing identity-diff in send_exit_events delivers Exit when the observer no longer appears in either list.

This way a TouchArea sibling of an element carrying a ToolTip still receives pointer-event(move) callbacks, while the tooltip still tracks hover and shows on dwell.

Fixes: #11863
