### PR TITLE
docs: serve markdown siblings for C++, Python, and Node.js docs

### DIFF
--- a/docs/common/package.json
+++ b/docs/common/package.json
@@ -6,7 +6,8 @@
     "format": "biome format",
     "format:fix": "biome format --write",
     "lint": "biome lint",
-    "lint:fix": "biome lint --fix"
+    "lint:fix": "biome lint --fix",
+    "test": "node --experimental-strip-types --test tests/markdown-endpoint.test.ts"
   },
   "dependencies": {
     "@expressive-code/core": "0.42.0",

--- a/docs/common/src/utils/markdown-endpoint.ts
+++ b/docs/common/src/utils/markdown-endpoint.ts
@@ -1,0 +1,120 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+/** Minimal structural shape of an `astro:content` collection entry. */
+export interface MarkdownDocEntry {
+    /** Collection id; the root index page has an empty id. */
+    id: string;
+    /** Frontmatter data (title, description, …). */
+    data: Record<string, unknown>;
+    /** Raw markdown body. */
+    body?: string;
+}
+
+/** A `linkMap` entry: the in-prose `<Link>` component resolves a `type` to an href. */
+export interface MarkdownLinkTarget {
+    href: string;
+}
+
+export interface MarkdownEndpointOptions {
+    /**
+     * Base path prefixed onto each resolved `<Link>` href (e.g. `/docs/`). Only
+     * used when `linkMap` is provided.
+     */
+    basePath?: string;
+    /**
+     * Optional map for rewriting the astro-specific `<Link type=… label=…/>`
+     * prose component into real markdown links. Sites without that component
+     * (the generated C++/Python/Node API references) omit this.
+     */
+    linkMap?: Record<string, MarkdownLinkTarget>;
+}
+
+/**
+ * Map a `docs` collection into the `{ params, props }` array expected by an
+ * Astro `getStaticPaths`. The root index (empty id) becomes `index.md`.
+ */
+export function markdownStaticPaths(entries: MarkdownDocEntry[]) {
+    return entries.map((entry) => ({
+        params: { slug: entry.id === "" ? "index" : entry.id },
+        props: { entry },
+    }));
+}
+
+/** Build the `text/markdown` Response for a single doc entry. */
+export function renderMarkdownResponse(
+    entry: MarkdownDocEntry,
+    options: MarkdownEndpointOptions = {},
+): Response {
+    const data = entry.data;
+    let body = entry.body ?? "";
+    if (options.linkMap) {
+        body = resolveLinkComponents(
+            body,
+            options.linkMap,
+            options.basePath ?? "",
+        );
+    }
+
+    const fm: string[] = ["---"];
+    if (typeof data.title === "string") {
+        fm.push(`title: ${quote(data.title)}`);
+    }
+    if (typeof data.description === "string") {
+        fm.push(`description: ${quote(data.description)}`);
+    }
+    fm.push("---", "");
+
+    return new Response(fm.join("\n") + body, {
+        headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+            // Lets a future edge function vary the HTML route on Accept
+            // without poisoning shared caches.
+            Vary: "Accept",
+        },
+    });
+}
+
+// YAML-safe double-quoting for single-line scalar values.
+function quote(s: string): string {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+// Replace `<Link type="X" label="Y" />` (the in-prose linking component used
+// across the docs) with a real markdown link. The resolved URL points at the
+// target page's .md sibling so an agent can chain markdown fetches without
+// having to rewrite URLs itself. Unknown link types are left as-is so the
+// build still surfaces them via existing checks.
+const LINK_RE = /<Link\b([^/>]*)\/>/g;
+const ATTR_RE = /(\w+)\s*=\s*"([^"]*)"/g;
+
+function resolveLinkComponents(
+    body: string,
+    linkMap: Record<string, MarkdownLinkTarget>,
+    basePath: string,
+): string {
+    return body.replace(LINK_RE, (whole, attrs: string) => {
+        const parsed: Record<string, string> = {};
+        for (const m of attrs.matchAll(ATTR_RE)) {
+            parsed[m[1]] = m[2];
+        }
+
+        const type = parsed.type;
+        if (!type || !(type in linkMap)) {
+            return whole;
+        }
+
+        const label = parsed.label ?? type;
+        return `[${label}](${basePath}${toMarkdownHref(linkMap[type].href)})`;
+    });
+}
+
+// Convert an HTML page href like "reference/common/#anchor" into the
+// corresponding .md sibling: "reference/common.md#anchor".
+function toMarkdownHref(href: string): string {
+    const hashIdx = href.indexOf("#");
+    const path = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
+    const hash = hashIdx >= 0 ? href.slice(hashIdx) : "";
+    const trimmed = path.endsWith("/") ? path.slice(0, -1) : path;
+    return `${trimmed}.md${hash}`;
+}

--- a/docs/common/tests/markdown-endpoint.test.ts
+++ b/docs/common/tests/markdown-endpoint.test.ts
@@ -1,0 +1,97 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// Runnable with: node --experimental-strip-types tests/markdown-endpoint.test.ts
+// Uses the built-in node:test runner so no extra dependency is required.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    markdownStaticPaths,
+    renderMarkdownResponse,
+    type MarkdownDocEntry,
+} from "../src/utils/markdown-endpoint.ts";
+
+function entry(over: Partial<MarkdownDocEntry>): MarkdownDocEntry {
+    return { id: "", data: {}, body: "", ...over };
+}
+
+test("root index (empty id) maps to the index.md slug", () => {
+    const paths = markdownStaticPaths([
+        entry({ id: "" }),
+        entry({ id: "guide/intro" }),
+    ]);
+    assert.deepEqual(
+        paths.map((p) => p.params.slug),
+        ["index", "guide/intro"],
+    );
+    // The entry travels through as a prop for the GET handler.
+    assert.equal(paths[1].props.entry.id, "guide/intro");
+});
+
+test("renders YAML frontmatter and serves text/markdown", async () => {
+    const res = renderMarkdownResponse(
+        entry({
+            data: { title: "Properties", description: "About properties" },
+            body: "## Body\n",
+        }),
+    );
+    assert.equal(
+        res.headers.get("Content-Type"),
+        "text/markdown; charset=utf-8",
+    );
+    assert.equal(res.headers.get("Vary"), "Accept");
+
+    const text = await res.text();
+    assert.match(
+        text,
+        /^---\ntitle: "Properties"\ndescription: "About properties"\n---\n/,
+    );
+    assert.match(text, /## Body/);
+});
+
+test("frontmatter omits absent fields and quotes safely", async () => {
+    const res = renderMarkdownResponse(
+        entry({ data: { title: 'He said "hi"' }, body: "" }),
+    );
+    const text = await res.text();
+    // description line is absent, and the embedded quote is escaped.
+    assert.match(text, /^---\ntitle: "He said \\"hi\\""\n---\n/);
+    assert.doesNotMatch(text, /description:/);
+});
+
+test("without a linkMap, <Link> components are left untouched", async () => {
+    const res = renderMarkdownResponse(
+        entry({ body: 'before <Link type="Expressions" /> after' }),
+    );
+    const text = await res.text();
+    assert.match(text, /before <Link type="Expressions" \/> after/);
+});
+
+test("with a linkMap, <Link> resolves to a .md sibling under the base path", async () => {
+    const res = renderMarkdownResponse(
+        entry({ body: '<Link type="Expressions" label="Expr" />' }),
+        {
+            basePath: "/docs/",
+            linkMap: {
+                Expressions: {
+                    href: "guide/language/coding/expressions-and-statements/#anchor",
+                },
+            },
+        },
+    );
+    const text = await res.text();
+    assert.match(
+        text,
+        /\[Expr\]\(\/docs\/guide\/language\/coding\/expressions-and-statements\.md#anchor\)/,
+    );
+});
+
+test("unknown link types are passed through unchanged", async () => {
+    const res = renderMarkdownResponse(
+        entry({ body: '<Link type="Nope" />' }),
+        { basePath: "/docs/", linkMap: {} },
+    );
+    const text = await res.text();
+    assert.match(text, /<Link type="Nope" \/>/);
+});

--- a/docs/cpp/src/pages/[...slug].md.ts
+++ b/docs/cpp/src/pages/[...slug].md.ts
@@ -3,8 +3,8 @@
 
 // Serves a plain-markdown sibling for every doc page so AI agents can fetch
 // docs without paying the HTML/JS overhead. Example:
-//   /docs/guide/language/coding/properties/      -> rendered HTML page
-//   /docs/guide/language/coding/properties.md    -> this endpoint, raw markdown
+//   …/docs/cpp/api/slint/color/      -> rendered HTML page
+//   …/docs/cpp/api/slint/color.md    -> this endpoint, raw markdown
 
 import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection, type CollectionEntry } from "astro:content";
@@ -12,8 +12,6 @@ import {
     markdownStaticPaths,
     renderMarkdownResponse,
 } from "@slint/common-files/src/utils/markdown-endpoint";
-import { linkMap } from "@slint/common-files/src/utils/utils";
-import { BASE_PATH } from "@slint/common-files/src/utils/site-config";
 
 export const getStaticPaths: GetStaticPaths = async () => {
     return markdownStaticPaths(await getCollection("docs"));
@@ -22,4 +20,4 @@ export const getStaticPaths: GetStaticPaths = async () => {
 type Props = { entry: CollectionEntry<"docs"> };
 
 export const GET: APIRoute<Props> = ({ props }) =>
-    renderMarkdownResponse(props.entry, { basePath: BASE_PATH, linkMap });
+    renderMarkdownResponse(props.entry);

--- a/docs/nodejs/src/pages/[...slug].md.ts
+++ b/docs/nodejs/src/pages/[...slug].md.ts
@@ -3,8 +3,8 @@
 
 // Serves a plain-markdown sibling for every doc page so AI agents can fetch
 // docs without paying the HTML/JS overhead. Example:
-//   /docs/guide/language/coding/properties/      -> rendered HTML page
-//   /docs/guide/language/coding/properties.md    -> this endpoint, raw markdown
+//   …/docs/node/api/classes/Window/      -> rendered HTML page
+//   …/docs/node/api/classes/Window.md    -> this endpoint, raw markdown
 
 import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection, type CollectionEntry } from "astro:content";
@@ -12,8 +12,6 @@ import {
     markdownStaticPaths,
     renderMarkdownResponse,
 } from "@slint/common-files/src/utils/markdown-endpoint";
-import { linkMap } from "@slint/common-files/src/utils/utils";
-import { BASE_PATH } from "@slint/common-files/src/utils/site-config";
 
 export const getStaticPaths: GetStaticPaths = async () => {
     return markdownStaticPaths(await getCollection("docs"));
@@ -22,4 +20,4 @@ export const getStaticPaths: GetStaticPaths = async () => {
 type Props = { entry: CollectionEntry<"docs"> };
 
 export const GET: APIRoute<Props> = ({ props }) =>
-    renderMarkdownResponse(props.entry, { basePath: BASE_PATH, linkMap });
+    renderMarkdownResponse(props.entry);

--- a/docs/python/src/pages/[...slug].md.ts
+++ b/docs/python/src/pages/[...slug].md.ts
@@ -3,8 +3,8 @@
 
 // Serves a plain-markdown sibling for every doc page so AI agents can fetch
 // docs without paying the HTML/JS overhead. Example:
-//   /docs/guide/language/coding/properties/      -> rendered HTML page
-//   /docs/guide/language/coding/properties.md    -> this endpoint, raw markdown
+//   …/docs/python/api/classes/ComponentInstance/      -> rendered HTML page
+//   …/docs/python/api/classes/ComponentInstance.md    -> this endpoint, raw markdown
 
 import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection, type CollectionEntry } from "astro:content";
@@ -12,8 +12,6 @@ import {
     markdownStaticPaths,
     renderMarkdownResponse,
 } from "@slint/common-files/src/utils/markdown-endpoint";
-import { linkMap } from "@slint/common-files/src/utils/utils";
-import { BASE_PATH } from "@slint/common-files/src/utils/site-config";
 
 export const getStaticPaths: GetStaticPaths = async () => {
     return markdownStaticPaths(await getCollection("docs"));
@@ -22,4 +20,4 @@ export const getStaticPaths: GetStaticPaths = async () => {
 type Props = { entry: CollectionEntry<"docs"> };
 
 export const GET: APIRoute<Props> = ({ props }) =>
-    renderMarkdownResponse(props.entry, { basePath: BASE_PATH, linkMap });
+    renderMarkdownResponse(props.entry);


### PR DESCRIPTION
Extract the .html -> .md endpoint logic from docs/astro into a shared helper in @slint/common-files and use it in the cpp, python, and nodejs Starlight sites.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
