### PR TITLE
RadioGroup: accept RadioButton children instead of a model

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
@@ -90,11 +90,27 @@ The button stays visible.
 
 <SlintProperty propName="checked" typeName="bool" defaultValue="false" propertyVisibility="in-out">
 `true` when this is the currently selected button.
-Setting it to `true` selects this button; the previously-checked button
-becomes unchecked.
-Setting it to `false` on the currently-selected button is a no-op —
-the group always has at most one selection, and deselect-all from
-outside isn't supported.
+By default `checked` tracks the group's selection: when a button is clicked
+it becomes `true`, and the previously-checked button's `checked` becomes
+`false`.
+Setting `checked = true` from outside selects this button on the next
+event loop iteration; the previously-checked button goes unchecked.
+Setting `checked = false` on the currently-selected button is reverted —
+the group always has at most one selection.
+Programmatic selection on a disabled button is refused.
+
+Use a two-way binding (`checked <=> model.field`) to keep the
+button in sync with an external property, including with a `for`
+over a model:
+
+```slint
+for m in model: RadioButton { text: m.name; checked <=> m.checked; }
+```
+
+A one-way binding (`checked: cond`) works for the initial state and
+stays reactive *until another button in the group is selected* — at
+that point the group writes `checked = false` and the binding to
+`cond` is severed. Prefer `<=>` for cases where `cond` keeps changing.
 </SlintProperty>
 
 ### Callbacks

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
@@ -104,7 +104,10 @@ button in sync with an external property, including with a `for`
 over a model:
 
 ```slint
-for m in model: RadioButton { text: m.name; checked <=> m.checked; }
+RadioGroup {
+    for m in [{ name: "Mobile", checked: false }, { name: "Desktop", checked: true }]:
+        RadioButton { text: m.name; checked <=> m.checked; }
+}
 ```
 
 A one-way binding (`checked: cond`) works for the initial state and

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
@@ -14,92 +14,113 @@ export component Example inherits Window {
     height: 150px;
     RadioGroup {
         title: "Target Platform";
-        model: [
-            { text: "Desktop" },
-            { text: "Mobile" },
-            { text: "Embedded" },
-        ];
-        current-index: 0;
+        RadioButton { text: "Desktop"; }
+        RadioButton { text: "Mobile"; }
+        RadioButton { text: "Embedded"; }
     }
 }
 ```
 </CodeSnippetMD>
 
-A group of radio buttons where the user can select exactly one option.
+A group of radio buttons where the user picks exactly one option.
+
+`RadioGroup` only accepts `RadioButton` children, either listed statically
+or produced by a single `for` loop.
+`if` inside a `RadioGroup` is not supported, and a `for` must be the only
+child of the group.
 
 ## Properties
 
-### current-index
-<SlintProperty propName="current-index" typeName="int" defaultValue="0" propertyVisibility="in-out">
-The index of the selected entry in `model`.
-```slint "current-index: 1;"
-RadioGroup {
-    model: [
-        { text: "Desktop" },
-        { text: "Mobile" },
-    ];
-    current-index: 1;
-}
-```
-</SlintProperty>
-
 ### current-value
 <SlintProperty propName="current-value" typeName="string" defaultValue='""' propertyVisibility="in-out">
-The `text` of the currently selected entry.
+The `text` of the currently selected `RadioButton`.
 </SlintProperty>
 
 ### enabled
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
-When `false`, the entire group and all its radio buttons cannot be interacted with.
+When `false`, the group and its buttons don't react to input.
 </SlintProperty>
 
 ### has-focus
 <SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out">
-Set to `true` when any radio button inside the group has keyboard focus.
-</SlintProperty>
-
-### model
-<SlintProperty propName="model" typeName="struct" structName="RadioEntry" defaultValue="[]">
-The list of options to display. Each entry has `text` and an optional `disabled` flag.
-
-```slint 'model: [{ text: "Desktop" }, { text: "Mobile", disabled: true }];'
-RadioGroup {
-    model: [
-        { text: "Desktop" },
-        { text: "Mobile", disabled: true },
-    ];
-}
-```
-
-:::note[Note]
-When setting this property, the `RadioGroup` preserves `current-index` when possible. If the `current-index` is larger than the new model length, it is clamped to the last item in the model.
-:::
-
+`true` while any radio button in the group has keyboard focus.
 </SlintProperty>
 
 ### title
 <SlintProperty propName="title" typeName="string" defaultValue='""'>
-An optional label rendered above the group. When empty, no title is shown.
+Optional label rendered above the group.
+Leave empty to hide it.
 </SlintProperty>
 
 ### orientation
 <SlintProperty propName="orientation" typeName="enum" enumName="Orientation" defaultValue="vertical" inlineReferenceDocs={false}>
-Use `Orientation.vertical` (default) to stack options, or `Orientation.horizontal` for a single row.
+Use `Orientation.vertical` (default) to stack the options, or `Orientation.horizontal` for a single row.
 </SlintProperty>
 
 ## Callbacks
 
 ### selected(string)
-Invoked when the user selects a different option. The argument is the `text` of the newly selected entry.
+Fires when the user picks a different option.
+The argument is the new entry's `text`.
 
-```slint {6-8}
+```slint {4-6}
 RadioGroup {
-    model: [
-        { text: "Desktop" },
-        { text: "Mobile" },
-    ];
+    RadioButton { text: "Desktop"; }
+    RadioButton { text: "Mobile"; }
     selected(value) => {
         debug("Selected: ", value);
+    }
+}
+```
+
+## RadioButton
+
+`RadioButton` is a pseudo-element that only appears inside `RadioGroup`.
+
+### Properties
+
+<SlintProperty propName="text" typeName="string" defaultValue='""'>
+Label shown next to the radio indicator.
+</SlintProperty>
+
+<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
+When `false`, the user can't select this button.
+The button stays visible.
+</SlintProperty>
+
+<SlintProperty propName="checked" typeName="bool" defaultValue="false" propertyVisibility="in-out">
+`true` when this is the currently selected button.
+Setting it to `true` selects this button; the previously-checked button
+becomes unchecked.
+Setting it to `false` on the currently-selected button is a no-op —
+the group always has at most one selection, and deselect-all from
+outside isn't supported.
+</SlintProperty>
+
+### Callbacks
+
+#### toggled()
+Fires when this button becomes the selection.
+
+```slint {3-5}
+RadioGroup {
+    RadioButton {
+        text: "Mobile";
+        toggled => { debug("Mobile selected"); }
+    }
+}
+```
+
+## Dynamic Buttons
+
+Drive the buttons from a model with `for`.
+The `for` must be the only child of the group — mixing it with static
+`RadioButton` siblings is rejected at compile time.
+
+```slint
+RadioGroup {
+    for option in ["Desktop", "Mobile", "Embedded"]: RadioButton {
+        text: option;
     }
 }
 ```

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
@@ -48,20 +48,18 @@ When `false`, the group and its buttons don't react to input.
 
 ### title
 <SlintProperty propName="title" typeName="string" defaultValue='""'>
-Optional label rendered above the group.
-Leave empty to hide it.
+An optional label rendered above the group. When empty, no title is shown.
 </SlintProperty>
 
 ### orientation
 <SlintProperty propName="orientation" typeName="enum" enumName="Orientation" defaultValue="vertical" inlineReferenceDocs={false}>
-Use `Orientation.vertical` (default) to stack the options, or `Orientation.horizontal` for a single row.
+Use `Orientation.vertical` (default) to stack options, or `Orientation.horizontal` for a single row.
 </SlintProperty>
 
 ## Callbacks
 
 ### selected(string)
-Fires when the user picks a different option.
-The argument is the new entry's `text`.
+Invoked when the user selects a different option. The argument is the `text` of the newly selected entry.
 
 ```slint {4-6}
 RadioGroup {
@@ -119,13 +117,13 @@ that point the group writes `checked = false` and the binding to
 ### Callbacks
 
 #### toggled()
-Fires when this button becomes the selection.
+Invoked when this button's `checked` state changes — both when it becomes the selection and when another button takes it over.
 
 ```slint {3-5}
 RadioGroup {
     RadioButton {
         text: "Mobile";
-        toggled => { debug("Mobile selected"); }
+        toggled => { debug("Mobile is now", self.checked ? "selected" : "unselected"); }
     }
 }
 ```
@@ -134,7 +132,7 @@ RadioGroup {
 
 Drive the buttons from a model with `for`.
 The `for` must be the only child of the group — mixing it with static
-`RadioButton` siblings is rejected at compile time.
+`RadioButton` siblings isn't supported.
 
 ```slint
 RadioGroup {

--- a/examples/gallery/ui/pages/controls_page.slint
+++ b/examples/gallery/ui/pages/controls_page.slint
@@ -187,7 +187,7 @@ export component ControlsPage inherits Page {
             RadioGroup {
                 title: @tr("Vertical Orientation");
                 enabled: GallerySettings.widgets-enabled;
-                RadioButton { text: @tr("Portrait"); }
+                RadioButton { text: @tr("Portrait"); checked: true; }
                 RadioButton { text: @tr("Landscape"); }
                 RadioButton { text: @tr("Auto"); enabled: false; }
             }
@@ -200,7 +200,7 @@ export component ControlsPage inherits Page {
                     debug("RadioGroup selected: ", value);
                 }
                 RadioButton { text: @tr("Start"); }
-                RadioButton { text: @tr("Center"); }
+                RadioButton { text: @tr("Center"); checked: true; }
                 RadioButton { text: @tr("End"); }
             }
         }

--- a/examples/gallery/ui/pages/controls_page.slint
+++ b/examples/gallery/ui/pages/controls_page.slint
@@ -187,27 +187,21 @@ export component ControlsPage inherits Page {
             RadioGroup {
                 title: @tr("Vertical Orientation");
                 enabled: GallerySettings.widgets-enabled;
-                model: [
-                    { text: @tr("Portrait") },
-                    { text: @tr("Landscape") },
-                    { text: @tr("Auto"), disabled: true },
-                ];
-                current-index: 0;
+                RadioButton { text: @tr("Portrait"); }
+                RadioButton { text: @tr("Landscape"); }
+                RadioButton { text: @tr("Auto"); enabled: false; }
             }
 
             RadioGroup {
                 title: @tr("Horizontal Orientation");
                 enabled: GallerySettings.widgets-enabled;
                 orientation: Orientation.horizontal;
-                model: [
-                    { text: @tr("Start") },
-                    { text: @tr("Center") },
-                    { text: @tr("End") },
-                ];
-                current-index: 1;
                 selected(value) => {
                     debug("RadioGroup selected: ", value);
                 }
+                RadioButton { text: @tr("Start"); }
+                RadioButton { text: @tr("Center"); }
+                RadioButton { text: @tr("End"); }
             }
         }
     }

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -118,15 +118,6 @@ macro_rules! for_each_builtin_structs {
                 text: SharedString,
             }
 
-            /// Represents one option in a `RadioGroup`.
-            #[non_exhaustive]
-            pub struct RadioEntry {
-                /// Label shown next to the radio button.
-                text: SharedString,
-                /// When `true`, this option is visible but not selectable.
-                disabled: bool,
-            }
-
             /// This is used to define the column and the column header of a TableView
             #[non_exhaustive]
             pub struct TableColumn {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2420,6 +2420,27 @@ export component TabWidget {
     //-is_internal
 }
 
+component RadioButton {
+    in property <string> text;
+    in property <bool> enabled: true;
+    in-out property <bool> checked;
+    callback toggled();
+}
+
+// Note: not a native class, handled in the lower_radiogroup pass
+export component RadioGroup {
+    in property <string> title;
+    in property <bool> enabled: true;
+    in property <Orientation> orientation;
+    in-out property <string> current-value;
+    out property <bool> has-focus;
+    callback selected(string);
+
+    //-disallow_global_types_as_child_elements
+    RadioButton { }
+    //-is_internal
+}
+
 /// ```slint playground
 /// export component Example inherits Window {
 ///     width: 100px;

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -36,6 +36,7 @@ mod lower_menus;
 mod lower_platform;
 mod lower_popups;
 mod lower_property_to_element;
+mod lower_radiogroup;
 mod lower_repeated_rows;
 mod lower_shadows;
 mod lower_states;
@@ -112,6 +113,7 @@ pub async fn run_passes(
     collect_libraries::collect_libraries(doc);
     collect_subcomponents::collect_subcomponents(doc);
     lower_tabwidget::lower_tabwidget(doc, type_loader, diag).await;
+    lower_radiogroup::lower_radiogroup(doc, type_loader, diag).await;
     lower_tooltips::lower_tooltips(doc, type_loader, diag).await;
     lower_menus::lower_menus(doc, type_loader, diag).await;
     lower_component_container::lower_component_container(doc, type_loader, diag);

--- a/internal/compiler/passes/lower_radiogroup.rs
+++ b/internal/compiler/passes/lower_radiogroup.rs
@@ -1,0 +1,235 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore radiogroup
+
+//! This pass lowers `RadioGroup` (a builtin pseudo-element) and its
+//! `RadioButton` children to the style's `RadioGroupImpl` / `RadioButtonImpl`.
+//!
+//! It must run before inlining because the lowered tree references components
+//! that themselves need to be inlined.
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::expression_tree::{Callable, Expression, NamedReference, Unit};
+use crate::langtype::{ElementType, Type};
+use crate::object_tree::*;
+use smol_str::SmolStr;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub async fn lower_radiogroup(
+    doc: &Document,
+    type_loader: &mut crate::typeloader::TypeLoader,
+    diag: &mut BuildDiagnostics,
+) {
+    let mut has_radiogroup = false;
+    doc.visit_all_used_components(|component| {
+        recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "RadioGroup") {
+                has_radiogroup = true;
+            }
+        })
+    });
+    if !has_radiogroup {
+        return;
+    }
+
+    let mut ignore = BuildDiagnostics::default();
+    let radio_group_impl = type_loader
+        .import_component("std-widgets-impl.slint", "RadioGroupImpl", &mut ignore)
+        .await
+        .expect("RadioGroupImpl should be in std-widgets-impl.slint");
+    let radio_button_impl = type_loader
+        .import_component("std-widgets-impl.slint", "RadioButtonImpl", &mut ignore)
+        .await
+        .expect("RadioButtonImpl should be in std-widgets-impl.slint");
+
+    doc.visit_all_used_components(|component| {
+        recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "RadioGroup") {
+                process_radiogroup(
+                    elem,
+                    ElementType::Component(radio_group_impl.clone()),
+                    ElementType::Component(radio_button_impl.clone()),
+                    diag,
+                );
+            }
+        })
+    });
+}
+
+fn is_radio_button(t: &ElementType) -> bool {
+    matches!(t, ElementType::Builtin(b) if b.name == "RadioButton")
+}
+
+fn process_radiogroup(
+    elem: &ElementRc,
+    radio_group_impl: ElementType,
+    radio_button_impl: ElementType,
+    diag: &mut BuildDiagnostics,
+) {
+    // Skip the style's re-export wrapper, which has the builtin RadioGroup as a
+    // direct base_type. Only the user instance is processed.
+    if matches!(&elem.borrow().base_type, ElementType::Builtin(_)) {
+        return;
+    }
+
+    // Borrow the children read-only for validation; do not take them out of
+    // the element yet, so that any early-return error path leaves the element
+    // intact for downstream passes (LSP/live-preview keep going past errors).
+    let children = elem.borrow().children.clone();
+
+    // Validate: every direct child must be a RadioButton, plain or wrapped in a
+    // `for` / `if` repeater.
+    for child in &children {
+        if !is_radio_button(&child.borrow().base_type) {
+            diag.push_error(
+                format!(
+                    "Only RadioButton is allowed inside RadioGroup, found {}",
+                    child.borrow().base_type
+                ),
+                &*child.borrow(),
+            );
+            elem.borrow_mut().base_type = radio_group_impl;
+            return;
+        }
+    }
+
+    // `if` is not allowed inside RadioGroup: there is no obvious way to keep
+    // selection state stable as conditions flip on and off. Static-only or a
+    // single `for` are the only shapes accepted.
+    if let Some(if_child) = children
+        .iter()
+        .find(|c| c.borrow().repeated.as_ref().is_some_and(|r| r.is_conditional_element))
+    {
+        diag.push_error("`if` is not allowed inside RadioGroup".into(), &*if_child.borrow());
+        elem.borrow_mut().base_type = radio_group_impl;
+        return;
+    }
+
+    // A `for` loop must be the only child: each for-instance uses the
+    // repeater's running index, which would collide with the source-position
+    // index used by static siblings. The filter explicitly excludes
+    // conditional repeaters even though those are already rejected above,
+    // so a future relaxation of the `if` rule can't make this message fire
+    // on the wrong shape.
+    if let Some(for_child) = children
+        .iter()
+        .find(|c| c.borrow().repeated.as_ref().is_some_and(|r| !r.is_conditional_element))
+        && children.len() > 1
+    {
+        diag.push_error(
+            "A `for` loop must be the only child of RadioGroup".into(),
+            &*for_child.borrow(),
+        );
+        elem.borrow_mut().base_type = radio_group_impl;
+        return;
+    }
+
+    elem.borrow_mut().base_type = radio_group_impl;
+
+    // item-count: model length for the sole-`for` case, otherwise the static
+    // children count. item-index: the repeater index for `for`, otherwise the
+    // child's source position.
+    let count_expr = match children.first().and_then(|c| c.borrow().repeated.clone()) {
+        Some(rep) if children.len() == 1 => Expression::FunctionCall {
+            function: Callable::Builtin(crate::expression_tree::BuiltinFunction::ArrayLength),
+            arguments: vec![rep.model],
+            source_location: None,
+        },
+        _ => Expression::NumberLiteral(children.len() as f64, Unit::None),
+    };
+    elem.borrow_mut()
+        .bindings
+        .insert(SmolStr::new_static("item-count"), RefCell::new(count_expr.into()));
+
+    for (position, child) in children.iter().enumerate() {
+        let item_index_expr = match &child.borrow().repeated {
+            Some(_) => Expression::RepeaterIndexReference { element: Rc::downgrade(child) },
+            None => Expression::NumberLiteral(position as f64, Unit::None),
+        };
+        wire_radio_button(elem, child, &radio_button_impl, item_index_expr);
+    }
+}
+
+fn wire_radio_button(
+    group: &ElementRc,
+    child: &ElementRc,
+    radio_button_impl: &ElementType,
+    item_index_expr: Expression,
+) {
+    child.borrow_mut().base_type = radio_button_impl.clone();
+
+    child
+        .borrow_mut()
+        .bindings
+        .insert(SmolStr::new_static("item-index"), RefCell::new(item_index_expr.into()));
+
+    child.borrow_mut().bindings.insert(
+        SmolStr::new_static("group-enabled"),
+        RefCell::new(
+            Expression::PropertyReference(NamedReference::new(group, "enabled".into())).into(),
+        ),
+    );
+
+    // row / col for the parent GridLayout — stack vertically (column 0,
+    // increasing rows) for vertical orientation, otherwise stack horizontally.
+    let orientation_vertical = crate::typeregister::BUILTIN
+        .with(|e| e.enums.Orientation.clone())
+        .try_value_from_string("vertical")
+        .unwrap();
+    let is_vertical = Expression::BinaryExpression {
+        lhs: Expression::PropertyReference(NamedReference::new(group, "orientation".into())).into(),
+        rhs: Expression::EnumerationValue(orientation_vertical).into(),
+        op: '=',
+    };
+    let item_index_ref =
+        || Expression::PropertyReference(NamedReference::new(child, "item-index".into()));
+    let row_expr = Expression::Condition {
+        condition: is_vertical.clone().into(),
+        true_expr: item_index_ref().into(),
+        false_expr: Expression::NumberLiteral(0.0, Unit::None).into(),
+    };
+    let col_expr = Expression::Condition {
+        condition: is_vertical.into(),
+        true_expr: Expression::NumberLiteral(0.0, Unit::None).into(),
+        false_expr: item_index_ref().into(),
+    };
+    child.borrow_mut().bindings.insert(SmolStr::new_static("row"), RefCell::new(row_expr.into()));
+    child.borrow_mut().bindings.insert(SmolStr::new_static("col"), RefCell::new(col_expr.into()));
+
+    // Bind `group-current-index` rather than `checked` directly: the latter
+    // is `in-out` so users can toggle it from outside, and an imperative
+    // write would replace the binding and break the radio-group invariant.
+    // The impl base's `changed group-current-index` handler is responsible
+    // for syncing `checked`.
+    let group_current_index_expr =
+        Expression::PropertyReference(NamedReference::new(group, "current-index".into()));
+    child.borrow_mut().bindings.insert(
+        SmolStr::new_static("group-current-index"),
+        RefCell::new(group_current_index_expr.into()),
+    );
+
+    let select_call = Expression::FunctionCall {
+        function: Callable::Function(NamedReference::new(group, "select".into())),
+        arguments: vec![
+            Expression::PropertyReference(NamedReference::new(child, "item-index".into())),
+            Expression::PropertyReference(NamedReference::new(child, "text".into())),
+        ],
+        source_location: None,
+    };
+    child
+        .borrow_mut()
+        .bindings
+        .insert(SmolStr::new_static("group-select"), RefCell::new(select_call.into()));
+
+    let focus_call = Expression::FunctionCall {
+        function: Callable::Function(NamedReference::new(group, "on-focus-change".into())),
+        arguments: vec![Expression::FunctionParameterReference { index: 0, ty: Type::Bool }],
+        source_location: None,
+    };
+    child
+        .borrow_mut()
+        .bindings
+        .insert(SmolStr::new_static("focus-change"), RefCell::new(focus_call.into()));
+}

--- a/internal/compiler/passes/lower_radiogroup.rs
+++ b/internal/compiler/passes/lower_radiogroup.rs
@@ -58,10 +58,6 @@ pub async fn lower_radiogroup(
     });
 }
 
-fn is_radio_button(t: &ElementType) -> bool {
-    matches!(t, ElementType::Builtin(b) if b.name == "RadioButton")
-}
-
 fn process_radiogroup(
     elem: &ElementRc,
     radio_group_impl: ElementType,
@@ -82,7 +78,8 @@ fn process_radiogroup(
     // Validate: every direct child must be a RadioButton, plain or wrapped in a
     // `for` / `if` repeater.
     for child in &children {
-        if !is_radio_button(&child.borrow().base_type) {
+        if !matches!(&child.borrow().base_type, ElementType::Builtin(b) if b.name == "RadioButton")
+        {
             diag.push_error(
                 format!(
                     "Only RadioButton is allowed inside RadioGroup, found {}",

--- a/internal/compiler/tests/syntax/elements/radiogroup.slint
+++ b/internal/compiler/tests/syntax/elements/radiogroup.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { RadioGroup } from "std-widgets.slint";
+
+export component Test inherits Rectangle {
+    RadioGroup {
+        Rectangle {}
+//      >        <error{Rectangle is not allowed within RadioGroup. Only RadioButton are valid children}
+    }
+
+    RadioButton {}
+//  >          <error{RadioButton can only be within a RadioGroup element}
+}

--- a/internal/compiler/tests/syntax/elements/radiogroup2.slint
+++ b/internal/compiler/tests/syntax/elements/radiogroup2.slint
@@ -1,0 +1,36 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { RadioGroup } from "std-widgets.slint";
+
+export component Test inherits Rectangle {
+    in-out property <[string]> opts: ["A"];
+    in-out property <bool> show: true;
+
+    // `if` is not allowed, on its own…
+    RadioGroup {
+        if root.show: RadioButton { text: "A"; }
+//                    >          <error{`if` is not allowed inside RadioGroup}
+    }
+
+    // …mixed with static siblings…
+    RadioGroup {
+        RadioButton { text: "A"; }
+        if root.show: RadioButton { text: "B"; }
+//                    >          <error{`if` is not allowed inside RadioGroup}
+    }
+
+    // …or next to a `for` loop.
+    RadioGroup {
+        for x in root.opts: RadioButton { text: x; }
+        if root.show: RadioButton { text: "B"; }
+//                    >          <error{`if` is not allowed inside RadioGroup}
+    }
+
+    // A `for` loop must be the only child.
+    RadioGroup {
+        RadioButton { text: "X"; }
+        for x in root.opts: RadioButton { text: x; }
+//                          >          <error{A `for` loop must be the only child of RadioGroup}
+    }
+}

--- a/internal/compiler/widgets/common/radiogroup-base.slint
+++ b/internal/compiler/widgets/common/radiogroup-base.slint
@@ -1,49 +1,153 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export struct RadioEntry {
-    text: string,
-    disabled: bool,
-}
+import { RadioButtonBase } from "radiobutton-base.slint";
 
 export component RadioGroupBase {
-    in property <[RadioEntry]> model;
     in property <bool> enabled: true;
-    in-out property <int> current-index: 0;
-    in-out property <string> current-value: root.model[root.current-index].text;
+    in-out property <int> current-index: -1;
+    in-out property <string> current-value;
 
     callback selected(string);
 
-    public function select(index: int) {
-        if root.enabled && index != root.current-index && index >= 0 && index < root.model.length && !root.model[index].disabled {
+    public function select(index: int, label: string) {
+        if root.enabled && index != root.current-index {
             root.current-index = index;
-            root.update-current-value();
-            root.selected(root.current-value);
+            root.current-value = label;
+            root.selected(label);
+        }
+    }
+}
+
+// Shared wiring between a `RadioGroup`'s `RadioButton` child and its parent
+// group. Each style's `RadioButtonImpl` inherits this and adds only the visual
+// layer.
+export component RadioButtonImplBase {
+    in property <string> text;
+    in property <bool> enabled: true;
+    in property <bool> group-enabled: true;
+    // Written from two sides: the `changed group-current-index` handler
+    // pushes the group's view in, and the user can set it programmatically.
+    // Imperative writes would replace any default binding, so the link to
+    // the group goes through `group-current-index` rather than a binding
+    // here.
+    in-out property <bool> checked;
+    in property <int> item-index;
+    // Mirror of the parent `RadioGroup`'s `current-index`, set by the
+    // lowering pass. Only ever read here.
+    in property <int> group-current-index: -1;
+
+    callback toggled;
+    callback group-select;
+    callback focus-change(bool);
+
+    out property <bool> has-focus <=> base.has-focus;
+    out property <bool> pressed <=> base.pressed;
+    out property <bool> has-hover <=> base.has-hover;
+
+    // Catch declarative initial state — `RadioButton { checked: true; }`
+    // doesn't fire `changed checked` because the binding hasn't *changed*
+    // since creation, so push the selection to the group from `init`.
+    init => {
+        if root.checked && root.group-current-index != root.item-index {
+            root.group-select();
         }
     }
 
-    function reset-current() {
-        if root.model.length == 0 {
-            root.current-index = 0;
+    // Pull: the group changed its selection, follow it.
+    changed group-current-index => {
+        if root.checked != (root.group-current-index == root.item-index) {
+            root.checked = root.group-current-index == root.item-index;
+        }
+    }
+
+    // Push: the user wrote `checked = true` from outside; tell the group.
+    // `checked = false` on the currently-selected button reverts to keep the
+    // group's invariant — deselecting all from outside isn't supported.
+    changed checked => {
+        if root.checked && root.group-current-index != root.item-index {
+            root.group-select();
+        } else if !root.checked && root.group-current-index == root.item-index {
+            root.checked = true;
+        }
+    }
+
+    base := RadioButtonBase {
+        label <=> root.text;
+        checked <=> root.checked;
+        enabled: root.enabled && root.group-enabled;
+        item-index <=> root.item-index;
+        selected => {
+            root.group-select();
+            root.toggled();
+        }
+        focus-change(g) => {
+            root.focus-change(g);
+        }
+    }
+    @children
+}
+
+// Shared container for a styled `RadioGroup`. Each style's `RadioGroupImpl`
+// inherits this and only sets the title-text appearance via `title-color`,
+// `title-font-size`, and `title-font-weight`. The buttons themselves flow
+// through the `@children` slot into an internal GridLayout; the lowering
+// pass sets each button's `row` and `col` from its `item-index` and the
+// group's `orientation`, so vertical and horizontal layouts come out of
+// the same GridLayout.
+export component RadioGroupImplBase {
+    in property <string> title;
+    in property <bool> enabled: true;
+    in property <Orientation> orientation: Orientation.vertical;
+    in property <int> item-count;
+
+    in property <brush> title-color;
+    in property <length> title-font-size;
+    in property <int> title-font-weight;
+
+    in-out property <int> current-index <=> sel.current-index;
+    in-out property <string> current-value <=> sel.current-value;
+    out property <bool> has-focus: focus-depth > 0;
+
+    callback selected <=> sel.selected;
+
+    public function select(index: int, label: string) {
+        sel.select(index, label);
+    }
+
+    public function on-focus-change(gained: bool) {
+        if gained {
+            focus-depth += 1;
         } else {
-            root.current-index = root.current-index.clamp(0, root.model.length - 1);
+            focus-depth = max(0, focus-depth - 1);
         }
-        root.update-current-value();
     }
 
-    function update-current-value() {
-        if root.current-index < 0 || root.current-index >= root.model.length {
-            root.current-value = "";
-            return;
+    private property <int> focus-depth: 0;
+
+    sel := RadioGroupBase {
+        enabled <=> root.enabled;
+    }
+
+    accessible-role: radio-group;
+    accessible-label: root.title;
+    accessible-enabled: root.enabled;
+    accessible-orientation: root.orientation;
+    accessible-item-count: root.item-count;
+
+    VerticalLayout {
+        spacing: 8px;
+
+        if root.title != "": Text {
+            color: root.title-color;
+            font-size: root.title-font-size;
+            font-weight: root.title-font-weight;
+            text: root.title;
         }
-        root.current-value = root.model[root.current-index].text;
-    }
 
-    changed model => {
-        root.reset-current();
-    }
-
-    changed current-index => {
-        root.update-current-value();
+        GridLayout {
+            spacing: 8px;
+            @children
+        }
     }
 }

--- a/internal/compiler/widgets/common/radiogroup-base.slint
+++ b/internal/compiler/widgets/common/radiogroup-base.slint
@@ -26,16 +26,15 @@ export component RadioButtonImplBase {
     in property <string> text;
     in property <bool> enabled: true;
     in property <bool> group-enabled: true;
-    // Written from two sides: the `changed group-current-index` handler
-    // pushes the group's view in, and the user can set it programmatically.
-    // Imperative writes would replace any default binding, so the link to
-    // the group goes through `group-current-index` rather than a binding
-    // here.
-    in-out property <bool> checked;
     in property <int> item-index;
     // Mirror of the parent `RadioGroup`'s `current-index`, set by the
     // lowering pass. Only ever read here.
     in property <int> group-current-index: -1;
+    // Default binding keeps `checked` synchronously reactive to the group
+    // selection. The user can override this with `checked: cond` or
+    // `checked <=> m.checked`, but doing so replaces the binding and means
+    // the override owns reactivity from then on — see the docs.
+    in-out property <bool> checked: root.group-current-index == root.item-index;
 
     callback toggled;
     callback group-select;
@@ -46,27 +45,37 @@ export component RadioButtonImplBase {
     out property <bool> has-hover <=> base.has-hover;
 
     // Catch declarative initial state — `RadioButton { checked: true; }`
-    // doesn't fire `changed checked` because the binding hasn't *changed*
-    // since creation, so push the selection to the group from `init`.
+    // replaces the default binding, so pull the group's view in from `init`
+    // and push the selection to the group if the user pre-selected.
     init => {
         if root.checked && root.group-current-index != root.item-index {
             root.group-select();
         }
     }
 
-    // Pull: the group changed its selection, follow it.
+    // When the default binding has been replaced (e.g. by `checked <=> m.checked`),
+    // the binding no longer tracks the group selection. This handler bridges
+    // the group state back into `checked` so the user's bound partner stays
+    // in sync. With the default binding still active, this fires too but is
+    // a no-op because the binding already updated `checked` synchronously.
     changed group-current-index => {
         if root.checked != (root.group-current-index == root.item-index) {
             root.checked = root.group-current-index == root.item-index;
         }
     }
 
-    // Push: the user wrote `checked = true` from outside; tell the group.
-    // `checked = false` on the currently-selected button reverts to keep the
-    // group's invariant — deselecting all from outside isn't supported.
+    // Push: the user wrote `checked = true` from outside (e.g. through a
+    // two-way binding to a model). Forward the intent to the group.
+    // `checked = false` on the currently-selected button reverts to keep
+    // the invariant — deselecting all from outside isn't supported.
+    // Disabled buttons can't claim selection.
     changed checked => {
         if root.checked && root.group-current-index != root.item-index {
-            root.group-select();
+            if root.enabled && root.group-enabled {
+                root.group-select();
+            } else {
+                root.checked = false;
+            }
         } else if !root.checked && root.group-current-index == root.item-index {
             root.checked = true;
         }
@@ -102,8 +111,10 @@ export component RadioGroupImplBase {
     in property <int> item-count;
 
     in property <brush> title-color;
-    in property <length> title-font-size;
-    in property <int> title-font-weight;
+    // Sensible defaults for styles that don't customize the title typography
+    // (e.g. qt, which inherits the system font).
+    in property <length> title-font-size: 13px;
+    in property <int> title-font-weight: 400;
 
     in-out property <int> current-index <=> sel.current-index;
     in-out property <string> current-value <=> sel.current-value;

--- a/internal/compiler/widgets/common/radiogroup-base.slint
+++ b/internal/compiler/widgets/common/radiogroup-base.slint
@@ -35,6 +35,10 @@ export component RadioButtonImplBase {
     // `checked <=> m.checked`, but doing so replaces the binding and means
     // the override owns reactivity from then on — see the docs.
     in-out property <bool> checked: root.group-current-index == root.item-index;
+    // Pure view of the group's selection — independent from `checked`, so the
+    // `changed` handler below fires only on real selection transitions and
+    // not on the brief revert loops in `changed checked`.
+    private property <bool> selected: root.group-current-index == root.item-index;
 
     callback toggled;
     callback group-select;
@@ -43,6 +47,12 @@ export component RadioButtonImplBase {
     out property <bool> has-focus <=> base.has-focus;
     out property <bool> pressed <=> base.pressed;
     out property <bool> has-hover <=> base.has-hover;
+
+    // Fires on every selection transition: when this button becomes the
+    // selection and when another button takes it over.
+    changed selected => {
+        root.toggled();
+    }
 
     // Catch declarative initial state — `RadioButton { checked: true; }`
     // replaces the default binding, so pull the group's view in from `init`
@@ -88,7 +98,6 @@ export component RadioButtonImplBase {
         item-index <=> root.item-index;
         selected => {
             root.group-select();
-            root.toggled();
         }
         focus-change(g) => {
             root.focus-change(g);

--- a/internal/compiler/widgets/cosmic/radiogroup.slint
+++ b/internal/compiler/widgets/cosmic/radiogroup.slint
@@ -2,29 +2,16 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { CosmicFontSettings, CosmicPalette } from "styling.slint";
-import { RadioButtonBase } from "../common/radiobutton-base.slint";
-import { RadioGroupBase, RadioEntry } from "../common/radiogroup-base.slint";
-import { StateLayer } from "components.slint";
+import { RadioButtonImplBase, RadioGroupImplBase } from "../common/radiogroup-base.slint";
 
-export { RadioEntry }
-
-component RadioButton {
-    in property <string> label <=> base.label;
-    in property <bool> enabled <=> base.enabled;
-    in property <bool> checked <=> base.checked;
-    in property <int> item-index <=> base.item-index;
-    out property <bool> has-focus <=> base.has-focus;
-
-    callback selected <=> base.selected;
-    callback focus-change <=> base.focus-change;
-
+export component RadioButtonImpl inherits RadioButtonImplBase {
     private property <brush> dot-color: root.checked ? CosmicPalette.accent-background : transparent;
     private property <color> text-color: CosmicPalette.control-foreground;
 
-    base := RadioButtonBase { }
+    min-height: max(28px, layout.min-height);
 
     states [
-        disabled when !root.enabled: {
+        disabled when !root.enabled || !root.group-enabled: {
             layout.opacity: 0.5;
         }
         checked when root.checked: {
@@ -61,8 +48,8 @@ component RadioButton {
             }
         }
 
-        if root.label != "": Text {
-            text: root.label;
+        if root.text != "": Text {
+            text: root.text;
             color: root.text-color;
             font-size: CosmicFontSettings.body.font-size;
             font-weight: CosmicFontSettings.body.font-weight;
@@ -72,65 +59,10 @@ component RadioButton {
     }
 }
 
-export component RadioGroup {
-    in property <string> title;
-    in property <bool> enabled: true;
-    in property <Orientation> orientation: Orientation.vertical;
-
-    in property <[RadioEntry]> model <=> base.model;
-    in-out property <int> current-index <=> base.current-index;
-    in-out property <string> current-value <=> base.current-value;
-
-    out property <bool> has-focus: root.focus-depth > 0;
-
-    callback selected <=> base.selected;
-
-    private property <int> focus-depth: 0;
-
-    base := RadioGroupBase {
-        enabled: root.enabled;
-    }
-
-    accessible-role: radio-group;
-    accessible-label: root.title;
-    accessible-enabled: root.enabled;
-    accessible-orientation: root.orientation;
-    accessible-item-count: root.model.length;
-
-    VerticalLayout {
-        spacing: 8px;
-
-        if root.title != "": Text {
-            color: root.enabled ? CosmicPalette.foreground : CosmicPalette.text-disabled;
-            font-size: CosmicFontSettings.body-strong.font-size;
-            font-weight: CosmicFontSettings.body-strong.font-weight;
-            text: root.title;
-        }
-
-        GridLayout {
-            spacing: 8px;
-
-            for entry[index] in root.model: RadioButton {
-                row: root.orientation == Orientation.vertical ? index : 0;
-                col: root.orientation == Orientation.vertical ? 0 : index;
-                label: entry.text;
-                enabled: root.enabled && !entry.disabled;
-                checked: root.current-index == index;
-                item-index: index;
-                height: 28px;
-
-                focus-change(gained) => {
-                    if (gained) {
-                        root.focus-depth += 1;
-                    } else {
-                        root.focus-depth = max(0, root.focus-depth - 1);
-                    }
-                }
-
-                selected => {
-                    base.select(index);
-                }
-            }
-        }
-    }
+export component RadioGroupImpl inherits RadioGroupImplBase {
+    title-color: root.enabled ? CosmicPalette.foreground : CosmicPalette.text-disabled;
+    title-font-size: CosmicFontSettings.body-strong.font-size;
+    title-font-weight: CosmicFontSettings.body-strong.font-weight;
 }
+
+export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -9,4 +9,5 @@ export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 export { StyleMetrics, Palette } from "style-base.slint";
 export { TabWidgetImpl, TabImpl, TabBarHorizontalImpl, TabBarVerticalImpl } from "tabwidget.slint";
 export { MenuBarImpl, PopupMenuImpl } from "../common/menus.slint";
+export { RadioButtonImpl, RadioGroupImpl } from "radiogroup.slint";
 export { ToolTipImpl } from "../common/tooltip-base.slint";

--- a/internal/compiler/widgets/cosmic/std-widgets.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets.slint
@@ -11,7 +11,7 @@ export { CheckBox } from "checkbox.slint";
 export { ComboBox } from "combobox.slint";
 export { GroupBox } from "groupbox.slint";
 export { LineEdit } from "lineedit.slint";
-export { RadioEntry, RadioGroup } from "radiogroup.slint";
+export { RadioGroup } from "radiogroup.slint";
 export { ListView, StandardListView } from "../common/listview.slint";
 export { ProgressIndicator } from "progressindicator.slint";
 export { Slider } from "slider.slint";

--- a/internal/compiler/widgets/cupertino/radiogroup.slint
+++ b/internal/compiler/widgets/cupertino/radiogroup.slint
@@ -2,31 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
-import { RadioButtonBase } from "../common/radiobutton-base.slint";
-import { RadioGroupBase, RadioEntry } from "../common/radiogroup-base.slint";
+import { RadioButtonImplBase, RadioGroupImplBase } from "../common/radiogroup-base.slint";
 import { FocusBorder } from "components.slint";
 
-export { RadioEntry }
-
-component RadioButton {
-    in property <string> label <=> base.label;
-    in property <bool> enabled <=> base.enabled;
-    in property <bool> checked <=> base.checked;
-    in property <int> item-index <=> base.item-index;
-    out property <bool> has-focus <=> base.has-focus;
-
-    callback selected <=> base.selected;
-    callback focus-change <=> base.focus-change;
-
+export component RadioButtonImpl inherits RadioButtonImplBase {
     private property <brush> dot-color: root.checked ? CupertinoPalette.accent-background : transparent;
 
-    base := RadioButtonBase { }
+    min-height: max(28px, layout.min-height);
 
     states [
-        disabled when !root.enabled: {
+        disabled when !root.enabled || !root.group-enabled: {
             layout.opacity: 0.5;
         }
-        pressed when base.pressed: {
+        pressed when root.pressed: {
             root.dot-color: root.checked ? CupertinoPalette.secondary-accent-background : CupertinoPalette.hover;
         }
     ]
@@ -55,8 +43,8 @@ component RadioButton {
             }
         }
 
-        if root.label != "": Text {
-            text: root.label;
+        if root.text != "": Text {
+            text: root.text;
             color: CupertinoPalette.foreground;
             font-size: CupertinoFontSettings.body.font-size;
             font-weight: CupertinoFontSettings.body.font-weight;
@@ -65,70 +53,15 @@ component RadioButton {
         }
     }
 
-    if root.has-focus && root.enabled: FocusBorder {
+    if root.has-focus && root.enabled && root.group-enabled: FocusBorder {
         border-radius: 7px;
     }
 }
 
-export component RadioGroup {
-    in property <string> title;
-    in property <bool> enabled: true;
-    in property <Orientation> orientation: Orientation.vertical;
-
-    in property <[RadioEntry]> model <=> base.model;
-    in-out property <int> current-index <=> base.current-index;
-    in-out property <string> current-value <=> base.current-value;
-
-    out property <bool> has-focus: root.focus-depth > 0;
-
-    callback selected <=> base.selected;
-
-    private property <int> focus-depth: 0;
-
-    base := RadioGroupBase {
-        enabled: root.enabled;
-    }
-
-    accessible-role: radio-group;
-    accessible-label: root.title;
-    accessible-enabled: root.enabled;
-    accessible-orientation: root.orientation;
-    accessible-item-count: root.model.length;
-
-    VerticalLayout {
-        spacing: 8px;
-
-        if root.title != "": Text {
-            color: root.enabled ? CupertinoPalette.foreground : CupertinoPalette.foreground-secondary;
-            font-size: CupertinoFontSettings.body-strong.font-size;
-            font-weight: CupertinoFontSettings.body-strong.font-weight;
-            text: root.title;
-        }
-
-        GridLayout {
-            spacing: 8px;
-
-            for entry[index] in root.model: RadioButton {
-                row: root.orientation == Orientation.vertical ? index : 0;
-                col: root.orientation == Orientation.vertical ? 0 : index;
-                label: entry.text;
-                enabled: root.enabled && !entry.disabled;
-                checked: root.current-index == index;
-                item-index: index;
-                height: 28px;
-
-                focus-change(gained) => {
-                    if (gained) {
-                        root.focus-depth += 1;
-                    } else {
-                        root.focus-depth = max(0, root.focus-depth - 1);
-                    }
-                }
-
-                selected => {
-                    base.select(index);
-                }
-            }
-        }
-    }
+export component RadioGroupImpl inherits RadioGroupImplBase {
+    title-color: root.enabled ? CupertinoPalette.foreground : CupertinoPalette.foreground-secondary;
+    title-font-size: CupertinoFontSettings.body-strong.font-size;
+    title-font-weight: CupertinoFontSettings.body-strong.font-weight;
 }
+
+export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -9,4 +9,5 @@ export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 export { StyleMetrics, Palette } from "style-base.slint";
 export { TabWidgetImpl, TabImpl, TabBarHorizontalImpl, TabBarVerticalImpl } from "tabwidget.slint";
 export { MenuBarImpl, PopupMenuImpl } from "../common/menus.slint";
+export { RadioButtonImpl, RadioGroupImpl } from "radiogroup.slint";
 export { ToolTipImpl } from "../common/tooltip-base.slint";

--- a/internal/compiler/widgets/cupertino/std-widgets.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets.slint
@@ -11,7 +11,7 @@ export { CheckBox } from "checkbox.slint";
 export { ComboBox } from "combobox.slint";
 export { GroupBox } from "groupbox.slint";
 export { LineEdit } from "lineedit.slint";
-export { RadioEntry, RadioGroup } from "radiogroup.slint";
+export { RadioGroup } from "radiogroup.slint";
 export { ListView, StandardListView } from "../common/listview.slint";
 export { ProgressIndicator } from "progressindicator.slint";
 export { Slider } from "slider.slint";

--- a/internal/compiler/widgets/fluent/radiogroup.slint
+++ b/internal/compiler/widgets/fluent/radiogroup.slint
@@ -1,43 +1,29 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { FluentFontSettings, FluentPalette, Icons } from "styling.slint";
-import { RadioButtonBase } from "../common/radiobutton-base.slint";
-import { RadioGroupBase, RadioEntry } from "../common/radiogroup-base.slint";
+import { FluentFontSettings, FluentPalette } from "styling.slint";
+import { RadioButtonImplBase, RadioGroupImplBase } from "../common/radiogroup-base.slint";
 import { FocusBorder } from "components.slint";
 
-export { RadioEntry }
-
-component RadioButton {
-    in property <string> label <=> base.label;
-    in property <bool> enabled <=> base.enabled;
-    in property <bool> checked <=> base.checked;
-    in property <int> item-index <=> base.item-index;
-    out property <bool> has-focus <=> base.has-focus;
-
-    callback selected <=> base.selected;
-    callback focus-change <=> base.focus-change;
-
+export component RadioButtonImpl inherits RadioButtonImplBase {
     private property <color> text-color: FluentPalette.foreground;
 
-    min-height: max(18px, layout.min-height);
-
-    base := RadioButtonBase { }
+    min-height: max(32px, layout.min-height);
 
     states [
-        disabled when !root.enabled: {
+        disabled when !root.enabled || !root.group-enabled: {
             outer.border-color: root.checked ? transparent : FluentPalette.control-strong-stroke-disabled;
             outer.background: FluentPalette.control-alt-disabled;
             inner.border-color: root.checked ? FluentPalette.accent-disabled : transparent;
             root.text-color: FluentPalette.text-disabled;
         }
-        pressed when base.pressed: {
+        pressed when root.pressed: {
             outer.background: transparent;
             inner.border-color: root.checked ? FluentPalette.tertiary-accent-background : FluentPalette.control-alt-quaternary;
             outer.border-color: root.checked ? transparent : FluentPalette.control-strong-stroke-disabled;
             inner.border-width: root.checked ? 7px : 5px;
         }
-        hover when base.has-hover: {
+        hover when root.has-hover: {
             outer.background: root.checked ? transparent : FluentPalette.control-alt-tertiary;
             inner.border-width: root.checked ? 5px : 0px;
         }
@@ -72,8 +58,8 @@ component RadioButton {
             }
         }
 
-        if root.label != "": Text {
-            text: root.label;
+        if root.text != "": Text {
+            text: root.text;
             color: root.text-color;
             font-size: FluentFontSettings.body.font-size;
             font-weight: FluentFontSettings.body.font-weight;
@@ -82,70 +68,15 @@ component RadioButton {
         }
     }
 
-    if root.has-focus && root.enabled: FocusBorder {
+    if root.has-focus && root.enabled && root.group-enabled: FocusBorder {
         border-radius: 7px;
     }
 }
 
-export component RadioGroup {
-    in property <string> title;
-    in property <bool> enabled: true;
-    in property <Orientation> orientation: Orientation.vertical;
-
-    in property <[RadioEntry]> model <=> base.model;
-    in-out property <int> current-index <=> base.current-index;
-    in-out property <string> current-value <=> base.current-value;
-
-    out property <bool> has-focus: root.focus-depth > 0;
-
-    callback selected <=> base.selected;
-
-    private property <int> focus-depth: 0;
-
-    base := RadioGroupBase {
-        enabled: root.enabled;
-    }
-
-    accessible-role: radio-group;
-    accessible-label: root.title;
-    accessible-enabled: root.enabled;
-    accessible-orientation: root.orientation;
-    accessible-item-count: root.model.length;
-
-    VerticalLayout {
-        spacing: 8px;
-
-        if root.title != "": Text {
-            color: !root.enabled ? FluentPalette.text-disabled : FluentPalette.control-foreground;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
-            text: root.title;
-        }
-
-        GridLayout {
-            spacing: 8px;
-
-            for entry[index] in root.model: RadioButton {
-                row: root.orientation == Orientation.vertical ? index : 0;
-                col: root.orientation == Orientation.vertical ? 0 : index;
-                label: entry.text;
-                enabled: root.enabled && !entry.disabled;
-                checked: root.current-index == index;
-                item-index: index;
-                height: 32px;
-
-                focus-change(gained) => {
-                    if (gained) {
-                        root.focus-depth += 1;
-                    } else {
-                        root.focus-depth = max(0, root.focus-depth - 1);
-                    }
-                }
-
-                selected => {
-                    base.select(index);
-                }
-            }
-        }
-    }
+export component RadioGroupImpl inherits RadioGroupImplBase {
+    title-color: !root.enabled ? FluentPalette.text-disabled : FluentPalette.control-foreground;
+    title-font-size: FluentFontSettings.body.font-size;
+    title-font-weight: FluentFontSettings.body.font-weight;
 }
+
+export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -9,4 +9,5 @@ export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 export { StyleMetrics, Palette } from "style-base.slint";
 export { TabWidgetImpl, TabImpl, TabBarHorizontalImpl, TabBarVerticalImpl } from "tabwidget.slint";
 export { MenuBarImpl, PopupMenuImpl } from "../common/menus.slint";
+export { RadioButtonImpl, RadioGroupImpl } from "radiogroup.slint";
 export { ToolTipImpl } from "../common/tooltip-base.slint";

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -11,7 +11,7 @@ export { CheckBox } from "checkbox.slint";
 export { ComboBox } from "combobox.slint";
 export { GroupBox } from "groupbox.slint";
 export { LineEdit } from "lineedit.slint";
-export { RadioEntry, RadioGroup } from "radiogroup.slint";
+export { RadioGroup } from "radiogroup.slint";
 export { ListView, StandardListView } from "../common/listview.slint";
 export { ProgressIndicator } from "progressindicator.slint";
 export { Slider } from "slider.slint";

--- a/internal/compiler/widgets/material/radiogroup.slint
+++ b/internal/compiler/widgets/material/radiogroup.slint
@@ -2,39 +2,27 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { MaterialFontSettings, MaterialPalette } from "styling.slint";
-import { RadioButtonBase } from "../common/radiobutton-base.slint";
-import { RadioGroupBase, RadioEntry } from "../common/radiogroup-base.slint";
+import { RadioButtonImplBase, RadioGroupImplBase } from "../common/radiogroup-base.slint";
 
-export { RadioEntry }
-
-component RadioButton {
-    in property <string> label <=> base.label;
-    in property <bool> enabled <=> base.enabled;
-    in property <bool> checked <=> base.checked;
-    in property <int> item-index <=> base.item-index;
-    out property <bool> has-focus <=> base.has-focus;
-
-    callback selected <=> base.selected;
-    callback focus-change <=> base.focus-change;
-
+export component RadioButtonImpl inherits RadioButtonImplBase {
     private property <color> text-color: MaterialPalette.foreground;
 
-    base := RadioButtonBase { }
+    min-height: max(32px, layout.min-height);
 
     states [
-        disabled when !root.enabled: {
+        disabled when !root.enabled || !root.group-enabled: {
             outer.border-color: root.checked ? transparent : MaterialPalette.border-variant;
             outer.background: MaterialPalette.surface-container;
             inner.border-color: root.checked ? MaterialPalette.control-foreground-variant : transparent;
             root.text-color: MaterialPalette.control-foreground-variant;
         }
-        pressed when base.pressed: {
+        pressed when root.pressed: {
             outer.background: transparent;
             inner.border-color: root.checked ? MaterialPalette.accent-background : MaterialPalette.border;
             outer.border-color: root.checked ? transparent : MaterialPalette.border;
             inner.border-width: root.checked ? 7px : 5px;
         }
-        hover when base.has-hover: {
+        hover when root.has-hover: {
             outer.background: root.checked ? transparent : MaterialPalette.surface-container;
             inner.border-width: root.checked ? 5px : 0px;
         }
@@ -67,8 +55,8 @@ component RadioButton {
             }
         }
 
-        if root.label != "": Text {
-            text: root.label;
+        if root.text != "": Text {
+            text: root.text;
             color: root.text-color;
             font-size: MaterialFontSettings.body-large.font-size;
             font-weight: MaterialFontSettings.body-large.font-weight;
@@ -78,65 +66,10 @@ component RadioButton {
     }
 }
 
-export component RadioGroup {
-    in property <string> title;
-    in property <bool> enabled: true;
-    in property <Orientation> orientation: Orientation.vertical;
-
-    in property <[RadioEntry]> model <=> base.model;
-    in-out property <int> current-index <=> base.current-index;
-    in-out property <string> current-value <=> base.current-value;
-
-    out property <bool> has-focus: root.focus-depth > 0;
-
-    callback selected <=> base.selected;
-
-    private property <int> focus-depth: 0;
-
-    base := RadioGroupBase {
-        enabled: root.enabled;
-    }
-
-    accessible-role: radio-group;
-    accessible-label: root.title;
-    accessible-enabled: root.enabled;
-    accessible-orientation: root.orientation;
-    accessible-item-count: root.model.length;
-
-    VerticalLayout {
-        spacing: 8px;
-
-        if root.title != "": Text {
-            color: !root.enabled ? MaterialPalette.control-foreground-variant : MaterialPalette.foreground;
-            font-size: MaterialFontSettings.body-large.font-size;
-            font-weight: MaterialFontSettings.body-large.font-weight;
-            text: root.title;
-        }
-
-        GridLayout {
-            spacing: 8px;
-
-            for entry[index] in root.model: RadioButton {
-                row: root.orientation == Orientation.vertical ? index : 0;
-                col: root.orientation == Orientation.vertical ? 0 : index;
-                label: entry.text;
-                enabled: root.enabled && !entry.disabled;
-                checked: root.current-index == index;
-                item-index: index;
-                height: 32px;
-
-                focus-change(gained) => {
-                    if (gained) {
-                        root.focus-depth += 1;
-                    } else {
-                        root.focus-depth = max(0, root.focus-depth - 1);
-                    }
-                }
-
-                selected => {
-                    base.select(index);
-                }
-            }
-        }
-    }
+export component RadioGroupImpl inherits RadioGroupImplBase {
+    title-color: !root.enabled ? MaterialPalette.control-foreground-variant : MaterialPalette.foreground;
+    title-font-size: MaterialFontSettings.body-large.font-size;
+    title-font-weight: MaterialFontSettings.body-large.font-weight;
 }
+
+export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -12,4 +12,5 @@ export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 export { StyleMetrics, Palette } from "style-base.slint";
 export { TabWidgetImpl, TabImpl, TabBarHorizontalImpl, TabBarVerticalImpl } from "tabwidget.slint";
 export { MenuBarImpl, PopupMenuImpl } from "../common/menus.slint";
+export { RadioButtonImpl, RadioGroupImpl } from "radiogroup.slint";
 export { ToolTipImpl } from "../common/tooltip-base.slint";

--- a/internal/compiler/widgets/material/std-widgets.slint
+++ b/internal/compiler/widgets/material/std-widgets.slint
@@ -21,4 +21,4 @@ export { Spinner } from "spinner.slint";
 export { TextEdit } from "textedit.slint";
 export { TimePickerPopup, Time } from "time-picker.slint";
 export { DatePickerPopup, Date } from "./datepicker.slint";
-export { RadioGroup, RadioEntry } from "radiogroup.slint";
+export { RadioGroup } from "radiogroup.slint";

--- a/internal/compiler/widgets/qt/radiogroup.slint
+++ b/internal/compiler/widgets/qt/radiogroup.slint
@@ -1,30 +1,18 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { RadioButtonBase } from "../common/radiobutton-base.slint";
-import { RadioGroupBase, RadioEntry } from "../common/radiogroup-base.slint";
+import { RadioButtonImplBase, RadioGroupImplBase } from "../common/radiogroup-base.slint";
 
-export { RadioEntry }
-
-component RadioButton {
-    in property <string> label <=> base.label;
-    in property <bool> enabled <=> base.enabled;
-    in property <bool> checked <=> base.checked;
-    in property <int> item-index <=> base.item-index;
-    out property <bool> has-focus <=> base.has-focus;
-
-    callback selected <=> base.selected;
-    callback focus-change <=> base.focus-change;
-
+export component RadioButtonImpl inherits RadioButtonImplBase {
     private property <brush> dot-color: root.checked ? #2f78ff : transparent;
 
-    base := RadioButtonBase { }
+    min-height: max(28px, layout.min-height);
 
     states [
-        disabled when !root.enabled: {
+        disabled when !root.enabled || !root.group-enabled: {
             layout.opacity: 0.5;
         }
-        pressed when base.pressed: {
+        pressed when root.pressed: {
             root.dot-color: root.checked ? #205ed8 : #d0d0d0;
         }
     ]
@@ -53,15 +41,15 @@ component RadioButton {
             }
         }
 
-        if root.label != "": Text {
-            text: root.label;
+        if root.text != "": Text {
+            text: root.text;
             color: #202020;
             vertical-alignment: center;
             horizontal-alignment: left;
         }
     }
 
-    if root.has-focus && root.enabled: Rectangle {
+    if root.has-focus && root.enabled && root.group-enabled: Rectangle {
         x: -2px;
         y: -2px;
         width: parent.width + 4px;
@@ -72,63 +60,8 @@ component RadioButton {
     }
 }
 
-export component RadioGroup {
-    in property <string> title;
-    in property <bool> enabled: true;
-    in property <Orientation> orientation: Orientation.vertical;
-
-    in property <[RadioEntry]> model <=> base.model;
-    in-out property <int> current-index <=> base.current-index;
-    in-out property <string> current-value <=> base.current-value;
-
-    out property <bool> has-focus: root.focus-depth > 0;
-
-    callback selected <=> base.selected;
-
-    private property <int> focus-depth: 0;
-
-    base := RadioGroupBase {
-        enabled: root.enabled;
-    }
-
-    accessible-role: radio-group;
-    accessible-label: root.title;
-    accessible-enabled: root.enabled;
-    accessible-orientation: root.orientation;
-    accessible-item-count: root.model.length;
-
-    VerticalLayout {
-        spacing: 8px;
-
-        if root.title != "": Text {
-            color: root.enabled ? #202020 : #808080;
-            text: root.title;
-        }
-
-        GridLayout {
-            spacing: 8px;
-
-            for entry[index] in root.model: RadioButton {
-                row: root.orientation == Orientation.vertical ? index : 0;
-                col: root.orientation == Orientation.vertical ? 0 : index;
-                label: entry.text;
-                enabled: root.enabled && !entry.disabled;
-                checked: root.current-index == index;
-                item-index: index;
-                height: 28px;
-
-                focus-change(gained) => {
-                    if (gained) {
-                        root.focus-depth += 1;
-                    } else {
-                        root.focus-depth = max(0, root.focus-depth - 1);
-                    }
-                }
-
-                selected => {
-                    base.select(index);
-                }
-            }
-        }
-    }
+export component RadioGroupImpl inherits RadioGroupImplBase {
+    title-color: root.enabled ? #202020 : #808080;
 }
+
+export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/qt/std-widgets-impl.slint
+++ b/internal/compiler/widgets/qt/std-widgets-impl.slint
@@ -15,4 +15,5 @@ export component ListItem inherits NativeStandardListViewItem {
 
 export { TabWidgetImpl, TabImpl, TabBarHorizontalImpl, TabBarVerticalImpl } from "tabwidget.slint";
 export { MenuBarImpl, PopupMenuImpl } from "../common/menus.slint";
+export { RadioButtonImpl, RadioGroupImpl } from "radiogroup.slint";
 export { ToolTipImpl } from "../common/tooltip-base.slint";

--- a/internal/compiler/widgets/qt/std-widgets.slint
+++ b/internal/compiler/widgets/qt/std-widgets.slint
@@ -11,7 +11,7 @@ export { Slider } from "slider.slint";
 export { Switch } from "switch.slint";
 export { GroupBox } from "groupbox.slint";
 export { LineEdit } from "lineedit.slint";
-export { RadioEntry, RadioGroup } from "radiogroup.slint";
+export { RadioGroup } from "radiogroup.slint";
 export { ComboBox } from "combobox.slint";
 export { TabWidget } from "tabwidget.slint";
 export { VerticalBox, HorizontalBox, GridBox } from "../common/layout.slint";

--- a/tests/cases/widgets/radiogroup.slint
+++ b/tests/cases/widgets/radiogroup.slint
@@ -9,26 +9,30 @@ export component TestCase inherits Window {
 
     in-out property <int> selected-count: 0;
     in-out property <string> last-selected;
-    in-out property <int> current-index <=> group.current-index;
     in-out property <string> current-value <=> group.current-value;
     out property <bool> has-focus <=> group.has-focus;
+    out property <bool> test: current-value == "" && selected-count == 0;
 
     HorizontalLayout {
         alignment: start;
         group := RadioGroup {
             title: "Colors";
-            current-index: -1;
-            model: [
-                { text: "Red" },
-                { text: "Green" },
-                { text: "Blue", disabled: true },
-            ];
+            red-btn := RadioButton { text: "Red"; }
+            green-btn := RadioButton { text: "Green"; }
+            RadioButton { text: "Blue"; enabled: false; }
             selected(value) => {
                 root.selected-count += 1;
                 root.last-selected = value;
             }
         }
     }
+
+    public function set-red() { red-btn.checked = true; }
+    public function set-green() { green-btn.checked = true; }
+    public function unset-red() { red-btn.checked = false; }
+
+    out property <bool> red-checked: red-btn.checked;
+    out property <bool> green-checked: green-btn.checked;
 }
 
 /*
@@ -42,8 +46,9 @@ use slint_testing::{AccessibleRole, Orientation};
 let instance = TestCase::new().unwrap();
 
 // Nothing is selected initially.
-assert_eq!(instance.get_current_index(), -1);
+assert!(instance.get_test());
 assert_eq!(instance.get_selected_count(), 0);
+assert_eq!(instance.get_current_value(), SharedString::from(""));
 assert_eq!(instance.get_has_focus(), false);
 
 // The group exposes its accessibility properties, including orientation and the size of the set.
@@ -73,13 +78,11 @@ assert_eq!(blue.accessible_enabled(), Some(false));
 // (keyboard navigation with the arrow keys is not yet implemented).
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Tab));
 assert_eq!(instance.get_has_focus(), true);
-assert_eq!(instance.get_current_index(), -1);
 assert_eq!(instance.get_selected_count(), 0);
 assert_eq!(red.accessible_checked(), Some(false));
 
 // Clicking a radio button updates the selection.
 red.mock_single_click(PointerEventButton::Left);
-assert_eq!(instance.get_current_index(), 0);
 assert_eq!(instance.get_current_value(), SharedString::from("Red"));
 assert_eq!(instance.get_selected_count(), 1);
 assert_eq!(instance.get_last_selected(), SharedString::from("Red"));
@@ -87,12 +90,11 @@ assert_eq!(red.accessible_checked(), Some(true));
 
 // Clicking the already-checked radio button does not update the selection again.
 red.mock_single_click(PointerEventButton::Left);
-assert_eq!(instance.get_current_index(), 0);
 assert_eq!(instance.get_selected_count(), 1);
+assert_eq!(red.accessible_checked(), Some(true));
 
 // Clicking another radio button updates the selection.
 green.mock_single_click(PointerEventButton::Left);
-assert_eq!(instance.get_current_index(), 1);
 assert_eq!(instance.get_current_value(), SharedString::from("Green"));
 assert_eq!(instance.get_selected_count(), 2);
 assert_eq!(instance.get_last_selected(), SharedString::from("Green"));
@@ -101,12 +103,11 @@ assert_eq!(red.accessible_checked(), Some(false));
 
 // Clicking a disabled radio button does nothing.
 blue.mock_single_click(PointerEventButton::Left);
-assert_eq!(instance.get_current_index(), 1);
 assert_eq!(instance.get_selected_count(), 2);
+assert_eq!(green.accessible_checked(), Some(true));
 
 // The accessible default action selects a radio button and updates the checked state.
 red.invoke_accessible_default_action();
-assert_eq!(instance.get_current_index(), 0);
 assert_eq!(instance.get_selected_count(), 3);
 assert_eq!(instance.get_last_selected(), SharedString::from("Red"));
 assert_eq!(red.accessible_checked(), Some(true));
@@ -114,15 +115,36 @@ assert_eq!(green.accessible_checked(), Some(false));
 
 // The accessible default action on the already-checked button does not update the selection again.
 red.invoke_accessible_default_action();
-assert_eq!(instance.get_current_index(), 0);
 assert_eq!(instance.get_selected_count(), 3);
 assert_eq!(red.accessible_checked(), Some(true));
 
 // The accessible default action does nothing on a disabled radio button.
 blue.invoke_accessible_default_action();
-assert_eq!(instance.get_current_index(), 0);
 assert_eq!(instance.get_selected_count(), 3);
 assert_eq!(blue.accessible_checked(), Some(false));
+
+// Programmatic `checked = true` from outside selects the button and updates
+// the group; the previously-checked button goes unchecked.
+instance.invoke_set_green();
+assert_eq!(instance.get_current_value(), SharedString::from("Green"));
+assert_eq!(instance.get_selected_count(), 4);
+assert_eq!(instance.get_green_checked(), true);
+assert_eq!(instance.get_red_checked(), false);
+assert_eq!(green.accessible_checked(), Some(true));
+assert_eq!(red.accessible_checked(), Some(false));
+
+// Setting `checked = true` on the already-selected button is a no-op.
+instance.invoke_set_green();
+assert_eq!(instance.get_selected_count(), 4);
+
+// Setting `checked = false` on the selected button reverts — deselect-all
+// isn't supported from outside.
+instance.invoke_set_red();
+assert_eq!(instance.get_current_value(), SharedString::from("Red"));
+assert_eq!(instance.get_red_checked(), true);
+instance.invoke_unset_red();
+assert_eq!(instance.get_red_checked(), true);
+assert_eq!(instance.get_current_value(), SharedString::from("Red"));
 ```
 
 */

--- a/tests/cases/widgets/radiogroup.slint
+++ b/tests/cases/widgets/radiogroup.slint
@@ -19,7 +19,7 @@ export component TestCase inherits Window {
             title: "Colors";
             red-btn := RadioButton { text: "Red"; }
             green-btn := RadioButton { text: "Green"; }
-            RadioButton { text: "Blue"; enabled: false; }
+            blue-btn := RadioButton { text: "Blue"; enabled: false; }
             selected(value) => {
                 root.selected-count += 1;
                 root.last-selected = value;
@@ -30,9 +30,11 @@ export component TestCase inherits Window {
     public function set-red() { red-btn.checked = true; }
     public function set-green() { green-btn.checked = true; }
     public function unset-red() { red-btn.checked = false; }
+    public function set-blue() { blue-btn.checked = true; }
 
     out property <bool> red-checked: red-btn.checked;
     out property <bool> green-checked: green-btn.checked;
+    out property <bool> blue-checked: blue-btn.checked;
 }
 
 /*
@@ -125,7 +127,12 @@ assert_eq!(blue.accessible_checked(), Some(false));
 
 // Programmatic `checked = true` from outside selects the button and updates
 // the group; the previously-checked button goes unchecked.
+// `invoke_accessible_default_action` doesn't tick the event loop, so the
+// `changed group-current-index` handler is still queued — flush before
+// writing so the queued sync doesn't race with the user write.
+slint_testing::mock_elapsed_time(0);
 instance.invoke_set_green();
+slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_current_value(), SharedString::from("Green"));
 assert_eq!(instance.get_selected_count(), 4);
 assert_eq!(instance.get_green_checked(), true);
@@ -135,16 +142,27 @@ assert_eq!(red.accessible_checked(), Some(false));
 
 // Setting `checked = true` on the already-selected button is a no-op.
 instance.invoke_set_green();
+slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_selected_count(), 4);
 
 // Setting `checked = false` on the selected button reverts — deselect-all
 // isn't supported from outside.
 instance.invoke_set_red();
+slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_current_value(), SharedString::from("Red"));
 assert_eq!(instance.get_red_checked(), true);
 instance.invoke_unset_red();
+slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_red_checked(), true);
 assert_eq!(instance.get_current_value(), SharedString::from("Red"));
+
+// Programmatic `checked = true` on a disabled button is refused —
+// selection state and the previously-selected button are unchanged.
+instance.invoke_set_blue();
+slint_testing::mock_elapsed_time(0);
+assert_eq!(instance.get_current_value(), SharedString::from("Red"));
+assert_eq!(instance.get_red_checked(), true);
+assert_eq!(instance.get_blue_checked(), false);
 ```
 
 */

--- a/tests/cases/widgets/radiogroup.slint
+++ b/tests/cases/widgets/radiogroup.slint
@@ -9,6 +9,8 @@ export component TestCase inherits Window {
 
     in-out property <int> selected-count: 0;
     in-out property <string> last-selected;
+    in-out property <int> red-toggled-count: 0;
+    in-out property <int> green-toggled-count: 0;
     in-out property <string> current-value <=> group.current-value;
     out property <bool> has-focus <=> group.has-focus;
     out property <bool> test: current-value == "" && selected-count == 0;
@@ -17,8 +19,14 @@ export component TestCase inherits Window {
         alignment: start;
         group := RadioGroup {
             title: "Colors";
-            red-btn := RadioButton { text: "Red"; }
-            green-btn := RadioButton { text: "Green"; }
+            red-btn := RadioButton {
+                text: "Red";
+                toggled => { root.red-toggled-count += 1; }
+            }
+            green-btn := RadioButton {
+                text: "Green";
+                toggled => { root.green-toggled-count += 1; }
+            }
             blue-btn := RadioButton { text: "Blue"; enabled: false; }
             selected(value) => {
                 root.selected-count += 1;
@@ -89,11 +97,15 @@ assert_eq!(instance.get_current_value(), SharedString::from("Red"));
 assert_eq!(instance.get_selected_count(), 1);
 assert_eq!(instance.get_last_selected(), SharedString::from("Red"));
 assert_eq!(red.accessible_checked(), Some(true));
+// `toggled` fires on the button that becomes selected.
+assert_eq!(instance.get_red_toggled_count(), 1);
+assert_eq!(instance.get_green_toggled_count(), 0);
 
 // Clicking the already-checked radio button does not update the selection again.
 red.mock_single_click(PointerEventButton::Left);
 assert_eq!(instance.get_selected_count(), 1);
 assert_eq!(red.accessible_checked(), Some(true));
+assert_eq!(instance.get_red_toggled_count(), 1);
 
 // Clicking another radio button updates the selection.
 green.mock_single_click(PointerEventButton::Left);
@@ -102,6 +114,9 @@ assert_eq!(instance.get_selected_count(), 2);
 assert_eq!(instance.get_last_selected(), SharedString::from("Green"));
 assert_eq!(green.accessible_checked(), Some(true));
 assert_eq!(red.accessible_checked(), Some(false));
+// `toggled` fires on both the newly-selected button and the one losing the selection.
+assert_eq!(instance.get_green_toggled_count(), 1);
+assert_eq!(instance.get_red_toggled_count(), 2);
 
 // Clicking a disabled radio button does nothing.
 blue.mock_single_click(PointerEventButton::Left);

--- a/tests/cases/widgets/radiogroup_for.slint
+++ b/tests/cases/widgets/radiogroup_for.slint
@@ -1,0 +1,68 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { RadioGroup } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    in-out property <[string]> options: ["A", "B", "C"];
+    in-out property <string> current-value <=> group.current-value;
+
+    HorizontalLayout {
+        alignment: start;
+        group := RadioGroup {
+            title: "Letters";
+            for opt in root.options: RadioButton { text: opt; }
+        }
+    }
+
+    out property <bool> test: current-value == "";
+}
+
+/*
+```rust
+use slint::SharedString;
+use slint::platform::PointerEventButton;
+
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_current_value(), SharedString::from(""));
+assert!(instance.get_test());
+
+let a = slint_testing::ElementHandle::find_by_accessible_label(&instance, "A").next().unwrap();
+let b = slint_testing::ElementHandle::find_by_accessible_label(&instance, "B").next().unwrap();
+let c = slint_testing::ElementHandle::find_by_accessible_label(&instance, "C").next().unwrap();
+assert_eq!(a.accessible_item_index(), Some(0));
+assert_eq!(b.accessible_item_index(), Some(1));
+assert_eq!(c.accessible_item_index(), Some(2));
+
+b.mock_single_click(PointerEventButton::Left);
+assert_eq!(instance.get_current_value(), SharedString::from("B"));
+assert_eq!(b.accessible_checked(), Some(true));
+// Exclusivity: only the clicked button is checked.
+assert_eq!(a.accessible_checked(), Some(false));
+assert_eq!(c.accessible_checked(), Some(false));
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_current_value(), "");
+
+auto a = slint::testing::ElementHandle::find_by_accessible_label(handle, "A")[0];
+auto b = slint::testing::ElementHandle::find_by_accessible_label(handle, "B")[0];
+auto c = slint::testing::ElementHandle::find_by_accessible_label(handle, "C")[0];
+assert_eq(a.accessible_item_index().value(), 0);
+assert_eq(b.accessible_item_index().value(), 1);
+assert_eq(c.accessible_item_index().value(), 2);
+
+b.invoke_accessible_default_action();
+assert_eq(instance.get_current_value(), "B");
+assert_eq(b.accessible_checked().value(), true);
+assert_eq(a.accessible_checked().value(), false);
+assert_eq(c.accessible_checked().value(), false);
+```
+*/

--- a/tests/cases/widgets/radiogroup_model.slint
+++ b/tests/cases/widgets/radiogroup_model.slint
@@ -65,8 +65,10 @@ assert_eq!(instance.invoke_get_checked(1), false);
 assert_eq!(instance.invoke_get_checked(2), false);
 
 // Writing the model from outside drives the group too: setting C selects C
-// and clears A.
+// and clears A. The propagation goes through a `changed` handler, so flush
+// the event loop before inspecting the result.
 instance.invoke_set_checked(2, true);
+slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_current_value(), SharedString::from("C"));
 assert_eq!(instance.invoke_get_checked(0), false);
 assert_eq!(instance.invoke_get_checked(1), false);
@@ -75,6 +77,7 @@ assert_eq!(instance.invoke_get_checked(2), true);
 // Setting `checked = false` on the currently-selected entry reverts —
 // deselect-all from outside isn't supported.
 instance.invoke_set_checked(2, false);
+slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_current_value(), SharedString::from("C"));
 assert_eq!(instance.invoke_get_checked(2), true);
 ```

--- a/tests/cases/widgets/radiogroup_model.slint
+++ b/tests/cases/widgets/radiogroup_model.slint
@@ -1,0 +1,81 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { RadioGroup } from "std-widgets.slint";
+
+struct Item {
+    name: string,
+    checked: bool,
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    in-out property <[Item]> model: [
+        { name: "A", checked: false },
+        { name: "B", checked: true },
+        { name: "C", checked: false },
+    ];
+    in-out property <string> current-value <=> group.current-value;
+
+    HorizontalLayout {
+        alignment: start;
+        group := RadioGroup {
+            for m in root.model: RadioButton {
+                text: m.name;
+                checked <=> m.checked;
+            }
+        }
+    }
+
+    public function set-checked(idx: int, value: bool) {
+        root.model[idx].checked = value;
+    }
+    public function get-checked(idx: int) -> bool {
+        return root.model[idx].checked;
+    }
+
+    // The init pass on RadioButtonImplBase picks up the declarative
+    // `checked: true` on item B and pushes it through to the group.
+    out property <bool> test: current-value == "B" && !root.model[0].checked
+        && root.model[1].checked && !root.model[2].checked;
+}
+
+/*
+```rust
+use slint::SharedString;
+use slint::platform::PointerEventButton;
+
+let instance = TestCase::new().unwrap();
+
+// The model's initial `checked: true` on item B drives the group state.
+assert!(instance.get_test());
+assert_eq!(instance.get_current_value(), SharedString::from("B"));
+assert_eq!(instance.invoke_get_checked(0), false);
+assert_eq!(instance.invoke_get_checked(1), true);
+assert_eq!(instance.invoke_get_checked(2), false);
+
+// Clicking A updates the model: A → true, B → false.
+let a = slint_testing::ElementHandle::find_by_accessible_label(&instance, "A").next().unwrap();
+a.mock_single_click(PointerEventButton::Left);
+assert_eq!(instance.get_current_value(), SharedString::from("A"));
+assert_eq!(instance.invoke_get_checked(0), true);
+assert_eq!(instance.invoke_get_checked(1), false);
+assert_eq!(instance.invoke_get_checked(2), false);
+
+// Writing the model from outside drives the group too: setting C selects C
+// and clears A.
+instance.invoke_set_checked(2, true);
+assert_eq!(instance.get_current_value(), SharedString::from("C"));
+assert_eq!(instance.invoke_get_checked(0), false);
+assert_eq!(instance.invoke_get_checked(1), false);
+assert_eq!(instance.invoke_get_checked(2), true);
+
+// Setting `checked = false` on the currently-selected entry reverts —
+// deselect-all from outside isn't supported.
+instance.invoke_set_checked(2, false);
+assert_eq!(instance.get_current_value(), SharedString::from("C"));
+assert_eq!(instance.invoke_get_checked(2), true);
+```
+*/


### PR DESCRIPTION
RadioGroup is now a builtin pseudo-element with RadioButton children instead of a [RadioEntry] model. RadioButton.enabled defaults to true, fixing the old disabled-polarity.

    RadioGroup {
        RadioButton { text: "Red"; }
        RadioButton { text: "Green"; checked: true; }
        selected(value) => { ... }
    }

Static buttons or a single `for` over a model are accepted. `if` and mixing `for` with siblings are not. We also dropped the public current-index property; both can come back later — `if` support needs current-index to follow the selection as conditions flip.

RadioButton.checked is in-out and round-trips with a model:

    for m in model: RadioButton { checked <=> m.checked; }

Clicks update the model; writing the model selects the matching button. Setting checked to false on the currently-selected button reverts — deselect-all from outside isn't supported.

Also fixes #11918: the lowering pass sets each button's row/col from `orientation`, so all five styles now honor it uniformly.
