### PR TITLE
ComboBox: warn on current-value writes from host code; RadioGroup: make it `out`

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/combobox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/combobox.mdx
@@ -40,7 +40,13 @@ ComboBox {
 
 ### current-value
 <SlintProperty propName="current-value" typeName="string" defaultValue='""' propertyVisibility="in-out">
-The currently selected text
+The currently selected text.
+
+:::caution[Note]
+To change the selection from host code (Rust, C++, JavaScript, Python), write to
+`current-index`. Writes to `current-value` are not supported — they don't change
+the selection. The visible state continues to reflect `model[current-index]`.
+:::
 </SlintProperty>
 
 ### enabled

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
@@ -32,8 +32,10 @@ child of the group.
 ## Properties
 
 ### current-value
-<SlintProperty propName="current-value" typeName="string" defaultValue='""' propertyVisibility="in-out">
-The `text` of the currently selected `RadioButton`.
+<SlintProperty propName="current-value" typeName="string" defaultValue='""' propertyVisibility="out">
+The `text` of the currently selected `RadioButton`. To change the selection from
+host code, set the target `RadioButton`'s `checked` to `true` — typically through
+a two-way binding (`checked <=> model.field`).
 </SlintProperty>
 
 ### enabled

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2432,7 +2432,7 @@ export component RadioGroup {
     in property <string> title;
     in property <bool> enabled: true;
     in property <Orientation> orientation;
-    in-out property <string> current-value;
+    out property <string> current-value;
     out property <bool> has-focus;
     callback selected(string);
 

--- a/internal/compiler/widgets/common/combobox-base.slint
+++ b/internal/compiler/widgets/common/combobox-base.slint
@@ -80,6 +80,16 @@ export component ComboBoxBase {
         root.update-current-value();
     }
 
+    // Writes to `current-value` from host code don't change the selection;
+    // the visible state still reflects `model[current-index]`. Warn on the
+    // divergence so the developer learns to use `current-index` instead.
+    // See https://github.com/slint-ui/slint/issues/11970.
+    changed current-value => {
+        if root.current-value != root.model[root.current-index] {
+            debug("ComboBox: `current-value` writes don't change the selection. Use `current-index` instead. See https://github.com/slint-ui/slint/issues/11970.");
+        }
+    }
+
     /// Minimum scroll delta so that the scroll wheel changes the value.
     in property <length> scroll-delta: 2px;
 

--- a/internal/compiler/widgets/common/radiogroup-base.slint
+++ b/internal/compiler/widgets/common/radiogroup-base.slint
@@ -6,7 +6,7 @@ import { RadioButtonBase } from "radiobutton-base.slint";
 export component RadioGroupBase {
     in property <bool> enabled: true;
     in-out property <int> current-index: -1;
-    in-out property <string> current-value;
+    out property <string> current-value;
 
     callback selected(string);
 
@@ -126,7 +126,7 @@ export component RadioGroupImplBase {
     in property <int> title-font-weight: 400;
 
     in-out property <int> current-index <=> sel.current-index;
-    in-out property <string> current-value <=> sel.current-value;
+    out property <string> current-value: sel.current-value;
     out property <bool> has-focus: focus-depth > 0;
 
     callback selected <=> sel.selected;

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -254,6 +254,15 @@ instance.set_model(Rc::new(VecModel::from_slice(&[
 instance.set_current_index(2);
 mock_elapsed_time(500);
 assert_selection(2, "!!!THIS!!!");
+
+// Writes to `current-value` from host code are not a supported way to change
+// the selection — the widget emits a debug warning but doesn't revert the
+// host write. The current-index (and therefore the visible selection in the
+// popup) stays where it was. See https://github.com/slint-ui/slint/issues/11970.
+instance.set_current_value(SharedString::from("not this3"));
+mock_elapsed_time(500);
+assert_eq!(instance.get_current_index(), 2);
+assert_eq!(instance.get_current_value(), SharedString::from("not this3"));
 ```
 
 */

--- a/tests/cases/widgets/radiogroup.slint
+++ b/tests/cases/widgets/radiogroup.slint
@@ -11,7 +11,7 @@ export component TestCase inherits Window {
     in-out property <string> last-selected;
     in-out property <int> red-toggled-count: 0;
     in-out property <int> green-toggled-count: 0;
-    in-out property <string> current-value <=> group.current-value;
+    out property <string> current-value: group.current-value;
     out property <bool> has-focus <=> group.has-focus;
     out property <bool> test: current-value == "" && selected-count == 0;
 
@@ -178,6 +178,7 @@ slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_current_value(), SharedString::from("Red"));
 assert_eq!(instance.get_red_checked(), true);
 assert_eq!(instance.get_blue_checked(), false);
+
 ```
 
 */

--- a/tests/cases/widgets/radiogroup_for.slint
+++ b/tests/cases/widgets/radiogroup_for.slint
@@ -8,7 +8,7 @@ export component TestCase inherits Window {
     height: 300px;
 
     in-out property <[string]> options: ["A", "B", "C"];
-    in-out property <string> current-value <=> group.current-value;
+    out property <string> current-value: group.current-value;
 
     HorizontalLayout {
         alignment: start;

--- a/tests/cases/widgets/radiogroup_model.slint
+++ b/tests/cases/widgets/radiogroup_model.slint
@@ -17,7 +17,7 @@ export component TestCase inherits Window {
         { name: "B", checked: true },
         { name: "C", checked: false },
     ];
-    in-out property <string> current-value <=> group.current-value;
+    out property <string> current-value: group.current-value;
 
     HorizontalLayout {
         alignment: start;


### PR DESCRIPTION
## Summary

`ComboBox.current-value` and `RadioGroup.current-value` are `in-out`, but host
writes from Rust/C++/JS/Python don't actually change the selection: ComboBox's
value re-derives from `model[current-index]`, and RadioGroup's checked state
stays where it was. The misuse is silent today.

**ComboBox** has been `in-out` for many releases, so this adds a
`changed current-value` handler that emits one `debug(...)` line per host
write. No revert — the host's value stays where they put it. The combobox
still displays `model[current-index]`. Interim mitigation per #11970,
removable once #2752 / #8561 land and the widget can do a pure-Slint
reverse lookup.

**RadioGroup** is new in 1.17 (unreleased), so per @ogoffart's review I
changed `current-value` from `in-out` to `out` outright. Host writes are
now a compile error, and the runtime warning + `last-selected-value`
tracker are gone.

## Changes

- `internal/compiler/widgets/common/combobox-base.slint`: new
  `changed current-value` handler comparing against `model[current-index]`.
- `internal/compiler/builtins.slint`: `RadioGroup.current-value` →
  `out property`.
- `internal/compiler/widgets/common/radiogroup-base.slint`:
  `RadioGroupBase` / `RadioGroupImplBase` `current-value` → `out`.
- `docs/.../combobox.mdx`: caution note on `current-value` directing host
  code to `current-index`.
- `docs/.../radiogroup.mdx`: visibility changed to `out`, caution note
  reduced to a one-liner pointing host code at `RadioButton.checked`.
- `tests/cases/widgets/combobox.slint`: new assertion pinning the
  warn-only contract — the host's write sticks on `current-value` while
  `current-index` is unchanged.
- `tests/cases/widgets/radiogroup.slint`, `radiogroup_for.slint`,
  `radiogroup_model.slint`: switch from `current-value <=> group.current-value`
  to a one-way `current-value: group.current-value` since the source is
  now `out`.

## Test plan

- [x] `cargo test -p test-driver-rust` — combobox + radiogroup (all styles)
- [x] `cargo test -p test-driver-interpreter` — 121 widget tests pass
- [x] `cargo test -p test-driver-cpp` — combobox + radiogroup (all styles)
- [x] `cargo test -p doctests` — 285 pass
- [x] `cargo test -p i-slint-compiler --features display-diagnostics --test syntax_tests`