### PR TITLE
skia: work around armv7 build failures with cross

### DIFF
--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -9,7 +9,7 @@ RUN dpkg --add-architecture armhf && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes libfontconfig1-dev:armhf libxcb1-dev:armhf libxcb-render0-dev:armhf libxcb-shape0-dev:armhf libxcb-xfixes0-dev:armhf libxkbcommon-dev:armhf libinput-dev:armhf libgbm-dev:armhf libssl-dev:armhf python3 python3-pip \
     libfontconfig1-dev \
-    clang libstdc++-10-dev:armhf ninja-build
+    clang g++-10-arm-linux-gnueabihf libstdc++-10-dev:armhf ninja-build
 
 # Work around the Skia source build requiring a newer git version (that supports --path-format=relative with rev-parse, as needed by git-sync-deps.py),
 # as well as a disabling of the directory safety checks (https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765) as
@@ -27,3 +27,8 @@ ENV PKG_CONFIG_ALLOW_CROSS=1
 # In the absence of a sysroot, the header files we install earlier (such as libfontconfig1-dev:armhf) are in /usr/include
 # so remember to teach bindgen to also look there, despite its --target.
 ENV BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf=-I/usr/include
+
+# Compile C/C++ (e.g. the skia-bindings glue) with GCC 10 instead of the default GCC 9: Skia m148
+# requires -std=c++20, which GCC 9 does not recognize (it only has -std=c++2a).
+ENV CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc-10 \
+    CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++-10

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -107,8 +107,7 @@ skia-safe = { version = "0.97.2", features = ["gl", "vulkan"] }
 wgpu-28 = { workspace = true, optional = true, features = ["vulkan"] }
 wgpu-29 = { workspace = true, optional = true, features = ["vulkan"] }
 
-[target.'cfg(any(target_os = "ios", target_os="macos", target_os="windows", target_os="android", target_os="linux"))'.dependencies]
-# Text layout is enabled here just so that we can make use of the pre-built Skia libraries.
+[target.'cfg(all(any(target_os = "ios", target_os="macos", target_os="windows", target_os="android", target_os="linux"), not(target_arch = "arm")))'.dependencies]
 skia-safe = { version = "0.97.2", features = ["textlayout"] }
 
 [target.aarch64-apple-ios-sim.dependencies]


### PR DESCRIPTION
Don't enable textlayout on 32-bit arm. armv7 has no pre-built Skia binaries, so it builds Skia from source. The textlayout feature pulls in Skia's bundled ICU, which fails to compile with the old clang in the cross image we're using.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
