### PR TITLE
docs: don't show default values for out properties

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/button.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/button.mdx
@@ -54,7 +54,7 @@ Defaults to true. When false, the button cannot be pressed.
 </SlintProperty>
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out">
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out">
 Set to true when the button has keyboard focus
 </SlintProperty>
 
@@ -69,7 +69,7 @@ The size of the icon shown in the button. The default value depends on the style
 </SlintProperty>
 
 ### pressed
-<SlintProperty propName="pressed" typeName="bool" defaultValue="false" propertyVisibility="out">
+<SlintProperty propName="pressed" typeName="bool" propertyVisibility="out">
 Set to true when the button is pressed.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/checkbox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/checkbox.mdx
@@ -54,7 +54,7 @@ The weight of the font of the label text.
 </SlintProperty>
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out" >
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out" >
 Set to true when the checkbox has keyboard focus.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/combobox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/combobox.mdx
@@ -49,7 +49,7 @@ Defaults to true. When false, the combobox can't be interacted with
 </SlintProperty>
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out">
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out">
 Set to true when the combobox has keyboard focus.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
@@ -54,7 +54,7 @@ When `false`, the entire group and all its radio buttons cannot be interacted wi
 </SlintProperty>
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out">
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out">
 Set to `true` when any radio button inside the group has keyboard focus.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/slider.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/slider.mdx
@@ -32,7 +32,7 @@ You can't interact with the slider if enabled is false.
 </SlintProperty>
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out">
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out">
 Set to true when the slider currently has the focus
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinbox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinbox.mdx
@@ -32,7 +32,7 @@ You can't interact with the spinbox if enabled is false.
 </SlintProperty>
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="out">
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out">
 Set to true when the spinbox currently has the focus.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/views/standardtableview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/standardtableview.mdx
@@ -50,8 +50,8 @@ export component Example inherits Window {
 Same as <Link type="ListView" />, and in addition:
 
 ### current-sort-column
-<SlintProperty typeName="int" propName="current-sort-column" default="-1" propertyVisibility="out">
-Indicates the sorted column. -1 mean no column is sorted.
+<SlintProperty typeName="int" propName="current-sort-column" propertyVisibility="out">
+Indicates the sorted column, or `-1` when no column is sorted.
 </SlintProperty>
 
 ### columns

--- a/docs/common/src/components/SlintProperty.astro
+++ b/docs/common/src/components/SlintProperty.astro
@@ -72,7 +72,11 @@ const enumContent = await getEnumContent(enumName);
 const structContent = await getStructContent(structName);
 
 const isOutput = propertyVisibility === "out";
-const defaultValue_ = defaultValue ? defaultValue : (isOutput ? "" : typeInfo.defaultValue);
+const defaultValue_ = defaultValue
+    ? defaultValue
+    : isOutput
+      ? ""
+      : typeInfo.defaultValue;
 
 if (!defaultValue_ && !isOutput) {
     console.error("No defaultValue for:", propName);

--- a/docs/common/src/components/SlintProperty.astro
+++ b/docs/common/src/components/SlintProperty.astro
@@ -80,8 +80,7 @@ const defaultValue_ = defaultValue
 
 if (!defaultValue_ && !isOutput) {
     console.error("No defaultValue for:", propName);
-}
-if (defaultValue && isOutput) {
+} else if (defaultValue && isOutput) {
     console.error("defaultValue set on out property:", propName);
 }
 

--- a/docs/common/src/components/SlintProperty.astro
+++ b/docs/common/src/components/SlintProperty.astro
@@ -81,6 +81,9 @@ const defaultValue_ = defaultValue
 if (!defaultValue_ && !isOutput) {
     console.error("No defaultValue for:", propName);
 }
+if (defaultValue && isOutput) {
+    console.error("defaultValue set on out property:", propName);
+}
 
 if ((enumName || structName) && !Astro.slots.has("default")) {
     throw new Error(

--- a/docs/common/src/components/SlintProperty.astro
+++ b/docs/common/src/components/SlintProperty.astro
@@ -71,9 +71,10 @@ if (typeInfo.href !== "") {
 const enumContent = await getEnumContent(enumName);
 const structContent = await getStructContent(structName);
 
-const defaultValue_ = defaultValue ? defaultValue : typeInfo.defaultValue;
+const isOutput = propertyVisibility === "out";
+const defaultValue_ = defaultValue ? defaultValue : (isOutput ? "" : typeInfo.defaultValue);
 
-if (!defaultValue_) {
+if (!defaultValue_ && !isOutput) {
     console.error("No defaultValue for:", propName);
 }
 
@@ -95,7 +96,7 @@ if ((enumName || structName) && !Astro.slots.has("default")) {
       </a>
     )}
     {propertyVisibility && <code>{`(${propertyVisibility})`}</code>}
-    <span class="default-value">default: <code class="plain-code" dir="auto">{defaultValue_}</code></span><br>
+    {defaultValue_ && <span class="default-value">default: <code class="plain-code" dir="auto">{defaultValue_}</code></span>}<br>
   </p>
    <slot/>
    {enumName && <Fragment set:html={enumContent}/>}

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1174,7 +1174,6 @@ export component ScaleRotateGestureHandler {
     /// The cumulative scale factor of the gesture. Always starts at `1.0` when the gesture begins.
     /// A value greater than `1.0` means zooming in, less than `1.0` means zooming out.
     /// When the gesture is not active, the value is `1.0`.
-    /// \default 1.0
     out property <float> scale;
     /// The cumulative rotation angle of the gesture. Always starts at `0deg` when the gesture begins.
     /// Positive values indicate clockwise rotation, negative values indicate counter-clockwise rotation.
@@ -2786,13 +2785,11 @@ export global Platform {
     /// :::note{Note}
     /// When Slint is ported to new operating systems in the future, new enum values will be added.
     /// :::
-    /// \default known at runtime
     out property <OperatingSystemType> os;
     /// The name of the currently selected <Link type="StyleWidgets" label="widget style"/>. Some widget
     /// styles have dark and light variant suffixes, such as `fluent-light`. This property contains the
     /// style name without the suffix. Use <Link type="Palette" label="Palette"/>'s `color-scheme` to
     /// determine the currently used scheme.
-    /// \default known at runtime
     out property <string> style-name;
     /// Opens the specified URL in an external browser. This function invokes the platform's URL opening mechanism.
     /// Returns `true` on success, or `false` if the platform doesn't support opening URLs or the operation failed.

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -17,8 +17,8 @@ export component TabWidgetImpl inherits Rectangle {
     out property <length> content-y: orientation==Orientation.horizontal? root.tabbar-preferred-height: 0;
     out property <length> content-height: orientation==Orientation.horizontal? root.height - root.tabbar-preferred-height: root.height;
     out property <length> content-width: orientation==Orientation.horizontal? root.width: root.width - root.tabbar-preferred-width;
-    out property <length> tabbar-x: 0;
-    out property <length> tabbar-y: 0;
+    out property <length> tabbar-x;
+    out property <length> tabbar-y;
     out property <length> tabbar-height: orientation==Orientation.horizontal? root.tabbar-preferred-height: root.height;
     out property <length> tabbar-width: orientation==Orientation.horizontal? root.width: root.tabbar-preferred-width;
 

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -17,8 +17,8 @@ export component TabWidgetImpl inherits Rectangle {
     out property <length> content-y: orientation==Orientation.horizontal? root.tabbar-preferred-height: 0;
     out property <length> content-height: orientation==Orientation.horizontal? root.height - root.tabbar-preferred-height: root.height;
     out property <length> content-width: orientation==Orientation.horizontal? root.width: root.width - root.tabbar-preferred-width;
-    out property <length> tabbar-x: 0;
-    out property <length> tabbar-y: 0;
+    out property <length> tabbar-x;
+    out property <length> tabbar-y;
     out property <length> tabbar-height: orientation==Orientation.horizontal? root.tabbar-preferred-height: root.height;
     out property <length> tabbar-width: orientation==Orientation.horizontal? root.width: root.tabbar-preferred-width;
 

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -17,8 +17,8 @@ export component TabWidgetImpl inherits Rectangle {
     out property <length> content-y: orientation == Orientation.horizontal ? root.tabbar-preferred-height : 0;
     out property <length> content-height:orientation == Orientation.horizontal ? root.height - root.tabbar-preferred-height : root.height;
     out property <length> content-width: orientation == Orientation.horizontal ? root.width : root.width - root.tabbar-preferred-width;
-    out property <length> tabbar-x: 0;
-    out property <length> tabbar-y: 0;
+    out property <length> tabbar-x;
+    out property <length> tabbar-y;
     out property <length> tabbar-height: orientation == Orientation.horizontal ? root.tabbar-preferred-height : root.height;
     out property <length> tabbar-width: orientation == Orientation.horizontal ? root.width : root.tabbar-preferred-width;
     preferred-width: root.content-min-width;

--- a/internal/compiler/widgets/interfaces/lineedit.slint
+++ b/internal/compiler/widgets/interfaces/lineedit.slint
@@ -11,7 +11,7 @@ export interface LineEdit {
     in property <string> placeholder-text: "";
     in property <bool> read-only: false;
 
-    out property <bool> has-focus: false;
+    out property <bool> has-focus;
 
     in-out property <string> text: "";
 

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -17,8 +17,8 @@ export component TabWidgetImpl inherits Rectangle {
     out property <length> content-y: orientation==Orientation.horizontal?root.tabbar-preferred-height:0;
     out property <length> content-height: orientation==Orientation.horizontal?root.height - root.tabbar-preferred-height:root.height;
     out property <length> content-width: orientation==Orientation.horizontal?root.width:root.width - root.tabbar-preferred-width;
-    out property <length> tabbar-x: 0;
-    out property <length> tabbar-y: 0;
+    out property <length> tabbar-x;
+    out property <length> tabbar-y;
     out property <length> tabbar-height: orientation==Orientation.horizontal?root.tabbar-preferred-height:root.height;
     out property <length> tabbar-width: orientation==Orientation.horizontal?root.width:root.tabbar-preferred-width;
 


### PR DESCRIPTION
An out property is a computed/read-only value; its "default" is not something callers can rely on. Skip rendering it in SlintProperty, and clean up the cargo-cult initializers (`: false`, `: 0`) and `\default` doc directives that no longer have any purpose.

Keep `current-sort-column: -1` in the tableview implementations: the `-1` is a real "no column sorted" sentinel that the code branches on. The accompanying prose in standardtableview.mdx explains it.
