### PR TITLE
lsp: rename Rust/C++ accessors alongside Slint properties (#11841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ All notable changes to this project are documented in this file.
  - LSP: Update the preview highlight on hover.
  - LSP: formatter preserve newlines in expression, as well as enum declarations and export lists.
  - LSP: show runtime warnings in the console (eg: missing image file).
- - LSP: New "Rename property and its Rust/C++ accessors..." refactor (CodeAction) on public property, callback, and function identifiers in `.slint` files. Prompts for the new name in the editor, runs the standard Slint rename, and additionally rewrites the generated Rust/C++ accessor (`get_<n>`, `set_<n>`, `invoke_<n>`, `on_<n>`) at every textual call site in workspace `.rs`, `.cpp`, and header files. Requires editor extension support (initially VS Code). The scanner is purely textual; users review the rename preview before applying. (#11841)
+ - LSP: When renaming a public property, callback, or function in `.slint`, the LSP now asks (via `window/showMessageRequest`) whether to additionally rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`, `invoke_<n>`, `on_<n>`) at every textual call site in workspace `.rs`, `.cpp`, and header files. A *Skip and don't ask again* option suppresses the prompt for the rest of the session for that declaration. The scanner is purely textual and tokenizes identifiers via Unicode XID; review the proposed edits before applying. No editor-specific extension is required — any LSP client implementing standard rename + `showMessageRequest` gets the feature. (#11841)
  - Improved file watcher by tracking new file and moved directories.
  - Compiler: Report precise error location within `@markdown` and `@tr` strings. (#11577)
  - Added MCP server feature. (#11542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,11 @@ All notable changes to this project are documented in this file.
  - LSP: Update the preview highlight on hover.
  - LSP: formatter preserve newlines in expression, as well as enum declarations and export lists.
  - LSP: show runtime warnings in the console (eg: missing image file).
- - LSP: When renaming a public property, callback, or function in `.slint`, the LSP now asks (via `window/showMessageRequest`) whether to additionally rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`, `invoke_<n>`, `on_<n>`) at every textual call site in workspace `.rs`, `.cpp`, and header files. A *Skip and don't ask again* option suppresses the prompt for the rest of the session for that declaration. The scanner is purely textual and tokenizes identifiers via Unicode XID; review the proposed edits before applying. No editor-specific extension is required — any LSP client implementing standard rename + `showMessageRequest` gets the feature. (#11841)
+ - LSP: When renaming a public property, callback, or function in `.slint`, the LSP can search and replace matching generated Rust/C++ accessor identifiers in workspace source files.
+   The search is textual and includes comments and strings.
+   *Skip and don't ask again* suppresses the prompt for the rest of the LSP session.
+   Clients may apply the follow-up edit immediately, so inspect the resulting changes with source control.
+   This feature requires standard rename, `window/showMessageRequest`, and `workspace/applyEdit` support. (#11841)
  - Improved file watcher by tracking new file and moved directories.
  - Compiler: Report precise error location within `@markdown` and `@tr` strings. (#11577)
  - Added MCP server feature. (#11542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project are documented in this file.
  - LSP: Update the preview highlight on hover.
  - LSP: formatter preserve newlines in expression, as well as enum declarations and export lists.
  - LSP: show runtime warnings in the console (eg: missing image file).
+ - LSP: Renaming a public property, callback, or function in a `.slint` file can now also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`, `invoke_<n>`, `on_<n>`) at call sites in workspace `.rs`, `.cpp`, and header files. Opt-in via the new `slint.renameAccessorsInHostLanguages` config (`"never"` (default) / `"always"`). (#11841)
  - Improved file watcher by tracking new file and moved directories.
  - Compiler: Report precise error location within `@markdown` and `@tr` strings. (#11577)
  - Added MCP server feature. (#11542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ All notable changes to this project are documented in this file.
  - LSP: Update the preview highlight on hover.
  - LSP: formatter preserve newlines in expression, as well as enum declarations and export lists.
  - LSP: show runtime warnings in the console (eg: missing image file).
- - LSP: Renaming a public property, callback, or function in a `.slint` file can now also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`, `invoke_<n>`, `on_<n>`) at call sites in workspace `.rs`, `.cpp`, and header files. Opt-in via the new `slint.renameAccessorsInHostLanguages` config (`"never"` (default) / `"always"`). (#11841)
+ - LSP: New "Rename property and its Rust/C++ accessors..." refactor (CodeAction) on public property, callback, and function identifiers in `.slint` files. Prompts for the new name in the editor, runs the standard Slint rename, and additionally rewrites the generated Rust/C++ accessor (`get_<n>`, `set_<n>`, `invoke_<n>`, `on_<n>`) at every textual call site in workspace `.rs`, `.cpp`, and header files. Requires editor extension support (initially VS Code). The scanner is purely textual; users review the rename preview before applying. (#11841)
  - Improved file watcher by tracking new file and moved directories.
  - Compiler: Report precise error location within `@markdown` and `@tr` strings. (#11577)
  - Added MCP server feature. (#11542)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10613,6 +10613,7 @@ dependencies = [
  "i-slint-compiler",
  "i-slint-core",
  "i-slint-live-preview",
+ "icu_properties",
  "itertools 0.14.0",
  "js-sys",
  "lsp-server",

--- a/docs/development/lsp-architecture.md
+++ b/docs/development/lsp-architecture.md
@@ -320,55 +320,75 @@ sources.
 
 Renaming a public property/callback/function in `.slint` can optionally
 also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`,
-`invoke_<n>`, `on_<n>`) at every call site in the workspace. The
-behavior is gated by the user-facing `slint.renameAccessorsInHostLanguages`
-workspace setting (`"never"` (default) / `"always"`).
+`invoke_<n>`, `on_<n>`) at every textual call site in the workspace.
+The feature surfaces as a CodeAction ("Rename property and its Rust/C++
+accessors...") on public property/callback/function identifiers; the
+standard `textDocument/rename` is unchanged.
 
-The pipeline, invoked from the Rename handler when the policy is
-`"always"`:
+The flow involves both the LSP and the editor extension because
+`textDocument/codeAction` cannot precompute the WorkspaceEdit -- the
+server doesn't know the new name at CodeAction time:
 
-1. **Classify** the renamed declaration via
-   `DeclarationNode::host_language_classification` (in
-   `rename_component.rs`). Walks every loaded `Document` (via
-   `DocumentCache::all_documents()`) and, for each exported non-interface
-   component, follows the `inherits` chain looking for a property
-   declaration whose syntax node matches the rename target. The walk is
-   bounded (depth + visited-set) so a cyclic `inherits` chain from a
-   mid-edit state can't hang the synchronous handler. Returns the
-   declaration kind, current name, and source file -- or `None` if the
-   declaration isn't exposed in the generated public API (private
-   visibility, non-`ok_for_public_api` type, not reachable from any
-   exported component, etc.).
-2. **Skip** when `normalize_identifier(new_name) == old_name` -- a
-   kebab/snake no-op rename has no host-language effect.
-3. **Scan** the workspace via
-   `host_language_search::scan_host_language_accessors`. Resolves the
-   scan root (`workspace_folders` → `root_uri` → `root_path`) to the
-   most-specific folder containing the renamed `.slint`, walks it
-   (`std::fs`, no symlink-following, skipping `target/`, `build/`,
-   `node_modules/`, etc., case-insensitive on `.rs`/`.cpp`/`.cc`/`.cxx`/
-   `.h`/`.hpp`/`.hh`), and for each file runs a small lexer state machine
-   that emits word-boundary-aligned matches for the kind-specific
-   accessor names. The lexer skips line comments, block comments,
-   string literals, and short char literals; raw strings, byte strings,
-   lifetimes, and nested block comments are accepted false-positive
-   surface.
-4. **Merge** the resulting `Vec<SingleTextEdit>` into the `.slint`
-   `WorkspaceEdit` via `common::merge_workspace_edits`.
+1. **CodeAction** (server, `get_code_actions` in `language.rs`): when
+   the cursor is on an identifier that
+   `DeclarationNode::host_language_classification` recognizes as a
+   public property/callback/function, return a CodeAction whose
+   `command` is the editor-side `slint.renameWithHostAccessors` with
+   `[uri, position]` arguments.
+2. **Editor prompt** (extension, `extension.ts`): the VS Code extension
+   registers `slint.renameWithHostAccessors`, prompts the user via
+   `window.showInputBox`, and forwards `[uri, position, new_name]` to
+   the LSP-side `slint/renameWithHostAccessors` command via
+   `workspace/executeCommand`. Editors without this command get no
+   feature today (a future Helix/Neovim extension can register the
+   same command name).
+3. **Server command** (server, `rename_with_host_accessors_command` in
+   `language.rs`):
+   - Re-resolves the declaration and runs the standard
+     `DeclarationNode::rename` to produce the `.slint` edits.
+   - Calls `DeclarationNode::host_language_classification`. This walks
+     every loaded `Document` (via `DocumentCache::all_documents()`)
+     and, for each exported non-interface component, follows the
+     `inherits` chain looking for a property declaration whose syntax
+     node matches the rename target. The walk is bounded (depth +
+     visited-set) so a cyclic `inherits` chain from a mid-edit state
+     can't hang the synchronous handler. Returns the declaration
+     kind, current name, and source file -- or `None` if the
+     declaration isn't reachable from any exported component or its
+     visibility/type rules it out.
+   - Skips the scan when
+     `normalize_identifier(new_name) == old_name` (kebab/snake no-op).
+   - Calls `host_language_search::scan_host_language_accessors`. The
+     scan root is the most-specific configured workspace folder
+     containing the renamed `.slint` (`workspace_folders` → `root_uri`
+     → `root_path` fallback chain). Walks with `std::fs`, no symlink
+     following, skipping `target/`, `build/`, `node_modules/`, etc.,
+     case-insensitive on `.rs`/`.cpp`/`.cc`/`.cxx`/`.h`/`.hpp`/`.hh`.
+   - The matcher is **flat textual**: byte-level word-boundary scan
+     for the kind-specific accessor names. No comment/string/raw-
+     string handling -- the rename is honest about being find-and-
+     replace, and the user reviews the edit preview before applying.
+     Word boundaries treat any byte >= 0x80 as identifier-extending
+     so UTF-8 multi-byte characters defeat the boundary.
+   - Merges the resulting `Vec<SingleTextEdit>` into the `.slint`
+     `WorkspaceEdit` via `common::merge_workspace_edits`.
+   - Sends `workspace/applyEdit` to the client with the merged edit;
+     the editor's rename-preview UI shows the full diff.
 
 Failure modes (renamed file outside any workspace folder, or scan
 exceeds its file-count cap) **soft-degrade**: the handler logs a
-`tracing::warn!` and applies only the `.slint` edits. Rejecting the
-whole rename would lose work the user expected; the policy is opt-in
-and the user can disable it if the warnings become a problem.
+`tracing::warn!` and applies only the `.slint` edits. The user
+explicitly invoked the CodeAction; losing the slint edits on top of a
+scanner edge case is worse than partial work.
 
 Accessor names are shared between the codegen (`internal/compiler/
 generator/{rust,cpp}.rs`) and the scanner via
 `internal/compiler/generator/accessor_names.rs`, so the two can't
 drift.
 
-The scanner module is gated `cfg(not(target_arch = "wasm32"))` since
-the WASM LSP has no filesystem.
+The scanner module and command handler are gated
+`cfg(not(target_arch = "wasm32"))` since the WASM LSP has no
+filesystem.
 
 ## Live Preview
 

--- a/docs/development/lsp-architecture.md
+++ b/docs/development/lsp-architecture.md
@@ -32,6 +32,9 @@ The Slint LSP (Language Server Protocol) server provides IDE features for `.slin
 | `tools/lsp/language/semantic_tokens.rs` | Syntax highlighting |
 | `tools/lsp/language/signature_help.rs` | Function/callback signatures |
 | `tools/lsp/common/document_cache.rs` | Document caching and compilation |
+| `tools/lsp/common/rename_component.rs` | Rename of components, structs, enums, properties, callbacks, functions |
+| `tools/lsp/common/host_language_search.rs` | Cross-language rename: walks workspace files to rewrite Rust/C++ accessor call sites |
+| `internal/compiler/generator/accessor_names.rs` | Shared name mapping for Rust/C++ property/callback/function accessors (used by both codegen and the LSP scanner) |
 | `tools/lsp/preview.rs` | Live preview engine |
 | `tools/lsp/fmt/` | Code formatter |
 
@@ -303,6 +306,69 @@ pub fn goto_definition(
 - Type names → Struct/component definition
 - Import paths → Imported file
 - Qualified names → Resolved definition
+
+## Rename
+
+Rename support lives in `tools/lsp/common/rename_component.rs` and is
+dispatched from the `textDocument/rename` handler in `language.rs`. It
+handles components, structs, enums, internal/export names, properties,
+callbacks, and functions through a single `DeclarationNode::rename`
+entry point that returns a `WorkspaceEdit` covering the `.slint`
+sources.
+
+### Cross-language rename
+
+Renaming a public property/callback/function in `.slint` can optionally
+also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`,
+`invoke_<n>`, `on_<n>`) at every call site in the workspace. The
+behavior is gated by the user-facing `slint.renameAccessorsInHostLanguages`
+workspace setting (`"never"` (default) / `"always"`).
+
+The pipeline, invoked from the Rename handler when the policy is
+`"always"`:
+
+1. **Classify** the renamed declaration via
+   `DeclarationNode::host_language_classification` (in
+   `rename_component.rs`). Walks every loaded `Document` (via
+   `DocumentCache::all_documents()`) and, for each exported non-interface
+   component, follows the `inherits` chain looking for a property
+   declaration whose syntax node matches the rename target. The walk is
+   bounded (depth + visited-set) so a cyclic `inherits` chain from a
+   mid-edit state can't hang the synchronous handler. Returns the
+   declaration kind, current name, and source file -- or `None` if the
+   declaration isn't exposed in the generated public API (private
+   visibility, non-`ok_for_public_api` type, not reachable from any
+   exported component, etc.).
+2. **Skip** when `normalize_identifier(new_name) == old_name` -- a
+   kebab/snake no-op rename has no host-language effect.
+3. **Scan** the workspace via
+   `host_language_search::scan_host_language_accessors`. Resolves the
+   scan root (`workspace_folders` → `root_uri` → `root_path`) to the
+   most-specific folder containing the renamed `.slint`, walks it
+   (`std::fs`, no symlink-following, skipping `target/`, `build/`,
+   `node_modules/`, etc., case-insensitive on `.rs`/`.cpp`/`.cc`/`.cxx`/
+   `.h`/`.hpp`/`.hh`), and for each file runs a small lexer state machine
+   that emits word-boundary-aligned matches for the kind-specific
+   accessor names. The lexer skips line comments, block comments,
+   string literals, and short char literals; raw strings, byte strings,
+   lifetimes, and nested block comments are accepted false-positive
+   surface.
+4. **Merge** the resulting `Vec<SingleTextEdit>` into the `.slint`
+   `WorkspaceEdit` via `common::merge_workspace_edits`.
+
+Failure modes (renamed file outside any workspace folder, or scan
+exceeds its file-count cap) **soft-degrade**: the handler logs a
+`tracing::warn!` and applies only the `.slint` edits. Rejecting the
+whole rename would lose work the user expected; the policy is opt-in
+and the user can disable it if the warnings become a problem.
+
+Accessor names are shared between the codegen (`internal/compiler/
+generator/{rust,cpp}.rs`) and the scanner via
+`internal/compiler/generator/accessor_names.rs`, so the two can't
+drift.
+
+The scanner module is gated `cfg(not(target_arch = "wasm32"))` since
+the WASM LSP has no filesystem.
 
 ## Live Preview
 

--- a/docs/development/lsp-architecture.md
+++ b/docs/development/lsp-architecture.md
@@ -318,42 +318,10 @@ sources.
 
 ### Cross-language rename
 
-Renaming a public property/callback/function in `.slint` can optionally
-also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`,
-`invoke_<n>`, `on_<n>`) at every textual call site in the workspace.
-The feature lives inside the standard `textDocument/rename` flow:
-after the `.slint` edits are returned synchronously, an asynchronous
-follow-up detects whether the renamed declaration is exposed in the
-generated public API and (once per declaration per session) prompts
-the user via `window/showMessageRequest` with three actions:
-
-1. **Rewrite Rust/C++ accessors** — runs the host-language scanner
-   and sends a second `workspace/applyEdit` with the textual edits.
-2. **Skip** — leaves the host-language sources unchanged.
-3. **Skip and don't ask again for this declaration** — same as Skip,
-   plus records the suppression for the rest of the session keyed on
-   `(slint_uri, original_name)`. TODO(#12111): persist across sessions
-   once client-side settings storage is available.
-
-The slint rename and the host-language rewrite arrive as two
-independent `workspace/applyEdit` calls; if the user rejects the
-prompt (or dismisses it, or the scanner errors), the slint rename
-still stands. A `window/showMessage` summarizes the outcome in either
-direction.
-
-No per-editor extension is required; any LSP client that implements
-`textDocument/rename` and `window/showMessageRequest` gets the
-feature for free.
-
-Implementation detail (handler shape, scanner algorithm, Unicode
-identifier tokenizer, soft-degrade behavior) lives in the
-module-doc comments of `tools/lsp/common/rename_component.rs` and
-`tools/lsp/common/host_language_search.rs`. Accessor names are the
-single source of truth in
-`internal/compiler/generator/accessor_names.rs`, shared between
-codegen (`rust.rs`, `cpp.rs`) and the scanner so the two can't drift.
-The scanner module is gated `cfg(not(target_arch = "wasm32"))` since
-the WASM LSP has no filesystem.
+Renaming a public property, callback, or function can also search and replace
+its generated Rust/C++ accessors in workspace files.
+See `tools/lsp/common/rename_component.rs` for the rename flow and
+`tools/lsp/common/host_language_search.rs` for the workspace search.
 
 ## Live Preview
 

--- a/docs/development/lsp-architecture.md
+++ b/docs/development/lsp-architecture.md
@@ -321,74 +321,39 @@ sources.
 Renaming a public property/callback/function in `.slint` can optionally
 also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`,
 `invoke_<n>`, `on_<n>`) at every textual call site in the workspace.
-The feature surfaces as a CodeAction ("Rename property and its Rust/C++
-accessors...") on public property/callback/function identifiers; the
-standard `textDocument/rename` is unchanged.
+The feature lives inside the standard `textDocument/rename` flow:
+after the `.slint` edits are returned synchronously, an asynchronous
+follow-up detects whether the renamed declaration is exposed in the
+generated public API and (once per declaration per session) prompts
+the user via `window/showMessageRequest` with three actions:
 
-The flow involves both the LSP and the editor extension because
-`textDocument/codeAction` cannot precompute the WorkspaceEdit -- the
-server doesn't know the new name at CodeAction time:
+1. **Rewrite Rust/C++ accessors** — runs the host-language scanner
+   and sends a second `workspace/applyEdit` with the textual edits.
+2. **Skip** — leaves the host-language sources unchanged.
+3. **Skip and don't ask again for this declaration** — same as Skip,
+   plus records the suppression for the rest of the session keyed on
+   `(slint_uri, original_name)`. TODO(#12111): persist across sessions
+   once client-side settings storage is available.
 
-1. **CodeAction** (server, `get_code_actions` in `language.rs`): when
-   the cursor is on an identifier that
-   `DeclarationNode::host_language_classification` recognizes as a
-   public property/callback/function, return a CodeAction whose
-   `command` is the editor-side `slint.renameWithHostAccessors` with
-   `[uri, position]` arguments.
-2. **Editor prompt** (extension, `extension.ts`): the VS Code extension
-   registers `slint.renameWithHostAccessors`, prompts the user via
-   `window.showInputBox`, and forwards `[uri, position, new_name]` to
-   the LSP-side `slint/renameWithHostAccessors` command via
-   `workspace/executeCommand`. Editors without this command get no
-   feature today (a future Helix/Neovim extension can register the
-   same command name).
-3. **Server command** (server, `rename_with_host_accessors_command` in
-   `language.rs`):
-   - Re-resolves the declaration and runs the standard
-     `DeclarationNode::rename` to produce the `.slint` edits.
-   - Calls `DeclarationNode::host_language_classification`. This walks
-     every loaded `Document` (via `DocumentCache::all_documents()`)
-     and, for each exported non-interface component, follows the
-     `inherits` chain looking for a property declaration whose syntax
-     node matches the rename target. The walk is bounded (depth +
-     visited-set) so a cyclic `inherits` chain from a mid-edit state
-     can't hang the synchronous handler. Returns the declaration
-     kind, current name, and source file -- or `None` if the
-     declaration isn't reachable from any exported component or its
-     visibility/type rules it out.
-   - Skips the scan when
-     `normalize_identifier(new_name) == old_name` (kebab/snake no-op).
-   - Calls `host_language_search::scan_host_language_accessors`. The
-     scan root is the most-specific configured workspace folder
-     containing the renamed `.slint` (`workspace_folders` → `root_uri`
-     → `root_path` fallback chain). Walks with `std::fs`, no symlink
-     following, skipping `target/`, `build/`, `node_modules/`, etc.,
-     case-insensitive on `.rs`/`.cpp`/`.cc`/`.cxx`/`.h`/`.hpp`/`.hh`.
-   - The matcher is **flat textual**: byte-level word-boundary scan
-     for the kind-specific accessor names. No comment/string/raw-
-     string handling -- the rename is honest about being find-and-
-     replace, and the user reviews the edit preview before applying.
-     Word boundaries treat any byte >= 0x80 as identifier-extending
-     so UTF-8 multi-byte characters defeat the boundary.
-   - Merges the resulting `Vec<SingleTextEdit>` into the `.slint`
-     `WorkspaceEdit` via `common::merge_workspace_edits`.
-   - Sends `workspace/applyEdit` to the client with the merged edit;
-     the editor's rename-preview UI shows the full diff.
+The slint rename and the host-language rewrite arrive as two
+independent `workspace/applyEdit` calls; if the user rejects the
+prompt (or dismisses it, or the scanner errors), the slint rename
+still stands. A `window/showMessage` summarizes the outcome in either
+direction.
 
-Failure modes (renamed file outside any workspace folder, or scan
-exceeds its file-count cap) **soft-degrade**: the handler logs a
-`tracing::warn!` and applies only the `.slint` edits. The user
-explicitly invoked the CodeAction; losing the slint edits on top of a
-scanner edge case is worse than partial work.
+No per-editor extension is required; any LSP client that implements
+`textDocument/rename` and `window/showMessageRequest` gets the
+feature for free.
 
-Accessor names are shared between the codegen (`internal/compiler/
-generator/{rust,cpp}.rs`) and the scanner via
-`internal/compiler/generator/accessor_names.rs`, so the two can't
-drift.
-
-The scanner module and command handler are gated
-`cfg(not(target_arch = "wasm32"))` since the WASM LSP has no
-filesystem.
+Implementation detail (handler shape, scanner algorithm, Unicode
+identifier tokenizer, soft-degrade behavior) lives in the
+module-doc comments of `tools/lsp/common/rename_component.rs` and
+`tools/lsp/common/host_language_search.rs`. Accessor names are the
+single source of truth in
+`internal/compiler/generator/accessor_names.rs`, shared between
+codegen (`rust.rs`, `cpp.rs`) and the scanner so the two can't drift.
+The scanner module is gated `cfg(not(target_arch = "wasm32"))` since
+the WASM LSP has no filesystem.
 
 ## Live Preview
 

--- a/docs/development/lsp-architecture.md
+++ b/docs/development/lsp-architecture.md
@@ -33,7 +33,7 @@ The Slint LSP (Language Server Protocol) server provides IDE features for `.slin
 | `tools/lsp/language/signature_help.rs` | Function/callback signatures |
 | `tools/lsp/common/document_cache.rs` | Document caching and compilation |
 | `tools/lsp/common/rename_component.rs` | Rename of components, structs, enums, properties, callbacks, functions |
-| `tools/lsp/common/host_language_search.rs` | Cross-language rename: walks workspace files to rewrite Rust/C++ accessor call sites |
+| `tools/lsp/common/host_language_search.rs` | Cross-language rename: walks workspace files to replace matching Rust/C++ accessor identifiers |
 | `internal/compiler/generator/accessor_names.rs` | Shared name mapping for Rust/C++ property/callback/function accessors (used by both codegen and the LSP scanner) |
 | `tools/lsp/preview.rs` | Live preview engine |
 | `tools/lsp/fmt/` | Code formatter |

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,7 +10,7 @@ This extension for VS Code adds support for the [Slint](https://slint.dev) desig
 -   Live Preview of a .slint file
 -   Completion of properties
 -   Jump to definition (currently, only definition of Component)
--   Rename refactoring across `.slint` files, with opt-in propagation to Rust/C++ accessor call sites in workspace `.rs`/`.cpp`/`.h` files (set `slint.renameAccessorsInHostLanguages` to `"always"`)
+-   Rename refactoring across `.slint` files, plus a "Rename property and its Rust/C++ accessors..." CodeAction that additionally rewrites the generated accessor at call sites in workspace `.rs`/`.cpp`/`.h` files (textual; review the rename preview before applying)
 
 ## Installation
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,6 +10,7 @@ This extension for VS Code adds support for the [Slint](https://slint.dev) desig
 -   Live Preview of a .slint file
 -   Completion of properties
 -   Jump to definition (currently, only definition of Component)
+-   Rename refactoring across `.slint` files, with opt-in propagation to Rust/C++ accessor call sites in workspace `.rs`/`.cpp`/`.h` files (set `slint.renameAccessorsInHostLanguages` to `"always"`)
 
 ## Installation
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,7 +10,9 @@ This extension for VS Code adds support for the [Slint](https://slint.dev) desig
 -   Live Preview of a .slint file
 -   Completion of properties
 -   Jump to definition (currently, only definition of Component)
--   Rename refactoring across `.slint` files. When renaming a public property/callback/function, the LSP also offers to rewrite the generated Rust/C++ accessor at every call site in workspace `.rs`/`.cpp`/`.h` files (textual; review the edits before applying)
+-   Rename refactoring across `.slint` files.
+    When renaming a public property, callback, or function, the LSP can search and replace matching generated Rust/C++ accessor identifiers in workspace Rust and C++ source files.
+    The search is textual and includes comments and strings; inspect the resulting changes with source control.
 
 ## Installation
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,7 +10,7 @@ This extension for VS Code adds support for the [Slint](https://slint.dev) desig
 -   Live Preview of a .slint file
 -   Completion of properties
 -   Jump to definition (currently, only definition of Component)
--   Rename refactoring across `.slint` files, plus a "Rename property and its Rust/C++ accessors..." CodeAction that additionally rewrites the generated accessor at call sites in workspace `.rs`/`.cpp`/`.h` files (textual; review the rename preview before applying)
+-   Rename refactoring across `.slint` files. When renaming a public property/callback/function, the LSP also offers to rewrite the generated Rust/C++ accessor at every call site in workspace `.rs`/`.cpp`/`.h` files (textual; review the edits before applying)
 
 ## Installation
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -168,17 +168,6 @@
           "type": "string",
           "default": "",
           "description": "The path to the slint-lsp. Leave empty to use the packaged LSP"
-        },
-        "slint.renameAccessorsInHostLanguages": {
-          "type": "string",
-          "enum": ["never", "always"],
-          "enumDescriptions": [
-            "Leave Rust/C++ files untouched. Default.",
-            "Extend each rename WorkspaceEdit with textual rewrites of the generated accessor names in workspace .rs/.cpp/header files."
-          ],
-          "default": "never",
-          "description": "Whether renaming a Slint property/callback/function should also rewrite the generated Rust/C++ accessor at call sites in workspace source files.",
-          "markdownDescription": "When renaming a property, callback, or function in a `.slint` file, also rewrite the generated Rust/C++ accessor (`get_<name>`, `set_<name>`, `invoke_<name>`, `on_<name>`) at call sites in workspace `.rs`, `.cpp`, and header files.\n\n- `\"never\"` (default) leaves host-language files untouched.\n- `\"always\"` walks the workspace folder containing the renamed `.slint` and proposes textual replacements.\n\nThe scanner is intentionally simple and may produce false positives in unrelated code that happens to use the same accessor name. **Review the rename preview before applying.**"
         }
       }
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -168,6 +168,17 @@
           "type": "string",
           "default": "",
           "description": "The path to the slint-lsp. Leave empty to use the packaged LSP"
+        },
+        "slint.renameAccessorsInHostLanguages": {
+          "type": "string",
+          "enum": ["never", "always"],
+          "enumDescriptions": [
+            "Leave Rust/C++ files untouched. Default.",
+            "Extend each rename WorkspaceEdit with textual rewrites of the generated accessor names in workspace .rs/.cpp/header files."
+          ],
+          "default": "never",
+          "description": "Whether renaming a Slint property/callback/function should also rewrite the generated Rust/C++ accessor at call sites in workspace source files.",
+          "markdownDescription": "When renaming a property, callback, or function in a `.slint` file, also rewrite the generated Rust/C++ accessor (`get_<name>`, `set_<name>`, `invoke_<name>`, `on_<name>`) at call sites in workspace `.rs`, `.cpp`, and header files.\n\n- `\"never\"` (default) leaves host-language files untouched.\n- `\"always\"` walks the workspace folder containing the renamed `.slint` and proposes textual replacements.\n\nThe scanner is intentionally simple and may produce false positives in unrelated code that happens to use the same accessor name. **Review the rename preview before applying.**"
         }
       }
     },

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -291,7 +291,10 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand("slint.newProject", newProject),
         vscode.commands.registerCommand(
             "slint.renameWithHostAccessors",
-            async (uri: string, position: { line: number; character: number }) => {
+            async (
+                uri: string,
+                position: { line: number; character: number },
+            ) => {
                 // The CodeAction invokes us with the LSP-shaped uri + position
                 // of the declaration. Prompt for the new name and forward to
                 // the LSP-side command which runs the slint rename + scanner
@@ -309,7 +312,11 @@ export function activate(context: vscode.ExtensionContext) {
                 if (!newName) {
                     return;
                 }
-                await lsp_commands.renameWithHostAccessors(uri, position, newName);
+                await lsp_commands.renameWithHostAccessors(
+                    uri,
+                    position,
+                    newName,
+                );
             },
         ),
     );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -289,6 +289,29 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand("slint.newProject", newProject),
+        vscode.commands.registerCommand(
+            "slint.renameWithHostAccessors",
+            async (uri: string, position: { line: number; character: number }) => {
+                // The CodeAction invokes us with the LSP-shaped uri + position
+                // of the declaration. Prompt for the new name and forward to
+                // the LSP-side command which runs the slint rename + scanner
+                // and sends back the workspace/applyEdit.
+                const newName = await vscode.window.showInputBox({
+                    title: "Rename Slint declaration and its Rust/C++ accessors",
+                    prompt: "Enter the new name. The Rust/C++ call sites will be rewritten textually; review the preview before applying.",
+                    validateInput: (value) => {
+                        if (!value.trim()) {
+                            return "Name cannot be empty";
+                        }
+                        return null;
+                    },
+                });
+                if (!newName) {
+                    return;
+                }
+                await lsp_commands.renameWithHostAccessors(uri, position, newName);
+            },
+        ),
     );
 
     startTelemetryTimer(context, telemetryLogger);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -11,7 +11,6 @@ import * as vscode from "vscode";
 import { SlintTelemetrySender } from "./telemetry";
 import * as common from "./common";
 import { NotificationType } from "vscode-languageclient";
-import * as lsp_commands from "./lsp_commands";
 
 import {
     LanguageClient,
@@ -289,36 +288,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand("slint.newProject", newProject),
-        vscode.commands.registerCommand(
-            "slint.renameWithHostAccessors",
-            async (
-                uri: string,
-                position: { line: number; character: number },
-            ) => {
-                // The CodeAction invokes us with the LSP-shaped uri + position
-                // of the declaration. Prompt for the new name and forward to
-                // the LSP-side command which runs the slint rename + scanner
-                // and sends back the workspace/applyEdit.
-                const newName = await vscode.window.showInputBox({
-                    title: "Rename Slint declaration and its Rust/C++ accessors",
-                    prompt: "Enter the new name. The Rust/C++ call sites will be rewritten textually; review the preview before applying.",
-                    validateInput: (value) => {
-                        if (!value.trim()) {
-                            return "Name cannot be empty";
-                        }
-                        return null;
-                    },
-                });
-                if (!newName) {
-                    return;
-                }
-                await lsp_commands.renameWithHostAccessors(
-                    uri,
-                    position,
-                    newName,
-                );
-            },
-        ),
     );
 
     startTelemetryTimer(context, telemetryLogger);

--- a/editors/vscode/src/lsp_commands.ts
+++ b/editors/vscode/src/lsp_commands.ts
@@ -21,3 +21,20 @@ import * as vscode from "vscode";
 export function showPreview(url: LspURI, component: string): Thenable<unknown> {
     return vscode.commands.executeCommand("slint/showPreview", url, component);
 }
+
+// Send the LSP-side `slint/renameWithHostAccessors` command. The LSP runs the
+// Slint rename, merges in textual rewrites of the generated Rust/C++
+// accessor at workspace call sites, and sends back a `workspace/applyEdit`
+// for the editor to apply.
+export function renameWithHostAccessors(
+    uri: LspURI,
+    position: { line: number; character: number },
+    newName: string,
+): Thenable<unknown> {
+    return vscode.commands.executeCommand(
+        "slint/renameWithHostAccessors",
+        uri,
+        position,
+        newName,
+    );
+}

--- a/editors/vscode/src/lsp_commands.ts
+++ b/editors/vscode/src/lsp_commands.ts
@@ -21,20 +21,3 @@ import * as vscode from "vscode";
 export function showPreview(url: LspURI, component: string): Thenable<unknown> {
     return vscode.commands.executeCommand("slint/showPreview", url, component);
 }
-
-// Send the LSP-side `slint/renameWithHostAccessors` command. The LSP runs the
-// Slint rename, merges in textual rewrites of the generated Rust/C++
-// accessor at workspace call sites, and sends back a `workspace/applyEdit`
-// for the editor to apply.
-export function renameWithHostAccessors(
-    uri: LspURI,
-    position: { line: number; character: number },
-    newName: string,
-): Thenable<unknown> {
-    return vscode.commands.executeCommand(
-        "slint/renameWithHostAccessors",
-        uri,
-        position,
-        newName,
-    );
-}

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -19,6 +19,8 @@ use crate::langtype::{BuiltinStruct, ElementType, StructName};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, Document, ElementRc};
 
+pub mod accessor_names;
+
 #[cfg(feature = "cpp")]
 pub mod cpp;
 #[cfg(feature = "cpp")]

--- a/internal/compiler/generator/accessor_names.rs
+++ b/internal/compiler/generator/accessor_names.rs
@@ -1,0 +1,168 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Single source of truth for the names of the public accessors emitted by the
+//! Rust and C++ backends for a property, callback, or function.
+//!
+//! Both backends apply only one transformation to the declaration name (`-` →
+//! `_`) and then prefix it with `get_`/`set_`/`invoke_`/`on_` depending on the
+//! declaration kind. Keeping that mapping here means codegen sites and any
+//! consumer that needs to refer to accessors by name (notably the LSP, when
+//! computing cross-language rename edits) cannot drift.
+
+use smol_str::{SmolStr, format_smolstr};
+
+/// Kind of a public Slint declaration whose accessors we emit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DeclarationKind {
+    Property,
+    Callback,
+    Function,
+}
+
+/// Individual accessor a backend emits for a public declaration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AccessorKind {
+    /// `get_<name>` — property getter.
+    Getter,
+    /// `set_<name>` — property setter.
+    Setter,
+    /// `invoke_<name>` — callback or function caller.
+    Invoker,
+    /// `on_<name>` — callback handler installer.
+    Handler,
+}
+
+impl AccessorKind {
+    pub const fn prefix(self) -> &'static str {
+        match self {
+            Self::Getter => "get_",
+            Self::Setter => "set_",
+            Self::Invoker => "invoke_",
+            Self::Handler => "on_",
+        }
+    }
+}
+
+impl DeclarationKind {
+    /// Accessor kinds emitted for this declaration, in the order both backends
+    /// declare them.
+    pub const fn accessor_kinds(self) -> &'static [AccessorKind] {
+        match self {
+            Self::Property => &[AccessorKind::Getter, AccessorKind::Setter],
+            Self::Callback => &[AccessorKind::Invoker, AccessorKind::Handler],
+            Self::Function => &[AccessorKind::Invoker],
+        }
+    }
+}
+
+/// The accessor name emitted by the Rust backend for a declaration named
+/// `name` (e.g. `"get_foo_bar"` for `("foo-bar", Getter)`).
+///
+/// Mirrors the suffix transformation in [`super::rust::ident`]. The prefix
+/// guarantees the result is never a Rust keyword, so no raw-identifier
+/// escaping is applied here.
+pub fn rust_accessor_name(name: &str, accessor: AccessorKind) -> SmolStr {
+    format_accessor_name(name, accessor)
+}
+
+/// The accessor name emitted by the C++ backend for a declaration named
+/// `name`.
+///
+/// Mirrors [`super::cpp::concatenate_ident`]. Today this is identical to
+/// [`rust_accessor_name`]; the helpers are kept separate so the two backends
+/// can diverge cleanly if either ever needs language-specific escaping.
+pub fn cpp_accessor_name(name: &str, accessor: AccessorKind) -> SmolStr {
+    format_accessor_name(name, accessor)
+}
+
+fn format_accessor_name(name: &str, accessor: AccessorKind) -> SmolStr {
+    let prefix = accessor.prefix();
+    if name.contains('-') {
+        let snake = name.replace('-', "_");
+        format_smolstr!("{prefix}{snake}")
+    } else {
+        format_smolstr!("{prefix}{name}")
+    }
+}
+
+/// Same as [`rust_accessor_name`] but wrapped in a [`proc_macro2::Ident`] for
+/// direct use in `quote!` templates.
+#[cfg(feature = "rust")]
+pub fn rust_accessor_ident(name: &str, accessor: AccessorKind) -> proc_macro2::Ident {
+    quote::format_ident!("{}", rust_accessor_name(name, accessor).as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn property_accessors() {
+        assert_eq!(rust_accessor_name("foo", AccessorKind::Getter), "get_foo");
+        assert_eq!(rust_accessor_name("foo", AccessorKind::Setter), "set_foo");
+        assert_eq!(cpp_accessor_name("foo", AccessorKind::Getter), "get_foo");
+        assert_eq!(cpp_accessor_name("foo", AccessorKind::Setter), "set_foo");
+    }
+
+    #[test]
+    fn callback_accessors() {
+        assert_eq!(rust_accessor_name("clicked", AccessorKind::Invoker), "invoke_clicked");
+        assert_eq!(rust_accessor_name("clicked", AccessorKind::Handler), "on_clicked");
+        assert_eq!(cpp_accessor_name("clicked", AccessorKind::Invoker), "invoke_clicked");
+        assert_eq!(cpp_accessor_name("clicked", AccessorKind::Handler), "on_clicked");
+    }
+
+    #[test]
+    fn function_accessors() {
+        assert_eq!(rust_accessor_name("do-it", AccessorKind::Invoker), "invoke_do_it");
+        assert_eq!(cpp_accessor_name("do-it", AccessorKind::Invoker), "invoke_do_it");
+    }
+
+    #[test]
+    fn kebab_case_becomes_snake_case() {
+        assert_eq!(rust_accessor_name("foo-bar", AccessorKind::Getter), "get_foo_bar");
+        assert_eq!(
+            rust_accessor_name("multi-word-name", AccessorKind::Setter),
+            "set_multi_word_name",
+        );
+    }
+
+    #[test]
+    fn snake_case_passes_through() {
+        assert_eq!(rust_accessor_name("foo_bar", AccessorKind::Getter), "get_foo_bar");
+    }
+
+    #[test]
+    fn prefix_neutralizes_language_keywords() {
+        // `type` is a Rust keyword and `class` is a C++ keyword; the prefix
+        // turns each into a plain identifier, so no escaping is needed here.
+        assert_eq!(rust_accessor_name("type", AccessorKind::Getter), "get_type");
+        assert_eq!(rust_accessor_name("if", AccessorKind::Handler), "on_if");
+        assert_eq!(cpp_accessor_name("class", AccessorKind::Getter), "get_class");
+        assert_eq!(cpp_accessor_name("delete", AccessorKind::Invoker), "invoke_delete");
+    }
+
+    #[test]
+    fn declaration_kind_accessor_sets() {
+        assert_eq!(
+            DeclarationKind::Property.accessor_kinds(),
+            &[AccessorKind::Getter, AccessorKind::Setter],
+        );
+        assert_eq!(
+            DeclarationKind::Callback.accessor_kinds(),
+            &[AccessorKind::Invoker, AccessorKind::Handler],
+        );
+        assert_eq!(DeclarationKind::Function.accessor_kinds(), &[AccessorKind::Invoker]);
+    }
+
+    #[test]
+    fn kebab_and_snake_collapse_to_same_accessor() {
+        // Both spellings produce the same accessor; the collision is intentional
+        // and is the LSP scanner's concern, not this helper's.
+        assert_eq!(
+            rust_accessor_name("foo-bar", AccessorKind::Getter),
+            rust_accessor_name("foo_bar", AccessorKind::Getter),
+        );
+    }
+}

--- a/internal/compiler/generator/accessor_names.rs
+++ b/internal/compiler/generator/accessor_names.rs
@@ -98,62 +98,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn property_accessors() {
-        assert_eq!(rust_accessor_name("foo", AccessorKind::Getter), "get_foo");
-        assert_eq!(rust_accessor_name("foo", AccessorKind::Setter), "set_foo");
-        assert_eq!(cpp_accessor_name("foo", AccessorKind::Getter), "get_foo");
-        assert_eq!(cpp_accessor_name("foo", AccessorKind::Setter), "set_foo");
-    }
-
-    #[test]
-    fn callback_accessors() {
-        assert_eq!(rust_accessor_name("clicked", AccessorKind::Invoker), "invoke_clicked");
-        assert_eq!(rust_accessor_name("clicked", AccessorKind::Handler), "on_clicked");
-        assert_eq!(cpp_accessor_name("clicked", AccessorKind::Invoker), "invoke_clicked");
-        assert_eq!(cpp_accessor_name("clicked", AccessorKind::Handler), "on_clicked");
-    }
-
-    #[test]
-    fn function_accessors() {
-        assert_eq!(rust_accessor_name("do-it", AccessorKind::Invoker), "invoke_do_it");
-        assert_eq!(cpp_accessor_name("do-it", AccessorKind::Invoker), "invoke_do_it");
-    }
-
-    #[test]
-    fn kebab_case_becomes_snake_case() {
-        assert_eq!(rust_accessor_name("foo-bar", AccessorKind::Getter), "get_foo_bar");
-        assert_eq!(
-            rust_accessor_name("multi-word-name", AccessorKind::Setter),
-            "set_multi_word_name",
-        );
-    }
-
-    #[test]
-    fn snake_case_passes_through() {
-        assert_eq!(rust_accessor_name("foo_bar", AccessorKind::Getter), "get_foo_bar");
-    }
-
-    #[test]
-    fn prefix_neutralizes_language_keywords() {
-        // `type` is a Rust keyword and `class` is a C++ keyword; the prefix
-        // turns each into a plain identifier, so no escaping is needed here.
-        assert_eq!(rust_accessor_name("type", AccessorKind::Getter), "get_type");
-        assert_eq!(rust_accessor_name("if", AccessorKind::Handler), "on_if");
-        assert_eq!(cpp_accessor_name("class", AccessorKind::Getter), "get_class");
-        assert_eq!(cpp_accessor_name("delete", AccessorKind::Invoker), "invoke_delete");
-    }
-
-    #[test]
-    fn declaration_kind_accessor_sets() {
-        assert_eq!(
-            DeclarationKind::Property.accessor_kinds(),
-            &[AccessorKind::Getter, AccessorKind::Setter],
-        );
-        assert_eq!(
-            DeclarationKind::Callback.accessor_kinds(),
-            &[AccessorKind::Invoker, AccessorKind::Handler],
-        );
-        assert_eq!(DeclarationKind::Function.accessor_kinds(), &[AccessorKind::Invoker]);
+    fn accessor_name_mapping() {
+        // (input_name, accessor_kind, expected_accessor)
+        // Rust and C++ produce identical output today, so each row is asserted
+        // against both helpers in one loop. Adding a case anywhere -- new
+        // kebab-case form, new keyword collision, new whitespace edge case --
+        // is a single row here, not two parallel asserts.
+        const CASES: &[(&str, AccessorKind, &str)] = &[
+            // Bare snake-case / single-word inputs.
+            ("foo", AccessorKind::Getter, "get_foo"),
+            ("foo", AccessorKind::Setter, "set_foo"),
+            ("clicked", AccessorKind::Invoker, "invoke_clicked"),
+            ("clicked", AccessorKind::Handler, "on_clicked"),
+            ("foo_bar", AccessorKind::Getter, "get_foo_bar"),
+            // Kebab-case becomes snake-case.
+            ("foo-bar", AccessorKind::Getter, "get_foo_bar"),
+            ("multi-word-name", AccessorKind::Setter, "set_multi_word_name"),
+            ("do-it", AccessorKind::Invoker, "invoke_do_it"),
+            // The accessor prefix neutralizes language keywords on both sides,
+            // so neither backend needs an escape pass.
+            ("type", AccessorKind::Getter, "get_type"),
+            ("if", AccessorKind::Handler, "on_if"),
+            ("class", AccessorKind::Getter, "get_class"),
+            ("delete", AccessorKind::Invoker, "invoke_delete"),
+        ];
+        for &(name, kind, expected) in CASES {
+            assert_eq!(rust_accessor_name(name, kind), expected, "rust: ({name:?}, {kind:?})");
+            assert_eq!(cpp_accessor_name(name, kind), expected, "cpp: ({name:?}, {kind:?})");
+        }
     }
 
     #[test]
@@ -164,5 +136,17 @@ mod tests {
             rust_accessor_name("foo-bar", AccessorKind::Getter),
             rust_accessor_name("foo_bar", AccessorKind::Getter),
         );
+    }
+
+    #[test]
+    fn declaration_kind_accessor_sets() {
+        const CASES: &[(DeclarationKind, &[AccessorKind])] = &[
+            (DeclarationKind::Property, &[AccessorKind::Getter, AccessorKind::Setter]),
+            (DeclarationKind::Callback, &[AccessorKind::Invoker, AccessorKind::Handler]),
+            (DeclarationKind::Function, &[AccessorKind::Invoker]),
+        ];
+        for &(kind, expected) in CASES {
+            assert_eq!(kind.accessor_kinds(), expected, "{kind:?}");
+        }
     }
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -6,6 +6,7 @@
 
 // cSpell:ignore cmath constexpr cstdlib decltype intptr itertools nullptr prepended struc subcomponent uintptr vals compl consteval constinit glyphset glyphsets reflexpr
 
+use super::accessor_names::{self, AccessorKind};
 use crate::fileaccess;
 use std::collections::HashSet;
 use std::fmt::Write;
@@ -3350,8 +3351,6 @@ fn generate_public_api_for_properties(
     ctx: &EvaluationContext,
 ) {
     for p in public_properties {
-        let prop_ident = concatenate_ident(&p.name);
-
         let access = access_member(&p.prop, ctx).unwrap();
 
         if let Type::Callback(callback) = &p.ty {
@@ -3369,7 +3368,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("invoke_{prop_ident}"),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Invoker),
                     signature: format!(
                         "({}) const -> {}",
                         param_types
@@ -3395,7 +3394,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("on_{}", concatenate_ident(&p.name)),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Handler),
                     template_parameters: Some(format!(
                         "std::invocable<{}> Functor",
                         param_types.join(", "),
@@ -3420,7 +3419,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("invoke_{}", concatenate_ident(&p.name)),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Invoker),
                     signature: format!(
                         "({}) const -> {ret}",
                         param_types
@@ -3443,7 +3442,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("get_{}", &prop_ident),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Getter),
                     signature: format!("() const -> {}", &cpp_property_type),
                     statements: Some(prop_getter),
                     ..Default::default()
@@ -3459,7 +3458,7 @@ fn generate_public_api_for_properties(
                 declarations.push((
                     Access::Public,
                     Declaration::Function(Function {
-                        name: format_smolstr!("set_{}", &prop_ident),
+                        name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Setter),
                         signature: format!("(const {} &value) const -> void", &cpp_property_type),
                         statements: Some(prop_setter),
                         ..Default::default()
@@ -3469,7 +3468,7 @@ fn generate_public_api_for_properties(
                 declarations.push((
                     Access::Private,
                     Declaration::Function(Function {
-                        name: format_smolstr!("set_{}", &prop_ident),
+                        name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Setter),
                         signature: format!(
                             "(const {cpp_property_type} &) const = SLINT_DELETED_FUNCTION(\"property '{}' is declared as 'out' (read-only). Declare it as 'in' or 'in-out' to enable the setter\")", p.name
                         ),
@@ -3481,14 +3480,12 @@ fn generate_public_api_for_properties(
     }
 
     for (name, ty) in private_properties {
-        let prop_ident = concatenate_ident(name);
-
         if let Type::Function(function) = &ty {
             let param_types = function.args.iter().map(|t| t.cpp_type().unwrap()).join(", ");
             declarations.push((
                 Access::Private,
                 Declaration::Function(Function {
-                    name: format_smolstr!("invoke_{prop_ident}"),
+                    name: accessor_names::cpp_accessor_name(name, AccessorKind::Invoker),
                     signature: format!(
                         "({param_types}) const = SLINT_DELETED_FUNCTION(\"the function '{name}' is declared as private. Declare it as 'public'\")",
                     ),
@@ -3499,7 +3496,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Private,
                 Declaration::Function(Function {
-                    name: format_smolstr!("get_{prop_ident}"),
+                    name: accessor_names::cpp_accessor_name(name, AccessorKind::Getter),
                     signature: format!(
                         "() const = SLINT_DELETED_FUNCTION(\"the property '{name}' is declared as private. Declare it as 'in', 'out', or 'in-out' to make it public\")",
                     ),
@@ -3509,7 +3506,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Private,
                 Declaration::Function(Function {
-                    name: format_smolstr!("set_{}", &prop_ident),
+                    name: accessor_names::cpp_accessor_name(name, AccessorKind::Setter),
                     signature: format!(
                         "(const auto &) const = SLINT_DELETED_FUNCTION(\"property '{name}' is declared as private. Declare it as 'in' or 'in-out' to make it public\")",
                     ),

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use super::accessor_names::{self, AccessorKind};
 use super::cpp::{Config, concatenate_ident, cpp_ast::*, ident};
 use crate::CompilerConfiguration;
 use crate::langtype::{EnumerationValue, StructName, Type};
@@ -282,7 +283,6 @@ fn generate_public_api_for_properties(
 ) {
     for p in public_properties {
         let prop_name = &p.name;
-        let prop_ident = concatenate_ident(prop_name);
 
         if let Type::Callback(callback) = &p.ty {
             let ret = callback.return_type.cpp_type().unwrap();
@@ -296,7 +296,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("invoke_{prop_ident}"),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Invoker),
                     signature: format!(
                         "({}) const -> {ret}",
                         param_types
@@ -326,7 +326,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("on_{}", concatenate_ident(&p.name)),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Handler),
                     template_parameters: Some(format!(
                         "std::invocable<{}> Functor",
                         param_types.join(", "),
@@ -353,7 +353,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("invoke_{}", concatenate_ident(&p.name)),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Invoker),
                     signature: format!(
                         "({}) const -> {ret}",
                         param_types
@@ -375,7 +375,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Public,
                 Declaration::Function(Function {
-                    name: format_smolstr!("get_{}", &prop_ident),
+                    name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Getter),
                     signature: format!("() const -> {cpp_property_type}"),
                     statements: Some(prop_getter),
                     ..Default::default()
@@ -393,7 +393,7 @@ fn generate_public_api_for_properties(
                 declarations.push((
                     Access::Public,
                     Declaration::Function(Function {
-                        name: format_smolstr!("set_{}", &prop_ident),
+                        name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Setter),
                         signature: format!("(const {} &value) const -> void", cpp_property_type),
                         statements: Some(prop_setter),
                         ..Default::default()
@@ -403,7 +403,7 @@ fn generate_public_api_for_properties(
                 declarations.push((
                     Access::Private,
                     Declaration::Function(Function {
-                        name: format_smolstr!("set_{}", &prop_ident),
+                        name: accessor_names::cpp_accessor_name(&p.name, AccessorKind::Setter),
                         signature: format!(
                             "(const {cpp_property_type} &) const = delete /* property '{}' is declared as 'out' (read-only). Declare it as 'in' or 'in-out' to enable the setter */", p.name
                         ),
@@ -415,14 +415,12 @@ fn generate_public_api_for_properties(
     }
 
     for (name, ty) in private_properties {
-        let prop_ident = concatenate_ident(name);
-
         if let Type::Function(function) = &ty {
             let param_types = function.args.iter().map(|t| t.cpp_type().unwrap()).join(", ");
             declarations.push((
                 Access::Private,
                 Declaration::Function(Function {
-                    name: format_smolstr!("invoke_{prop_ident}"),
+                    name: accessor_names::cpp_accessor_name(name, AccessorKind::Invoker),
                     signature: format!(
                         "({param_types}) const = delete /* the function '{name}' is declared as private. Declare it as 'public' */",
                     ),
@@ -433,7 +431,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Private,
                 Declaration::Function(Function {
-                    name: format_smolstr!("get_{prop_ident}"),
+                    name: accessor_names::cpp_accessor_name(name, AccessorKind::Getter),
                     signature: format!(
                         "() const = delete /* the property '{name}' is declared as private. Declare it as 'in', 'out', or 'in-out' to make it public */",
                     ),
@@ -443,7 +441,7 @@ fn generate_public_api_for_properties(
             declarations.push((
                 Access::Private,
                 Declaration::Function(Function {
-                    name: format_smolstr!("set_{}", &prop_ident),
+                    name: accessor_names::cpp_accessor_name(name, AccessorKind::Setter),
                     signature: format!(
                         "(const auto &) const = delete /* property '{name}' is declared as private. Declare it as 'in' or 'in-out' to make it public */",
                     ),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -12,6 +12,7 @@ Some convention used in the generated code:
    this is usually a local variable to the init code that shouldn't be relied upon by the binding code.
 */
 
+use super::accessor_names::{self, AccessorKind};
 use crate::CompilerConfiguration;
 use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp, OperatorClass};
 use crate::langtype::{Enumeration, EnumerationValue, Struct, StructName, Type};
@@ -1009,7 +1010,6 @@ fn public_api(
 ) -> TokenStream {
     let mut property_and_callback_accessors: Vec<TokenStream> = Vec::new();
     for p in public_properties {
-        let prop_ident = ident(&p.name);
         let prop = access_member(&p.prop, ctx).unwrap();
 
         if let Type::Callback(callback) = &p.ty {
@@ -1018,7 +1018,7 @@ fn public_api(
             let return_type = rust_primitive_type(&callback.return_type).unwrap();
             let args_name =
                 (0..callback.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
-            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            let caller_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Invoker);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
@@ -1026,7 +1026,7 @@ fn public_api(
                     #prop.call(&(#(#args_name,)*))
                 }
             ));
-            let on_ident = format_ident!("on_{}", prop_ident);
+            let on_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Handler);
             let args_index = (0..callback_args.len()).map(proc_macro2::Literal::usize_unsuffixed);
             let tracker_access = access_callback_tracker(&p.prop, ctx);
             let set_dirty = tracker_access.map(|t| quote!(#t.mark_dirty();));
@@ -1048,7 +1048,7 @@ fn public_api(
             let return_type = rust_primitive_type(&function.return_type).unwrap();
             let args_name =
                 (0..function.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
-            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            let caller_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Invoker);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
@@ -1059,7 +1059,7 @@ fn public_api(
         } else {
             let rust_property_type = rust_primitive_type(&p.ty).unwrap();
 
-            let getter_ident = format_ident!("get_{}", prop_ident);
+            let getter_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Getter);
 
             let prop_expression = primitive_property_value(&p.ty, MemberAccess::Direct(prop));
 
@@ -1072,7 +1072,7 @@ fn public_api(
                 }
             ));
 
-            let setter_ident = format_ident!("set_{}", prop_ident);
+            let setter_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Setter);
             if !p.read_only {
                 let set_value = property_set_value_tokens(&p.prop, quote!(value), ctx);
                 property_and_callback_accessors.push(quote!(
@@ -1092,15 +1092,14 @@ fn public_api(
     }
 
     for (name, ty) in private_properties {
-        let prop_ident = ident(name);
         if let Type::Function { .. } = ty {
-            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            let caller_ident = accessor_names::rust_accessor_ident(name, AccessorKind::Invoker);
             property_and_callback_accessors.push(
                 quote!( #[allow(dead_code)] fn #caller_ident(&self, _private_function: ()) {} ),
             );
         } else {
-            let getter_ident = format_ident!("get_{}", prop_ident);
-            let setter_ident = format_ident!("set_{}", prop_ident);
+            let getter_ident = accessor_names::rust_accessor_ident(name, AccessorKind::Getter);
+            let setter_ident = accessor_names::rust_accessor_ident(name, AccessorKind::Setter);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)] fn #getter_ident(&self, _private_property: ()) {}
                 #[allow(dead_code)] fn #setter_ident(&self, _private_property: ()) {}

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use super::accessor_names::{self, AccessorKind};
 use super::rust::{ident, rust_primitive_type};
 use crate::CompilerConfiguration;
 use crate::langtype::{Struct, StructName, Type};
@@ -95,7 +96,6 @@ fn generate_public_component(
     let mut property_and_callback_accessors: Vec<TokenStream> = Vec::new();
     for p in &llr.public_properties {
         let prop_name = p.name.as_str();
-        let prop_ident = ident(&p.name);
 
         if let Type::Callback(callback) = &p.ty {
             let callback_args =
@@ -103,7 +103,7 @@ fn generate_public_component(
             let return_type = rust_primitive_type(&callback.return_type).unwrap();
             let args_name =
                 (0..callback.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
-            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            let caller_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Invoker);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
@@ -111,7 +111,7 @@ fn generate_public_component(
                         .try_into().unwrap_or_else(|_| panic!("Invalid return type for callback {}::{}", #component_name, #prop_name))
                 }
             ));
-            let on_ident = format_ident!("on_{}", prop_ident);
+            let on_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Handler);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #on_ident(&self, f: impl FnMut(#(#callback_args),*) -> #return_type + 'static) {
@@ -128,7 +128,7 @@ fn generate_public_component(
             let return_type = rust_primitive_type(&function.return_type).unwrap();
             let args_name =
                 (0..function.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
-            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            let caller_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Invoker);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
@@ -141,7 +141,7 @@ fn generate_public_component(
             let convert_to_value = convert_to_value_fn(&p.ty);
             let convert_from_value = convert_from_value_fn(&p.ty);
 
-            let getter_ident = format_ident!("get_{}", prop_ident);
+            let getter_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Getter);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #getter_ident(&self) -> #rust_property_type {
@@ -150,7 +150,7 @@ fn generate_public_component(
                 }
             ));
 
-            let setter_ident = format_ident!("set_{}", prop_ident);
+            let setter_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Setter);
             if !p.read_only {
                 property_and_callback_accessors.push(quote!(
                     #[allow(dead_code)]
@@ -258,7 +258,6 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
     let mut property_and_callback_accessors: Vec<TokenStream> = Vec::new();
     for p in &global.public_properties {
         let prop_name = p.name.as_str();
-        let prop_ident = ident(&p.name);
 
         if let Type::Callback(callback) = &p.ty {
             let callback_args =
@@ -266,7 +265,7 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
             let return_type = rust_primitive_type(&callback.return_type).unwrap();
             let args_name =
                 (0..callback.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
-            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            let caller_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Invoker);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
@@ -274,7 +273,7 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
                         .try_into().unwrap_or_else(|_| panic!("Invalid return type for callback {}::{}", #global_name, #prop_name))
                 }
             ));
-            let on_ident = format_ident!("on_{}", prop_ident);
+            let on_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Handler);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #on_ident(&self, f: impl FnMut(#(#callback_args),*) -> #return_type + 'static) {
@@ -291,7 +290,7 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
             let return_type = rust_primitive_type(&function.return_type).unwrap();
             let args_name =
                 (0..function.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
-            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            let caller_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Invoker);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
@@ -304,7 +303,7 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
             let convert_to_value = convert_to_value_fn(&p.ty);
             let convert_from_value = convert_from_value_fn(&p.ty);
 
-            let getter_ident = format_ident!("get_{}", prop_ident);
+            let getter_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Getter);
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #getter_ident(&self) -> #rust_property_type {
@@ -313,7 +312,7 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
                 }
             ));
 
-            let setter_ident = format_ident!("set_{}", prop_ident);
+            let setter_ident = accessor_names::rust_accessor_ident(&p.name, AccessorKind::Setter);
             if !p.read_only {
                 property_and_callback_accessors.push(quote!(
                     #[allow(dead_code)]

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -133,6 +133,9 @@ lsp-server = "0.7"
 tokio = { version = "1.50.0", features = ["rt", "sync", "time", "macros", "io-std", "io-util", "net", "fs", "process"] }
 dashmap = "6.1.0"
 mdns-sd = "0.20.0"
+# Unicode XID property lookup used by the host-language accessor scanner to
+# tokenize identifiers in Rust/C++ source rather than scanning byte-by-byte.
+icu_properties = { version = "2.2.0", features = ["compiled_data"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -455,6 +455,41 @@ pub fn create_workspace_edit_from_text_document_edits(
     WorkspaceEdit { document_changes, ..Default::default() }
 }
 
+/// Merge the document-change edits from `additional` into `base`.
+///
+/// Both `WorkspaceEdit`s must use the `document_changes: Edits(...)` form --
+/// the one produced by [`create_workspace_edit_from_single_text_edits`] and
+/// the other `create_workspace_edit*` helpers. The following fields on
+/// `additional` are intentionally **not** merged:
+///
+/// - `document_changes: Operations(...)` -- our codebase only produces the
+///   `Edits` form; an `Operations` variant on `additional` is silently dropped.
+/// - `changes` -- the legacy `Url -> Vec<TextEdit>` map. Unused in this
+///   codebase; would be silently dropped.
+/// - `change_annotations` -- annotated edits. Unused in this codebase; would
+///   be silently dropped.
+///
+/// If `additional` ever needs to carry any of those, this helper must be
+/// extended; today the assertion below catches the misuse in debug builds.
+pub fn merge_workspace_edits(base: &mut WorkspaceEdit, additional: WorkspaceEdit) {
+    debug_assert!(
+        additional.changes.is_none() && additional.change_annotations.is_none(),
+        "merge_workspace_edits only merges document_changes; got changes/change_annotations on additional",
+    );
+    let Some(lsp_types::DocumentChanges::Edits(more)) = additional.document_changes else {
+        return;
+    };
+    match &mut base.document_changes {
+        Some(lsp_types::DocumentChanges::Edits(existing)) => existing.extend(more),
+        None => {
+            base.document_changes = Some(lsp_types::DocumentChanges::Edits(more));
+        }
+        Some(lsp_types::DocumentChanges::Operations(_)) => {
+            // Operations form is not produced by our codebase; nothing to merge into.
+        }
+    }
+}
+
 pub fn create_workspace_edit_from_single_text_edits(
     mut inputs: Vec<SingleTextEdit>,
 ) -> WorkspaceEdit {
@@ -708,6 +743,55 @@ pub fn fuzzy_filter_iter<T: std::fmt::Debug>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn mk_edit(uri: &str, new_text: &str) -> SingleTextEdit {
+        SingleTextEdit {
+            url: Url::parse(uri).unwrap(),
+            version: None,
+            edit: TextEdit {
+                range: lsp_types::Range::new(
+                    lsp_types::Position::new(0, 0),
+                    lsp_types::Position::new(0, 0),
+                ),
+                new_text: new_text.into(),
+            },
+        }
+    }
+
+    fn doc_edits(edit: &WorkspaceEdit) -> &Vec<lsp_types::TextDocumentEdit> {
+        match edit.document_changes.as_ref().unwrap() {
+            lsp_types::DocumentChanges::Edits(v) => v,
+            _ => panic!("expected DocumentChanges::Edits"),
+        }
+    }
+
+    #[test]
+    fn merge_workspace_edits_combines_edits_lists() {
+        let mut base =
+            create_workspace_edit_from_single_text_edits(vec![mk_edit("file:///a.slint", "a")]);
+        let additional =
+            create_workspace_edit_from_single_text_edits(vec![mk_edit("file:///b.rs", "b")]);
+        merge_workspace_edits(&mut base, additional);
+        assert_eq!(doc_edits(&base).len(), 2);
+    }
+
+    #[test]
+    fn merge_workspace_edits_into_empty_base() {
+        let mut base = WorkspaceEdit::default();
+        let additional =
+            create_workspace_edit_from_single_text_edits(vec![mk_edit("file:///b.rs", "b")]);
+        merge_workspace_edits(&mut base, additional);
+        assert_eq!(doc_edits(&base).len(), 1);
+    }
+
+    #[test]
+    fn merge_workspace_edits_noop_for_empty_additional() {
+        let mut base =
+            create_workspace_edit_from_single_text_edits(vec![mk_edit("file:///a.slint", "a")]);
+        let before_len = doc_edits(&base).len();
+        merge_workspace_edits(&mut base, WorkspaceEdit::default());
+        assert_eq!(doc_edits(&base).len(), before_len);
+    }
 
     #[test]
     fn test_uri_conversion_of_builtins() {

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -19,6 +19,8 @@ pub mod component_catalog;
 pub mod document_cache;
 pub use document_cache::DocumentCache;
 pub use i_slint_compiler::diagnostics::ByteFormat;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod host_language_search;
 mod lsp_to_previews;
 pub mod rename_component;
 pub mod rename_element_id;

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -455,22 +455,17 @@ pub fn create_workspace_edit_from_text_document_edits(
     WorkspaceEdit { document_changes, ..Default::default() }
 }
 
-/// Merge the document-change edits from `additional` into `base`.
+/// Merge the document-change edits from `additional` into `base`. Test-only
+/// since the rename flow now sends two independent `workspace/applyEdit`
+/// requests; the helper exists for tests that want to assert on the
+/// combined edit shape.
 ///
 /// Both `WorkspaceEdit`s must use the `document_changes: Edits(...)` form --
 /// the one produced by [`create_workspace_edit_from_single_text_edits`] and
-/// the other `create_workspace_edit*` helpers. The following fields on
-/// `additional` are intentionally **not** merged:
-///
-/// - `document_changes: Operations(...)` -- our codebase only produces the
-///   `Edits` form; an `Operations` variant on `additional` is silently dropped.
-/// - `changes` -- the legacy `Url -> Vec<TextEdit>` map. Unused in this
-///   codebase; would be silently dropped.
-/// - `change_annotations` -- annotated edits. Unused in this codebase; would
-///   be silently dropped.
-///
-/// If `additional` ever needs to carry any of those, this helper must be
-/// extended; today the assertion below catches the misuse in debug builds.
+/// the other `create_workspace_edit*` helpers. Fields not in `document_changes`
+/// are not merged (`changes`, `change_annotations`, and the `Operations`
+/// variant); the assertion below catches the misuse in debug builds.
+#[cfg(test)]
 pub fn merge_workspace_edits(base: &mut WorkspaceEdit, additional: WorkspaceEdit) {
     debug_assert!(
         additional.changes.is_none() && additional.change_annotations.is_none(),

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -198,6 +198,11 @@ impl DocumentCache {
         self.type_loader.get_document(&path)
     }
 
+    /// Iterator over every fully-loaded `object_tree::Document` in the cache.
+    pub fn all_documents(&self) -> impl Iterator<Item = &Document> + '_ {
+        self.type_loader.all_documents()
+    }
+
     fn uses_widgets_impl(&self, doc_path: PathBuf, dedup: &mut HashSet<PathBuf>) -> bool {
         if dedup.contains(&doc_path) {
             return false;

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -1,0 +1,884 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore absolutized bget countñ xéget xget xñget xxget
+
+//! Scan the workspace for Rust/C++ call sites of Slint-generated property,
+//! callback, and function accessors so that a Slint rename can extend its
+//! `WorkspaceEdit` with edits in host-language source files.
+//!
+//! The scanner is intentionally simple: byte-level word-boundary search for a
+//! small set of accessor names derived from
+//! [`i_slint_compiler::generator::accessor_names`]. It does not parse Rust or
+//! C++. Cross-component accessor collisions are possible by construction; see
+//! the design in the PR for #11841 for the mitigations (config opt-in,
+//! preview-before-apply in v2).
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use i_slint_compiler::diagnostics::{ByteFormat, SourceFile, SourceFileInner};
+use i_slint_compiler::generator::accessor_names::{self, DeclarationKind};
+use lsp_types::{InitializeParams, TextEdit, Url, WorkspaceFolder};
+
+use super::SingleTextEdit;
+
+/// Host-language file extensions the scanner considers.
+const HOST_FILE_EXTENSIONS: &[&str] = &["rs", "cpp", "cc", "cxx", "h", "hpp", "hh"];
+
+/// Directory names skipped during the walk.
+const SKIP_DIRS: &[&str] = &["target", "build", "out", "dist", "node_modules", ".git"];
+
+/// User policy for extending a Slint rename with host-language accessor
+/// edits. Mapped from the `slint.renameAccessorsInHostLanguages` workspace
+/// configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RenameAccessorsPolicy {
+    /// No host-language edits. Current behavior.
+    #[default]
+    Never,
+    /// Extend every `textDocument/rename` `WorkspaceEdit` with the scanner's
+    /// host-language edits.
+    Always,
+}
+
+impl RenameAccessorsPolicy {
+    /// Parse the string form used in the workspace config.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "never" => Some(Self::Never),
+            "always" => Some(Self::Always),
+            _ => None,
+        }
+    }
+}
+
+/// Hard limits on scan work. `textDocument/rename` is synchronous in the LSP;
+/// an unbounded scan would stall the server.
+#[derive(Debug, Clone, Copy)]
+pub struct ScanBounds {
+    /// Maximum number of host-language files inspected.
+    pub max_files: usize,
+    /// Maximum size in bytes of a single file. Larger files are skipped
+    /// (not an error — likely generated code or vendored sources).
+    pub max_file_bytes: u64,
+}
+
+impl Default for ScanBounds {
+    fn default() -> Self {
+        Self { max_files: 5_000, max_file_bytes: 1 << 20 /* 1 MiB */ }
+    }
+}
+
+/// Failure modes for the scanner. The Rename handler in `language.rs`
+/// soft-degrades these to a `tracing::warn!` and applies only the
+/// `.slint`-side edits, so callers should treat them as advisory rather
+/// than fatal. The error variants exist so the warning can be specific.
+#[derive(Debug)]
+pub enum HostLanguageScanError {
+    /// The renamed `.slint` file is not under any configured workspace
+    /// folder, so there is no well-defined scan root.
+    OutsideWorkspace,
+    /// The scan would inspect more than `bounds.max_files` files.
+    TooManyFiles { limit: usize },
+}
+
+impl std::fmt::Display for HostLanguageScanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OutsideWorkspace => f.write_str(
+                "Cannot scan host-language files: the renamed .slint file is \
+                 not under any workspace folder",
+            ),
+            Self::TooManyFiles { limit } => write!(
+                f,
+                "Cannot scan host-language files: workspace exceeds {limit} \
+                 files. Disable slint.renameAccessorsInHostLanguages or \
+                 narrow the workspace folder.",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for HostLanguageScanError {}
+
+/// Walk the workspace folder containing `renamed_source` for `.rs`/`.cpp`/...
+/// files, replace any occurrence of the old accessor names derived from
+/// `(kind, old_name)` with the corresponding new accessor names derived from
+/// `(kind, new_name)`, and return the resulting per-file edits.
+///
+/// The returned edits can be merged with the `.slint`-only edits via
+/// [`super::create_workspace_edit_from_single_text_edits`].
+pub fn scan_host_language_accessors(
+    workspace_folders: &[WorkspaceFolder],
+    renamed_source: &Path,
+    kind: DeclarationKind,
+    old_name: &str,
+    new_name: &str,
+    format: ByteFormat,
+    bounds: ScanBounds,
+) -> Result<Vec<SingleTextEdit>, HostLanguageScanError> {
+    let scan_root = workspace_folder_for(workspace_folders, renamed_source)
+        .ok_or(HostLanguageScanError::OutsideWorkspace)?;
+
+    let accessors = accessor_pairs(kind, old_name, new_name);
+
+    let mut files = Vec::new();
+    collect_files(&scan_root, &mut files, bounds.max_files)?;
+
+    let mut edits = Vec::new();
+    for path in files {
+        let metadata = match std::fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if metadata.len() > bounds.max_file_bytes {
+            continue;
+        }
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue, // non-UTF-8 or unreadable; skip
+        };
+
+        let file_edits = scan_file_contents(&contents, &accessors);
+        if file_edits.is_empty() {
+            continue;
+        }
+
+        let url = match Url::from_file_path(&path) {
+            Ok(u) => u,
+            Err(()) => continue,
+        };
+        // Synthesize a SourceFile for line/column conversion. Host-language
+        // files are not in the LSP document cache, so they have no version.
+        let source_file: SourceFile = Rc::new(SourceFileInner::new(path.clone(), contents));
+        for (range, new_text) in file_edits {
+            let lsp_range = byte_range_to_lsp_range(&source_file, range, format);
+            edits.push(SingleTextEdit {
+                url: url.clone(),
+                version: None,
+                edit: TextEdit { range: lsp_range, new_text },
+            });
+        }
+    }
+    Ok(edits)
+}
+
+/// Build the set of workspace folders the scanner should consider.
+///
+/// Prefers `init_param.workspace_folders` when the client sent any; falls
+/// back to the (LSP-deprecated but still common) `root_uri` / `root_path` so
+/// editors that initialize the server in single-folder mode (older VS Code,
+/// many Neovim setups, Helix) still get host-language scanning.
+///
+/// Returns an empty Vec if no folder could be derived; the scanner will then
+/// fail with `OutsideWorkspace` (which the handler soft-degrades to a
+/// warning).
+#[allow(deprecated)] // root_uri / root_path are deprecated but widely used
+pub fn resolve_workspace_folders(init_param: &InitializeParams) -> Vec<WorkspaceFolder> {
+    if let Some(folders) = init_param.workspace_folders.as_ref()
+        && !folders.is_empty()
+    {
+        return folders.clone();
+    }
+    if let Some(uri) = init_param.root_uri.as_ref() {
+        return vec![WorkspaceFolder { uri: uri.clone(), name: String::new() }];
+    }
+    if let Some(path) = init_param.root_path.as_ref()
+        && let Ok(uri) = Url::from_file_path(path)
+    {
+        return vec![WorkspaceFolder { uri, name: String::new() }];
+    }
+    Vec::new()
+}
+
+/// Most-specific workspace folder whose URI's filesystem path is an ancestor
+/// of `path`. Returns `None` if no folder qualifies.
+///
+/// Performs the prefix comparison on absolutized (but not canonicalized)
+/// paths so that:
+/// - unsaved/untitled documents whose path doesn't exist on disk still match
+///   their containing workspace folder;
+/// - a `.slint` reached via a symlink isn't excluded because canonicalize
+///   resolves it outside the workspace.
+///
+/// The trade-off is that a symlink-based "outside-the-workspace" file path
+/// can falsely match its symlink parent; that's a milder failure than
+/// silently dropping every rename for symlinked files.
+fn workspace_folder_for(folders: &[WorkspaceFolder], path: &Path) -> Option<PathBuf> {
+    let target = absolute_path(path);
+    folders
+        .iter()
+        .filter_map(|f| f.uri.to_file_path().ok())
+        .map(|p| absolute_path(&p))
+        .filter(|folder| target.starts_with(folder))
+        .max_by_key(|folder| folder.components().count())
+}
+
+/// Make a path absolute without touching the filesystem. Falls back to the
+/// path as-given if joining with the current dir would fail (which it
+/// effectively can't for our inputs).
+fn absolute_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map(|cwd| cwd.join(path)).unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+/// Compute the `(old, new)` accessor name pairs for the rename. Rust and C++
+/// emit identical accessor strings today, so a single pair set suffices for
+/// both languages.
+fn accessor_pairs(kind: DeclarationKind, old_name: &str, new_name: &str) -> Vec<(String, String)> {
+    kind.accessor_kinds()
+        .iter()
+        .map(|&ak| {
+            (
+                accessor_names::rust_accessor_name(old_name, ak).to_string(),
+                accessor_names::rust_accessor_name(new_name, ak).to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Recursive walk of `root`, appending host-language file paths into `out`.
+/// Returns `TooManyFiles` if `max_files` is exceeded. Unreadable directories
+/// are silently skipped (don't fail the whole rename on a permission error
+/// in some sibling folder).
+///
+/// Does not follow symlinks: an `entry.file_type()` whose `is_symlink()` is
+/// true is skipped entirely. This avoids unbounded recursion through symlink
+/// cycles (vendored deps, sibling-crate links) at the cost of not scanning
+/// symlinked source trees -- users who want those scanned should add the
+/// real directory as a workspace folder.
+fn collect_files(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    max_files: usize,
+) -> Result<(), HostLanguageScanError> {
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!("host-language scan: skipping unreadable dir {}: {e}", root.display());
+            return Ok(());
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::debug!(
+                    "host-language scan: skipping unreadable entry under {}: {e}",
+                    root.display()
+                );
+                continue;
+            }
+        };
+        let Ok(file_type) = entry.file_type() else { continue };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        if file_type.is_dir() {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && SKIP_DIRS.contains(&name)
+            {
+                continue;
+            }
+            collect_files(&path, out, max_files)?;
+        } else if file_type.is_file() && has_host_extension(&path) {
+            if out.len() >= max_files {
+                return Err(HostLanguageScanError::TooManyFiles { limit: max_files });
+            }
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Case-insensitive check against [`HOST_FILE_EXTENSIONS`].
+fn has_host_extension(path: &Path) -> bool {
+    let Some(ext) = path.extension().and_then(|e| e.to_str()) else { return false };
+    HOST_FILE_EXTENSIONS.iter().any(|known| known.eq_ignore_ascii_case(ext))
+}
+
+/// Find every word-boundary-aligned occurrence of any old accessor name in
+/// `contents`, paired with the replacement text.
+///
+/// The walk maintains a small lexer state so matches inside line comments,
+/// block comments, double-quoted string literals, and short char literals
+/// (`'X'`, `'\\X'`) are skipped. The lexer is intentionally minimal -- raw
+/// strings, byte strings, Rust lifetimes (`'a`), nested block comments,
+/// and language-specific escapes aren't handled. False positives in those
+/// contexts are an accepted v1 limitation; users opted in via
+/// `slint.renameAccessorsInHostLanguages = "always"` and should review the
+/// proposed edits before applying.
+///
+/// Word boundaries treat any non-ASCII byte as if it extended an identifier,
+/// so a UTF-8 continuation byte adjacent to a match defeats the boundary --
+/// `xñget_count` is correctly rejected.
+///
+/// Optional leading `r#` (raw identifier syntax in Rust) is included in the
+/// matched range so that the replacement drops it; the accessor prefixes
+/// (`get_`, `set_`, etc.) make the result never a Rust keyword.
+fn scan_file_contents(
+    contents: &str,
+    accessors: &[(String, String)],
+) -> Vec<(std::ops::Range<usize>, String)> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum LexState {
+        Code,
+        LineComment,
+        BlockComment,
+        String,
+    }
+
+    let bytes = contents.as_bytes();
+    let mut matches = Vec::new();
+    let mut state = LexState::Code;
+    let mut i = 0;
+    while i < bytes.len() {
+        match state {
+            LexState::Code => {
+                if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/') {
+                    state = LexState::LineComment;
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+                    state = LexState::BlockComment;
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    state = LexState::String;
+                    i += 1;
+                    continue;
+                }
+                // Char literal: `'X'` or `'\\X'` (any single escape).
+                // Lifetimes look like `'a` without a closing quote; we
+                // peek ahead and only skip if a matching `'` is present
+                // within a short distance, otherwise treat `'` as a
+                // plain code byte and fall through.
+                if bytes[i] == b'\''
+                    && let Some(end) = try_consume_char_literal(bytes, i)
+                {
+                    i = end;
+                    continue;
+                }
+                // Try matching each accessor needle at the current position.
+                let mut matched_len = 0;
+                for (old, new) in accessors {
+                    let needle = old.as_bytes();
+                    if bytes[i..].starts_with(needle) {
+                        let end = i + needle.len();
+                        let after_ok = end == bytes.len() || !extends_identifier(bytes[end]);
+                        let (effective_start, before_ok) =
+                            if i >= 2 && bytes[i - 2] == b'r' && bytes[i - 1] == b'#' {
+                                let s = i - 2;
+                                (s, s == 0 || !extends_identifier(bytes[s - 1]))
+                            } else {
+                                (i, i == 0 || !extends_identifier(bytes[i - 1]))
+                            };
+                        if before_ok && after_ok {
+                            matches.push((effective_start..end, new.clone()));
+                            matched_len = needle.len();
+                            break;
+                        }
+                    }
+                }
+                if matched_len > 0 {
+                    i += matched_len;
+                } else {
+                    i += utf8_char_len(bytes, i);
+                }
+            }
+            LexState::LineComment => {
+                if bytes[i] == b'\n' {
+                    state = LexState::Code;
+                }
+                i += 1;
+            }
+            LexState::BlockComment => {
+                if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                    state = LexState::Code;
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+            }
+            LexState::String => {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    i += 2; // skip escape sequence (\" included)
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    state = LexState::Code;
+                }
+                i += 1;
+            }
+        }
+    }
+    matches.sort_by_key(|(r, _)| r.start);
+    matches
+}
+
+/// If `bytes[i]` starts a short char literal (`'X'` or `'\\X'`), return the
+/// byte offset just past the closing quote; otherwise return `None`. The
+/// caller should then treat `'` as a plain code byte (Rust lifetimes look
+/// like `'a` without a closing quote).
+fn try_consume_char_literal(bytes: &[u8], i: usize) -> Option<usize> {
+    debug_assert_eq!(bytes[i], b'\'');
+    // `'\X'` where X is any single byte (covers `'\n'`, `'\''`, `'\"'`, etc.)
+    if bytes.get(i + 1) == Some(&b'\\') && i + 3 < bytes.len() && bytes[i + 3] == b'\'' {
+        return Some(i + 4);
+    }
+    // `'X'` where X is one UTF-8 code point.
+    if i + 1 < bytes.len() && bytes[i + 1] != b'\'' {
+        let char_len = utf8_char_len(bytes, i + 1);
+        let close = i + 1 + char_len;
+        if bytes.get(close) == Some(&b'\'') {
+            return Some(close + 1);
+        }
+    }
+    None
+}
+
+/// Returns the length of the UTF-8 code point starting at `bytes[i]`,
+/// or 1 if the byte is invalid UTF-8 (defensive — we already hold a `&str`).
+fn utf8_char_len(bytes: &[u8], i: usize) -> usize {
+    match bytes[i] {
+        0x00..=0x7F => 1,
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => 1,
+    }
+}
+
+/// True if a byte at a candidate word boundary would prevent the boundary
+/// from being placed there -- i.e. it's an ASCII identifier byte or the
+/// (continuation or leading) byte of a non-ASCII identifier character.
+/// Treating every byte >= 0x80 as identifier-extending is conservative but
+/// safe: it makes matches adjacent to any multi-byte UTF-8 character reject.
+fn extends_identifier(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80
+}
+
+fn byte_range_to_lsp_range(
+    source_file: &SourceFile,
+    range: std::ops::Range<usize>,
+    format: ByteFormat,
+) -> lsp_types::Range {
+    let (line_start, col_start) = source_file.line_column(range.start, format);
+    let (line_end, col_end) = source_file.line_column(range.end, format);
+    lsp_types::Range {
+        start: lsp_types::Position::new(
+            (line_start as u32).saturating_sub(1),
+            (col_start as u32).saturating_sub(1),
+        ),
+        end: lsp_types::Position::new(
+            (line_end as u32).saturating_sub(1),
+            (col_end as u32).saturating_sub(1),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pairs(kind: DeclarationKind, old: &str, new: &str) -> Vec<(String, String)> {
+        accessor_pairs(kind, old, new)
+    }
+
+    #[test]
+    fn property_matches_get_and_set() {
+        let contents = "fn main() {\n    let v = obj.get_count();\n    obj.set_count(v + 1);\n}\n";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 2);
+        let (range_get, new_get) = &edits[0];
+        assert_eq!(&contents[range_get.clone()], "get_count");
+        assert_eq!(new_get, "get_total");
+        let (range_set, new_set) = &edits[1];
+        assert_eq!(&contents[range_set.clone()], "set_count");
+        assert_eq!(new_set, "set_total");
+    }
+
+    #[test]
+    fn callback_matches_invoke_and_on() {
+        let contents = "obj.invoke_clicked(); obj.on_clicked(|| {});";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Callback, "clicked", "pressed"));
+        assert_eq!(edits.len(), 2);
+        let texts: Vec<_> = edits.iter().map(|(r, _)| &contents[r.clone()]).collect();
+        assert!(texts.contains(&"invoke_clicked"));
+        assert!(texts.contains(&"on_clicked"));
+    }
+
+    #[test]
+    fn function_matches_invoke_only() {
+        let contents = "obj.invoke_multiply(2);";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Function, "multiply", "double"));
+        assert_eq!(edits.len(), 1);
+        assert_eq!(&contents[edits[0].0.clone()], "invoke_multiply");
+    }
+
+    #[test]
+    fn skip_matches_inside_line_comments() {
+        let contents = "let x = obj.get_count(); // get_count again here\n";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1, "only the live call should match, got {edits:?}");
+        assert_eq!(&contents[edits[0].0.clone()], "get_count");
+    }
+
+    #[test]
+    fn skip_matches_inside_block_comments() {
+        let contents = "/* old API used obj.get_count() */\nobj.get_count();";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1, "match inside block comment must be skipped, got {edits:?}");
+    }
+
+    #[test]
+    fn skip_matches_inside_string_literals() {
+        let contents = r#"
+            let msg = "see obj.get_count for details";
+            obj.get_count();
+        "#;
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1, "match inside string literal must be skipped, got {edits:?}");
+    }
+
+    #[test]
+    fn string_escapes_do_not_close_string_prematurely() {
+        // The escaped \" must not be interpreted as the end of the string.
+        let contents = "let s = \"a\\\" get_count not here\"; obj.get_count();";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1);
+    }
+
+    #[test]
+    fn skip_matches_inside_char_literals() {
+        // The `"` inside the char literal must not flip the lexer into
+        // String state; otherwise the subsequent real call site is missed.
+        let contents = "let c = '\"'; obj.get_count();";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1);
+        assert_eq!(&contents[edits[0].0.clone()], "get_count");
+    }
+
+    #[test]
+    fn lifetime_is_not_consumed_as_char_literal() {
+        // `'a` in `&'a T` is a lifetime, not a char literal. The lexer must
+        // not enter Char state and swallow the rest of the file.
+        let contents = "fn f<'a>(x: &'a u32) { obj.get_count(); }";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1);
+    }
+
+    #[test]
+    fn escaped_char_literal_is_consumed() {
+        // `'\n'`, `'\''`, `'\"'` etc. should all be skipped wholesale.
+        let contents = "let n = '\\n'; let q = '\\''; obj.get_count();";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1);
+    }
+
+    #[test]
+    fn non_ascii_char_after_match_defeats_word_boundary() {
+        // Symmetric to non_ascii_char_before_match_defeats_word_boundary --
+        // the byte AFTER the match must also be treated as identifier-
+        // extending when non-ASCII, so `get_countñ` is rejected.
+        let contents = "let xxget_countñ = 1; obj.get_count();";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1, "only the call-site match is valid, got {edits:?}");
+        assert_eq!(&contents[edits[0].0.clone()], "get_count");
+    }
+
+    #[test]
+    fn non_ascii_char_before_match_defeats_word_boundary() {
+        // `é` is two bytes (0xC3, 0xA9); the byte before `get_count` is a
+        // continuation byte. Without the non-ASCII guard, the old logic
+        // would accept the match and corrupt the unrelated identifier.
+        let contents = "let xéget_count = 1; obj.get_count();";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert_eq!(edits.len(), 1, "only the call-site match is valid, got {edits:?}");
+        assert_eq!(&contents[edits[0].0.clone()], "get_count");
+    }
+
+    #[test]
+    fn raw_identifier_prefix_included_in_match() {
+        let contents = "obj.r#get_type();";
+        let edits = scan_file_contents(contents, &pairs(DeclarationKind::Property, "type", "kind"));
+        assert_eq!(edits.len(), 1);
+        // The match swallows `r#` so the rewrite is the bare accessor.
+        assert_eq!(&contents[edits[0].0.clone()], "r#get_type");
+        assert_eq!(edits[0].1, "get_kind");
+    }
+
+    #[test]
+    fn word_boundary_rejects_substrings() {
+        // `get_counter` and `bget_count` and `get_count_more` must NOT match the rename of `count`.
+        let contents =
+            "obj.get_counter(); xget_count(); obj.get_count_more(); let _ = my_get_count_;";
+        let edits =
+            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        assert!(edits.is_empty(), "matched substrings: {edits:?}");
+    }
+
+    #[test]
+    fn snake_case_old_name() {
+        // Slint source written as kebab-case `my-counter` produces accessor `get_my_counter`.
+        let contents = "obj.get_my_counter()";
+        let edits = scan_file_contents(
+            contents,
+            &pairs(DeclarationKind::Property, "my-counter", "my-total"),
+        );
+        assert_eq!(edits.len(), 1);
+        assert_eq!(&contents[edits[0].0.clone()], "get_my_counter");
+        assert_eq!(edits[0].1, "get_my_total");
+    }
+
+    #[test]
+    fn multiple_call_sites() {
+        let contents = "obj.get_x(); other.get_x(); a.get_x() + b.get_x();";
+        let edits = scan_file_contents(contents, &pairs(DeclarationKind::Property, "x", "y"));
+        assert_eq!(edits.len(), 4);
+    }
+
+    #[test]
+    fn collect_files_skips_target_and_filters_by_extension() {
+        let tmp = tempdir();
+        std::fs::write(tmp.path().join("a.rs"), "").unwrap();
+        std::fs::write(tmp.path().join("b.cpp"), "").unwrap();
+        std::fs::write(tmp.path().join("ignored.txt"), "").unwrap();
+        std::fs::create_dir(tmp.path().join("target")).unwrap();
+        std::fs::write(tmp.path().join("target").join("c.rs"), "").unwrap();
+        std::fs::create_dir(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src").join("d.rs"), "").unwrap();
+
+        let mut out = Vec::new();
+        collect_files(tmp.path(), &mut out, 100).unwrap();
+        let names: Vec<_> =
+            out.iter().map(|p| p.file_name().unwrap().to_str().unwrap().to_string()).collect();
+        assert!(names.contains(&"a.rs".to_string()));
+        assert!(names.contains(&"b.cpp".to_string()));
+        assert!(names.contains(&"d.rs".to_string()));
+        assert!(!names.contains(&"ignored.txt".to_string()));
+        assert!(!names.contains(&"c.rs".to_string()), "target/ should be skipped");
+    }
+
+    #[test]
+    fn end_to_end_scan_produces_workspace_edits() {
+        let tmp = tempdir();
+        // Use `tmp.path()` directly rather than canonicalize: on Windows
+        // `canonicalize()` returns a `\\?\` UNC path which doesn't round-trip
+        // through `Url::from_file_path` / `Url::to_file_path` (the latter
+        // strips the prefix), breaking the workspace-folder prefix match.
+        let root = tmp.path();
+        std::fs::write(
+            root.join("main.rs"),
+            "fn main() { let v = obj.get_count(); obj.set_count(v); }\n",
+        )
+        .unwrap();
+        std::fs::create_dir(root.join("ui")).unwrap();
+        std::fs::write(root.join("ui").join("app.slint"), "// fake\n").unwrap();
+
+        let folders =
+            vec![WorkspaceFolder { uri: Url::from_file_path(root).unwrap(), name: "test".into() }];
+
+        let edits = scan_host_language_accessors(
+            &folders,
+            &root.join("ui").join("app.slint"),
+            DeclarationKind::Property,
+            "count",
+            "total",
+            ByteFormat::Utf16,
+            ScanBounds::default(),
+        )
+        .unwrap();
+        assert_eq!(edits.len(), 2);
+        assert!(edits.iter().all(|e| e.url.path().ends_with("main.rs")));
+        let texts: Vec<_> = edits.iter().map(|e| e.edit.new_text.clone()).collect();
+        assert!(texts.contains(&"get_total".to_string()));
+        assert!(texts.contains(&"set_total".to_string()));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn resolve_workspace_folders_prefers_workspace_folders() {
+        let tmp = tempdir();
+        let mut init = InitializeParams::default();
+        let folder =
+            WorkspaceFolder { uri: Url::from_file_path(tmp.path()).unwrap(), name: "ws".into() };
+        init.workspace_folders = Some(vec![folder.clone()]);
+        init.root_uri = Some(Url::parse("file:///should/not/be/used").unwrap());
+        let resolved = resolve_workspace_folders(&init);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].uri, folder.uri);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn resolve_workspace_folders_falls_back_to_root_uri() {
+        let tmp = tempdir();
+        let mut init = InitializeParams::default();
+        let uri = Url::from_file_path(tmp.path()).unwrap();
+        init.workspace_folders = None;
+        init.root_uri = Some(uri.clone());
+        let resolved = resolve_workspace_folders(&init);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].uri, uri);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn resolve_workspace_folders_falls_back_to_root_path() {
+        let tmp = tempdir();
+        let init = InitializeParams {
+            workspace_folders: Some(Vec::new()), // empty, not None
+            root_uri: None,
+            root_path: Some(tmp.path().to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        let resolved = resolve_workspace_folders(&init);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].uri.to_file_path().unwrap(), tmp.path());
+    }
+
+    #[test]
+    fn unsaved_buffer_path_still_resolves_to_workspace_folder() {
+        // Path doesn't exist on disk (simulating an untitled buffer or an
+        // unsaved new file) but is still under a configured workspace folder.
+        // Pre-fix this returned OutsideWorkspace via canonicalize().
+        let tmp = tempdir();
+        let folders = vec![WorkspaceFolder {
+            uri: Url::from_file_path(tmp.path()).unwrap(),
+            name: "ws".into(),
+        }];
+        let unsaved = tmp.path().join("never-saved.slint");
+        assert!(!unsaved.exists());
+        let folder = workspace_folder_for(&folders, &unsaved).expect("should match");
+        assert_eq!(folder, tmp.path().to_path_buf());
+    }
+
+    #[test]
+    fn outside_workspace_fails_closed() {
+        let tmp_workspace = tempdir();
+        let tmp_outside = tempdir();
+        let folders = vec![WorkspaceFolder {
+            uri: Url::from_file_path(tmp_workspace.path()).unwrap(),
+            name: "test".into(),
+        }];
+        std::fs::write(tmp_outside.path().join("orphan.slint"), "// fake").unwrap();
+        let result = scan_host_language_accessors(
+            &folders,
+            &tmp_outside.path().join("orphan.slint"),
+            DeclarationKind::Property,
+            "x",
+            "y",
+            ByteFormat::Utf16,
+            ScanBounds::default(),
+        );
+        match result {
+            Err(HostLanguageScanError::OutsideWorkspace) => {}
+            Err(other) => panic!("expected OutsideWorkspace, got {other:?}"),
+            Ok(_) => panic!("expected OutsideWorkspace error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn collect_files_extension_match_is_case_insensitive() {
+        let tmp = tempdir();
+        std::fs::write(tmp.path().join("Main.RS"), "").unwrap();
+        std::fs::write(tmp.path().join("Window.HPP"), "").unwrap();
+        std::fs::write(tmp.path().join("README.md"), "").unwrap();
+        let mut out = Vec::new();
+        collect_files(tmp.path(), &mut out, 100).unwrap();
+        let names: Vec<_> =
+            out.iter().map(|p| p.file_name().unwrap().to_str().unwrap().to_string()).collect();
+        assert!(names.contains(&"Main.RS".to_string()), "got {names:?}");
+        assert!(names.contains(&"Window.HPP".to_string()), "got {names:?}");
+        assert!(!names.contains(&"README.md".to_string()), "got {names:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_files_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempdir();
+        // Create a real file and a symlinked directory cycle.
+        std::fs::write(tmp.path().join("real.rs"), "").unwrap();
+        std::fs::create_dir(tmp.path().join("sub")).unwrap();
+        std::fs::write(tmp.path().join("sub").join("nested.rs"), "").unwrap();
+        // Symlink cycle: sub/back -> ..
+        symlink("..", tmp.path().join("sub").join("back")).unwrap();
+        // Symlink to a file that would otherwise match.
+        symlink(tmp.path().join("real.rs"), tmp.path().join("linked.rs")).unwrap();
+
+        let mut out = Vec::new();
+        collect_files(tmp.path(), &mut out, 100).unwrap();
+        let names: Vec<_> =
+            out.iter().map(|p| p.file_name().unwrap().to_str().unwrap().to_string()).collect();
+        // The real files are present, the symlinked dir wasn't recursed
+        // (no stack overflow), and the symlink to a file was skipped.
+        assert!(names.contains(&"real.rs".to_string()));
+        assert!(names.contains(&"nested.rs".to_string()));
+        assert!(!names.contains(&"linked.rs".to_string()), "symlink should be skipped");
+    }
+
+    #[test]
+    fn collect_files_respects_max_files() {
+        let tmp = tempdir();
+        for i in 0..10 {
+            std::fs::write(tmp.path().join(format!("f{i}.rs")), "").unwrap();
+        }
+        let mut out = Vec::new();
+        let err = collect_files(tmp.path(), &mut out, 3).unwrap_err();
+        assert!(matches!(err, HostLanguageScanError::TooManyFiles { limit: 3 }));
+    }
+
+    /// A throwaway directory that cleans itself up on drop.
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn tempdir() -> TempDir {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "slint-lsp-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir(&path).unwrap();
+        TempDir { path }
+    }
+}

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -31,30 +31,6 @@ const HOST_FILE_EXTENSIONS: &[&str] = &["rs", "cpp", "cc", "cxx", "h", "hpp", "h
 /// Directory names skipped during the walk.
 const SKIP_DIRS: &[&str] = &["target", "build", "out", "dist", "node_modules", ".git"];
 
-/// User policy for extending a Slint rename with host-language accessor
-/// edits. Mapped from the `slint.renameAccessorsInHostLanguages` workspace
-/// configuration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum RenameAccessorsPolicy {
-    /// No host-language edits. Current behavior.
-    #[default]
-    Never,
-    /// Extend every `textDocument/rename` `WorkspaceEdit` with the scanner's
-    /// host-language edits.
-    Always,
-}
-
-impl RenameAccessorsPolicy {
-    /// Parse the string form used in the workspace config.
-    pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "never" => Some(Self::Never),
-            "always" => Some(Self::Always),
-            _ => None,
-        }
-    }
-}
-
 /// Hard limits on scan work. `textDocument/rename` is synchronous in the LSP;
 /// an unbounded scan would stall the server.
 #[derive(Debug, Clone, Copy)]
@@ -94,9 +70,8 @@ impl std::fmt::Display for HostLanguageScanError {
             ),
             Self::TooManyFiles { limit } => write!(
                 f,
-                "Cannot scan host-language files: workspace exceeds {limit} \
-                 files. Disable slint.renameAccessorsInHostLanguages or \
-                 narrow the workspace folder.",
+                "Cannot scan host-language files: workspace exceeds {limit} files. \
+                 Narrow the workspace folder.",
             ),
         }
     }
@@ -307,14 +282,15 @@ fn has_host_extension(path: &Path) -> bool {
 /// Find every word-boundary-aligned occurrence of any old accessor name in
 /// `contents`, paired with the replacement text.
 ///
-/// The walk maintains a small lexer state so matches inside line comments,
-/// block comments, double-quoted string literals, and short char literals
-/// (`'X'`, `'\\X'`) are skipped. The lexer is intentionally minimal -- raw
-/// strings, byte strings, Rust lifetimes (`'a`), nested block comments,
-/// and language-specific escapes aren't handled. False positives in those
-/// contexts are an accepted v1 limitation; users opted in via
-/// `slint.renameAccessorsInHostLanguages = "always"` and should review the
-/// proposed edits before applying.
+/// This is a flat textual scan with no awareness of comments, string
+/// literals, raw strings, lifetimes, or any other language construct. The
+/// rename is *textual by design*: the feature is reached through a CodeAction
+/// that produces a `WorkspaceEdit` shown in the editor's rename-preview UI,
+/// and the user reviews proposed edits before applying. Selectively skipping
+/// some contexts (comments, strings) while still rewriting unrelated types
+/// that happen to share the accessor name was inconsistent enough to mislead
+/// users about what the tool actually does; the simpler flat scan is honest
+/// about the trade-off.
 ///
 /// Word boundaries treat any non-ASCII byte as if it extended an identifier,
 /// so a UTF-8 continuation byte adjacent to a match defeats the boundary --
@@ -327,123 +303,38 @@ fn scan_file_contents(
     contents: &str,
     accessors: &[(String, String)],
 ) -> Vec<(std::ops::Range<usize>, String)> {
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    enum LexState {
-        Code,
-        LineComment,
-        BlockComment,
-        String,
-    }
-
     let bytes = contents.as_bytes();
     let mut matches = Vec::new();
-    let mut state = LexState::Code;
     let mut i = 0;
     while i < bytes.len() {
-        match state {
-            LexState::Code => {
-                if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/') {
-                    state = LexState::LineComment;
-                    i += 2;
-                    continue;
-                }
-                if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
-                    state = LexState::BlockComment;
-                    i += 2;
-                    continue;
-                }
-                if bytes[i] == b'"' {
-                    state = LexState::String;
-                    i += 1;
-                    continue;
-                }
-                // Char literal: `'X'` or `'\\X'` (any single escape).
-                // Lifetimes look like `'a` without a closing quote; we
-                // peek ahead and only skip if a matching `'` is present
-                // within a short distance, otherwise treat `'` as a
-                // plain code byte and fall through.
-                if bytes[i] == b'\''
-                    && let Some(end) = try_consume_char_literal(bytes, i)
-                {
-                    i = end;
-                    continue;
-                }
-                // Try matching each accessor needle at the current position.
-                let mut matched_len = 0;
-                for (old, new) in accessors {
-                    let needle = old.as_bytes();
-                    if bytes[i..].starts_with(needle) {
-                        let end = i + needle.len();
-                        let after_ok = end == bytes.len() || !extends_identifier(bytes[end]);
-                        let (effective_start, before_ok) =
-                            if i >= 2 && bytes[i - 2] == b'r' && bytes[i - 1] == b'#' {
-                                let s = i - 2;
-                                (s, s == 0 || !extends_identifier(bytes[s - 1]))
-                            } else {
-                                (i, i == 0 || !extends_identifier(bytes[i - 1]))
-                            };
-                        if before_ok && after_ok {
-                            matches.push((effective_start..end, new.clone()));
-                            matched_len = needle.len();
-                            break;
-                        }
-                    }
-                }
-                if matched_len > 0 {
-                    i += matched_len;
-                } else {
-                    i += utf8_char_len(bytes, i);
+        let mut matched_len = 0;
+        for (old, new) in accessors {
+            let needle = old.as_bytes();
+            if bytes[i..].starts_with(needle) {
+                let end = i + needle.len();
+                let after_ok = end == bytes.len() || !extends_identifier(bytes[end]);
+                let (effective_start, before_ok) =
+                    if i >= 2 && bytes[i - 2] == b'r' && bytes[i - 1] == b'#' {
+                        let s = i - 2;
+                        (s, s == 0 || !extends_identifier(bytes[s - 1]))
+                    } else {
+                        (i, i == 0 || !extends_identifier(bytes[i - 1]))
+                    };
+                if before_ok && after_ok {
+                    matches.push((effective_start..end, new.clone()));
+                    matched_len = needle.len();
+                    break;
                 }
             }
-            LexState::LineComment => {
-                if bytes[i] == b'\n' {
-                    state = LexState::Code;
-                }
-                i += 1;
-            }
-            LexState::BlockComment => {
-                if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
-                    state = LexState::Code;
-                    i += 2;
-                    continue;
-                }
-                i += 1;
-            }
-            LexState::String => {
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    i += 2; // skip escape sequence (\" included)
-                    continue;
-                }
-                if bytes[i] == b'"' {
-                    state = LexState::Code;
-                }
-                i += 1;
-            }
+        }
+        if matched_len > 0 {
+            i += matched_len;
+        } else {
+            i += utf8_char_len(bytes, i);
         }
     }
     matches.sort_by_key(|(r, _)| r.start);
     matches
-}
-
-/// If `bytes[i]` starts a short char literal (`'X'` or `'\\X'`), return the
-/// byte offset just past the closing quote; otherwise return `None`. The
-/// caller should then treat `'` as a plain code byte (Rust lifetimes look
-/// like `'a` without a closing quote).
-fn try_consume_char_literal(bytes: &[u8], i: usize) -> Option<usize> {
-    debug_assert_eq!(bytes[i], b'\'');
-    // `'\X'` where X is any single byte (covers `'\n'`, `'\''`, `'\"'`, etc.)
-    if bytes.get(i + 1) == Some(&b'\\') && i + 3 < bytes.len() && bytes[i + 3] == b'\'' {
-        return Some(i + 4);
-    }
-    // `'X'` where X is one UTF-8 code point.
-    if i + 1 < bytes.len() && bytes[i + 1] != b'\'' {
-        let char_len = utf8_char_len(bytes, i + 1);
-        let close = i + 1 + char_len;
-        if bytes.get(close) == Some(&b'\'') {
-            return Some(close + 1);
-        }
-    }
-    None
 }
 
 /// Returns the length of the UTF-8 code point starting at `bytes[i]`,
@@ -529,70 +420,19 @@ mod tests {
     }
 
     #[test]
-    fn skip_matches_inside_line_comments() {
-        let contents = "let x = obj.get_count(); // get_count again here\n";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
-        assert_eq!(edits.len(), 1, "only the live call should match, got {edits:?}");
-        assert_eq!(&contents[edits[0].0.clone()], "get_count");
-    }
-
-    #[test]
-    fn skip_matches_inside_block_comments() {
-        let contents = "/* old API used obj.get_count() */\nobj.get_count();";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
-        assert_eq!(edits.len(), 1, "match inside block comment must be skipped, got {edits:?}");
-    }
-
-    #[test]
-    fn skip_matches_inside_string_literals() {
+    fn textual_scan_does_match_inside_comments_and_strings() {
+        // The scanner is flat textual — it deliberately doesn't try to skip
+        // comments or string literals. The reshape (PR feedback) committed
+        // to "users review the rename preview before applying" rather than
+        // selectively skipping some contexts but not others.
         let contents = r#"
-            let msg = "see obj.get_count for details";
+            // see obj.get_count for details
+            let msg = "obj.get_count is great";
             obj.get_count();
         "#;
         let edits =
             scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
-        assert_eq!(edits.len(), 1, "match inside string literal must be skipped, got {edits:?}");
-    }
-
-    #[test]
-    fn string_escapes_do_not_close_string_prematurely() {
-        // The escaped \" must not be interpreted as the end of the string.
-        let contents = "let s = \"a\\\" get_count not here\"; obj.get_count();";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
-        assert_eq!(edits.len(), 1);
-    }
-
-    #[test]
-    fn skip_matches_inside_char_literals() {
-        // The `"` inside the char literal must not flip the lexer into
-        // String state; otherwise the subsequent real call site is missed.
-        let contents = "let c = '\"'; obj.get_count();";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
-        assert_eq!(edits.len(), 1);
-        assert_eq!(&contents[edits[0].0.clone()], "get_count");
-    }
-
-    #[test]
-    fn lifetime_is_not_consumed_as_char_literal() {
-        // `'a` in `&'a T` is a lifetime, not a char literal. The lexer must
-        // not enter Char state and swallow the rest of the file.
-        let contents = "fn f<'a>(x: &'a u32) { obj.get_count(); }";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
-        assert_eq!(edits.len(), 1);
-    }
-
-    #[test]
-    fn escaped_char_literal_is_consumed() {
-        // `'\n'`, `'\''`, `'\"'` etc. should all be skipped wholesale.
-        let contents = "let n = '\\n'; let q = '\\''; obj.get_count();";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
-        assert_eq!(edits.len(), 1);
+        assert_eq!(edits.len(), 3, "all three textual matches should fire, got {edits:?}");
     }
 
     #[test]

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -126,6 +126,16 @@ pub fn search_replace_host_language_accessors(
         if metadata.len() > bounds.max_file_bytes {
             continue;
         }
+        // TODO: Reading the file directly here may cause issues with files that are open and edited in the
+        // editor.
+        // Unfortunately, the LSP spec does not easily allow us to request the contents of a certain
+        // file. So we would have to keep track of all the workspace edits, even if the files are
+        // not relevant for the LSP otherwise.
+        // For now, we'll just not do this and hope that the files on disk are reasonably up to
+        // date.
+        //
+        // If this causes issues for our users, we should add another document cache that stores the
+        // contents of all open files, even if they're not Slint files and then read from that.
         let contents = match std::fs::read_to_string(&path) {
             Ok(s) => s,
             Err(_) => continue, // non-UTF-8 or unreadable; skip

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -1,21 +1,22 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore absolutized bget countñ xéget xget xñget xxget
+// cSpell: ignore bget countñ xéget xget xñget xxget
 
 //! Scan the workspace for Rust/C++ call sites of Slint-generated property,
 //! callback, and function accessors so that a Slint rename can extend its
 //! `WorkspaceEdit` with edits in host-language source files.
 //!
-//! The scanner is intentionally simple: byte-level word-boundary search for a
-//! small set of accessor names derived from
-//! [`i_slint_compiler::generator::accessor_names`]. It does not parse Rust or
-//! C++. Cross-component accessor collisions are possible by construction; see
-//! the design in the PR for #11841 for the mitigations (config opt-in,
-//! preview-before-apply in v2).
+//! The scanner tokenizes identifiers using Unicode XID_Start / XID_Continue
+//! (via [`icu_properties`]) and matches whole identifiers against a small
+//! lookup table derived from [`i_slint_compiler::generator::accessor_names`].
+//! It does not parse Rust or C++. Cross-component accessor collisions are
+//! possible by construction; the LSP shows the proposed edits via
+//! `workspace/applyEdit` so the user reviews them before they land.
 
 #![cfg(not(target_arch = "wasm32"))]
 
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -28,11 +29,18 @@ use super::SingleTextEdit;
 /// Host-language file extensions the scanner considers.
 const HOST_FILE_EXTENSIONS: &[&str] = &["rs", "cpp", "cc", "cxx", "h", "hpp", "hh"];
 
-/// Directory names skipped during the walk.
+// TODO: `.gitignore` semantics would be the right way to pick which files to
+// scan -- it already encodes what is and isn't source. The Language Server
+// Protocol has no server-side query for the client's set of "active" or
+// "ignored" files; the hard-coded skip list below is the closest
+// approximation we can ship today. Replace this when an LSP extension or
+// client capability for that exists, or switch to the `ignore` crate if we
+// accept its filesystem-walk cost.
 const SKIP_DIRS: &[&str] = &["target", "build", "out", "dist", "node_modules", ".git"];
 
-/// Hard limits on scan work. `textDocument/rename` is synchronous in the LSP;
-/// an unbounded scan would stall the server.
+/// Hard limits on scan work. The host-language follow-up runs in a
+/// spawned task, but we still bound it so a misconfigured workspace can't
+/// hold the LSP open indefinitely.
 #[derive(Debug, Clone, Copy)]
 pub struct ScanBounds {
     /// Maximum number of host-language files inspected.
@@ -42,36 +50,34 @@ pub struct ScanBounds {
     pub max_file_bytes: u64,
 }
 
-impl Default for ScanBounds {
-    fn default() -> Self {
-        Self { max_files: 5_000, max_file_bytes: 1 << 20 /* 1 MiB */ }
-    }
+impl ScanBounds {
+    pub const DEFAULT: Self = Self { max_files: 5_000, max_file_bytes: 1 << 20 /* 1 MiB */ };
 }
 
-/// Failure modes for the scanner. The Rename handler in `language.rs`
-/// soft-degrades these to a `tracing::warn!` and applies only the
-/// `.slint`-side edits, so callers should treat them as advisory rather
-/// than fatal. The error variants exist so the warning can be specific.
+/// Failure modes for the scanner. The Rename follow-up in `language.rs`
+/// soft-degrades these to a `tracing::warn!` and a `window/showMessage`,
+/// so callers should treat them as advisory rather than fatal.
 #[derive(Debug)]
 pub enum HostLanguageScanError {
-    /// The renamed `.slint` file is not under any configured workspace
-    /// folder, so there is no well-defined scan root.
-    OutsideWorkspace,
-    /// The scan would inspect more than `bounds.max_files` files.
+    /// The client did not report any open workspace folders, so the
+    /// scanner has nowhere to walk.
+    NoWorkspaceFolders,
+    /// The scan would inspect more than `bounds.max_files` files across all
+    /// configured workspace folders combined.
     TooManyFiles { limit: usize },
 }
 
 impl std::fmt::Display for HostLanguageScanError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::OutsideWorkspace => f.write_str(
-                "Cannot scan host-language files: the renamed .slint file is \
-                 not under any workspace folder",
+            Self::NoWorkspaceFolders => f.write_str(
+                "Cannot scan host-language files: the client did not report \
+                 any open workspace folders",
             ),
             Self::TooManyFiles { limit } => write!(
                 f,
                 "Cannot scan host-language files: workspace exceeds {limit} files. \
-                 Narrow the workspace folder.",
+                 Narrow the workspace folders.",
             ),
         }
     }
@@ -79,29 +85,41 @@ impl std::fmt::Display for HostLanguageScanError {
 
 impl std::error::Error for HostLanguageScanError {}
 
-/// Walk the workspace folder containing `renamed_source` for `.rs`/`.cpp`/...
-/// files, replace any occurrence of the old accessor names derived from
-/// `(kind, old_name)` with the corresponding new accessor names derived from
-/// `(kind, new_name)`, and return the resulting per-file edits.
+/// Walk every configured workspace folder for `.rs`/`.cpp`/... files, replace
+/// any occurrence of the old accessor names derived from `(kind, old_name)`
+/// with the corresponding new accessor names derived from `(kind, new_name)`,
+/// and return the resulting per-file edits.
 ///
-/// The returned edits can be merged with the `.slint`-only edits via
-/// [`super::create_workspace_edit_from_single_text_edits`].
+/// Each [`WorkspaceFolder`] is walked independently; per the LSP spec, an
+/// editor can attach unrelated directories as separate workspace folders to
+/// the same server, and call sites for one folder's `.slint` declarations may
+/// live in another folder.
 pub fn scan_host_language_accessors(
     workspace_folders: &[WorkspaceFolder],
-    renamed_source: &Path,
     kind: DeclarationKind,
     old_name: &str,
     new_name: &str,
     format: ByteFormat,
     bounds: ScanBounds,
 ) -> Result<Vec<SingleTextEdit>, HostLanguageScanError> {
-    let scan_root = workspace_folder_for(workspace_folders, renamed_source)
-        .ok_or(HostLanguageScanError::OutsideWorkspace)?;
+    if workspace_folders.is_empty() {
+        return Err(HostLanguageScanError::NoWorkspaceFolders);
+    }
 
-    let accessors = accessor_pairs(kind, old_name, new_name);
+    let pairs = accessor_pairs(kind, old_name, new_name);
+    let accessors: HashMap<&str, &str> =
+        pairs.iter().map(|(o, n)| (o.as_str(), n.as_str())).collect();
 
     let mut files = Vec::new();
-    collect_files(&scan_root, &mut files, bounds.max_files)?;
+    for folder in workspace_folders {
+        let Ok(folder_path) = folder.uri.to_file_path() else { continue };
+        collect_files(&folder_path, &mut files, bounds.max_files)?;
+    }
+    // Distinct workspace folders can share files (one folder being an
+    // ancestor of another, or symlinked overlap). Dedup so we don't emit
+    // duplicate TextEdits per file.
+    files.sort();
+    files.dedup();
 
     let mut edits = Vec::new();
     for path in files {
@@ -117,7 +135,7 @@ pub fn scan_host_language_accessors(
             Err(_) => continue, // non-UTF-8 or unreadable; skip
         };
 
-        let file_edits = scan_file_contents(&contents, &accessors);
+        let file_edits = search_replace_file_contents(&contents, &accessors);
         if file_edits.is_empty() {
             continue;
         }
@@ -141,16 +159,13 @@ pub fn scan_host_language_accessors(
     Ok(edits)
 }
 
-/// Build the set of workspace folders the scanner should consider.
-///
-/// Prefers `init_param.workspace_folders` when the client sent any; falls
-/// back to the (LSP-deprecated but still common) `root_uri` / `root_path` so
-/// editors that initialize the server in single-folder mode (older VS Code,
-/// many Neovim setups, Helix) still get host-language scanning.
+/// Build the set of workspace folders the scanner should consider, falling
+/// back through the LSP-deprecated-but-widely-used `root_uri` / `root_path`
+/// so editors that initialize the server in single-folder mode still get
+/// host-language scanning.
 ///
 /// Returns an empty Vec if no folder could be derived; the scanner will then
-/// fail with `OutsideWorkspace` (which the handler soft-degrades to a
-/// warning).
+/// fail with `NoWorkspaceFolders`.
 #[allow(deprecated)] // root_uri / root_path are deprecated but widely used
 pub fn resolve_workspace_folders(init_param: &InitializeParams) -> Vec<WorkspaceFolder> {
     if let Some(folders) = init_param.workspace_folders.as_ref()
@@ -169,38 +184,35 @@ pub fn resolve_workspace_folders(init_param: &InitializeParams) -> Vec<Workspace
     Vec::new()
 }
 
-/// Most-specific workspace folder whose URI's filesystem path is an ancestor
-/// of `path`. Returns `None` if no folder qualifies.
+/// Ask the client for its current workspace folders via the
+/// `workspace/workspaceFolders` request, falling back to the cached
+/// [`InitializeParams`] when the client doesn't advertise support.
 ///
-/// Performs the prefix comparison on absolutized (but not canonicalized)
-/// paths so that:
-/// - unsaved/untitled documents whose path doesn't exist on disk still match
-///   their containing workspace folder;
-/// - a `.slint` reached via a symlink isn't excluded because canonicalize
-///   resolves it outside the workspace.
-///
-/// The trade-off is that a symlink-based "outside-the-workspace" file path
-/// can falsely match its symlink parent; that's a milder failure than
-/// silently dropping every rename for symlinked files.
-fn workspace_folder_for(folders: &[WorkspaceFolder], path: &Path) -> Option<PathBuf> {
-    let target = absolute_path(path);
-    folders
-        .iter()
-        .filter_map(|f| f.uri.to_file_path().ok())
-        .map(|p| absolute_path(&p))
-        .filter(|folder| target.starts_with(folder))
-        .max_by_key(|folder| folder.components().count())
-}
-
-/// Make a path absolute without touching the filesystem. Falls back to the
-/// path as-given if joining with the current dir would fail (which it
-/// effectively can't for our inputs).
-fn absolute_path(path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir().map(|cwd| cwd.join(path)).unwrap_or_else(|_| path.to_path_buf())
+/// Folders can change after initialization (the user opens or closes folders
+/// in their editor); using the cached `init_param.workspace_folders` would
+/// scan a stale set and either miss files or scan files no longer in the
+/// workspace. Clients that don't advertise the capability never send change
+/// notifications either, so the InitializeParams snapshot is the best we can
+/// do for them.
+pub async fn current_workspace_folders(
+    server_notifier: &crate::ServerNotifier,
+    init_param: &InitializeParams,
+) -> Vec<WorkspaceFolder> {
+    let supports_query = init_param
+        .capabilities
+        .workspace
+        .as_ref()
+        .and_then(|w| w.workspace_folders)
+        .unwrap_or(false);
+    if supports_query
+        && let Ok(fut) =
+            server_notifier.send_request::<lsp_types::request::WorkspaceFoldersRequest>(())
+        && let Ok(Some(folders)) = fut.await
+        && !folders.is_empty()
+    {
+        return folders;
     }
+    resolve_workspace_folders(init_param)
 }
 
 /// Compute the `(old, new)` accessor name pairs for the rename. Rust and C++
@@ -218,13 +230,16 @@ fn accessor_pairs(kind: DeclarationKind, old_name: &str, new_name: &str) -> Vec<
         .collect()
 }
 
-/// Recursive walk of `root`, appending host-language file paths into `out`.
-/// Returns `TooManyFiles` if `max_files` is exceeded. Unreadable directories
-/// are silently skipped (don't fail the whole rename on a permission error
-/// in some sibling folder).
+/// Iterative breadth-first walk of `root`, appending host-language file paths
+/// into `out`. Returns `TooManyFiles` if `max_files` is exceeded.
+///
+/// Iterative rather than recursive so we don't burn stack on arbitrarily deep
+/// directory trees, and so a future change can fan the queue out to multiple
+/// worker tasks. Unreadable directories are silently skipped (don't fail the
+/// whole rename on a permission error in some sibling folder).
 ///
 /// Does not follow symlinks: an `entry.file_type()` whose `is_symlink()` is
-/// true is skipped entirely. This avoids unbounded recursion through symlink
+/// true is skipped entirely. This avoids unbounded traversal through symlink
 /// cycles (vendored deps, sibling-crate links) at the cost of not scanning
 /// symlinked source trees -- users who want those scanned should add the
 /// real directory as a workspace folder.
@@ -233,129 +248,138 @@ fn collect_files(
     out: &mut Vec<PathBuf>,
     max_files: usize,
 ) -> Result<(), HostLanguageScanError> {
-    let entries = match std::fs::read_dir(root) {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::debug!("host-language scan: skipping unreadable dir {}: {e}", root.display());
-            return Ok(());
-        }
-    };
-    for entry in entries {
-        let entry = match entry {
+    let mut queue: VecDeque<PathBuf> = VecDeque::new();
+    queue.push_back(root.to_path_buf());
+    while let Some(dir) = queue.pop_front() {
+        let entries = match std::fs::read_dir(&dir) {
             Ok(e) => e,
             Err(e) => {
                 tracing::debug!(
-                    "host-language scan: skipping unreadable entry under {}: {e}",
-                    root.display()
+                    "host-language scan: skipping unreadable dir {}: {e}",
+                    dir.display()
                 );
                 continue;
             }
         };
-        let Ok(file_type) = entry.file_type() else { continue };
-        if file_type.is_symlink() {
-            continue;
-        }
-        let path = entry.path();
-        if file_type.is_dir() {
-            if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                && SKIP_DIRS.contains(&name)
-            {
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::debug!(
+                        "host-language scan: skipping unreadable entry under {}: {e}",
+                        dir.display()
+                    );
+                    continue;
+                }
+            };
+            let Ok(file_type) = entry.file_type() else { continue };
+            if file_type.is_symlink() {
                 continue;
             }
-            collect_files(&path, out, max_files)?;
-        } else if file_type.is_file() && has_host_extension(&path) {
-            if out.len() >= max_files {
-                return Err(HostLanguageScanError::TooManyFiles { limit: max_files });
+            let path = entry.path();
+            if file_type.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                    && SKIP_DIRS.contains(&name)
+                {
+                    continue;
+                }
+                queue.push_back(path);
+            } else if file_type.is_file() && has_host_extension(&path) {
+                if out.len() >= max_files {
+                    return Err(HostLanguageScanError::TooManyFiles { limit: max_files });
+                }
+                out.push(path);
             }
-            out.push(path);
         }
     }
     Ok(())
 }
 
-/// Case-insensitive check against [`HOST_FILE_EXTENSIONS`].
 fn has_host_extension(path: &Path) -> bool {
     let Some(ext) = path.extension().and_then(|e| e.to_str()) else { return false };
+    // Case-insensitive: Windows filesystems are case-insensitive by default
+    // and projects in the wild ship files like `Window.HPP`.
     HOST_FILE_EXTENSIONS.iter().any(|known| known.eq_ignore_ascii_case(ext))
 }
 
-/// Find every word-boundary-aligned occurrence of any old accessor name in
-/// `contents`, paired with the replacement text.
+/// Tokenize `contents` into Unicode identifiers and emit a replacement for
+/// every identifier whose text matches a key in `accessors`.
 ///
 /// This is a flat textual scan with no awareness of comments, string
 /// literals, raw strings, lifetimes, or any other language construct. The
-/// rename is *textual by design*: the feature is reached through a CodeAction
-/// that produces a `WorkspaceEdit` shown in the editor's rename-preview UI,
-/// and the user reviews proposed edits before applying. Selectively skipping
-/// some contexts (comments, strings) while still rewriting unrelated types
-/// that happen to share the accessor name was inconsistent enough to mislead
-/// users about what the tool actually does; the simpler flat scan is honest
-/// about the trade-off.
+/// rename is *textual by design*: the LSP shows the proposed edits via
+/// `workspace/applyEdit` and the user reviews them before applying.
+/// Selectively skipping some contexts (comments, strings) while still
+/// rewriting unrelated types that happen to share the accessor name was
+/// inconsistent enough to mislead users about what the tool actually does;
+/// the simpler flat scan is honest about the trade-off.
 ///
-/// Word boundaries treat any non-ASCII byte as if it extended an identifier,
-/// so a UTF-8 continuation byte adjacent to a match defeats the boundary --
-/// `xñget_count` is correctly rejected.
+/// Identifiers are recognized via Unicode `XID_Start` / `XID_Continue`
+/// (matching Rust's identifier rules and the wider modern-language family),
+/// so `xñget_count` becomes a single identifier and equality-rejects against
+/// `get_count` rather than producing a partial match.
 ///
 /// Optional leading `r#` (raw identifier syntax in Rust) is included in the
 /// matched range so that the replacement drops it; the accessor prefixes
 /// (`get_`, `set_`, etc.) make the result never a Rust keyword.
-fn scan_file_contents(
+fn search_replace_file_contents(
     contents: &str,
-    accessors: &[(String, String)],
+    accessors: &HashMap<&str, &str>,
 ) -> Vec<(std::ops::Range<usize>, String)> {
-    let bytes = contents.as_bytes();
+    let xid_start = icu_properties::CodePointSetData::new::<icu_properties::props::XidStart>();
+    let xid_continue =
+        icu_properties::CodePointSetData::new::<icu_properties::props::XidContinue>();
+
     let mut matches = Vec::new();
-    let mut i = 0;
-    while i < bytes.len() {
-        let mut matched_len = 0;
-        for (old, new) in accessors {
-            let needle = old.as_bytes();
-            if bytes[i..].starts_with(needle) {
-                let end = i + needle.len();
-                let after_ok = end == bytes.len() || !extends_identifier(bytes[end]);
-                let (effective_start, before_ok) =
-                    if i >= 2 && bytes[i - 2] == b'r' && bytes[i - 1] == b'#' {
-                        let s = i - 2;
-                        (s, s == 0 || !extends_identifier(bytes[s - 1]))
-                    } else {
-                        (i, i == 0 || !extends_identifier(bytes[i - 1]))
-                    };
-                if before_ok && after_ok {
-                    matches.push((effective_start..end, new.clone()));
-                    matched_len = needle.len();
-                    break;
-                }
+    let mut chars = contents.char_indices().peekable();
+    while let Some(&(start, ch)) = chars.peek() {
+        if !is_identifier_start(ch, xid_start) {
+            chars.next();
+            continue;
+        }
+        // Consume one identifier.
+        let mut end = start + ch.len_utf8();
+        chars.next();
+        while let Some(&(idx, c)) = chars.peek() {
+            if is_identifier_continue(c, xid_continue) {
+                end = idx + c.len_utf8();
+                chars.next();
+            } else {
+                break;
             }
         }
-        if matched_len > 0 {
-            i += matched_len;
+        let Some(&new) = accessors.get(&contents[start..end]) else { continue };
+
+        // If the identifier was written as a Rust raw identifier (`r#name`),
+        // extend the match to include the `r#` so the replacement drops it.
+        // Accessor names always begin with `get_`/`set_`/`invoke_`/`on_` so
+        // they are never Rust keywords; the bare identifier is always legal.
+        // Only treat `r#` as a prefix when it sits at a word boundary (e.g.
+        // not as part of `xr#name`, which is not legal Rust syntax anyway).
+        let effective_start = if start >= 2 && &contents[start - 2..start] == "r#" {
+            let prev_is_boundary = start == 2
+                || !contents[..start - 2]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| is_identifier_continue(c, xid_continue));
+            if prev_is_boundary { start - 2 } else { start }
         } else {
-            i += utf8_char_len(bytes, i);
-        }
+            start
+        };
+        matches.push((effective_start..end, new.to_string()));
     }
-    matches.sort_by_key(|(r, _)| r.start);
     matches
 }
 
-/// Returns the length of the UTF-8 code point starting at `bytes[i]`,
-/// or 1 if the byte is invalid UTF-8 (defensive — we already hold a `&str`).
-fn utf8_char_len(bytes: &[u8], i: usize) -> usize {
-    match bytes[i] {
-        0x00..=0x7F => 1,
-        0xC0..=0xDF => 2,
-        0xE0..=0xEF => 3,
-        0xF0..=0xF7 => 4,
-        _ => 1,
-    }
+fn is_identifier_start(ch: char, xid_start: icu_properties::CodePointSetDataBorrowed<'_>) -> bool {
+    ch == '_' || xid_start.contains(ch)
 }
 
-/// True if a byte at a candidate word boundary would prevent the boundary
-/// from being placed there -- i.e. it's an ASCII identifier byte or the
-/// (continuation or leading) byte of a non-ASCII identifier character.
-/// Treating every byte >= 0x80 as identifier-extending is conservative but
-/// safe: it makes matches adjacent to any multi-byte UTF-8 character reject.
-fn extends_identifier(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80
+fn is_identifier_continue(
+    ch: char,
+    xid_continue: icu_properties::CodePointSetDataBorrowed<'_>,
+) -> bool {
+    xid_continue.contains(ch)
 }
 
 fn byte_range_to_lsp_range(
@@ -381,15 +405,24 @@ fn byte_range_to_lsp_range(
 mod tests {
     use super::*;
 
-    fn pairs(kind: DeclarationKind, old: &str, new: &str) -> Vec<(String, String)> {
-        accessor_pairs(kind, old, new)
+    /// Build the owned accessor pairs and emit edits in one call -- the
+    /// scanner takes a `HashMap<&str, &str>` borrowing into those pairs.
+    fn scan(
+        contents: &str,
+        kind: DeclarationKind,
+        old: &str,
+        new: &str,
+    ) -> Vec<(std::ops::Range<usize>, String)> {
+        let pairs = accessor_pairs(kind, old, new);
+        let map: HashMap<&str, &str> =
+            pairs.iter().map(|(o, n)| (o.as_str(), n.as_str())).collect();
+        search_replace_file_contents(contents, &map)
     }
 
     #[test]
     fn property_matches_get_and_set() {
         let contents = "fn main() {\n    let v = obj.get_count();\n    obj.set_count(v + 1);\n}\n";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        let edits = scan(contents, DeclarationKind::Property, "count", "total");
         assert_eq!(edits.len(), 2);
         let (range_get, new_get) = &edits[0];
         assert_eq!(&contents[range_get.clone()], "get_count");
@@ -402,8 +435,7 @@ mod tests {
     #[test]
     fn callback_matches_invoke_and_on() {
         let contents = "obj.invoke_clicked(); obj.on_clicked(|| {});";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Callback, "clicked", "pressed"));
+        let edits = scan(contents, DeclarationKind::Callback, "clicked", "pressed");
         assert_eq!(edits.len(), 2);
         let texts: Vec<_> = edits.iter().map(|(r, _)| &contents[r.clone()]).collect();
         assert!(texts.contains(&"invoke_clicked"));
@@ -413,8 +445,7 @@ mod tests {
     #[test]
     fn function_matches_invoke_only() {
         let contents = "obj.invoke_multiply(2);";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Function, "multiply", "double"));
+        let edits = scan(contents, DeclarationKind::Function, "multiply", "double");
         assert_eq!(edits.len(), 1);
         assert_eq!(&contents[edits[0].0.clone()], "invoke_multiply");
     }
@@ -430,31 +461,27 @@ mod tests {
             let msg = "obj.get_count is great";
             obj.get_count();
         "#;
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        let edits = scan(contents, DeclarationKind::Property, "count", "total");
         assert_eq!(edits.len(), 3, "all three textual matches should fire, got {edits:?}");
     }
 
     #[test]
     fn non_ascii_char_after_match_defeats_word_boundary() {
-        // Symmetric to non_ascii_char_before_match_defeats_word_boundary --
-        // the byte AFTER the match must also be treated as identifier-
-        // extending when non-ASCII, so `get_countñ` is rejected.
+        // The XID tokenizer treats `ñ` as identifier-continue, so
+        // `get_countñ` is one identifier and equality-rejects against
+        // `get_count`.
         let contents = "let xxget_countñ = 1; obj.get_count();";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        let edits = scan(contents, DeclarationKind::Property, "count", "total");
         assert_eq!(edits.len(), 1, "only the call-site match is valid, got {edits:?}");
         assert_eq!(&contents[edits[0].0.clone()], "get_count");
     }
 
     #[test]
     fn non_ascii_char_before_match_defeats_word_boundary() {
-        // `é` is two bytes (0xC3, 0xA9); the byte before `get_count` is a
-        // continuation byte. Without the non-ASCII guard, the old logic
-        // would accept the match and corrupt the unrelated identifier.
+        // `é` is XID_Continue, so `xéget_count` is one identifier and the
+        // accessor lookup rejects it cleanly.
         let contents = "let xéget_count = 1; obj.get_count();";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        let edits = scan(contents, DeclarationKind::Property, "count", "total");
         assert_eq!(edits.len(), 1, "only the call-site match is valid, got {edits:?}");
         assert_eq!(&contents[edits[0].0.clone()], "get_count");
     }
@@ -462,7 +489,7 @@ mod tests {
     #[test]
     fn raw_identifier_prefix_included_in_match() {
         let contents = "obj.r#get_type();";
-        let edits = scan_file_contents(contents, &pairs(DeclarationKind::Property, "type", "kind"));
+        let edits = scan(contents, DeclarationKind::Property, "type", "kind");
         assert_eq!(edits.len(), 1);
         // The match swallows `r#` so the rewrite is the bare accessor.
         assert_eq!(&contents[edits[0].0.clone()], "r#get_type");
@@ -474,8 +501,7 @@ mod tests {
         // `get_counter` and `bget_count` and `get_count_more` must NOT match the rename of `count`.
         let contents =
             "obj.get_counter(); xget_count(); obj.get_count_more(); let _ = my_get_count_;";
-        let edits =
-            scan_file_contents(contents, &pairs(DeclarationKind::Property, "count", "total"));
+        let edits = scan(contents, DeclarationKind::Property, "count", "total");
         assert!(edits.is_empty(), "matched substrings: {edits:?}");
     }
 
@@ -483,10 +509,7 @@ mod tests {
     fn snake_case_old_name() {
         // Slint source written as kebab-case `my-counter` produces accessor `get_my_counter`.
         let contents = "obj.get_my_counter()";
-        let edits = scan_file_contents(
-            contents,
-            &pairs(DeclarationKind::Property, "my-counter", "my-total"),
-        );
+        let edits = scan(contents, DeclarationKind::Property, "my-counter", "my-total");
         assert_eq!(edits.len(), 1);
         assert_eq!(&contents[edits[0].0.clone()], "get_my_counter");
         assert_eq!(edits[0].1, "get_my_total");
@@ -495,7 +518,7 @@ mod tests {
     #[test]
     fn multiple_call_sites() {
         let contents = "obj.get_x(); other.get_x(); a.get_x() + b.get_x();";
-        let edits = scan_file_contents(contents, &pairs(DeclarationKind::Property, "x", "y"));
+        let edits = scan(contents, DeclarationKind::Property, "x", "y");
         assert_eq!(edits.len(), 4);
     }
 
@@ -542,12 +565,11 @@ mod tests {
 
         let edits = scan_host_language_accessors(
             &folders,
-            &root.join("ui").join("app.slint"),
             DeclarationKind::Property,
             "count",
             "total",
             ByteFormat::Utf16,
-            ScanBounds::default(),
+            ScanBounds::DEFAULT,
         )
         .unwrap();
         assert_eq!(edits.len(), 2);
@@ -600,44 +622,52 @@ mod tests {
     }
 
     #[test]
-    fn unsaved_buffer_path_still_resolves_to_workspace_folder() {
-        // Path doesn't exist on disk (simulating an untitled buffer or an
-        // unsaved new file) but is still under a configured workspace folder.
-        // Pre-fix this returned OutsideWorkspace via canonicalize().
-        let tmp = tempdir();
-        let folders = vec![WorkspaceFolder {
-            uri: Url::from_file_path(tmp.path()).unwrap(),
-            name: "ws".into(),
-        }];
-        let unsaved = tmp.path().join("never-saved.slint");
-        assert!(!unsaved.exists());
-        let folder = workspace_folder_for(&folders, &unsaved).expect("should match");
-        assert_eq!(folder, tmp.path().to_path_buf());
-    }
-
-    #[test]
-    fn outside_workspace_fails_closed() {
-        let tmp_workspace = tempdir();
-        let tmp_outside = tempdir();
-        let folders = vec![WorkspaceFolder {
-            uri: Url::from_file_path(tmp_workspace.path()).unwrap(),
-            name: "test".into(),
-        }];
-        std::fs::write(tmp_outside.path().join("orphan.slint"), "// fake").unwrap();
+    fn empty_workspace_fails_closed() {
         let result = scan_host_language_accessors(
-            &folders,
-            &tmp_outside.path().join("orphan.slint"),
+            &[],
             DeclarationKind::Property,
             "x",
             "y",
             ByteFormat::Utf16,
-            ScanBounds::default(),
+            ScanBounds::DEFAULT,
         );
         match result {
-            Err(HostLanguageScanError::OutsideWorkspace) => {}
-            Err(other) => panic!("expected OutsideWorkspace, got {other:?}"),
-            Ok(_) => panic!("expected OutsideWorkspace error, got Ok"),
+            Err(HostLanguageScanError::NoWorkspaceFolders) => {}
+            Err(other) => panic!("expected NoWorkspaceFolders, got {other:?}"),
+            Ok(_) => panic!("expected NoWorkspaceFolders error, got Ok"),
         }
+    }
+
+    #[test]
+    fn multiple_workspace_folders_scan_independently() {
+        let folder_a = tempdir();
+        let folder_b = tempdir();
+        std::fs::write(folder_a.path().join("a.rs"), "fn f() { x.get_count(); }\n").unwrap();
+        std::fs::write(folder_b.path().join("b.rs"), "fn g() { y.set_count(0); }\n").unwrap();
+        let folders = vec![
+            WorkspaceFolder {
+                uri: Url::from_file_path(folder_a.path()).unwrap(),
+                name: "a".into(),
+            },
+            WorkspaceFolder {
+                uri: Url::from_file_path(folder_b.path()).unwrap(),
+                name: "b".into(),
+            },
+        ];
+
+        let edits = scan_host_language_accessors(
+            &folders,
+            DeclarationKind::Property,
+            "count",
+            "total",
+            ByteFormat::Utf16,
+            ScanBounds::DEFAULT,
+        )
+        .unwrap();
+
+        // Both folders contributed one edit.
+        let urls: std::collections::HashSet<_> = edits.iter().map(|e| e.url.clone()).collect();
+        assert_eq!(urls.len(), 2);
     }
 
     #[test]

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -94,7 +94,7 @@ impl std::error::Error for HostLanguageScanError {}
 /// editor can attach unrelated directories as separate workspace folders to
 /// the same server, and call sites for one folder's `.slint` declarations may
 /// live in another folder.
-pub fn scan_host_language_accessors(
+pub fn search_replace_host_language_accessors(
     workspace_folders: &[WorkspaceFolder],
     kind: DeclarationKind,
     old_name: &str,
@@ -318,10 +318,6 @@ fn has_host_extension(path: &Path) -> bool {
 /// (matching Rust's identifier rules and the wider modern-language family),
 /// so `xñget_count` becomes a single identifier and equality-rejects against
 /// `get_count` rather than producing a partial match.
-///
-/// Optional leading `r#` (raw identifier syntax in Rust) is included in the
-/// matched range so that the replacement drops it; the accessor prefixes
-/// (`get_`, `set_`, etc.) make the result never a Rust keyword.
 fn search_replace_file_contents(
     contents: &str,
     accessors: &HashMap<&str, &str>,
@@ -350,23 +346,7 @@ fn search_replace_file_contents(
         }
         let Some(&new) = accessors.get(&contents[start..end]) else { continue };
 
-        // If the identifier was written as a Rust raw identifier (`r#name`),
-        // extend the match to include the `r#` so the replacement drops it.
-        // Accessor names always begin with `get_`/`set_`/`invoke_`/`on_` so
-        // they are never Rust keywords; the bare identifier is always legal.
-        // Only treat `r#` as a prefix when it sits at a word boundary (e.g.
-        // not as part of `xr#name`, which is not legal Rust syntax anyway).
-        let effective_start = if start >= 2 && &contents[start - 2..start] == "r#" {
-            let prev_is_boundary = start == 2
-                || !contents[..start - 2]
-                    .chars()
-                    .next_back()
-                    .is_some_and(|c| is_identifier_continue(c, xid_continue));
-            if prev_is_boundary { start - 2 } else { start }
-        } else {
-            start
-        };
-        matches.push((effective_start..end, new.to_string()));
+        matches.push((start..end, new.to_string()));
     }
     matches
 }
@@ -487,12 +467,11 @@ mod tests {
     }
 
     #[test]
-    fn raw_identifier_prefix_included_in_match() {
+    fn raw_identifier_prefix_is_preserved() {
         let contents = "obj.r#get_type();";
         let edits = scan(contents, DeclarationKind::Property, "type", "kind");
         assert_eq!(edits.len(), 1);
-        // The match swallows `r#` so the rewrite is the bare accessor.
-        assert_eq!(&contents[edits[0].0.clone()], "r#get_type");
+        assert_eq!(&contents[edits[0].0.clone()], "get_type");
         assert_eq!(edits[0].1, "get_kind");
     }
 
@@ -563,7 +542,7 @@ mod tests {
         let folders =
             vec![WorkspaceFolder { uri: Url::from_file_path(root).unwrap(), name: "test".into() }];
 
-        let edits = scan_host_language_accessors(
+        let edits = search_replace_host_language_accessors(
             &folders,
             DeclarationKind::Property,
             "count",
@@ -623,7 +602,7 @@ mod tests {
 
     #[test]
     fn empty_workspace_fails_closed() {
-        let result = scan_host_language_accessors(
+        let result = search_replace_host_language_accessors(
             &[],
             DeclarationKind::Property,
             "x",
@@ -655,7 +634,7 @@ mod tests {
             },
         ];
 
-        let edits = scan_host_language_accessors(
+        let edits = search_replace_host_language_accessors(
             &folders,
             DeclarationKind::Property,
             "count",

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -3,20 +3,20 @@
 
 // cSpell: ignore bget countñ xéget xget xñget xxget
 
-//! Scan the workspace for Rust/C++ call sites of Slint-generated property,
-//! callback, and function accessors so that a Slint rename can extend its
-//! `WorkspaceEdit` with edits in host-language source files.
+//! Scan the workspace for identifiers that match Slint-generated Rust/C++
+//! property, callback, and function accessors.
 //!
 //! The scanner tokenizes identifiers using Unicode XID_Start / XID_Continue
 //! (via [`icu_properties`]) and matches whole identifiers against a small
 //! lookup table derived from [`i_slint_compiler::generator::accessor_names`].
 //! It does not parse Rust or C++. Cross-component accessor collisions are
-//! possible by construction; the LSP shows the proposed edits via
-//! `workspace/applyEdit` so the user reviews them before they land.
+//! possible by construction. The client may apply the `workspace/applyEdit`
+//! request immediately, so users should inspect the resulting changes with
+//! source control.
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -92,8 +92,7 @@ impl std::error::Error for HostLanguageScanError {}
 ///
 /// Each [`WorkspaceFolder`] is walked independently; per the LSP spec, an
 /// editor can attach unrelated directories as separate workspace folders to
-/// the same server, and call sites for one folder's `.slint` declarations may
-/// live in another folder.
+/// the same server, and matching identifiers may live in any folder.
 pub fn search_replace_host_language_accessors(
     workspace_folders: &[WorkspaceFolder],
     kind: DeclarationKind,
@@ -110,16 +109,13 @@ pub fn search_replace_host_language_accessors(
     let accessors: HashMap<&str, &str> =
         pairs.iter().map(|(o, n)| (o.as_str(), n.as_str())).collect();
 
-    let mut files = Vec::new();
+    let mut files = HashSet::new();
     for folder in workspace_folders {
         let Ok(folder_path) = folder.uri.to_file_path() else { continue };
         collect_files(&folder_path, &mut files, bounds.max_files)?;
     }
-    // Distinct workspace folders can share files (one folder being an
-    // ancestor of another, or symlinked overlap). Dedup so we don't emit
-    // duplicate TextEdits per file.
+    let mut files: Vec<_> = files.into_iter().collect();
     files.sort();
-    files.dedup();
 
     let mut edits = Vec::new();
     for path in files {
@@ -245,7 +241,7 @@ fn accessor_pairs(kind: DeclarationKind, old_name: &str, new_name: &str) -> Vec<
 /// real directory as a workspace folder.
 fn collect_files(
     root: &Path,
-    out: &mut Vec<PathBuf>,
+    out: &mut HashSet<PathBuf>,
     max_files: usize,
 ) -> Result<(), HostLanguageScanError> {
     let mut queue: VecDeque<PathBuf> = VecDeque::new();
@@ -285,10 +281,13 @@ fn collect_files(
                 }
                 queue.push_back(path);
             } else if file_type.is_file() && has_host_extension(&path) {
+                if out.contains(&path) {
+                    continue;
+                }
                 if out.len() >= max_files {
                     return Err(HostLanguageScanError::TooManyFiles { limit: max_files });
                 }
-                out.push(path);
+                out.insert(path);
             }
         }
     }
@@ -307,8 +306,8 @@ fn has_host_extension(path: &Path) -> bool {
 ///
 /// This is a flat textual scan with no awareness of comments, string
 /// literals, raw strings, lifetimes, or any other language construct. The
-/// rename is *textual by design*: the LSP shows the proposed edits via
-/// `workspace/applyEdit` and the user reviews them before applying.
+/// rename is *textual by design*. The client may apply the
+/// `workspace/applyEdit` request without showing a preview.
 /// Selectively skipping some contexts (comments, strings) while still
 /// rewriting unrelated types that happen to share the accessor name was
 /// inconsistent enough to mislead users about what the tool actually does;
@@ -432,10 +431,8 @@ mod tests {
 
     #[test]
     fn textual_scan_does_match_inside_comments_and_strings() {
-        // The scanner is flat textual — it deliberately doesn't try to skip
-        // comments or string literals. The reshape (PR feedback) committed
-        // to "users review the rename preview before applying" rather than
-        // selectively skipping some contexts but not others.
+        // The scanner is flat textual and deliberately doesn't skip comments
+        // or string literals.
         let contents = r#"
             // see obj.get_count for details
             let msg = "obj.get_count is great";
@@ -452,7 +449,7 @@ mod tests {
         // `get_count`.
         let contents = "let xxget_countñ = 1; obj.get_count();";
         let edits = scan(contents, DeclarationKind::Property, "count", "total");
-        assert_eq!(edits.len(), 1, "only the call-site match is valid, got {edits:?}");
+        assert_eq!(edits.len(), 1, "only the standalone match is valid, got {edits:?}");
         assert_eq!(&contents[edits[0].0.clone()], "get_count");
     }
 
@@ -462,7 +459,7 @@ mod tests {
         // accessor lookup rejects it cleanly.
         let contents = "let xéget_count = 1; obj.get_count();";
         let edits = scan(contents, DeclarationKind::Property, "count", "total");
-        assert_eq!(edits.len(), 1, "only the call-site match is valid, got {edits:?}");
+        assert_eq!(edits.len(), 1, "only the standalone match is valid, got {edits:?}");
         assert_eq!(&contents[edits[0].0.clone()], "get_count");
     }
 
@@ -512,7 +509,7 @@ mod tests {
         std::fs::create_dir(tmp.path().join("src")).unwrap();
         std::fs::write(tmp.path().join("src").join("d.rs"), "").unwrap();
 
-        let mut out = Vec::new();
+        let mut out = HashSet::new();
         collect_files(tmp.path(), &mut out, 100).unwrap();
         let names: Vec<_> =
             out.iter().map(|p| p.file_name().unwrap().to_str().unwrap().to_string()).collect();
@@ -533,7 +530,7 @@ mod tests {
         let root = tmp.path();
         std::fs::write(
             root.join("main.rs"),
-            "fn main() { let v = obj.get_count(); obj.set_count(v); }\n",
+            "// 😀 obj.get_count();\nfn main() { obj.set_count(1); }\n",
         )
         .unwrap();
         std::fs::create_dir(root.join("ui")).unwrap();
@@ -556,6 +553,9 @@ mod tests {
         let texts: Vec<_> = edits.iter().map(|e| e.edit.new_text.clone()).collect();
         assert!(texts.contains(&"get_total".to_string()));
         assert!(texts.contains(&"set_total".to_string()));
+        let getter = edits.iter().find(|e| e.edit.new_text == "get_total").unwrap();
+        assert_eq!(getter.edit.range.start, lsp_types::Position::new(0, 10));
+        assert_eq!(getter.edit.range.end, lsp_types::Position::new(0, 19));
     }
 
     #[test]
@@ -650,12 +650,61 @@ mod tests {
     }
 
     #[test]
+    fn overlapping_workspace_folders_count_unique_files() {
+        let root = tempdir();
+        let nested = root.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(root.path().join("root.rs"), "obj.get_count();").unwrap();
+        std::fs::write(nested.join("nested.rs"), "obj.set_count(1);").unwrap();
+        let folders = vec![
+            WorkspaceFolder { uri: Url::from_file_path(root.path()).unwrap(), name: "root".into() },
+            WorkspaceFolder { uri: Url::from_file_path(&nested).unwrap(), name: "nested".into() },
+        ];
+
+        let edits = search_replace_host_language_accessors(
+            &folders,
+            DeclarationKind::Property,
+            "count",
+            "total",
+            ByteFormat::Utf16,
+            ScanBounds { max_files: 2, max_file_bytes: 1024 },
+        )
+        .unwrap();
+
+        assert_eq!(edits.len(), 2);
+        let urls: HashSet<_> = edits.iter().map(|e| &e.url).collect();
+        assert_eq!(urls.len(), 2);
+    }
+
+    #[test]
+    fn files_larger_than_the_size_bound_are_skipped() {
+        let root = tempdir();
+        std::fs::write(root.path().join("main.rs"), "obj.get_count();").unwrap();
+        let folders = vec![WorkspaceFolder {
+            uri: Url::from_file_path(root.path()).unwrap(),
+            name: "root".into(),
+        }];
+
+        let edits = search_replace_host_language_accessors(
+            &folders,
+            DeclarationKind::Property,
+            "count",
+            "total",
+            ByteFormat::Utf16,
+            ScanBounds { max_files: 1, max_file_bytes: 4 },
+        )
+        .unwrap();
+
+        assert!(edits.is_empty());
+    }
+
+    #[test]
     fn collect_files_extension_match_is_case_insensitive() {
         let tmp = tempdir();
         std::fs::write(tmp.path().join("Main.RS"), "").unwrap();
         std::fs::write(tmp.path().join("Window.HPP"), "").unwrap();
         std::fs::write(tmp.path().join("README.md"), "").unwrap();
-        let mut out = Vec::new();
+        let mut out = HashSet::new();
         collect_files(tmp.path(), &mut out, 100).unwrap();
         let names: Vec<_> =
             out.iter().map(|p| p.file_name().unwrap().to_str().unwrap().to_string()).collect();
@@ -678,7 +727,7 @@ mod tests {
         // Symlink to a file that would otherwise match.
         symlink(tmp.path().join("real.rs"), tmp.path().join("linked.rs")).unwrap();
 
-        let mut out = Vec::new();
+        let mut out = HashSet::new();
         collect_files(tmp.path(), &mut out, 100).unwrap();
         let names: Vec<_> =
             out.iter().map(|p| p.file_name().unwrap().to_str().unwrap().to_string()).collect();
@@ -695,7 +744,7 @@ mod tests {
         for i in 0..10 {
             std::fs::write(tmp.path().join(format!("f{i}.rs")), "").unwrap();
         }
-        let mut out = Vec::new();
+        let mut out = HashSet::new();
         let err = collect_files(tmp.path(), &mut out, 3).unwrap_err();
         assert!(matches!(err, HostLanguageScanError::TooManyFiles { limit: 3 }));
     }

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -1,13 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore newtype
+// cSpell: ignore newtype CROSSFILE
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use crate::{common, util};
 
-use i_slint_compiler::diagnostics::Spanned;
+use i_slint_compiler::diagnostics::{SourceFile, Spanned};
+use i_slint_compiler::generator::accessor_names::DeclarationKind;
+use i_slint_compiler::object_tree;
 use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken, syntax_nodes};
 use lsp_types::Url;
 use smol_str::SmolStr;
@@ -533,6 +535,134 @@ impl DeclarationNode {
             }
         }
     }
+
+    /// If this declaration would be exposed in the generated Rust/C++ public
+    /// API, return the information the host-language scanner needs to find
+    /// call sites in `.rs`/`.cpp`/`.h` files.
+    ///
+    /// Returns `None` for declarations that don't emit Rust/C++ accessors:
+    /// private properties, declarations inside non-exported inner components,
+    /// structs, enums, components themselves, etc.
+    ///
+    /// Mirrors the logic of `i_slint_compiler::passes::check_public_api`
+    /// rather than reading `expose_in_public_api`: the LSP only runs
+    /// `run_import_passes`, so that flag is never set in this context.
+    pub fn host_language_classification(
+        &self,
+        document_cache: &common::DocumentCache,
+    ) -> Option<HostLanguageRenameInfo> {
+        let DeclarationNodeKind::DeclaredIdentifier(decl_id) = &self.kind else {
+            return None;
+        };
+
+        let parent = decl_id.parent()?;
+        let kind = match parent.kind() {
+            SyntaxKind::PropertyDeclaration => DeclarationKind::Property,
+            SyntaxKind::CallbackDeclaration => DeclarationKind::Callback,
+            SyntaxKind::Function => DeclarationKind::Function,
+            _ => return None,
+        };
+
+        let name = i_slint_compiler::parser::identifier_text(decl_id)?;
+        let source_file = decl_id.source_file.clone();
+        // Ensure the source file is known to the LSP -- avoids classifying
+        // declarations from documents the cache hasn't loaded.
+        document_cache.get_document_for_source_file(&source_file)?;
+
+        // The LSP only runs `run_import_passes`, not the full pipeline; the
+        // `check_public_api` pass that sets `expose_in_public_api` never runs
+        // here, and `inlining` (which would copy inherited declarations onto
+        // the exported component's root_element) is also absent. Compute the
+        // public-API exposure ourselves: the declaration must be reachable
+        // from an exported, non-interface component's root_element (walking
+        // its `inherits` chain), the type must be `ok_for_public_api`, and
+        // the visibility must not be `private`. Mirrors the gating logic of
+        // `passes::check_public_api`.
+        //
+        // Iterate every loaded document, not just the one containing the
+        // renamed declaration: a non-exported base in file A can be
+        // inherited by an exported component in file B, and the codegen for
+        // B WILL emit accessors for the inherited declaration.
+        for doc in document_cache.all_documents() {
+            for component in doc.exports.iter().filter_map(|(_, e)| e.as_ref().left()) {
+                if component.is_interface() {
+                    // Interfaces don't generate Rust/C++ accessors.
+                    continue;
+                }
+                if matching_decl_in_inheritance_chain(component, &name, &parent, &source_file) {
+                    return Some(HostLanguageRenameInfo { kind, old_name: name, source_file });
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Walk `component.root_element` and its `inherits` chain looking for a
+/// declaration whose syntax node matches `declaration_node` (the syntax
+/// node of the `PropertyDeclaration` / `CallbackDeclaration` / `Function`
+/// being renamed), and which would be exposed in the generated Rust/C++
+/// public API: non-private visibility and a type that `ok_for_public_api`.
+///
+/// Bounded by a fixed depth and by a visited-set on `Rc::as_ptr`: in a
+/// healthy program `inherits` never cycles, but the LSP runs only
+/// `run_import_passes` and may see mid-edit states where the cycle check
+/// hasn't run yet. We must not hang the synchronous rename handler.
+fn matching_decl_in_inheritance_chain(
+    component: &Rc<object_tree::Component>,
+    name: &SmolStr,
+    declaration_node: &SyntaxNode,
+    source_file: &SourceFile,
+) -> bool {
+    const MAX_DEPTH: usize = 64;
+    let mut element = component.root_element.clone();
+    let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for _ in 0..MAX_DEPTH {
+        if !visited.insert(Rc::as_ptr(&element) as usize) {
+            return false; // cycle in `inherits` chain
+        }
+        let element_borrow = element.borrow();
+        if let Some(decl) = element_borrow.property_declarations.get(name)
+            && let Some(node) = decl.node.as_ref()
+            && node.text_range() == declaration_node.text_range()
+            && Rc::ptr_eq(&node.source_file, source_file)
+        {
+            if decl.visibility == object_tree::PropertyVisibility::Private {
+                return false;
+            }
+            if !decl.property_type.ok_for_public_api() {
+                return false;
+            }
+            return true;
+        }
+        let base = element_borrow.base_type.clone();
+        drop(element_borrow);
+        match base {
+            i_slint_compiler::langtype::ElementType::Component(c) => {
+                element = c.root_element.clone();
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// Information needed by the host-language scanner to compute Rust/C++
+/// accessor-rename edits to pair with a Slint property/callback/function
+/// rename.
+#[derive(Clone, Debug)]
+pub struct HostLanguageRenameInfo {
+    /// Whether the renamed declaration is a property, callback, or function.
+    /// Determines which accessor prefixes (`get_`/`set_`/`invoke_`/`on_`) the
+    /// scanner searches for.
+    pub kind: DeclarationKind,
+    /// The current (pre-rename) Slint name. The scanner derives the old
+    /// accessor names from this via
+    /// [`i_slint_compiler::generator::accessor_names`].
+    pub old_name: SmolStr,
+    /// The `.slint` file containing the declaration. Used to pick the
+    /// workspace folder the scanner should walk.
+    pub source_file: SourceFile,
 }
 
 fn find_last_declared_identifier_at_or_before(
@@ -1234,6 +1364,179 @@ mod tests {
         suffix: &str,
     ) -> Vec<text_edit::EditedText> {
         rename_tester_with_new_name(document_cache, document_path, suffix, "XxxYyyZzz")
+    }
+
+    #[test]
+    fn test_host_language_classification() {
+        let document_cache = test::compile_test_with_sources(
+            "fluent",
+            HashMap::from([(
+                Url::from_file_path(test::main_test_file_name()).unwrap(),
+                r#"
+export component Foo inherits Window {
+    in property <int> count /* <- TEST_ME_PROP */;
+    private property <string> secret /* <- TEST_ME_PRIV */;
+    callback clicked /* <- TEST_ME_CB */();
+    public function multiply /* <- TEST_ME_FN */(x: int) -> int { x * 2 }
+}
+
+component Inner {
+    in property <int> hidden /* <- TEST_ME_INNER */;
+}
+                "#
+                .to_string(),
+            )]),
+            true,
+        );
+
+        let classify = |suffix: &str| -> Option<HostLanguageRenameInfo> {
+            let token =
+                find_token_by_comment(&document_cache, &test::main_test_file_name(), suffix);
+            find_declaration_node(&document_cache, &token)?
+                .host_language_classification(&document_cache)
+        };
+
+        let prop = classify("_PROP").expect("public property should classify");
+        assert_eq!(prop.kind, DeclarationKind::Property);
+        assert_eq!(prop.old_name, "count");
+
+        assert!(classify("_PRIV").is_none(), "private property must not classify");
+
+        let cb = classify("_CB").expect("public callback should classify");
+        assert_eq!(cb.kind, DeclarationKind::Callback);
+        assert_eq!(cb.old_name, "clicked");
+
+        let func = classify("_FN").expect("public function should classify");
+        assert_eq!(func.kind, DeclarationKind::Function);
+        assert_eq!(func.old_name, "multiply");
+
+        assert!(
+            classify("_INNER").is_none(),
+            "property on non-exported inner component must not classify",
+        );
+    }
+
+    #[test]
+    fn test_host_language_classification_global_property() {
+        // Globals also emit Rust/C++ public accessors (via global<T>()).
+        // Their declarations must classify just like component-root
+        // declarations.
+        let document_cache = test::compile_test_with_sources(
+            "fluent",
+            HashMap::from([(
+                Url::from_file_path(test::main_test_file_name()).unwrap(),
+                r#"
+export global Settings {
+    in-out property <int> volume /* <- TEST_ME_GLOBAL_PROP */;
+    callback changed /* <- TEST_ME_GLOBAL_CB */;
+}
+
+export component Host inherits Window { }
+                "#
+                .to_string(),
+            )]),
+            true,
+        );
+
+        let classify = |suffix: &str| -> Option<HostLanguageRenameInfo> {
+            let token =
+                find_token_by_comment(&document_cache, &test::main_test_file_name(), suffix);
+            find_declaration_node(&document_cache, &token)?
+                .host_language_classification(&document_cache)
+        };
+
+        let prop = classify("_GLOBAL_PROP").expect("public global property should classify");
+        assert_eq!(prop.kind, DeclarationKind::Property);
+        assert_eq!(prop.old_name, "volume");
+
+        let cb = classify("_GLOBAL_CB").expect("public global callback should classify");
+        assert_eq!(cb.kind, DeclarationKind::Callback);
+    }
+
+    #[test]
+    fn test_host_language_classification_cross_file_inherited_property() {
+        // Property declared in a non-exported base in file A, inherited by
+        // an exported component in file B. The classifier must walk all
+        // documents (not just the renamed file's own document) to find the
+        // exported descendant.
+        let base_url = Url::from_file_path(test::test_file_name("base.slint")).unwrap();
+        let app_url = Url::from_file_path(test::main_test_file_name()).unwrap();
+        let document_cache = test::compile_test_with_sources(
+            "fluent",
+            HashMap::from([
+                (
+                    base_url.clone(),
+                    r#"
+export component Base {
+    in property <int> base-count /* <- TEST_ME_CROSSFILE */;
+}
+                    "#
+                    .to_string(),
+                ),
+                (
+                    app_url.clone(),
+                    format!(
+                        r#"
+import {{ Base }} from "{}";
+export component App inherits Base {{ }}
+                        "#,
+                        "base.slint",
+                    ),
+                ),
+            ]),
+            true,
+        );
+
+        let base_path = test::test_file_name("base.slint");
+        let token = find_token_by_comment(&document_cache, &base_path, "_CROSSFILE");
+        let info = find_declaration_node(&document_cache, &token)
+            .and_then(|n| n.host_language_classification(&document_cache))
+            .expect("inherited property exposed via cross-file export must classify");
+        assert_eq!(info.kind, DeclarationKind::Property);
+        assert_eq!(info.old_name, "base-count");
+    }
+
+    #[test]
+    fn test_host_language_classification_inherited_property() {
+        // A property declared on a non-exported base but exposed by an
+        // exported component via `inherits` must still classify -- the
+        // codegen DOES generate the accessor on the exported component.
+        let document_cache = test::compile_test_with_sources(
+            "fluent",
+            HashMap::from([(
+                Url::from_file_path(test::main_test_file_name()).unwrap(),
+                r#"
+component Base {
+    in property <int> base-count /* <- TEST_ME_INHERITED */;
+}
+
+export component App inherits Window {
+    base := Base { }
+}
+
+export component DerivedApp inherits Base {
+    in property <int> own-prop /* <- TEST_ME_OWN */;
+}
+                "#
+                .to_string(),
+            )]),
+            true,
+        );
+
+        let classify = |suffix: &str| -> Option<HostLanguageRenameInfo> {
+            let token =
+                find_token_by_comment(&document_cache, &test::main_test_file_name(), suffix);
+            find_declaration_node(&document_cache, &token)?
+                .host_language_classification(&document_cache)
+        };
+
+        let inherited = classify("_INHERITED")
+            .expect("property inherited into an exported component must classify");
+        assert_eq!(inherited.kind, DeclarationKind::Property);
+        assert_eq!(inherited.old_name, "base-count");
+
+        let own = classify("_OWN").expect("locally-declared property on exported component");
+        assert_eq!(own.old_name, "own-prop");
     }
 
     #[test]
@@ -3835,5 +4138,611 @@ global Foo {
                 panic!("Unexpected file!");
             }
         }
+    }
+}
+
+/// Integration tests for the full cross-language rename pipeline:
+/// `find_declaration_node` -> `rename()` -> `host_language_classification()`
+/// -> `scan_host_language_accessors()` -> `merge_workspace_edits`. Exercises
+/// the same flow the LSP Rename handler runs, against real `.slint` and `.rs`
+/// files in a tempdir.
+#[cfg(test)]
+mod host_language_rename_tests {
+    use super::*;
+    use crate::common;
+    use crate::common::host_language_search::{self, ScanBounds, scan_host_language_accessors};
+    use i_slint_compiler::diagnostics::{BuildDiagnostics, ByteFormat};
+    use lsp_types::{Url, WorkspaceEdit, WorkspaceFolder};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// Throwaway tempdir; cleans itself up on drop.
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn path(&self) -> &std::path::Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn tempdir() -> TempDir {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        // Per-test serial -- bare timestamps collide when many tests start
+        // in the same nanosecond under cargo's parallel runner.
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let serial = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "slint-lsp-rename-roundtrip-{}-{}-{serial}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir(&path).unwrap();
+        TempDir { path }
+    }
+
+    /// Build a workspace under `tempdir`: writes the given `.slint` files and
+    /// `.rs` files to disk, then loads the slint files into a `DocumentCache`.
+    /// The first slint file in `slint_files` is treated as the "main" one
+    /// and its URL is returned.
+    ///
+    /// The second arg to load_url is the source version; we use 1 so that
+    /// the produced WorkspaceEdit has a non-None document version on the
+    /// slint side -- which the host scanner deliberately leaves as None for
+    /// `.rs`/`.cpp` files (those aren't in the cache).
+    fn setup(
+        tmp: &TempDir,
+        slint_files: &[(&str, &str)],
+        host_files: &[(&str, &str)],
+    ) -> (common::DocumentCache, Url, Vec<WorkspaceFolder>) {
+        // Write all host-language files to disk. The scanner is language-
+        // agnostic at this layer (same accessor strings emitted for Rust and
+        // C++), so `host_files` may contain `.rs`, `.cpp`, `.h`, etc.
+        for (rel_path, contents) in host_files {
+            let full = tmp.path().join(rel_path);
+            if let Some(parent) = full.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&full, contents).unwrap();
+        }
+
+        // Build the DocumentCache.
+        let config = common::document_cache::CompilerConfiguration {
+            style: Some("fluent".into()),
+            ..Default::default()
+        };
+        let mut cache = common::DocumentCache::new(config);
+        spin_on::spin_on(cache.preload_builtins());
+
+        // Write each slint file and load it into the cache.
+        let mut main_url: Option<Url> = None;
+        for (i, (rel_path, contents)) in slint_files.iter().enumerate() {
+            let full = tmp.path().join(rel_path);
+            if let Some(parent) = full.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&full, contents).unwrap();
+            let url = Url::from_file_path(&full).unwrap();
+            let mut diag = BuildDiagnostics::default();
+            spin_on::spin_on(cache.load_url(&url, Some(1), contents.to_string(), &mut diag))
+                .unwrap();
+            assert!(
+                !diag.has_errors(),
+                "slint diagnostics in {rel_path}: {:?}",
+                diag.iter().map(|d| d.message().to_string()).collect::<Vec<_>>(),
+            );
+            if i == 0 {
+                main_url = Some(url);
+            }
+        }
+
+        let folders = vec![WorkspaceFolder {
+            uri: Url::from_file_path(tmp.path()).unwrap(),
+            name: "ws".into(),
+        }];
+        (cache, main_url.unwrap(), folders)
+    }
+
+    /// Locate the token immediately before a `/* <- TEST_ME<suffix> */` marker
+    /// in the document at `url`.
+    #[track_caller]
+    fn find_token_in_url(
+        document_cache: &common::DocumentCache,
+        url: &Url,
+        suffix: &str,
+    ) -> SyntaxToken {
+        let document = document_cache.get_document(url).unwrap();
+        let document = document.node.as_ref().unwrap();
+        let offset =
+            document.text().to_string().find(&format!("<- TEST_ME{suffix} ")).unwrap() as u32;
+        let comment = document.token_at_offset(offset.into()).next().unwrap();
+        assert_eq!(comment.kind(), SyntaxKind::Comment);
+        let mut token = comment.prev_token();
+        while let Some(t) = &token {
+            if ![SyntaxKind::Comment, SyntaxKind::Eof, SyntaxKind::Whitespace].contains(&t.kind()) {
+                break;
+            }
+            token = t.prev_token();
+        }
+        token.unwrap()
+    }
+
+    /// Run the same flow as the LSP Rename handler under
+    /// `RenameAccessorsPolicy::Always`: slint rename + classify + scan + merge.
+    fn perform_rename(
+        document_cache: &common::DocumentCache,
+        folders: &[WorkspaceFolder],
+        slint_url: &Url,
+        token_suffix: &str,
+        new_name: &str,
+    ) -> WorkspaceEdit {
+        let token = find_token_in_url(document_cache, slint_url, token_suffix);
+        let decl =
+            find_declaration_node(document_cache, &token).expect("declaration node must be found");
+        let mut workspace_edit = decl.rename(document_cache, new_name).expect("rename");
+
+        if let Some(info) = decl.host_language_classification(document_cache)
+            && i_slint_compiler::parser::normalize_identifier(new_name) != info.old_name
+        {
+            let host_edits = scan_host_language_accessors(
+                folders,
+                info.source_file.path(),
+                info.kind,
+                &info.old_name,
+                new_name,
+                ByteFormat::Utf16,
+                ScanBounds::default(),
+            )
+            .expect("scan");
+            if !host_edits.is_empty() {
+                let host_we = common::create_workspace_edit_from_single_text_edits(host_edits);
+                common::merge_workspace_edits(&mut workspace_edit, host_we);
+            }
+        }
+        workspace_edit
+    }
+
+    /// Collect the (URL -> [new_text]) map from a WorkspaceEdit's
+    /// `document_changes::Edits` form, for assertion ergonomics.
+    fn edits_by_url(edit: &WorkspaceEdit) -> HashMap<Url, Vec<String>> {
+        let mut out: HashMap<Url, Vec<String>> = HashMap::new();
+        if let Some(lsp_types::DocumentChanges::Edits(v)) = edit.document_changes.as_ref() {
+            for tde in v {
+                let url = tde.text_document.uri.clone();
+                for e in &tde.edits {
+                    if let lsp_types::OneOf::Left(te) = e {
+                        out.entry(url.clone()).or_default().push(te.new_text.clone());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn rs_url(tmp: &TempDir, rel: &str) -> Url {
+        Url::from_file_path(tmp.path().join(rel)).unwrap()
+    }
+
+    fn slint_url(tmp: &TempDir, rel: &str) -> Url {
+        Url::from_file_path(tmp.path().join(rel)).unwrap()
+    }
+
+    /// Property rename: `count` -> `total` in .slint should rewrite the
+    /// `.slint` declaration AND the `get_count`/`set_count` accessors in
+    /// the .rs file.
+    #[test]
+    fn property_rename_rewrites_slint_and_rust() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    in property <int> count /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[("src/main.rs", "fn main() { let v = obj.get_count(); obj.set_count(v + 1); }\n")],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "total");
+        let by_url = edits_by_url(&edit);
+        let rs = rs_url(&tmp, "src/main.rs");
+        let slint = slint_url(&tmp, "ui/app.slint");
+        assert!(by_url.contains_key(&slint), "missing .slint edits");
+        let rust_edits = by_url.get(&rs).expect("missing .rs edits");
+        assert!(rust_edits.contains(&"get_total".to_string()), "got: {rust_edits:?}");
+        assert!(rust_edits.contains(&"set_total".to_string()), "got: {rust_edits:?}");
+    }
+
+    /// Callback rename: `clicked` -> `pressed` should rewrite `invoke_clicked`
+    /// and `on_clicked` in the .rs file.
+    #[test]
+    fn callback_rename_rewrites_invoke_and_on() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    callback clicked /* <- TEST_ME */();
+}
+                "#,
+            )],
+            &[("src/main.rs", "fn main() { obj.invoke_clicked(); obj.on_clicked(|| {}); }\n")],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "pressed");
+        let by_url = edits_by_url(&edit);
+        let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
+        assert!(rust_edits.contains(&"invoke_pressed".to_string()), "{rust_edits:?}");
+        assert!(rust_edits.contains(&"on_pressed".to_string()), "{rust_edits:?}");
+    }
+
+    /// Function rename: `bump` -> `add` should rewrite `invoke_bump` (no
+    /// `on_` for functions).
+    #[test]
+    fn function_rename_rewrites_invoke_only() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    public function bump /* <- TEST_ME */(by: int) -> int { by + 1 }
+}
+                "#,
+            )],
+            &[("src/main.rs", "fn main() { let _ = obj.invoke_bump(2); }\n")],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "add");
+        let by_url = edits_by_url(&edit);
+        let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
+        assert_eq!(rust_edits, &vec!["invoke_add".to_string()]);
+    }
+
+    /// Private property: classifier returns None, scanner is skipped, only
+    /// the .slint edit is produced.
+    #[test]
+    fn private_property_does_not_touch_host_files() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    private property <int> secret /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[(
+                "src/main.rs",
+                // Even though the text 'get_secret' appears, it shouldn't
+                // be rewritten because the slint property is private.
+                "fn main() { let _ = obj.get_secret(); }\n",
+            )],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "hidden");
+        let by_url = edits_by_url(&edit);
+        assert!(
+            !by_url.contains_key(&rs_url(&tmp, "src/main.rs")),
+            "private property must not produce .rs edits"
+        );
+    }
+
+    /// Kebab/snake normalization no-op (`my-count` -> `my_count` both
+    /// produce `get_my_count`): the scanner must NOT run, otherwise the
+    /// preview would show every .rs file as "modified" with identical text.
+    #[test]
+    fn noop_normalization_skips_scanner() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    in property <int> my-count /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[("src/main.rs", "fn main() { let _ = obj.get_my_count(); }\n")],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "my_count");
+        let by_url = edits_by_url(&edit);
+        assert!(
+            !by_url.contains_key(&rs_url(&tmp, "src/main.rs")),
+            "no-op normalization must skip host-language scanning"
+        );
+    }
+
+    /// Cross-file inheritance: property declared in a non-exported base in
+    /// `base.slint`, inherited by an exported component in `app.slint`. The
+    /// .rs file calls accessors on the derived component. Renaming the base
+    /// declaration must update both .slint files AND the .rs file.
+    #[test]
+    fn cross_file_inheritance_rewrites_all_three_files() {
+        let tmp = tempdir();
+        // base.slint must be loaded into the cache BEFORE app.slint, since
+        // app.slint imports it. setup() loads files in array order.
+        let (cache, _, folders) = setup(
+            &tmp,
+            &[
+                (
+                    "ui/base.slint",
+                    r#"
+export component Base {
+    in property <int> shared /* <- TEST_ME */;
+}
+                    "#,
+                ),
+                (
+                    "ui/app.slint",
+                    r#"
+import { Base } from "base.slint";
+export component App inherits Base { }
+                    "#,
+                ),
+            ],
+            &[("src/main.rs", "fn main() { obj.set_shared(42); }\n")],
+        );
+
+        // The renamed declaration is in base.slint, so we drive the rename
+        // from base.slint's URL.
+        let base_url = slint_url(&tmp, "ui/base.slint");
+        let edit = perform_rename(&cache, &folders, &base_url, "", "common");
+        let by_url = edits_by_url(&edit);
+        let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
+        assert_eq!(rust_edits, &vec!["set_common".to_string()]);
+    }
+
+    /// Globals: `export global Settings { in property <int> volume; }` plus
+    /// `Settings.volume` accessed via `global<Settings>().get_volume()` on
+    /// the Rust side. Renaming `volume` must rewrite the .rs call site.
+    #[test]
+    fn global_rename_rewrites_rust_accessors() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export global Settings {
+    in-out property <int> volume /* <- TEST_ME */;
+}
+export component App inherits Window { }
+                "#,
+            )],
+            &[("src/main.rs", "fn main() { app.global::<Settings>().set_volume(5); }\n")],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "level");
+        let by_url = edits_by_url(&edit);
+        let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
+        assert!(rust_edits.contains(&"set_level".to_string()), "{rust_edits:?}");
+    }
+
+    /// `.slint` outside any workspace folder: scanner returns
+    /// `OutsideWorkspace`, the handler's soft-degrade applies only the
+    /// `.slint` edits. We assert the .rs file is untouched even though it
+    /// contains the accessor.
+    #[test]
+    fn outside_workspace_soft_degrades_to_slint_only() {
+        let tmp_slint = tempdir();
+        let tmp_workspace = tempdir();
+        let (cache, url, _) = setup(
+            &tmp_slint,
+            &[(
+                "app.slint",
+                r#"
+export component App inherits Window {
+    in property <int> count /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[],
+        );
+        // Write the .rs file under a *different* tempdir treated as the
+        // workspace; the .slint is in tmp_slint which is NOT a workspace
+        // folder.
+        std::fs::write(tmp_workspace.path().join("main.rs"), "obj.get_count();").unwrap();
+        let folders = vec![WorkspaceFolder {
+            uri: Url::from_file_path(tmp_workspace.path()).unwrap(),
+            name: "ws".into(),
+        }];
+
+        // Call perform_rename directly; the scan_host_language_accessors
+        // would return OutsideWorkspace, but we mirror the handler's
+        // soft-degrade: if scan fails, only .slint edits land.
+        let token = find_token_in_url(&cache, &url, "");
+        let decl = find_declaration_node(&cache, &token).unwrap();
+        let workspace_edit = decl.rename(&cache, "total").unwrap();
+        if let Some(info) = decl.host_language_classification(&cache) {
+            match scan_host_language_accessors(
+                &folders,
+                info.source_file.path(),
+                info.kind,
+                &info.old_name,
+                "total",
+                ByteFormat::Utf16,
+                ScanBounds::default(),
+            ) {
+                Ok(_) => panic!("expected OutsideWorkspace"),
+                Err(host_language_search::HostLanguageScanError::OutsideWorkspace) => {
+                    // soft-degrade -- keep workspace_edit as-is
+                }
+                Err(other) => panic!("unexpected error: {other:?}"),
+            }
+        }
+
+        let by_url = edits_by_url(&workspace_edit);
+        assert!(
+            by_url.contains_key(&Url::from_file_path(tmp_slint.path().join("app.slint")).unwrap()),
+            ".slint edits must still land"
+        );
+        let rs = Url::from_file_path(tmp_workspace.path().join("main.rs")).unwrap();
+        assert!(!by_url.contains_key(&rs), ".rs must NOT be touched on OutsideWorkspace");
+    }
+
+    /// Scanner respects the comment lexer: an unrelated `get_count` inside a
+    /// Rust comment must not be rewritten.
+    #[test]
+    fn rust_comment_call_site_is_not_rewritten() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    in property <int> count /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[("src/main.rs", "// old name was get_count\nfn main() { obj.get_count(); }\n")],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "total");
+        let by_url = edits_by_url(&edit);
+        let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
+        // Exactly one rewrite -- the call site, not the comment.
+        assert_eq!(rust_edits.len(), 1);
+        assert_eq!(rust_edits[0], "get_total");
+    }
+
+    /// Property rename should rewrite the same `get_<n>`/`set_<n>` accessors
+    /// in a `.cpp` source file -- the scanner is language-agnostic at the
+    /// byte level and both backends emit identical accessor names.
+    #[test]
+    fn cpp_property_rename_rewrites_slint_and_cpp() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    in property <int> count /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[(
+                "src/main.cpp",
+                "int main() { auto v = app->get_count(); app->set_count(v + 1); }\n",
+            )],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "total");
+        let by_url = edits_by_url(&edit);
+        let cpp = Url::from_file_path(tmp.path().join("src/main.cpp")).unwrap();
+        let cpp_edits = by_url.get(&cpp).expect("missing .cpp edits");
+        assert!(cpp_edits.contains(&"get_total".to_string()), "{cpp_edits:?}");
+        assert!(cpp_edits.contains(&"set_total".to_string()), "{cpp_edits:?}");
+    }
+
+    /// Header files (`.h`, `.hpp`) are also walked. A caller that holds a
+    /// reference to the generated component in a header method must be
+    /// rewritten too.
+    #[test]
+    fn cpp_header_call_site_is_rewritten() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    callback clicked /* <- TEST_ME */();
+}
+                "#,
+            )],
+            &[("include/binding.hpp", "inline void wire(App* app) { app->on_clicked([](){}); }\n")],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "pressed");
+        let by_url = edits_by_url(&edit);
+        let hpp = Url::from_file_path(tmp.path().join("include/binding.hpp")).unwrap();
+        let hpp_edits = by_url.get(&hpp).expect("missing .hpp edits");
+        assert_eq!(hpp_edits, &vec!["on_pressed".to_string()]);
+    }
+
+    /// Mixed-language workspace: a single rename must rewrite call sites in
+    /// both `.rs` and `.cpp` files in a single `WorkspaceEdit`.
+    #[test]
+    fn mixed_rust_and_cpp_workspace_both_rewritten() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    in property <int> count /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[
+                ("rust/src/main.rs", "fn main() { obj.get_count(); }\n"),
+                ("cpp/src/main.cpp", "int main() { app->set_count(1); }\n"),
+            ],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "total");
+        let by_url = edits_by_url(&edit);
+        let rs = Url::from_file_path(tmp.path().join("rust/src/main.rs")).unwrap();
+        let cpp = Url::from_file_path(tmp.path().join("cpp/src/main.cpp")).unwrap();
+        assert_eq!(by_url.get(&rs).map(Vec::as_slice), Some(&["get_total".to_string()][..]));
+        assert_eq!(by_url.get(&cpp).map(Vec::as_slice), Some(&["set_total".to_string()][..]));
+    }
+
+    /// C++ comment skipping: `//` and `/* ... */` work for C++ too, since the
+    /// lexer is generic enough to cover both languages' single-line and
+    /// block-comment syntax.
+    #[test]
+    fn cpp_comment_call_site_is_not_rewritten() {
+        let tmp = tempdir();
+        let (cache, url, folders) = setup(
+            &tmp,
+            &[(
+                "ui/app.slint",
+                r#"
+export component App inherits Window {
+    in property <int> count /* <- TEST_ME */;
+}
+                "#,
+            )],
+            &[(
+                "src/main.cpp",
+                "// see get_count for details\n\
+                 /* also get_count here */\n\
+                 int main() { return app->get_count(); }\n",
+            )],
+        );
+
+        let edit = perform_rename(&cache, &folders, &url, "", "total");
+        let by_url = edits_by_url(&edit);
+        let cpp = Url::from_file_path(tmp.path().join("src/main.cpp")).unwrap();
+        let cpp_edits = by_url.get(&cpp).expect("missing .cpp edits");
+        // Only the real call site; not the two comment mentions.
+        assert_eq!(cpp_edits.len(), 1);
+        assert_eq!(cpp_edits[0], "get_total");
     }
 }

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -4278,8 +4278,8 @@ mod host_language_rename_tests {
         token.unwrap()
     }
 
-    /// Run the same flow as the LSP Rename handler under
-    /// `RenameAccessorsPolicy::Always`: slint rename + classify + scan + merge.
+    /// Run the same flow as the LSP "Rename property and Rust/C++ accessors"
+    /// CodeAction command: slint rename + classify + scan + merge.
     fn perform_rename(
         document_cache: &common::DocumentCache,
         folders: &[WorkspaceFolder],
@@ -4602,10 +4602,11 @@ export component App inherits Window {
         assert!(!by_url.contains_key(&rs), ".rs must NOT be touched on OutsideWorkspace");
     }
 
-    /// Scanner respects the comment lexer: an unrelated `get_count` inside a
-    /// Rust comment must not be rewritten.
+    /// The scanner is textual by design (post-reshape): occurrences inside
+    /// comments are also rewritten, and the user reviews the rename preview
+    /// before applying.
     #[test]
-    fn rust_comment_call_site_is_not_rewritten() {
+    fn textual_rename_includes_rust_comment_mentions() {
         let tmp = tempdir();
         let (cache, url, folders) = setup(
             &tmp,
@@ -4623,9 +4624,10 @@ export component App inherits Window {
         let edit = perform_rename(&cache, &folders, &url, "", "total");
         let by_url = edits_by_url(&edit);
         let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
-        // Exactly one rewrite -- the call site, not the comment.
-        assert_eq!(rust_edits.len(), 1);
-        assert_eq!(rust_edits[0], "get_total");
+        // Both the comment mention and the live call rewrite -- the user
+        // reviews the diff in the rename preview.
+        assert_eq!(rust_edits.len(), 2);
+        assert!(rust_edits.iter().all(|t| t == "get_total"));
     }
 
     /// Property rename should rewrite the same `get_<n>`/`set_<n>` accessors
@@ -4715,9 +4717,10 @@ export component App inherits Window {
 
     /// C++ comment skipping: `//` and `/* ... */` work for C++ too, since the
     /// lexer is generic enough to cover both languages' single-line and
-    /// block-comment syntax.
+    /// The scanner is textual by design (post-reshape): C++ comments are also
+    /// rewritten, same as Rust comments.
     #[test]
-    fn cpp_comment_call_site_is_not_rewritten() {
+    fn textual_rename_includes_cpp_comment_mentions() {
         let tmp = tempdir();
         let (cache, url, folders) = setup(
             &tmp,
@@ -4741,8 +4744,9 @@ export component App inherits Window {
         let by_url = edits_by_url(&edit);
         let cpp = Url::from_file_path(tmp.path().join("src/main.cpp")).unwrap();
         let cpp_edits = by_url.get(&cpp).expect("missing .cpp edits");
-        // Only the real call site; not the two comment mentions.
-        assert_eq!(cpp_edits.len(), 1);
-        assert_eq!(cpp_edits[0], "get_total");
+        // All three textual matches rewrite -- two comment mentions plus the
+        // live call. User reviews the preview.
+        assert_eq!(cpp_edits.len(), 3);
+        assert!(cpp_edits.iter().all(|t| t == "get_total"));
     }
 }

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -2,6 +2,59 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore newtype CROSSFILE
+
+//! `.slint` rename support, plus the classifier that decides when a rename
+//! should be paired with a Rust/C++ host-language rewrite.
+//!
+//! # Host-language follow-up flow
+//!
+//! Renaming a public property/callback/function in `.slint` can optionally
+//! also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`,
+//! `invoke_<n>`, `on_<n>`) at every textual call site in the workspace. The
+//! `textDocument/rename` handler in `language.rs` returns the slint-only
+//! edits synchronously; the host-language follow-up runs in a `spawn_local`
+//! task because the rename handler is sync but the dialog and the second
+//! `workspace/applyEdit` are async.
+//!
+//! After the synchronous slint rename, the spawned task:
+//!
+//! 1. Calls [`DeclarationNode::host_language_classification`]. This walks
+//!    every loaded `Document` (via `DocumentCache::all_documents()`) and,
+//!    for each exported non-interface component, follows the `inherits`
+//!    chain looking for a declaration whose syntax node matches the rename
+//!    target. The walk is bounded (depth + visited-set) so a cyclic
+//!    `inherits` chain from a mid-edit state can't hang the task. Returns
+//!    the declaration kind and current name -- or `None` if the
+//!    declaration isn't reachable from any exported component or its
+//!    visibility/type rules it out.
+//! 2. Skips the dialog entirely when
+//!    `normalize_identifier(new_name) == old_name` (kebab/snake no-op
+//!    that produces no accessor change).
+//! 3. Checks an in-memory "don't ask again" set keyed by
+//!    `(slint_uri, original_name)`. Hits short-circuit out before the
+//!    dialog. TODO(#12111): persist this across sessions.
+//! 4. Sends `window/showMessageRequest` with three actions: *Rewrite
+//!    Rust/C++ accessors*, *Skip*, *Skip and don't ask again*. Dismissal
+//!    is treated as Skip.
+//! 5. On *Rewrite*, queries `workspace/workspaceFolders` (or falls back
+//!    to the cached `InitializeParams` when the client doesn't support
+//!    the query), runs
+//!    [`crate::common::host_language_search::scan_host_language_accessors`]
+//!    against every folder, and sends a second `workspace/applyEdit` with
+//!    the host-language edits.
+//! 6. Reports the outcome via `window/showMessage`: count of rewritten
+//!    sites on success, or a warning on scan failure / refused edit.
+//!
+//! The slint rename and the host-language rewrite arrive as two
+//! independent edits; the editor's undo treats them separately. That is
+//! intentional: if the user rejects the host-language rewrite or the
+//! scanner errors, the slint rename still stands.
+//!
+//! Failure modes (no workspace folders, scan exceeds `max_files`, client
+//! refuses the applyEdit) **soft-degrade**: tracing warning + a
+//! `window/showMessage` to the user, but the slint rename is not rolled
+//! back.
+
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -590,7 +643,7 @@ impl DeclarationNode {
                     continue;
                 }
                 if matching_decl_in_inheritance_chain(component, &name, &parent, &source_file) {
-                    return Some(HostLanguageRenameInfo { kind, old_name: name, source_file });
+                    return Some(HostLanguageRenameInfo { kind, old_name: name });
                 }
             }
         }
@@ -660,9 +713,6 @@ pub struct HostLanguageRenameInfo {
     /// accessor names from this via
     /// [`i_slint_compiler::generator::accessor_names`].
     pub old_name: SmolStr,
-    /// The `.slint` file containing the declaration. Used to pick the
-    /// workspace folder the scanner should walk.
-    pub source_file: SourceFile,
 }
 
 fn find_last_declared_identifier_at_or_before(
@@ -4150,7 +4200,7 @@ global Foo {
 mod host_language_rename_tests {
     use super::*;
     use crate::common;
-    use crate::common::host_language_search::{self, ScanBounds, scan_host_language_accessors};
+    use crate::common::host_language_search::{ScanBounds, scan_host_language_accessors};
     use i_slint_compiler::diagnostics::{BuildDiagnostics, ByteFormat};
     use lsp_types::{Url, WorkspaceEdit, WorkspaceFolder};
     use std::collections::HashMap;
@@ -4297,12 +4347,11 @@ mod host_language_rename_tests {
         {
             let host_edits = scan_host_language_accessors(
                 folders,
-                info.source_file.path(),
                 info.kind,
                 &info.old_name,
                 new_name,
                 ByteFormat::Utf16,
-                ScanBounds::default(),
+                ScanBounds::DEFAULT,
             )
             .expect("scan");
             if !host_edits.is_empty() {
@@ -4538,68 +4587,6 @@ export component App inherits Window { }
         let by_url = edits_by_url(&edit);
         let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
         assert!(rust_edits.contains(&"set_level".to_string()), "{rust_edits:?}");
-    }
-
-    /// `.slint` outside any workspace folder: scanner returns
-    /// `OutsideWorkspace`, the handler's soft-degrade applies only the
-    /// `.slint` edits. We assert the .rs file is untouched even though it
-    /// contains the accessor.
-    #[test]
-    fn outside_workspace_soft_degrades_to_slint_only() {
-        let tmp_slint = tempdir();
-        let tmp_workspace = tempdir();
-        let (cache, url, _) = setup(
-            &tmp_slint,
-            &[(
-                "app.slint",
-                r#"
-export component App inherits Window {
-    in property <int> count /* <- TEST_ME */;
-}
-                "#,
-            )],
-            &[],
-        );
-        // Write the .rs file under a *different* tempdir treated as the
-        // workspace; the .slint is in tmp_slint which is NOT a workspace
-        // folder.
-        std::fs::write(tmp_workspace.path().join("main.rs"), "obj.get_count();").unwrap();
-        let folders = vec![WorkspaceFolder {
-            uri: Url::from_file_path(tmp_workspace.path()).unwrap(),
-            name: "ws".into(),
-        }];
-
-        // Call perform_rename directly; the scan_host_language_accessors
-        // would return OutsideWorkspace, but we mirror the handler's
-        // soft-degrade: if scan fails, only .slint edits land.
-        let token = find_token_in_url(&cache, &url, "");
-        let decl = find_declaration_node(&cache, &token).unwrap();
-        let workspace_edit = decl.rename(&cache, "total").unwrap();
-        if let Some(info) = decl.host_language_classification(&cache) {
-            match scan_host_language_accessors(
-                &folders,
-                info.source_file.path(),
-                info.kind,
-                &info.old_name,
-                "total",
-                ByteFormat::Utf16,
-                ScanBounds::default(),
-            ) {
-                Ok(_) => panic!("expected OutsideWorkspace"),
-                Err(host_language_search::HostLanguageScanError::OutsideWorkspace) => {
-                    // soft-degrade -- keep workspace_edit as-is
-                }
-                Err(other) => panic!("unexpected error: {other:?}"),
-            }
-        }
-
-        let by_url = edits_by_url(&workspace_edit);
-        assert!(
-            by_url.contains_key(&Url::from_file_path(tmp_slint.path().join("app.slint")).unwrap()),
-            ".slint edits must still land"
-        );
-        let rs = Url::from_file_path(tmp_workspace.path().join("main.rs")).unwrap();
-        assert!(!by_url.contains_key(&rs), ".rs must NOT be touched on OutsideWorkspace");
     }
 
     /// The scanner is textual by design (post-reshape): occurrences inside

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -9,8 +9,8 @@
 //! # Host-language follow-up flow
 //!
 //! Renaming a public property/callback/function in `.slint` can optionally
-//! also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`,
-//! `invoke_<n>`, `on_<n>`) at every textual call site in the workspace. The
+//! also replace matching generated Rust/C++ accessor identifiers (`get_<n>`,
+//! `set_<n>`, `invoke_<n>`, `on_<n>`) throughout the workspace. The
 //! `textDocument/rename` handler in `language.rs` returns the slint-only
 //! edits synchronously; the host-language follow-up runs in a `spawn_local`
 //! task because the rename handler is sync but the dialog and the second
@@ -36,14 +36,14 @@
 //! 4. Sends `window/showMessageRequest` with three actions: *Search & Replace
 //!    Rust/C++ accessors*, *Skip*, *Skip and don't ask again*. Dismissal is
 //!    treated as Skip.
-//! 5. On *Rewrite*, queries `workspace/workspaceFolders` (or falls back
+//! 5. On *Search & Replace*, queries `workspace/workspaceFolders` (or falls back
 //!    to the cached `InitializeParams` when the client doesn't support
 //!    the query), runs
 //!    [`crate::common::host_language_search::search_replace_host_language_accessors`]
 //!    against every folder, and sends a second `workspace/applyEdit` with
 //!    the host-language edits.
-//! 6. Reports the outcome via `window/showMessage`: count of rewritten
-//!    sites on success, or a warning on scan failure / refused edit.
+//! 6. Reports the outcome via `window/showMessage`: count of replaced
+//!    occurrences on success, or a warning on scan failure / refused edit.
 //!
 //! The slint rename and the host-language rewrite arrive as two
 //! independent edits; the editor's undo treats them separately. That is
@@ -591,7 +591,7 @@ impl DeclarationNode {
 
     /// If this declaration would be exposed in the generated Rust/C++ public
     /// API, return the information the host-language scanner needs to find
-    /// call sites in `.rs`/`.cpp`/`.h` files.
+    /// matching accessor identifiers in Rust and C++ source files.
     ///
     /// Returns `None` for declarations that don't emit Rust/C++ accessors:
     /// private properties, declarations inside non-exported inner components,
@@ -4191,11 +4191,11 @@ global Foo {
     }
 }
 
-/// Integration tests for the full cross-language rename pipeline:
+/// Integration tests for the classification and search portions of the
+/// cross-language rename pipeline:
 /// `find_declaration_node` -> `rename()` -> `host_language_classification()`
-/// -> `search_replace_host_language_accessors()` -> `merge_workspace_edits`. Exercises
-/// the same flow the LSP Rename handler runs, against real `.slint` and `.rs`
-/// files in a tempdir.
+/// -> `search_replace_host_language_accessors()`.
+/// Tests for the interactive LSP requests live in `language.rs`.
 #[cfg(test)]
 mod host_language_rename_tests {
     use super::*;
@@ -4328,8 +4328,8 @@ mod host_language_rename_tests {
         token.unwrap()
     }
 
-    /// Run the same flow as the LSP "Rename property and Rust/C++ accessors"
-    /// CodeAction command: slint rename + classify + scan + merge.
+    /// Compose Slint and host-language edits for concise assertions.
+    /// Production sends these as two independent workspace edits.
     fn perform_rename(
         document_cache: &common::DocumentCache,
         folders: &[WorkspaceFolder],
@@ -4589,34 +4589,6 @@ export component App inherits Window { }
         assert!(rust_edits.contains(&"set_level".to_string()), "{rust_edits:?}");
     }
 
-    /// The scanner is textual by design (post-reshape): occurrences inside
-    /// comments are also rewritten, and the user reviews the rename preview
-    /// before applying.
-    #[test]
-    fn textual_rename_includes_rust_comment_mentions() {
-        let tmp = tempdir();
-        let (cache, url, folders) = setup(
-            &tmp,
-            &[(
-                "ui/app.slint",
-                r#"
-export component App inherits Window {
-    in property <int> count /* <- TEST_ME */;
-}
-                "#,
-            )],
-            &[("src/main.rs", "// old name was get_count\nfn main() { obj.get_count(); }\n")],
-        );
-
-        let edit = perform_rename(&cache, &folders, &url, "", "total");
-        let by_url = edits_by_url(&edit);
-        let rust_edits = by_url.get(&rs_url(&tmp, "src/main.rs")).expect("missing .rs edits");
-        // Both the comment mention and the live call rewrite -- the user
-        // reviews the diff in the rename preview.
-        assert_eq!(rust_edits.len(), 2);
-        assert!(rust_edits.iter().all(|t| t == "get_total"));
-    }
-
     /// Property rename should rewrite the same `get_<n>`/`set_<n>` accessors
     /// in a `.cpp` source file -- the scanner is language-agnostic at the
     /// byte level and both backends emit identical accessor names.
@@ -4700,40 +4672,5 @@ export component App inherits Window {
         let cpp = Url::from_file_path(tmp.path().join("cpp/src/main.cpp")).unwrap();
         assert_eq!(by_url.get(&rs).map(Vec::as_slice), Some(&["get_total".to_string()][..]));
         assert_eq!(by_url.get(&cpp).map(Vec::as_slice), Some(&["set_total".to_string()][..]));
-    }
-
-    /// C++ comment skipping: `//` and `/* ... */` work for C++ too, since the
-    /// lexer is generic enough to cover both languages' single-line and
-    /// The scanner is textual by design (post-reshape): C++ comments are also
-    /// rewritten, same as Rust comments.
-    #[test]
-    fn textual_rename_includes_cpp_comment_mentions() {
-        let tmp = tempdir();
-        let (cache, url, folders) = setup(
-            &tmp,
-            &[(
-                "ui/app.slint",
-                r#"
-export component App inherits Window {
-    in property <int> count /* <- TEST_ME */;
-}
-                "#,
-            )],
-            &[(
-                "src/main.cpp",
-                "// see get_count for details\n\
-                 /* also get_count here */\n\
-                 int main() { return app->get_count(); }\n",
-            )],
-        );
-
-        let edit = perform_rename(&cache, &folders, &url, "", "total");
-        let by_url = edits_by_url(&edit);
-        let cpp = Url::from_file_path(tmp.path().join("src/main.cpp")).unwrap();
-        let cpp_edits = by_url.get(&cpp).expect("missing .cpp edits");
-        // All three textual matches rewrite -- two comment mentions plus the
-        // live call. User reviews the preview.
-        assert_eq!(cpp_edits.len(), 3);
-        assert!(cpp_edits.iter().all(|t| t == "get_total"));
     }
 }

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -30,16 +30,16 @@
 //! 2. Skips the dialog entirely when
 //!    `normalize_identifier(new_name) == old_name` (kebab/snake no-op
 //!    that produces no accessor change).
-//! 3. Checks an in-memory "don't ask again" set keyed by
-//!    `(slint_uri, original_name)`. Hits short-circuit out before the
-//!    dialog. TODO(#12111): persist this across sessions.
-//! 4. Sends `window/showMessageRequest` with three actions: *Rewrite
-//!    Rust/C++ accessors*, *Skip*, *Skip and don't ask again*. Dismissal
-//!    is treated as Skip.
+//! 3. Checks an in-memory "don't ask again" flag that suppresses the dialog
+//!    for the rest of the session. TODO(#12111): Persist this setting across
+//!    sessions.
+//! 4. Sends `window/showMessageRequest` with three actions: *Search & Replace
+//!    Rust/C++ accessors*, *Skip*, *Skip and don't ask again*. Dismissal is
+//!    treated as Skip.
 //! 5. On *Rewrite*, queries `workspace/workspaceFolders` (or falls back
 //!    to the cached `InitializeParams` when the client doesn't support
 //!    the query), runs
-//!    [`crate::common::host_language_search::scan_host_language_accessors`]
+//!    [`crate::common::host_language_search::search_replace_host_language_accessors`]
 //!    against every folder, and sends a second `workspace/applyEdit` with
 //!    the host-language edits.
 //! 6. Reports the outcome via `window/showMessage`: count of rewritten
@@ -4193,14 +4193,14 @@ global Foo {
 
 /// Integration tests for the full cross-language rename pipeline:
 /// `find_declaration_node` -> `rename()` -> `host_language_classification()`
-/// -> `scan_host_language_accessors()` -> `merge_workspace_edits`. Exercises
+/// -> `search_replace_host_language_accessors()` -> `merge_workspace_edits`. Exercises
 /// the same flow the LSP Rename handler runs, against real `.slint` and `.rs`
 /// files in a tempdir.
 #[cfg(test)]
 mod host_language_rename_tests {
     use super::*;
     use crate::common;
-    use crate::common::host_language_search::{ScanBounds, scan_host_language_accessors};
+    use crate::common::host_language_search::{ScanBounds, search_replace_host_language_accessors};
     use i_slint_compiler::diagnostics::{BuildDiagnostics, ByteFormat};
     use lsp_types::{Url, WorkspaceEdit, WorkspaceFolder};
     use std::collections::HashMap;
@@ -4345,7 +4345,7 @@ mod host_language_rename_tests {
         if let Some(info) = decl.host_language_classification(document_cache)
             && i_slint_compiler::parser::normalize_identifier(new_name) != info.old_name
         {
-            let host_edits = scan_host_language_accessors(
+            let host_edits = search_replace_host_language_accessors(
                 folders,
                 info.kind,
                 &info.old_name,

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -292,6 +292,7 @@ async fn lsp_main(
         open_urls: Default::default(),
         to_preview,
         pending_recompile: Default::default(),
+        host_language_rename_dont_ask_again: Default::default(),
     };
 
     // Load the initial document through the compiler. This triggers the import

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -287,7 +287,6 @@ async fn lsp_main(
         preview_config: Default::default(),
         server_notifier: notifier,
         init_param: Default::default(),
-        rename_accessors_policy: Default::default(),
         #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
         to_show: Default::default(),
         open_urls: Default::default(),

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -287,6 +287,7 @@ async fn lsp_main(
         preview_config: Default::default(),
         server_notifier: notifier,
         init_param: Default::default(),
+        rename_accessors_policy: Default::default(),
         #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
         to_show: Default::default(),
         open_urls: Default::default(),

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -861,7 +861,7 @@ pub fn rename_with_host_accessors_command(
         return Err(bad("no token at position"));
     };
     let Some(decl) = common::rename_component::find_declaration_node(document_cache, &token) else {
-        return Err(bad("position is not a renameable declaration"));
+        return Err(bad("position is not a declaration that can be renamed"));
     };
 
     let mut workspace_edit = decl

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -47,7 +47,7 @@ use lsp_types::{
     },
 };
 
-use std::cell::RefCell;
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
@@ -266,14 +266,9 @@ pub struct Context {
     /// Files to recompile after all other operations are done
     /// (i.e. recompilations triggered by updates to unopened files)
     pub pending_recompile: HashSet<lsp_types::Url>,
-    /// Per-declaration "don't ask again" suppression for the host-language
-    /// rename prompt. Keyed by `(slint file URL, original Slint decl name)` so
-    /// the user is asked only once per visible declaration per session. The
-    /// entry implicitly lapses after a successful rename: the next rename
-    /// sees a new key. TODO(#12111): persist across sessions when client-side
-    /// settings storage is available.
-    pub host_language_rename_dont_ask_again:
-        Rc<RefCell<HashSet<(lsp_types::Url, smol_str::SmolStr)>>>,
+    /// Disables the host-language rename prompt for the rest of the session.
+    /// TODO(#12111): Persist this setting across sessions.
+    pub host_language_rename_dont_ask_again: Rc<Cell<bool>>,
 }
 
 /// An error from a LSP request
@@ -605,17 +600,12 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                     |e| LspError { code: LspErrorCode::RequestFailed, message: e.to_string() },
                 )?;
                 // After the synchronous slint-only rename, ask the user (once)
-                // whether to also rewrite the generated Rust/C++ accessors at
-                // workspace call sites. The dialog and follow-up edit have to
+                // whether to also search and replace the generated Rust/C++
+                // accessors. The dialog and follow-up edit have to
                 // run asynchronously: the request handler is synchronous and
                 // must return the slint edit immediately.
                 #[cfg(not(target_arch = "wasm32"))]
-                schedule_host_language_rename_followup(
-                    ctx,
-                    &declaration_node,
-                    &uri,
-                    &params.new_name,
-                );
+                schedule_host_language_rename_followup(ctx, &declaration_node, &params.new_name);
                 return Ok(Some(edit));
             }
         }
@@ -843,7 +833,6 @@ pub fn populate_command(
 fn schedule_host_language_rename_followup(
     ctx: &Context,
     declaration_node: &common::rename_component::DeclarationNode,
-    slint_uri: &Url,
     new_name: &str,
 ) {
     let Some(info) = declaration_node.host_language_classification(&ctx.document_cache) else {
@@ -855,8 +844,7 @@ fn schedule_host_language_rename_followup(
     if i_slint_compiler::parser::normalize_identifier(new_name) == info.old_name {
         return;
     }
-    let key = (slint_uri.clone(), info.old_name.clone());
-    if ctx.host_language_rename_dont_ask_again.borrow().contains(&key) {
+    if ctx.host_language_rename_dont_ask_again.get() {
         return;
     }
 
@@ -879,7 +867,6 @@ fn schedule_host_language_rename_followup(
             format,
             info,
             new_name,
-            key,
         )
         .await;
     });
@@ -888,12 +875,11 @@ fn schedule_host_language_rename_followup(
 #[cfg(not(target_arch = "wasm32"))]
 async fn run_host_language_rename_followup(
     server_notifier: crate::ServerNotifier,
-    dont_ask_again: Rc<RefCell<HashSet<(Url, smol_str::SmolStr)>>>,
+    dont_ask_again: Rc<Cell<bool>>,
     workspace_folders: Vec<lsp_types::WorkspaceFolder>,
     format: common::ByteFormat,
     info: common::rename_component::HostLanguageRenameInfo,
     new_name: String,
-    dont_ask_again_key: (Url, smol_str::SmolStr),
 ) {
     use i_slint_compiler::generator::accessor_names::DeclarationKind;
 
@@ -904,13 +890,13 @@ async fn run_host_language_rename_followup(
     };
     let message = format!(
         "Slint {kind_label} '{}' is exposed to host language code. \
-         Also rewrite its Rust/C++ accessors at workspace call sites? \
+         Search & Replace the Rust/C++ code with the new accessors? \
          (The slint rename has already been applied.)",
         info.old_name,
     );
-    let action_replace = "Rewrite Rust/C++ accessors";
+    let action_replace = "Search & Replace Rust/C++ accessors";
     let action_skip = "Skip";
-    let action_never = "Skip and don't ask again for this declaration";
+    let action_never = "Skip and don't ask again";
 
     let action_items = vec![
         lsp_types::MessageActionItem {
@@ -945,7 +931,7 @@ async fn run_host_language_rename_followup(
 
     match chosen.as_deref() {
         Some(title) if title == action_replace => {
-            let scan_result = common::host_language_search::scan_host_language_accessors(
+            let scan_result = common::host_language_search::search_replace_host_language_accessors(
                 &workspace_folders,
                 info.kind,
                 &info.old_name,
@@ -985,10 +971,10 @@ async fn run_host_language_rename_followup(
             }
         }
         Some(title) if title == action_never => {
-            dont_ask_again.borrow_mut().insert(dont_ask_again_key);
+            dont_ask_again.set(true);
             show_info(
                 &server_notifier,
-                "Slint rename applied; skipping host-language rewrite (won't ask again for this declaration).",
+                "Slint rename applied; skipping host-language rewrite (won't ask again this session).",
             );
         }
         _ => {
@@ -1009,7 +995,7 @@ async fn apply_host_language_edits(
 ) {
     let request = match server_notifier.send_request::<lsp_types::request::ApplyWorkspaceEdit>(
         lsp_types::ApplyWorkspaceEditParams {
-            label: Some("Rewrite Rust/C++ accessors for Slint rename".into()),
+            label: Some("Search & Replace Rust/C++ accessors for Slint rename".into()),
             edit,
         },
     ) {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -256,6 +256,10 @@ pub struct Context {
     pub preview_config: PreviewConfig,
     pub server_notifier: crate::ServerNotifier,
     pub init_param: InitializeParams,
+    /// Whether `textDocument/rename` should also rewrite Rust/C++ accessor
+    /// call sites in workspace files. See #11841.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub rename_accessors_policy: common::host_language_search::RenameAccessorsPolicy,
     /// The last component for which the user clicked "show preview"
     #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
     pub to_show: Option<PreviewComponent>,
@@ -592,13 +596,54 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
             if let Some(declaration_node) =
                 common::rename_component::find_declaration_node(&ctx.document_cache, &tk)
             {
-                return declaration_node
-                    .rename(&ctx.document_cache, &params.new_name)
-                    .map(Some)
-                    .map_err(|e| LspError {
-                        code: LspErrorCode::RequestFailed,
-                        message: e.to_string(),
-                    });
+                let mut workspace_edit =
+                    declaration_node.rename(&ctx.document_cache, &params.new_name).map_err(
+                        |e| LspError { code: LspErrorCode::RequestFailed, message: e.to_string() },
+                    )?;
+                #[cfg(not(target_arch = "wasm32"))]
+                if matches!(
+                    ctx.rename_accessors_policy,
+                    common::host_language_search::RenameAccessorsPolicy::Always,
+                ) && let Some(info) =
+                    declaration_node.host_language_classification(&ctx.document_cache)
+                    && i_slint_compiler::parser::normalize_identifier(&params.new_name)
+                        != info.old_name
+                {
+                    // Skip the scan when the slint rename normalizes to the
+                    // same identifier (e.g. `my-count` -> `my_count`): the
+                    // accessor names are unchanged, so the scanner would
+                    // produce identical-text TextEdits and the rename preview
+                    // would list every host-language file as "modified".
+                    let folders =
+                        common::host_language_search::resolve_workspace_folders(&ctx.init_param);
+                    // Soft-degrade: a scanner failure logs a warning and falls
+                    // back to slint-only edits. The user opted into `"always"`
+                    // and can re-run with the config off if the warning is
+                    // a problem; rejecting the whole rename loses the slint
+                    // edits they actually wanted.
+                    match common::host_language_search::scan_host_language_accessors(
+                        &folders,
+                        info.source_file.path(),
+                        info.kind,
+                        &info.old_name,
+                        &params.new_name,
+                        ctx.document_cache.format,
+                        common::host_language_search::ScanBounds::default(),
+                    ) {
+                        Ok(host_edits) if !host_edits.is_empty() => {
+                            let host_workspace_edit =
+                                common::create_workspace_edit_from_single_text_edits(host_edits);
+                            common::merge_workspace_edits(&mut workspace_edit, host_workspace_edit);
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                "Slint cross-language rename: host-language scan skipped: {e}"
+                            );
+                        }
+                    }
+                }
+                return Ok(Some(workspace_edit));
             }
         }
 
@@ -1655,6 +1700,8 @@ struct WorkspaceConfig {
     library_paths: Option<HashMap<String, PathBuf>>,
     style: Option<String>,
     experimental: bool,
+    #[cfg(not(target_arch = "wasm32"))]
+    rename_accessors_in_host_languages: common::host_language_search::RenameAccessorsPolicy,
 }
 
 fn parse_configuration(workspace_config: Vec<serde_json::Value>) -> WorkspaceConfig {
@@ -1663,6 +1710,9 @@ fn parse_configuration(workspace_config: Vec<serde_json::Value>) -> WorkspaceCon
     let mut library_paths = None;
     let mut style = None;
     let mut experimental = false;
+    #[cfg(not(target_arch = "wasm32"))]
+    let mut rename_accessors_in_host_languages =
+        common::host_language_search::RenameAccessorsPolicy::default();
 
     for config_value in workspace_config {
         if let Some(config_object) = config_value.as_object() {
@@ -1695,9 +1745,29 @@ fn parse_configuration(workspace_config: Vec<serde_json::Value>) -> WorkspaceCon
             if config_object.get("experimental").and_then(|v| v.as_bool()) == Some(true) {
                 experimental = true;
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Some(raw) =
+                config_object.get("renameAccessorsInHostLanguages").and_then(|v| v.as_str())
+            {
+                match common::host_language_search::RenameAccessorsPolicy::parse(raw) {
+                    Some(parsed) => rename_accessors_in_host_languages = parsed,
+                    None => tracing::warn!(
+                        "Ignoring invalid slint.renameAccessorsInHostLanguages value {raw:?}; \
+                         expected \"never\" or \"always\""
+                    ),
+                }
+            }
         }
     }
-    WorkspaceConfig { hide_ui, include_paths, library_paths, style, experimental }
+    WorkspaceConfig {
+        hide_ui,
+        include_paths,
+        library_paths,
+        style,
+        experimental,
+        #[cfg(not(target_arch = "wasm32"))]
+        rename_accessors_in_host_languages,
+    }
 }
 
 pub async fn load_configuration(ctx: &mut Context) -> common::Result<()> {
@@ -1728,8 +1798,15 @@ pub async fn load_configuration(ctx: &mut Context) -> common::Result<()> {
 
     let workspace_config = parse_configuration(workspace_config);
     tracing::debug!("Loaded configuration: {workspace_config:?}");
-    let WorkspaceConfig { hide_ui, include_paths, library_paths, style, experimental } =
-        workspace_config;
+    let WorkspaceConfig {
+        hide_ui,
+        include_paths,
+        library_paths,
+        style,
+        experimental,
+        #[cfg(not(target_arch = "wasm32"))]
+        rename_accessors_in_host_languages,
+    } = workspace_config;
 
     let mut diag = BuildDiagnostics::default();
     let (cc, all_files) = ctx
@@ -1757,6 +1834,10 @@ pub async fn load_configuration(ctx: &mut Context) -> common::Result<()> {
     {
         ctx.preview_config = config.clone();
         ctx.to_preview.send(&LspToPreviewMessage::SetConfiguration { config });
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        ctx.rename_accessors_policy = rename_accessors_in_host_languages;
     }
 
     tracing::debug!("Loaded configuration from client");

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -891,7 +891,7 @@ async fn run_host_language_rename_followup(
     let message = format!(
         "Slint {kind_label} '{}' is exposed to host language code. \
          Search & Replace the Rust/C++ code with the new accessors? \
-         (The slint rename has already been applied.)",
+         (The Slint rename has already been applied.)",
         info.old_name,
     );
     let action_replace = "Search & Replace Rust/C++ accessors";

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -894,9 +894,9 @@ async fn run_host_language_rename_followup(
          (The Slint rename has already been applied.)",
         info.old_name,
     );
-    let action_replace = "Search & Replace Rust/C++ accessors";
-    let action_skip = "Skip";
-    let action_never = "Skip and don't ask again";
+    let action_replace = "🔍 Search & Replace Rust/C++ accessors";
+    let action_skip = "⏩ Skip";
+    let action_never = "⏭️ Skip and don't ask again";
 
     let action_items = vec![
         lsp_types::MessageActionItem {
@@ -2103,12 +2103,12 @@ pub mod tests {
         let actions: Vec<_> = params.actions.unwrap().into_iter().map(|a| a.title).collect();
         assert_eq!(
             actions,
-            ["Search & Replace Rust/C++ accessors", "Skip", "Skip and don't ask again"]
+            ["🔍 Search & Replace Rust/C++ accessors", "⏩ Skip", "⏭️ Skip and don't ask again"]
         );
         client.respond(
             request,
             Some(MessageActionItem {
-                title: "Skip and don't ask again".into(),
+                title: "⏭️ Skip and don't ask again".into(),
                 properties: Default::default(),
             }),
         );
@@ -2175,7 +2175,7 @@ pub mod tests {
         client.respond(
             prompt,
             Some(MessageActionItem {
-                title: "Search & Replace Rust/C++ accessors".into(),
+                title: "🔍 Search & Replace Rust/C++ accessors".into(),
                 properties: Default::default(),
             }),
         );

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -55,12 +55,27 @@ use std::rc::Rc;
 
 const POPULATE_COMMAND: &str = "slint/populate";
 pub const SHOW_PREVIEW_COMMAND: &str = "slint/showPreview";
+/// LSP-side command (invoked via `workspace/executeCommand`) that runs the
+/// Slint rename and extends the resulting `WorkspaceEdit` with textual
+/// rewrites of the generated Rust/C++ accessor at every call site in the
+/// workspace. The editor extension prompts the user for the new name before
+/// invoking this; see #11841.
+#[cfg(not(target_arch = "wasm32"))]
+pub const RENAME_WITH_HOST_ACCESSORS_COMMAND: &str = "slint/renameWithHostAccessors";
+/// Editor-side command name surfaced via `CodeAction.command`. The editor
+/// extension (e.g. the VS Code extension) registers this command,
+/// prompts the user for the new name, and then calls back with
+/// [`RENAME_WITH_HOST_ACCESSORS_COMMAND`].
+#[cfg(not(target_arch = "wasm32"))]
+pub const RENAME_WITH_HOST_ACCESSORS_EDITOR_COMMAND: &str = "slint.renameWithHostAccessors";
 
 fn command_list() -> Vec<String> {
     vec![
         POPULATE_COMMAND.into(),
         #[cfg(any(feature = "preview-builtin", feature = "preview-external"))]
         SHOW_PREVIEW_COMMAND.into(),
+        #[cfg(not(target_arch = "wasm32"))]
+        RENAME_WITH_HOST_ACCESSORS_COMMAND.into(),
     ]
 }
 
@@ -256,10 +271,6 @@ pub struct Context {
     pub preview_config: PreviewConfig,
     pub server_notifier: crate::ServerNotifier,
     pub init_param: InitializeParams,
-    /// Whether `textDocument/rename` should also rewrite Rust/C++ accessor
-    /// call sites in workspace files. See #11841.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub rename_accessors_policy: common::host_language_search::RenameAccessorsPolicy,
     /// The last component for which the user clicked "show preview"
     #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
     pub to_show: Option<PreviewComponent>,
@@ -513,6 +524,16 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                 });
                 return Ok(None::<serde_json::Value>);
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            cmd if cmd == RENAME_WITH_HOST_ACCESSORS_COMMAND => {
+                let future = rename_with_host_accessors_command(&params.arguments, ctx)?;
+                crate::common::spawn_local(async move {
+                    if let Err(err) = future.await {
+                        tracing::error!("Error executing renameWithHostAccessors command: {err}");
+                    }
+                });
+                return Ok(None::<serde_json::Value>);
+            }
             _ => {
                 tracing::error!("Received unknown command {}", params.command.as_str());
             }
@@ -596,54 +617,13 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
             if let Some(declaration_node) =
                 common::rename_component::find_declaration_node(&ctx.document_cache, &tk)
             {
-                let mut workspace_edit =
-                    declaration_node.rename(&ctx.document_cache, &params.new_name).map_err(
-                        |e| LspError { code: LspErrorCode::RequestFailed, message: e.to_string() },
-                    )?;
-                #[cfg(not(target_arch = "wasm32"))]
-                if matches!(
-                    ctx.rename_accessors_policy,
-                    common::host_language_search::RenameAccessorsPolicy::Always,
-                ) && let Some(info) =
-                    declaration_node.host_language_classification(&ctx.document_cache)
-                    && i_slint_compiler::parser::normalize_identifier(&params.new_name)
-                        != info.old_name
-                {
-                    // Skip the scan when the slint rename normalizes to the
-                    // same identifier (e.g. `my-count` -> `my_count`): the
-                    // accessor names are unchanged, so the scanner would
-                    // produce identical-text TextEdits and the rename preview
-                    // would list every host-language file as "modified".
-                    let folders =
-                        common::host_language_search::resolve_workspace_folders(&ctx.init_param);
-                    // Soft-degrade: a scanner failure logs a warning and falls
-                    // back to slint-only edits. The user opted into `"always"`
-                    // and can re-run with the config off if the warning is
-                    // a problem; rejecting the whole rename loses the slint
-                    // edits they actually wanted.
-                    match common::host_language_search::scan_host_language_accessors(
-                        &folders,
-                        info.source_file.path(),
-                        info.kind,
-                        &info.old_name,
-                        &params.new_name,
-                        ctx.document_cache.format,
-                        common::host_language_search::ScanBounds::default(),
-                    ) {
-                        Ok(host_edits) if !host_edits.is_empty() => {
-                            let host_workspace_edit =
-                                common::create_workspace_edit_from_single_text_edits(host_edits);
-                            common::merge_workspace_edits(&mut workspace_edit, host_workspace_edit);
-                        }
-                        Ok(_) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                "Slint cross-language rename: host-language scan skipped: {e}"
-                            );
-                        }
-                    }
-                }
-                return Ok(Some(workspace_edit));
+                return declaration_node
+                    .rename(&ctx.document_cache, &params.new_name)
+                    .map(Some)
+                    .map_err(|e| LspError {
+                        code: LspErrorCode::RequestFailed,
+                        message: e.to_string(),
+                    });
             }
         }
 
@@ -849,6 +829,100 @@ pub fn populate_command(
             });
         }
 
+        Ok(serde_json::to_value(()).expect("Failed to serialize ()!"))
+    })
+}
+
+/// Implementation of [`RENAME_WITH_HOST_ACCESSORS_COMMAND`]. Takes
+/// `[uri, position, new_name]` from the editor, runs the slint rename
+/// together with the host-language scanner, and applies the merged
+/// `WorkspaceEdit` via `workspace/applyEdit`.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn rename_with_host_accessors_command(
+    params: &[serde_json::Value],
+    ctx: &mut Context,
+) -> Result<impl Future<Output = Result<serde_json::Value, LspError>> + 'static, LspError> {
+    let bad = |msg: &str| LspError { code: LspErrorCode::InvalidParameter, message: msg.into() };
+
+    let uri =
+        serde_json::from_value::<Url>(params.first().ok_or_else(|| bad("missing uri"))?.clone())
+            .map_err(|_| bad("first argument is not a URL"))?;
+    let position = serde_json::from_value::<lsp_types::Position>(
+        params.get(1).ok_or_else(|| bad("missing position"))?.clone(),
+    )
+    .map_err(|_| bad("second argument is not a Position"))?;
+    let new_name = serde_json::from_value::<String>(
+        params.get(2).ok_or_else(|| bad("missing new name"))?.clone(),
+    )
+    .map_err(|_| bad("third argument is not a string"))?;
+
+    let document_cache = &ctx.document_cache;
+    let Some((token, _)) = token_descr(document_cache, &uri, &position) else {
+        return Err(bad("no token at position"));
+    };
+    let Some(decl) = common::rename_component::find_declaration_node(document_cache, &token) else {
+        return Err(bad("position is not a renameable declaration"));
+    };
+
+    let mut workspace_edit = decl
+        .rename(document_cache, &new_name)
+        .map_err(|e| LspError { code: LspErrorCode::RequestFailed, message: e.to_string() })?;
+
+    // Skip the host-language scan when the slint rename normalizes to the
+    // same identifier (e.g. `my-count` -> `my_count`): the accessor names
+    // are unchanged, so the scanner would produce identical-text TextEdits.
+    if let Some(info) = decl.host_language_classification(document_cache)
+        && i_slint_compiler::parser::normalize_identifier(&new_name) != info.old_name
+    {
+        let folders = common::host_language_search::resolve_workspace_folders(&ctx.init_param);
+        match common::host_language_search::scan_host_language_accessors(
+            &folders,
+            info.source_file.path(),
+            info.kind,
+            &info.old_name,
+            &new_name,
+            document_cache.format,
+            common::host_language_search::ScanBounds::default(),
+        ) {
+            Ok(host_edits) if !host_edits.is_empty() => {
+                let host_workspace_edit =
+                    common::create_workspace_edit_from_single_text_edits(host_edits);
+                common::merge_workspace_edits(&mut workspace_edit, host_workspace_edit);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "Slint cross-language rename: host-language scan skipped: {e}; \
+                     applying .slint edits only"
+                );
+            }
+        }
+    }
+
+    let server_notifier = ctx.server_notifier.clone();
+    Ok(async move {
+        let response = server_notifier
+            .send_request::<lsp_types::request::ApplyWorkspaceEdit>(
+                lsp_types::ApplyWorkspaceEditParams {
+                    label: Some("Rename Slint declaration and Rust/C++ accessors".into()),
+                    edit: workspace_edit,
+                },
+            )
+            .map_err(|_| LspError {
+                code: LspErrorCode::RequestFailed,
+                message: "Failed to send rename WorkspaceEdit".into(),
+            })?
+            .await
+            .map_err(|_| LspError {
+                code: LspErrorCode::RequestFailed,
+                message: "Failed to send rename WorkspaceEdit".into(),
+            })?;
+        if !response.applied {
+            return Err(LspError {
+                code: LspErrorCode::RequestFailed,
+                message: "Client refused to apply rename WorkspaceEdit".into(),
+            });
+        }
         Ok(serde_json::to_value(()).expect("Failed to serialize ()!"))
     })
 }
@@ -1200,6 +1274,33 @@ fn get_code_actions(
                 &component_name,
             )))
         }
+    }
+
+    // CodeAction: "Rename property and its Rust/C++ accessors..." -- offered
+    // on public property/callback/function identifiers in a .slint file. The
+    // editor extension is responsible for prompting the user for the new
+    // name; see RENAME_WITH_HOST_ACCESSORS_EDITOR_COMMAND.
+    #[cfg(not(target_arch = "wasm32"))]
+    if token.kind() == SyntaxKind::Identifier
+        && let Some(decl) = common::rename_component::find_declaration_node(document_cache, &token)
+        && let Some(info) = decl.host_language_classification(document_cache)
+    {
+        let position = util::token_to_lsp_range(&token, document_cache.format).start;
+        let label = match info.kind {
+            i_slint_compiler::generator::accessor_names::DeclarationKind::Property => "property",
+            i_slint_compiler::generator::accessor_names::DeclarationKind::Callback => "callback",
+            i_slint_compiler::generator::accessor_names::DeclarationKind::Function => "function",
+        };
+        result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+            title: format!("Rename {label} and its Rust/C++ accessors..."),
+            kind: Some(lsp_types::CodeActionKind::REFACTOR_REWRITE),
+            command: Some(Command::new(
+                format!("Rename {label} and its Rust/C++ accessors..."),
+                RENAME_WITH_HOST_ACCESSORS_EDITOR_COMMAND.into(),
+                Some(vec![uri.as_str().into(), serde_json::to_value(position).unwrap()]),
+            )),
+            ..Default::default()
+        }));
     }
 
     if token.kind() == SyntaxKind::StringLiteral && node.kind() == SyntaxKind::Expression {
@@ -1700,8 +1801,6 @@ struct WorkspaceConfig {
     library_paths: Option<HashMap<String, PathBuf>>,
     style: Option<String>,
     experimental: bool,
-    #[cfg(not(target_arch = "wasm32"))]
-    rename_accessors_in_host_languages: common::host_language_search::RenameAccessorsPolicy,
 }
 
 fn parse_configuration(workspace_config: Vec<serde_json::Value>) -> WorkspaceConfig {
@@ -1710,9 +1809,6 @@ fn parse_configuration(workspace_config: Vec<serde_json::Value>) -> WorkspaceCon
     let mut library_paths = None;
     let mut style = None;
     let mut experimental = false;
-    #[cfg(not(target_arch = "wasm32"))]
-    let mut rename_accessors_in_host_languages =
-        common::host_language_search::RenameAccessorsPolicy::default();
 
     for config_value in workspace_config {
         if let Some(config_object) = config_value.as_object() {
@@ -1745,29 +1841,9 @@ fn parse_configuration(workspace_config: Vec<serde_json::Value>) -> WorkspaceCon
             if config_object.get("experimental").and_then(|v| v.as_bool()) == Some(true) {
                 experimental = true;
             }
-            #[cfg(not(target_arch = "wasm32"))]
-            if let Some(raw) =
-                config_object.get("renameAccessorsInHostLanguages").and_then(|v| v.as_str())
-            {
-                match common::host_language_search::RenameAccessorsPolicy::parse(raw) {
-                    Some(parsed) => rename_accessors_in_host_languages = parsed,
-                    None => tracing::warn!(
-                        "Ignoring invalid slint.renameAccessorsInHostLanguages value {raw:?}; \
-                         expected \"never\" or \"always\""
-                    ),
-                }
-            }
         }
     }
-    WorkspaceConfig {
-        hide_ui,
-        include_paths,
-        library_paths,
-        style,
-        experimental,
-        #[cfg(not(target_arch = "wasm32"))]
-        rename_accessors_in_host_languages,
-    }
+    WorkspaceConfig { hide_ui, include_paths, library_paths, style, experimental }
 }
 
 pub async fn load_configuration(ctx: &mut Context) -> common::Result<()> {
@@ -1798,15 +1874,8 @@ pub async fn load_configuration(ctx: &mut Context) -> common::Result<()> {
 
     let workspace_config = parse_configuration(workspace_config);
     tracing::debug!("Loaded configuration: {workspace_config:?}");
-    let WorkspaceConfig {
-        hide_ui,
-        include_paths,
-        library_paths,
-        style,
-        experimental,
-        #[cfg(not(target_arch = "wasm32"))]
-        rename_accessors_in_host_languages,
-    } = workspace_config;
+    let WorkspaceConfig { hide_ui, include_paths, library_paths, style, experimental } =
+        workspace_config;
 
     let mut diag = BuildDiagnostics::default();
     let (cc, all_files) = ctx
@@ -1834,10 +1903,6 @@ pub async fn load_configuration(ctx: &mut Context) -> common::Result<()> {
     {
         ctx.preview_config = config.clone();
         ctx.to_preview.send(&LspToPreviewMessage::SetConfiguration { config });
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        ctx.rename_accessors_policy = rename_accessors_in_host_languages;
     }
 
     tracing::debug!("Loaded configuration from client");

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -47,6 +47,7 @@ use lsp_types::{
     },
 };
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
@@ -55,27 +56,12 @@ use std::rc::Rc;
 
 const POPULATE_COMMAND: &str = "slint/populate";
 pub const SHOW_PREVIEW_COMMAND: &str = "slint/showPreview";
-/// LSP-side command (invoked via `workspace/executeCommand`) that runs the
-/// Slint rename and extends the resulting `WorkspaceEdit` with textual
-/// rewrites of the generated Rust/C++ accessor at every call site in the
-/// workspace. The editor extension prompts the user for the new name before
-/// invoking this; see #11841.
-#[cfg(not(target_arch = "wasm32"))]
-pub const RENAME_WITH_HOST_ACCESSORS_COMMAND: &str = "slint/renameWithHostAccessors";
-/// Editor-side command name surfaced via `CodeAction.command`. The editor
-/// extension (e.g. the VS Code extension) registers this command,
-/// prompts the user for the new name, and then calls back with
-/// [`RENAME_WITH_HOST_ACCESSORS_COMMAND`].
-#[cfg(not(target_arch = "wasm32"))]
-pub const RENAME_WITH_HOST_ACCESSORS_EDITOR_COMMAND: &str = "slint.renameWithHostAccessors";
 
 fn command_list() -> Vec<String> {
     vec![
         POPULATE_COMMAND.into(),
         #[cfg(any(feature = "preview-builtin", feature = "preview-external"))]
         SHOW_PREVIEW_COMMAND.into(),
-        #[cfg(not(target_arch = "wasm32"))]
-        RENAME_WITH_HOST_ACCESSORS_COMMAND.into(),
     ]
 }
 
@@ -280,6 +266,14 @@ pub struct Context {
     /// Files to recompile after all other operations are done
     /// (i.e. recompilations triggered by updates to unopened files)
     pub pending_recompile: HashSet<lsp_types::Url>,
+    /// Per-declaration "don't ask again" suppression for the host-language
+    /// rename prompt. Keyed by `(slint file URL, original Slint decl name)` so
+    /// the user is asked only once per visible declaration per session. The
+    /// entry implicitly lapses after a successful rename: the next rename
+    /// sees a new key. TODO(#12111): persist across sessions when client-side
+    /// settings storage is available.
+    pub host_language_rename_dont_ask_again:
+        Rc<RefCell<HashSet<(lsp_types::Url, smol_str::SmolStr)>>>,
 }
 
 /// An error from a LSP request
@@ -524,16 +518,6 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                 });
                 return Ok(None::<serde_json::Value>);
             }
-            #[cfg(not(target_arch = "wasm32"))]
-            cmd if cmd == RENAME_WITH_HOST_ACCESSORS_COMMAND => {
-                let future = rename_with_host_accessors_command(&params.arguments, ctx)?;
-                crate::common::spawn_local(async move {
-                    if let Err(err) = future.await {
-                        tracing::error!("Error executing renameWithHostAccessors command: {err}");
-                    }
-                });
-                return Ok(None::<serde_json::Value>);
-            }
             _ => {
                 tracing::error!("Received unknown command {}", params.command.as_str());
             }
@@ -617,13 +601,22 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
             if let Some(declaration_node) =
                 common::rename_component::find_declaration_node(&ctx.document_cache, &tk)
             {
-                return declaration_node
-                    .rename(&ctx.document_cache, &params.new_name)
-                    .map(Some)
-                    .map_err(|e| LspError {
-                        code: LspErrorCode::RequestFailed,
-                        message: e.to_string(),
-                    });
+                let edit = declaration_node.rename(&ctx.document_cache, &params.new_name).map_err(
+                    |e| LspError { code: LspErrorCode::RequestFailed, message: e.to_string() },
+                )?;
+                // After the synchronous slint-only rename, ask the user (once)
+                // whether to also rewrite the generated Rust/C++ accessors at
+                // workspace call sites. The dialog and follow-up edit have to
+                // run asynchronously: the request handler is synchronous and
+                // must return the slint edit immediately.
+                #[cfg(not(target_arch = "wasm32"))]
+                schedule_host_language_rename_followup(
+                    ctx,
+                    &declaration_node,
+                    &uri,
+                    &params.new_name,
+                );
+                return Ok(Some(edit));
             }
         }
 
@@ -833,98 +826,243 @@ pub fn populate_command(
     })
 }
 
-/// Implementation of [`RENAME_WITH_HOST_ACCESSORS_COMMAND`]. Takes
-/// `[uri, position, new_name]` from the editor, runs the slint rename
-/// together with the host-language scanner, and applies the merged
-/// `WorkspaceEdit` via `workspace/applyEdit`.
+/// Synchronous step in the host-language rename flow: classify the
+/// declaration the user just renamed, and -- if it is exposed in the
+/// generated Rust/C++ public API and the rename actually changes the
+/// accessor name -- spawn the async dialog + scanner + applyEdit follow-up.
+///
+/// The handler that calls this has already returned the slint-only
+/// `WorkspaceEdit` synchronously, so by the time the dialog appears the
+/// `.slint` file has already been updated by the client. The host-language
+/// scanner runs against the *old* accessor name on disk and produces a
+/// second `workspace/applyEdit` from the spawned task; the editor's
+/// undo/redo treats the two edits independently. That is intentional: if
+/// the user rejects the host-language rewrite (or the scanner errors),
+/// the slint rename still stands.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn rename_with_host_accessors_command(
-    params: &[serde_json::Value],
-    ctx: &mut Context,
-) -> Result<impl Future<Output = Result<serde_json::Value, LspError>> + 'static, LspError> {
-    let bad = |msg: &str| LspError { code: LspErrorCode::InvalidParameter, message: msg.into() };
-
-    let uri =
-        serde_json::from_value::<Url>(params.first().ok_or_else(|| bad("missing uri"))?.clone())
-            .map_err(|_| bad("first argument is not a URL"))?;
-    let position = serde_json::from_value::<lsp_types::Position>(
-        params.get(1).ok_or_else(|| bad("missing position"))?.clone(),
-    )
-    .map_err(|_| bad("second argument is not a Position"))?;
-    let new_name = serde_json::from_value::<String>(
-        params.get(2).ok_or_else(|| bad("missing new name"))?.clone(),
-    )
-    .map_err(|_| bad("third argument is not a string"))?;
-
-    let document_cache = &ctx.document_cache;
-    let Some((token, _)) = token_descr(document_cache, &uri, &position) else {
-        return Err(bad("no token at position"));
+fn schedule_host_language_rename_followup(
+    ctx: &Context,
+    declaration_node: &common::rename_component::DeclarationNode,
+    slint_uri: &Url,
+    new_name: &str,
+) {
+    let Some(info) = declaration_node.host_language_classification(&ctx.document_cache) else {
+        return;
     };
-    let Some(decl) = common::rename_component::find_declaration_node(document_cache, &token) else {
-        return Err(bad("position is not a declaration that can be renamed"));
-    };
-
-    let mut workspace_edit = decl
-        .rename(document_cache, &new_name)
-        .map_err(|e| LspError { code: LspErrorCode::RequestFailed, message: e.to_string() })?;
-
-    // Skip the host-language scan when the slint rename normalizes to the
-    // same identifier (e.g. `my-count` -> `my_count`): the accessor names
-    // are unchanged, so the scanner would produce identical-text TextEdits.
-    if let Some(info) = decl.host_language_classification(document_cache)
-        && i_slint_compiler::parser::normalize_identifier(&new_name) != info.old_name
-    {
-        let folders = common::host_language_search::resolve_workspace_folders(&ctx.init_param);
-        match common::host_language_search::scan_host_language_accessors(
-            &folders,
-            info.source_file.path(),
-            info.kind,
-            &info.old_name,
-            &new_name,
-            document_cache.format,
-            common::host_language_search::ScanBounds::default(),
-        ) {
-            Ok(host_edits) if !host_edits.is_empty() => {
-                let host_workspace_edit =
-                    common::create_workspace_edit_from_single_text_edits(host_edits);
-                common::merge_workspace_edits(&mut workspace_edit, host_workspace_edit);
-            }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::warn!(
-                    "Slint cross-language rename: host-language scan skipped: {e}; \
-                     applying .slint edits only"
-                );
-            }
-        }
+    // No-op when the slint rename normalizes to the same identifier
+    // (e.g. `my-count` -> `my_count`): accessor names are unchanged so the
+    // scanner would only produce identical-text TextEdits.
+    if i_slint_compiler::parser::normalize_identifier(new_name) == info.old_name {
+        return;
+    }
+    let key = (slint_uri.clone(), info.old_name.clone());
+    if ctx.host_language_rename_dont_ask_again.borrow().contains(&key) {
+        return;
     }
 
     let server_notifier = ctx.server_notifier.clone();
-    Ok(async move {
-        let response = server_notifier
-            .send_request::<lsp_types::request::ApplyWorkspaceEdit>(
-                lsp_types::ApplyWorkspaceEditParams {
-                    label: Some("Rename Slint declaration and Rust/C++ accessors".into()),
-                    edit: workspace_edit,
-                },
-            )
-            .map_err(|_| LspError {
-                code: LspErrorCode::RequestFailed,
-                message: "Failed to send rename WorkspaceEdit".into(),
-            })?
-            .await
-            .map_err(|_| LspError {
-                code: LspErrorCode::RequestFailed,
-                message: "Failed to send rename WorkspaceEdit".into(),
-            })?;
-        if !response.applied {
-            return Err(LspError {
-                code: LspErrorCode::RequestFailed,
-                message: "Client refused to apply rename WorkspaceEdit".into(),
-            });
+    let dont_ask_again = ctx.host_language_rename_dont_ask_again.clone();
+    let init_param = ctx.init_param.clone();
+    let format = ctx.document_cache.format;
+    let new_name = new_name.to_string();
+
+    crate::common::spawn_local(async move {
+        // Folders can change after initialization; query the client now
+        // rather than reusing the InitializeParams snapshot.
+        let workspace_folders =
+            common::host_language_search::current_workspace_folders(&server_notifier, &init_param)
+                .await;
+        run_host_language_rename_followup(
+            server_notifier,
+            dont_ask_again,
+            workspace_folders,
+            format,
+            info,
+            new_name,
+            key,
+        )
+        .await;
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn run_host_language_rename_followup(
+    server_notifier: crate::ServerNotifier,
+    dont_ask_again: Rc<RefCell<HashSet<(Url, smol_str::SmolStr)>>>,
+    workspace_folders: Vec<lsp_types::WorkspaceFolder>,
+    format: common::ByteFormat,
+    info: common::rename_component::HostLanguageRenameInfo,
+    new_name: String,
+    dont_ask_again_key: (Url, smol_str::SmolStr),
+) {
+    use i_slint_compiler::generator::accessor_names::DeclarationKind;
+
+    let kind_label = match info.kind {
+        DeclarationKind::Property => "property",
+        DeclarationKind::Callback => "callback",
+        DeclarationKind::Function => "function",
+    };
+    let message = format!(
+        "Slint {kind_label} '{}' is exposed to host language code. \
+         Also rewrite its Rust/C++ accessors at workspace call sites? \
+         (The slint rename has already been applied.)",
+        info.old_name,
+    );
+    let action_replace = "Rewrite Rust/C++ accessors";
+    let action_skip = "Skip";
+    let action_never = "Skip and don't ask again for this declaration";
+
+    let action_items = vec![
+        lsp_types::MessageActionItem {
+            title: action_replace.into(),
+            properties: Default::default(),
+        },
+        lsp_types::MessageActionItem { title: action_skip.into(), properties: Default::default() },
+        lsp_types::MessageActionItem { title: action_never.into(), properties: Default::default() },
+    ];
+
+    let request = match server_notifier.send_request::<lsp_types::request::ShowMessageRequest>(
+        lsp_types::ShowMessageRequestParams {
+            typ: lsp_types::MessageType::INFO,
+            message,
+            actions: Some(action_items),
+        },
+    ) {
+        Ok(fut) => fut,
+        Err(e) => {
+            tracing::warn!("Slint host-language rename: failed to send prompt: {e}");
+            return;
         }
-        Ok(serde_json::to_value(()).expect("Failed to serialize ()!"))
-    })
+    };
+    let chosen = match request.await {
+        Ok(Some(item)) => Some(item.title),
+        Ok(None) => None, // user dismissed
+        Err(e) => {
+            tracing::warn!("Slint host-language rename: prompt request failed: {e}");
+            return;
+        }
+    };
+
+    match chosen.as_deref() {
+        Some(title) if title == action_replace => {
+            let scan_result = common::host_language_search::scan_host_language_accessors(
+                &workspace_folders,
+                info.kind,
+                &info.old_name,
+                &new_name,
+                format,
+                common::host_language_search::ScanBounds::DEFAULT,
+            );
+            match scan_result {
+                Ok(edits) if edits.is_empty() => {
+                    show_info(
+                        &server_notifier,
+                        "Slint rename applied; no Rust/C++ accessor call sites found in the workspace.",
+                    );
+                }
+                Ok(edits) => {
+                    let file_count = edits.iter().map(|e| &e.url).collect::<HashSet<_>>().len();
+                    let edit_count = edits.len();
+                    let workspace_edit =
+                        common::create_workspace_edit_from_single_text_edits(edits);
+                    apply_host_language_edits(
+                        &server_notifier,
+                        workspace_edit,
+                        edit_count,
+                        file_count,
+                    )
+                    .await;
+                }
+                Err(e) => {
+                    show_warning(
+                        &server_notifier,
+                        format!(
+                            "Slint rename applied; host-language scan failed: {e}. \
+                             Rust/C++ accessor call sites were not rewritten."
+                        ),
+                    );
+                }
+            }
+        }
+        Some(title) if title == action_never => {
+            dont_ask_again.borrow_mut().insert(dont_ask_again_key);
+            show_info(
+                &server_notifier,
+                "Slint rename applied; skipping host-language rewrite (won't ask again for this declaration).",
+            );
+        }
+        _ => {
+            show_info(
+                &server_notifier,
+                "Slint rename applied; host-language Rust/C++ accessors were not rewritten.",
+            );
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn apply_host_language_edits(
+    server_notifier: &crate::ServerNotifier,
+    edit: lsp_types::WorkspaceEdit,
+    edit_count: usize,
+    file_count: usize,
+) {
+    let request = match server_notifier.send_request::<lsp_types::request::ApplyWorkspaceEdit>(
+        lsp_types::ApplyWorkspaceEditParams {
+            label: Some("Rewrite Rust/C++ accessors for Slint rename".into()),
+            edit,
+        },
+    ) {
+        Ok(fut) => fut,
+        Err(e) => {
+            show_warning(
+                server_notifier,
+                format!("Failed to send host-language WorkspaceEdit: {e}."),
+            );
+            return;
+        }
+    };
+    match request.await {
+        Ok(response) if response.applied => {
+            show_info(
+                server_notifier,
+                format!(
+                    "Rewrote {edit_count} Rust/C++ accessor call site{} across {file_count} file{}.",
+                    if edit_count == 1 { "" } else { "s" },
+                    if file_count == 1 { "" } else { "s" },
+                ),
+            );
+        }
+        Ok(_) => {
+            show_warning(
+                server_notifier,
+                "Client refused to apply the host-language rename WorkspaceEdit.",
+            );
+        }
+        Err(e) => {
+            show_warning(
+                server_notifier,
+                format!("Failed to apply host-language WorkspaceEdit: {e}."),
+            );
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn show_info(server_notifier: &crate::ServerNotifier, message: impl Into<String>) {
+    let _ = server_notifier.send_notification::<lsp_types::notification::ShowMessage>(
+        lsp_types::ShowMessageParams { typ: lsp_types::MessageType::INFO, message: message.into() },
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn show_warning(server_notifier: &crate::ServerNotifier, message: impl Into<String>) {
+    let _ = server_notifier.send_notification::<lsp_types::notification::ShowMessage>(
+        lsp_types::ShowMessageParams {
+            typ: lsp_types::MessageType::WARNING,
+            message: message.into(),
+        },
+    );
 }
 
 pub(crate) async fn load_document_impl(
@@ -1274,33 +1412,6 @@ fn get_code_actions(
                 &component_name,
             )))
         }
-    }
-
-    // CodeAction: "Rename property and its Rust/C++ accessors..." -- offered
-    // on public property/callback/function identifiers in a .slint file. The
-    // editor extension is responsible for prompting the user for the new
-    // name; see RENAME_WITH_HOST_ACCESSORS_EDITOR_COMMAND.
-    #[cfg(not(target_arch = "wasm32"))]
-    if token.kind() == SyntaxKind::Identifier
-        && let Some(decl) = common::rename_component::find_declaration_node(document_cache, &token)
-        && let Some(info) = decl.host_language_classification(document_cache)
-    {
-        let position = util::token_to_lsp_range(&token, document_cache.format).start;
-        let label = match info.kind {
-            i_slint_compiler::generator::accessor_names::DeclarationKind::Property => "property",
-            i_slint_compiler::generator::accessor_names::DeclarationKind::Callback => "callback",
-            i_slint_compiler::generator::accessor_names::DeclarationKind::Function => "function",
-        };
-        result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
-            title: format!("Rename {label} and its Rust/C++ accessors..."),
-            kind: Some(lsp_types::CodeActionKind::REFACTOR_REWRITE),
-            command: Some(Command::new(
-                format!("Rename {label} and its Rust/C++ accessors..."),
-                RENAME_WITH_HOST_ACCESSORS_EDITOR_COMMAND.into(),
-                Some(vec![uri.as_str().into(), serde_json::to_value(position).unwrap()]),
-            )),
-            ..Default::default()
-        }));
     }
 
     if token.kind() == SyntaxKind::StringLiteral && node.kind() == SyntaxKind::Expression {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -943,7 +943,7 @@ async fn run_host_language_rename_followup(
                 Ok(edits) if edits.is_empty() => {
                     show_info(
                         &server_notifier,
-                        "Slint rename applied; no Rust/C++ accessor call sites found in the workspace.",
+                        "Slint rename applied; no matching Rust/C++ accessor identifiers found in the workspace.",
                     );
                 }
                 Ok(edits) => {
@@ -964,7 +964,7 @@ async fn run_host_language_rename_followup(
                         &server_notifier,
                         format!(
                             "Slint rename applied; host-language scan failed: {e}. \
-                             Rust/C++ accessor call sites were not rewritten."
+                             Rust/C++ accessor identifiers were not replaced."
                         ),
                     );
                 }
@@ -1013,7 +1013,7 @@ async fn apply_host_language_edits(
             show_info(
                 server_notifier,
                 format!(
-                    "Rewrote {edit_count} Rust/C++ accessor call site{} across {file_count} file{}.",
+                    "Replaced {edit_count} Rust/C++ accessor occurrence{} across {file_count} file{}.",
                     if edit_count == 1 { "" } else { "s" },
                     if file_count == 1 { "" } else { "s" },
                 ),
@@ -2015,7 +2015,236 @@ pub mod tests {
     use crate::language::test::{
         complex_document_cache, loaded_document_cache, loaded_document_cache_with_file_name,
     };
-    use lsp_types::WorkspaceEdit;
+    use lsp_server::{Message, Request, Response};
+    use lsp_types::{
+        ApplyWorkspaceEditResponse, MessageActionItem, WorkspaceEdit, WorkspaceFolder,
+    };
+
+    struct TestLspClient {
+        receiver: crossbeam_channel::Receiver<Message>,
+        queue: crate::OutgoingRequestQueue,
+    }
+
+    impl TestLspClient {
+        fn next_request(&self, expected_method: &str) -> Request {
+            let message = self
+                .receiver
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("expected an LSP request");
+            let Message::Request(request) = message else {
+                panic!("expected request, got {message:?}");
+            };
+            assert_eq!(request.method, expected_method);
+            request
+        }
+
+        fn respond(&self, request: Request, result: impl serde::Serialize) {
+            let mut entry = loop {
+                if let Some(entry) = self.queue.get_mut(&request.id) {
+                    break entry;
+                }
+                std::thread::yield_now();
+            };
+            if let crate::OutgoingRequest::Pending(waker) = &*entry {
+                waker.wake_by_ref();
+            }
+            *entry = crate::OutgoingRequest::Done(Response::new_ok(
+                request.id,
+                serde_json::to_value(result).unwrap(),
+            ));
+        }
+
+        fn next_show_message(&self) -> lsp_types::ShowMessageParams {
+            let message = self
+                .receiver
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("expected a show-message notification");
+            let Message::Notification(notification) = message else {
+                panic!("expected notification, got {message:?}");
+            };
+            assert_eq!(notification.method, "window/showMessage");
+            serde_json::from_value(notification.params).unwrap()
+        }
+    }
+
+    fn test_lsp_client() -> (crate::ServerNotifier, TestLspClient) {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let queue = crate::OutgoingRequestQueue::default();
+        (crate::ServerNotifier { sender, queue: queue.clone() }, TestLspClient { receiver, queue })
+    }
+
+    fn poll_future<F: Future>(future: std::pin::Pin<&mut F>) -> std::task::Poll<F::Output> {
+        let waker = std::task::Waker::noop();
+        let mut context = std::task::Context::from_waker(waker);
+        future.poll(&mut context)
+    }
+
+    #[test]
+    fn host_language_followup_can_disable_prompts_for_the_session() {
+        let (notifier, client) = test_lsp_client();
+        let dont_ask_again = Rc::new(Cell::new(false));
+        let info = common::rename_component::HostLanguageRenameInfo {
+            kind: i_slint_compiler::generator::accessor_names::DeclarationKind::Property,
+            old_name: "count".into(),
+        };
+        let mut future = Box::pin(run_host_language_rename_followup(
+            notifier,
+            dont_ask_again.clone(),
+            Vec::new(),
+            common::ByteFormat::Utf16,
+            info,
+            "total".into(),
+        ));
+
+        assert!(poll_future(future.as_mut()).is_pending());
+        let request = client.next_request("window/showMessageRequest");
+        let params: lsp_types::ShowMessageRequestParams =
+            serde_json::from_value(request.params.clone()).unwrap();
+        let actions: Vec<_> = params.actions.unwrap().into_iter().map(|a| a.title).collect();
+        assert_eq!(
+            actions,
+            ["Search & Replace Rust/C++ accessors", "Skip", "Skip and don't ask again"]
+        );
+        client.respond(
+            request,
+            Some(MessageActionItem {
+                title: "Skip and don't ask again".into(),
+                properties: Default::default(),
+            }),
+        );
+
+        assert!(poll_future(future.as_mut()).is_ready());
+        assert!(dont_ask_again.get());
+        assert!(client.next_show_message().message.contains("won't ask again this session"));
+    }
+
+    #[test]
+    fn session_suppression_prevents_a_later_prompt() {
+        let (document_cache, url, diagnostics) =
+            loaded_document_cache("export component App { in property <int> count; }".into());
+        assert!(diagnostics.get(&url).unwrap().is_empty());
+        let document = document_cache.get_document(&url).unwrap().node.as_ref().unwrap();
+        let offset = document.text().to_string().find("count").unwrap() as u32;
+        let token = document
+            .token_at_offset(offset.into())
+            .find(|token| token.kind() == SyntaxKind::Identifier)
+            .unwrap();
+        let declaration =
+            common::rename_component::find_declaration_node(&document_cache, &token).unwrap();
+        let (notifier, client) = test_lsp_client();
+        let mut context = test::mock_context();
+        context.document_cache = document_cache;
+        context.server_notifier = notifier;
+        context.host_language_rename_dont_ask_again.set(true);
+
+        schedule_host_language_rename_followup(&context, &declaration, "total");
+
+        assert!(matches!(
+            client.receiver.recv_timeout(std::time::Duration::from_millis(50)),
+            Err(crossbeam_channel::RecvTimeoutError::Timeout)
+        ));
+    }
+
+    #[test]
+    fn host_language_followup_requests_and_reports_the_second_workspace_edit() {
+        let path = std::env::temp_dir().join(format!(
+            "slint-lsp-followup-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join("main.rs"), "obj.get_count();").unwrap();
+        let folders =
+            vec![WorkspaceFolder { uri: Url::from_file_path(&path).unwrap(), name: "test".into() }];
+        let (notifier, client) = test_lsp_client();
+        let info = common::rename_component::HostLanguageRenameInfo {
+            kind: i_slint_compiler::generator::accessor_names::DeclarationKind::Property,
+            old_name: "count".into(),
+        };
+        let mut future = Box::pin(run_host_language_rename_followup(
+            notifier,
+            Rc::new(Cell::new(false)),
+            folders,
+            common::ByteFormat::Utf16,
+            info,
+            "total".into(),
+        ));
+
+        assert!(poll_future(future.as_mut()).is_pending());
+        let prompt = client.next_request("window/showMessageRequest");
+        client.respond(
+            prompt,
+            Some(MessageActionItem {
+                title: "Search & Replace Rust/C++ accessors".into(),
+                properties: Default::default(),
+            }),
+        );
+        assert!(poll_future(future.as_mut()).is_pending());
+        let apply = client.next_request("workspace/applyEdit");
+        let params: lsp_types::ApplyWorkspaceEditParams =
+            serde_json::from_value(apply.params.clone()).unwrap();
+        assert_eq!(
+            params.label.as_deref(),
+            Some("Search & Replace Rust/C++ accessors for Slint rename")
+        );
+        assert!(serde_json::to_string(&params.edit).unwrap().contains("get_total"));
+        client.respond(
+            apply,
+            ApplyWorkspaceEditResponse { applied: true, failure_reason: None, failed_change: None },
+        );
+
+        assert!(poll_future(future.as_mut()).is_ready());
+        assert_eq!(
+            client.next_show_message().message,
+            "Replaced 1 Rust/C++ accessor occurrence across 1 file."
+        );
+        std::fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn refused_host_language_workspace_edit_is_reported() {
+        let (notifier, client) = test_lsp_client();
+        let mut future =
+            Box::pin(apply_host_language_edits(&notifier, WorkspaceEdit::default(), 1, 1));
+
+        assert!(poll_future(future.as_mut()).is_pending());
+        let apply = client.next_request("workspace/applyEdit");
+        client.respond(
+            apply,
+            ApplyWorkspaceEditResponse {
+                applied: false,
+                failure_reason: Some("no".into()),
+                failed_change: None,
+            },
+        );
+
+        assert!(poll_future(future.as_mut()).is_ready());
+        let message = client.next_show_message();
+        assert_eq!(message.typ, lsp_types::MessageType::WARNING);
+        assert!(message.message.contains("Client refused"));
+    }
+
+    #[test]
+    fn current_workspace_folders_queries_capable_clients() {
+        let (notifier, client) = test_lsp_client();
+        let expected = WorkspaceFolder {
+            uri: Url::parse("file:///current-workspace").unwrap(),
+            name: "current".into(),
+        };
+        let mut init = InitializeParams::default();
+        init.capabilities.workspace = Some(lsp_types::WorkspaceClientCapabilities {
+            workspace_folders: Some(true),
+            ..Default::default()
+        });
+        let mut future =
+            Box::pin(common::host_language_search::current_workspace_folders(&notifier, &init));
+
+        assert!(poll_future(future.as_mut()).is_pending());
+        let request = client.next_request("workspace/workspaceFolders");
+        client.respond(request, Some(vec![expected.clone()]));
+
+        assert_eq!(poll_future(future.as_mut()), std::task::Poll::Ready(vec![expected]));
+    }
 
     #[test]
     fn test_load_document_invalid_contents() {

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -197,6 +197,8 @@ fn test_goto_definition_multi_files() {
         preview_config: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
+        #[cfg(not(target_arch = "wasm32"))]
+        rename_accessors_policy: Default::default(),
         to_show: None,
         open_urls: Default::default(),
         to_preview: crate::common::LspToPreviews::with_one(common::DummyLspToPreview::default()),

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -197,8 +197,6 @@ fn test_goto_definition_multi_files() {
         preview_config: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
-        #[cfg(not(target_arch = "wasm32"))]
-        rename_accessors_policy: Default::default(),
         to_show: None,
         open_urls: Default::default(),
         to_preview: crate::common::LspToPreviews::with_one(common::DummyLspToPreview::default()),

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -201,6 +201,7 @@ fn test_goto_definition_multi_files() {
         open_urls: Default::default(),
         to_preview: crate::common::LspToPreviews::with_one(common::DummyLspToPreview::default()),
         pending_recompile: Default::default(),
+        host_language_rename_dont_ask_again: Default::default(),
     };
     let (extra_files, diag) = spin_on::spin_on(crate::language::load_document_impl(
         &mut ctx,

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -31,8 +31,6 @@ pub fn mock_context() -> Context {
         preview_config: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
-        #[cfg(not(target_arch = "wasm32"))]
-        rename_accessors_policy: Default::default(),
         #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
         to_show: None,
         open_urls: HashSet::new(),
@@ -77,8 +75,6 @@ pub fn loaded_document_cache_with_file_name(
         preview_config: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
-        #[cfg(not(target_arch = "wasm32"))]
-        rename_accessors_policy: Default::default(),
         to_show: None,
         open_urls: Default::default(),
         to_preview: LspToPreviews::with_one(common::DummyLspToPreview::default()),

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -31,6 +31,8 @@ pub fn mock_context() -> Context {
         preview_config: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
+        #[cfg(not(target_arch = "wasm32"))]
+        rename_accessors_policy: Default::default(),
         #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
         to_show: None,
         open_urls: HashSet::new(),
@@ -75,6 +77,8 @@ pub fn loaded_document_cache_with_file_name(
         preview_config: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
+        #[cfg(not(target_arch = "wasm32"))]
+        rename_accessors_policy: Default::default(),
         to_show: None,
         open_urls: Default::default(),
         to_preview: LspToPreviews::with_one(common::DummyLspToPreview::default()),

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -36,6 +36,7 @@ pub fn mock_context() -> Context {
         open_urls: HashSet::new(),
         to_preview: LspToPreviews::with_one(common::DummyLspToPreview::default()),
         pending_recompile: Default::default(),
+        host_language_rename_dont_ask_again: Default::default(),
     }
 }
 
@@ -79,6 +80,7 @@ pub fn loaded_document_cache_with_file_name(
         open_urls: Default::default(),
         to_preview: LspToPreviews::with_one(common::DummyLspToPreview::default()),
         pending_recompile: Default::default(),
+        host_language_rename_dont_ask_again: Default::default(),
     };
     let (extra_files, diag) =
         spin_on::spin_on(load_document_impl(&mut ctx, content, url.clone(), Some(42)));

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -530,7 +530,6 @@ async fn run_main_loop(
         preview_config: Default::default(),
         server_notifier,
         init_param,
-        rename_accessors_policy: Default::default(),
         #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
         to_show: Default::default(),
         open_urls: Default::default(),

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -535,6 +535,7 @@ async fn run_main_loop(
         open_urls: Default::default(),
         to_preview,
         pending_recompile: Default::default(),
+        host_language_rename_dont_ask_again: Default::default(),
     };
 
     let connection = Arc::new(connection);

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -530,6 +530,7 @@ async fn run_main_loop(
         preview_config: Default::default(),
         server_notifier,
         init_param,
+        rename_accessors_policy: Default::default(),
         #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
         to_show: Default::default(),
         open_urls: Default::default(),

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -608,6 +608,8 @@ export component Main { }
                 preview_config: Default::default(),
                 server_notifier: crate::ServerNotifier::dummy(),
                 init_param: Default::default(),
+                #[cfg(not(target_arch = "wasm32"))]
+                rename_accessors_policy: Default::default(),
                 to_show: None,
                 open_urls: Default::default(),
                 to_preview: crate::common::LspToPreviews::with_one(

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -608,8 +608,6 @@ export component Main { }
                 preview_config: Default::default(),
                 server_notifier: crate::ServerNotifier::dummy(),
                 init_param: Default::default(),
-                #[cfg(not(target_arch = "wasm32"))]
-                rename_accessors_policy: Default::default(),
                 to_show: None,
                 open_urls: Default::default(),
                 to_preview: crate::common::LspToPreviews::with_one(

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -614,6 +614,7 @@ export component Main { }
                     crate::common::DummyLspToPreview::default(),
                 ),
                 pending_recompile: Default::default(),
+                host_language_rename_dont_ask_again: Default::default(),
             };
             let (url, _) = crate::language::test::load(
                 &mut ctx,

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -294,6 +294,7 @@ pub fn create(
             open_urls: Default::default(),
             to_preview,
             pending_recompile: Default::default(),
+            host_language_rename_dont_ask_again: Default::default(),
         }),
         rh: Rc::new(rh),
     })


### PR DESCRIPTION
## Summary

Closes #11841. Adds opt-in cross-language rename to the Slint LSP: renaming a public property, callback, or function in a `.slint` file can now also rewrite the generated Rust/C++ accessor (`get_<n>`, `set_<n>`, `invoke_<n>`, `on_<n>`) at every call site in workspace `.rs`, `.cpp`, and header files. Gated by a new workspace config:

\`\`\`json
"slint.renameAccessorsInHostLanguages": "never" | "always"
\`\`\`

Default `"never"` — no behavior change for existing users. Under `"always"`, the Rename handler extends its `WorkspaceEdit` with edits scanned out of the workspace folder containing the renamed `.slint`.

## Structure for review

The PR is four commits, each scoped so it reviews cleanly on its own:

1. **`compiler: consolidate Rust/C++ public accessor naming into a helper`** — pure refactor. Extracts the `get_/set_/invoke_/on_` accessor-name composition that was inlined across `rust.rs`, `cpp.rs`, and the two live-preview generators into a shared `internal/compiler/generator/accessor_names.rs` module. Codegen output is byte-identical (verified by the existing test driver). The new helper becomes the single source of truth that both the codegen and the LSP scanner consume.

2. **`lsp: classify property/callback/function declarations as public API`** — adds `DeclarationNode::host_language_classification()` which mirrors `passes::check_public_api`'s gating logic in-LSP (we only run `run_import_passes`, so `expose_in_public_api` isn't set). Walks every loaded document and follows the `inherits` chain on each exported non-interface component so cross-file inheritance is handled. Bounded by depth + visited-set on `Rc::as_ptr` to defend against cyclic `inherits` in mid-edit LSP state. Includes 13 roundtrip tests (see below).

3. **`lsp: add host-language accessor scanner`** — new `tools/lsp/common/host_language_search.rs`. Walks the workspace folder containing the renamed `.slint`, byte-level word-boundary search with a small lexer that skips line/block comments, double-quoted strings, and short char literals. Treats every byte ≥ 0x80 as identifier-extending so multi-byte UTF-8 adjacent to a match defeats the boundary. Does not follow symlinks (uses `entry.file_type()`). Case-insensitive extension match. Bounded by file count and per-file size. \`cfg(not(target_arch = \"wasm32\"))\`.

4. **`lsp: rename Rust/C++ accessors alongside Slint properties (#11841)`** — wiring + config + docs. Extends \`WorkspaceConfig\` and the Rename handler. Soft-degrades scanner failures to \`tracing::warn!\` + slint-only edits rather than rejecting the whole rename. Includes the no-op normalization guard, invalid-policy-value warning, VS Code \`contributes.configuration\` schema entry with \`enumDescriptions\` + \`markdownDescription\`, CHANGELOG entry, \`docs/development/lsp-architecture.md\` updates, and a \`merge_workspace_edits\` helper for combining the slint and host-language \`WorkspaceEdit\`s.

## Deferred to v2 (worth a follow-up issue)

- **\`\"ask\"\` mode** with a CodeAction + editor-command flow that prompts the user before applying. \`textDocument/codeAction\` cannot precompute the edit (the server doesn't know the new name at CodeAction time), so this requires editor-extension cooperation per editor.
- **Reverse rename** (Rust accessor → Slint property). rust-analyzer has no hook for \"another LSP claims this symbol.\"
- **JS / Python backends**. JS uses camelCase (\`getCount\`); Python uses \`@property\` descriptors. Scanner has no entry for either.

## Known v1 limitations

- Cross-component accessor collisions are possible by construction (\`get_visible\` exists on many components). Mitigated by the opt-in default; documented in the config description.
- \`slint!{}\` macro bodies inside \`.rs\` files aren't visible to the LSP document cache, so renames inside macro bodies aren't handled. \`build.rs\` users (the majority) are unaffected.
- Lexer doesn't handle Rust raw strings, byte strings, nested block comments, or lifetimes — accepted false-positive surface. Users review the rename preview before applying.

## Test plan

- [x] 311 i-slint-compiler tests pass (303 existing + 8 new \`accessor_names\` unit tests)
- [x] 331 LSP tests pass (was 285 pre-PR; +46 across classifier, scanner, merge helper, and roundtrip integration)
- [x] 13 integration tests under \`host_language_rename_tests\` exercise the full Rename handler pipeline against a real tempdir with on-disk \`.slint\` and host-language files — covering property/callback/function golden paths, private property, no-op normalization, cross-file inheritance, globals, outside-workspace soft-degrade, comment skipping, plus parallel \`.cpp\`/\`.hpp\` cases and a mixed Rust+C++ workspace
- [x] \`cargo clippy -p slint-lsp --bin slint-lsp --all-targets\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] Manual verification in VS Code extension dev host (recipe in #11841 comments)