### PR TITLE
Set OpenType font features in new `font-features`, `default-font-features` properties

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -611,6 +611,7 @@ component ComplexText inherits SimpleText {
     /// ```
     /// \default false
     in property <bool> font-italic;
+    in property <string> font-features;
     /// How the text should behave when it exceeds the available space.
     in property <TextOverflow> overflow;
     /// ```slint "wrap: word-wrap;" imageAlt="wrap" width="200" height="200" needsBackground
@@ -721,6 +722,7 @@ component StyledTextItem inherits Empty {
     in property <string> default-font-family;
     /// The default font size used to render the text, when no size is specified via markup. If unset (or zero), the value falls back to the enclosing `Window`'s `default-font-size`.
     in property <length> default-font-size;
+    in property <string> default-font-features;
     /// The horizontal alignment of the text.
     in property <TextHorizontalAlignment> horizontal-alignment;
     /// The color used for rendering links in the text.
@@ -1515,6 +1517,7 @@ component WindowItem {
     in property <length> default-font-size;
     /// The font weight to use as default in text elements inside this window, that don't have their `font-weight` property set. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight. Use the <Link type="FontWeight" /> namespace for predefined constants.
     in property <int> default-font-weight;
+    in property <string> default-font-features;
     /// The window icon shown in the title bar or the task bar on window managers supporting it.
     in property <image> icon;
     /// Whether the window should be borderless/frameless or not.
@@ -1631,6 +1634,7 @@ export component TextInput {
     in property <bool> font-italic;
     /// The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
     in property <int> font-weight;
+    in property <string> font-features;
     /// The color of the text.
     /// \default depends on the style
     in property <brush> color; // StyleMetrics.default-text-color  set in apply_default_properties_from_style
@@ -2808,7 +2812,8 @@ export global Platform {
     /// to the top of the window stack. On other platforms this function is a no-op.
     ///
     /// This corresponds to the standard macOS **Window › Bring All to Front** menu item.
-    function bring-all-to-front() { }
+    function bring-all-to-front() {
+    }
     /// The decimal separator currently used for localized float to string and vice versa conversions
     /// For more information about localization and how to change the decimal separator see <Link type="translations" label="translations page"/>.
     out property <string> decimal-separator;

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -937,6 +937,7 @@ fn visit_implicit_layout_info_dependencies(
             vis(&NamedReference::new(item, SmolStr::new_static("font-family")).into(), N);
             vis(&NamedReference::new(item, SmolStr::new_static("font-size")).into(), N);
             vis(&NamedReference::new(item, SmolStr::new_static("font-weight")).into(), N);
+            vis(&NamedReference::new(item, SmolStr::new_static("font-features")).into(), N);
             vis(&NamedReference::new(item, SmolStr::new_static("letter-spacing")).into(), N);
             vis(&NamedReference::new(item, SmolStr::new_static("wrap")).into(), N);
             let wrap_set = item.borrow().is_binding_set("wrap", false)

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -101,6 +101,8 @@ pub struct FontRequest {
     pub letter_spacing: Option<LogicalLength>,
     /// Whether to select an italic face of the font family.
     pub italic: bool,
+    /// The comma-delimited OpenType font features to be used, such as "'tnum', 'kern'". Parsed according to the CSS grammar.
+    pub features: Option<SharedString>,
 }
 
 #[cfg(feature = "shared-fontique")]

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -387,6 +387,7 @@ impl HasFont for (SharedString, Brush) {
             LogicalLength::default(),
             LogicalLength::default(),
             false,
+            SharedString::default(),
         )
     }
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1266,6 +1266,7 @@ pub struct WindowItem {
     pub default_font_family: Property<SharedString>,
     pub default_font_size: Property<LogicalLength>,
     pub default_font_weight: Property<i32>,
+    pub default_font_features: Property<SharedString>,
     pub cached_rendering_data: CachedRenderingData,
 }
 
@@ -1397,6 +1398,11 @@ impl WindowItem {
         if font_weight == 0 { None } else { Some(font_weight) }
     }
 
+    pub fn font_features(self: Pin<&Self>) -> Option<SharedString> {
+        let font_features = self.default_font_features();
+        if !font_features.is_empty() { Some(font_features) } else { None }
+    }
+
     pub fn resolved_default_font_size(item_tree: ItemTreeRc) -> LogicalLength {
         let first_item = ItemRc::new_root(item_tree);
         let window_item = next_window_item(&first_item).unwrap();
@@ -1435,6 +1441,7 @@ impl WindowItem {
         local_font_size: LogicalLength,
         local_letter_spacing: LogicalLength,
         local_italic: bool,
+        local_font_features: SharedString,
     ) -> FontRequest {
         let Some(window_item_rc) = next_window_item(self_rc) else {
             return FontRequest::default();
@@ -1469,6 +1476,16 @@ impl WindowItem {
                     )
                 } else {
                     Some(local_font_size)
+                }
+            },
+            features: {
+                if !local_font_features.is_empty() {
+                    Some(local_font_features)
+                } else {
+                    Self::resolve_font_property(
+                        &window_item_rc,
+                        crate::items::WindowItem::font_features,
+                    )
                 }
             },
             letter_spacing: Some(local_letter_spacing),

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -56,6 +56,7 @@ pub struct ComplexText {
 
     pub font_family: Property<SharedString>,
     pub font_italic: Property<bool>,
+    pub font_features: Property<SharedString>,
     pub wrap: Property<TextWrap>,
     pub overflow: Property<TextOverflow>,
     pub letter_spacing: Property<LogicalLength>,
@@ -174,6 +175,7 @@ impl HasFont for ComplexText {
             self.font_size(),
             self.letter_spacing(),
             self.font_italic(),
+            self.font_features(),
         )
     }
 }
@@ -242,6 +244,7 @@ pub struct StyledTextItem {
     pub default_color: Property<Brush>,
     pub default_font_size: Property<LogicalLength>,
     pub default_font_family: Property<SharedString>,
+    pub default_font_features: Property<SharedString>,
     pub horizontal_alignment: Property<TextHorizontalAlignment>,
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub link_clicked: Callback<StringArg>,
@@ -397,6 +400,7 @@ impl HasFont for StyledTextItem {
             self.default_font_size(),
             Default::default(),
             Default::default(),
+            self.default_font_features(),
         )
     }
 }
@@ -464,6 +468,7 @@ pub struct SimpleText {
     pub text: Property<SharedString>,
     pub font_size: Property<LogicalLength>,
     pub font_weight: Property<i32>,
+    pub font_features: Property<SharedString>,
     pub color: Property<Brush>,
     pub horizontal_alignment: Property<TextHorizontalAlignment>,
     pub vertical_alignment: Property<TextVerticalAlignment>,
@@ -580,6 +585,7 @@ impl HasFont for SimpleText {
             self.font_size(),
             LogicalLength::default(),
             false,
+            self.font_features(),
         )
     }
 }
@@ -754,6 +760,7 @@ pub struct TextInput {
     pub font_size: Property<LogicalLength>,
     pub font_weight: Property<i32>,
     pub font_italic: Property<bool>,
+    pub font_features: Property<SharedString>,
     pub color: Property<Brush>,
     pub selection_foreground_color: Property<Color>,
     pub selection_background_color: Property<Color>,
@@ -1289,6 +1296,7 @@ impl HasFont for TextInput {
             self.font_size(),
             self.letter_spacing(),
             self.font_italic(),
+            self.font_features(),
         )
     }
 }

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -24,6 +24,7 @@ use core::pin::Pin;
 use euclid::num::Zero;
 use i_slint_common::sharedfontique;
 use skrifa::MetadataProvider as _;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -254,6 +255,11 @@ impl LayoutWithoutLineBreaksBuilder {
             }
             if let Some(letter_spacing) = font_request.letter_spacing {
                 builder.push_default(parley::StyleProperty::LetterSpacing(letter_spacing.get()));
+            }
+            if let Some(features) = &font_request.features {
+                builder.push_default(parley::StyleProperty::FontFeatures(
+                    parley::style::FontFeatures::Source(Cow::Borrowed(features.as_str())),
+                ));
             }
             builder.push_default(parley::StyleProperty::FontStyle(if font_request.italic {
                 parley::style::FontStyle::Italic

--- a/tests/cases/text/features.slint
+++ b/tests/cases/text/features.slint
@@ -1,3 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 import { Button } from "std-widgets.slint";
 export component TestCase inherits Window {
     width: 200px;

--- a/tests/cases/text/features.slint
+++ b/tests/cases/text/features.slint
@@ -1,0 +1,43 @@
+import { Button } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 200px;
+    height: 100px;
+    default-font-family: "Inter";
+
+    property <bool> running: false;
+    property <string> str: "1";
+
+    Timer {
+        running: running;
+        interval: 500ms;
+        triggered => {
+            str += "1";
+        }
+    }
+
+    VerticalLayout {
+        alignment: start;
+
+        Text {
+            text: "font-features: \"'tnum'\"";
+            padding-bottom: 10px;
+        }
+
+        Text {
+            text: str;
+            font-features: "'tnum'";
+        }
+
+        Text {
+            text: str;
+        }
+
+        Button {
+            text: "start";
+            visible: !running;
+            clicked => {
+                running = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a draft/PoC, I am not sure about the API or the feasibility of this so please review and let me know. I still need to add tests and some documentation comments but the core functionality is there.

This adds a new `font-features` property to SimpleText, ComplexText, and TextInput, and a `default-font-features` property to StyledTextItem and WindowItem.

Demo showing `font-features: "'tnum'"` for tabular numbers:

<img width="1920" height="1080" alt="tnum" src="https://github.com/user-attachments/assets/4990ecdb-4332-4a20-be04-19a71e520a07" />

Example usage:

```slint
Text {
    text: "1234";
    font-family: "Inter";
    font-features: "'tnum', 'kern' 0";
}
```

Right now I'm just passing the string to `parley` to parse as a CSS list, not sure if we would want to introduce a custom syntax instead so you don't have to use quotes, like `font-features: "tnum, kern=0"`. Or something like `font-features: ["tnum", "kern=0"]` but performance wise not sure if that would work.

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
