### PR TITLE
iOS: Render the first frame for windows shown after the event loop st…

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1124,6 +1124,12 @@ impl WinitWindowAdapter {
                 self.draw()?;
             };
 
+            // On iOS making an already-created window visible doesn't generate a fresh
+            // RedrawRequested. winit's one initial RedrawRequested is delivered while the window is
+            // created (during `resumed`), so a window first shown later misses it and stays blank.
+            #[cfg(ios_and_friends)]
+            self.request_redraw();
+
             Ok(())
         } else {
             // Wayland doesn't support hiding a window, only destroying it entirely.


### PR DESCRIPTION
…arts

On iOS winit delivers its single initial RedrawRequested while the window is created (during `resumed`), and doesn't generate a fresh RedrawRequested when an already-created window is later made visible.

Request the first frame explicitly when the window becomes visible.

This is not a regression, it never used to work, but only shows in the slint-viewer, because that one calls show() after the event loop has started.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
