### PR TITLE
viewer: Show the main.slint placeholder again on compile errors

### DIFF
--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -116,18 +116,15 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
             }
         })
         .collect();
+    let address = local_ip_str.join("\n");
 
-    if let Err(err) =
-        window.set_property("address", SharedString::from(local_ip_str.join("\n")).into())
-    {
+    if let Err(err) = window.set_property("address", SharedString::from(address.as_str()).into()) {
         tracing::error!("Failed setting property: {err}");
     }
 
     if let Err(err) = window.set_property("name", SharedString::from(device_name.clone()).into()) {
         tracing::error!("Failed setting property: {err}");
     }
-
-    println!("{}", local_ip_str.join("\n"));
 
     window.show().inspect_err(|err| tracing::error!("window show: {err}"))?;
 
@@ -145,9 +142,12 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                 if let Some(new_instance) = build_and_show(
                     &compiler,
                     &preview_component,
-                    &inner_window,
+                    &main_ui,
+                    &mut inner_window,
                     &instance,
                     &connection,
+                    &address,
+                    &device_name,
                 )
                 .await?
                 {
@@ -160,9 +160,12 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                 if let Some(new_instance) = build_and_show(
                     &compiler,
                     &preview_component,
-                    &inner_window,
+                    &main_ui,
+                    &mut inner_window,
                     &instance,
                     &connection,
+                    &address,
+                    &device_name,
                 )
                 .await?
                 {
@@ -184,20 +187,8 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     last_connection = None;
                     current_preview = None;
                     connection.set_dependencies(Vec::new());
-                    inner_window = main_ui
-                        .create_with_existing_window(instance.window())
-                        .unwrap_or_else(|_| main_ui.create().unwrap());
-                    if let Err(err) = inner_window
-                        .set_property("address", SharedString::from(local_ip_str.join("\n")).into())
-                    {
-                        tracing::error!("Failed setting property: {err}");
-                    }
-                    if let Err(err) = inner_window
-                        .set_property("name", SharedString::from(device_name.clone()).into())
-                    {
-                        tracing::error!("Failed setting property: {err}");
-                    }
-                    inner_window.show().unwrap();
+                    inner_window =
+                        show_placeholder(&main_ui, &instance, &address, &device_name, "");
                     instance = inner_window.clone_strong();
                 }
             }
@@ -213,16 +204,23 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
 }
 
 /// Compile `preview_component` from the connection's file cache and replace the visible
-/// instance with it. Returns `Ok(Some(new))` after a successful build, `Ok(None)` if the
-/// build failed or the component wasn't found, and `Err` only when the platform can no
+/// instance with it. Returns `Ok(Some(new))` after a successful build or after swapping
+/// back to the placeholder because the build failed, `Ok(None)` for requests we can't
+/// act on at all (bad URL, file fetch failure), and `Err` only when the platform can no
 /// longer host a Slint window — the caller should propagate it and exit, since retrying
 /// on every keystroke would only repeat the underlying failure.
+///
+/// When the build fails after a project was previously shown, the placeholder window is
+/// brought back so the user actually sees the diagnostics instead of the now-stale UI.
 async fn build_and_show(
     compiler: &slint_interpreter::Compiler,
     preview_component: &PreviewComponent,
-    inner_window: &slint_interpreter::ComponentInstance,
+    main_ui: &slint_interpreter::ComponentDefinition,
+    inner_window: &mut slint_interpreter::ComponentInstance,
     instance: &slint_interpreter::ComponentInstance,
     connection: &Connection,
+    address: &str,
+    name: &str,
 ) -> anyhow::Result<Option<slint_interpreter::ComponentInstance>> {
     let Ok(path) = preview_component.url.to_file_path() else {
         tracing::error!("Not a file URL: {}", preview_component.url);
@@ -255,10 +253,9 @@ async fn build_and_show(
             .map(|d| d.to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        if let Err(err) = inner_window.set_property("message", SharedString::from(message).into()) {
-            tracing::error!("Failed setting property: {err}");
-        }
-        return Ok(None);
+        let placeholder = show_placeholder(main_ui, instance, address, name, &message);
+        *inner_window = placeholder.clone_strong();
+        return Ok(Some(placeholder));
     }
 
     let Some(component) = preview_component
@@ -271,21 +268,15 @@ async fn build_and_show(
         // Don't publish a Diagnostics message: that would clobber whatever the LSP
         // (or a previous compile) was showing in the editor for this URI, while
         // the only signal we have to surface is local to the viewer window.
-        if let Err(err) =
-            inner_window.set_property("message", SharedString::from("Component not found").into())
-        {
-            tracing::error!("Failed setting property: {err}");
-        }
         tracing::error!("Component not found");
-        return Ok(None);
+        let placeholder = show_placeholder(main_ui, instance, address, name, "Component not found");
+        *inner_window = placeholder.clone_strong();
+        return Ok(Some(placeholder));
     };
 
     // Clean build: publish the (possibly empty) diagnostic list so the editor
     // clears any errors we surfaced from the previous build.
     send_diagnostics(&compilation_result, &preview_component.url, connection);
-    if let Err(err) = inner_window.set_property("message", SharedString::new().into()) {
-        tracing::error!("Failed setting property: {err}");
-    }
 
     let new_instance = component
         .create_with_existing_window(instance.window())
@@ -294,6 +285,34 @@ async fn build_and_show(
     new_instance.show().map_err(|err| anyhow::anyhow!("Cannot show component: {err}"))?;
 
     Ok(Some(new_instance))
+}
+
+/// Create a fresh instance of the placeholder window on top of `instance`'s existing
+/// window, populate it with the static identification fields plus an optional `message`,
+/// and show it. Used both when no editor is connected and when a build fails — in either
+/// case it's the only UI we can give the user since the previously visible component
+/// instance can no longer be trusted to reflect the current file.
+fn show_placeholder(
+    main_ui: &slint_interpreter::ComponentDefinition,
+    instance: &slint_interpreter::ComponentInstance,
+    address: &str,
+    name: &str,
+    message: &str,
+) -> slint_interpreter::ComponentInstance {
+    let placeholder = main_ui
+        .create_with_existing_window(instance.window())
+        .unwrap_or_else(|_| main_ui.create().unwrap());
+    if let Err(err) = placeholder.set_property("address", SharedString::from(address).into()) {
+        tracing::error!("Failed setting property: {err}");
+    }
+    if let Err(err) = placeholder.set_property("name", SharedString::from(name).into()) {
+        tracing::error!("Failed setting property: {err}");
+    }
+    if let Err(err) = placeholder.set_property("message", SharedString::from(message).into()) {
+        tracing::error!("Failed setting property: {err}");
+    }
+    placeholder.show().unwrap();
+    placeholder
 }
 
 /// Platform-specific override for the friendly device name. Returns `None` on platforms

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import { TextEdit } from "std-widgets.slint";
+
 export component EmptyWindow inherits Window {
     // Friendly device name (e.g. "Simon's iPhone") this viewer advertises to editors.
     in property <string> name;
@@ -8,7 +10,6 @@ export component EmptyWindow inherits Window {
     in property <string> message;
 
     VerticalLayout {
-        alignment: start;
         // Keep the name clear of the status bar / notch / Dynamic Island.
         padding-top: root.safe-area-insets.top + 8px;
         padding-bottom: root.safe-area-insets.bottom;
@@ -20,18 +21,23 @@ export component EmptyWindow inherits Window {
             font-weight: 700;
         }
 
-        HorizontalLayout {
+        if message == "": HorizontalLayout {
             alignment: center;
             VerticalLayout {
                 alignment: center;
-
-                if message == "": Text {
+                Text {
                     text: address;
-                }
-                if message != "": Text {
-                    text: message;
+                    horizontal-alignment: center;
+                    wrap: word-wrap;
                 }
             }
+        }
+        // Compile diagnostics can be many lines long; a read-only TextEdit gives
+        // the user wrapping, scrolling, and selection/copy in one widget.
+        if message != "": TextEdit {
+            text: message;
+            read-only: true;
+            wrap: word-wrap;
         }
     }
 }


### PR DESCRIPTION
In remote mode, after the initial project compiled and the user component replaced the placeholder in the window, subsequent build errors only set a `message` property on the now-hidden placeholder instance, so the user kept seeing the stale UI with no indication that the latest reload had failed. Build errors and "component not found" now re-attach a fresh placeholder to the existing window so the diagnostics are actually visible.

Use a read-only TextEdit for the diagnostic message

Fixes: #11956
