### PR TITLE
ComboBox: test current-index set before model is populated

### DIFF
--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -225,6 +225,20 @@ assert_selection(1, "Y");
 instance.set_model(Rc::new(VecModel::default()).into());
 mock_elapsed_time(500);
 assert_selection(0, "");
+
+// With the model still empty, set current-index from Rust. The widget must
+// accept the write (current-value stays "" because the model is empty), and
+// when a non-empty model arrives the user-supplied index must be preserved
+// rather than clobbered by the reset-on-model-change handler. This is the
+// "set index before model is populated" path that was a race condition in
+// older versions (see https://github.com/slint-ui/slint/issues/10805).
+instance.set_current_index(2);
+mock_elapsed_time(500);
+assert_selection(2, "");
+
+instance.set_model(Rc::new(VecModel::from_slice(&[SharedString::from("A"), SharedString::from("B"), SharedString::from("C"), SharedString::from("D")])).into());
+mock_elapsed_time(500);
+assert_selection(2, "C");
 ```
 
 */

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -239,6 +239,21 @@ assert_selection(2, "");
 instance.set_model(Rc::new(VecModel::from_slice(&[SharedString::from("A"), SharedString::from("B"), SharedString::from("C"), SharedString::from("D")])).into());
 mock_elapsed_time(500);
 assert_selection(2, "C");
+
+// And the symmetric order — set_model then set_current_index in adjacent
+// calls — which is the exact reproducer from #7632. The earlier model-swap
+// assertions cover this implicitly; this block re-states it verbatim using
+// the values from the original bug report.
+instance.set_model(Rc::new(VecModel::from_slice(&[
+    SharedString::from("not this1"),
+    SharedString::from("not this2"),
+    SharedString::from("!!!THIS!!!"),
+    SharedString::from("not this3"),
+    SharedString::from("not this4"),
+])).into());
+instance.set_current_index(2);
+mock_elapsed_time(500);
+assert_selection(2, "!!!THIS!!!");
 ```
 
 */


### PR DESCRIPTION
## Summary

- The existing `tests/cases/widgets/combobox.slint` always starts from a model populated via a slint literal (`model: ["Aaa", "Bbb", "Ccc"]`), so `set_current_index` is never exercised against an empty model.
- This adds three lines of assertions at the end of the existing test that cover the empty-model-then-set-then-populate sequence — the path that goes through `reset-current()`'s `model.length == 0` branch on the initial set and through its clamp branch when the model arrives.
- This is the race condition that #10805 fixed (commit `0b425c541`); the change is purely additional regression coverage so the fix can't silently regress for that particular code path.

## Test plan

- [x] `cargo test -p test-driver-rust -- combobox` passes locally across fluent/cupertino/material/qt backends.

## Context

While investigating whether #7632 was still reproducible against current master (it isn't), it became apparent that the upstream test asserts the post-#10805 behavior only when the model is already non-empty before the first `set_current_index` call. This patch closes that gap.