### PR TITLE
winit: Fix iOS render surface excluding the safe area

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -27,6 +27,7 @@ use winit::event_loop::ActiveEventLoop;
 #[cfg(not(target_arch = "wasm32"))]
 mod clipboard;
 mod drag_resize_window;
+mod winit_compat;
 mod winitwindowadapter;
 use winitwindowadapter::*;
 pub(crate) mod event_loop;

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -221,7 +221,8 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
             },
         )?);
 
-        let size = winit_window.inner_size();
+        use crate::winit_compat::WindowSurfaceSizeExt;
+        let size = winit_window.surface_size();
 
         self.renderer.set_surface(
             Box::new(winit_window.clone())

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -3,6 +3,7 @@
 
 use std::{num::NonZeroU32, sync::Arc};
 
+use crate::winit_compat::WindowSurfaceSizeExt;
 use glutin::{
     config::GlConfig,
     context::{ContextApi, ContextAttributesBuilder},
@@ -152,7 +153,7 @@ impl OpenGLContext {
             format!("Failed to retrieve a window handle for window we just created: {err:?}")
         })?;
 
-        let size: winit::dpi::PhysicalSize<u32> = window.inner_size();
+        let size: winit::dpi::PhysicalSize<u32> = window.surface_size();
 
         let width: std::num::NonZeroU32 = size.width.try_into().map_err(|_| {
             format!(

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -4,6 +4,7 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
+use crate::winit_compat::WindowSurfaceSizeExt;
 use crate::winitwindowadapter::physical_size_to_slint;
 use i_slint_core::graphics::RequestedGraphicsAPI;
 use i_slint_core::platform::PlatformError;
@@ -180,7 +181,7 @@ impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
             },
         )?);
 
-        let size = winit_window.inner_size();
+        let size = winit_window.surface_size();
 
         self.renderer.set_window_handle(
             winit_window.clone(),

--- a/internal/backends/winit/winit_compat.rs
+++ b/internal/backends/winit/winit_compat.rs
@@ -1,0 +1,19 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Polyfill for `winit::window::Window::surface_size()`, which becomes a built-in method in
+//! winit 0.31.
+
+pub(crate) trait WindowSurfaceSizeExt {
+    fn surface_size(&self) -> winit::dpi::PhysicalSize<u32>;
+}
+
+impl WindowSurfaceSizeExt for winit::window::Window {
+    /// The physical size of the rendering surface backing a winit window.
+    fn surface_size(&self) -> winit::dpi::PhysicalSize<u32> {
+        // winit 0.30's iOS `inner_size()` returns the safe-area frame but the `CAMetalLayer` fills the whole
+        // window, so the render surface must match `outer_size()`. That's also what `WindowEvent::Resized`
+        // delivers.
+        if cfg!(target_os = "ios") { self.outer_size() } else { self.inner_size() }
+    }
+}

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -27,6 +27,7 @@ use winit::platform::windows::WindowExtWindows;
 #[cfg(muda)]
 use crate::muda::MudaType;
 use crate::renderer::WinitCompatibleRenderer;
+use crate::winit_compat::WindowSurfaceSizeExt;
 
 use corelib::item_tree::ItemTreeRc;
 #[cfg(enable_accesskit)]
@@ -689,7 +690,7 @@ impl WinitWindowAdapter {
             // Note: On displays with a scale factor != 1, we get a scale factor change
             // event and a resize event, so all is good.
             if self.pending_resize_event_after_show.take() {
-                self.resize_event(winit_window.inner_size())?;
+                self.resize_event(winit_window.surface_size())?;
             }
         }
 


### PR DESCRIPTION
On iOS winit's inner_size() returns the safe-area frame rather than the
full window. The CAMetalLayer fills the whole window, so sizing the render
surface to inner_size() leaves an unpainted (black) bar where the safe area
doesn't reach the screen edges.

In the common case, the window adapter is created before the event loop
starts, then the event loop starts, and we receive a
WindowEvent::Resized that with winit 0.30 covers the full window (it does
**not** exclude the safe area), which is what we want. That size gets
passed into corelib and comes back into the renderers via
RendererSealed::resize, which in turn then correctly resizes the
underlying surface.

If however the window is shown later, like in the slint-viewer that
calls show() from an async task, then WinitWindowAdapter's draw calls
self.resize_event(winit_window.inner_size()) if
pending_resize_event_after_show, and that means it gets the wrong size.

A minor red herring here is that inner_size() is also called when
creating the initial renderer surfaces, but that's mitigated through the
earlier mentioned resize event.

So as a minimally intrusive fix, introduce a helper trait that
introduces the correct winit 0.31 API already now and use that
(especially!) in draw().

In feature/winit-0.31 draw is already correct, but the trait should make
the merge easy.

