### PR TITLE
Rename `accessible-live` to `accessible-live-region`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project are documented in this file.
  - Added `align-items` property to `VerticalLayout` and `HorizontalLayout` for cross-axis alignment. (#2587)
  - Added two-way bindings to model row data. (#2013)
  - `@markdown()`: Fixed interpolation in link URLs and colors
- - Added `accessible-orientation` and `accessible-live` properties
+ - Added `accessible-orientation` and `accessible-live-region` properties
  - Added `DragArea` and `DropArea` elements for drag and drop support within a window.
  - Added `data-transfer` type
  - Deprecated calling `init()` explicitly (#11696)

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -38,7 +38,7 @@ fn enums(path: &Path) -> anyhow::Result<()> {
         (Orientation) => {
             Some(None)
         };
-        (AccessibleLive) => {
+        (AccessibleLiveRegion) => {
             Some(None)
         };
         (AccessibleRole) => {

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -391,17 +391,17 @@ public:
         return std::nullopt;
     }
 
-    /// Returns the accessible-live of that element, if any.
-    std::optional<AccessibleLive> accessible_live() const
+    /// Returns the accessible-live-region of that element, if any.
+    std::optional<AccessibleLiveRegion> accessible_live_region() const
     {
         if (auto str = get_accessible_string_property(
-                    cbindgen_private::AccessibleStringProperty::Live)) {
+                    cbindgen_private::AccessibleStringProperty::LiveRegion)) {
             if (*str == "off")
-                return AccessibleLive::Off;
+                return AccessibleLiveRegion::Off;
             if (*str == "polite")
-                return AccessibleLive::Polite;
+                return AccessibleLiveRegion::Polite;
             if (*str == "assertive")
-                return AccessibleLive::Assertive;
+                return AccessibleLiveRegion::Assertive;
         }
         return std::nullopt;
     }

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -112,4 +112,4 @@ pub fn configure_test_fonts() {
     .unwrap();
 }
 
-pub use i_slint_core::items::{AccessibleLive, AccessibleRole, Orientation};
+pub use i_slint_core::items::{AccessibleLiveRegion, AccessibleRole, Orientation};

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -794,14 +794,14 @@ impl ElementHandle {
             .and_then(|s| s.parse().ok())
     }
 
-    /// Returns the value of the `accessible-live` property, if present.
-    pub fn accessible_live(&self) -> Option<crate::AccessibleLive> {
+    /// Returns the value of the `accessible-live-region` property, if present.
+    pub fn accessible_live_region(&self) -> Option<crate::AccessibleLiveRegion> {
         if self.element_index != 0 {
             return None;
         }
         self.item
             .upgrade()
-            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Live))
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::LiveRegion))
             .and_then(|s| s.parse().ok())
     }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -689,13 +689,13 @@ impl NodeCollection {
         }
 
         if let Some(live) = item
-            .accessible_string_property(AccessibleStringProperty::Live)
-            .and_then(|s| s.parse::<i_slint_core::items::AccessibleLive>().ok())
+            .accessible_string_property(AccessibleStringProperty::LiveRegion)
+            .and_then(|s| s.parse::<i_slint_core::items::AccessibleLiveRegion>().ok())
         {
             node.set_live(match live {
-                i_slint_core::items::AccessibleLive::Off => Live::Off,
-                i_slint_core::items::AccessibleLive::Polite => Live::Polite,
-                i_slint_core::items::AccessibleLive::Assertive => Live::Assertive,
+                i_slint_core::items::AccessibleLiveRegion::Off => Live::Off,
+                i_slint_core::items::AccessibleLiveRegion::Polite => Live::Polite,
+                i_slint_core::items::AccessibleLiveRegion::Assertive => Live::Assertive,
                 _ => Live::Off,
             });
         }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -535,11 +535,11 @@ macro_rules! for_each_enums {
                 Search,
             }
 
-            /// This enum represents the different values of the `accessible-live` property.
+            /// This enum represents the different values of the `accessible-live-region` property.
             /// It indicates that an element is a live region whose content changes should be
             /// announced by assistive technologies.
             #[non_exhaustive]
-            enum AccessibleLive {
+            enum AccessibleLiveRegion {
                 /// The element is not a live region.
                 Off,
                 /// Updates are announced when the user is idle.

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -44,7 +44,7 @@ pub fn lower_accessibility_properties(component: &Rc<Component>, diag: &mut Buil
 
             for prop_name in crate::typeregister::reserved_accessibility_properties()
                 .map(|x| x.0)
-                .chain(["accessible-role", "accessible-orientation", "accessible-live"])
+                .chain(["accessible-role", "accessible-orientation", "accessible-live-region"])
             {
                 if accessible_role_set {
                     if elem.borrow().is_binding_set(prop_name, false) {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -346,8 +346,8 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
                 PropertyVisibility::Input,
             ),
             (
-                "accessible-live",
-                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleLive.clone())),
+                "accessible-live-region",
+                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleLiveRegion.clone())),
                 PropertyVisibility::Input,
             ),
         ]))

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -30,7 +30,7 @@ pub enum AccessibleStringProperty {
     ItemSelectable,
     ItemSelected,
     Label,
-    Live,
+    LiveRegion,
     Orientation,
     PlaceholderText,
     ReadOnly,

--- a/tests/cases/accessibility/live.slint
+++ b/tests/cases/accessibility/live.slint
@@ -1,34 +1,34 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test the accessible-live property.
+// Test the accessible-live-region property.
 
 export component TestCase inherits Window {
     width: 300phx;
     height: 300phx;
 
-    in-out property <AccessibleLive> status-live: AccessibleLive.polite;
+    in-out property <AccessibleLiveRegion> status-live: AccessibleLiveRegion.polite;
 
     VerticalLayout {
         Rectangle {
             accessible-role: text;
             accessible-label: "off-region";
-            accessible-live: AccessibleLive.off;
+            accessible-live-region: AccessibleLiveRegion.off;
         }
         Rectangle {
             accessible-role: text;
             accessible-label: "polite-region";
-            accessible-live: AccessibleLive.polite;
+            accessible-live-region: AccessibleLiveRegion.polite;
         }
         Rectangle {
             accessible-role: text;
             accessible-label: "assertive-region";
-            accessible-live: AccessibleLive.assertive;
+            accessible-live-region: AccessibleLiveRegion.assertive;
         }
         Rectangle {
             accessible-role: text;
             accessible-label: "dynamic-region";
-            accessible-live: root.status-live;
+            accessible-live-region: root.status-live;
         }
         Rectangle {
             accessible-role: text;
@@ -41,27 +41,27 @@ export component TestCase inherits Window {
 /*
 
 ```rust
-use slint_testing::AccessibleLive;
+use slint_testing::AccessibleLiveRegion;
 
 let instance = TestCase::new().unwrap();
 
 let off = slint_testing::ElementHandle::find_by_accessible_label(&instance, "off-region").next().unwrap();
-assert_eq!(off.accessible_live(), Some(AccessibleLive::Off));
+assert_eq!(off.accessible_live_region(), Some(AccessibleLiveRegion::Off));
 
 let polite = slint_testing::ElementHandle::find_by_accessible_label(&instance, "polite-region").next().unwrap();
-assert_eq!(polite.accessible_live(), Some(AccessibleLive::Polite));
+assert_eq!(polite.accessible_live_region(), Some(AccessibleLiveRegion::Polite));
 
 let assertive = slint_testing::ElementHandle::find_by_accessible_label(&instance, "assertive-region").next().unwrap();
-assert_eq!(assertive.accessible_live(), Some(AccessibleLive::Assertive));
+assert_eq!(assertive.accessible_live_region(), Some(AccessibleLiveRegion::Assertive));
 
 let d = slint_testing::ElementHandle::find_by_accessible_label(&instance, "dynamic-region").next().unwrap();
-assert_eq!(d.accessible_live(), Some(AccessibleLive::Polite));
-instance.set_status_live(AccessibleLive::Assertive);
-assert_eq!(d.accessible_live(), Some(AccessibleLive::Assertive));
+assert_eq!(d.accessible_live_region(), Some(AccessibleLiveRegion::Polite));
+instance.set_status_live(AccessibleLiveRegion::Assertive);
+assert_eq!(d.accessible_live_region(), Some(AccessibleLiveRegion::Assertive));
 
 let none = slint_testing::ElementHandle::find_by_accessible_label(&instance, "no-live").next().unwrap();
-// Element has no accessible-live binding, so the property is not exposed.
-assert!(none.accessible_live().is_none());
+// Element has no accessible-live-region binding, so the property is not exposed.
+assert!(none.accessible_live_region().is_none());
 ```
 
 ```cpp
@@ -70,26 +70,26 @@ const TestCase &instance = *handle;
 
 auto off = slint::testing::ElementHandle::find_by_accessible_label(handle, "off-region");
 assert_eq(off.size(), 1);
-assert(off[0].accessible_live().has_value());
-assert(*off[0].accessible_live() == slint::AccessibleLive::Off);
+assert(off[0].accessible_live_region().has_value());
+assert(*off[0].accessible_live_region() == slint::AccessibleLiveRegion::Off);
 
 auto polite = slint::testing::ElementHandle::find_by_accessible_label(handle, "polite-region");
 assert_eq(polite.size(), 1);
-assert(*polite[0].accessible_live() == slint::AccessibleLive::Polite);
+assert(*polite[0].accessible_live_region() == slint::AccessibleLiveRegion::Polite);
 
 auto assertive = slint::testing::ElementHandle::find_by_accessible_label(handle, "assertive-region");
 assert_eq(assertive.size(), 1);
-assert(*assertive[0].accessible_live() == slint::AccessibleLive::Assertive);
+assert(*assertive[0].accessible_live_region() == slint::AccessibleLiveRegion::Assertive);
 
 auto d = slint::testing::ElementHandle::find_by_accessible_label(handle, "dynamic-region");
 assert_eq(d.size(), 1);
-assert(*d[0].accessible_live() == slint::AccessibleLive::Polite);
-instance.set_status_live(slint::AccessibleLive::Assertive);
-assert(*d[0].accessible_live() == slint::AccessibleLive::Assertive);
+assert(*d[0].accessible_live_region() == slint::AccessibleLiveRegion::Polite);
+instance.set_status_live(slint::AccessibleLiveRegion::Assertive);
+assert(*d[0].accessible_live_region() == slint::AccessibleLiveRegion::Assertive);
 
 auto none = slint::testing::ElementHandle::find_by_accessible_label(handle, "no-live");
 assert_eq(none.size(), 1);
-assert(!none[0].accessible_live().has_value());
+assert(!none[0].accessible_live_region().has_value());
 ```
 
 */


### PR DESCRIPTION
Decided in the 1.17 API review: `accessible-live` reads as jargon without context, while "live region" is the actual WAI-ARIA term for the concept and is what Android's accessibility API spells out (`setAccessibilityLiveRegion`). The longer name makes the property self-explanatory.
Renaming the `AccessibleLive` enum to `AccessibleLiveRegion` keeps the type name aligned.
