### PR TITLE
Expose Keys to public Node.js API

### DIFF
--- a/api/node/rust/types/keys.rs
+++ b/api/node/rust/types/keys.rs
@@ -3,12 +3,13 @@
 
 use i_slint_core::input::Keys;
 
-/// Represents a key binding created by the `@keys(...)` macro in Slint.
+/// `Keys` represent a key combined with a list of modifiers (the `keys` type in the Slint language).
 ///
-/// This is an opaque type — instances are only obtained from Slint properties.
+/// To construct a `Keys` instance from JavaScript, use the `Keys.fromParts()` method.
+///
 /// Use `toString()` to get a platform-native representation of the key binding
 /// (e.g. "Ctrl+A" on Linux/Windows, "⌘A" on macOS).
-#[napi]
+#[napi(js_name = "Keys")]
 pub struct SlintKeys {
     pub(crate) inner: Keys,
 }
@@ -23,7 +24,7 @@ impl From<Keys> for SlintKeys {
 impl SlintKeys {
     /// Create a `Keys` from a list of string parts, e.g. `["Control", "Shift?", "Z"]`.
     ///
-    /// Each element is either a modifier name or a key name. Throws on parse failure.
+    /// Each element is either a modifier name or a key name. Throws an error on parse failure.
     #[napi(factory)]
     pub fn from_parts(parts: Vec<String>) -> napi::Result<Self> {
         Keys::from_parts(parts.iter().map(|s| s.as_str()))

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -9,7 +9,7 @@ export {
     Brush,
     DataTransfer,
     StyledText,
-    Keys
+    Keys,
 } from "../rust-module.cjs";
 
 import { Model } from "./models";

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -9,6 +9,7 @@ export {
     Brush,
     DataTransfer,
     StyledText,
+    Keys
 } from "../rust-module.cjs";
 
 import { Model } from "./models";
@@ -1030,7 +1031,6 @@ export namespace private_api {
     export import SlintSize = napi.SlintSize;
     export import SlintPoint = napi.SlintPoint;
     export import SlintImageData = napi.SlintImageData;
-    export import SlintKeys = napi.SlintKeys;
 
     export function send_mouse_click(
         component: Component,

--- a/docs/nodejs/src/content/docs/index.md
+++ b/docs/nodejs/src/content/docs/index.md
@@ -307,6 +307,7 @@ The types used for properties in .slint design markup each translate to specific
 | `string` | `String` | |
 | `color` | `RgbaColor` | |
 | `brush` | `Brush` | |
+| `keys` | `Keys` | |
 | `image` | `ImageData` | |
 | `length` | `Number` | |
 | `physical_length` | `Number` | |

--- a/tests/cases/elements/key_binding_from_parts.slint
+++ b/tests/cases/elements/key_binding_from_parts.slint
@@ -179,17 +179,17 @@ assert_eq(instance.get_matches(), 5);
 ```js
 var instance = new slint.TestCase({});
 
-let ctrl_p = slintlib.private_api.SlintKeys.fromParts(["Control", "P"]);
-let ctrl_plus = slintlib.private_api.SlintKeys.fromParts(["Control", "Plus"]);
-let f5 = slintlib.private_api.SlintKeys.fromParts(["F5"]);
-let empty = slintlib.private_api.SlintKeys.fromParts([]);
+let ctrl_p = slintlib.Keys.fromParts(["Control", "P"]);
+let ctrl_plus = slintlib.Keys.fromParts(["Control", "Plus"]);
+let f5 = slintlib.Keys.fromParts(["F5"]);
+let empty = slintlib.Keys.fromParts([]);
 
 // Equality with compile-time @keys
 assert(ctrl_p.equals(instance.reference_shortcut));
 
 // Error cases
-assert.throws(() => slintlib.private_api.SlintKeys.fromParts(["Ctrl", "P"]));
-assert.throws(() => slintlib.private_api.SlintKeys.fromParts(["Control"]));
+assert.throws(() => slintlib.Keys.fromParts(["Ctrl", "P"]));
+assert.throws(() => slintlib.Keys.fromParts(["Control"]));
 
 const KEY_CONTROL = "\u0011";
 const KEY_SHIFT   = "\u0010";


### PR DESCRIPTION
This allows constructing keys using `Keys.fromParts` from Node.js.

Closes #11949

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
