### PR TITLE
Let a global implement another global's callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented in this file.
 
 ### General
 
+ - A global can now implement a callback declared in another global, by declaring a two-way alias
+   to it (`callback foo <=> Other.foo;`) and providing a handler (`foo => { ... }`).
  - Upgraded WGPU dependency to version 29: The `unstable-wgpu-27` and `unstable-wgpu-28` Cargo features have been replaced
    by a single `unstable-wgpu-29` feature, alongside the new `slint::wgpu_29` module. Existing users of the
    `unstable-wgpu-27`/`unstable-wgpu-28` features need to migrate to `unstable-wgpu-29` and update their code to use

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1628,8 +1628,7 @@ impl Element {
                     let is_global_alias = r.base_type == ElementType::Global
                         && matches!(
                             &e.get().borrow().expression,
-                            Expression::Uncompiled(node)
-                                if syntax_nodes::TwoWayBinding::new(node.clone()).is_some()
+                            Expression::Uncompiled(node) if node.kind() == SyntaxKind::TwoWayBinding
                         );
                     if is_global_alias {
                         e.get_mut().get_mut().expression =

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1620,10 +1620,27 @@ impl Element {
                 Entry::Vacant(e) => {
                     e.insert(BindingExpression::new_uncompiled(con_node.clone().into()).into());
                 }
-                Entry::Occupied(_) => diag.push_error(
-                    "Duplicated callback".into(),
-                    &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                ),
+                Entry::Occupied(mut e) => {
+                    // A global may implement a callback declared in another global: the
+                    // callback is declared as a two-way alias (`callback foo <=> Other.foo;`)
+                    // and also given a handler (`foo => { ... }`). The alias node stays on
+                    // the declaration, and the handler takes the binding expression slot.
+                    let is_global_alias = r.base_type == ElementType::Global
+                        && matches!(
+                            &e.get().borrow().expression,
+                            Expression::Uncompiled(node)
+                                if syntax_nodes::TwoWayBinding::new(node.clone()).is_some()
+                        );
+                    if is_global_alias {
+                        e.get_mut().get_mut().expression =
+                            Expression::Uncompiled(con_node.clone().into());
+                    } else {
+                        diag.push_error(
+                            "Duplicated callback".into(),
+                            &con_node.child_token(SyntaxKind::Identifier).unwrap(),
+                        );
+                    }
+                }
             }
         }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1631,8 +1631,16 @@ impl Element {
                             Expression::Uncompiled(node) if node.kind() == SyntaxKind::TwoWayBinding
                         );
                     if is_global_alias {
-                        e.get_mut().get_mut().expression =
-                            Expression::Uncompiled(con_node.clone().into());
+                        // Keep the handler as the binding and point its span at the handler
+                        // name, so a duplicate-implementation error refers to the
+                        // implementation rather than the alias. The alias is recovered from
+                        // the declaration node, so dropping it from the binding is fine.
+                        let mut handler =
+                            BindingExpression::new_uncompiled(con_node.clone().into());
+                        if let Some(name) = con_node.child_token(SyntaxKind::Identifier) {
+                            handler.span = Some(name.to_source_location());
+                        }
+                        e.insert(handler.into());
                     } else {
                         diag.push_error(
                             "Duplicated callback".into(),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2145,14 +2145,12 @@ impl Element {
     /// and provide a handler (`foo => { ... }`): the handler then occupies the binding
     /// expression slot, so the alias node lives on the callback declaration instead.
     pub fn two_way_binding_node(&self, name: &str) -> Option<syntax_nodes::TwoWayBinding> {
-        if let Some(binding) = self.bindings.get(name) {
-            if let Ok(b) = binding.try_borrow() {
-                if let Expression::Uncompiled(node) = b.expression.ignore_debug_hooks() {
-                    if let Some(twb) = syntax_nodes::TwoWayBinding::new(node.clone()) {
-                        return Some(twb);
-                    }
-                }
-            }
+        if let Some(binding) = self.bindings.get(name)
+            && let Ok(b) = binding.try_borrow()
+            && let Expression::Uncompiled(node) = b.expression.ignore_debug_hooks()
+            && let Some(twb) = syntax_nodes::TwoWayBinding::new(node.clone())
+        {
+            return Some(twb);
         }
         self.callback_alias_declaration_node(name)
     }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2122,6 +2122,41 @@ impl Element {
         }
     }
 
+    /// Return the alias node of a `callback foo <=> ...;` declaration, if `name` is one.
+    ///
+    /// This lives on the callback declaration itself, which is where the alias of a
+    /// global callback that also has a handler ends up (the handler takes the binding
+    /// expression slot).
+    pub fn callback_alias_declaration_node(
+        &self,
+        name: &str,
+    ) -> Option<syntax_nodes::TwoWayBinding> {
+        self.property_declarations
+            .get(name)
+            .and_then(|d| d.node.clone())
+            .and_then(syntax_nodes::CallbackDeclaration::new)
+            .and_then(|cb| cb.TwoWayBinding())
+    }
+
+    /// Return the two-way-binding syntax node of a `<=>` alias for the given property, if any.
+    ///
+    /// Usually the alias is the binding's own (uncompiled) expression. But a global
+    /// callback may both alias another global's callback (`callback foo <=> Other.foo;`)
+    /// and provide a handler (`foo => { ... }`): the handler then occupies the binding
+    /// expression slot, so the alias node lives on the callback declaration instead.
+    pub fn two_way_binding_node(&self, name: &str) -> Option<syntax_nodes::TwoWayBinding> {
+        if let Some(binding) = self.bindings.get(name) {
+            if let Ok(b) = binding.try_borrow() {
+                if let Expression::Uncompiled(node) = b.expression.ignore_debug_hooks() {
+                    if let Some(twb) = syntax_nodes::TwoWayBinding::new(node.clone()) {
+                        return Some(twb);
+                    }
+                }
+            }
+        }
+        self.callback_alias_declaration_node(name)
+    }
+
     pub fn native_class(&self) -> Option<Rc<NativeClass>> {
         let mut base_type = self.base_type.clone();
         loop {

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -73,45 +73,6 @@ pub fn ignore_debug_hooks(expr: &Expression) -> &Expression {
     }
 }
 
-/// Return the alias node of a `callback foo <=> ...;` declaration, if `prop` is one.
-///
-/// This lives on the callback declaration itself, which is where the alias of a
-/// global callback that also has a handler ends up (the handler takes the binding
-/// expression slot).
-pub fn callback_alias_declaration_node(
-    elem: &crate::object_tree::Element,
-    prop: &str,
-) -> Option<crate::parser::syntax_nodes::TwoWayBinding> {
-    elem.property_declarations
-        .get(prop)
-        .and_then(|d| d.node.clone())
-        .and_then(crate::parser::syntax_nodes::CallbackDeclaration::new)
-        .and_then(|cb| cb.TwoWayBinding())
-}
-
-/// Return the two-way-binding syntax node of a `<=>` alias for the given property, if any.
-///
-/// Usually the alias is the binding's own (uncompiled) expression. But a global
-/// callback may both alias another global's callback (`callback foo <=> Other.foo;`)
-/// and provide a handler (`foo => { ... }`): the handler then occupies the binding
-/// expression slot, so the alias node lives on the callback declaration instead.
-pub fn two_way_binding_node(
-    elem: &crate::object_tree::Element,
-    prop: &str,
-) -> Option<crate::parser::syntax_nodes::TwoWayBinding> {
-    use crate::parser::syntax_nodes;
-    if let Some(binding) = elem.bindings.get(prop) {
-        if let Ok(b) = binding.try_borrow() {
-            if let Expression::Uncompiled(node) = ignore_debug_hooks(&b.expression) {
-                if let Some(twb) = syntax_nodes::TwoWayBinding::new(node.clone()) {
-                    return Some(twb);
-                }
-            }
-        }
-    }
-    callback_alias_declaration_node(elem, prop)
-}
-
 pub async fn run_passes(
     doc: &mut crate::object_tree::Document,
     type_loader: &mut crate::typeloader::TypeLoader,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -73,6 +73,45 @@ pub fn ignore_debug_hooks(expr: &Expression) -> &Expression {
     }
 }
 
+/// Return the alias node of a `callback foo <=> ...;` declaration, if `prop` is one.
+///
+/// This lives on the callback declaration itself, which is where the alias of a
+/// global callback that also has a handler ends up (the handler takes the binding
+/// expression slot).
+pub fn callback_alias_declaration_node(
+    elem: &crate::object_tree::Element,
+    prop: &str,
+) -> Option<crate::parser::syntax_nodes::TwoWayBinding> {
+    elem.property_declarations
+        .get(prop)
+        .and_then(|d| d.node.clone())
+        .and_then(crate::parser::syntax_nodes::CallbackDeclaration::new)
+        .and_then(|cb| cb.TwoWayBinding())
+}
+
+/// Return the two-way-binding syntax node of a `<=>` alias for the given property, if any.
+///
+/// Usually the alias is the binding's own (uncompiled) expression. But a global
+/// callback may both alias another global's callback (`callback foo <=> Other.foo;`)
+/// and provide a handler (`foo => { ... }`): the handler then occupies the binding
+/// expression slot, so the alias node lives on the callback declaration instead.
+pub fn two_way_binding_node(
+    elem: &crate::object_tree::Element,
+    prop: &str,
+) -> Option<crate::parser::syntax_nodes::TwoWayBinding> {
+    use crate::parser::syntax_nodes;
+    if let Some(binding) = elem.bindings.get(prop) {
+        if let Ok(b) = binding.try_borrow() {
+            if let Expression::Uncompiled(node) = ignore_debug_hooks(&b.expression) {
+                if let Some(twb) = syntax_nodes::TwoWayBinding::new(node.clone()) {
+                    return Some(twb);
+                }
+            }
+        }
+    }
+    callback_alias_declaration_node(elem, prop)
+}
+
 pub async fn run_passes(
     doc: &mut crate::object_tree::Document,
     type_loader: &mut crate::typeloader::TypeLoader,

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -8,11 +8,10 @@
 //! This pass will attempt to assign a type to these based on the type of property they alias.
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{Expression, TwoWayBinding};
+use crate::expression_tree::TwoWayBinding;
 use crate::langtype::Type;
 use crate::lookup::LookupCtx;
 use crate::object_tree::{Document, ElementRc};
-use crate::parser::syntax_nodes;
 use crate::typeregister::TypeRegister;
 use std::rc::Rc;
 
@@ -77,29 +76,19 @@ fn resolve_alias(
     };
     drop(borrow_mut);
 
-    let borrow = elem.borrow();
-    let Some(binding) = borrow.bindings.get(prop) else {
-        assert!(diag.has_errors());
-        return;
+    let twb = {
+        let Some(node) = crate::passes::two_way_binding_node(&elem.borrow(), prop) else {
+            // The parser only allows omitting the type for a two-way binding, so a missing
+            // alias node here means an error was already reported for this component.
+            assert!(diag.has_errors(), "The parser only avoid missing types for two way bindings");
+            return;
+        };
+        let mut lookup_ctx = LookupCtx::empty_context(type_register, diag);
+        lookup_ctx.property_name = Some(prop);
+        lookup_ctx.property_type = old_type.clone();
+        lookup_ctx.component_scope = &scope.0;
+        crate::passes::resolving::resolve_two_way_binding(node, &mut lookup_ctx)
     };
-    let twb = match super::ignore_debug_hooks(&binding.borrow().expression) {
-        Expression::Uncompiled(node) => {
-            let Some(node) = syntax_nodes::TwoWayBinding::new(node.clone()) else {
-                assert!(
-                    diag.has_errors(),
-                    "The parser only avoid missing types for two way bindings"
-                );
-                return;
-            };
-            let mut lookup_ctx = LookupCtx::empty_context(type_register, diag);
-            lookup_ctx.property_name = Some(prop);
-            lookup_ctx.property_type = old_type.clone();
-            lookup_ctx.component_scope = &scope.0;
-            crate::passes::resolving::resolve_two_way_binding(node, &mut lookup_ctx)
-        }
-        _ => panic!("There should be a Uncompiled expression at this point."),
-    };
-    drop(borrow);
 
     let mut ty = Type::Invalid;
     match &twb {
@@ -154,8 +143,12 @@ fn resolve_alias(
                 );
             }
         } else if let Some(nr) = twb.unwrap().property() {
-            let is_global = nr.element().borrow().base_type == crate::langtype::ElementType::Global;
+            let target_is_global =
+                nr.element().borrow().base_type == crate::langtype::ElementType::Global;
             let purity = nr.element().borrow().lookup_property(nr.name()).declared_pure;
+            // A global aliasing another global's callback is the supported way for one
+            // global to implement another's callback, so it isn't deprecated.
+            let aliasing_global = elem.borrow().base_type == crate::langtype::ElementType::Global;
             let mut elem = elem.borrow_mut();
             let decl = elem.property_declarations.get_mut(prop).unwrap();
             if decl.pure.unwrap_or(false) != purity.unwrap_or(false) {
@@ -164,7 +157,7 @@ fn resolve_alias(
                     &decl.type_node(),
                 );
             }
-            if is_global {
+            if target_is_global && !aliasing_global {
                 diag.push_warning("Aliases to global callback are deprecated. Export the global to access the global callback directly from native code".into(), &decl.node);
             }
             decl.property_type = ty;

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -77,7 +77,7 @@ fn resolve_alias(
     drop(borrow_mut);
 
     let twb = {
-        let Some(node) = crate::passes::two_way_binding_node(&elem.borrow(), prop) else {
+        let Some(node) = elem.borrow().two_way_binding_node(prop) else {
             // The parser only allows omitting the type for a two-way binding, so a missing
             // alias node here means an error was already reported for this component.
             assert!(diag.has_errors(), "The parser only avoid missing types for two way bindings");

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -5,6 +5,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BindingExpression, Expression, NamedReference, TwoWayBinding};
+use crate::langtype::Type;
 use crate::object_tree::*;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, btree_map::Entry};
@@ -106,6 +107,42 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
     // and only the master property will keep its binding
     for set in property_sets.all_sets {
         let set = set.borrow();
+
+        // Globals are singletons, so a callback aliased across globals must have at most
+        // one implementation. More than one handler in the set is an ambiguous conflict.
+        // (For non-global elements multiple handlers are fine: instances legitimately
+        // override a base's handler, resolved below by binding priority.)
+        let implementers: Vec<NamedReference> = set
+            .iter()
+            .filter(|nr| {
+                if !matches!(nr.ty(), Type::Callback(..)) {
+                    return false;
+                }
+                let elem = nr.element();
+                let elem = elem.borrow();
+                elem.enclosing_component.upgrade().is_some_and(|c| c.is_global())
+                    && elem.bindings.get(nr.name()).is_some_and(|b| {
+                        !matches!(
+                            super::ignore_debug_hooks(&b.borrow().expression),
+                            Expression::Invalid
+                        )
+                    })
+            })
+            .cloned()
+            .collect();
+        if implementers.len() > 1 {
+            for nr in &implementers {
+                let elem = nr.element();
+                let elem = elem.borrow();
+                if let Some(b) = elem.bindings.get(nr.name()) {
+                    diag.push_error(
+                        format!("Callback '{}' is implemented in more than one global", nr.name()),
+                        &*b.borrow(),
+                    );
+                }
+            }
+        }
+
         let mut set_iter = set.iter();
         if let Some(mut best) = set_iter.next().cloned() {
             for candidate in set_iter {
@@ -153,6 +190,11 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             &elem.borrow().enclosing_component,
             &to_elem.borrow().enclosing_component,
         );
+        // Globals are singletons, so a handler an aliasing global provides for another
+        // global's callback must be carried over to the master, just like within a component.
+        let both_global =
+            elem.borrow().enclosing_component.upgrade().is_some_and(|c| c.is_global())
+                && to_elem.borrow().enclosing_component.upgrade().is_some_and(|c| c.is_global());
         match to_elem.borrow_mut().bindings.entry(to.name().clone()) {
             Entry::Occupied(mut e) => {
                 let b = e.get_mut().get_mut();
@@ -165,7 +207,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                 }
             }
             Entry::Vacant(e) => {
-                if same_component && old_binding.has_binding() {
+                if (same_component || both_global) && old_binding.has_binding() {
                     e.insert(old_binding.into());
                 }
             }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2214,9 +2214,19 @@ fn resolve_two_way_bindings_for_element(
 
     for (prop_name, binding) in &elem.borrow().bindings {
         let mut binding = binding.borrow_mut();
-        if let Expression::Uncompiled(node) = binding.expression.ignore_debug_hooks().clone()
-            && let Some(n) = syntax_nodes::TwoWayBinding::new(node.clone())
-        {
+        // The alias node is normally the binding's own (uncompiled) expression. But a
+        // global callback may both alias another global's callback and provide a handler:
+        // the handler then occupies the expression slot and the alias node lives on the
+        // callback declaration, in which case the handler expression must be preserved.
+        let twb_from_expression = match binding.expression.ignore_debug_hooks() {
+            Expression::Uncompiled(node) => syntax_nodes::TwoWayBinding::new(node.clone()),
+            _ => None,
+        };
+        let twb_node = twb_from_expression
+            .clone()
+            .or_else(|| super::callback_alias_declaration_node(&elem.borrow(), prop_name));
+        if let Some(n) = twb_node {
+            let node: SyntaxNode = n.clone().into();
             let lhs_lookup = elem.borrow().lookup_property(prop_name);
             if !lhs_lookup.is_valid() {
                 // An attempt to resolve this already failed when trying to resolve the property type
@@ -2235,7 +2245,11 @@ fn resolve_two_way_bindings_for_element(
                 local_variables: Vec::new(),
             };
 
-            binding.expression = Expression::Invalid;
+            // Only the alias-only case stores the two-way binding in the expression slot;
+            // the combined case must keep its handler expression intact.
+            if twb_from_expression.is_some() {
+                binding.expression = Expression::Invalid;
+            }
 
             if let Some(twb) = resolve_two_way_binding(n, &mut lookup_ctx) {
                 if matches!(lhs_lookup.property_type, Type::InferredProperty) {
@@ -2507,7 +2521,12 @@ fn check_callback_alias_validity(
         return;
     };
 
-    if alias.element().borrow().base_type == ElementType::Global {
+    // A non-global element can be instantiated many times, so letting it assign a handler
+    // to a singleton global's callback is ambiguous. A global is itself a singleton, so it
+    // may implement another global's callback.
+    if alias.element().borrow().base_type == ElementType::Global
+        && elem_borrow.base_type != ElementType::Global
+    {
         diag.push_error(
             "Can't assign a local callback handler to an alias to a global callback".into(),
             &node.child_token(SyntaxKind::Identifier).unwrap(),

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2224,7 +2224,7 @@ fn resolve_two_way_bindings_for_element(
         };
         let twb_node = twb_from_expression
             .clone()
-            .or_else(|| super::callback_alias_declaration_node(&elem.borrow(), prop_name));
+            .or_else(|| elem.borrow().callback_alias_declaration_node(prop_name));
         if let Some(n) = twb_node {
             let node: SyntaxNode = n.clone().into();
             let lhs_lookup = elem.borrow().lookup_property(prop_name);

--- a/internal/compiler/tests/syntax/lookup/callback_implemented_in_two_globals.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_implemented_in_two_globals.slint
@@ -7,12 +7,12 @@ export global A {
 
 export global B {
     callback compute <=> A.compute;
-//                   >           <error{Callback 'compute' is implemented in more than one global}
     compute(x) => { return x * 2; }
+//  >     <error{Callback 'compute' is implemented in more than one global}
 }
 
 export global C {
     callback compute <=> A.compute;
-//                   >           <error{Callback 'compute' is implemented in more than one global}
     compute(x) => { return x * 3; }
+//  >     <error{Callback 'compute' is implemented in more than one global}
 }

--- a/internal/compiler/tests/syntax/lookup/callback_implemented_in_two_globals.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_implemented_in_two_globals.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export global A {
+    callback compute(int) -> int;
+}
+
+export global B {
+    callback compute <=> A.compute;
+//                   >           <error{Callback 'compute' is implemented in more than one global}
+    compute(x) => { return x * 2; }
+}
+
+export global C {
+    callback compute <=> A.compute;
+//                   >           <error{Callback 'compute' is implemented in more than one global}
+    compute(x) => { return x * 3; }
+}

--- a/tests/cases/globals/global_implements_global_callback.slint
+++ b/tests/cases/globals/global_implements_global_callback.slint
@@ -4,7 +4,7 @@
 // A global may implement a callback declared in another global, by declaring a
 // two-way alias to it and providing a handler.
 
-global Provider {
+export global Provider {
     out property <int> factor: 10;
     pure callback compute(int) -> int;
     pure callback offset(int) -> int;
@@ -36,6 +36,11 @@ assert_eq!(instance.get_shifted(), 15);
 // A handler installed from native code wins over the one implemented in Slint.
 instance.global::<Impl<'_>>().on_compute(|x| x + 1);
 assert_eq!(instance.get_computed(), 6);
+
+// Both globals alias the same callback, so setting it through either one targets
+// the same single handler slot: the last handler set wins.
+instance.global::<Provider<'_>>().on_compute(|x| x + 100);
+assert_eq!(instance.get_computed(), 105);
 ```
 
 ```cpp
@@ -47,6 +52,11 @@ assert_eq(instance.get_shifted(), 15);
 // A handler installed from native code wins over the one implemented in Slint.
 instance.global<Impl>().on_compute([](int x) { return x + 1; });
 assert_eq(instance.get_computed(), 6);
+
+// Both globals alias the same callback, so setting it through either one targets
+// the same single handler slot: the last handler set wins.
+instance.global<Provider>().on_compute([](int x) { return x + 100; });
+assert_eq(instance.get_computed(), 105);
 ```
 
 ```js
@@ -57,6 +67,11 @@ assert.equal(instance.shifted, 15);
 // A handler installed from native code wins over the one implemented in Slint.
 instance.Impl.compute = function(x) { return x + 1; };
 assert.equal(instance.computed, 6);
+
+// Both globals alias the same callback, so setting it through either one targets
+// the same single handler slot: the last handler set wins.
+instance.Provider.compute = function(x) { return x + 100; };
+assert.equal(instance.computed, 105);
 ```
 
 ```python
@@ -67,5 +82,10 @@ assert instance.shifted == 15
 # A handler installed from native code wins over the one implemented in Slint.
 instance.Impl.compute = lambda x: x + 1
 assert instance.computed == 6
+
+# Both globals alias the same callback, so setting it through either one targets
+# the same single handler slot: the last handler set wins.
+instance.Provider.compute = lambda x: x + 100
+assert instance.computed == 105
 ```
 */

--- a/tests/cases/globals/global_implements_global_callback.slint
+++ b/tests/cases/globals/global_implements_global_callback.slint
@@ -1,0 +1,71 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A global may implement a callback declared in another global, by declaring a
+// two-way alias to it and providing a handler.
+
+global Provider {
+    out property <int> factor: 10;
+    pure callback compute(int) -> int;
+    pure callback offset(int) -> int;
+}
+
+export global Impl {
+    pure callback compute <=> Provider.compute;
+    pure callback offset <=> Provider.offset;
+    compute(x) => {
+        return x * Provider.factor;
+    }
+    offset(x) => {
+        return x + Provider.factor;
+    }
+}
+
+export component TestCase inherits Window {
+    out property <int> computed: Provider.compute(5);
+    out property <int> shifted: Provider.offset(5);
+    out property <bool> test: computed == 50 && shifted == 15;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_computed(), 50);
+assert_eq!(instance.get_shifted(), 15);
+
+// A handler installed from native code wins over the one implemented in Slint.
+instance.global::<Impl<'_>>().on_compute(|x| x + 1);
+assert_eq!(instance.get_computed(), 6);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_computed(), 50);
+assert_eq(instance.get_shifted(), 15);
+
+// A handler installed from native code wins over the one implemented in Slint.
+instance.global<Impl>().on_compute([](int x) { return x + 1; });
+assert_eq(instance.get_computed(), 6);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert.equal(instance.computed, 50);
+assert.equal(instance.shifted, 15);
+
+// A handler installed from native code wins over the one implemented in Slint.
+instance.Impl.compute = function(x) { return x + 1; };
+assert.equal(instance.computed, 6);
+```
+
+```python
+instance = TestCase()
+assert instance.computed == 50
+assert instance.shifted == 15
+
+# A handler installed from native code wins over the one implemented in Slint.
+instance.Impl.compute = lambda x: x + 1
+assert instance.computed == 6
+```
+*/


### PR DESCRIPTION
Globals are singletons, so there is no ambiguity in which handler wins, unlike a component that can be instantiated many times. This lets one global provide the implementation for a callback declared elsewhere via a two-way alias plus a handler, instead of forcing it into native code.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
