### PR TITLE
iOS: Add support for querying the system font size

### DIFF
--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, atomic::AtomicUsize};
 #[cfg(not(no_qt))]
 thread_local! {
     /// Set once by [`Backend::bind_context`]; read from rust!() callbacks fired by the
-    /// Qt event filter installed on `qApp` so palette/theme changes can push the new
+    /// Qt event filter installed on `qApp` so palette/theme/font changes can push the new
     /// values onto the process-wide [`i_slint_core::SlintContext`] without going through
     /// any specific [`qt_window::QtWindow`].
     static QT_CONTEXT: std::cell::OnceCell<i_slint_core::SlintContextWeak> =
@@ -182,11 +182,12 @@ impl i_slint_core::platform::Platform for Backend {
         });
         // Read the host shell's current values once and push them to the context, then
         // install an `qApp`-level event filter that re-pushes whenever Qt reports a
-        // theme/palette change. The previous design did the read in `QtWindow::new` and
+        // theme/palette/font change. The previous design did the read in `QtWindow::new` and
         // the change-tracking in each window's `changeEvent`, which is wasteful when
         // there are multiple windows and outright broken when there are zero windows.
         update_palette_state();
-        install_palette_observer();
+        update_font_state();
+        install_app_state_observer();
     }
 
     fn create_window_adapter(
@@ -422,22 +423,43 @@ fn update_palette_state() {
 }
 
 #[cfg(not(no_qt))]
-fn install_palette_observer() {
+fn update_font_state() {
+    use cpp::cpp;
+    let default_font_size = cpp! {unsafe [] -> i32 as "int" {
+        return QFontInfo(qApp->font()).pixelSize();
+    }};
+    QT_CONTEXT.with(|cell| {
+        if let Some(ctx) = cell.get().and_then(|w| w.upgrade()) {
+            ctx.set_platform_default_font_size(Some(i_slint_core::lengths::LogicalLength::new(
+                default_font_size as f32,
+            )));
+        }
+    });
+}
+
+#[cfg(not(no_qt))]
+fn install_app_state_observer() {
     use cpp::cpp;
     cpp! {{
         #include <QtCore/QEvent>
         #include <QtCore/QObject>
+        #include <QtGui/QFontInfo>
         #include <QtWidgets/QApplication>
 
-        struct SlintPaletteObserver : QObject {
+        struct SlintAppStateObserver : QObject {
             using QObject::QObject;
             bool eventFilter(QObject *watched, QEvent *event) override {
-                if (watched == qApp
-                    && (event->type() == QEvent::ApplicationPaletteChange
-                        || event->type() == QEvent::ThemeChange)) {
-                    rust!(Slint_qt_palette_changed [] {
-                        crate::update_palette_state();
-                    });
+                if (watched == qApp) {
+                    if (event->type() == QEvent::ApplicationPaletteChange
+                        || event->type() == QEvent::ThemeChange) {
+                        rust!(Slint_qt_palette_changed [] {
+                            crate::update_palette_state();
+                        });
+                    } else if (event->type() == QEvent::ApplicationFontChange) {
+                        rust!(Slint_qt_font_changed [] {
+                            crate::update_font_state();
+                        });
+                    }
                 }
                 return false;
             }
@@ -447,7 +469,7 @@ fn install_palette_observer() {
         ensure_initialized(true);
         // Parented to qApp so it lives as long as the application and is cleaned up
         // automatically on exit. installEventFilter doesn't take ownership.
-        auto *observer = new SlintPaletteObserver(qApp);
+        auto *observer = new SlintAppStateObserver(qApp);
         qApp->installEventFilter(observer);
     }};
 }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2679,16 +2679,6 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         Ok(())
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        let default_font_size = cpp!(unsafe[] -> i32 as "int" {
-            return QFontInfo(qApp->font()).pixelSize();
-        });
-        // Ideally this would return the value from another property with a binding that's updated
-        // as a FontChange event is received. This is relevant for the case of using the Qt backend
-        // with a non-native style.
-        LogicalLength::new(default_font_size as f32)
-    }
-
     fn free_graphics_resources(
         &self,
         component: ItemTreeRef,

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -515,10 +515,6 @@ impl RendererSealed for TestingWindow {
         Ok(())
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        sharedparley::DEFAULT_FONT_SIZE
-    }
-
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
         // No-op since TestingWindow is also the WindowAdapter
     }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -130,7 +130,7 @@ i-slint-renderer-skia = { workspace = true, features = ["default"] }
 [target.'cfg(target_os = "ios")'.dependencies]
 objc2 = { workspace = true }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "block2", "NSString", "NSNotification", "NSOperation", "NSGeometry", "NSRunLoop", "objc2-core-foundation"] }
-objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIScreen", "UIWindow", "UIView", "UIViewAnimating", "UIViewPropertyAnimator", "UIResponder", "UIInterface", "UIPasteboard", "UITrait", "UITraitCollection", "objc2-core-foundation", "objc2-quartz-core", "block2"] }
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIScreen", "UIWindow", "UIView", "UIViewAnimating", "UIViewPropertyAnimator", "UIResponder", "UIInterface", "UIPasteboard", "UITrait", "UITraitCollection", "UIFont", "UIFontDescriptor", "objc2-core-foundation", "objc2-quartz-core", "block2"] }
 objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["CADisplayLink", "CATransaction"] }
 # Match version in objc2
 block2 = "0.6.2"

--- a/internal/backends/winit/ios.rs
+++ b/internal/backends/winit/ios.rs
@@ -3,14 +3,16 @@
 
 mod clipboard;
 mod color_scheme;
+mod font_size;
 mod keyboard_animator;
 mod touch_finger_id;
+mod trait_observer;
 mod virtual_keyboard;
 
 pub(crate) use clipboard::UiPasteboardClipboard;
-pub(crate) use color_scheme::{
-    ColorSchemeObserver, current_color_scheme, install_color_scheme_observer,
-};
+pub(crate) use color_scheme::{current_color_scheme, install_color_scheme_observer};
+pub(crate) use font_size::{current_default_font_size, install_font_size_observer};
 pub(crate) use keyboard_animator::KeyboardCurveSampler;
 pub(crate) use touch_finger_id::TouchFingerIdAllocator;
+pub(crate) use trait_observer::TraitChangeObserver;
 pub(crate) use virtual_keyboard::{KeyboardNotifications, register_keyboard_notifications};

--- a/internal/backends/winit/ios/color_scheme.rs
+++ b/internal/backends/winit/ios/color_scheme.rs
@@ -6,23 +6,16 @@
 // work on iOS and this whole module — plus the `ios_color_scheme_observer`
 // wiring in winitwindowadapter.rs — can be deleted.
 
-use std::ptr::NonNull;
 use std::rc::Weak;
 
-use block2::RcBlock;
-use objc2::{
-    ClassType, Message, available, msg_send,
-    rc::Retained,
-    runtime::{AnyClass, ProtocolObject},
-};
-use objc2_foundation::NSArray;
+use objc2::ClassType;
 use objc2_ui_kit::{
-    UITraitChangeObservable, UITraitChangeRegistration, UITraitCollection, UITraitEnvironment,
-    UITraitUserInterfaceStyle, UIUserInterfaceStyle, UIView,
+    UITraitEnvironment as _, UITraitUserInterfaceStyle, UIUserInterfaceStyle, UIView,
 };
 
 use i_slint_core::items::ColorScheme;
 
+use super::trait_observer::{TraitChangeObserver, install_trait_change_observer};
 use crate::winitwindowadapter::WinitWindowAdapter;
 
 fn style_to_color_scheme(style: UIUserInterfaceStyle) -> ColorScheme {
@@ -37,48 +30,13 @@ pub(crate) fn current_color_scheme(view: &UIView) -> ColorScheme {
     style_to_color_scheme(unsafe { view.traitCollection().userInterfaceStyle() })
 }
 
-pub(crate) struct ColorSchemeObserver {
-    view: Retained<UIView>,
-    registration: Retained<ProtocolObject<dyn UITraitChangeRegistration>>,
-}
-
-impl Drop for ColorSchemeObserver {
-    fn drop(&mut self) {
-        self.view.unregisterForTraitChanges(&self.registration);
-    }
-}
-
 pub(crate) fn install_color_scheme_observer(
     view: &UIView,
     adapter: Weak<WinitWindowAdapter>,
-) -> Option<ColorSchemeObserver> {
-    // `registerForTraitChanges:withHandler:` is iOS 17+. Older iOS still gets the
-    // initial scheme via `current_color_scheme`, but no live updates.
-    if !available!(ios = 17.0) {
-        return None;
-    }
-
-    let handler = RcBlock::new(
-        move |env: NonNull<ProtocolObject<dyn UITraitEnvironment>>,
-              _prev: NonNull<UITraitCollection>| {
-            let Some(adapter) = adapter.upgrade() else { return };
-            let env = unsafe { env.as_ref() };
-            let scheme =
-                style_to_color_scheme(unsafe { env.traitCollection().userInterfaceStyle() });
-            adapter.set_color_scheme(scheme);
-        },
-    );
-
-    let traits: Retained<NSArray<AnyClass>> =
-        NSArray::from_slice(&[UITraitUserInterfaceStyle::class()]);
-
-    let registration: Retained<ProtocolObject<dyn UITraitChangeRegistration>> = unsafe {
-        msg_send![
-            view,
-            registerForTraitChanges: &*traits,
-            withHandler: &*handler,
-        ]
-    };
-
-    Some(ColorSchemeObserver { view: view.retain(), registration })
+) -> Option<TraitChangeObserver> {
+    install_trait_change_observer(view, UITraitUserInterfaceStyle::class(), move |env| {
+        let Some(adapter) = adapter.upgrade() else { return };
+        let scheme = style_to_color_scheme(unsafe { env.traitCollection().userInterfaceStyle() });
+        adapter.set_color_scheme(scheme);
+    })
 }

--- a/internal/backends/winit/ios/font_size.rs
+++ b/internal/backends/winit/ios/font_size.rs
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Feeds the system's preferred body text size (Dynamic Type) into the
+// SlintContext, where it serves as the default font size for windows that
+// don't set `default-font-size` themselves (and as the basis for `rem`).
+
+use std::rc::Weak;
+
+use objc2::ClassType;
+use objc2_ui_kit::{
+    UIFont, UIFontTextStyleBody, UITraitCollection, UITraitEnvironment as _,
+    UITraitPreferredContentSizeCategory, UIView,
+};
+
+use i_slint_core::lengths::LogicalLength;
+
+use super::trait_observer::{TraitChangeObserver, install_trait_change_observer};
+use crate::winitwindowadapter::WinitWindowAdapter;
+
+/// Returns the preferred size for body text under the given trait collection's
+/// content size category. iOS points map 1:1 to Slint's logical pixels.
+fn body_font_size(traits: &UITraitCollection) -> LogicalLength {
+    let font = UIFont::preferredFontForTextStyle_compatibleWithTraitCollection(
+        unsafe { UIFontTextStyleBody },
+        Some(traits),
+    );
+    LogicalLength::new(unsafe { font.pointSize() } as f32)
+}
+
+pub(crate) fn current_default_font_size(view: &UIView) -> LogicalLength {
+    body_font_size(&view.traitCollection())
+}
+
+pub(crate) fn install_font_size_observer(
+    view: &UIView,
+    adapter: Weak<WinitWindowAdapter>,
+) -> Option<TraitChangeObserver> {
+    install_trait_change_observer(view, UITraitPreferredContentSizeCategory::class(), move |env| {
+        let Some(adapter) = adapter.upgrade() else { return };
+        adapter.set_platform_default_font_size(body_font_size(&env.traitCollection()));
+    })
+}

--- a/internal/backends/winit/ios/trait_observer.rs
+++ b/internal/backends/winit/ios/trait_observer.rs
@@ -1,0 +1,63 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Shared scaffolding for observing UIKit trait changes (color scheme, content
+// size category, ...) on a view. Callers pass the trait class to watch and a
+// plain closure; the block plumbing and (de)registration live here.
+
+use std::ptr::NonNull;
+
+use block2::RcBlock;
+use objc2::{
+    Message, available, msg_send,
+    rc::Retained,
+    runtime::{AnyClass, ProtocolObject},
+};
+use objc2_foundation::NSArray;
+use objc2_ui_kit::{
+    UITraitChangeObservable, UITraitChangeRegistration, UITraitCollection, UITraitEnvironment,
+    UIView,
+};
+
+pub(crate) struct TraitChangeObserver {
+    view: Retained<UIView>,
+    registration: Retained<ProtocolObject<dyn UITraitChangeRegistration>>,
+}
+
+impl Drop for TraitChangeObserver {
+    fn drop(&mut self) {
+        self.view.unregisterForTraitChanges(&self.registration);
+    }
+}
+
+/// Invokes `handler` with the changed trait environment whenever `trait_class`
+/// changes on `view`. `registerForTraitChanges:withHandler:` is iOS 17+; on older
+/// iOS this returns `None` and callers fall back to their initial one-shot query.
+pub(crate) fn install_trait_change_observer(
+    view: &UIView,
+    trait_class: &AnyClass,
+    handler: impl Fn(&ProtocolObject<dyn UITraitEnvironment>) + 'static,
+) -> Option<TraitChangeObserver> {
+    if !available!(ios = 17.0) {
+        return None;
+    }
+
+    let handler = RcBlock::new(
+        move |env: NonNull<ProtocolObject<dyn UITraitEnvironment>>,
+              _prev: NonNull<UITraitCollection>| {
+            handler(unsafe { env.as_ref() });
+        },
+    );
+
+    let traits: Retained<NSArray<AnyClass>> = NSArray::from_slice(&[trait_class]);
+
+    let registration: Retained<ProtocolObject<dyn UITraitChangeRegistration>> = unsafe {
+        msg_send![
+            view,
+            registerForTraitChanges: &*traits,
+            withHandler: &*handler,
+        ]
+    };
+
+    Some(TraitChangeObserver { view: view.retain(), registration })
+}

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -175,7 +175,9 @@ enum WinitWindowOrNone {
         #[cfg(target_os = "ios")]
         keyboard_curve_sampler: super::ios::KeyboardCurveSampler,
         #[cfg(target_os = "ios")]
-        _color_scheme_observer: Option<super::ios::ColorSchemeObserver>,
+        _color_scheme_observer: Option<super::ios::TraitChangeObserver>,
+        #[cfg(target_os = "ios")]
+        _font_size_observer: Option<super::ios::TraitChangeObserver>,
     },
     None(RefCell<WindowAttributes>),
 }
@@ -520,10 +522,15 @@ impl WinitWindowAdapter {
         };
 
         // winit doesn't surface iOS appearance, so query the view's trait
-        // collection directly; the matching live observer is installed below as
-        // part of the `HasWindow` variant so its lifetime is tied to the window.
+        // collection directly; the matching live observers are installed below as
+        // part of the `HasWindow` variant so their lifetime is tied to the window.
         #[cfg(target_os = "ios")]
-        self.set_color_scheme(crate::ios::current_color_scheme(&content_view));
+        {
+            self.set_color_scheme(crate::ios::current_color_scheme(&content_view));
+            self.set_platform_default_font_size(crate::ios::current_default_font_size(
+                &content_view,
+            ));
+        }
 
         let frame_throttle = crate::frame_throttle::create_frame_throttle(
             self.self_weak.clone(),
@@ -563,6 +570,11 @@ impl WinitWindowAdapter {
             ),
             #[cfg(target_os = "ios")]
             _color_scheme_observer: crate::ios::install_color_scheme_observer(
+                &content_view,
+                self.self_weak.clone(),
+            ),
+            #[cfg(target_os = "ios")]
+            _font_size_observer: crate::ios::install_font_size_observer(
                 &content_view,
                 self.self_weak.clone(),
             ),
@@ -920,6 +932,11 @@ impl WinitWindowAdapter {
                 _ => None,
             });
         }
+    }
+
+    #[cfg(target_os = "ios")]
+    pub fn set_platform_default_font_size(&self, size: i_slint_core::lengths::LogicalLength) {
+        WindowInner::from_pub(self.window()).context().set_platform_default_font_size(Some(size));
     }
 
     pub fn window_state_event(&self) {

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -81,7 +81,7 @@ pub(crate) struct SlintContextInner {
     pub(crate) accent_color: Property<Color>,
     /// Process-wide default font size as reported by the platform (e.g. iOS Dynamic
     /// Type). Backends write here; `WindowItem::resolved_default_font_size` consults it
-    /// before falling back to the renderer's built-in default. `None` when the backend
+    /// before falling back to `textlayout::DEFAULT_FONT_SIZE`. `None` when the backend
     /// doesn't report one.
     #[pin]
     pub(crate) platform_default_font_size: Property<Option<LogicalLength>>,

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -7,6 +7,7 @@ use crate::graphics::Color;
 use crate::input::InternalKeyboardModifierState;
 use crate::item_tree::{ItemRc, ItemTreeRc};
 use crate::items::ColorScheme;
+use crate::lengths::LogicalLength;
 use crate::platform::{EventLoopProxy, Platform, WindowAdapter, WindowEvent};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -78,6 +79,12 @@ pub(crate) struct SlintContextInner {
     /// transparent color when the platform doesn't expose one.
     #[pin]
     pub(crate) accent_color: Property<Color>,
+    /// Process-wide default font size as reported by the platform (e.g. iOS Dynamic
+    /// Type). Backends write here; `WindowItem::resolved_default_font_size` consults it
+    /// before falling back to the renderer's built-in default. `None` when the backend
+    /// doesn't report one.
+    #[pin]
+    pub(crate) platform_default_font_size: Property<Option<LogicalLength>>,
     pub(crate) window_shown_hook:
         core::cell::RefCell<Option<Box<dyn FnMut(&Rc<dyn crate::platform::WindowAdapter>)>>>,
     pub(crate) window_event_hook: core::cell::RefCell<Option<WindowEventHook>>,
@@ -117,6 +124,10 @@ impl SlintContext {
 
             color_scheme: Property::new_named(ColorScheme::Unknown, "SlintContext::color_scheme"),
             accent_color: Property::new_named(Color::default(), "SlintContext::accent_color"),
+            platform_default_font_size: Property::new_named(
+                None,
+                "SlintContext::platform_default_font_size",
+            ),
             window_shown_hook: Default::default(),
             window_event_hook: Default::default(),
             #[cfg(all(unix, not(target_os = "macos")))]
@@ -210,6 +221,19 @@ impl SlintContext {
     /// platform's system-theme observer; `Property::set` short-circuits no-op writes.
     pub fn set_accent_color(&self, color: Color) {
         self.0.as_ref().project_ref().accent_color.set(color);
+    }
+
+    /// Returns the platform-reported default font size, or `None` if the backend doesn't
+    /// report one. Reads register a property dependency, so bindings re-evaluate when the
+    /// platform reports a change (e.g. the user adjusts the system text size).
+    pub fn platform_default_font_size(&self) -> Option<LogicalLength> {
+        self.0.as_ref().project_ref().platform_default_font_size.get()
+    }
+
+    /// Backend-side write path for the platform-reported default font size. Called by
+    /// backends that track the system setting; `Property::set` short-circuits no-op writes.
+    pub fn set_platform_default_font_size(&self, size: Option<LogicalLength>) {
+        self.0.as_ref().project_ref().platform_default_font_size.set(size);
     }
 
     /// Add one to the counter of "things keeping the event loop alive".

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -2973,10 +2973,6 @@ mod tests {
             LogicalSize::new(5., 10.)
         }
 
-        fn default_font_size(&self) -> LogicalLength {
-            LogicalLength::new(10.)
-        }
-
         fn font_metrics(
             &self,
             _font_request: crate::graphics::FontRequest,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1401,7 +1401,18 @@ impl WindowItem {
         let first_item = ItemRc::new_root(item_tree);
         let window_item = next_window_item(&first_item).unwrap();
         Self::resolve_font_property(&window_item, Self::font_size)
+            .or_else(|| Self::platform_default_font_size(&first_item))
             .unwrap_or_else(|| first_item.window_adapter().unwrap().renderer().default_font_size())
+    }
+
+    /// Returns the default font size reported by the platform (e.g. iOS Dynamic Type),
+    /// or `None` when the backend doesn't report one. Used as fallback when no
+    /// `default-font-size` is set in the .slint code, before the renderer's built-in
+    /// default applies.
+    fn platform_default_font_size(item: &ItemRc) -> Option<LogicalLength> {
+        item.window_adapter().and_then(|adapter| {
+            WindowInner::from_pub(adapter.window()).context().platform_default_font_size()
+        })
     }
 
     fn resolve_font_property<T>(
@@ -1467,6 +1478,7 @@ impl WindowItem {
                         &window_item_rc,
                         crate::items::WindowItem::font_size,
                     )
+                    .or_else(|| Self::platform_default_font_size(self_rc))
                 } else {
                     Some(local_font_size)
                 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1402,7 +1402,7 @@ impl WindowItem {
         let window_item = next_window_item(&first_item).unwrap();
         Self::resolve_font_property(&window_item, Self::font_size)
             .or_else(|| Self::platform_default_font_size(&first_item))
-            .unwrap_or_else(|| first_item.window_adapter().unwrap().renderer().default_font_size())
+            .unwrap_or(crate::textlayout::DEFAULT_FONT_SIZE)
     }
 
     /// Returns the default font size reported by the platform (e.g. iOS Dynamic Type),

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -145,8 +145,6 @@ pub trait RendererSealed {
             .map(|wa| crate::window::WindowInner::from_pub(wa.window()).context().clone())
     }
 
-    fn default_font_size(&self) -> LogicalLength;
-
     fn resize(&self, _size: crate::api::PhysicalSize) -> Result<(), PlatformError> {
         Ok(())
     }

--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -29,6 +29,12 @@ use euclid::num::{One, Zero};
 
 use crate::items::{TextHorizontalAlignment, TextOverflow, TextVerticalAlignment, TextWrap};
 
+/// The font size to lay text out with when neither the `.slint` code nor the platform
+/// provide one. Last level of the precedence chain in
+/// [`crate::items::WindowItem::resolved_default_font_size`].
+pub const DEFAULT_FONT_SIZE: crate::lengths::LogicalLength =
+    crate::lengths::LogicalLength::new(12 as crate::Coord);
+
 #[cfg(feature = "unicode-linebreak")]
 mod linebreak_unicode;
 #[cfg(feature = "unicode-linebreak")]

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -152,7 +152,7 @@ pub trait GlyphRenderer: crate::item_rendering::ItemRenderer {
     fn fill_rectangle(&mut self, physical_rect: PhysicalRect, brush: Self::PlatformBrush);
 }
 
-pub const DEFAULT_FONT_SIZE: LogicalLength = LogicalLength::new(12.);
+pub use super::DEFAULT_FONT_SIZE;
 
 std::thread_local! {
     static LAYOUT_CONTEXT: RefCell<parley::LayoutContext<Brush>> = Default::default();

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -415,10 +415,6 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         Ok(())
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        sharedparley::DEFAULT_FONT_SIZE
-    }
-
     fn set_rendering_notifier(
         &self,
         callback: Box<dyn i_slint_core::api::RenderingNotifier>,

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -574,10 +574,6 @@ impl RendererSealed for FemtoVGWGPURenderer {
         self.0.register_font_from_path(path)
     }
 
-    fn default_font_size(&self) -> i_slint_core::lengths::LogicalLength {
-        self.0.default_font_size()
-    }
-
     fn set_rendering_notifier(
         &self,
         callback: Box<dyn i_slint_core::api::RenderingNotifier>,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -957,10 +957,6 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         }
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        sharedparley::DEFAULT_FONT_SIZE
-    }
-
     fn free_graphics_resources(
         &self,
         component: i_slint_core::item_tree::ItemTreeRef,

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -156,10 +156,6 @@ impl RendererSealed for SkiaWGPURenderer {
         self.renderer.register_font_from_path(path)
     }
 
-    fn default_font_size(&self) -> i_slint_core::lengths::LogicalLength {
-        self.renderer.default_font_size()
-    }
-
     fn set_rendering_notifier(
         &self,
         callback: Box<dyn i_slint_core::api::RenderingNotifier>,

--- a/internal/renderers/software/fonts.rs
+++ b/internal/renderers/software/fonts.rs
@@ -7,9 +7,8 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 
 use super::{Fixed, PhysicalLength, PhysicalSize};
-use i_slint_core::Coord;
 use i_slint_core::graphics::{BitmapFont, FontRequest};
-use i_slint_core::lengths::{LogicalLength, ScaleFactor};
+use i_slint_core::lengths::ScaleFactor;
 use i_slint_core::textlayout::TextLayout;
 
 i_slint_core::thread_local! {
@@ -69,7 +68,7 @@ pub trait GlyphRenderer {
     fn scale_delta(&self) -> Fixed<u16, 8>;
 }
 
-pub(super) const DEFAULT_FONT_SIZE: LogicalLength = LogicalLength::new(12 as Coord);
+pub(super) use i_slint_core::textlayout::DEFAULT_FONT_SIZE;
 
 mod pixelfont;
 #[cfg(feature = "systemfonts")]

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -1198,10 +1198,6 @@ impl RendererSealed for SoftwareRenderer {
         )
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        self::fonts::DEFAULT_FONT_SIZE
-    }
-
     fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
         #[cfg(feature = "systemfonts")]


### PR DESCRIPTION
This means we support rem etc. and when users increase the system font size (because of their eyesight), slint apps will work. This also lays the infrastructure to make it easier for other platforms to support.