### PR TITLE
node: keep `window` a non-optional property

### DIFF
--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -184,7 +184,7 @@ test("loadSource", () => {
     ]);
 });
 
-test("non-windowed components have no `window` property", () => {
+test("accessing `window` on non-windowed components throws", () => {
     const source = `
         export component Win inherits Window {
             in-out property <string> name: "world";
@@ -198,8 +198,8 @@ test("non-windowed components have no `window` property", () => {
     const win = new mod.Win();
     const tray = new mod.Tray();
 
-    expect("window" in win).toBe(true);
-    expect("window" in tray).toBe(false);
+    expect(win.window).toBeDefined();
+    expect(() => tray.window).toThrow();
 });
 
 test("loadSource constructor parameters", () => {

--- a/api/node/rust/interpreter/component_instance.rs
+++ b/api/node/rust/interpreter/component_instance.rs
@@ -425,6 +425,11 @@ impl JsComponentInstance {
 
     #[napi]
     pub fn window(&self) -> Result<JsWindow> {
+        if !self.inner.definition().is_window() {
+            return Err(napi::Error::from_reason(
+                "this component is not windowed (for example because it inherits from SystemTrayIcon) and has no window",
+            ));
+        }
         Ok(JsWindow { inner: WindowInner::from_pub(self.inner.window()).window_adapter() })
     }
 }

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -157,9 +157,9 @@ export interface ComponentHandle {
      * Returns the {@link Window} associated with this component instance.
      * The window API can be used to control different aspects of the integration into the windowing system, such as the position on the screen.
      *
-     * Not present on non-windowed components such as ones inheriting from `SystemTrayIcon`.
+     * Throws an error when accessed on non-windowed components such as ones inheriting from `SystemTrayIcon`.
      */
-    readonly window?: Window;
+    get window(): Window;
 }
 
 /**
@@ -174,17 +174,10 @@ class Component implements ComponentHandle {
      */
     constructor(instance: napi.ComponentInstance) {
         this.#instance = instance;
+    }
 
-        // Non-windowed components (e.g. `SystemTrayIcon`) don't have a `window`:
-        // the underlying `instance.window()` would panic. Install the getter
-        // only when meaningful so `'window' in component` reflects support.
-        if (instance.definition().isWindow) {
-            Object.defineProperty(this, "window", {
-                get: () => this.#instance.window(),
-                enumerable: true,
-                configurable: false,
-            });
-        }
+    get window(): Window {
+        return this.#instance.window();
     }
 
     /**


### PR DESCRIPTION
Making `window` optional on ComponentHandle (09cadf6477) broke existing TypeScript code such as `component.window.show()` under strict null checks. The Node.js API must stay source-compatible, so keep the accessor always present and throw a catchable error for non-windowed components instead.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
