### PR TITLE
API: expose AccessibleRole as a enum in the language module

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -41,9 +41,6 @@ fn enums(path: &Path) -> anyhow::Result<()> {
         (AccessibleLiveRegion) => {
             Some(None)
         };
-        (AccessibleRole) => {
-            Some(Some("testing"))
-        };
         ($_:ident) => {
             None
         };

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -18,7 +18,6 @@
 /// CMake options.
 namespace slint::testing {
 
-using slint::cbindgen_private::AccessibleRole;
 using slint::cbindgen_private::LayoutKind;
 
 /// Init the testing backend.
@@ -221,7 +220,7 @@ public:
 
     /// Returns the value of the element's `accessible-role` property, if present. Use this property
     /// to locate elements by their type/role, i.e. buttons, checkboxes, etc.
-    std::optional<slint::testing::AccessibleRole> accessible_role() const
+    std::optional<slint::language::AccessibleRole> accessible_role() const
     {
         if (inner.element_index != 0)
             return std::nullopt;

--- a/api/cpp/tests/testing.cpp
+++ b/api/cpp/tests/testing.cpp
@@ -58,7 +58,7 @@ SCENARIO("ElementHandle")
         REQUIRE(*elements[0].type_name() == "PushButton");
         REQUIRE((*elements[0].bases()).size() == 1);
         REQUIRE((*elements[0].bases())[0] == "ButtonBase");
-        REQUIRE(*elements[0].accessible_role() == slint::testing::AccessibleRole::Button);
+        REQUIRE(*elements[0].accessible_role() == slint::language::AccessibleRole::Button);
     }
 
     SECTION("Find by type name")

--- a/api/python/slint/build.rs
+++ b/api/python/slint/build.rs
@@ -89,10 +89,8 @@ macro_rules! generate_builtin_structs_pyi {
 i_slint_common::for_each_builtin_structs!(generate_builtin_structs_pyi);
 
 /// Convert a Rust CamelCase variant identifier (e.g. `NoDrop`) into the kebab-case string
-/// the Slint runtime stores in `Enumeration::values` (e.g. `"no-drop"`). Matches the helper
-/// in `i_slint_compiler::generator::to_kebab_case` and is reused for Python member names
-/// — kebab-case lowercases to a valid Python identifier as long as no `-` appears (the
-/// current public set is single-word only).
+/// the Slint runtime stores in `Enumeration::values` (e.g. `"no-drop"`).
+/// Matches the helper in `i_slint_compiler::generator::to_kebab_case`.
 fn to_kebab_case(s: &str) -> String {
     let mut out = Vec::with_capacity(s.len());
     for b in s.as_bytes() {
@@ -136,7 +134,8 @@ macro_rules! generate_public_enums_pyi {
                     writeln!(writer, "").unwrap();
                     $({
                         let kebab = to_kebab_case(stringify!($Value));
-                        writeln!(writer, "    {} = \"{}\"", kebab, kebab).unwrap();
+                        let member_name = kebab.replace('-', "_");
+                        writeln!(writer, "    {} = \"{}\"", member_name, kebab).unwrap();
                         let value_doc_lines: Vec<&str> = vec![$($value_doc),*];
                         let value_doc = value_doc_lines.join("\n").trim().to_string();
                         if !value_doc.is_empty() {

--- a/api/python/slint/language.rs
+++ b/api/python/slint/language.rs
@@ -7,12 +7,11 @@
 //! * `pub struct` declarations (via `for_each_builtin_structs!`) become
 //!   `collections.namedtuple` classes with documented defaults.
 //! * `pub enum` declarations (via `for_each_enums!`) become `enum.Enum`
-//!   subclasses whose member name and value are the kebab-case strings the
-//!   Slint runtime expects.
+//!   subclasses whose member `name` is a Python-safe identifier and whose
+//!   `value` is the kebab-case string the Slint runtime expects.
 //!
 //! Both kinds are registered as attributes of the `slint.language` submodule.
 
-use i_slint_compiler::generator::python::ident;
 use i_slint_compiler::generator::to_kebab_case;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
@@ -84,30 +83,31 @@ fn register_named_tuple(
 }
 
 /// Dynamically creates a Python `enum.Enum` subclass and registers it in the
-/// `slint.language` submodule. Each variant becomes a member whose name AND value
-/// are the kebab-case string the Slint runtime expects (`ColorScheme.dark.value`
-/// is `"dark"`). The interpreter's enum round-trip already keys off
-/// `member.name`, so name == value keeps the existing path working without any
-/// changes to `value.rs`.
+/// `slint.language` submodule.
+/// Each variant becomes a member whose `name` is a Python-safe identifier
+/// (dashes replaced with underscores) and whose `value` is the kebab-case string
+/// the Slint runtime expects (`AccessibleRole.radio_button.value` is `"radio-button"`).
+/// The interpreter's enum round-trip in `value.rs` keys off `member.value`,
+/// so multi-word variants round-trip correctly.
 fn register_enum_class(
     py: Python<'_>,
     m: &Bound<'_, PyModule>,
     class_name: &str,
     class_doc: &str,
-    variants: &[(String, String)], // (python_member_name, variant_doc)
+    variants: &[(String, String, String)], // (python_member_name, kebab_value, variant_doc)
 ) -> PyResult<()> {
     let enum_mod = py.import("enum")?;
     let enum_ctor = enum_mod.getattr("Enum")?;
 
     let members: Vec<(String, String)> =
-        variants.iter().map(|(name, _)| (name.clone(), name.clone())).collect();
+        variants.iter().map(|(name, value, _)| (name.clone(), value.clone())).collect();
 
     let kwargs = PyDict::new(py);
     kwargs.set_item("module", "slint.language")?;
     let class = enum_ctor.call((class_name, members), Some(&kwargs))?;
 
     let mut full_doc = class_doc.to_string();
-    for (name, doc) in variants {
+    for (name, _, doc) in variants {
         if !doc.is_empty() {
             use std::fmt::Write;
             let _ = write!(full_doc, "\n\n* ``{name}``: {doc}");
@@ -150,15 +150,15 @@ macro_rules! declare_python_public_structs {
 i_slint_common::for_each_builtin_structs!(declare_python_public_structs);
 
 /// Walks `for_each_enums!` and registers every `pub enum` as an `enum.Enum`
-/// subclass on `slint.language`. Private enums are skipped.
+/// subclass on `slint.language`.
+/// Private enums are skipped.
 ///
-/// Each variant's Python member name is the kebab-case string the Slint runtime expects
-/// (so `member.name == member.value`). The interpreter's enum round-trip in `value.rs`
-/// sends `member.name`, so keeping name == value here avoids touching that code path.
-/// Multi-word variants would need a different strategy (kebab isn't a valid Python
-/// identifier), but the current public set is single-word only — if a multi-word variant
-/// ever joins, `register_enum_class` will need to convert to snake case for the name and
-/// consumers will need `member.value` instead.
+/// Each variant's Python member name is a Python-safe identifier derived from the
+/// kebab-case form (dashes replaced with underscores), and the value is the kebab-case
+/// string the Slint runtime expects.
+/// For single-word variants name and value coincide (`ColorScheme.dark.value == "dark"`);
+/// for multi-word variants they differ (`AccessibleRole.radio_button.value == "radio-button"`).
+/// The interpreter's enum round-trip in `value.rs` keys off `member.value`.
 macro_rules! declare_python_public_enums {
     ($(
         $(#[doc = $enum_doc:literal])*
@@ -172,15 +172,19 @@ macro_rules! declare_python_public_enums {
                 if stringify!($vis) == "pub" {
                     let class_doc_lines: Vec<&str> = vec![$($enum_doc),*];
                     let class_doc = class_doc_lines.join("\n");
-                    let variants: Vec<(String, String)> = vec![
+                    let variants: Vec<(String, String, String)> = vec![
                         $(
-                            (
-                                ident(to_kebab_case(stringify!($Value)).as_str()).to_string(),
-                                {
-                                    let value_doc_lines: Vec<&str> = vec![$($value_doc),*];
-                                    value_doc_lines.join("\n")
-                                },
-                            ),
+                            {
+                                let kebab = to_kebab_case(stringify!($Value));
+                                (
+                                    kebab.replace('-', "_"),
+                                    kebab,
+                                    {
+                                        let value_doc_lines: Vec<&str> = vec![$($value_doc),*];
+                                        value_doc_lines.join("\n")
+                                    },
+                                )
+                            },
                         )*
                     ];
                     register_enum_class(py, m, stringify!($Name), &class_doc, &variants)?;

--- a/api/python/slint/value.rs
+++ b/api/python/slint/value.rs
@@ -332,11 +332,18 @@ impl TypeCollection {
         py: Python<'_>,
     ) -> Result<Py<PyAny>, PyErr> {
         let key = ident(enum_name);
+        // `enum_value` is the kebab-case string from the Slint runtime
+        // (e.g. `"radio-button"`); look up the member via `cls(value)` since
+        // kebab-case strings aren't valid Python attribute names.
         if let Some(cls) = self.enum_classes.get(key.as_str()) {
-            return cls.getattr(py, enum_value);
+            cls.bind(py).call1((enum_value,)).map(|v| v.unbind())
+        } else {
+            // Built-in language enums live on the `slint.language` module.
+            py.import("slint.language")?
+                .getattr(key.as_str())?
+                .call1((enum_value,))
+                .map(|v| v.unbind())
         }
-        // Built-in language enums live on the `slint.language` module.
-        py.import("slint.language")?.getattr(key.as_str())?.getattr(enum_value).map(|v| v.unbind())
     }
 
     pub fn model_to_py(
@@ -455,7 +462,9 @@ impl TypeCollection {
                         {
                             let enum_name =
                                 ob.getattr("__class__").and_then(|cls| cls.getattr("__name__"))?;
-                            let enum_value = ob.getattr("name")?;
+                            // `.value` is the kebab-case string the Slint runtime stores
+                            // in `Enumeration::values`.
+                            let enum_value = ob.getattr("value")?;
                             Ok(slint_interpreter::Value::EnumerationValue(
                                 enum_name.to_string(),
                                 enum_value.to_string(),

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -471,7 +471,7 @@ macro_rules! for_each_enums {
             /// See [WAI-ARIA Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
             /// for guidance on when and how to use them.
             #[non_exhaustive]
-            enum AccessibleRole {
+            pub enum AccessibleRole {
                 /// The element isn't accessible.
                 None,
                 /// The element is a `Button` or behaves like one.

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -59,7 +59,7 @@ assert(instance.get_test());
 auto img_search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::img");
 assert_eq(img_search.size(), 1);
 auto img = img_search[0];
-assert(*img.accessible_role() == slint::testing::AccessibleRole::Image);
+assert(*img.accessible_role() == slint::language::AccessibleRole::Image);
 ```
 
 


### PR DESCRIPTION
Remove the C++ one in the test namespace.

Also needed a patch for python for enums with multiple words.
