### PR TITLE
viewer: Scale remote screen text with the platform default font size

### DIFF
--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -72,14 +72,14 @@ export component EmptyWindow inherits Window {
                 opacity: 0.9;
                 Text {
                     text: "Connect Live Preview to";
-                    font-size: 24px;
+                    font-size: 1.41rem;
                     font-weight: 100;
                 }
             }
 
             Text {
                 text: root.showing-name && root.has-name ? name : address;
-                font-size: 24px;
+                font-size: 1.41rem;
                 font-weight: 400;
             }
         }
@@ -91,13 +91,13 @@ export component EmptyWindow inherits Window {
             visible: false;
             Text {
                 text: "Slint 1.17.0";
-                font-size: 14px;
+                font-size: 0.82rem;
                 font-weight: 400;
             }
 
             Text {
                 text: "Viewer v0.0.3";
-                font-size: 12px;
+                font-size: 0.71rem;
                 font-weight: 400;
             }
         }
@@ -123,7 +123,6 @@ export component EmptyWindow inherits Window {
             background: root.dark-color-scheme ? #212121 : #f6f7f8;
             Text {
                 text: @tr("IP copied to clipboard");
-                font-size: 16px;
                 font-weight: 400;
             }
         }
@@ -140,7 +139,6 @@ export component EmptyWindow inherits Window {
         if message != "": Text {
             text: message;
             horizontal-alignment: center;
-            font-size: 16px;
             font-weight: 400;
         }
     }


### PR DESCRIPTION
Express the placeholder screen's font sizes in rem instead of hardcoded px so they follow the window's default font size, which the platform can report and update live when the user changes their preferred text size.

Body-sized text leaves font-size unset to inherit that default; the larger heading and smaller version labels carry explicit rem sizes relative to it.