### PR TITLE
docs: Fix invoke_from_event_loop

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -1223,10 +1223,6 @@ mod weak_handle {
 
 pub use weak_handle::*;
 
-/// This trait provides the necessary functionality for allowing creating strongly-referenced
-/// clones and conversion into a weak pointer for a Global slint component.
-///
-/// This trait is implemented by the [generated component](index.html#generated-components)
 /// Adds the specified function to an internal queue, notifies the event loop to wake up.
 /// Once woken up, any queued up functions will be invoked.
 ///


### PR DESCRIPTION
These documentation comment were originally meant for the new global
traits that we recently introduced, but somehow ended up on the
invoke_from_event_loop function instead.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
