### PR TITLE
Remove DragArea.preferred-action

### DIFF
--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -58,7 +58,9 @@ Both `can-drop` and `dropped` return a <Link type="DragAction" />: `DragAction.c
 
 ## Drag actions
 
-A `DragArea` declares which actions it permits (`allow-copy`, `allow-move`, `allow-link`). When no modifier key is pressed, the proposed action is the first allowed of move, copy, link; modifier keys request a specific action (Ctrl -> copy, Shift -> move, Ctrl+Shift -> link).
+A `DragArea` declares which actions it permits (`allow-copy`, `allow-move`, `allow-link`).
+When no modifier key is pressed, the proposed action is the first allowed of move, copy, link;
+modifier keys request a specific action (Ctrl -> copy, Shift -> move, Ctrl+Shift -> link). On macOS, use Command (⌘) instead of Ctrl.
 The target picks the final action in `can-drop` (for hover) and `dropped` (final answer), the runtime clamps each against the source's allowed set, and when the drop completes the source's `drag-finished(action)` fires so a "move" source can remove the original data.
 
 ```slint no-test

--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -58,7 +58,7 @@ Both `can-drop` and `dropped` return a <Link type="DragAction" />: `DragAction.c
 
 ## Drag actions
 
-A `DragArea` declares which actions it permits (`allow-copy`, `allow-move`, `allow-link`) and a `preferred-action` that applies when no modifier is pressed.
+A `DragArea` declares which actions it permits (`allow-copy`, `allow-move`, `allow-link`). When no modifier key is pressed, the proposed action is the first allowed of move, copy, link; modifier keys request a specific action (Ctrl -> copy, Shift -> move, Ctrl+Shift -> link).
 The target picks the final action in `can-drop` (for hover) and `dropped` (final answer), the runtime clamps each against the source's allowed set, and when the drop completes the source's `drag-finished(action)` fires so a "move" source can remove the original data.
 
 ```slint no-test
@@ -66,7 +66,6 @@ DragArea {
     data: Api.make-data();
     allow-copy: false;
     allow-move: true;
-    preferred-action: DragAction.move;
     // Dim the source while the drag is in flight.
     opacity: self.dragging ? 0.4 : 1.0;
     drag-finished(action) => {

--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -33,6 +33,7 @@ export component Example inherits Window {
             background: #f0c000;
             DragArea {
                 data: Api.string-to-transfer("Hello World");
+                allow-copy: true;
             }
             Text { text: "Drag me"; }
         }
@@ -59,6 +60,7 @@ Both `can-drop` and `dropped` return a <Link type="DragAction" />: `DragAction.c
 ## Drag actions
 
 A `DragArea` declares which actions it permits (`allow-copy`, `allow-move`, `allow-link`).
+At least one must be set to true; a `DragArea` that permits no action never starts a drag (the compiler warns).
 When no modifier key is pressed, the proposed action is the first allowed of move, copy, link;
 modifier keys request a specific action (Ctrl -> copy, Shift -> move, Ctrl+Shift -> link). On macOS, use Command (⌘) instead of Ctrl.
 The target picks the final action in `can-drop` (for hover) and `dropped` (final answer), the runtime clamps each against the source's allowed set, and when the drop completes the source's `drag-finished(action)` fires so a "move" source can remove the original data.

--- a/examples/dnd-kanban/kanban.slint
+++ b/examples/dnd-kanban/kanban.slint
@@ -64,7 +64,6 @@ component Card inherits Rectangle {
         drag-image-offset-y: 28;
         allow-copy: true;
         allow-move: true;
-        preferred-action: DragAction.move;
         opacity: self.dragging ? 0.4 : 1.0;
 
         Text {

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -1395,6 +1395,7 @@ mod dispatch_result_tests {
                 VerticalLayout {
                     DragArea {
                         data: Api.make-data();
+                        allow-copy: true;
                         Rectangle { background: #abc; }
                     }
                     DropArea {
@@ -1437,6 +1438,7 @@ mod dispatch_result_tests {
                 height: 200px;
                 DragArea {
                     data: Api.make-data();
+                    allow-copy: true;
                     Rectangle { background: #abc; }
                 }
             }

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -104,10 +104,10 @@ macro_rules! for_each_builtin_structs {
                 /// Mirrors `DragArea.allow-link`: true if the source allows the drop to link to the data.
                 allow_link: bool,
 
-                /// The action negotiated from current modifier state and the source's `preferred-action`,
-                /// clamped to the allowed set. Updated on every `DragMove`. The target's `can-drop`
-                /// callback can return this to honor the user's modifier choice, or override with
-                /// any other allowed action.
+                /// The action negotiated from current modifier state, clamped to the allowed set;
+                /// when no modifier is pressed, the first allowed of move, copy, link.
+                /// Updated on every `DragMove`. The target's `can-drop` callback can return this
+                /// to honor the user's modifier choice, or override with any other allowed action.
                 proposed_action: DragAction,
             }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1205,10 +1205,11 @@ export component ScaleRotateGestureHandler {
 /// `data-transfer` values are opaque in Slint code:
 /// construct and read them via callbacks implemented in the host language.
 ///
-/// The source declares which actions it permits via `allow-copy`, `allow-move`, and `allow-link`,
-/// and a `preferred-action` that applies when no modifier key is pressed. The target picks the final
-/// action from this set in its `can-drop` callback. Once a drop completes (or the drag is cancelled),
-/// `drag-finished(action)` fires so a "move" source can remove the original data.
+/// The source declares which actions it permits via `allow-copy`, `allow-move`, and `allow-link`.
+/// When no modifier key is pressed, the proposed action is the first allowed of move, copy, link;
+/// modifier keys request a specific action (Ctrl -> copy, Shift -> move, Ctrl+Shift -> link).
+/// The target picks the final action from this set in its `can-drop` callback. Once a drop completes
+/// (or the drag is cancelled), `drag-finished(action)` fires so a "move" source can remove the original data.
 ///
 /// See <Link type="DragAndDrop" /> for a usage guide and a complete example.
 /// \group:drag-and-drop
@@ -1234,9 +1235,6 @@ export component DragArea {
     in property <bool> allow-move: false;
     /// Whether the source allows the drop to link to the data. Neither side gives up ownership.
     in property <bool> allow-link: false;
-    /// The action used when no modifier key is pressed. The runtime clamps it to the allowed set;
-    /// if the named action isn't allowed, falls back to the first allowed of move, copy, link.
-    in property <DragAction> preferred-action: DragAction.copy;
     /// `true` once the press has crossed the drag threshold and a drag is in flight,
     /// `false` once the drop completes or the drag is cancelled.
     out property <bool> dragging;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1206,6 +1206,7 @@ export component ScaleRotateGestureHandler {
 /// construct and read them via callbacks implemented in the host language.
 ///
 /// The source declares which actions it permits via `allow-copy`, `allow-move`, and `allow-link`.
+/// At least one must be set to true; a `DragArea` that permits no action never starts a drag.
 /// When no modifier key is pressed, the proposed action is the first allowed of move, copy, link;
 /// modifier keys request a specific action (Ctrl -> copy, Shift -> move, Ctrl+Shift -> link).
 /// The target picks the final action from this set in its `can-drop` callback. Once a drop completes
@@ -1229,12 +1230,12 @@ export component DragArea {
     /// `0` puts the image's top edge at the cursor.
     in property <int> drag-image-offset-y;
     /// Whether the source allows the drop to copy the data. The source retains the data.
-    in property <bool> allow-copy: true;
+    in property <bool> allow-copy;
     /// Whether the source allows the drop to move the data. The source should remove the
     /// original from its model in the `drag-finished` callback when the action is `move`.
-    in property <bool> allow-move: false;
+    in property <bool> allow-move;
     /// Whether the source allows the drop to link to the data. Neither side gives up ownership.
-    in property <bool> allow-link: false;
+    in property <bool> allow-link;
     /// `true` once the press has crossed the drag threshold and a drag is in flight,
     /// `false` once the drop completes or the drag is cancelled.
     out property <bool> dragging;

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2269,6 +2269,17 @@ impl Element {
         }
     }
 
+    /// Returns true if the property is set by a binding or an assignment expression
+    pub fn is_property_set(self: &Element, property_name: &str) -> bool {
+        self.bindings.contains_key(property_name)
+            || self
+                .property_analysis
+                .borrow()
+                .get(property_name)
+                .is_some_and(|a| a.is_set || a.is_linked)
+            || matches!(&self.base_type, ElementType::Component(base) if base.root_element.borrow().is_property_set(property_name))
+    }
+
     /// Set the property `property_name` of this Element only if it was not set.
     /// the `expression_fn` will only be called if it isn't set
     ///

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -4,6 +4,7 @@
 mod apply_default_properties_from_style;
 mod binding_analysis;
 mod border_radius;
+mod check_drag_area;
 mod check_expressions;
 mod check_public_api;
 mod clip;
@@ -153,6 +154,7 @@ pub async fn run_passes(
 
     doc.visit_all_used_components(|component| {
         border_radius::handle_border_radius(component, diag);
+        check_drag_area::check_drag_area(component, diag);
         deprecated_rotation_origin::handle_rotation_origin(component, diag);
         flickable::handle_flickable(component, &global_type_registry.borrow());
         lower_layout::lower_layouts(component, type_loader, &style_metrics, diag);

--- a/internal/compiler/passes/check_drag_area.rs
+++ b/internal/compiler/passes/check_drag_area.rs
@@ -1,0 +1,35 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! This pass warns about a `DragArea` that permits no drag action, i.e. none of
+//! `allow-copy`, `allow-move`, or `allow-link` is set. Such a `DragArea` never starts a drag.
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::object_tree::{Component, ElementRc};
+
+const ALLOW_PROPERTIES: [&str; 3] = ["allow-copy", "allow-move", "allow-link"];
+
+pub fn check_drag_area(component: &Component, diag: &mut BuildDiagnostics) {
+    crate::object_tree::recurse_elem_including_sub_components_no_borrow(
+        component,
+        &(),
+        &mut |elem, _| {
+            if !is_drag_area(elem) {
+                return;
+            }
+            if ALLOW_PROPERTIES.iter().any(|prop| elem.borrow().is_property_set(prop)) {
+                return;
+            }
+            diag.push_warning(
+                "This 'DragArea' permits no drag action and will never start a drag; \
+                 set 'allow-copy', 'allow-move', or 'allow-link' to true"
+                    .into(),
+                &*elem.borrow(),
+            );
+        },
+    );
+}
+
+fn is_drag_area(e: &ElementRc) -> bool {
+    e.borrow().builtin_type().is_some_and(|bt| bt.name.as_str() == "DragArea")
+}

--- a/internal/compiler/passes/deprecated_rotation_origin.rs
+++ b/internal/compiler/passes/deprecated_rotation_origin.rs
@@ -5,9 +5,8 @@
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::Expression;
-use crate::langtype::ElementType;
 use crate::namedreference::NamedReference;
-use crate::object_tree::{Component, Element, ElementRc};
+use crate::object_tree::{Component, ElementRc};
 use core::cell::RefCell;
 use smol_str::SmolStr;
 
@@ -21,7 +20,7 @@ pub fn handle_rotation_origin(component: &Component, diag: &mut BuildDiagnostics
             let mut must_materialize = false;
             let mut seen = false;
             for (prop, _) in crate::typeregister::DEPRECATED_ROTATION_ORIGIN_PROPERTIES {
-                if is_property_set(&elem.borrow(), prop) {
+                if elem.borrow().is_property_set(prop) {
                     let span = match elem
                         .borrow()
                         .bindings
@@ -85,11 +84,4 @@ pub fn handle_rotation_origin(component: &Component, diag: &mut BuildDiagnostics
 /// true if this element had a rotation-origin property
 fn is_image_or_text(e: &ElementRc) -> bool {
     e.borrow().builtin_type().is_some_and(|bt| matches!(bt.name.as_str(), "Image" | "Text"))
-}
-
-/// Returns true if the property is set by a binding or an assignment expression
-fn is_property_set(e: &Element, property_name: &str) -> bool {
-    e.bindings.contains_key(property_name)
-        || e.property_analysis.borrow().get(property_name).is_some_and(|a| a.is_set || a.is_linked)
-        || matches!(&e.base_type, ElementType::Component(base) if is_property_set(&base.root_element.borrow(), property_name))
 }

--- a/internal/compiler/tests/syntax/elements/dragarea.slint
+++ b/internal/compiler/tests/syntax/elements/dragarea.slint
@@ -1,0 +1,19 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test {
+    // No allowed action: warns.
+    DragArea { }
+//  >       <warning{This 'DragArea' permits no drag action and will never start a drag; set 'allow-copy', 'allow-move', or 'allow-link' to true}
+
+    // At least one allowed action: fine.
+    DragArea {
+        allow-move: true;
+    }
+
+    // Inherited allowed action: fine.
+    DragArea {
+        allow-copy: my-flag;
+        property <bool> my-flag: true;
+    }
+}

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -40,7 +40,6 @@ pub struct DragArea {
     pub allow_copy: Property<bool>,
     pub allow_move: Property<bool>,
     pub allow_link: Property<bool>,
-    pub preferred_action: Property<DragAction>,
     pub dragging: Property<bool>,
     pub drag_finished: Callback<DragActionArg, ()>,
     pressed: Cell<bool>,
@@ -231,36 +230,25 @@ impl DragArea {
         self.allow_copy() || self.allow_move() || self.allow_link()
     }
 
-    /// Returns the first allowed of: preferred_action, move, copy, link. None if no action is allowed.
-    pub(crate) fn effective_default_action(self: Pin<&Self>) -> DragAction {
-        let preferred = self.preferred_action();
-        let allowed = |a| match a {
-            DragAction::None => false,
-            DragAction::Copy => self.allow_copy(),
-            DragAction::Move => self.allow_move(),
-            DragAction::Link => self.allow_link(),
-        };
-        if allowed(preferred) {
-            return preferred;
-        }
-        for fallback in [DragAction::Move, DragAction::Copy, DragAction::Link] {
-            if allowed(fallback) {
-                return fallback;
-            }
-        }
-        DragAction::None
-    }
-
     /// Build the initial DropEvent for a drag starting on this DragArea, populating
-    /// the source's allowed actions and seeding `proposed_action` from the preferred default.
+    /// the source's allowed actions and seeding `proposed_action` from the default action
+    /// (the first allowed of move, copy, link).
     pub(crate) fn initial_drop_event(self: Pin<&Self>) -> DropEvent {
+        let allow_copy = self.allow_copy();
+        let allow_move = self.allow_move();
+        let allow_link = self.allow_link();
         DropEvent {
             data: self.data(),
             position: Default::default(),
-            allow_copy: self.allow_copy(),
-            allow_move: self.allow_move(),
-            allow_link: self.allow_link(),
-            proposed_action: self.effective_default_action(),
+            allow_copy,
+            allow_move,
+            allow_link,
+            proposed_action: compute_proposed_action(
+                KeyboardModifiers::default(),
+                allow_copy,
+                allow_move,
+                allow_link,
+            ),
         }
     }
 }
@@ -407,13 +395,12 @@ impl ItemConsts for DropArea {
 
 /// Compute the action proposed by the user's current modifier state, clamped to the source's
 /// allowed actions. Ctrl alone → copy, Shift alone → move, Ctrl+Shift → link, no modifier →
-/// `preferred` with deterministic fallback to the first allowed of move/copy/link.
+/// the first allowed of move/copy/link.
 pub(crate) fn compute_proposed_action(
     modifiers: KeyboardModifiers,
     allow_copy: bool,
     allow_move: bool,
     allow_link: bool,
-    preferred: DragAction,
 ) -> DragAction {
     let allowed = |a| match a {
         DragAction::Copy => allow_copy,
@@ -431,9 +418,6 @@ pub(crate) fn compute_proposed_action(
         && allowed(req)
     {
         return req;
-    }
-    if allowed(preferred) {
-        return preferred;
     }
     for fallback in [DragAction::Move, DragAction::Copy, DragAction::Link] {
         if allowed(fallback) {
@@ -475,10 +459,9 @@ mod tests {
 
     #[test]
     fn compute_proposed_action_modifier_table() {
-        let preferred = DragAction::Copy;
         // All actions allowed.
-        let a = |m| compute_proposed_action(m, true, true, true, preferred);
-        assert_eq!(a(modifiers(false, false)), DragAction::Copy);
+        let a = |m| compute_proposed_action(m, true, true, true);
+        assert_eq!(a(modifiers(false, false)), DragAction::Move);
         assert_eq!(a(modifiers(true, false)), DragAction::Copy);
         assert_eq!(a(modifiers(false, true)), DragAction::Move);
         assert_eq!(a(modifiers(true, true)), DragAction::Link);
@@ -488,31 +471,34 @@ mod tests {
     fn compute_proposed_action_falls_back_when_modifier_action_not_allowed() {
         // Source only allows move; user holds Ctrl (asking for copy).
         assert_eq!(
-            compute_proposed_action(modifiers(true, false), false, true, false, DragAction::Move),
+            compute_proposed_action(modifiers(true, false), false, true, false),
             DragAction::Move
         );
-        // User holds Ctrl+Shift asking for link, only copy allowed; preferred copy.
+        // User holds Ctrl+Shift asking for link, only copy allowed.
         assert_eq!(
-            compute_proposed_action(modifiers(true, true), true, false, false, DragAction::Copy),
+            compute_proposed_action(modifiers(true, true), true, false, false),
             DragAction::Copy
         );
     }
 
     #[test]
-    fn compute_proposed_action_preferred_clamped_to_allowed_set() {
-        // Preferred is move but only copy is allowed; no modifiers — should fall back to copy.
+    fn compute_proposed_action_default_is_first_allowed() {
+        // No modifiers: the first allowed of move, copy, link wins.
         assert_eq!(
-            compute_proposed_action(modifiers(false, false), true, false, false, DragAction::Move),
+            compute_proposed_action(modifiers(false, false), true, true, false),
+            DragAction::Move
+        );
+        assert_eq!(
+            compute_proposed_action(modifiers(false, false), true, false, false),
             DragAction::Copy
         );
-        // Preferred None — same behavior, picks first allowed.
         assert_eq!(
-            compute_proposed_action(modifiers(false, false), false, false, true, DragAction::None),
+            compute_proposed_action(modifiers(false, false), false, false, true),
             DragAction::Link
         );
         // Nothing allowed at all.
         assert_eq!(
-            compute_proposed_action(modifiers(false, false), false, false, false, DragAction::Copy),
+            compute_proposed_action(modifiers(false, false), false, false, false),
             DragAction::None
         );
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -726,19 +726,11 @@ impl WindowInner {
                     drop_event.position = crate::lengths::logical_position_to_api(*position);
                     // Recompute the proposed action from current modifier state so the target's
                     // `can-drop` callback sees an up-to-date `event.proposed-action`.
-                    let preferred = mouse_input_state
-                        .drag_source
-                        .as_ref()
-                        .and_then(|s| s.upgrade())
-                        .and_then(|i| i.downcast::<crate::items::DragArea>())
-                        .map(|d| d.as_pin_ref().preferred_action())
-                        .unwrap_or(crate::items::DragAction::Copy);
                     drop_event.proposed_action = crate::items::compute_proposed_action(
                         self.context().0.modifiers.get().into(),
                         drop_event.allow_copy,
                         drop_event.allow_move,
                         drop_event.allow_link,
-                        preferred,
                     );
                     // Mirror the position and proposed action into the persistent state so the
                     // renderer can place the drag-image overlay without re-deriving the cursor

--- a/tests/cases/elements/dragarea_actions.slint
+++ b/tests/cases/elements/dragarea_actions.slint
@@ -24,7 +24,6 @@ export component TestCase inherits Window {
                 allow-copy: false;
                 allow-move: true;
                 allow-link: false;
-                preferred-action: DragAction.move;
                 drag-finished(action) => {
                     last-finished = action;
                     finished-count += 1;

--- a/tests/cases/elements/dragarea_droparea.slint
+++ b/tests/cases/elements/dragarea_droparea.slint
@@ -34,6 +34,7 @@ export component TestCase inherits Window {
         Rectangle {
             background: inner_touch_area.has-hover ? yellow : red;
             dragger := DragArea {
+                allow-copy: true;
                 data: empty-data
                 ? Api.empty-transfer()
                 : (use-image

--- a/tests/cases/elements/dragarea_image.slint
+++ b/tests/cases/elements/dragarea_image.slint
@@ -25,6 +25,7 @@ export component TestCase inherits Window {
             background: red;
             DragArea {
                 data: Api.string-to-transfer("Hello World");
+                allow-copy: true;
                 drag-image: @image-url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
                 drag-image-offset-x: 4;
                 drag-image-offset-y: 8;

--- a/tests/cases/elements/dragarea_modifiers.slint
+++ b/tests/cases/elements/dragarea_modifiers.slint
@@ -23,7 +23,6 @@ export component TestCase inherits Window {
                 allow-copy: true;
                 allow-move: true;
                 allow-link: true;
-                preferred-action: DragAction.move;
             }
         }
         Rectangle {
@@ -52,7 +51,7 @@ instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPo
 slint_testing::mock_elapsed_time(20);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(22.0, 120.0) });
 slint_testing::mock_elapsed_time(20);
-// No modifiers → preferred-action move.
+// No modifiers -> first allowed action (move).
 assert_eq!(instance.get_current_action(), DragAction::Move);
 
 // Ctrl pressed without any mouse motion → proposed-action becomes copy.
@@ -67,7 +66,7 @@ assert_eq!(instance.get_current_action(), DragAction::Link);
 instance.window().dispatch_event(WindowEvent::KeyReleased { text: Key::Control.into() });
 assert_eq!(instance.get_current_action(), DragAction::Move);
 
-// Release Shift → back to preferred (move).
+// Release Shift -> back to the no-modifier default (move).
 instance.window().dispatch_event(WindowEvent::KeyReleased { text: Key::Shift.into() });
 assert_eq!(instance.get_current_action(), DragAction::Move);
 

--- a/tools/lsp/ui/components/expandable-listview.slint
+++ b/tools/lsp/ui/components/expandable-listview.slint
@@ -78,6 +78,7 @@ component ItemTemplate {
 
     DragArea {
         data: Api.new-component-data(data.index);
+        allow-copy: true;
 
         touch-area := TouchArea {
             changed has-hover => {

--- a/tools/lsp/ui/views/outline-view.slint
+++ b/tools/lsp/ui/views/outline-view.slint
@@ -58,7 +58,7 @@ export component OutlineView inherits VerticalLayout {
         for item[idx] in outline-data: DragArea {
             height: 38px;
             data: Api.move-element-instance-data(item.uri, item.offset);
-            allow-copy: true;
+            allow-move: true;
 
             property <bool> selected: item.uri == Api.current-element.source-uri && item.offset == Api.current-element.offset;
 

--- a/tools/lsp/ui/views/outline-view.slint
+++ b/tools/lsp/ui/views/outline-view.slint
@@ -58,6 +58,7 @@ export component OutlineView inherits VerticalLayout {
         for item[idx] in outline-data: DragArea {
             height: 38px;
             data: Api.move-element-instance-data(item.uri, item.offset);
+            allow-copy: true;
 
             property <bool> selected: item.uri == Api.current-element.source-uri && item.offset == Api.current-element.offset;
 


### PR DESCRIPTION
As discussed, it may not be possible to support this towards the windowing system but only within the process, at which point this isn't a very useful API to offer. In-app dnd continues to default to move as action.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
