### PR TITLE
remote viewer: Add device name for non-ios devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10880,6 +10880,7 @@ dependencies = [
  "i-slint-core",
  "i-slint-live-preview",
  "itertools 0.14.0",
+ "jni 0.22.4",
  "mdns-sd 0.17.2",
  "serde_json",
  "shlex",

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -131,6 +131,12 @@ pub struct Connection {
     /// outside this set are ignored, so unrelated edits in the user's editor don't trigger a
     /// rebuild. Updated by the viewer after each compile.
     dependencies: Arc<Mutex<HashSet<Url>>>,
+    /// Friendly device name shown to remote clients; also used as the mDNS instance name.
+    /// Always non-empty (an IP-derived label is substituted if no name source resolved).
+    /// On Apple this field does not exist — the name comes from Bonjour when the service
+    /// is registered.
+    #[cfg(not(target_vendor = "apple"))]
+    device_name: String,
 }
 
 /// Whether the connection can act on this URL. The remote preview protocol only handles
@@ -147,6 +153,7 @@ fn is_supported(url: &Url) -> bool {
 impl Connection {
     pub async fn listen(
         address: Option<SocketAddr>,
+        #[cfg(not(target_vendor = "apple"))] device_name_override: Option<String>,
         message_handler: impl Fn(ConnectionMessage) + 'static + Send + Sync,
     ) -> anyhow::Result<Self> {
         let file_cache = Arc::new(DashMap::<Url, CacheEntry>::new());
@@ -241,13 +248,30 @@ impl Connection {
         let local_addr = local_addr_receiver.await??;
         tracing::info!("Listening on {}", local_addr);
 
+        #[cfg(not(target_vendor = "apple"))]
+        let device_name = {
+            let raw =
+                device_name_override.filter(|n| !n.is_empty()).unwrap_or_else(default_device_name);
+            if raw.is_empty() { ip_derived_device_name(&local_ips_for(local_addr)) } else { raw }
+        };
         Ok(Self {
             local_addr,
             thread_handle: Some((thread_handle, quit_sender)),
             message_sender,
             file_cache,
             dependencies,
+            #[cfg(not(target_vendor = "apple"))]
+            device_name,
         })
+    }
+
+    /// Friendly device name to advertise over mDNS and show in the viewer UI on non-Apple
+    /// platforms. Guaranteed non-empty: an IP-derived label is substituted when no
+    /// user-set source was available. On Apple the name comes from Bonjour after the
+    /// service is registered, so this method is not available there.
+    #[cfg(not(target_vendor = "apple"))]
+    pub fn device_name(&self) -> &str {
+        &self.device_name
     }
 
     /// Replace the set of URLs the connection treats as relevant. A subsequent `SetContents`
@@ -460,31 +484,7 @@ impl Connection {
     }
 
     pub fn local_ips(&self) -> Vec<IpAddr> {
-        let unspecified = match self.local_addr {
-            SocketAddr::V4(socket_addr_v4) => socket_addr_v4.ip().is_unspecified(),
-            SocketAddr::V6(socket_addr_v6) => socket_addr_v6.ip().is_unspecified(),
-        };
-        if unspecified {
-            let mut ips: Vec<IpAddr> =
-                getifs::interface_addrs_by_filter(|addr| !addr.is_loopback())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|net| net.addr())
-                    .collect();
-            if ips.is_empty() {
-                // Fallback: open a UDP socket to a public address (nothing is
-                // sent) and read back the local IP the OS picked.
-                if let Ok(sock) = std::net::UdpSocket::bind("0.0.0.0:0")
-                    && sock.connect("8.8.8.8:80").is_ok()
-                    && let Ok(addr) = sock.local_addr()
-                {
-                    ips.push(addr.ip());
-                }
-            }
-            ips
-        } else {
-            vec![self.local_addr.ip()]
-        }
+        local_ips_for(self.local_addr)
     }
     pub fn local_port(&self) -> u16 {
         self.local_addr.port()
@@ -494,29 +494,22 @@ impl Connection {
     pub fn service(&self) -> anyhow::Result<ServiceInfo> {
         let local_ips = self.local_ips();
         let local_port = self.local_port();
-        let host = hostname::get()?;
-        let host = host.to_str().unwrap_or("unknown");
-        // "localhost" is useless for mDNS — derive a name from the first IP instead.
-        // The instance name is what the editor shows to the user, so prefer the
-        // machine's hostname (these platforms have no separate "device name" the way
-        // iOS/macOS do); fall back to an IP-derived name when it's missing.
-        let instance_name = if host == "localhost" || host.is_empty() {
-            local_ips
-                .first()
-                .map(|ip| format!("slint-viewer-{ip}"))
-                .unwrap_or_else(|| "slint-viewer".into())
-        } else {
-            host.to_owned()
-        };
-        let mdns_host = format!("{instance_name}.local.");
-        tracing::info!("Announcing service on {local_ips:?} as {mdns_host}");
+        // The instance name is the user-visible label in editors and can contain spaces,
+        // apostrophes, or non-ASCII characters. The SRV target ("host name") is consumed
+        // by DNS resolvers and must be limited to LDH characters / RFC 1035 label limits.
+        let mdns_host = format!("{}.local.", sanitize_dns_label(&self.device_name));
+        tracing::info!(
+            "Announcing service on {local_ips:?} as {} ({})",
+            self.device_name,
+            mdns_host
+        );
         let properties = HashMap::from([
             (TXT_PROTOCOLS_KEY.to_owned(), PROTOCOL_SUBPROTOCOL.to_owned()),
             (TXT_SLINT_VERSION_KEY.to_owned(), SLINT_VERSION.to_owned()),
         ]);
         ServiceInfo::new(
             crate::protocol::SERVICE_TYPE,
-            &instance_name,
+            &self.device_name,
             &mdns_host,
             local_ips.as_slice(),
             local_port,
@@ -526,11 +519,157 @@ impl Connection {
     }
 }
 
+fn local_ips_for(local_addr: SocketAddr) -> Vec<IpAddr> {
+    let unspecified = match local_addr {
+        SocketAddr::V4(socket_addr_v4) => socket_addr_v4.ip().is_unspecified(),
+        SocketAddr::V6(socket_addr_v6) => socket_addr_v6.ip().is_unspecified(),
+    };
+    if unspecified {
+        let mut ips: Vec<IpAddr> = getifs::interface_addrs_by_filter(|addr| !addr.is_loopback())
+            .unwrap_or_default()
+            .into_iter()
+            .map(|net| net.addr())
+            .collect();
+        if ips.is_empty() {
+            // Fallback: open a UDP socket to a public address (nothing is
+            // sent) and read back the local IP the OS picked.
+            if let Ok(sock) = std::net::UdpSocket::bind("0.0.0.0:0")
+                && sock.connect("8.8.8.8:80").is_ok()
+                && let Ok(addr) = sock.local_addr()
+            {
+                ips.push(addr.ip());
+            }
+        }
+        ips
+    } else {
+        vec![local_addr.ip()]
+    }
+}
+
+/// Compute the friendly device name to advertise on non-Apple platforms.
+///
+/// On Linux, prefer the systemd "pretty hostname" the user sets in Settings → About →
+/// Device Name (`PRETTY_HOSTNAME=` in `/etc/machine-info`). Everywhere else, fall back to
+/// the system hostname. `localhost` and empty strings are treated as missing so the caller
+/// can substitute an IP-derived label.
+#[cfg(not(target_vendor = "apple"))]
+fn default_device_name() -> String {
+    #[cfg(target_os = "linux")]
+    if let Some(pretty) = read_pretty_hostname() {
+        return non_localhost(pretty);
+    }
+    let host = hostname::get().ok().and_then(|h| h.into_string().ok()).unwrap_or_default();
+    non_localhost(host)
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn non_localhost(name: String) -> String {
+    if name == "localhost" { String::new() } else { name }
+}
+
+/// Fallback when no user-set device name is available. Picks a label derived from the
+/// first non-loopback local IP so the user can still tell two instances apart.
+#[cfg(not(target_vendor = "apple"))]
+fn ip_derived_device_name(local_ips: &[IpAddr]) -> String {
+    local_ips
+        .first()
+        .map(|ip| format!("slint-viewer-{ip}"))
+        .unwrap_or_else(|| "slint-viewer".into())
+}
+
+/// Convert a friendly device name into a DNS label suitable for the SRV target. Replaces
+/// non-LDH characters with `-`, collapses repeats, trims leading/trailing dashes, and
+/// clamps to the RFC 1035 63-octet label limit. Returns a safe fallback for empty inputs.
+#[cfg(not(target_vendor = "apple"))]
+fn sanitize_dns_label(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_dash = true;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.len() > 63 {
+        out.truncate(63);
+        while out.ends_with('-') {
+            out.pop();
+        }
+    }
+    if out.is_empty() { "slint-viewer".to_owned() } else { out }
+}
+
+/// Parse the PRETTY_HOSTNAME entry from /etc/machine-info. Handles unquoted values,
+/// single- or double-quoted values, and a trailing `# comment`. Does not implement
+/// systemd's full shell-style escape rules — values containing `\"` come through as-is.
+#[cfg(target_os = "linux")]
+fn read_pretty_hostname() -> Option<String> {
+    let contents = std::fs::read_to_string("/etc/machine-info").ok()?;
+    for line in contents.lines() {
+        let rest = match line.trim_start().strip_prefix("PRETTY_HOSTNAME=") {
+            Some(rest) => rest.trim_start(),
+            None => continue,
+        };
+        let value = match rest.chars().next() {
+            Some(quote @ ('"' | '\'')) => {
+                let after_open = &rest[quote.len_utf8()..];
+                let end = after_open.find(quote)?;
+                after_open[..end].to_owned()
+            }
+            _ => rest.split(['#']).next().unwrap_or("").trim_end().to_owned(),
+        };
+        let value = value.trim();
+        if !value.is_empty() {
+            return Some(value.to_owned());
+        }
+    }
+    None
+}
+
 impl Drop for Connection {
     fn drop(&mut self) {
         if let Some((thread_handle, quit_sender)) = self.thread_handle.take() {
             quit_sender.send(()).ok();
             thread_handle.join().ok();
         }
+    }
+}
+
+#[cfg(all(test, not(target_vendor = "apple")))]
+mod tests {
+    use super::sanitize_dns_label;
+
+    #[test]
+    fn sanitize_keeps_alnum() {
+        assert_eq!(sanitize_dns_label("MyBox42"), "MyBox42");
+    }
+
+    #[test]
+    fn sanitize_replaces_spaces_and_quotes() {
+        assert_eq!(sanitize_dns_label("Simon's Laptop"), "Simon-s-Laptop");
+    }
+
+    #[test]
+    fn sanitize_collapses_runs_and_trims_dashes() {
+        assert_eq!(sanitize_dns_label("  hello   world  "), "hello-world");
+        assert_eq!(sanitize_dns_label("---abc---"), "abc");
+    }
+
+    #[test]
+    fn sanitize_truncates_to_63_octets() {
+        let long = "a".repeat(200);
+        assert_eq!(sanitize_dns_label(&long).len(), 63);
+    }
+
+    #[test]
+    fn sanitize_falls_back_for_empty_or_all_invalid() {
+        assert_eq!(sanitize_dns_label(""), "slint-viewer");
+        assert_eq!(sanitize_dns_label("@@@"), "slint-viewer");
     }
 }

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore alnum localdomain notlocalhost
+
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
@@ -131,12 +133,11 @@ pub struct Connection {
     /// outside this set are ignored, so unrelated edits in the user's editor don't trigger a
     /// rebuild. Updated by the viewer after each compile.
     dependencies: Arc<Mutex<HashSet<Url>>>,
-    /// Friendly device name shown to remote clients; also used as the mDNS instance name.
-    /// Always non-empty (an IP-derived label is substituted if no name source resolved).
-    /// On Apple this field does not exist — the name comes from Bonjour when the service
-    /// is registered.
-    #[cfg(not(target_vendor = "apple"))]
-    device_name: String,
+    /// Friendly device name shown to remote clients; also used as the mDNS instance name
+    /// on non-Apple platforms. Always non-empty: an IP-derived label is substituted if no
+    /// name source resolved. On Apple, the initial value is the system hostname; the
+    /// viewer overwrites it with the Bonjour-reported name once the service is registered.
+    device_name: Mutex<String>,
 }
 
 /// Whether the connection can act on this URL. The remote preview protocol only handles
@@ -153,7 +154,7 @@ fn is_supported(url: &Url) -> bool {
 impl Connection {
     pub async fn listen(
         address: Option<SocketAddr>,
-        #[cfg(not(target_vendor = "apple"))] device_name_override: Option<String>,
+        device_name_override: Option<String>,
         message_handler: impl Fn(ConnectionMessage) + 'static + Send + Sync,
     ) -> anyhow::Result<Self> {
         let file_cache = Arc::new(DashMap::<Url, CacheEntry>::new());
@@ -248,7 +249,6 @@ impl Connection {
         let local_addr = local_addr_receiver.await??;
         tracing::info!("Listening on {}", local_addr);
 
-        #[cfg(not(target_vendor = "apple"))]
         let device_name = {
             let raw =
                 device_name_override.filter(|n| !n.is_empty()).unwrap_or_else(default_device_name);
@@ -260,18 +260,24 @@ impl Connection {
             message_sender,
             file_cache,
             dependencies,
-            #[cfg(not(target_vendor = "apple"))]
-            device_name,
+            device_name: Mutex::new(device_name),
         })
     }
 
-    /// Friendly device name to advertise over mDNS and show in the viewer UI on non-Apple
-    /// platforms. Guaranteed non-empty: an IP-derived label is substituted when no
-    /// user-set source was available. On Apple the name comes from Bonjour after the
-    /// service is registered, so this method is not available there.
-    #[cfg(not(target_vendor = "apple"))]
-    pub fn device_name(&self) -> &str {
-        &self.device_name
+    /// Friendly device name to advertise over mDNS and show in the viewer UI.
+    /// Guaranteed non-empty: an IP-derived label is substituted when no user-set source
+    /// is available. On Apple the value starts as the system hostname and is overwritten
+    /// by [`Self::set_device_name`] once Bonjour reports the registered instance name.
+    pub fn device_name(&self) -> String {
+        self.device_name.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    /// Replace the friendly device name. Empty or whitespace-only values are ignored so
+    /// callers can pass the raw output of an mDNS registration without pre-checking.
+    pub fn set_device_name(&self, name: String) {
+        if !name.trim().is_empty() {
+            *self.device_name.lock().unwrap_or_else(|e| e.into_inner()) = name;
+        }
     }
 
     /// Replace the set of URLs the connection treats as relevant. A subsequent `SetContents`
@@ -497,19 +503,16 @@ impl Connection {
         // The instance name is the user-visible label in editors and can contain spaces,
         // apostrophes, or non-ASCII characters. The SRV target ("host name") is consumed
         // by DNS resolvers and must be limited to LDH characters / RFC 1035 label limits.
-        let mdns_host = format!("{}.local.", sanitize_dns_label(&self.device_name));
-        tracing::info!(
-            "Announcing service on {local_ips:?} as {} ({})",
-            self.device_name,
-            mdns_host
-        );
+        let device_name = self.device_name();
+        let mdns_host = format!("{}.local.", sanitize_dns_label(&device_name));
+        tracing::info!("Announcing service on {local_ips:?} as {device_name} ({mdns_host})");
         let properties = HashMap::from([
             (TXT_PROTOCOLS_KEY.to_owned(), PROTOCOL_SUBPROTOCOL.to_owned()),
             (TXT_SLINT_VERSION_KEY.to_owned(), SLINT_VERSION.to_owned()),
         ]);
         ServiceInfo::new(
             crate::protocol::SERVICE_TYPE,
-            &self.device_name,
+            &device_name,
             &mdns_host,
             local_ips.as_slice(),
             local_port,
@@ -546,30 +549,35 @@ fn local_ips_for(local_addr: SocketAddr) -> Vec<IpAddr> {
     }
 }
 
-/// Compute the friendly device name to advertise on non-Apple platforms.
+/// Compute the friendly device name to advertise.
 ///
 /// On Linux, prefer the systemd "pretty hostname" the user sets in Settings → About →
 /// Device Name (`PRETTY_HOSTNAME=` in `/etc/machine-info`). Everywhere else, fall back to
 /// the system hostname. `localhost` and empty strings are treated as missing so the caller
-/// can substitute an IP-derived label.
-#[cfg(not(target_vendor = "apple"))]
+/// can substitute an IP-derived label. On Apple, the viewer overwrites this with the
+/// Bonjour-reported friendly name once the service is registered.
 fn default_device_name() -> String {
     #[cfg(target_os = "linux")]
     if let Some(pretty) = read_pretty_hostname() {
-        return non_localhost(pretty);
+        let cleaned = non_localhost(pretty);
+        if !cleaned.is_empty() {
+            return cleaned;
+        }
     }
     let host = hostname::get().ok().and_then(|h| h.into_string().ok()).unwrap_or_default();
     non_localhost(host)
 }
 
-#[cfg(not(target_vendor = "apple"))]
+/// Treat any `localhost` variant as missing — bare `localhost`, the RHEL/CentOS default
+/// `localhost.localdomain`, or case variants — so the caller falls through to the
+/// IP-derived label rather than advertising a name that conflicts with every other host.
 fn non_localhost(name: String) -> String {
-    if name == "localhost" { String::new() } else { name }
+    let lower = name.to_ascii_lowercase();
+    if lower == "localhost" || lower.starts_with("localhost.") { String::new() } else { name }
 }
 
 /// Fallback when no user-set device name is available. Picks a label derived from the
 /// first non-loopback local IP so the user can still tell two instances apart.
-#[cfg(not(target_vendor = "apple"))]
 fn ip_derived_device_name(local_ips: &[IpAddr]) -> String {
     local_ips
         .first()
@@ -605,28 +613,32 @@ fn sanitize_dns_label(name: &str) -> String {
     if out.is_empty() { "slint-viewer".to_owned() } else { out }
 }
 
-/// Parse the PRETTY_HOSTNAME entry from /etc/machine-info. Handles unquoted values,
-/// single- or double-quoted values, and a trailing `# comment`. Does not implement
-/// systemd's full shell-style escape rules — values containing `\"` come through as-is.
+/// Parse the PRETTY_HOSTNAME entry from /etc/machine-info. Handles unquoted values and
+/// single- or double-quoted values. Does not implement systemd's full shell-style escape
+/// rules — values containing `\"` come through as-is. The systemd env-file format only
+/// treats `#` as a comment at the start of a line, so `#` mid-value is preserved.
 #[cfg(target_os = "linux")]
 fn read_pretty_hostname() -> Option<String> {
     let contents = std::fs::read_to_string("/etc/machine-info").ok()?;
+    parse_pretty_hostname(&contents)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_pretty_hostname(contents: &str) -> Option<String> {
     for line in contents.lines() {
-        let rest = match line.trim_start().strip_prefix("PRETTY_HOSTNAME=") {
-            Some(rest) => rest.trim_start(),
-            None => continue,
-        };
+        let Some(rest) = line.trim_start().strip_prefix("PRETTY_HOSTNAME=") else { continue };
+        let rest = rest.trim_start();
         let value = match rest.chars().next() {
             Some(quote @ ('"' | '\'')) => {
                 let after_open = &rest[quote.len_utf8()..];
-                let end = after_open.find(quote)?;
+                // Malformed (unterminated) quote: skip this line, don't abandon the file.
+                let Some(end) = after_open.find(quote) else { continue };
                 after_open[..end].to_owned()
             }
-            _ => rest.split(['#']).next().unwrap_or("").trim_end().to_owned(),
+            _ => rest.trim_end().to_owned(),
         };
-        let value = value.trim();
         if !value.is_empty() {
-            return Some(value.to_owned());
+            return Some(value);
         }
     }
     None
@@ -671,5 +683,77 @@ mod tests {
     fn sanitize_falls_back_for_empty_or_all_invalid() {
         assert_eq!(sanitize_dns_label(""), "slint-viewer");
         assert_eq!(sanitize_dns_label("@@@"), "slint-viewer");
+    }
+}
+
+#[cfg(test)]
+mod parser_tests {
+    use super::{non_localhost, parse_pretty_hostname};
+
+    #[test]
+    fn non_localhost_drops_variants() {
+        assert!(non_localhost("localhost".into()).is_empty());
+        assert!(non_localhost("LOCALHOST".into()).is_empty());
+        assert!(non_localhost("localhost.localdomain".into()).is_empty());
+        assert!(non_localhost("localhost.local".into()).is_empty());
+    }
+
+    #[test]
+    fn non_localhost_keeps_others() {
+        assert_eq!(non_localhost("notlocalhost".into()), "notlocalhost");
+        assert_eq!(non_localhost("simon".into()), "simon");
+    }
+
+    #[test]
+    fn parse_picks_quoted_value() {
+        assert_eq!(
+            parse_pretty_hostname("PRETTY_HOSTNAME=\"Simon's Laptop\"\n").as_deref(),
+            Some("Simon's Laptop"),
+        );
+    }
+
+    #[test]
+    fn parse_preserves_inner_whitespace_in_quotes() {
+        assert_eq!(
+            parse_pretty_hostname("PRETTY_HOSTNAME=\"  My Box  \"\n").as_deref(),
+            Some("  My Box  "),
+        );
+    }
+
+    #[test]
+    fn parse_keeps_hash_in_unquoted_value() {
+        // systemd's env-file format treats `#` as a comment only at the start of a line.
+        assert_eq!(
+            parse_pretty_hostname("PRETTY_HOSTNAME=Build#42\n").as_deref(),
+            Some("Build#42"),
+        );
+    }
+
+    #[test]
+    fn parse_unquoted_strips_trailing_whitespace() {
+        assert_eq!(parse_pretty_hostname("PRETTY_HOSTNAME=hello   \n").as_deref(), Some("hello"),);
+    }
+
+    #[test]
+    fn parse_skips_unterminated_quote_but_continues() {
+        let input = "PRETTY_HOSTNAME=\"unterminated\nPRETTY_HOSTNAME=fallback\n";
+        assert_eq!(parse_pretty_hostname(input).as_deref(), Some("fallback"));
+    }
+
+    #[test]
+    fn parse_ignores_comment_lines() {
+        let input = "# PRETTY_HOSTNAME=ignored\nPRETTY_HOSTNAME=real\n";
+        assert_eq!(parse_pretty_hostname(input).as_deref(), Some("real"));
+    }
+
+    #[test]
+    fn parse_returns_none_when_absent() {
+        assert!(parse_pretty_hostname("ICON_NAME=computer\n").is_none());
+    }
+
+    #[test]
+    fn parse_returns_none_for_empty_value() {
+        assert!(parse_pretty_hostname("PRETTY_HOSTNAME=\n").is_none());
+        assert!(parse_pretty_hostname("PRETTY_HOSTNAME=\"\"\n").is_none());
     }
 }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -63,6 +63,7 @@ remote = [
   "i-slint-backend-android-activity?/native-activity",
   "i-slint-backend-android-activity?/aa-06",
   "i-slint-backend-selector/backend-android-activity",
+  "dep:jni",
 ]
 
 default = ["backend-default", "renderer-femtovg", "renderer-software"]
@@ -93,6 +94,7 @@ zeroconf-tokio = { version = "0.3.2", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-backend-android-activity = { workspace = true, optional = true }
+jni = { version = "0.22", optional = true }
 
 [target.'cfg(not(any(target_os = "openbsd", target_os = "windows", target_os = "ios", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/tools/viewer/lib.rs
+++ b/tools/viewer/lib.rs
@@ -21,9 +21,67 @@ compile_error!("The `remote` feature is required when building for Android");
 #[cfg(all(target_os = "android", feature = "remote"))]
 #[unsafe(no_mangle)]
 fn android_main(app: i_slint_backend_android_activity::android_activity::AndroidApp) {
+    *remote::ANDROID_DEVICE_NAME.lock().unwrap_or_else(|e| e.into_inner()) =
+        android_device_name(&app);
     i_slint_core::platform::set_platform(Box::new(
         i_slint_backend_android_activity::AndroidPlatform::new(app),
     ))
     .unwrap();
     remote::run(None, true).unwrap();
+}
+
+/// Read the user-set device name from `Settings.Global.DEVICE_NAME` via JNI.
+/// Returns `None` when the platform hasn't recorded a value (the setting is optional and
+/// guaranteed populated only from Android 7.1 / API 25 onwards) or when the JNI call fails.
+#[cfg(all(target_os = "android", feature = "remote"))]
+fn android_device_name(
+    app: &i_slint_backend_android_activity::android_activity::AndroidApp,
+) -> Option<String> {
+    use jni::JavaVM;
+    use jni::objects::{JObject, JString, JValue};
+    use jni::refs::Global;
+    use jni::{jni_sig, jni_str};
+
+    // Safety: documented contract of android-activity to obtain the JavaVM. `vm_as_ptr`
+    // itself asserts the pointer is non-null, so this never proceeds with a null VM.
+    let vm = unsafe { JavaVM::from_raw(app.vm_as_ptr() as *mut _) };
+    let result: jni::errors::Result<Option<String>> = vm.attach_current_thread(|env| {
+        let activity_ptr = app.activity_as_ptr() as jni::sys::jobject;
+        // Safety: `activity_as_ptr` returns an unowned global JNI reference that lives for
+        // the duration of `app`. Wrapping it as `Global<JObject>` via `as_cast_raw` is the
+        // pattern documented by android-activity and avoids treating a global as a local.
+        let activity = unsafe { env.as_cast_raw::<Global<JObject>>(&activity_ptr)? };
+        let resolver = env
+            .call_method(
+                activity.as_ref(),
+                jni_str!("getContentResolver"),
+                jni_sig!(() -> android.content.ContentResolver),
+                &[],
+            )?
+            .l()?;
+        let key = JString::new(env, "device_name")?;
+        let value = env
+            .call_static_method(
+                jni_str!("android/provider/Settings$Global"),
+                jni_str!("getString"),
+                jni_sig!(
+                    (resolver: android.content.ContentResolver, name: java.lang.String)
+                        -> java.lang.String
+                ),
+                &[JValue::Object(&resolver), JValue::Object(&key)],
+            )?
+            .l()?;
+        if value.is_null() {
+            return Ok(None);
+        }
+        let value = JString::cast_local(env, value)?.try_to_string(env)?;
+        Ok((!value.is_empty()).then_some(value))
+    });
+    match result {
+        Ok(name) => name,
+        Err(err) => {
+            tracing::warn!("Failed reading Settings.Global.DEVICE_NAME via JNI: {err}");
+            None
+        }
+    }
 }

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -27,9 +27,14 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     let (message_sender, mut message_receiver) = tokio::sync::mpsc::unbounded_channel();
 
     let connection = Rc::new(
-        Connection::listen(address, move |msg| {
-            let _ = message_sender.send(msg);
-        })
+        Connection::listen(
+            address,
+            #[cfg(not(target_vendor = "apple"))]
+            device_name_override(),
+            move |msg| {
+                let _ = message_sender.send(msg);
+            },
+        )
         .await?,
     );
 
@@ -106,7 +111,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
         String::new()
     };
     #[cfg(not(target_vendor = "apple"))]
-    let device_name = String::new();
+    let device_name = connection.device_name().to_owned();
 
     let local_port = connection.local_port();
     let local_ip_str: Vec<String> = connection
@@ -298,6 +303,26 @@ async fn build_and_show(
 
     Ok(Some(new_instance))
 }
+
+/// Platform-specific override for the friendly device name. Returns `None` on platforms
+/// where the default chain in `Connection` (pretty hostname → hostname) is already best.
+#[cfg(not(target_vendor = "apple"))]
+fn device_name_override() -> Option<String> {
+    #[cfg(target_os = "android")]
+    {
+        ANDROID_DEVICE_NAME.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        None
+    }
+}
+
+/// Set by `android_main` before `run` is called so the connection picks up the
+/// user-set device name from `Settings.Global.DEVICE_NAME`.
+#[cfg(target_os = "android")]
+pub(crate) static ANDROID_DEVICE_NAME: std::sync::Mutex<Option<String>> =
+    std::sync::Mutex::new(None);
 
 fn send_diagnostics(
     compilation_result: &slint_interpreter::CompilationResult,

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -27,14 +27,9 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     let (message_sender, mut message_receiver) = tokio::sync::mpsc::unbounded_channel();
 
     let connection = Rc::new(
-        Connection::listen(
-            address,
-            #[cfg(not(target_vendor = "apple"))]
-            device_name_override(),
-            move |msg| {
-                let _ = message_sender.send(msg);
-            },
-        )
+        Connection::listen(address, device_name_override(), move |msg| {
+            let _ = message_sender.send(msg);
+        })
         .await?,
     );
 
@@ -99,19 +94,16 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
         .flatten();
 
     #[cfg(target_vendor = "apple")]
-    let device_name = if let Some(mdns) = &mut mdns {
+    if let Some(mdns) = &mut mdns {
         match mdns.start().await {
-            Ok(registration) => registration.name().to_owned(),
-            Err(err) => {
-                tracing::error!("Failed to announce service: {err}");
-                String::new()
-            }
+            Ok(registration) => connection.set_device_name(registration.name().to_owned()),
+            Err(err) => tracing::error!("Failed to announce service: {err}"),
         }
-    } else {
-        String::new()
-    };
-    #[cfg(not(target_vendor = "apple"))]
-    let device_name = connection.device_name().to_owned();
+    }
+    // Snapshot after the Apple Bonjour overwrite above so the UI label matches the
+    // advertised mDNS instance. Re-read `connection.device_name()` here (not at the
+    // set_property sites) if a future change starts mutating the name post-registration.
+    let device_name = connection.device_name();
 
     let local_port = connection.local_port();
     let local_ip_str: Vec<String> = connection
@@ -305,8 +297,8 @@ async fn build_and_show(
 }
 
 /// Platform-specific override for the friendly device name. Returns `None` on platforms
-/// where the default chain in `Connection` (pretty hostname → hostname) is already best.
-#[cfg(not(target_vendor = "apple"))]
+/// where the default chain in `Connection` (pretty hostname → hostname, then Bonjour on
+/// Apple) is already best.
 fn device_name_override() -> Option<String> {
     #[cfg(target_os = "android")]
     {


### PR DESCRIPTION
Previous implementation only had a name on apple device. Fix that.