### PR TITLE
compiler: fix false positive and false negative in GridLayout row/col mix check

### DIFF
--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -494,7 +494,7 @@ fn lower_element_layout(
 }
 
 // to detect mixing auto and non-literal expressions in row/col values
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum RowColExpressionType {
     Auto, // not specified
     Literal,
@@ -511,6 +511,16 @@ impl RowColExpressionType {
             Some(_) => RowColExpressionType::RuntimeExpression,
         }
     }
+}
+
+/// Two views of the running auto-vs-runtime classification as we walk a
+/// GridLayout's children. See the call site in `lower_grid_layout` for why we
+/// keep both: the lenient view is the only signal that a given conflict was
+/// previously accepted (and so should be a warning rather than an error).
+#[derive(Default)]
+struct NumberingTypes {
+    strict: Option<RowColExpressionType>,
+    lenient: Option<RowColExpressionType>,
 }
 
 fn lower_grid_layout(
@@ -555,7 +565,24 @@ fn lower_grid_layout(
     let layout_children = std::mem::take(&mut grid_layout_element.borrow_mut().children);
     let mut collected_children = Vec::new();
     let mut new_row = false; // true until the first child of a Row, or the first item after an empty Row
-    let mut numbering_type: Option<RowColExpressionType> = None;
+    // The consistency check runs two classifications in parallel:
+    //
+    //   `strict`  — looks one level into a `for`/`if`'s sub-component for
+    //               row/col bindings that `repeater_component` moved off the
+    //               wrapper. This matches what the layout solver actually
+    //               consumes.
+    //   `lenient` — ignores those moved bindings, i.e. the same classification
+    //               the consistency check used to perform.
+    //
+    // Some layouts that *should* have been rejected as auto-vs-runtime mixes
+    // slipped through historically: the wrapper looked Auto from the outside
+    // because its bindings had been moved into a sub-component, so the check
+    // never saw the conflict. We can't simply error on every such input
+    // because real `.slint` files written against the old behavior are out
+    // there. Instead we keep both views and only emit a hard error when the
+    // lenient view would also have flagged the mix; cases the lenient view
+    // missed are downgraded to a warning so existing code keeps compiling.
+    let mut numbering_type = NumberingTypes::default();
     let mut num_cached_items: usize = 0;
     for layout_child in layout_children {
         let is_repeated_row = {
@@ -628,7 +655,7 @@ fn lower_grid_layout(
         }
     }
     grid_layout_element.borrow_mut().children = collected_children;
-    grid.uses_auto = numbering_type == Some(RowColExpressionType::Auto);
+    grid.uses_auto = numbering_type.strict == Some(RowColExpressionType::Auto);
     let span = grid_layout_element.borrow().to_source_location();
 
     layout_organized_data_prop.element().borrow_mut().bindings.insert(
@@ -704,59 +731,157 @@ impl GridLayout {
         layout_cache_prop_h: &NamedReference,
         layout_cache_prop_v: &NamedReference,
         organized_data_prop: &NamedReference,
-        numbering_type: &mut Option<RowColExpressionType>,
+        numbering_type: &mut NumberingTypes,
         diag: &mut BuildDiagnostics,
         num_cached_items: &mut usize,
     ) {
         // Some compile-time checks
         {
+            // Returns (strict, lenient, is_number_literal):
+            //
+            //   `strict`  - the binding the layout solver will see at runtime,
+            //               looking one level into a repeater wrapper's
+            //               sub-component when needed.
+            //   `lenient` - the binding visible directly on the wrapper, which
+            //               is empty for repeater wrappers because their
+            //               bindings have been moved into the sub-component.
+            //
+            // The two only differ for a repeater wrapper that had a row/col
+            // binding on its body; everywhere else they are equal. We hand
+            // both to the consistency check so it can tell apart cases that
+            // were already wrong before this code changed from cases that were
+            // only just unmasked.
+            //
+            // `is_number_literal` describes the strict expression. It is safe
+            // to share one flag because either direct == strict (the binding
+            // was on the wrapper) or direct is None (in which case the lenient
+            // classification will be Auto regardless of the flag).
             let mut check_expr = |name: &str| {
                 let mut is_number_literal = false;
-                let expr = item_element.borrow_mut().bindings.get(name).map(|e| {
-                    let expr = &e.borrow().expression;
-                    is_number_literal =
-                        check_number_literal_is_positive_integer(expr, name, &*e.borrow(), diag);
-                    expr.clone()
-                });
-                (expr, is_number_literal)
+                let mut read = |elem: &ElementRc, lit: &mut bool| -> Option<Expression> {
+                    let b = elem.borrow().bindings.get(name).cloned()?;
+                    let b_borrow = b.borrow();
+                    if !b_borrow.has_binding() {
+                        return None;
+                    }
+                    *lit = check_number_literal_is_positive_integer(
+                        &b_borrow.expression,
+                        name,
+                        &*b_borrow,
+                        diag,
+                    );
+                    Some(b_borrow.expression.clone())
+                };
+                let lenient = read(item_element, &mut is_number_literal);
+                let strict = if lenient.is_some() {
+                    lenient.clone()
+                } else if item_element.borrow().repeated.is_some()
+                    && let ElementType::Component(base) = item_element.borrow().base_type.clone()
+                {
+                    read(&base.root_element, &mut is_number_literal)
+                } else {
+                    None
+                };
+                (strict, lenient, is_number_literal)
             };
 
-            let (row_expr, row_is_number_literal) = check_expr("row");
-            let (col_expr, col_is_number_literal) = check_expr("col");
+            let (row_strict, row_lenient, row_lit) = check_expr("row");
+            let (col_strict, col_lenient, col_lit) = check_expr("col");
             check_expr("rowspan");
             check_expr("colspan");
 
-            let mut check_numbering_consistency =
-                |expr_type: RowColExpressionType, prop_name: &str| {
-                    if !matches!(expr_type, RowColExpressionType::Literal) {
-                        if let Some(current_numbering_type) = numbering_type {
-                            if *current_numbering_type != expr_type {
-                                let element_ref = item_element.borrow();
-                                let span: &dyn Spanned =
-                                    if let Some(binding) = element_ref.bindings.get(prop_name) {
-                                        &*binding.borrow()
-                                    } else {
-                                        &*element_ref
-                                    };
-                                diag.push_error(
-                                    format!("Cannot mix auto-numbering and runtime expressions for the '{prop_name}' property"),
-                                    span,
-                                );
-                            }
-                        } else {
-                            // Store the first auto or runtime expression case we see
-                            *numbering_type = Some(expr_type);
-                        }
+            // Returns true iff a classification of `ty`, compared against the
+            // already-recorded numbering `num`, would have errored under the
+            // historical rule (set on the first non-Literal element; mismatch
+            // after that is the mix).
+            let would_conflict = |num: &Option<RowColExpressionType>,
+                                  ty: &RowColExpressionType|
+             -> bool {
+                !matches!(ty, RowColExpressionType::Literal) && matches!(num, Some(t) if t != ty)
+            };
+
+            // Classify each axis into the diagnostic it would produce, and
+            // immediately fold its non-Literal types into `numbering_type` so
+            // an intra-element mix (row Runtime + col Auto on the same
+            // wrapper) still trips when the second axis is checked.
+            let mut classify_and_update =
+                |strict: RowColExpressionType, lenient: RowColExpressionType| -> Option<bool> {
+                    let diag = if would_conflict(&numbering_type.strict, &strict) {
+                        // true ↔ strict-and-lenient conflict ↔ this was
+                        // already wrong under the old check, so it stays an
+                        // error; false ↔ strict-only conflict ↔ warning.
+                        Some(would_conflict(&numbering_type.lenient, &lenient))
+                    } else {
+                        None
+                    };
+                    // Record the first non-Literal value seen for each view,
+                    // even after a conflict — once set, never overwritten,
+                    // matching the historical check's behavior.
+                    if numbering_type.strict.is_none()
+                        && !matches!(strict, RowColExpressionType::Literal)
+                    {
+                        numbering_type.strict = Some(strict);
                     }
+                    if numbering_type.lenient.is_none()
+                        && !matches!(lenient, RowColExpressionType::Literal)
+                    {
+                        numbering_type.lenient = Some(lenient);
+                    }
+                    diag
                 };
 
-            let row_expr_type =
-                RowColExpressionType::from_option_expr(&row_expr, row_is_number_literal);
-            check_numbering_consistency(row_expr_type, "row");
+            let row_strict_ty = RowColExpressionType::from_option_expr(&row_strict, row_lit);
+            let row_lenient_ty = RowColExpressionType::from_option_expr(&row_lenient, row_lit);
+            let col_strict_ty = RowColExpressionType::from_option_expr(&col_strict, col_lit);
+            let col_lenient_ty = RowColExpressionType::from_option_expr(&col_lenient, col_lit);
 
-            let col_expr_type =
-                RowColExpressionType::from_option_expr(&col_expr, col_is_number_literal);
-            check_numbering_consistency(col_expr_type, "col");
+            let row_diag = classify_and_update(row_strict_ty, row_lenient_ty);
+            let col_diag = classify_and_update(col_strict_ty, col_lenient_ty);
+
+            // Pick the most severe diagnostic across both axes. `Some(true)`
+            // (error) wins over `Some(false)` (warning); ties prefer row for
+            // a stable, source-order span.
+            let report = match (row_diag, col_diag) {
+                (Some(true), _) => Some(("row", true)),
+                (_, Some(true)) => Some(("col", true)),
+                (Some(false), _) => Some(("row", false)),
+                (_, Some(false)) => Some(("col", false)),
+                _ => None,
+            };
+
+            if let Some((prop_name, is_error)) = report {
+                // Pick the tightest span we can: a binding on the wrapper if
+                // there is one, otherwise the same binding inside the
+                // repeater's sub-component root, otherwise the wrapper as a
+                // whole.
+                let element_ref = item_element.borrow();
+                let inner_borrow = match &element_ref.base_type {
+                    ElementType::Component(base) if element_ref.repeated.is_some() => {
+                        Some(base.root_element.clone())
+                    }
+                    _ => None,
+                };
+                let direct_binding = element_ref.bindings.get(prop_name).cloned();
+                let inner_binding =
+                    inner_borrow.as_ref().and_then(|e| e.borrow().bindings.get(prop_name).cloned());
+                let binding = direct_binding.or(inner_binding);
+                let binding_borrow = binding.as_ref().map(|b| b.borrow());
+                let span: &dyn Spanned = match &binding_borrow {
+                    Some(b) => &**b,
+                    None => &*element_ref,
+                };
+                if is_error {
+                    diag.push_error(
+                        format!("Cannot mix auto-numbering and runtime expressions for the '{prop_name}' property"),
+                        span,
+                    );
+                } else {
+                    diag.push_warning(
+                        format!("Cannot mix auto-numbering and runtime expressions for the '{prop_name}' property. This was accepted by previous versions of Slint, but may become an error in the future"),
+                        span,
+                    );
+                }
+            }
         }
 
         let propref = |name: &'static str| -> Option<RowColExpr> {

--- a/internal/compiler/tests/syntax/layout/grid_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/grid_layout_properties.slint
@@ -111,4 +111,72 @@ export X := Rectangle {
             }
         }
     }
+
+    // Inside a `for`/`if`, setting one axis but not the other still has to
+    // line up with the surrounding GridLayout's other children. This shape
+    // (runtime `row`, auto-numbered `col` next to an auto-numbered sibling)
+    // was silently accepted in older Slint versions; it is now reported but
+    // only as a warning so that those files keep compiling.
+    lay5 := GridLayout {
+        for _[idx] in 5: Text {
+//                       >   <warning{Cannot mix auto-numbering and runtime expressions for the 'col' property. This was accepted by previous versions of Slint, but may become an error in the future}
+            row: idx;
+        }
+        Text { }
+//      >   <warning{Cannot mix auto-numbering and runtime expressions for the 'row' property. This was accepted by previous versions of Slint, but may become an error in the future}
+    }
+
+    lay6 := GridLayout {
+        if true: Text {
+//               >   <warning{Cannot mix auto-numbering and runtime expressions for the 'col' property. This was accepted by previous versions of Slint, but may become an error in the future}
+            row: lay2.last_row;
+        }
+        Text { }
+//      >   <warning{Cannot mix auto-numbering and runtime expressions for the 'row' property. This was accepted by previous versions of Slint, but may become an error in the future}
+    }
+
+    // A single GridLayout that exercises both diagnostic levels. The first
+    // child seeds the numbering with auto (its row is missing); the second
+    // child has a runtime row only via piercing into the repeater body, so
+    // its `col` is still auto and the mix is reported as a warning; the
+    // third child has both row and col set directly so the lenient view
+    // also flags the mix, and it is reported as a real error.
+    lay7 := GridLayout {
+        Text { col: 1; }
+        for _[idx] in 5: Text {
+            row: idx;
+//               >  <warning{Cannot mix auto-numbering and runtime expressions for the 'row' property. This was accepted by previous versions of Slint, but may become an error in the future}
+        }
+        Text {
+            row: lay2.last_row;
+//               >            <error{Cannot mix auto-numbering and runtime expressions for the 'row' property}
+            col: lay2.last_row;
+        }
+    }
+
+    // Cover a mix of every shape that contributes a row/col classification:
+    // a plain auto-numbered element, a `for` that introduces the first
+    // runtime expression via piercing (warning), more auto siblings, a
+    // static element with direct runtime row/col (error), two more auto
+    // siblings, and finally an `if` with runtime row/col (warning).
+    lay8 := GridLayout {
+        Text { }
+        for _[idx] in 3: Text {
+            row: idx;
+//               >  <warning{Cannot mix auto-numbering and runtime expressions for the 'row' property. This was accepted by previous versions of Slint, but may become an error in the future}
+        }
+        Text { }
+        Text {
+            row: lay2.last_row;
+//               >            <error{Cannot mix auto-numbering and runtime expressions for the 'row' property}
+            col: lay2.last_row;
+        }
+        Text { }
+        Text { }
+        if true: Text {
+            row: lay2.last_row;
+//               >            <warning{Cannot mix auto-numbering and runtime expressions for the 'row' property. This was accepted by previous versions of Slint, but may become an error in the future}
+            col: lay2.last_row;
+        }
+    }
 }

--- a/tests/cases/layout/grid_variable_row_col.slint
+++ b/tests/cases/layout/grid_variable_row_col.slint
@@ -51,6 +51,31 @@ export component TestCase inherits Window {
         txt.text == "0,2"
     }
 
+    // A GridLayout with both static children and an `if`-wrapped child, all
+    // carrying runtime `row`/`col` bindings (property references, not
+    // integer literals, so they take the runtime-expression classification
+    // path). The wrapper's bindings live in a separate sub-component after
+    // lowering, so any consistency check that only inspects the wrapper's
+    // direct bindings would wrongly classify this as a mix of auto and
+    // runtime. Placed off-screen so it doesn't fight the first GridLayout
+    // for room inside the same Window.
+    property <int> mix_base;
+    Rectangle {
+        x: 1000phx;
+        GridLayout {
+            ma := Rectangle { background: blue;  row: mix_base;     col: mix_base; }
+            if true: Rectangle { background: green; row: mix_base + 1; col: mix_base; }
+            mc := Rectangle { background: red;  row: mix_base + 2; col: mix_base; }
+        }
+    }
+    // The layout solver places ma and mc in the same column and on
+    // different rows. Checking solver-computed positions (not just the
+    // bound row property) ensures the solver's view of row/col agrees with
+    // the compiler-side consistency check.
+    out property <bool> mixed_grid_ok:
+        ma.row == 0 && mc.row == 2 &&
+        ma.x == mc.x && ma.y < mc.y;
+
     public function change_grid() {
         green_col = 0;
         red_row = 1;
@@ -69,6 +94,7 @@ export component TestCase inherits Window {
 
     init => {
         if !initial_grid_ok { root.error = "!initial_grid_ok"; }
+        if !mixed_grid_ok { root.error = "!mixed_grid_ok"; }
         change_grid()
     }
     out property <string> error;


### PR DESCRIPTION
`lower_layout`'s numbering-consistency check looked only at each GridLayout child's direct `bindings` map. For a `for`/`if` wrapper, `repeater_component` has moved every binding into a freshly created sub-component's `root_element`, so the wrapper's direct bindings are empty. That produced two kinds of wrong answer:

* False negative: a wrapper whose body sets `row` but not `col` (or vice versa) looked Auto for both axes, so the mismatch against an auto-numbered sibling was never reported. Files have shipped with that shape and lay out by accident, because the layout solver itself uses `propref` and does see the moved binding.

* False positive: a wrapper whose body sets *both* `row` and `col` (e.g. an `if`-wrapped child alongside static siblings that also set row/col explicitly) was wrongly rejected as an auto-vs-runtime mix even though every visible child carried a runtime expression.

Have the check look one level into a repeater's sub-component for the moved binding so its classification matches what the solver actually uses. To avoid silently breaking the false-negative files, run the legacy direct-only classification in parallel and downgrade the strict-only conflicts to a warning that announces the planned tightening.

