### PR TITLE
Improve RadioGroup accessibility

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -537,7 +537,7 @@ impl NodeCollection {
                     i_slint_core::items::AccessibleRole::ListItem => Role::ListBoxOption,
                     i_slint_core::items::AccessibleRole::Image => Role::Image,
                     i_slint_core::items::AccessibleRole::RadioButton => Role::RadioButton,
-                    i_slint_core::items::AccessibleRole::RadioGroup => Role::Group,
+                    i_slint_core::items::AccessibleRole::RadioGroup => Role::RadioGroup,
                     i_slint_core::items::AccessibleRole::Banner => Role::Banner,
                     i_slint_core::items::AccessibleRole::Complementary => Role::Complementary,
                     i_slint_core::items::AccessibleRole::ContentInfo => Role::ContentInfo,

--- a/internal/compiler/widgets/common/radiobutton-base.slint
+++ b/internal/compiler/widgets/common/radiobutton-base.slint
@@ -5,6 +5,7 @@ export component RadioButtonBase {
     in property <string> label;
     in property <bool> enabled <=> touch-area.enabled;
     in property <bool> checked: false;
+    in property <int> item-index: -1;
 
     out property <bool> has-focus: focus-scope.has-focus;
     out property <bool> pressed: touch-area.pressed;
@@ -17,6 +18,7 @@ export component RadioButtonBase {
     accessible-label: root.label;
     accessible-checked <=> root.checked;
     accessible-role: radio-button;
+    accessible-item-index: root.item-index;
     width: 100%;
     height: 100%;
 

--- a/internal/compiler/widgets/common/radiogroup-base.slint
+++ b/internal/compiler/widgets/common/radiogroup-base.slint
@@ -15,7 +15,7 @@ export component RadioGroupBase {
     callback selected(string);
 
     public function select(index: int) {
-        if root.enabled && index >= 0 && index < root.model.length && !root.model[index].disabled {
+        if root.enabled && index != root.current-index && index >= 0 && index < root.model.length && !root.model[index].disabled {
             root.current-index = index;
             root.update-current-value();
             root.selected(root.current-value);

--- a/internal/compiler/widgets/cosmic/radiogroup.slint
+++ b/internal/compiler/widgets/cosmic/radiogroup.slint
@@ -25,7 +25,7 @@ component RadioButton {
 
     states [
         disabled when !root.enabled: {
-            opacity: 0.5;
+            layout.opacity: 0.5;
         }
         checked when root.checked: {
             border.border-color: CosmicPalette.accent-background;

--- a/internal/compiler/widgets/cosmic/radiogroup.slint
+++ b/internal/compiler/widgets/cosmic/radiogroup.slint
@@ -12,6 +12,7 @@ component RadioButton {
     in property <string> label <=> base.label;
     in property <bool> enabled <=> base.enabled;
     in property <bool> checked <=> base.checked;
+    in property <int> item-index <=> base.item-index;
     out property <bool> has-focus <=> base.has-focus;
 
     callback selected <=> base.selected;
@@ -93,7 +94,8 @@ export component RadioGroup {
     accessible-role: radio-group;
     accessible-label: root.title;
     accessible-enabled: root.enabled;
-    accessible-value <=> root.current-value;
+    accessible-orientation: root.orientation;
+    accessible-item-count: root.model.length;
 
     VerticalLayout {
         spacing: 8px;
@@ -114,6 +116,7 @@ export component RadioGroup {
                 label: entry.text;
                 enabled: root.enabled && !entry.disabled;
                 checked: root.current-index == index;
+                item-index: index;
                 height: 28px;
 
                 focus-change(gained) => {

--- a/internal/compiler/widgets/cupertino/radiogroup.slint
+++ b/internal/compiler/widgets/cupertino/radiogroup.slint
@@ -12,6 +12,7 @@ component RadioButton {
     in property <string> label <=> base.label;
     in property <bool> enabled <=> base.enabled;
     in property <bool> checked <=> base.checked;
+    in property <int> item-index <=> base.item-index;
     out property <bool> has-focus <=> base.has-focus;
 
     callback selected <=> base.selected;
@@ -91,7 +92,8 @@ export component RadioGroup {
     accessible-role: radio-group;
     accessible-label: root.title;
     accessible-enabled: root.enabled;
-    accessible-value <=> root.current-value;
+    accessible-orientation: root.orientation;
+    accessible-item-count: root.model.length;
 
     VerticalLayout {
         spacing: 8px;
@@ -112,6 +114,7 @@ export component RadioGroup {
                 label: entry.text;
                 enabled: root.enabled && !entry.disabled;
                 checked: root.current-index == index;
+                item-index: index;
                 height: 28px;
 
                 focus-change(gained) => {

--- a/internal/compiler/widgets/cupertino/radiogroup.slint
+++ b/internal/compiler/widgets/cupertino/radiogroup.slint
@@ -24,7 +24,7 @@ component RadioButton {
 
     states [
         disabled when !root.enabled: {
-            opacity: 0.5;
+            layout.opacity: 0.5;
         }
         pressed when base.pressed: {
             root.dot-color: root.checked ? CupertinoPalette.secondary-accent-background : CupertinoPalette.hover;

--- a/internal/compiler/widgets/fluent/radiogroup.slint
+++ b/internal/compiler/widgets/fluent/radiogroup.slint
@@ -12,6 +12,7 @@ component RadioButton {
     in property <string> label <=> base.label;
     in property <bool> enabled <=> base.enabled;
     in property <bool> checked <=> base.checked;
+    in property <int> item-index <=> base.item-index;
     out property <bool> has-focus <=> base.has-focus;
 
     callback selected <=> base.selected;
@@ -108,7 +109,8 @@ export component RadioGroup {
     accessible-role: radio-group;
     accessible-label: root.title;
     accessible-enabled: root.enabled;
-    accessible-value <=> root.current-value;
+    accessible-orientation: root.orientation;
+    accessible-item-count: root.model.length;
 
     VerticalLayout {
         spacing: 8px;
@@ -129,6 +131,7 @@ export component RadioGroup {
                 label: entry.text;
                 enabled: root.enabled && !entry.disabled;
                 checked: root.current-index == index;
+                item-index: index;
                 height: 32px;
 
                 focus-change(gained) => {

--- a/internal/compiler/widgets/material/radiogroup.slint
+++ b/internal/compiler/widgets/material/radiogroup.slint
@@ -11,6 +11,7 @@ component RadioButton {
     in property <string> label <=> base.label;
     in property <bool> enabled <=> base.enabled;
     in property <bool> checked <=> base.checked;
+    in property <int> item-index <=> base.item-index;
     out property <bool> has-focus <=> base.has-focus;
 
     callback selected <=> base.selected;
@@ -99,7 +100,8 @@ export component RadioGroup {
     accessible-role: radio-group;
     accessible-label: root.title;
     accessible-enabled: root.enabled;
-    accessible-value <=> root.current-value;
+    accessible-orientation: root.orientation;
+    accessible-item-count: root.model.length;
 
     VerticalLayout {
         spacing: 8px;
@@ -120,6 +122,7 @@ export component RadioGroup {
                 label: entry.text;
                 enabled: root.enabled && !entry.disabled;
                 checked: root.current-index == index;
+                item-index: index;
                 height: 32px;
 
                 focus-change(gained) => {

--- a/internal/compiler/widgets/qt/radiogroup.slint
+++ b/internal/compiler/widgets/qt/radiogroup.slint
@@ -10,6 +10,7 @@ component RadioButton {
     in property <string> label <=> base.label;
     in property <bool> enabled <=> base.enabled;
     in property <bool> checked <=> base.checked;
+    in property <int> item-index <=> base.item-index;
     out property <bool> has-focus <=> base.has-focus;
 
     callback selected <=> base.selected;
@@ -93,7 +94,8 @@ export component RadioGroup {
     accessible-role: radio-group;
     accessible-label: root.title;
     accessible-enabled: root.enabled;
-    accessible-value <=> root.current-value;
+    accessible-orientation: root.orientation;
+    accessible-item-count: root.model.length;
 
     VerticalLayout {
         spacing: 8px;
@@ -112,6 +114,7 @@ export component RadioGroup {
                 label: entry.text;
                 enabled: root.enabled && !entry.disabled;
                 checked: root.current-index == index;
+                item-index: index;
                 height: 28px;
 
                 focus-change(gained) => {

--- a/internal/compiler/widgets/qt/radiogroup.slint
+++ b/internal/compiler/widgets/qt/radiogroup.slint
@@ -22,7 +22,7 @@ component RadioButton {
 
     states [
         disabled when !root.enabled: {
-            opacity: 0.5;
+            layout.opacity: 0.5;
         }
         pressed when base.pressed: {
             root.dot-color: root.checked ? #205ed8 : #d0d0d0;

--- a/tests/cases/accessibility/materialized.slint
+++ b/tests/cases/accessibility/materialized.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore innerlabel mycombo myradiogroup
+// cSpell: ignore innerlabel mycombo myradiogroup myradiobutton
 // Test the propagation of maximum and minimum size through nested grid layouts
 
 component Btn inherits Rectangle {
@@ -37,6 +37,15 @@ component ComboBox inherits Rectangle {
 component RadioGroup inherits Rectangle {
     accessible-role: radio-group;
     accessible-label: "myradiogroup";
+    accessible-orientation: Orientation.horizontal;
+    accessible-item-count: 3;
+}
+
+component RadioBtn inherits Rectangle {
+    in property <int> index;
+    accessible-role: radio-button;
+    accessible-label: "myradiobutton";
+    accessible-item-index: root.index;
 }
 
 component TestCase inherits Rectangle {
@@ -62,6 +71,8 @@ component TestCase inherits Rectangle {
         ComboBox {}
 
         rg := RadioGroup {}
+
+        rb := RadioBtn { index: 2; }
     }
 
     for t in ["abc"] : Text { x:0;y:0; text: t; accessible-description: t;  }
@@ -74,12 +85,18 @@ component TestCase inherits Rectangle {
     in-out property<string> materialized_txt_label: txt.accessible-label;
     in-out property<AccessibleRole> materialized_rg_role: rg.accessible-role;
     in-out property<string> materialized_rg_label: rg.accessible-label;
+    in-out property<Orientation> materialized_rg_orientation: rg.accessible-orientation;
+    in-out property<int> materialized_rg_item_count: rg.accessible-item-count;
+    in-out property<int> materialized_rb_item_index: rb.accessible-item-index;
+    in-out property<AccessibleRole> materialized_rb_role: rb.accessible-role;
 
     in-out property <bool> test:
         root.materialized_b1_role == AccessibleRole.button && root.materialized_b2_label == "minus"
         && root.materialized_vl_label == "" && root.materialized_vl_role == AccessibleRole.none
         && root.materialized_txt_label == "automatic text value" && root.materialized_txt_role == AccessibleRole.text
         && root.materialized_rg_role == AccessibleRole.radio-group && root.materialized_rg_label == "myradiogroup"
+        && root.materialized_rg_orientation == Orientation.horizontal && root.materialized_rg_item_count == 3
+        && root.materialized_rb_role == AccessibleRole.radio-button && root.materialized_rb_item_index == 2
         && cb.accessible-checked && !b1.accessible-checked;
 }
 
@@ -100,6 +117,7 @@ assert!(instance.get_test());
 assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "mycombo").collect::<Vec<_>>().len(), 1);
 assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "innerlabel").collect::<Vec<_>>().len(), 1);
 assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "myradiogroup").collect::<Vec<_>>().len(), 1);
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "myradiobutton").collect::<Vec<_>>().len(), 1);
 ```
 
 ```js

--- a/tests/cases/widgets/radiogroup.slint
+++ b/tests/cases/widgets/radiogroup.slint
@@ -1,0 +1,128 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { RadioGroup } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    in-out property <int> selected-count: 0;
+    in-out property <string> last-selected;
+    in-out property <int> current-index <=> group.current-index;
+    in-out property <string> current-value <=> group.current-value;
+    out property <bool> has-focus <=> group.has-focus;
+
+    HorizontalLayout {
+        alignment: start;
+        group := RadioGroup {
+            title: "Colors";
+            current-index: -1;
+            model: [
+                { text: "Red" },
+                { text: "Green" },
+                { text: "Blue", disabled: true },
+            ];
+            selected(value) => {
+                root.selected-count += 1;
+                root.last-selected = value;
+            }
+        }
+    }
+}
+
+/*
+
+```rust
+use slint::platform::Key;
+use slint::platform::PointerEventButton;
+use slint::SharedString;
+use slint_testing::{AccessibleRole, Orientation};
+
+let instance = TestCase::new().unwrap();
+
+// Nothing is selected initially.
+assert_eq!(instance.get_current_index(), -1);
+assert_eq!(instance.get_selected_count(), 0);
+assert_eq!(instance.get_has_focus(), false);
+
+// The group exposes its accessibility properties, including orientation and the size of the set.
+let group = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Colors").next().unwrap();
+assert_eq!(group.accessible_role(), Some(AccessibleRole::RadioGroup));
+assert_eq!(group.accessible_orientation(), Some(Orientation::Vertical));
+assert_eq!(group.accessible_item_count(), Some(3));
+assert_eq!(group.accessible_enabled(), Some(true));
+// A radio group has no value of its own; the selection is conveyed by the checked button.
+assert_eq!(group.accessible_value(), None);
+
+// Each radio button exposes its role, checkable state and position in the set.
+let red = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Red").next().unwrap();
+let green = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Green").next().unwrap();
+let blue = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Blue").next().unwrap();
+assert_eq!(red.accessible_role(), Some(AccessibleRole::RadioButton));
+assert_eq!(red.accessible_checkable(), Some(true));
+assert_eq!(red.accessible_item_index(), Some(0));
+assert_eq!(green.accessible_item_index(), Some(1));
+assert_eq!(blue.accessible_item_index(), Some(2));
+assert_eq!(red.accessible_checked(), Some(false));
+assert_eq!(red.accessible_enabled(), Some(true));
+// The disabled entry is reported as disabled.
+assert_eq!(blue.accessible_enabled(), Some(false));
+
+// Tabbing into the group moves focus into it without changing the selection
+// (keyboard navigation with the arrow keys is not yet implemented).
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Tab));
+assert_eq!(instance.get_has_focus(), true);
+assert_eq!(instance.get_current_index(), -1);
+assert_eq!(instance.get_selected_count(), 0);
+assert_eq!(red.accessible_checked(), Some(false));
+
+// Clicking a radio button updates the selection.
+red.mock_single_click(PointerEventButton::Left);
+assert_eq!(instance.get_current_index(), 0);
+assert_eq!(instance.get_current_value(), SharedString::from("Red"));
+assert_eq!(instance.get_selected_count(), 1);
+assert_eq!(instance.get_last_selected(), SharedString::from("Red"));
+assert_eq!(red.accessible_checked(), Some(true));
+
+// Clicking the already-checked radio button does not update the selection again.
+red.mock_single_click(PointerEventButton::Left);
+assert_eq!(instance.get_current_index(), 0);
+assert_eq!(instance.get_selected_count(), 1);
+
+// Clicking another radio button updates the selection.
+green.mock_single_click(PointerEventButton::Left);
+assert_eq!(instance.get_current_index(), 1);
+assert_eq!(instance.get_current_value(), SharedString::from("Green"));
+assert_eq!(instance.get_selected_count(), 2);
+assert_eq!(instance.get_last_selected(), SharedString::from("Green"));
+assert_eq!(green.accessible_checked(), Some(true));
+assert_eq!(red.accessible_checked(), Some(false));
+
+// Clicking a disabled radio button does nothing.
+blue.mock_single_click(PointerEventButton::Left);
+assert_eq!(instance.get_current_index(), 1);
+assert_eq!(instance.get_selected_count(), 2);
+
+// The accessible default action selects a radio button and updates the checked state.
+red.invoke_accessible_default_action();
+assert_eq!(instance.get_current_index(), 0);
+assert_eq!(instance.get_selected_count(), 3);
+assert_eq!(instance.get_last_selected(), SharedString::from("Red"));
+assert_eq!(red.accessible_checked(), Some(true));
+assert_eq!(green.accessible_checked(), Some(false));
+
+// The accessible default action on the already-checked button does not update the selection again.
+red.invoke_accessible_default_action();
+assert_eq!(instance.get_current_index(), 0);
+assert_eq!(instance.get_selected_count(), 3);
+assert_eq!(red.accessible_checked(), Some(true));
+
+// The accessible default action does nothing on a disabled radio button.
+blue.invoke_accessible_default_action();
+assert_eq!(instance.get_current_index(), 0);
+assert_eq!(instance.get_selected_count(), 3);
+assert_eq!(blue.accessible_checked(), Some(false));
+```
+
+*/


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Exposes the orientation, item count and index in the accessibility tree, use proper AccessKit role and remove accessible value (invalid to set on radio groups).