### PR TITLE
license xtask: fall back to license-file when no SPDX license is set

### DIFF
--- a/xtask/src/license.rs
+++ b/xtask/src/license.rs
@@ -107,8 +107,18 @@ pub fn generate(args: &GenerateArgs) -> anyhow::Result<()> {
     let mut rows: Vec<CrateRow> = Vec::new();
 
     for pkg in &packages {
-        let Some(expression) = pkg.license.clone() else {
-            bail!("Crate {} {} has no license information", pkg.name, pkg.version);
+        // A few older crates declare only `license-file = "..."` (no SPDX
+        // expression). Fall back to recognizing the canonical text of a
+        // well-known license, and salvage a `Copyright …` line for the author
+        // column from the same file.
+        let (expression, fallback_author) = match pkg.license.clone() {
+            Some(e) => (e, None),
+            None => {
+                let (id, copyright) = detect_from_license_file(pkg).with_context(|| {
+                    format!("Crate {} {} has no license information", pkg.name, pkg.version)
+                })?;
+                (id.to_string(), Some(copyright))
+            }
         };
 
         // Lax parsing accepts the deprecated `/` OR-separator and imprecise
@@ -139,7 +149,7 @@ pub fn generate(args: &GenerateArgs) -> anyhow::Result<()> {
         rows.push(CrateRow {
             name: pkg.name.to_string(),
             version: pkg.version.to_string(),
-            author: pkg.authors.join(", "),
+            author: fallback_author.unwrap_or_else(|| pkg.authors.join(", ")),
             license: expression,
         });
     }
@@ -369,6 +379,69 @@ fn dependency_enabled(
     }
     // If no matching manifest entry was found (unusual), keep the dependency.
     !matched
+}
+
+/// Fallback for crates that declare only `license-file = "..."` (no SPDX
+/// `license` field): read that file and recognize the canonical text of one of
+/// the licenses in `ACCEPTED`, plus the copyright holder(s) from its
+/// `Copyright …` lines. Bails when either cannot be identified.
+fn detect_from_license_file(
+    pkg: &cargo_metadata::Package,
+) -> anyhow::Result<(&'static str, String)> {
+    let path = pkg.license_file().context("no license-file field either")?;
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("Cannot read license file {path}"))?;
+    let normalized = text.to_ascii_lowercase().split_whitespace().collect::<Vec<_>>().join(" ");
+    // Distinctive phrases per license. All required phrases must be present.
+    const FINGERPRINTS: &[(&str, &[&str])] = &[
+        (
+            "MIT",
+            &["permission is hereby granted, free of charge", "the software is provided \"as is\""],
+        ),
+        ("Apache-2.0", &["apache license", "version 2.0", "licensed under the apache license"]),
+        ("BSL-1.0", &["boost software license", "version 1.0"]),
+        ("ISC", &["permission to use, copy, modify, and/or distribute this software"]),
+        ("Zlib", &["this software is provided 'as-is', without any express or implied warranty"]),
+        ("Unlicense", &["this is free and unencumbered software released into the public domain"]),
+        ("CC0-1.0", &["creative commons cc0 1.0 universal"]),
+    ];
+    let id = FINGERPRINTS
+        .iter()
+        .find(|(_, needles)| needles.iter().all(|n| normalized.contains(n)))
+        .map(|(id, _)| *id)
+        .with_context(|| format!("Cannot recognize the contents of {path} as a known license"))?;
+    let copyright = copyright_holders(&text)
+        .with_context(|| format!("Cannot find a copyright holder in {path}"))?;
+    Ok((id, copyright))
+}
+
+/// Salvage any `Copyright …` lines from a license file. The leading
+/// `Copyright`, year and surrounding punctuation are stripped, leaving just
+/// the rights holders. Multiple matches are joined with `, `; returns `None`
+/// when no copyright line is found.
+fn copyright_holders(text: &str) -> Option<String> {
+    let mut holders: Vec<String> = Vec::new();
+    for raw in text.lines() {
+        let line = raw.trim().trim_end_matches('.');
+        let Some(rest) =
+            line.get(..9).filter(|s| s.eq_ignore_ascii_case("Copyright")).map(|_| &line[9..])
+        else {
+            continue;
+        };
+        // Strip an optional `(c)` / `©` marker first (only here may `c`/`C` be
+        // consumed), then a leading year or year-range and its separators.
+        let rest = rest
+            .trim_start()
+            .trim_start_matches(|c: char| "()cC©".contains(c))
+            .trim_start_matches(|c: char| {
+                c.is_ascii_digit() || c.is_ascii_whitespace() || ",-".contains(c)
+            })
+            .trim();
+        if !rest.is_empty() && !holders.iter().any(|h| h == rest) {
+            holders.push(rest.to_string());
+        }
+    }
+    (!holders.is_empty()).then(|| holders.join(", "))
 }
 
 /// The canonical SPDX string for a requirement, e.g. `MIT` or


### PR DESCRIPTION
Some older crates (e.g. tokio-tungstenite-wasm 0.8.2, a slint-lsp dependency) declare only `license-file = "..."` and no SPDX `license` field. When that happens, read the referenced file and recognize the canonical text of one of the accepted licenses. If the file does not match a known license, the xtask still bails out.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
