### PR TITLE
remote viewer: advertise and show a friendly device name

### DIFF
--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -206,11 +206,14 @@ export function activate(
     client.add_updater((cl) => {
         wasm_preview.initClientForPreview(context, cl);
         cl?.onNotification("slint/remote_viewer_discovered", (params) => {
+            // Friendly, user-assigned name (e.g. "Simon's iPhone") from the mDNS
+            // service instance name; fall back to the `.local` host for older viewers.
+            const name: string = params.name ?? params.host;
             vscode.window.showInformationMessage(
-                `Remote viewer discovered: ${params.host}`,
+                `Remote viewer discovered: ${name}`,
             );
             cl.outputChannel.appendLine(
-                `Remote viewer discovered: ${params.host} (${params.addresses.join(", ")}:${params.port})`,
+                `Remote viewer discovered: ${name} (${params.host} ${params.addresses.join(", ")}:${params.port})`,
             );
             const old_entry = remote_viewers.get(params.host);
             if (old_entry) {
@@ -242,7 +245,7 @@ export function activate(
             const remote_viewer_entry: RemoteViewerInfo = {
                 id: params.host,
 
-                label: `${labelPrefix}${params.host}`,
+                label: `${labelPrefix}${name}`,
                 detail: params.addresses.join(", "),
                 description: versionTag,
 

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -497,12 +497,18 @@ impl Connection {
         let host = hostname::get()?;
         let host = host.to_str().unwrap_or("unknown");
         // "localhost" is useless for mDNS — derive a name from the first IP instead.
-        let mdns_host = if host == "localhost" || host.is_empty() {
-            let ip = local_ips.first().map(|ip| ip.to_string()).unwrap_or("unknown".into());
-            format!("slint-viewer-{ip}.local.")
+        // The instance name is what the editor shows to the user, so prefer the
+        // machine's hostname (these platforms have no separate "device name" the way
+        // iOS/macOS do); fall back to an IP-derived name when it's missing.
+        let instance_name = if host == "localhost" || host.is_empty() {
+            local_ips
+                .first()
+                .map(|ip| format!("slint-viewer-{ip}"))
+                .unwrap_or_else(|| "slint-viewer".into())
         } else {
-            format!("{host}.local.")
+            host.to_owned()
         };
+        let mdns_host = format!("{instance_name}.local.");
         tracing::info!("Announcing service on {local_ips:?} as {mdns_host}");
         let properties = HashMap::from([
             (TXT_PROTOCOLS_KEY.to_owned(), PROTOCOL_SUBPROTOCOL.to_owned()),
@@ -510,7 +516,7 @@ impl Connection {
         ]);
         ServiceInfo::new(
             crate::protocol::SERVICE_TYPE,
-            "viewer",
+            &instance_name,
             &mdns_host,
             local_ips.as_slice(),
             local_port,

--- a/tools/lsp/preview/connector/remote.rs
+++ b/tools/lsp/preview/connector/remote.rs
@@ -154,6 +154,18 @@ impl RemoteLspToPreview {
                         use crate::preview::connector::remote::remote_notifications::RemoteViewerDiscoveredMessage;
 
                         tracing::debug!("mDNS service resolved: {resolved_service:?}");
+                        // The instance name is the friendly, user-assigned name
+                        // (e.g. "Simon's iPhone"); it's the leading label of the
+                        // fullname `<instance>.<ty_domain>`. mdns-sd keeps labels raw
+                        // (no presentation escaping), so stripping the fixed type
+                        // suffix recovers it verbatim. Fall back to the sanitized
+                        // `.local` host if anything looks off.
+                        let name = resolved_service
+                            .fullname
+                            .strip_suffix(&format!(".{}", resolved_service.ty_domain))
+                            .filter(|n| !n.is_empty())
+                            .map(str::to_owned)
+                            .unwrap_or_else(|| resolved_service.host.clone());
                         let viewer_protocols = resolved_service
                             .txt_properties
                             .get_property_val_str(TXT_PROTOCOLS_KEY)
@@ -165,6 +177,7 @@ impl RemoteLspToPreview {
                         if let Err(err) = server_notifier
                             .send_notification::<RemoteViewerDiscoveredMessage>(
                                 RemoteViewerDiscoveredMessage {
+                                    name,
                                     host: resolved_service.host,
                                     port: resolved_service.port,
                                     addresses: resolved_service

--- a/tools/lsp/preview/connector/remote/remote_notifications.rs
+++ b/tools/lsp/preview/connector/remote/remote_notifications.rs
@@ -6,6 +6,9 @@ use lsp_types::notification::Notification;
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RemoteViewerDiscoveredMessage {
+    /// User-facing name of the viewer (e.g. "Simon's iPhone").
+    pub name: String,
+    /// The sanitized mDNS `.local` hostname of the viewer.
     pub host: String,
     pub port: u16,
     pub addresses: Vec<String>,

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -72,7 +72,10 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                 )?,
                 connection.local_port(),
             );
-            service.set_name("viewer");
+            // Deliberately don't set a name: with a NULL/empty instance name Bonjour
+            // substitutes the system default service name, which is the user-assigned
+            // device name (e.g. "Simon's iPhone" on iOS, the computer name on macOS).
+            // This is the friendly name we want to show in the editor.
             let mut txt = zeroconf_tokio::TxtRecord::new();
             txt.insert(
                 i_slint_live_preview::protocol::TXT_PROTOCOLS_KEY,
@@ -91,11 +94,19 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
         .flatten();
 
     #[cfg(target_vendor = "apple")]
-    if let Some(mdns) = &mut mdns
-        && let Err(err) = mdns.start().await
-    {
-        tracing::error!("Failed to announce service: {err}");
-    }
+    let device_name = if let Some(mdns) = &mut mdns {
+        match mdns.start().await {
+            Ok(registration) => registration.name().to_owned(),
+            Err(err) => {
+                tracing::error!("Failed to announce service: {err}");
+                String::new()
+            }
+        }
+    } else {
+        String::new()
+    };
+    #[cfg(not(target_vendor = "apple"))]
+    let device_name = String::new();
 
     let local_port = connection.local_port();
     let local_ip_str: Vec<String> = connection
@@ -112,6 +123,10 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     if let Err(err) =
         window.set_property("address", SharedString::from(local_ip_str.join("\n")).into())
     {
+        tracing::error!("Failed setting property: {err}");
+    }
+
+    if let Err(err) = window.set_property("name", SharedString::from(device_name.clone()).into()) {
         tracing::error!("Failed setting property: {err}");
     }
 
@@ -177,6 +192,11 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                         .unwrap_or_else(|_| main_ui.create().unwrap());
                     if let Err(err) = inner_window
                         .set_property("address", SharedString::from(local_ip_str.join("\n")).into())
+                    {
+                        tracing::error!("Failed setting property: {err}");
+                    }
+                    if let Err(err) = inner_window
+                        .set_property("name", SharedString::from(device_name.clone()).into())
                     {
                         tracing::error!("Failed setting property: {err}");
                     }

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -2,19 +2,35 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component EmptyWindow inherits Window {
+    // Friendly device name (e.g. "Simon's iPhone") this viewer advertises to editors.
+    in property <string> name;
     in property <string> address;
     in property <string> message;
 
-    HorizontalLayout {
-        alignment: center;
-        VerticalLayout {
-            alignment: center;
+    VerticalLayout {
+        alignment: start;
+        // Keep the name clear of the status bar / notch / Dynamic Island.
+        padding-top: root.safe-area-insets.top + 8px;
+        padding-bottom: root.safe-area-insets.bottom;
 
-            if message == "": Text {
-                text: address;
-            }
-            if message != "": Text {
-                text: message;
+        if name != "": Text {
+            text: name;
+            horizontal-alignment: center;
+            font-size: 20px;
+            font-weight: 700;
+        }
+
+        HorizontalLayout {
+            alignment: center;
+            VerticalLayout {
+                alignment: center;
+
+                if message == "": Text {
+                    text: address;
+                }
+                if message != "": Text {
+                    text: message;
+                }
             }
         }
     }


### PR DESCRIPTION
Show a clean, user-facing name (the device name on iOS, e.g. "Simon's iPhone") instead of a generic "viewer" / sanitized `.local` host.

On Apple this comes from leaving the mDNS instance name empty so Bonjour substitutes the system default name; we read it back from the registration for the viewer's idle UI. Other platforms use the hostname. The LSP recovers the name from the resolved service and forwards it to VS Code, which shows it in the discovery toast and device picker.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
