### PR TITLE
node: replace ArrayModel.insert with splice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ All notable changes to this project are documented in this file.
  - Integrate event loop with libuv fd on Linux and macOS with node to avoid excessive polling
  - Fixed leak when a callback handler has a reference to a component instance.
  - exposed StyledText markdown parsing API.
- - Added `ArrayModel.insert` to insert a value at a given index.
+ - Added `ArrayModel.splice` to remove and/or insert values at a given index, following the semantics of `Array.prototype.splice`.
  - Added public API to create `keys`
 
 ### Python

--- a/api/node/__test__/models.spec.mts
+++ b/api/node/__test__/models.spec.mts
@@ -16,38 +16,49 @@ import {
 
 private_api.initTesting();
 
-test("ArrayModel.insert at start, middle, and end", () => {
+test("ArrayModel.splice inserts at start, middle, and end", () => {
     const m = new ArrayModel<number>([1, 2, 3]);
-    m.insert(0, 0);
+    m.splice(0, 0, 0);
     expect([...m.values()]).toEqual([0, 1, 2, 3]);
-    m.insert(2, 99);
+    m.splice(2, 0, 99);
     expect([...m.values()]).toEqual([0, 1, 99, 2, 3]);
-    m.insert(m.rowCount(), 100);
+    m.splice(m.rowCount(), 0, 100);
     expect([...m.values()]).toEqual([0, 1, 99, 2, 3, 100]);
     expect(m.rowCount()).toBe(6);
 });
 
-test("ArrayModel.insert clamps out-of-range indices", () => {
+test("ArrayModel.splice removes and returns elements", () => {
+    const m = new ArrayModel<number>([1, 2, 3, 4, 5]);
+    expect(m.splice(1, 2)).toEqual([2, 3]);
+    expect([...m.values()]).toEqual([1, 4, 5]);
+    // Omitted deleteCount removes everything from `start` to the end.
+    expect(m.splice(1)).toEqual([4, 5]);
+    expect([...m.values()]).toEqual([1]);
+});
+
+test("ArrayModel.splice replaces elements", () => {
+    const m = new ArrayModel<number>([1, 2, 3, 4]);
+    expect(m.splice(1, 2, 20, 30)).toEqual([2, 3]);
+    expect([...m.values()]).toEqual([1, 20, 30, 4]);
+});
+
+test("ArrayModel.splice handles out-of-range indices like Array.prototype.splice", () => {
     const m = new ArrayModel<number>([1, 2, 3]);
-    m.insert(-5, 7);
-    expect([...m.values()]).toEqual([7, 1, 2, 3]);
-    m.insert(100, 8);
-    expect([...m.values()]).toEqual([7, 1, 2, 3, 8]);
+    m.splice(-1, 0, 7);
+    expect([...m.values()]).toEqual([1, 2, 7, 3]);
+    m.splice(-100, 0, 8);
+    expect([...m.values()]).toEqual([8, 1, 2, 7, 3]);
+    m.splice(100, 1, 9);
+    expect([...m.values()]).toEqual([8, 1, 2, 7, 3, 9]);
 });
 
-test("ArrayModel.insert accepts multiple values", () => {
-    const m = new ArrayModel<number>([1, 4]);
-    m.insert(1, 2, 3);
-    expect([...m.values()]).toEqual([1, 2, 3, 4]);
-});
-
-test("ArrayModel.insert into empty model", () => {
+test("ArrayModel.splice into empty model", () => {
     const m = new ArrayModel<number>([]);
-    m.insert(0, 42);
+    expect(m.splice(0, 0, 42)).toEqual([]);
     expect([...m.values()]).toEqual([42]);
 });
 
-test("ArrayModel.insert notifies the run-time", () => {
+test("ArrayModel.splice notifies the run-time", () => {
     const source = `
     export component App {
       in-out property <[int]> data;
@@ -59,10 +70,12 @@ test("ArrayModel.insert notifies the run-time", () => {
     const m = new ArrayModel<number>([10, 20]);
     instance.data = m;
     expect(instance.total).toBe(30);
-    m.insert(0, 5);
+    m.splice(0, 0, 5);
     expect(instance.total).toBe(25);
-    m.insert(m.rowCount(), 100);
+    m.splice(m.rowCount(), 0, 100);
     expect(instance.total).toBe(105);
+    m.splice(0, 1, 7);
+    expect(instance.total).toBe(107);
 });
 
 test("MapModel notify rowChanged", () => {

--- a/api/node/typescript/models.ts
+++ b/api/node/typescript/models.ts
@@ -175,7 +175,8 @@ export abstract class Model<T> implements Iterable<T> {
 
 /**
  * ArrayModel wraps a JavaScript array for use in `.slint` views. The underlying
- * array can be modified with the [[ArrayModel.push]] and [[ArrayModel.remove]] methods.
+ * array can be modified with the [[ArrayModel.push]], [[ArrayModel.remove]], and
+ * [[ArrayModel.splice]] methods.
  */
 export class ArrayModel<T> extends Model<T> {
     /**
@@ -250,7 +251,6 @@ export class ArrayModel<T> extends Model<T> {
         return last;
     }
 
-    // FIXME: should this be named splice and have the splice api?
     /**
      * Removes the specified number of element from the array that's backing
      * the model, starting at the specified index.
@@ -263,15 +263,32 @@ export class ArrayModel<T> extends Model<T> {
     }
 
     /**
-     * Inserts new values into the array that's backing the model at the given
-     * index and notifies the run-time about the added rows.
-     * @param index zero-based index at which to insert; clamped to [0, length].
-     * @param values list of values to insert.
+     * Removes elements from the array that's backing the model and, if
+     * necessary, inserts new elements in their place, following the semantics
+     * of `Array.prototype.splice`. The run-time is notified about the removed
+     * and added rows.
+     * @param start zero-based index at which to start changing the array; negative values count back from the end and out-of-range values are clamped.
+     * @param deleteCount number of elements to remove starting at `start`; if omitted, all elements from `start` to the end are removed.
+     * @param items elements to insert at `start`.
+     * @returns an array containing the removed elements.
      */
-    insert(index: number, ...values: T[]) {
-        const clamped = Math.max(0, Math.min(index, this.#array.length));
-        this.#array.splice(clamped, 0, ...values);
-        this.notifyRowAdded(clamped, values.length);
+    splice(start: number, deleteCount?: number, ...items: T[]): T[] {
+        const len = this.#array.length;
+        // Normalize `start` the way `Array.prototype.splice` does, so the
+        // change notifications point at the actual mutation index.
+        const actualStart =
+            start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
+        const removed =
+            deleteCount === undefined
+                ? this.#array.splice(actualStart)
+                : this.#array.splice(actualStart, deleteCount, ...items);
+        if (removed.length > 0) {
+            this.notifyRowRemoved(actualStart, removed.length);
+        }
+        if (items.length > 0) {
+            this.notifyRowAdded(actualStart, items.length);
+        }
+        return removed;
     }
 
     /**

--- a/examples/dnd-kanban/main.js
+++ b/examples/dnd-kanban/main.js
@@ -28,9 +28,7 @@ const doing = new slint.ArrayModel([
     { title: "Polish drag-and-drop example" },
     { title: "Review kanban PR" },
 ]);
-const done = new slint.ArrayModel([
-    { title: "Set up project skeleton" },
-]);
+const done = new slint.ArrayModel([{ title: "Set up project skeleton" }]);
 
 appWindow.todo = todo;
 appWindow.doing = doing;
@@ -63,7 +61,7 @@ appWindow.Api.dropped = (event, targetColumn, targetIndex) => {
     if (payload instanceof DragPayload) {
         if (event.proposed_action !== DragAction.Move) {
             // Anything that isn't an explicit move is treated as a copy.
-            columns[targetColumn].insert(targetIndex, payload.task);
+            columns[targetColumn].splice(targetIndex, 0, payload.task);
             return;
         }
         const source = payload.sourceColumn;
@@ -73,19 +71,23 @@ appWindow.Api.dropped = (event, targetColumn, targetIndex) => {
             // Same-column reorder. Drops at the source slot or immediately
             // after it are no-ops; otherwise remove the source first, adjusting
             // the target index for the shift that the removal causes.
-            if (targetIndex === sourceIndex || targetIndex === sourceIndex + 1) return;
+            if (targetIndex === sourceIndex || targetIndex === sourceIndex + 1)
+                return;
             const task = payload.task;
-            columns[source].remove(sourceIndex, 1);
-            const adjusted = targetIndex > sourceIndex ? targetIndex - 1 : targetIndex;
-            columns[targetColumn].insert(adjusted, task);
+            columns[source].splice(sourceIndex, 1);
+            const adjusted =
+                targetIndex > sourceIndex ? targetIndex - 1 : targetIndex;
+            columns[targetColumn].splice(adjusted, 0, task);
         } else {
             // Cross-column move. Source and target are independent models, so
             // the order of operations doesn't affect index stability.
-            columns[source].remove(sourceIndex, 1);
-            columns[targetColumn].insert(targetIndex, payload.task);
+            columns[source].splice(sourceIndex, 1);
+            columns[targetColumn].splice(targetIndex, 0, payload.task);
         }
     } else if (event.data.hasPlainText) {
-        columns[targetColumn].insert(targetIndex, { title: event.data.plainText });
+        columns[targetColumn].splice(targetIndex, 0, {
+            title: event.data.plainText,
+        });
     }
 };
 


### PR DESCRIPTION
JavaScript developers already know Array.prototype.splice, and one method following its exact semantics covers insertion, removal, and replacement. Since `insert` was never in a release, replace it before it ships rather than carrying two overlapping APIs.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
