### PR TITLE
Tooltip: change text property to styled-text

### DIFF
--- a/examples/gallery/ui/pages/controls_page.slint
+++ b/examples/gallery/ui/pages/controls_page.slint
@@ -91,7 +91,7 @@ export component ControlsPage inherits Page {
                 enabled: GallerySettings.widgets-enabled;
 
                 Tooltip {
-                    text: @tr("This is a tooltip.");
+                    text: @markdown("\{@tr("This is a tooltip.")}");
                 }
             }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2475,7 +2475,7 @@ export component TooltipArea inherits Empty {
     // Pointer y within this area during hover.
     out property <length> mouse-y;
     // Tooltip configuration folded from the user-facing Tooltip element during lowering.
-    in property <string> text;
+    in property <styled-text> text;
     // Delay and offset are not user-facing in 1.17; the values used here are the
     // built-in defaults applied to the synthesized element on instantiation.
     in property <duration> delay: 500ms;
@@ -2500,7 +2500,7 @@ export component TooltipArea inherits Empty {
 ///             text: "Hover me";
 ///
 ///             Tooltip {
-///                 text: "This is a tooltip";
+///                 text: @markdown("This is a tooltip");
 ///             }
 ///         }
 ///     }
@@ -2582,7 +2582,7 @@ export component TooltipArea inherits Empty {
 export component Tooltip inherits Empty {
     /// The text to display in the tooltip.
     /// Don't set this property when using custom content.
-    in property <string> text;
+    in property <styled-text> text;
     //-can_be_declared_without_children_slot
     //-is_non_item_type
 }

--- a/internal/compiler/tests/syntax/elements/tooltip_access_from_outside.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_access_from_outside.slint
@@ -6,30 +6,30 @@ export component Test inherits Window {
     Rectangle {
         tt := Tooltip {
 //            >      <error{Cannot access property or callback 'tt.text' inside of a Tooltip from enclosing component}
-            text: "Hello";
+            text: @markdown("Hello");
         }
     }
-    property <string> val: tt.text;
+    property <styled-text> val: tt.text;
 
     // Access a named tooltip's text property from a separate parent.
     Rectangle {
         tt2 := Tooltip {
 //             >      <error{Cannot access property or callback 'tt2.text' inside of a Tooltip from enclosing component}
-            text: "tip";
+            text: @markdown("tip");
         }
     }
-    property <string> d: tt2.text;
+    property <styled-text> d: tt2.text;
 
     // Multiple references to the same tooltip property produce multiple errors.
     Rectangle {
         tt3 := Tooltip {
 //             >      <error{Cannot access property or callback 'tt3.text' inside of a Tooltip from enclosing component}
 //             >      <^error{Cannot access property or callback 'tt3.text' inside of a Tooltip from enclosing component}
-            text: "multi";
+            text: @markdown("multi");
         }
     }
-    property <string> a: tt3.text;
-    property <string> b: tt3.text;
+    property <styled-text> a: tt3.text;
+    property <styled-text> b: tt3.text;
 
     // Named custom-content tooltip — access the tooltip element itself.
     Rectangle {
@@ -38,7 +38,7 @@ export component Test inherits Window {
             Rectangle { background: red; }
         }
     }
-    property <string> cd: tt4.text;
+    property <styled-text> cd: tt4.text;
 
     // Access a named child inside a custom-content tooltip.
     Rectangle {

--- a/internal/compiler/tests/syntax/elements/tooltip_children_placeholder.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_children_placeholder.slint
@@ -9,7 +9,7 @@ export component Test inherits Window {
     Rectangle {
         TipWithChildren {
 //      >              <error{Tooltip cannot be inherited}
-            text: "Hello";
+            text: @markdown("Hello");
         }
     }
 }

--- a/internal/compiler/tests/syntax/elements/tooltip_geometry_properties.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_geometry_properties.slint
@@ -4,7 +4,7 @@
 export component Test inherits Window {
     Rectangle {
         Tooltip {
-            text: "Hello";
+            text: @markdown("Hello");
             x: 10px;
 //          ^error{Unknown property x in Tooltip}
             y: 20px;

--- a/internal/compiler/tests/syntax/elements/tooltip_in_for.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_for.slint
@@ -5,7 +5,7 @@ export component Test inherits Window {
     Rectangle {
         for x in 3: Tooltip {
 //                  >      <error{Tooltip cannot be in a `for` element}
-            text: "not allowed";
+            text: @markdown("not allowed");
         }
     }
 }

--- a/internal/compiler/tests/syntax/elements/tooltip_in_layout.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_layout.slint
@@ -5,7 +5,7 @@ export component Test inherits Window {
     HorizontalLayout {
         Tooltip {
 //      >      <error{Tooltip cannot be used inside layout elements}
-            text: "Not allowed directly inside layout";
+            text: @markdown("Not allowed directly inside layout");
         }
     }
 }

--- a/internal/compiler/tests/syntax/elements/tooltip_in_menu.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_menu.slint
@@ -7,7 +7,7 @@ export component Test inherits Window {
             title: "File";
             Tooltip {
 //          >      <error{Tooltip cannot be used inside non-item elements}
-                text: "No tooltip here";
+                text: @markdown("No tooltip here");
             }
         }
     }

--- a/internal/compiler/tests/syntax/elements/tooltip_in_timer.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_timer.slint
@@ -6,7 +6,7 @@ export component Test inherits Window {
         interval: 200ms;
         Tooltip {
 //      >      <error{Tooltip cannot be used inside non-item elements}
-            text: "No tooltip here";
+            text: @markdown("No tooltip here");
         }
     }
 }

--- a/internal/compiler/tests/syntax/elements/tooltip_inherit.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_inherit.slint
@@ -8,7 +8,7 @@ export component Test inherits Window {
     Rectangle {
         MyToolTip {
 //      >        <error{Tooltip cannot be inherited}
-            text: "Inherited tooltip";
+            text: @markdown("Inherited tooltip");
         }
     }
 }

--- a/internal/compiler/tests/syntax/elements/tooltip_multiple.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_multiple.slint
@@ -4,12 +4,12 @@
 export component Test inherits Window {
     Rectangle {
         Tooltip {
-            text: "first";
+            text: @markdown("first");
         }
 
         Tooltip {
 //      >      <error{Only one Tooltip is allowed as a child of an element}
-            text: "second";
+            text: @markdown("second");
         }
     }
 }

--- a/internal/compiler/tests/syntax/elements/tooltip_nested.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_nested.slint
@@ -5,10 +5,10 @@ export component Test inherits Window {
     Rectangle {
         Tooltip {
 //      >      <error{Tooltip cannot have both text and custom content}
-            text: "Outer";
+            text: @markdown("Outer");
             Tooltip {
 //          >      <error{Tooltip cannot be used inside non-item elements}
-                text: "Nested";
+                text: @markdown("Nested");
             }
         }
     }

--- a/internal/compiler/tests/syntax/elements/tooltip_text_and_custom_content.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_text_and_custom_content.slint
@@ -5,7 +5,7 @@ export component Test inherits Window {
     Rectangle {
         Tooltip {
 //      >      <error{Tooltip cannot have both text and custom content}
-            text: "Hello";
+            text: @markdown("Hello");
             Rectangle {}
         }
     }

--- a/internal/compiler/widgets/common/tooltip-base.slint
+++ b/internal/compiler/widgets/common/tooltip-base.slint
@@ -4,7 +4,7 @@
 import { Palette } from "std-widgets-impl.slint";
 
 export component ToolTipImpl inherits Rectangle {
-    in property <string> text;
+    in property <styled-text> text;
 
     background: Palette.alternate-background;
     border-radius: 4px;
@@ -17,9 +17,9 @@ export component ToolTipImpl inherits Rectangle {
         padding-top: 6px;
         padding-bottom: 6px;
 
-        Text {
+        StyledText {
             text: root.text;
-            color: Palette.foreground;
+            default-color: Palette.foreground;
         }
     }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1969,7 +1969,7 @@ pub struct TooltipArea {
     pub has_hover: Property<bool>,
     pub mouse_x: Property<LogicalLength>,
     pub mouse_y: Property<LogicalLength>,
-    pub text: Property<SharedString>,
+    pub text: Property<crate::styled_text::StyledText>,
     pub delay: Property<i64>,
     pub offset: Property<LogicalLength>,
     pub show: Callback<VoidArg>,


### PR DESCRIPTION
Allows `@markdown(...)` for formatted tooltip content. Renders via StyledText instead of Text. Callers must wrap plain strings with `@markdown(...)` since there is no implicit string -> styled-text conversion.
