### PR TITLE
Make the Slint editor binary an example binary

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -24,7 +24,7 @@ icon = ["../../logo/slint-logo.icns"]
 name = "slint-lsp"
 path = "main.rs"
 
-[[bin]]
+[[example]]
 name = "slint-editor"
 path = "editor_main.rs"
 


### PR DESCRIPTION
This prevents cargo install from installing it by default because at the
moment we just want it to install the Slint LSP binary and not the
editor.

Closes #11913
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
