### PR TITLE
license xtask: fall back to license files when authors is missing

### DIFF
--- a/xtask/src/license.rs
+++ b/xtask/src/license.rs
@@ -146,10 +146,18 @@ pub fn generate(args: &GenerateArgs) -> anyhow::Result<()> {
             used_ids.insert(id);
         }
 
+        // The `authors` field is optional and newer crates increasingly omit
+        // it; salvage the copyright holder(s) from the license files shipped
+        // in the crate's package instead.
+        let author = fallback_author
+            .or_else(|| (!pkg.authors.is_empty()).then(|| pkg.authors.join(", ")))
+            .or_else(|| authors_from_license_files(pkg))
+            .unwrap_or_default();
+
         rows.push(CrateRow {
             name: pkg.name.to_string(),
             version: pkg.version.to_string(),
-            author: fallback_author.unwrap_or_else(|| pkg.authors.join(", ")),
+            author,
             license: expression,
         });
     }
@@ -410,35 +418,79 @@ fn detect_from_license_file(
         .find(|(_, needles)| needles.iter().all(|n| normalized.contains(n)))
         .map(|(id, _)| *id)
         .with_context(|| format!("Cannot recognize the contents of {path} as a known license"))?;
-    let copyright = copyright_holders(&text)
+    let copyright = copyright_holders([&text])
         .with_context(|| format!("Cannot find a copyright holder in {path}"))?;
     Ok((id, copyright))
 }
 
-/// Salvage any `Copyright …` lines from a license file. The leading
+/// Fallback author for crates whose manifest carries no `authors`: salvage
+/// the copyright holder(s) from the license files shipped in the crate's
+/// package (`LICENSE*` / `COPYING*` / `NOTICE*` next to its `Cargo.toml`).
+/// Returns `None` when no such file yields an attribution line.
+fn authors_from_license_files(pkg: &cargo_metadata::Package) -> Option<String> {
+    let dir = pkg.manifest_path.parent()?;
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path.file_name().and_then(|n| n.to_str()).is_some_and(|name| {
+                    let name = name.to_ascii_lowercase();
+                    ["license", "licence", "copying", "notice"]
+                        .iter()
+                        .any(|prefix| name.starts_with(prefix))
+                })
+        })
+        .collect();
+    paths.sort();
+    // Unreadable (e.g. non-UTF-8) files are skipped.
+    copyright_holders(paths.iter().filter_map(|path| std::fs::read_to_string(path).ok()))
+}
+
+/// Salvage any `Copyright …` lines from the given license texts. The leading
 /// `Copyright`, year and surrounding punctuation are stripped, leaving just
-/// the rights holders. Multiple matches are joined with `, `; returns `None`
-/// when no copyright line is found.
-fn copyright_holders(text: &str) -> Option<String> {
+/// the rights holders. Matches are deduplicated and joined with `, `; returns
+/// `None` when no copyright line is found.
+fn copyright_holders<T: AsRef<str>>(texts: impl IntoIterator<Item = T>) -> Option<String> {
     let mut holders: Vec<String> = Vec::new();
-    for raw in text.lines() {
-        let line = raw.trim().trim_end_matches('.');
-        let Some(rest) =
-            line.get(..9).filter(|s| s.eq_ignore_ascii_case("Copyright")).map(|_| &line[9..])
-        else {
-            continue;
-        };
-        // Strip an optional `(c)` / `©` marker first (only here may `c`/`C` be
-        // consumed), then a leading year or year-range and its separators.
-        let rest = rest
-            .trim_start()
-            .trim_start_matches(|c: char| "()cC©".contains(c))
-            .trim_start_matches(|c: char| {
-                c.is_ascii_digit() || c.is_ascii_whitespace() || ",-".contains(c)
-            })
-            .trim();
-        if !rest.is_empty() && !holders.iter().any(|h| h == rest) {
-            holders.push(rest.to_string());
+    for text in texts {
+        for raw in text.as_ref().lines() {
+            let line = raw.trim().trim_end_matches('.');
+            let Some(rest) =
+                line.get(..9).filter(|s| s.eq_ignore_ascii_case("Copyright")).map(|_| &line[9..])
+            else {
+                continue;
+            };
+            // Only lines where the keyword is followed by a `(c)`/`©` marker
+            // or a year carry an attribution. This skips license prose that
+            // merely mentions a "copyright license ..." as well as the
+            // Apache-2.0 appendix template
+            // `Copyright [yyyy] [name of copyright owner]`.
+            let rest = rest.trim_start();
+            if !rest.starts_with(['(', '©']) && !rest.starts_with(|c: char| c.is_ascii_digit()) {
+                continue;
+            }
+            // Strip an optional `(c)` / `©` marker first (only here may
+            // `c`/`C` be consumed), then a leading year or year-range and its
+            // separators.
+            let rest = rest
+                .trim_start_matches(|c: char| "()cC©".contains(c))
+                .trim_start_matches(|c: char| {
+                    c.is_ascii_digit() || c.is_ascii_whitespace() || ",-".contains(c)
+                })
+                .trim();
+            // License files wrap their lines, which can leave a holder-list
+            // entry ending in a dangling conjunction ("… Sun Microsystems
+            // or"). Drop it.
+            let rest = rest
+                .strip_suffix(" or")
+                .or_else(|| rest.strip_suffix(" and"))
+                .unwrap_or(rest)
+                .trim();
+            if !rest.is_empty() && !holders.iter().any(|h| h == rest) {
+                holders.push(rest.to_string());
+            }
         }
     }
     (!holders.is_empty()).then(|| holders.join(", "))


### PR DESCRIPTION
The authors field in Cargo.toml is optional and newer crates increasingly omit it, leaving the Author/Copyright column of the dependency table empty (99 of 510 rows for api/cpp). Salvage the copyright holder(s) from the LICENSE*/COPYING*/NOTICE* files shipped in the crate's package instead, reusing the Copyright-line extraction of the license-file fallback.

Require a (c)/year after the Copyright keyword so Apache-2.0 prose and its appendix template are not mistaken for attribution lines, and drop the dangling conjunction that line-wrapped holder lists leave behind.

This fills 67 of the 99 empty rows for api/cpp (32 remain: crates whose packages ship no attribution at all, or only a holder-less license template). api/node ends up with 33 of 536 rows empty, api/python with 35 of 544.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
