### PR TITLE
docs: update slintcn URLs to new repo location

### DIFF
--- a/docs/astro/src/content/docs/guide/development/third-party-libraries.mdx
+++ b/docs/astro/src/content/docs/guide/development/third-party-libraries.mdx
@@ -46,11 +46,11 @@ https://github.com/uAtomicBoolean/sleek-ui/
 
 ### slintcn
 
-[slintcn](https://github.com/stevekwon211/slintcn) is a shadcn/ui-style component registry for Slint.
+[slintcn](https://github.com/zero-sq/slintcn) is a shadcn/ui-style component registry for Slint.
 Use the `slintcn` CLI to copy components directly into your project and edit the `.slint` files to fit your design system.
-Documentation and a live WASM preview are at https://stevekwon211.github.io/slintcn/docs/.
+Documentation and a live WASM preview are at https://zero-sq.github.io/slintcn/docs/.
 
-https://github.com/stevekwon211/slintcn
+https://github.com/zero-sq/slintcn
 
 ## Templates
 


### PR DESCRIPTION
The `slintcn` repository has moved from `stevekwon211/slintcn` to `zero-sq/slintcn`. This updates the three URLs added in #11893.

Note: the GitHub Pages docs link (`stevekwon211.github.io/slintcn/docs/`) now returns 404 since GitHub Pages does not redirect across accounts — the new link `zero-sq.github.io/slintcn/docs/` is live. The two `github.com` repo links still work via GitHub's transfer redirect but are updated for clarity.