### PR TITLE
Tooltip: reject `for`, honor `if condition`

### DIFF
--- a/internal/compiler/passes/lower_tooltips.rs
+++ b/internal/compiler/passes/lower_tooltips.rs
@@ -20,6 +20,12 @@
 //!   - text mode: `text` binding is present, no children
 //!   - custom mode: children are present, no `text` binding
 //! - custom mode expects one root child element which is used directly as tooltip content.
+//!
+//! Placement around `for`/`if`:
+//! - `for ... : Tooltip { ... }` is rejected at compile time.
+//! - `if cond : Tooltip { ... }` is allowed; the condition is forwarded onto the synthesized
+//!   `TooltipArea` (which owns the generated `PopupWindow` as its child), so the area only
+//!   exists while `cond` is true.
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{BindingExpression, BuiltinFunction, Expression, Unit};
@@ -159,6 +165,7 @@ fn build_tooltip_area(
     popup_id: &SmolStr,
     enclosing_component: &std::rc::Weak<Component>,
     tooltip_area_type: &ElementType,
+    repeated: Option<RepeatedElementInfo>,
 ) -> ElementRc {
     let mut elem = Element {
         id: format_smolstr!("{}-area", popup_id),
@@ -184,6 +191,7 @@ fn build_tooltip_area(
         ]
         .into_iter()
         .collect(),
+        repeated,
         ..Default::default()
     };
     // `Element::from_node` runs `apply_default_type_properties` on user-written elements;
@@ -243,12 +251,11 @@ fn wire_tooltip_visibility_behavior(
         RefCell::new(Expression::CodeBlock(vec![close_popup]).into()),
     );
 
-    {
-        let mut elem_borrow = elem.borrow_mut();
-        elem_borrow.children.insert(tooltip_child_index, tooltip_area.clone());
-        elem_borrow.children.insert(tooltip_child_index + 1, popup_window_rc);
-        elem_borrow.has_popup_child = true;
-    }
+    // Make the PopupWindow a child of the TooltipArea so that the popup's bindings
+    // (`x`/`y` referring to `TooltipArea.mouse-x`/`mouse-y`) and the conditional
+    // gating (`repeated` on `TooltipArea`) stay in the same scope.
+    tooltip_area.borrow_mut().children.push(popup_window_rc);
+    elem.borrow_mut().children.insert(tooltip_child_index, tooltip_area.clone());
 }
 
 fn lower_tooltips_in_component(
@@ -312,6 +319,17 @@ fn lower_tooltips_in_component(
         let tooltip_child_index = tooltip_indices[0];
 
         let tooltip_candidate = elem.borrow().children[tooltip_child_index].clone();
+        // `if cond : Tooltip { ... }` is allowed (the wrapper switches the synthesized
+        // TooltipArea + PopupWindow on/off with the condition); `for ... : Tooltip { ... }`
+        // is not.
+        let tooltip_repeated = tooltip_candidate.borrow_mut().repeated.take();
+        if tooltip_repeated.as_ref().is_some_and(|r| !r.is_conditional_element) {
+            diag.push_error(
+                "Tooltip cannot be in a `for` element".into(),
+                &*tooltip_candidate.borrow(),
+            );
+            return;
+        }
         if elem.borrow().builtin_type().is_some_and(|builtin| {
             LAYOUT_ELEMENTS_DISALLOWING_TOOLTIP.contains(&builtin.name.as_str())
         }) {
@@ -370,7 +388,12 @@ fn lower_tooltips_in_component(
             (tooltip_config, enclosing_component, popup_id, custom_children)
         };
 
-        let tooltip_area = build_tooltip_area(&popup_id, &enclosing_component, &tooltip_area_type);
+        let tooltip_area = build_tooltip_area(
+            &popup_id,
+            &enclosing_component,
+            &tooltip_area_type,
+            tooltip_repeated,
+        );
         // Propagate a user-set binding from the `Tooltip` element onto the synthesized
         // `TooltipArea`, keyed by the same property name. Currently only `text` is shared,
         // but the helper is kept so adding more shared properties later is a one-liner.

--- a/internal/compiler/tests/syntax/elements/tooltip_in_for.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_for.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test inherits Window {
+    Rectangle {
+        for x in 3: Tooltip {
+//                  >      <error{Tooltip cannot be in a `for` element}
+            text: "not allowed";
+        }
+    }
+}

--- a/tests/cases/elements/tooltip_conditional.slint
+++ b/tests/cases/elements/tooltip_conditional.slint
@@ -1,0 +1,142 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `if <cond>: Tooltip { ... }` gates the synthesized TooltipArea on the
+// condition: when the condition is false the tooltip does not show on hover.
+
+export component TestCase {
+    width: 200px;
+    height: 100px;
+
+    in-out property <bool> tooltip-enabled: false;
+    in-out property <int> init-count;
+
+    TouchArea {
+        if root.tooltip-enabled: Tooltip {
+            Rectangle {
+                init => { root.init-count += 1; }
+            }
+        }
+    }
+}
+
+/*
+
+```rust
+use slint::{platform::WindowEvent, LogicalPosition};
+
+let instance = TestCase::new().unwrap();
+let inner = slint_testing::WindowInner::from_pub(&instance.window());
+
+// Disabled: hovering and waiting past the show delay does not show the tooltip.
+assert_eq!(instance.get_init_count(), 0);
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(100.0, 50.0),
+});
+slint_testing::mock_elapsed_time(600);
+assert_eq!(instance.get_init_count(), 0);
+assert_eq!(inner.active_popups.borrow().len(), 0);
+
+// Move the pointer away so re-entering re-arms the hover timer.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(-10.0, -10.0),
+});
+slint_testing::mock_elapsed_time(2000);
+
+// Enable and hover again: the tooltip now shows after the delay.
+instance.set_tooltip_enabled(true);
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(100.0, 50.0),
+});
+assert_eq!(instance.get_init_count(), 0);
+slint_testing::mock_elapsed_time(600);
+assert_eq!(instance.get_init_count(), 1);
+assert_eq!(inner.active_popups.borrow().len(), 1);
+
+// Disable again while the popup is open: the next layout drops the
+// conditional sub-component instance, and `unregister_item_tree` closes the
+// popup because its `parent_item` no longer upgrades.
+instance.set_tooltip_enabled(false);
+slint_testing::mock_elapsed_time(1);
+assert_eq!(inner.active_popups.borrow().len(), 0);
+
+// Move away then back: hover no longer triggers the tooltip.
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(-10.0, -10.0),
+});
+slint_testing::mock_elapsed_time(2000);
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(100.0, 50.0),
+});
+slint_testing::mock_elapsed_time(600);
+assert_eq!(instance.get_init_count(), 1);
+assert_eq!(inner.active_popups.borrow().len(), 0);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+// Disabled: hovering and waiting past the show delay does not show the tooltip.
+assert_eq(instance.get_init_count(), 0);
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({100.0, 50.0}));
+slint_testing::mock_elapsed_time(600);
+assert_eq(instance.get_init_count(), 0);
+
+// Move the pointer away so re-entering re-arms the hover timer.
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({-10.0, -10.0}));
+slint_testing::mock_elapsed_time(2000);
+
+// Enable and hover again: the tooltip now shows after the delay.
+instance.set_tooltip_enabled(true);
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({100.0, 50.0}));
+assert_eq(instance.get_init_count(), 0);
+slint_testing::mock_elapsed_time(600);
+assert_eq(instance.get_init_count(), 1);
+
+// Disable again while the popup is open: the synthesized area is torn down,
+// which (via unregister_item_tree) closes the popup. Re-enter to confirm
+// hover no longer triggers the tooltip.
+instance.set_tooltip_enabled(false);
+slint_testing::mock_elapsed_time(1);
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({-10.0, -10.0}));
+slint_testing::mock_elapsed_time(2000);
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({100.0, 50.0}));
+slint_testing::mock_elapsed_time(600);
+assert_eq(instance.get_init_count(), 1);
+```
+
+```js
+var instance = new slint.TestCase({});
+
+// Disabled: hovering (via the move emitted by send_mouse_click) and waiting past
+// the show delay does not instantiate the tooltip content.
+assert.equal(instance.init_count, 0);
+slintlib.private_api.send_mouse_click(instance, 100., 50.);
+slintlib.private_api.mock_elapsed_time(600);
+assert.equal(instance.init_count, 0);
+
+// Move the pointer away (via a click at a different position) so re-entering
+// re-arms the hover timer.
+slintlib.private_api.send_mouse_click(instance, 0., 0.);
+slintlib.private_api.mock_elapsed_time(2000);
+
+// Enable and hover again: the tooltip now shows after the delay.
+instance.tooltip_enabled = true;
+slintlib.private_api.send_mouse_click(instance, 100., 50.);
+slintlib.private_api.mock_elapsed_time(600);
+assert.equal(instance.init_count, 1);
+
+// Disable again while the popup is open: the next layout tears down the
+// area and closes the popup via unregister_item_tree. Re-enter to confirm
+// hover no longer triggers the tooltip.
+instance.tooltip_enabled = false;
+slintlib.private_api.mock_elapsed_time(1);
+slintlib.private_api.send_mouse_click(instance, 0., 0.);
+slintlib.private_api.mock_elapsed_time(2000);
+slintlib.private_api.send_mouse_click(instance, 100., 50.);
+slintlib.private_api.mock_elapsed_time(600);
+assert.equal(instance.init_count, 1);
+```
+
+*/


### PR DESCRIPTION
`for ... : Tooltip { ... }` is now a build error. `if cond : Tooltip { ... }` forward the condition to the `TooltipArea`

Fixes: #11922
Fixes: #11923

Move the generated PopupWindow under the TooltipArea so the popup's references to `mouse-x`/`mouse-y` stay in the same scope when the area is gated by `repeated`. The condition then drives whether TooltipArea exists at all, replacing the previous gate on the `show` callback body.
