### PR TITLE
Remote Viewer: Show debug() in LSP output

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -91,13 +91,13 @@
       },
       {
         "command": "slint.selectRemotePreview",
-        "title": "(Experimental) Connect to Remote Preview",
+        "title": "(Experimental) Connect to Remote Slint Viewer",
         "category": "Slint",
         "icon": "$(preview)"
       },
       {
         "command": "slint.disconnectRemotePreview",
-        "title": "(Experimental) Disconnect Remote Preview",
+        "title": "(Experimental) Disconnect Remote Slint Viewer",
         "category": "Slint",
         "icon": "$(debug-disconnect)"
       },

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -34,4 +34,10 @@ pub enum PreviewToLspMessage {
     SendShowMessage { message: lsp_types::ShowMessageParams },
     /// Send a telemetry event
     TelemetryEvent(serde_json::Map<String, serde_json::Value>),
+    /// A debug message from the preview, to be shown by the LSP
+    DebugMessage {
+        /// location is the file path, plus the line and column
+        location: Option<(std::path::PathBuf, usize, usize)>,
+        message: String,
+    },
 }

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -117,6 +117,7 @@ pub trait PreviewToLsp {
 }
 
 /// Converts a debug message from the preview to a string to be logged by the LSP
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
 pub fn preview_debug_message_to_string(
     location: &Option<(std::path::PathBuf, usize, usize)>,
     message: &str,

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -116,6 +116,18 @@ pub trait PreviewToLsp {
     }
 }
 
+/// Converts a debug message from the preview to a string to be logged by the LSP
+pub fn preview_debug_message_to_string(
+    location: &Option<(std::path::PathBuf, usize, usize)>,
+    message: &str,
+) -> String {
+    if let Some((file, line, column)) = location {
+        format!("DEBUG {file}:{line}:{column}> {message}", file = file.display())
+    } else {
+        format!("DEBUG> {message}")
+    }
+}
+
 /// Check whether a node is marked to be ignored in the LSP/live preview
 /// using a comment containing `@lsp:ignore-node`
 pub fn is_element_node_ignored(node: &syntax_nodes::Element) -> bool {

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -398,6 +398,10 @@ fn handle_preview_message(msg: PreviewToLspMessage, ctx: &language::Context) {
                 _ => tracing::info!("Preview: {}", message.message),
             };
         }
+        DebugMessage { location, message } => {
+            eprintln!("{}", common::preview_debug_message_to_string(location, message));
+        }
+
         Diagnostics { .. }
         | ShowDocument { .. }
         | PreviewTypeChanged { .. }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -728,6 +728,9 @@ async fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Conte
                 lsp_types::OneOf::Left(object),
             )?
         }
+        M::DebugMessage { location, message } => {
+            eprintln!("{}", common::preview_debug_message_to_string(&location, &message));
+        }
     }
     Ok(())
 }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -3,7 +3,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 #![allow(clippy::await_holding_refcell_ref)]
-#![deny(clippy::print_stderr, clippy::print_stdout, clippy::disallowed_methods)]
+#![deny(clippy::print_stdout, clippy::disallowed_methods)]
 
 #[cfg(all(feature = "preview-engine", not(feature = "preview-builtin")))]
 compile_error!(

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1575,14 +1575,18 @@ fn set_preview_factory(
                     (f.clone(), line, column)
                 })
             });
-            if let Some((file, line, column)) = &location {
-                i_slint_core::debug_log!(
-                    "DEBUG {}:{line}:{column}> {text}",
-                    file.path().display(),
-                );
-            } else {
-                i_slint_core::debug_log!("DEBUG> {text}");
-            }
+            PREVIEW_STATE.with_borrow_mut(|state| {
+                let to_lsp = state.to_lsp.try_borrow();
+                let Some(to_lsp) = to_lsp.ok() else { return };
+                if let Some(to_lsp) = &*to_lsp {
+                    let location = location.as_ref().map(|(source_file, line, column)| {
+                        (source_file.path().to_owned(), *line, *column)
+                    });
+                    to_lsp
+                        .send(&PreviewToLspMessage::DebugMessage { location, message: text.into() })
+                        .ok();
+                }
+            });
 
             let location = location.as_ref().map(|(file, line, column)| {
                 (file.path().to_string_lossy().to_string().into(), *line, *column)

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -386,6 +386,9 @@ impl SlintServer {
                         lsp_types::OneOf::Left(object),
                     );
             }
+            M::DebugMessage { location, message } => {
+                log(&common::preview_debug_message_to_string(&location, &message));
+            }
         }
         Ok(())
     }
@@ -513,6 +516,9 @@ fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Context) ->
                 ctx.server_notifier.send_notification::<lsp_types::notification::TelemetryEvent>(
                     lsp_types::OneOf::Left(object),
                 );
+        }
+        M::DebugMessage { location, message } => {
+            log(&crate::common::preview_debug_message_to_string(&location, &message));
         }
     }
     Ok(())

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -66,7 +66,7 @@ remote = [
   "dep:jni",
 ]
 
-default = ["backend-default", "renderer-femtovg", "renderer-software"]
+default = ["backend-default", "renderer-femtovg", "renderer-software", "remote"]
 
 [dependencies]
 i-slint-compiler = { workspace = true }

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -67,16 +67,13 @@ struct Cli {
     library_paths: Vec<String>,
 
     /// The .slint file to load ('-' for stdin)
-    #[cfg_attr(feature = "remote", arg(name = "path", action, required_unless_present = "remote"))]
-    #[cfg_attr(not(feature = "remote"), arg(name = "path", action, required = true))]
+    #[arg(name = "path", action, required_unless_present = "remote")]
     path: Option<std::path::PathBuf>,
 
-    #[cfg(feature = "remote")]
     /// Start in remote viewer mode: listen for WebSocket connections from the LSP
     #[arg(long)]
     remote: bool,
 
-    #[cfg(feature = "remote")]
     /// Address to listen on in remote mode (default: auto-assigned port on all interfaces)
     #[arg(long, value_name = "address")]
     remote_address: Option<std::net::SocketAddr>,
@@ -173,10 +170,19 @@ fn main() -> Result<()> {
         }
     }
 
-    #[cfg(feature = "remote")]
     if args.remote {
-        remote::run(args.remote_address, true)?;
-        return Ok(());
+        #[cfg(feature = "remote")]
+        {
+            remote::run(args.remote_address, true)?;
+            return Ok(());
+        }
+        #[cfg(not(feature = "remote"))]
+        {
+            eprintln!(
+                "Remote mode is not supported in this build, recompile Slint Viewer with the \"remote\" feature enabled."
+            );
+            return Err(Error("Remote mode not enabled".into()));
+        }
     }
 
     if args.auto_reload && args.save_data.is_some() {

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -4,6 +4,7 @@
 use std::{net::SocketAddr, rc::Rc};
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::diagnostics::Spanned;
 use i_slint_core::InternalToken;
 use i_slint_core::SharedString;
 use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage, lsp_types};
@@ -218,10 +219,12 @@ async fn build_and_show(
     main_ui: &slint_interpreter::ComponentDefinition,
     inner_window: &mut slint_interpreter::ComponentInstance,
     instance: &slint_interpreter::ComponentInstance,
-    connection: &Connection,
+    connection: &Rc<Connection>,
     address: &str,
     name: &str,
 ) -> anyhow::Result<Option<slint_interpreter::ComponentInstance>> {
+    tracing::debug!("build_and_show");
+
     let Ok(path) = preview_component.url.to_file_path() else {
         tracing::error!("Not a file URL: {}", preview_component.url);
         return Ok(None);
@@ -278,6 +281,27 @@ async fn build_and_show(
     // clears any errors we surfaced from the previous build.
     send_diagnostics(&compilation_result, &preview_component.url, connection);
 
+    let connection = Rc::downgrade(connection);
+    component.set_debug_handler(
+        move |location, message| {
+            let Some(connection) = connection.upgrade() else {
+                return;
+            };
+            let location = location.and_then(|location| {
+                location.source_file().map(|file| {
+                    let (line, column) = file.line_column(
+                        location.span.offset,
+                        i_slint_compiler::diagnostics::ByteFormat::Utf8,
+                    );
+                    (file.path().to_owned(), line, column)
+                })
+            });
+            connection
+                .send(PreviewToLspMessage::DebugMessage { location, message: message.into() })
+                .ok();
+        },
+        i_slint_core::InternalToken,
+    );
     let new_instance = component
         .create_with_existing_window(instance.window())
         .map_err(|err| anyhow::anyhow!("Cannot create component instance: {err}"))?;


### PR DESCRIPTION
This PR adds another message to the preview protocol to print a debug message.

This is now sent by both the remote viewer and the built-in live preview and their output now in both cases ends up in the LSP's output pane.

Note that this solves the issue for VS Code but does not yet solve the issue for something like NeoVim where the LSP output is typically hidden.

- **Slint Viewer: Enable `remote` flag by default**
- **Rename Remote Preview to Remote Slint Viewer**
- **Add debug messages to preview protocol**

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
