### PR TITLE
Centralize the data type for touch ids

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -367,7 +367,7 @@ impl AndroidWindowAdapter {
                             self.long_press.replace(Some(LongPressDetection { position, _timer }));
                             if let Some(p) = motion_event.pointers().next() {
                                 WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id() as u64,
+                                    p.pointer_id(),
                                     touch_pos(&p),
                                     TouchPhase::Started,
                                 );
@@ -378,7 +378,7 @@ impl AndroidWindowAdapter {
                             self.long_press.take();
                             if let Some(p) = motion_event.pointers().next() {
                                 WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id() as u64,
+                                    p.pointer_id(),
                                     touch_pos(&p),
                                     TouchPhase::Ended,
                                 );
@@ -401,7 +401,7 @@ impl AndroidWindowAdapter {
                             let runtime_window = WindowInner::from_pub(&self.window);
                             for p in motion_event.pointers() {
                                 runtime_window.process_touch_input(
-                                    p.pointer_id() as u64,
+                                    p.pointer_id(),
                                     touch_pos(&p),
                                     TouchPhase::Moved,
                                 );
@@ -414,7 +414,7 @@ impl AndroidWindowAdapter {
                             let idx = motion_event.pointer_index();
                             if let Some(p) = motion_event.pointers().nth(idx) {
                                 WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id() as u64,
+                                    p.pointer_id(),
                                     touch_pos(&p),
                                     TouchPhase::Started,
                                 );
@@ -425,7 +425,7 @@ impl AndroidWindowAdapter {
                             let idx = motion_event.pointer_index();
                             if let Some(p) = motion_event.pointers().nth(idx) {
                                 WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id() as u64,
+                                    p.pointer_id(),
                                     touch_pos(&p),
                                     TouchPhase::Ended,
                                 );
@@ -443,7 +443,7 @@ impl AndroidWindowAdapter {
                             let runtime_window = WindowInner::from_pub(&self.window);
                             for p in motion_event.pointers() {
                                 runtime_window.process_touch_input(
-                                    p.pointer_id() as u64,
+                                    p.pointer_id(),
                                     touch_pos(&p),
                                     TouchPhase::Cancelled,
                                 );

--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -124,7 +124,7 @@ pub struct LibInputHandler<'a> {
     /// identifier is available, so we replay the last known position.
     /// Fixed-capacity to avoid heap allocation — touchscreens rarely report
     /// more than 5 simultaneous contacts.
-    last_touch_positions: [(u64, Option<LogicalPosition>); 5],
+    last_touch_positions: [(i32, Option<LogicalPosition>); 5],
     window: &'a RefCell<Option<Rc<FullscreenWindowAdapter>>>,
     keystate: Option<xkb::State>,
     libinput_event_hook: &'a Option<Box<dyn Fn(&::input::Event) -> bool>>,
@@ -163,8 +163,8 @@ impl<'a> LibInputHandler<'a> {
 }
 
 fn set_touch_pos(
-    positions: &mut [(u64, Option<LogicalPosition>); 5],
-    slot: u64,
+    positions: &mut [(i32, Option<LogicalPosition>); 5],
+    slot: i32,
     pos: LogicalPosition,
 ) {
     if let Some(entry) = positions.iter_mut().find(|(s, _)| *s == slot) {
@@ -175,8 +175,8 @@ fn set_touch_pos(
 }
 
 fn take_touch_pos(
-    positions: &mut [(u64, Option<LogicalPosition>); 5],
-    slot: u64,
+    positions: &mut [(i32, Option<LogicalPosition>); 5],
+    slot: i32,
 ) -> LogicalPosition {
     positions
         .iter_mut()
@@ -275,7 +275,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                             touch_down_event.x_transformed(screen_size.width as u32) as _,
                             touch_down_event.y_transformed(screen_size.height as u32) as _,
                         );
-                        let slot = touch_down_event.slot().unwrap_or(0) as u64;
+                        let slot = touch_down_event.slot().unwrap_or(0) as i32;
                         set_touch_pos(&mut self.last_touch_positions, slot, pos);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,
@@ -284,7 +284,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                         );
                     }
                     input::event::TouchEvent::Up(touch_up_event) => {
-                        let slot = touch_up_event.slot().unwrap_or(0) as u64;
+                        let slot = touch_up_event.slot().unwrap_or(0) as i32;
                         let pos = take_touch_pos(&mut self.last_touch_positions, slot);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,
@@ -297,7 +297,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                             touch_motion_event.x_transformed(screen_size.width as u32) as _,
                             touch_motion_event.y_transformed(screen_size.height as u32) as _,
                         );
-                        let slot = touch_motion_event.slot().unwrap_or(0) as u64;
+                        let slot = touch_motion_event.slot().unwrap_or(0) as i32;
                         set_touch_pos(&mut self.last_touch_positions, slot, pos);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,
@@ -306,7 +306,7 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                         );
                     }
                     input::event::TouchEvent::Cancel(touch_cancel_event) => {
-                        let slot = touch_cancel_event.slot().unwrap_or(0) as u64;
+                        let slot = touch_cancel_event.slot().unwrap_or(0) as i32;
                         let pos = take_touch_pos(&mut self.last_touch_positions, slot);
                         WindowInner::from_pub(window).process_touch_input(
                             slot,

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -89,6 +89,10 @@ pub struct EventLoopState {
     /// Set to true when pumping events for the shortest amount of time possible.
     pumping_events_instantly: bool,
 
+    /// Allocates small i32 finger ids for iOS's pointer-valued touch ids.
+    #[cfg(target_os = "ios")]
+    touch_finger_ids: crate::ios::TouchFingerIdAllocator,
+
     custom_application_handler: Option<Box<dyn crate::CustomApplicationHandler>>,
 }
 
@@ -105,6 +109,8 @@ impl EventLoopState {
             current_resize_direction: Default::default(),
             pending_mouse_move: Default::default(),
             pumping_events_instantly: Default::default(),
+            #[cfg(target_os = "ios")]
+            touch_finger_ids: Default::default(),
             custom_application_handler,
         }
     }
@@ -457,11 +463,29 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
             WindowEvent::Touch(touch) => {
                 let location = touch.location.to_logical(runtime_window.scale_factor() as f64);
                 let position = euclid::point2(location.x, location.y);
-                runtime_window.process_touch_input(
-                    touch.id,
-                    position,
-                    winit_touch_phase(touch.phase),
-                );
+                // winit types the touch id as u64, but on all platforms except
+                // iOS it is in fact a small integer that fits in i32. Only iOS
+                // stores a UITouch pointer address in it, which
+                // TouchFingerIdAllocator maps to a small id instead.
+                #[cfg(not(target_os = "ios"))]
+                let finger_id =
+                    Some(i32::try_from(touch.id).expect("winit touch id out of i32 range"));
+                #[cfg(target_os = "ios")]
+                let finger_id = match touch.phase {
+                    winit::event::TouchPhase::Started | winit::event::TouchPhase::Moved => {
+                        self.touch_finger_ids.id_for(touch.id)
+                    }
+                    winit::event::TouchPhase::Ended | winit::event::TouchPhase::Cancelled => {
+                        self.touch_finger_ids.take(touch.id)
+                    }
+                };
+                if let Some(finger_id) = finger_id {
+                    runtime_window.process_touch_input(
+                        finger_id,
+                        position,
+                        winit_touch_phase(touch.phase),
+                    );
+                }
             }
             WindowEvent::ScaleFactorChanged { scale_factor, inner_size_writer: _ } => {
                 if std::env::var("SLINT_SCALE_FACTOR").is_err() {

--- a/internal/backends/winit/ios.rs
+++ b/internal/backends/winit/ios.rs
@@ -4,6 +4,7 @@
 mod clipboard;
 mod color_scheme;
 mod keyboard_animator;
+mod touch_finger_id;
 mod virtual_keyboard;
 
 pub(crate) use clipboard::UiPasteboardClipboard;
@@ -11,4 +12,5 @@ pub(crate) use color_scheme::{
     ColorSchemeObserver, current_color_scheme, install_color_scheme_observer,
 };
 pub(crate) use keyboard_animator::KeyboardCurveSampler;
+pub(crate) use touch_finger_id::TouchFingerIdAllocator;
 pub(crate) use virtual_keyboard::{KeyboardNotifications, register_keyboard_notifications};

--- a/internal/backends/winit/ios/touch_finger_id.rs
+++ b/internal/backends/winit/ios/touch_finger_id.rs
@@ -1,0 +1,45 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Maps iOS winit touch ids (UITouch pointer addresses) to small stable i32
+//! finger ids, without ever casting the u64.
+
+#[derive(Default)]
+pub(crate) struct TouchFingerIdAllocator {
+    /// Index in this array = the allocated finger id; entry = the winit touch
+    /// id currently occupying that slot.
+    slots: [Option<u64>; 8],
+}
+
+impl TouchFingerIdAllocator {
+    /// Returns the finger id for `winit_id`, claiming the lowest free slot for
+    /// ids not seen yet. Returns `None` when all slots are taken (the event is
+    /// then dropped; the core's gesture recognition tracks at most 5 touches anyway).
+    pub(crate) fn id_for(&mut self, winit_id: u64) -> Option<i32> {
+        // Re-use the slot already claimed by this touch id.
+        for (slot, id) in self.slots.iter().zip(0i32..) {
+            if *slot == Some(winit_id) {
+                return Some(id);
+            }
+        }
+        // Otherwise claim the lowest free slot.
+        for (slot, id) in self.slots.iter_mut().zip(0i32..) {
+            if slot.is_none() {
+                *slot = Some(winit_id);
+                return Some(id);
+            }
+        }
+        None
+    }
+
+    /// Returns the finger id for `winit_id` and frees its slot.
+    pub(crate) fn take(&mut self, winit_id: u64) -> Option<i32> {
+        for (slot, id) in self.slots.iter_mut().zip(0i32..) {
+            if *slot == Some(winit_id) {
+                *slot = None;
+                return Some(id);
+            }
+        }
+        None
+    }
+}

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1779,7 +1779,7 @@ impl TextCursorBlinker {
 /// A single active touch point.
 #[derive(Clone, Copy, Default)]
 struct TouchPoint {
-    id: u64,
+    id: i32,
     position: LogicalPoint,
 }
 
@@ -1803,11 +1803,11 @@ impl Default for TouchMap {
 }
 
 impl TouchMap {
-    fn get(&self, id: u64) -> Option<&TouchPoint> {
+    fn get(&self, id: i32) -> Option<&TouchPoint> {
         self.entries[..self.len].iter().find(|tp| tp.id == id)
     }
 
-    fn get_mut(&mut self, id: u64) -> Option<&mut TouchPoint> {
+    fn get_mut(&mut self, id: i32) -> Option<&mut TouchPoint> {
         self.entries[..self.len].iter_mut().find(|tp| tp.id == id)
     }
 
@@ -1820,7 +1820,7 @@ impl TouchMap {
         }
     }
 
-    fn remove(&mut self, id: u64) {
+    fn remove(&mut self, id: i32) {
         if let Some(idx) = self.entries[..self.len].iter().position(|tp| tp.id == id) {
             self.len -= 1;
             self.entries[idx] = self.entries[self.len];
@@ -1832,7 +1832,7 @@ impl TouchMap {
     }
 
     /// Returns the first two distinct IDs, or `None` if fewer than 2 entries.
-    fn first_two_ids(&self) -> Option<(u64, u64)> {
+    fn first_two_ids(&self) -> Option<(i32, i32)> {
         if self.len >= 2 { Some((self.entries[0].id, self.entries[1].id)) } else { None }
     }
 
@@ -1882,10 +1882,10 @@ enum GestureRecognitionState {
     #[default]
     Idle,
     /// 2 fingers down, waiting for movement to exceed threshold.
-    TwoFingersDown { finger_ids: (u64, u64), initial_distance: f32, last_angle: euclid::Angle<f32> },
+    TwoFingersDown { finger_ids: (i32, i32), initial_distance: f32, last_angle: euclid::Angle<f32> },
     /// Actively synthesizing PinchGesture/RotationGesture events.
     Pinching {
-        finger_ids: (u64, u64),
+        finger_ids: (i32, i32),
         initial_distance: f32,
         last_scale: f32,
         last_angle: euclid::Angle<f32>,
@@ -1901,7 +1901,7 @@ enum GestureRecognitionState {
 pub(crate) struct TouchState {
     active_touches: TouchMap,
     /// The finger forwarded as mouse events during single-touch.
-    primary_touch_id: Option<u64>,
+    primary_touch_id: Option<i32>,
     gesture_state: GestureRecognitionState,
 }
 
@@ -1923,7 +1923,7 @@ impl TouchState {
     const ROTATION_THRESHOLD: f32 = 5.0;
 
     /// Returns the finger IDs from the current gesture state, if any.
-    fn gesture_finger_ids(&self) -> Option<(u64, u64)> {
+    fn gesture_finger_ids(&self) -> Option<(i32, i32)> {
         match self.gesture_state {
             GestureRecognitionState::TwoFingersDown { finger_ids, .. }
             | GestureRecognitionState::Pinching { finger_ids, .. } => Some(finger_ids),
@@ -1932,7 +1932,7 @@ impl TouchState {
     }
 
     /// Returns (distance, angle) between two specific touch points.
-    fn geometry_for(&self, (id_a, id_b): (u64, u64)) -> Option<(f32, euclid::Angle<f32>)> {
+    fn geometry_for(&self, (id_a, id_b): (i32, i32)) -> Option<(f32, euclid::Angle<f32>)> {
         let a = self.active_touches.get(id_a)?;
         let b = self.active_touches.get(id_b)?;
         let delta = (b.position - a.position).cast::<f32>();
@@ -1962,7 +1962,7 @@ impl TouchState {
     }
 
     /// Returns true if the given touch ID is one of the two gesture fingers.
-    fn is_gesture_finger(&self, id: u64) -> bool {
+    fn is_gesture_finger(&self, id: i32) -> bool {
         self.gesture_finger_ids().is_some_and(|(a, b)| id == a || id == b)
     }
 
@@ -1974,7 +1974,7 @@ impl TouchState {
     /// rather than requiring a manual `drop` at every branch.
     pub(crate) fn process(
         &mut self,
-        id: u64,
+        id: i32,
         position: LogicalPoint,
         phase: TouchPhase,
     ) -> TouchEventBuffer {
@@ -1988,7 +1988,7 @@ impl TouchState {
         events
     }
 
-    fn process_started(&mut self, id: u64, position: LogicalPoint, events: &mut TouchEventBuffer) {
+    fn process_started(&mut self, id: i32, position: LogicalPoint, events: &mut TouchEventBuffer) {
         self.active_touches.insert(TouchPoint { id, position });
 
         let total = self.active_touches.len();
@@ -2000,7 +2000,7 @@ impl TouchState {
                 position,
                 button: PointerEventButton::Left,
                 click_count: 0,
-                touch_finger_id: (id + 1) as i32,
+                touch_finger_id: id + 1,
             });
         } else if total == 2 {
             // Second finger: transition Idle → TwoFingersDown.
@@ -2027,14 +2027,14 @@ impl TouchState {
                 position: primary_pos,
                 button: PointerEventButton::Left,
                 click_count: 0,
-                touch_finger_id: (id as i32 + 1),
+                touch_finger_id: id + 1,
             });
         }
         // 3+ fingers: tracked in active_touches but ignored for gesture.
     }
 
     #[allow(clippy::collapsible_match)]
-    fn process_moved(&mut self, id: u64, position: LogicalPoint, events: &mut TouchEventBuffer) {
+    fn process_moved(&mut self, id: i32, position: LogicalPoint, events: &mut TouchEventBuffer) {
         if let Some(tp) = self.active_touches.get_mut(id) {
             tp.position = position;
         }
@@ -2044,7 +2044,7 @@ impl TouchState {
         match self.gesture_state {
             GestureRecognitionState::Idle => {
                 if self.primary_touch_id == Some(id) {
-                    events.push(MouseEvent::Moved { position, touch_finger_id: (id + 1) as i32 });
+                    events.push(MouseEvent::Moved { position, touch_finger_id: id + 1 });
                 }
             }
             GestureRecognitionState::TwoFingersDown {
@@ -2126,7 +2126,7 @@ impl TouchState {
     #[allow(clippy::collapsible_match)]
     fn process_ended(
         &mut self,
-        id: u64,
+        id: i32,
         position: LogicalPoint,
         is_cancelled: bool,
         events: &mut TouchEventBuffer,
@@ -2144,7 +2144,7 @@ impl TouchState {
                         position,
                         button: PointerEventButton::Left,
                         click_count: 0,
-                        touch_finger_id: (id + 1) as i32,
+                        touch_finger_id: id + 1,
                     });
                     events.push(MouseEvent::Exit);
                 }
@@ -2159,7 +2159,7 @@ impl TouchState {
                             position: remaining_pos,
                             button: PointerEventButton::Left,
                             click_count: 0,
-                            touch_finger_id: (remaining.id + 1) as i32,
+                            touch_finger_id: remaining.id + 1,
                         });
                     } else {
                         self.primary_touch_id = None;
@@ -2203,7 +2203,7 @@ impl TouchState {
                         position: rpos,
                         button: PointerEventButton::Left,
                         click_count: 0,
-                        touch_finger_id: (rid + 1) as i32,
+                        touch_finger_id: rid + 1,
                     });
                 } else {
                     events.push(MouseEvent::Exit);
@@ -2275,7 +2275,7 @@ mod touch_tests {
     fn touch_map_capacity() {
         let mut map = TouchMap::default();
         for i in 0..MAX_TRACKED_TOUCHES {
-            map.insert(TouchPoint { id: i as u64, position: pt(i as f32, 0.0) });
+            map.insert(TouchPoint { id: i as i32, position: pt(i as f32, 0.0) });
         }
         assert_eq!(map.len(), MAX_TRACKED_TOUCHES);
         // Inserting beyond capacity is silently ignored.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -980,7 +980,7 @@ impl WindowInner {
     /// (the common case), this stays `None` throughout.
     pub fn process_touch_input(
         &self,
-        id: u64,
+        id: i32,
         position: LogicalPoint,
         phase: TouchPhase,
     ) -> Option<MouseDispatchResult> {


### PR DESCRIPTION
In the public Slint API (PointerEvent), the touch_finger_id is an i32. In the core library it was a u64, in some backends it's an i32, u32, or u64.

As it turns out, on the web the touch id is an i32 (https://w3c.github.io/touch-events/#dom-touch-identifier is a long, which is i32). Therefore, make it an i32 in the core library and the API towards the backends. For Android and linuxkms/libinput this is straight-forward as well, winit is the odd one out:

The only place where that is a problem is iOS, uikit doesn't provide one in public API (WebKit has one, but it's private behind their SPI). So instead, it's common to take the address of the UITouch (guaranteed to be stable), which is what winit does.

So just for iOS we map the u64 to an i32. That's ugly, but at least it's left in just one corner.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
