### PR TITLE
Rename Platform.bring-all-to-front() to Platform.macos-bring-all-wind…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to this project are documented in this file.
  - Added `ToolTip` element
  - Added `minimized`, `maximized`, `close`, and `hide` on `Window`
  - Added `drop-shadow-spread` and `inset-shadow-{color,blur,offset-x,offset-y,spread}` properties to rectangle. (Only supported in Skia)
- - added `Platform.bring-all-to-front()`
+ - added `Platform.macos-bring-all-windows-to-front()`
  - Fixed percentage size in children impacting parent layout (#3346)
  - Re-evaluate property bindings when a callback handler is changed from native code (#9551)
  - TextInput: allow setting the accessibility value

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -363,9 +363,9 @@ inline bool open_url(const SharedString &url, const WindowAdapterRc &window_adap
     return cbindgen_private::slint_open_url(&url, &window_adapter.handle());
 }
 
-inline void bring_all_to_front()
+inline void macos_bring_all_windows_to_front()
 {
-    cbindgen_private::slint_bring_all_to_front();
+    cbindgen_private::slint_macos_bring_all_windows_to_front();
 }
 
 inline SharedString translate_from_bundle(std::span<const char8_t *const> strs,

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -292,8 +292,8 @@ pub unsafe extern "C" fn slint_open_url(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn slint_bring_all_to_front() {
-    i_slint_core::bring_all_to_front()
+pub extern "C" fn slint_macos_bring_all_windows_to_front() {
+    i_slint_core::macos_bring_all_windows_to_front()
 }
 
 #[unsafe(no_mangle)]

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -176,7 +176,6 @@ pub mod re_exports {
     };
     pub use i_slint_core::animations::{EasingCurve, animation_tick, current_tick};
     pub use i_slint_core::api::LogicalPosition;
-    pub use i_slint_core::bring_all_to_front;
     pub use i_slint_core::callbacks::Callback;
     pub use i_slint_core::context::SlintContext;
     pub use i_slint_core::data_transfer::DataTransfer;
@@ -200,6 +199,7 @@ pub mod re_exports {
     pub use i_slint_core::lengths::{
         LogicalLength, LogicalPoint, LogicalRect, logical_position_to_api,
     };
+    pub use i_slint_core::macos_bring_all_windows_to_front;
     pub use i_slint_core::menus::{Menu, MenuFromItemTree, MenuVTable};
     pub use i_slint_core::model::*;
     pub use i_slint_core::open_url;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2829,7 +2829,7 @@ export global Platform {
     /// to the top of the window stack. On other platforms this function is a no-op.
     ///
     /// This corresponds to the standard macOS **Window › Bring All to Front** menu item.
-    function bring-all-to-front() { }
+    function macos-bring-all-windows-to-front() { }
     /// The decimal separator currently used for localized float to string and vice versa conversions
     /// For more information about localization and how to change the decimal separator see <Link type="translations" label="translations page"/>.
     out property <string> decimal-separator;

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -123,7 +123,7 @@ pub enum BuiltinFunction {
     StopTimer,
     RestartTimer,
     OpenUrl,
-    BringAllToFront,
+    MacosBringAllWindowsToFront,
     ParseMarkdown,
     StringToStyledText,
     /// Converts a color to a hex string wrapped in StyledText.
@@ -311,7 +311,7 @@ declare_builtin_function_types!(
     StringToStyledText: (Type::String) -> Type::StyledText,
     ColorToStyledText: (Type::Color) -> Type::StyledText
     OpenUrl: (Type::String) -> Type::Bool,
-    BringAllToFront: () -> Type::Void,
+    MacosBringAllWindowsToFront: () -> Type::Void,
 );
 
 impl Default for BuiltinFunctionTypes {
@@ -423,7 +423,7 @@ impl BuiltinFunction {
             BuiltinFunction::StringToStyledText => true,
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
-            BuiltinFunction::BringAllToFront => false,
+            BuiltinFunction::MacosBringAllWindowsToFront => false,
         }
     }
 
@@ -511,7 +511,7 @@ impl BuiltinFunction {
             BuiltinFunction::StringToStyledText => true,
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
-            BuiltinFunction::BringAllToFront => false,
+            BuiltinFunction::MacosBringAllWindowsToFront => false,
         }
     }
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5010,8 +5010,8 @@ fn compile_builtin_function_call(
             let window = access_window_field(ctx);
             format!("slint::private_api::open_url({url}, {window})")
         }
-        BuiltinFunction::BringAllToFront => {
-            "slint::private_api::bring_all_to_front()".to_owned()
+        BuiltinFunction::MacosBringAllWindowsToFront => {
+            "slint::private_api::macos_bring_all_windows_to_front()".to_owned()
         }
         BuiltinFunction::ParseMarkdown => {
             let format_string = a.next().unwrap();

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -4260,8 +4260,8 @@ fn compile_builtin_function_call(
             let window_adapter_tokens = access_window_adapter_field(ctx);
             quote!(sp::open_url(&#url, #window_adapter_tokens.window()).is_ok())
         }
-        BuiltinFunction::BringAllToFront => {
-            quote!(sp::bring_all_to_front())
+        BuiltinFunction::MacosBringAllWindowsToFront => {
+            quote!(sp::macos_bring_all_windows_to_front())
         }
         BuiltinFunction::ParseMarkdown => {
             let format_string = a.next().unwrap();

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -169,7 +169,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::StringToStyledText => ALLOC_COST,
         BuiltinFunction::ColorToStyledText => ALLOC_COST,
         BuiltinFunction::OpenUrl => isize::MAX,
-        BuiltinFunction::BringAllToFront => isize::MAX,
+        BuiltinFunction::MacosBringAllWindowsToFront => isize::MAX,
     }
 }
 

--- a/internal/compiler/passes/lower_platform.rs
+++ b/internal/compiler/passes/lower_platform.rs
@@ -42,9 +42,9 @@ pub fn lower_platform(component: &Rc<Component>, type_loader: &mut crate::typelo
             }
             Expression::FunctionCall { function, .. }
                 if matches!(&*function, Callable::Function(nr)
-                    if is_platform(nr) && nr.name() == "bring-all-to-front") =>
+                    if is_platform(nr) && nr.name() == "macos-bring-all-windows-to-front") =>
             {
-                *function = BuiltinFunction::BringAllToFront.into();
+                *function = BuiltinFunction::MacosBringAllWindowsToFront.into();
             }
             _ => {}
         })

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -177,7 +177,7 @@ pub fn open_url(url: &str, window: &crate::api::Window) -> Result<(), crate::api
 }
 
 #[cfg(target_os = "macos")]
-pub fn bring_all_to_front() {
+pub fn macos_bring_all_windows_to_front() {
     use objc2::MainThreadMarker;
     use objc2_app_kit::NSApplication;
     let Some(mtm) = MainThreadMarker::new() else { return };
@@ -185,4 +185,4 @@ pub fn bring_all_to_front() {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn bring_all_to_front() {}
+pub fn macos_bring_all_windows_to_front() {}

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1752,8 +1752,8 @@ fn call_builtin_function(
             let window_adapter = local_context.component_instance.window_adapter();
             Value::Bool(corelib::open_url(&url, window_adapter.window()).is_ok())
         }
-        BuiltinFunction::BringAllToFront => {
-            corelib::bring_all_to_front();
+        BuiltinFunction::MacosBringAllWindowsToFront => {
+            corelib::macos_bring_all_windows_to_front();
             Value::Void
         }
         BuiltinFunction::ParseMarkdown => {

--- a/tests/cases/globals/macos_bring_all_windows_to_front.slint
+++ b/tests/cases/globals/macos_bring_all_windows_to_front.slint
@@ -1,11 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test that Platform.bring-all-to-front() compiles and runs (it is a no-op on non-macOS).
+// Test that Platform.macos-bring-all-windows-to-front() compiles and runs (it is a no-op on non-macOS).
 
 export component TestCase inherits Window {
-    public function do-bring-all-to-front() {
-        Platform.bring-all-to-front();
+    public function do-bring-all-windows-to-front() {
+        Platform.macos-bring-all-windows-to-front();
     }
     out property <bool> test: true;
 }
@@ -13,19 +13,19 @@ export component TestCase inherits Window {
 /*
 ```rust
 let instance = TestCase::new().unwrap();
-instance.invoke_do_bring_all_to_front();
+instance.invoke_do_bring_all_windows_to_front();
 assert!(instance.get_test());
 ```
 
 ```cpp
 auto instance = TestCase::create();
-instance->invoke_do_bring_all_to_front();
+instance->invoke_do_bring_all_windows_to_front();
 assert(instance->get_test());
 ```
 
 ```js
 let instance = new slint.TestCase({});
-instance.do_bring_all_to_front();
+instance.do_bring_all_windows_to_front();
 assert(instance.test);
 ```
 */


### PR DESCRIPTION
…ows-to-front()

Make it explicit in the name that this function is macOS-specific and a no-op on other platforms.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
