### PR TITLE
Don't use LTO for release build, keep fat LTO for distributed binaries

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -19,6 +19,10 @@ env:
     SLINT_MCU_FEATURES: "-DSLINT_FEATURE_FREESTANDING=ON -DSLINT_FEATURE_RENDERER_SOFTWARE=ON"
     # env variable used by espup https://github.com/esp-rs/espup?tab=readme-ov-file#github-api
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Use fat LTO for the distributed C++ packages: smaller shared library and better runtime perf.
+    # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+    CARGO_PROFILE_RELEASE_LTO: "fat"
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
 
 jobs:
     cmake_package_desktop:

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -22,6 +22,10 @@ env:
     # Keep in sync with features in slint_tool_binary.yaml, cpp_package.yaml, api/node/Cargo.toml, and api/python/slint/Cargo.toml
     SLINT_BINARY_FEATURES: "backend-linuxkms-noseat,backend-winit,renderer-femtovg,renderer-skia,renderer-software"
     MACOSX_DEPLOYMENT_TARGET: "11.0"
+    # Use fat LTO for distributed binaries: smaller size and better runtime perf.
+    # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+    CARGO_PROFILE_RELEASE_LTO: "fat"
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
 
 jobs:
     slint-viewer-binary:

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -24,6 +24,12 @@ permissions:
     id-token: write  # Required for OIDC
     contents: read
 
+env:
+    # Use fat LTO for the published npm native binaries: smaller size and better runtime perf.
+    # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+    CARGO_PROFILE_RELEASE_LTO: "fat"
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+
 jobs:
     determine_version:
         runs-on: ubuntu-latest

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -60,6 +60,10 @@ on:
 
 env:
     MACOSX_DEPLOYMENT_TARGET: "11.0"
+    # Use fat LTO for distributed binaries: smaller size and better runtime perf.
+    # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+    CARGO_PROFILE_RELEASE_LTO: "fat"
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
 
 jobs:
     build_windows:

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -16,6 +16,10 @@ jobs:
     build_binaries:
         env:
             MACOSX_DEPLOYMENT_TARGET: "11.0"
+            # Use fat LTO for the published Python wheels: smaller size and better runtime perf.
+            # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+            CARGO_PROFILE_RELEASE_LTO: "fat"
+            CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
         strategy:
             matrix:
                 platform:

--- a/.github/workflows/upload_pypi_slint_compiler.yaml
+++ b/.github/workflows/upload_pypi_slint_compiler.yaml
@@ -12,6 +12,12 @@ on:
         required: false
         description: "Release? If false, publish to test.pypi.org, if true, publish to pypi.org"
 
+env:
+  # Use fat LTO for the published Python wheels: smaller size and better runtime perf.
+  # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+  CARGO_PROFILE_RELEASE_LTO: "fat"
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+
 jobs:
   build-wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/wasm_demos.yaml
+++ b/.github/workflows/wasm_demos.yaml
@@ -17,6 +17,10 @@ jobs:
         env:
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             CARGO_INCREMENTAL: false
+            # Use fat LTO for the published demo WASMs to minimize download size.
+            # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+            CARGO_PROFILE_RELEASE_LTO: "fat"
+            CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -12,6 +12,10 @@ jobs:
         env:
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             CARGO_INCREMENTAL: false
+            # Use fat LTO for the published WASMs to minimize download size.
+            # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
+            CARGO_PROFILE_RELEASE_LTO: "fat"
+            CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,6 @@ objc2 = { version = "0.6.3" }
 lsp-types = "0.95.0"
 
 [profile.release]
-lto = true
 panic = "abort"
 
 [profile.dev]


### PR DESCRIPTION
cargo build --release was slow because [profile.release] used fat LTO, which merges all LLVM bitcode into one module and optimizes it serially. Switch the default to thin LTO + codegen-units = 16 so day-to-day dev release builds parallelize properly.

Distributed binaries still want fat LTO for the size and runtime perf gains. Two routes preserve that:

- New [profile.release-dist] profile (inherits release, lto = "fat", codegen-units = 1) for `cargo build --profile release-dist`.
- CARGO_PROFILE_RELEASE_LTO=fat / CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 env vars added to the CI workflows that ship artifacts: nightly_snapshot, slint_tool_binary, cpp_package, publish_npm_package, upload_pypi, upload_pypi_slint_compiler, wasm_editor_and_interpreter, wasm_demos. The env-var route is necessary for wasm because wasm-pack 0.13 hardcodes --release and rejects --profile <name>.

Measurements on this branch (24-core build host, default features except WASM uses CARGO_PROFILE_RELEASE_OPT_LEVEL=s like CI):

| Artifact                  | thin LTO  | fat LTO   | size delta |
|---------------------------|-----------|-----------|------------|
| slint-viewer (native)     | 42.5 MB   | 33.0 MB   | -22%       |
| slint-lsp (native)        | 51.1 MB   | 37.8 MB   | -26%       |
| wasm_interpreter (raw)    | 12.8 MB   | 12.1 MB   |  -5%       |
| wasm_lsp (raw)            | 19.4 MB   | 16.9 MB   | -13%       |
| wasm_interpreter (gz -9)  |  5.66 MB  |  5.46 MB  |  -4%       |
| wasm_lsp (gz -9)          |  7.79 MB  |  6.99 MB  | -10%       |

| Artifact         | thin LTO  | fat LTO   |
|------------------|-----------|-----------|
| slint-viewer     | 1m 07s    | 4m 33s    |
| slint-lsp        | 2m 08s    | 6m 17s    |
| wasm_interpreter | 2m 46s    | 2m 41s    |
| wasm_lsp         | 4m 39s    | 5m 50s    |

## UPDATE: don't use LTO at all

| Artifact                  | dev build |  lto build |
|---------------------------|-----------|------------|
| slint-viewer (native)     |   43.2 MB |    33.1 MB |
| slint-lsp (native)        |   49.0 MB |    37.8 MB |
| wasm_interpreter (raw)    |   12.9 MB |    12.1 MB |
| wasm_lsp (raw)            |   19.6 MB |    16.9 MB |
| wasm_interpreter (gz -9)  |    5.6 MB |     5.5 MB |
| wasm_lsp (gz -9)          |    7.8 MB |     7.0 MB |

| Artifact         | dev build |  lto build |
|------------------|-----------|------------|
| slint-viewer     |    1m 10s |     4m 33s |
| slint-lsp        |    1m 30s |     6m 17s |
| wasm_interpreter |    2m 42s |     2m 41s |
| wasm_lsp         |    5m 04s |     5m 50s |

