### PR TITLE
Add array predicate expressions

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -73,6 +73,36 @@ void model_insert(const std::shared_ptr<M> &model, std::ptrdiff_t index, const M
     }
 }
 
+template<typename M, typename P>
+bool model_any(const std::shared_ptr<M> &model, P predicate)
+{
+    long int count = model_length(model);
+
+    for (long int i = 0; i < count; ++i) {
+        auto data = access_array_index(model, i);
+        if (predicate(data)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+template<typename M, typename P>
+bool model_all(const std::shared_ptr<M> &model, P predicate)
+{
+    long int count = model_length(model);
+
+    for (long int i = 0; i < count; ++i) {
+        auto data = access_array_index(model, i);
+        if (!predicate(data)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 } // namespace private_api
 
 /// A Model is providing Data for Slint Models or ListView elements of the

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -388,7 +388,7 @@ pub fn to_value(
         | Type::ArrayOfU16
         | Type::ElementReference
         | Type::MouseCursor
-        | Type::Predicate => Err(napi::Error::from_reason("reason")),
+        | Type::Closure => Err(napi::Error::from_reason("reason")),
         Type::StyledText => {
             let obj = unknown.coerce_to_object()?;
             let styled_instance: ClassInstance<SlintStyledText> =

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -387,7 +387,8 @@ pub fn to_value(
         | Type::LayoutCache
         | Type::ArrayOfU16
         | Type::ElementReference
-        | Type::MouseCursor => Err(napi::Error::from_reason("reason")),
+        | Type::MouseCursor
+        | Type::Predicate => Err(napi::Error::from_reason("reason")),
         Type::StyledText => {
             let obj = unknown.coerce_to_object()?;
             let styled_instance: ClassInstance<SlintStyledText> =

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -264,6 +264,10 @@ export default defineConfig({
                                                   slug: "guide/experimental/match-elements",
                                               },
                                               {
+                                                  label: "Array Predicates",
+                                                  slug: "guide/experimental/array-predicates",
+                                              },
+                                              {
                                                   label: "Named Slots",
                                                   slug: "guide/experimental/named-slots",
                                               },

--- a/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
@@ -6,7 +6,7 @@ description: Experimental predicate expressions for the array operations any and
 The array operations `any` and `all` test the elements of an array against a predicate expression.
 
 > **Note**: Array predicates are experimental and subject to change.
-> Tracking PR: [slint-ui/slint#11989](https://github.com/slint-ui/slint/pull/11989).
+> Tracking issue: [slint-ui/slint#12777](https://github.com/slint-ui/slint/issues/12777).
 
 ## Syntax
 

--- a/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
@@ -41,3 +41,5 @@ export component Example {
 Predicates are the only form of closure in the Slint language, and they are only accepted
 as the argument of `any` and `all`.
 A predicate cannot be stored in a property, passed to a function or callback, or called directly.
+The predicate must be written inline in the call to `any` or `all`;
+passing a closure stored in a local variable is rejected with an error.

--- a/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
@@ -1,0 +1,43 @@
+---
+title: Array Predicates
+description: Experimental predicate expressions for the array operations any and all.
+---
+
+The array operations `any` and `all` test the elements of an array against a predicate expression.
+
+> **Note**: Array predicates are experimental and subject to change.
+> Tracking PR: [slint-ui/slint#11989](https://github.com/slint-ui/slint/pull/11989).
+
+## Syntax
+
+A predicate expression has the form `(name) => condition`.
+It binds `name` to a value and evaluates `condition`, which must be a `bool`.
+The name is in scope only inside `condition`.
+
+Predicates are passed to the array operations `any` and `all`,
+which supply each element in turn as `name`:
+
+- `array.any((name) => condition)` reads `true` if `condition` holds for at least one element.
+- `array.all((name) => condition)` reads `true` if `condition` holds for every element.
+
+The argument name is available only inside the predicate expression,
+and its type is inferred from the array element type.
+
+`any` returns `false` for an empty array, while `all` returns `true` for an empty array.
+
+## Example
+
+```slint no-test
+export component Example {
+    in-out property<[int]> list-of-int: [1, 2, 3];
+
+    out property <bool> contains-two: list-of-int.any((value) => value == 2);   // true
+    out property <bool> all-positive: list-of-int.all((value) => value > 0);    // true
+}
+```
+
+## Current Limitations
+
+Predicates are the only form of closure in the Slint language, and they are only accepted
+as the argument of `any` and `all`.
+A predicate cannot be stored in a property, passed to a function or callback, or called directly.

--- a/docs/astro/src/content/docs/reference/language/expressions.mdx
+++ b/docs/astro/src/content/docs/reference/language/expressions.mdx
@@ -12,18 +12,8 @@ An expression is a color literal or a length literal. \{#sls.expr.forms}
 
 Further expression forms exist:
 [operators](../operators/), [member access](../operators/#member-access-and-indexing),
-function and callback calls, [predicates](#predicates), and the literals of the other
+function and callback calls, and the literals of the other
 [built-in types](../../property-types/).
-
-## Predicates
-
-A predicate expression has the form `(name) => condition`.
-It binds `name` to a value and evaluates `condition`, which must be a `bool`.
-The name is in scope only inside `condition`.
-
-Predicates are passed to the array operations
-[`any` and `all`](../../property-types/arrays-and-models/#predicates),
-which supply each element in turn as `name`.
 
 <SC>
 ## Color Literals

--- a/docs/astro/src/content/docs/reference/language/expressions.mdx
+++ b/docs/astro/src/content/docs/reference/language/expressions.mdx
@@ -12,8 +12,18 @@ An expression is a color literal or a length literal. \{#sls.expr.forms}
 
 Further expression forms exist:
 [operators](../operators/), [member access](../operators/#member-access-and-indexing),
-function and callback calls, and the literals of the other
+function and callback calls, [predicates](#predicates), and the literals of the other
 [built-in types](../../property-types/).
+
+## Predicates
+
+A predicate expression has the form `(name) => condition`.
+It binds `name` to a value and evaluates `condition`, which must be a `bool`.
+The name is in scope only inside `condition`.
+
+Predicates are passed to the array operations
+[`any` and `all`](../../property-types/arrays-and-models/#predicates),
+which supply each element in turn as `name`.
 
 <SC>
 ## Color Literals

--- a/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
@@ -48,14 +48,14 @@ The following operations apply to a value of an array type.
 - `array.remove(index)` removes the element at `index`.
 - `array.insert(index, value)` inserts `value` before the element at `index`, shifting later elements up.
   `value` must have the element type.
-- `array.any(name => condition)` reads `true` if `condition` holds for at least one element.
-- `array.all(name => condition)` reads `true` if `condition` holds for every element.
+- `array.any((name) => condition)` reads `true` if `condition` holds for at least one element.
+- `array.all((name) => condition)` reads `true` if `condition` holds for every element.
 
 `length`, `push`, `remove`, `insert`, `any`, and `all` are members of the array; `index` is written with the `[ ]` operator.
 
 ## Predicates
 
-`any` and `all` take a predicate written as `name => condition`. The predicate is evaluated
+`any` and `all` take a predicate written as `(name) => condition`. The predicate is evaluated
 once per element, with `name` bound to that element. The argument name is available only inside
 the predicate expression, and its type is inferred from the array element type. `condition` must
 be a boolean expression.
@@ -66,8 +66,8 @@ be a boolean expression.
 export component Example {
     in-out property<[int]> list-of-int: [1, 2, 3];
 
-    out property <bool> contains-two: list-of-int.any(value => value == 2);   // true
-    out property <bool> all-positive: list-of-int.all(value => value > 0);    // true
+    out property <bool> contains-two: list-of-int.any((value) => value == 2);   // true
+    out property <bool> all-positive: list-of-int.all((value) => value > 0);    // true
 }
 ```
 

--- a/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
@@ -48,8 +48,28 @@ The following operations apply to a value of an array type.
 - `array.remove(index)` removes the element at `index`.
 - `array.insert(index, value)` inserts `value` before the element at `index`, shifting later elements up.
   `value` must have the element type.
+- `array.any(name => condition)` reads `true` if `condition` holds for at least one element.
+- `array.all(name => condition)` reads `true` if `condition` holds for every element.
 
-`length`, `push`, `remove`, and `insert` are members of the array; `index` is written with the `[ ]` operator.
+`length`, `push`, `remove`, `insert`, `any`, and `all` are members of the array; `index` is written with the `[ ]` operator.
+
+## Predicates
+
+`any` and `all` take a predicate written as `name => condition`. The predicate is evaluated
+once per element, with `name` bound to that element. The argument name is available only inside
+the predicate expression, and its type is inferred from the array element type. `condition` must
+be a boolean expression.
+
+`any` returns `false` for an empty array, while `all` returns `true` for an empty array.
+
+```slint
+export component Example {
+    in-out property<[int]> list-of-int: [1, 2, 3];
+
+    out property <bool> contains-two: list-of-int.any(value => value == 2);   // true
+    out property <bool> all-positive: list-of-int.all(value => value > 0);    // true
+}
+```
 
 ## Out-of-bounds behavior
 

--- a/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
@@ -48,28 +48,8 @@ The following operations apply to a value of an array type.
 - `array.remove(index)` removes the element at `index`.
 - `array.insert(index, value)` inserts `value` before the element at `index`, shifting later elements up.
   `value` must have the element type.
-- `array.any((name) => condition)` reads `true` if `condition` holds for at least one element.
-- `array.all((name) => condition)` reads `true` if `condition` holds for every element.
 
-`length`, `push`, `remove`, `insert`, `any`, and `all` are members of the array; `index` is written with the `[ ]` operator.
-
-## Predicates
-
-`any` and `all` take a predicate written as `(name) => condition`. The predicate is evaluated
-once per element, with `name` bound to that element. The argument name is available only inside
-the predicate expression, and its type is inferred from the array element type. `condition` must
-be a boolean expression.
-
-`any` returns `false` for an empty array, while `all` returns `true` for an empty array.
-
-```slint
-export component Example {
-    in-out property<[int]> list-of-int: [1, 2, 3];
-
-    out property <bool> contains-two: list-of-int.any((value) => value == 2);   // true
-    out property <bool> all-positive: list-of-int.all((value) => value > 0);    // true
-}
-```
+`length`, `push`, `remove`, and `insert` are members of the array; `index` is written with the `[ ]` operator.
 
 ## Out-of-bounds behavior
 

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -472,7 +472,9 @@ module.exports = grammar({
       prec.right(
         2,
         seq(
+          "(",
           field("argument", $.simple_identifier),
+          ")",
           "=>",
           field("body", $.expression),
         ),

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -459,6 +459,7 @@ module.exports = grammar({
           $.simple_identifier,
           $.function_call,
           $.member_access,
+          $.closure_expression,
           $.unary_expression,
           $.binary_expression,
           $.ternary_expression,
@@ -466,6 +467,16 @@ module.exports = grammar({
       ),
 
     parens_op: ($) => seq("(", field("left", $.expression), ")"),
+
+    closure_expression: ($) =>
+      prec.right(
+        2,
+        seq(
+          field("argument", $.simple_identifier),
+          "=>",
+          field("body", $.expression),
+        ),
+      ),
 
     index_op: ($) =>
       prec(

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -446,6 +446,7 @@ module.exports = grammar({
     expression: ($) =>
       prec.right(
         choice(
+          $.closure_expression,
           $.keys,
           $.parens_op,
           $.index_op,
@@ -459,7 +460,6 @@ module.exports = grammar({
           $.simple_identifier,
           $.function_call,
           $.member_access,
-          $.closure_expression,
           $.unary_expression,
           $.binary_expression,
           $.ternary_expression,
@@ -470,15 +470,18 @@ module.exports = grammar({
 
     closure_expression: ($) =>
       prec.right(
-        2,
+        1,
         seq(
           "(",
           field("argument", $.simple_identifier),
-          ")",
-          "=>",
+          $._closure_arrow,
           field("body", $.expression),
         ),
       ),
+
+    // Keep `)` and `=>` together so `(foo)` remains a parenthesized expression
+    // when no arrow follows.
+    _closure_arrow: (_) => token(seq(")", /[\s\r\n]*/, "=>")),
 
     index_op: ($) =>
       prec(

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -551,7 +551,7 @@ fn to_debug_string(
         | Type::ArrayOfU16
         | Type::Model
         | Type::PathData
-        | Type::Predicate => {
+        | Type::Closure => {
             diag.push_error("Cannot debug this expression".into(), node);
             Expression::Invalid
         }

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -550,7 +550,8 @@ fn to_debug_string(
         | Type::LayoutCache
         | Type::ArrayOfU16
         | Type::Model
-        | Type::PathData => {
+        | Type::PathData
+        | Type::Predicate => {
             diag.push_error("Cannot debug this expression".into(), node);
             Expression::Invalid
         }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -2480,7 +2480,7 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
         }
         Expression::Closure { arg_name, expression } => {
             let display_name = arg_name.strip_prefix("local_").unwrap_or(arg_name);
-            write!(f, "{display_name} => ")?;
+            write!(f, "({display_name}) => ")?;
             pretty_print(f, expression)
         }
     }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -92,6 +92,8 @@ pub enum BuiltinFunction {
     ArrayPush,
     ArrayRemove,
     ArrayInsert,
+    ArrayAny,
+    ArrayAll,
     Rgb,
     Hsv,
     Oklch,
@@ -282,6 +284,8 @@ declare_builtin_function_types!(
     ArrayPush: (Type::Model, Type::InferredProperty) -> Type::Void,
     ArrayRemove: (Type::Model, Type::Int32) -> Type::Void,
     ArrayInsert: (Type::Model, Type::Int32, Type::InferredProperty) -> Type::Void,
+    ArrayAny: (Type::Model, Type::Predicate) -> Type::Bool,
+    ArrayAll: (Type::Model, Type::Predicate) -> Type::Bool,
     Rgb: (Type::Int32, Type::Int32, Type::Int32, Type::Float32) -> Type::Color,
     Hsv: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
     Oklch: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
@@ -441,6 +445,7 @@ impl BuiltinFunction {
             BuiltinFunction::MacosBringAllWindowsToFront => false,
             BuiltinFunction::PathPointAt => true,
             BuiltinFunction::PathAngleAt => true,
+            BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => true,
         }
     }
 
@@ -537,6 +542,7 @@ impl BuiltinFunction {
             BuiltinFunction::MacosBringAllWindowsToFront => false,
             BuiltinFunction::PathPointAt => true,
             BuiltinFunction::PathAngleAt => true,
+            BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => true,
         }
     }
 }
@@ -988,6 +994,11 @@ pub enum Expression {
     },
 
     EmptyComponentFactory,
+
+    Predicate {
+        arg_name: SmolStr,
+        expression: Box<Expression>,
+    },
 }
 
 impl Expression {
@@ -1115,6 +1126,7 @@ impl Expression {
             Expression::MinMax { ty, .. } => ty.clone(),
             Expression::EmptyComponentFactory => Type::ComponentFactory,
             Expression::DebugHook { expression, .. } => expression.ty(),
+            Expression::Predicate { .. } => Type::Predicate,
         }
     }
 
@@ -1257,6 +1269,7 @@ impl Expression {
             }
             Expression::EmptyComponentFactory => {}
             Expression::DebugHook { expression, .. } => visitor(expression),
+            Expression::Predicate { expression, .. } => visitor(expression),
         }
     }
 
@@ -1401,6 +1414,7 @@ impl Expression {
             }
             Expression::EmptyComponentFactory => {}
             Expression::DebugHook { expression, .. } => visitor(expression),
+            Expression::Predicate { expression, .. } => visitor(expression),
         }
     }
 
@@ -1524,6 +1538,7 @@ impl Expression {
             Expression::MinMax { lhs, rhs, .. } => lhs.is_constant(ga) && rhs.is_constant(ga),
             Expression::EmptyComponentFactory => true,
             Expression::DebugHook { .. } => false,
+            Expression::Predicate { expression, .. } => expression.is_constant(ga),
         }
     }
 
@@ -1790,6 +1805,7 @@ impl Expression {
                 arguments: vec![Self::default_value_for_type(&Type::String)],
                 source_location: None,
             },
+            Type::Predicate => Expression::Invalid,
         }
     }
 
@@ -2461,6 +2477,10 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
                 write!(f, " SYNTHETIC")?;
             }
             write!(f, "\"{id}\")")
+        }
+        Expression::Predicate { arg_name, expression } => {
+            write!(f, "{arg_name} => ")?;
+            pretty_print(f, expression)
         }
     }
 }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -284,8 +284,8 @@ declare_builtin_function_types!(
     ArrayPush: (Type::Model, Type::InferredProperty) -> Type::Void,
     ArrayRemove: (Type::Model, Type::Int32) -> Type::Void,
     ArrayInsert: (Type::Model, Type::Int32, Type::InferredProperty) -> Type::Void,
-    ArrayAny: (Type::Model, Type::Predicate) -> Type::Bool,
-    ArrayAll: (Type::Model, Type::Predicate) -> Type::Bool,
+    ArrayAny: (Type::Model, Type::Closure) -> Type::Bool,
+    ArrayAll: (Type::Model, Type::Closure) -> Type::Bool,
     Rgb: (Type::Int32, Type::Int32, Type::Int32, Type::Float32) -> Type::Color,
     Hsv: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
     Oklch: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
@@ -995,7 +995,7 @@ pub enum Expression {
 
     EmptyComponentFactory,
 
-    Predicate {
+    Closure {
         arg_name: SmolStr,
         expression: Box<Expression>,
     },
@@ -1126,7 +1126,7 @@ impl Expression {
             Expression::MinMax { ty, .. } => ty.clone(),
             Expression::EmptyComponentFactory => Type::ComponentFactory,
             Expression::DebugHook { expression, .. } => expression.ty(),
-            Expression::Predicate { .. } => Type::Predicate,
+            Expression::Closure { .. } => Type::Closure,
         }
     }
 
@@ -1269,7 +1269,7 @@ impl Expression {
             }
             Expression::EmptyComponentFactory => {}
             Expression::DebugHook { expression, .. } => visitor(expression),
-            Expression::Predicate { expression, .. } => visitor(expression),
+            Expression::Closure { expression, .. } => visitor(expression),
         }
     }
 
@@ -1414,7 +1414,7 @@ impl Expression {
             }
             Expression::EmptyComponentFactory => {}
             Expression::DebugHook { expression, .. } => visitor(expression),
-            Expression::Predicate { expression, .. } => visitor(expression),
+            Expression::Closure { expression, .. } => visitor(expression),
         }
     }
 
@@ -1538,7 +1538,7 @@ impl Expression {
             Expression::MinMax { lhs, rhs, .. } => lhs.is_constant(ga) && rhs.is_constant(ga),
             Expression::EmptyComponentFactory => true,
             Expression::DebugHook { .. } => false,
-            Expression::Predicate { expression, .. } => expression.is_constant(ga),
+            Expression::Closure { expression, .. } => expression.is_constant(ga),
         }
     }
 
@@ -1805,7 +1805,7 @@ impl Expression {
                 arguments: vec![Self::default_value_for_type(&Type::String)],
                 source_location: None,
             },
-            Type::Predicate => Expression::Invalid,
+            Type::Closure => Expression::Invalid,
         }
     }
 
@@ -2478,8 +2478,9 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
             }
             write!(f, "\"{id}\")")
         }
-        Expression::Predicate { arg_name, expression } => {
-            write!(f, "{arg_name} => ")?;
+        Expression::Closure { arg_name, expression } => {
+            let display_name = arg_name.strip_prefix("local_").unwrap_or(arg_name);
+            write!(f, "{display_name} => ")?;
             pretty_print(f, expression)
         }
     }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4835,7 +4835,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 ),
             }
         }
-        Expression::Predicate { arg_name, expression } => {
+        Expression::Closure { arg_name, expression } => {
             let arg = ident(arg_name);
             let expr = compile_expression(expression, ctx);
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4835,6 +4835,12 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 ),
             }
         }
+        Expression::Predicate { arg_name, expression } => {
+            let arg = ident(arg_name);
+            let expr = compile_expression(expression, ctx);
+
+            format!("[&](auto const &{arg}) -> bool {{ return {expr}; }}")
+        }
     }
 }
 
@@ -5553,6 +5559,12 @@ fn compile_builtin_function_call(
                 panic!("internal error: invalid args to PathAngleAt {arguments:?}")
             }
         }
+        BuiltinFunction::ArrayAny => {
+            format!("slint::private_api::model_any({}, {})", a.next().unwrap(), a.next().unwrap())
+        },
+        BuiltinFunction::ArrayAll => {
+            format!("slint::private_api::model_all({}, {})", a.next().unwrap(), a.next().unwrap())
+        },
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3335,7 +3335,7 @@ fn compile_expression_to_value(expr: &Expression, ctx: &EvaluationContext) -> To
             | Expression::RadialGradient { .. }
             | Expression::ConicGradient { .. }
             | Expression::EnumerationValue(..)
-            | Expression::Predicate { .. } => true,
+            | Expression::Closure { .. } => true,
             Expression::Condition { true_expr, false_expr, .. } => {
                 produces_owned_value(true_expr) && produces_owned_value(false_expr)
             }
@@ -3580,7 +3580,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         Expression::EmptyComponentFactory => quote!(slint::ComponentFactory::default()),
         Expression::EmptyDataTransfer => quote!(slint::DataTransfer::default()),
         Expression::TranslationReference { .. } => compile_translation_reference(expr, ctx),
-        Expression::Predicate { arg_name, expression } => {
+        Expression::Closure { arg_name, expression } => {
             let arg_name = ident(arg_name);
             let expression = compile_expression(expression, ctx);
             quote! {
@@ -5061,16 +5061,28 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::ArrayAny => {
-            let arr_expression = a.next().unwrap();
-            let predicate_expression = a.next().unwrap();
-            // `.iter()` resolves to `sp::ModelExt::iter`, imported at the top of the generated module.
-            quote!({ let arr = #arr_expression; arr.iter().any(#predicate_expression) })
+            let arr_expression = compile_expression_to_value(&arguments[0], ctx);
+            let Expression::Closure { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: ArrayAny expects a closure as second argument")
+            };
+            let arg_name = ident(arg_name);
+            let closure_expression = compile_expression(expression, ctx);
+            quote!({
+                let arr = #arr_expression;
+                sp::model_any(&arr, |#arg_name| -> bool { #closure_expression })
+            })
         }
         BuiltinFunction::ArrayAll => {
-            let arr_expression = a.next().unwrap();
-            let predicate_expression = a.next().unwrap();
-            // `.iter()` resolves to `sp::ModelExt::iter`, imported at the top of the generated module.
-            quote!({ let arr = #arr_expression; arr.iter().all(#predicate_expression) })
+            let arr_expression = compile_expression_to_value(&arguments[0], ctx);
+            let Expression::Closure { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: ArrayAll expects a closure as second argument")
+            };
+            let arg_name = ident(arg_name);
+            let closure_expression = compile_expression(expression, ctx);
+            quote!({
+                let arr = #arr_expression;
+                sp::model_all(&arr, |#arg_name| -> bool { #closure_expression })
+            })
         }
     }
 }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3334,7 +3334,8 @@ fn compile_expression_to_value(expr: &Expression, ctx: &EvaluationContext) -> To
             | Expression::LinearGradient { .. }
             | Expression::RadialGradient { .. }
             | Expression::ConicGradient { .. }
-            | Expression::EnumerationValue(..) => true,
+            | Expression::EnumerationValue(..)
+            | Expression::Predicate { .. } => true,
             Expression::Condition { true_expr, false_expr, .. } => {
                 produces_owned_value(true_expr) && produces_owned_value(false_expr)
             }
@@ -3345,7 +3346,6 @@ fn compile_expression_to_value(expr: &Expression, ctx: &EvaluationContext) -> To
     }
 
     let compiled_expr = compile_expression(expr, ctx);
-
     if produces_owned_value(expr) { compiled_expr } else { quote!((#compiled_expr).clone()) }
 }
 
@@ -3580,6 +3580,13 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         Expression::EmptyComponentFactory => quote!(slint::ComponentFactory::default()),
         Expression::EmptyDataTransfer => quote!(slint::DataTransfer::default()),
         Expression::TranslationReference { .. } => compile_translation_reference(expr, ctx),
+        Expression::Predicate { arg_name, expression } => {
+            let arg_name = ident(arg_name);
+            let expression = compile_expression(expression, ctx);
+            quote! {
+                |#arg_name| {#expression}
+            }
+        }
     }
 }
 
@@ -5052,6 +5059,18 @@ fn compile_builtin_function_call(
             } else {
                 panic!("internal error: invalid args to PathAngleAt {arguments:?}")
             }
+        }
+        BuiltinFunction::ArrayAny => {
+            let arr_expression = a.next().unwrap();
+            let predicate_expression = a.next().unwrap();
+            // `.iter()` resolves to `sp::ModelExt::iter`, imported at the top of the generated module.
+            quote!({ let arr = #arr_expression; arr.iter().any(#predicate_expression) })
+        }
+        BuiltinFunction::ArrayAll => {
+            let arr_expression = a.next().unwrap();
+            let predicate_expression = a.next().unwrap();
+            // `.iter()` resolves to `sp::ModelExt::iter`, imported at the top of the generated module.
+            quote!({ let arr = #arr_expression; arr.iter().all(#predicate_expression) })
         }
     }
 }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -73,7 +73,7 @@ pub enum Type {
 
     StyledText,
     MouseCursor,
-    Predicate,
+    Closure,
 }
 
 impl core::cmp::PartialEq for Type {
@@ -119,7 +119,7 @@ impl core::cmp::PartialEq for Type {
             Type::ArrayOfU16 => matches!(other, Type::ArrayOfU16),
             Type::StyledText => matches!(other, Type::StyledText),
             Type::DataTransfer => matches!(other, Type::DataTransfer),
-            Type::Predicate => matches!(other, Type::Predicate),
+            Type::Closure => matches!(other, Type::Closure),
         }
     }
 }
@@ -180,7 +180,7 @@ impl Display for Type {
             Type::LayoutCache => write!(f, "layout cache"),
             Type::ArrayOfU16 => write!(f, "[u16]"),
             Type::StyledText => write!(f, "styled-text"),
-            Type::Predicate => write!(f, "predicate"),
+            Type::Closure => write!(f, "closure"),
         }
     }
 }
@@ -332,7 +332,7 @@ impl Type {
             Type::LayoutCache => None,
             Type::ArrayOfU16 => None,
             Type::StyledText => None,
-            Type::Predicate => None,
+            Type::Closure => None,
         }
     }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -73,6 +73,7 @@ pub enum Type {
 
     StyledText,
     MouseCursor,
+    Predicate,
 }
 
 impl core::cmp::PartialEq for Type {
@@ -118,6 +119,7 @@ impl core::cmp::PartialEq for Type {
             Type::ArrayOfU16 => matches!(other, Type::ArrayOfU16),
             Type::StyledText => matches!(other, Type::StyledText),
             Type::DataTransfer => matches!(other, Type::DataTransfer),
+            Type::Predicate => matches!(other, Type::Predicate),
         }
     }
 }
@@ -178,6 +180,7 @@ impl Display for Type {
             Type::LayoutCache => write!(f, "layout cache"),
             Type::ArrayOfU16 => write!(f, "[u16]"),
             Type::StyledText => write!(f, "styled-text"),
+            Type::Predicate => write!(f, "predicate"),
         }
     }
 }
@@ -329,6 +332,7 @@ impl Type {
             Type::LayoutCache => None,
             Type::ArrayOfU16 => None,
             Type::StyledText => None,
+            Type::Predicate => None,
         }
     }
 

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -316,6 +316,11 @@ pub enum Expression {
         /// The `n` value to use for the plural form if it is a plural form
         plural: Option<Box<Expression>>,
     },
+
+    Predicate {
+        arg_name: SmolStr,
+        expression: Box<Expression>,
+    },
 }
 
 /// The type of a binary expression with the given operator:
@@ -340,7 +345,8 @@ impl Expression {
             | Type::InferredCallback
             | Type::ElementReference
             | Type::LayoutCache
-            | Type::ArrayOfU16 => return None,
+            | Type::ArrayOfU16
+            | Type::Predicate => return None,
             Type::Float32
             | Type::Duration
             | Type::Int32
@@ -463,6 +469,7 @@ impl Expression {
             Self::EmptyComponentFactory => Type::ComponentFactory,
             Self::EmptyDataTransfer => Type::DataTransfer,
             Self::TranslationReference { .. } => Type::String,
+            Self::Predicate { .. } => Type::Predicate,
         }
     }
 }
@@ -630,6 +637,9 @@ macro_rules! visit_impl {
                 if let Some(plural) = plural {
                     $visitor(plural);
                 }
+            }
+            Expression::Predicate { expression, .. } => {
+                $visitor(expression);
             }
         }
     };

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -317,7 +317,7 @@ pub enum Expression {
         plural: Option<Box<Expression>>,
     },
 
-    Predicate {
+    Closure {
         arg_name: SmolStr,
         expression: Box<Expression>,
     },
@@ -346,7 +346,7 @@ impl Expression {
             | Type::ElementReference
             | Type::LayoutCache
             | Type::ArrayOfU16
-            | Type::Predicate => return None,
+            | Type::Closure => return None,
             Type::Float32
             | Type::Duration
             | Type::Int32
@@ -469,7 +469,7 @@ impl Expression {
             Self::EmptyComponentFactory => Type::ComponentFactory,
             Self::EmptyDataTransfer => Type::DataTransfer,
             Self::TranslationReference { .. } => Type::String,
-            Self::Predicate { .. } => Type::Predicate,
+            Self::Closure { .. } => Type::Closure,
         }
     }
 }
@@ -638,7 +638,7 @@ macro_rules! visit_impl {
                     $visitor(plural);
                 }
             }
-            Expression::Predicate { expression, .. } => {
+            Expression::Closure { expression, .. } => {
                 $visitor(expression);
             }
         }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -228,6 +228,10 @@ pub fn lower_expression(
         tree_Expression::EmptyComponentFactory => llr_Expression::EmptyComponentFactory,
         tree_Expression::EmptyDataTransfer => llr_Expression::EmptyDataTransfer,
         tree_Expression::DebugHook { expression, .. } => lower_expression(expression, ctx),
+        tree_Expression::Predicate { arg_name, expression } => llr_Expression::Predicate {
+            arg_name: arg_name.clone(),
+            expression: Box::new(lower_expression(expression, ctx)),
+        },
     }
 }
 

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -228,7 +228,7 @@ pub fn lower_expression(
         tree_Expression::EmptyComponentFactory => llr_Expression::EmptyComponentFactory,
         tree_Expression::EmptyDataTransfer => llr_Expression::EmptyDataTransfer,
         tree_Expression::DebugHook { expression, .. } => lower_expression(expression, ctx),
-        tree_Expression::Predicate { arg_name, expression } => llr_Expression::Predicate {
+        tree_Expression::Closure { arg_name, expression } => llr_Expression::Closure {
             arg_name: arg_name.clone(),
             expression: Box::new(lower_expression(expression, ctx)),
         },

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -79,6 +79,9 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::EmptyComponentFactory => 10,
         Expression::EmptyDataTransfer => 10,
         Expression::TranslationReference { .. } => PROPERTY_ACCESS_COST + 2 * ALLOC_COST,
+        // The body cost is added by the visit() walk below; returning the body
+        // cost here would double-count it.
+        Expression::Predicate { .. } => 0,
     };
 
     exp.visit(|e| cost = cost.saturating_add(expression_cost(e, ctx)));
@@ -180,6 +183,8 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::MacosBringAllWindowsToFront => isize::MAX,
         BuiltinFunction::PathPointAt => isize::MAX,
         BuiltinFunction::PathAngleAt => isize::MAX,
+        // Iterating the model and running the predicate is unbounded; never inline.
+        BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => isize::MAX,
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -81,7 +81,7 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::TranslationReference { .. } => PROPERTY_ACCESS_COST + 2 * ALLOC_COST,
         // The body cost is added by the visit() walk below; returning the body
         // cost here would double-count it.
-        Expression::Predicate { .. } => 0,
+        Expression::Closure { .. } => 0,
     };
 
     exp.visit(|e| cost = cost.saturating_add(expression_cost(e, ctx)));
@@ -183,7 +183,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::MacosBringAllWindowsToFront => isize::MAX,
         BuiltinFunction::PathPointAt => isize::MAX,
         BuiltinFunction::PathAngleAt => isize::MAX,
-        // Iterating the model and running the predicate is unbounded; never inline.
+        // Iterating the model and running the closure is unbounded; never inline.
         BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => isize::MAX,
     }
 }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -696,7 +696,7 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             }
             Expression::Closure { arg_name, expression } => {
                 let display_name = arg_name.strip_prefix("local_").unwrap_or(arg_name);
-                write!(f, "{} => {}", display_name, e(expression))
+                write!(f, "({}) => {}", display_name, e(expression))
             }
         }
     }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -694,6 +694,9 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                     ),
                 }
             }
+            Expression::Predicate { arg_name, expression } => {
+                write!(f, "{} => {}", arg_name, e(expression))
+            }
         }
     }
 }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -694,8 +694,9 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                     ),
                 }
             }
-            Expression::Predicate { arg_name, expression } => {
-                write!(f, "{} => {}", arg_name, e(expression))
+            Expression::Closure { arg_name, expression } => {
+                let display_name = arg_name.strip_prefix("local_").unwrap_or(arg_name);
+                write!(f, "{} => {}", display_name, e(expression))
             }
         }
     }

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -61,6 +61,19 @@ pub struct LookupCtx<'a> {
 
     /// A stack of local variable scopes
     pub local_variables: Vec<Vec<(SmolStr, Type)>>,
+
+    /// A stack of `(source_name, internal_name, type)` for the predicate arguments currently in scope.
+    /// Predicates can nest (a predicate body may itself contain another predicate), so this is a stack.
+    pub predicate_arguments: Vec<(SmolStr, SmolStr, Type)>,
+
+    /// When set, this is the element type the next-resolved `SyntaxKind::Predicate` should
+    /// bind its argument to. Set by `Expression::from_function_call_node` when descending
+    /// into the predicate argument of `.any()`/`.all()`, consumed (taken) by
+    /// `from_predicate_node`.
+    pub predicate_arg_type: Option<Type>,
+
+    /// A flag that indicates if predicates are currently allowed (currently only inside a function argument)
+    pub predicates_allowed: bool,
 }
 
 impl<'a> LookupCtx<'a> {
@@ -82,6 +95,9 @@ impl<'a> LookupCtx<'a> {
             type_loader: None,
             current_token: None,
             local_variables: Default::default(),
+            predicate_arguments: Default::default(),
+            predicate_arg_type: None,
+            predicates_allowed: false,
         }
     }
 
@@ -135,7 +151,10 @@ pub enum LookupResultCallable {
     MemberFunction {
         /// This becomes the first argument of the function call
         base: Expression,
-        base_node: Option<NodeOrToken>,
+        /// Syntax node used as the diagnostic source span for `base`. In practice this is
+        /// often the node that originated the member-function lookup (e.g. the `.focus`
+        /// token), not the node of `base` itself.
+        source_node: Option<NodeOrToken>,
         member: Box<LookupResultCallable>,
     },
 }
@@ -303,6 +322,27 @@ impl LookupObject for ArgumentsLookup {
             if let Some(r) =
                 f(name, Expression::FunctionParameterReference { index, ty: ty.clone() }.into())
             {
+                return Some(r);
+            }
+        }
+        None
+    }
+}
+
+struct PredicateArgumentsLookup;
+impl LookupObject for PredicateArgumentsLookup {
+    fn for_each_entry<R>(
+        &self,
+        ctx: &LookupCtx,
+        f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
+    ) -> Option<R> {
+        // Search innermost predicates first so predicate arguments shadow outer variables.
+        for (source_name, internal_name, ty) in ctx.predicate_arguments.iter().rev() {
+            if let Some(r) = f(
+                source_name,
+                Expression::ReadLocalVariable { name: internal_name.clone(), ty: ty.clone() }
+                    .into(),
+            ) {
                 return Some(r);
             }
         }
@@ -590,7 +630,7 @@ fn expression_from_reference(
             if matches!(function.args.first(), Some(Type::ElementReference)) {
                 LookupResult::Callable(LookupResultCallable::MemberFunction {
                     base: Expression::ElementReference(base_expr),
-                    base_node: None,
+                    source_node: None,
                     member: Box::new(LookupResultCallable::Callable(callable)),
                 })
             } else {
@@ -995,18 +1035,24 @@ impl LookupObject for BuiltinNamespaceLookup {
 
 pub fn global_lookup() -> impl LookupObject {
     (
-        LocalVariableLookup,
+        PredicateArgumentsLookup,
         (
-            ArgumentsLookup,
+            LocalVariableLookup,
             (
-                SpecialIdLookup,
+                ArgumentsLookup,
                 (
-                    IdLookup,
+                    SpecialIdLookup,
                     (
-                        InScopeLookup,
+                        IdLookup,
                         (
-                            LookupType,
-                            (BuiltinNamespaceLookup, (TypeSpecificLookup, BuiltinFunctionLookup)),
+                            InScopeLookup,
+                            (
+                                LookupType,
+                                (
+                                    BuiltinNamespaceLookup,
+                                    (TypeSpecificLookup, BuiltinFunctionLookup),
+                                ),
+                            ),
                         ),
                     ),
                 ),
@@ -1128,7 +1174,7 @@ impl LookupObject for ColorExpression<'_> {
             };
             LookupResult::Callable(LookupResultCallable::MemberFunction {
                 base,
-                base_node: ctx.current_token.clone(), // Note that this is not the base_node, but the function's node
+                source_node: ctx.current_token.clone(),
                 member: Box::new(LookupResultCallable::Callable(Callable::Builtin(f))),
             })
         };
@@ -1193,6 +1239,13 @@ impl LookupObject for ArrayExpression<'_> {
         ctx: &LookupCtx,
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
+        let member_function = |f: BuiltinFunction| {
+            LookupResult::Callable(LookupResultCallable::MemberFunction {
+                base: self.0.clone(),
+                source_node: ctx.current_token.clone(),
+                member: LookupResultCallable::Callable(Callable::Builtin(f)).into(),
+            })
+        };
         let function_call = |f: BuiltinFunction| {
             LookupResult::from(Expression::FunctionCall {
                 function: Callable::Builtin(f),
@@ -1207,6 +1260,8 @@ impl LookupObject for ArrayExpression<'_> {
             .or_else(|| f("push", member_macro(BuiltinMacroFunction::ArrayPush)))
             .or_else(|| f("remove", member_macro(BuiltinMacroFunction::ArrayRemove)))
             .or_else(|| f("insert", member_macro(BuiltinMacroFunction::ArrayInsert)))
+            .or_else(|| f("any", member_function(BuiltinFunction::ArrayAny)))
+            .or_else(|| f("all", member_function(BuiltinFunction::ArrayAll)))
     }
 }
 
@@ -1250,7 +1305,7 @@ fn builtin_member_function_generator<'a>(
     move |func: BuiltinFunction| {
         LookupResult::Callable(LookupResultCallable::MemberFunction {
             base: base.clone(),
-            base_node: ctx.current_token.clone(),
+            source_node: ctx.current_token.clone(),
             member: Box::new(LookupResultCallable::Callable(Callable::Builtin(func))),
         })
     }
@@ -1258,12 +1313,12 @@ fn builtin_member_function_generator<'a>(
 
 fn member_macro_generator(
     base: Expression,
-    base_node: Option<NodeOrToken>,
+    source_node: Option<NodeOrToken>,
 ) -> impl FnMut(BuiltinMacroFunction) -> LookupResult {
     move |func: BuiltinMacroFunction| {
         LookupResult::Callable(LookupResultCallable::MemberFunction {
             base: base.clone(),
-            base_node: base_node.clone(),
+            source_node: source_node.clone(),
             member: Box::new(LookupResultCallable::Macro(func)),
         })
     }

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -1217,8 +1217,14 @@ impl LookupObject for ArrayExpression<'_> {
             .or_else(|| f("push", member_macro(BuiltinMacroFunction::ArrayPush)))
             .or_else(|| f("remove", member_macro(BuiltinMacroFunction::ArrayRemove)))
             .or_else(|| f("insert", member_macro(BuiltinMacroFunction::ArrayInsert)))
-            .or_else(|| f("any", member_function(BuiltinFunction::ArrayAny)))
-            .or_else(|| f("all", member_function(BuiltinFunction::ArrayAll)))
+            .or_else(|| {
+                // `any` and `all` take a closure argument; closures are experimental.
+                if !ctx.diag.enable_experimental && !ctx.type_register.expose_internal_types {
+                    return None;
+                }
+                f("any", member_function(BuiltinFunction::ArrayAny))
+                    .or_else(|| f("all", member_function(BuiltinFunction::ArrayAll)))
+            })
     }
 }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -61,19 +61,6 @@ pub struct LookupCtx<'a> {
 
     /// A stack of local variable scopes
     pub local_variables: Vec<Vec<(SmolStr, Type)>>,
-
-    /// A stack of `(source_name, internal_name, type)` for the predicate arguments currently in scope.
-    /// Predicates can nest (a predicate body may itself contain another predicate), so this is a stack.
-    pub predicate_arguments: Vec<(SmolStr, SmolStr, Type)>,
-
-    /// When set, this is the element type the next-resolved `SyntaxKind::Predicate` should
-    /// bind its argument to. Set by `Expression::from_function_call_node` when descending
-    /// into the predicate argument of `.any()`/`.all()`, consumed (taken) by
-    /// `from_predicate_node`.
-    pub predicate_arg_type: Option<Type>,
-
-    /// A flag that indicates if predicates are currently allowed (currently only inside a function argument)
-    pub predicates_allowed: bool,
 }
 
 impl<'a> LookupCtx<'a> {
@@ -95,9 +82,6 @@ impl<'a> LookupCtx<'a> {
             type_loader: None,
             current_token: None,
             local_variables: Default::default(),
-            predicate_arguments: Default::default(),
-            predicate_arg_type: None,
-            predicates_allowed: false,
         }
     }
 
@@ -292,8 +276,8 @@ impl LookupObject for LocalVariableLookup {
         ctx: &LookupCtx,
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
-        for scope in ctx.local_variables.iter() {
-            for (name, ty) in scope {
+        for scope in ctx.local_variables.iter().rev() {
+            for (name, ty) in scope.iter().rev() {
                 if let Some(r) = f(
                     // we need to strip the "local_" prefix because a lookup call will not include it
                     &name.strip_prefix("local_").unwrap_or(name).into(),
@@ -322,27 +306,6 @@ impl LookupObject for ArgumentsLookup {
             if let Some(r) =
                 f(name, Expression::FunctionParameterReference { index, ty: ty.clone() }.into())
             {
-                return Some(r);
-            }
-        }
-        None
-    }
-}
-
-struct PredicateArgumentsLookup;
-impl LookupObject for PredicateArgumentsLookup {
-    fn for_each_entry<R>(
-        &self,
-        ctx: &LookupCtx,
-        f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
-    ) -> Option<R> {
-        // Search innermost predicates first so predicate arguments shadow outer variables.
-        for (source_name, internal_name, ty) in ctx.predicate_arguments.iter().rev() {
-            if let Some(r) = f(
-                source_name,
-                Expression::ReadLocalVariable { name: internal_name.clone(), ty: ty.clone() }
-                    .into(),
-            ) {
                 return Some(r);
             }
         }
@@ -1035,24 +998,18 @@ impl LookupObject for BuiltinNamespaceLookup {
 
 pub fn global_lookup() -> impl LookupObject {
     (
-        PredicateArgumentsLookup,
+        LocalVariableLookup,
         (
-            LocalVariableLookup,
+            ArgumentsLookup,
             (
-                ArgumentsLookup,
+                SpecialIdLookup,
                 (
-                    SpecialIdLookup,
+                    IdLookup,
                     (
-                        IdLookup,
+                        InScopeLookup,
                         (
-                            InScopeLookup,
-                            (
-                                LookupType,
-                                (
-                                    BuiltinNamespaceLookup,
-                                    (TypeSpecificLookup, BuiltinFunctionLookup),
-                                ),
-                            ),
+                            LookupType,
+                            (BuiltinNamespaceLookup, (TypeSpecificLookup, BuiltinFunctionLookup)),
                         ),
                     ),
                 ),

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -405,7 +405,7 @@ declare_syntax! {
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
-                       ?MemberAccess, ?AtKeys, ?Predicate ],
+                       ?MemberAccess, ?AtKeys, ?Closure ],
         /// Concatenate the children Expressions and StringLiteral to make a string
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
@@ -486,7 +486,7 @@ declare_syntax! {
         /// `@rust-attr(...)`
         AtRustAttr -> [],
         /// `x => x > 0`
-        Predicate -> [DeclaredIdentifier, Expression],
+        Closure -> [DeclaredIdentifier, Expression],
     }
 }
 

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -485,7 +485,7 @@ declare_syntax! {
         EnumValue -> [],
         /// `@rust-attr(...)`
         AtRustAttr -> [],
-        /// `x => x > 0`
+        /// `(x) => x > 0`
         Closure -> [DeclaredIdentifier, Expression],
     }
 }

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -405,7 +405,7 @@ declare_syntax! {
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
-                       ?MemberAccess, ?AtKeys ],
+                       ?MemberAccess, ?AtKeys, ?Predicate ],
         /// Concatenate the children Expressions and StringLiteral to make a string
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
@@ -485,6 +485,8 @@ declare_syntax! {
         EnumValue -> [],
         /// `@rust-attr(...)`
         AtRustAttr -> [],
+        /// `x => x > 0`
+        Predicate -> [DeclaredIdentifier, Expression],
     }
 }
 

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -30,6 +30,7 @@ use super::prelude::*;
 /// array[index]
 /// {object:42}
 /// "foo".bar.something().something.xx({a: 1.foo}.a)
+/// x => x > 0
 /// ```
 pub fn parse_expression(p: &mut impl Parser) -> bool {
     p.peek(); // consume the whitespace so they aren't part of the Expression node
@@ -58,7 +59,11 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
     let mut possible_range = false;
     match p.nth(0).kind() {
         SyntaxKind::Identifier => {
-            parse_qualified_name(&mut *p);
+            if p.nth(1).kind() == SyntaxKind::FatArrow {
+                parse_predicate(&mut *p);
+            } else {
+                parse_qualified_name(&mut *p);
+            }
         }
         SyntaxKind::StringLiteral => {
             if p.nth(0).as_str().ends_with('{') {
@@ -228,6 +233,25 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         parse_expression(&mut *p);
     }
     true
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test
+/// x => x > 0
+/// y => y == 42
+/// z => true
+/// ```
+fn parse_predicate(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::Predicate);
+
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+
+    p.expect(SyntaxKind::FatArrow);
+
+    parse_expression(&mut *p);
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -60,7 +60,7 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
     match p.nth(0).kind() {
         SyntaxKind::Identifier => {
             if p.nth(1).kind() == SyntaxKind::FatArrow {
-                parse_predicate(&mut *p);
+                parse_closure(&mut *p);
             } else {
                 parse_qualified_name(&mut *p);
             }
@@ -241,8 +241,8 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
 /// y => y == 42
 /// z => true
 /// ```
-fn parse_predicate(p: &mut impl Parser) {
-    let mut p = p.start_node(SyntaxKind::Predicate);
+fn parse_closure(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::Closure);
 
     {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -30,7 +30,7 @@ use super::prelude::*;
 /// array[index]
 /// {object:42}
 /// "foo".bar.something().something.xx({a: 1.foo}.a)
-/// x => x > 0
+/// (x) => x > 0
 /// ```
 pub fn parse_expression(p: &mut impl Parser) -> bool {
     p.peek(); // consume the whitespace so they aren't part of the Expression node
@@ -59,11 +59,7 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
     let mut possible_range = false;
     match p.nth(0).kind() {
         SyntaxKind::Identifier => {
-            if p.nth(1).kind() == SyntaxKind::FatArrow {
-                parse_closure(&mut *p);
-            } else {
-                parse_qualified_name(&mut *p);
-            }
+            parse_qualified_name(&mut *p);
         }
         SyntaxKind::StringLiteral => {
             if p.nth(0).as_str().ends_with('{') {
@@ -80,9 +76,16 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         }
         SyntaxKind::ColorLiteral => p.consume(),
         SyntaxKind::LParent => {
-            p.consume();
-            parse_expression(&mut *p);
-            p.expect(SyntaxKind::RParent);
+            if p.nth(1).kind() == SyntaxKind::Identifier
+                && p.nth(2).kind() == SyntaxKind::RParent
+                && p.nth(3).kind() == SyntaxKind::FatArrow
+            {
+                parse_closure(&mut *p);
+            } else {
+                p.consume();
+                parse_expression(&mut *p);
+                p.expect(SyntaxKind::RParent);
+            }
         }
         SyntaxKind::LBracket => parse_array(&mut *p),
         SyntaxKind::LBrace => parse_object_notation(&mut *p),
@@ -237,17 +240,21 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
 
 #[cfg_attr(test, parser_test)]
 /// ```test
-/// x => x > 0
-/// y => y == 42
-/// z => true
+/// (x) => x > 0
+/// (y) => y == 42
+/// (z) => true
 /// ```
 fn parse_closure(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::Closure);
+
+    p.expect(SyntaxKind::LParent);
 
     {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);
     }
+
+    p.expect(SyntaxKind::RParent);
 
     p.expect(SyntaxKind::FatArrow);
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -19,7 +19,7 @@ use crate::parser::{NodeOrToken, SyntaxKind, SyntaxNode, identifier_text, syntax
 use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
 use core::num::IntErrorKind;
-use smol_str::{SmolStr, ToSmolStr, format_smolstr};
+use smol_str::{SmolStr, ToSmolStr};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -55,9 +55,6 @@ fn resolve_expression(
             type_loader: Some(type_loader),
             current_token: None,
             local_variables: Vec::new(),
-            predicate_arguments: vec![],
-            predicate_arg_type: None,
-            predicates_allowed: false,
         };
         lookup_ctx.expected_type = lookup_ctx.return_type().clone();
 
@@ -545,8 +542,8 @@ impl Expression {
                         ctx.diag.slint_sc_error("String interpolation expressions are", &node);
                         return Self::from_string_template_node(node.into(), ctx);
                     }
-                    SyntaxKind::Predicate => {
-                        return Self::from_predicate_node(node.into(), ctx);
+                    SyntaxKind::Closure => {
+                        return Self::from_closure_node(node.into(), ctx, None);
                     }
                     _ => {}
                 },
@@ -1555,20 +1552,6 @@ impl Expression {
         node: syntax_nodes::FunctionCallExpression,
         ctx: &mut LookupCtx,
     ) -> Expression {
-        // Save state so nested calls (or function calls inside a predicate body) can't leak
-        // their settings out into the enclosing scope. Restore on every exit path.
-        let prev_predicates_allowed = std::mem::replace(&mut ctx.predicates_allowed, false);
-        let prev_predicate_arg_type = ctx.predicate_arg_type.take();
-        let result = Self::resolve_function_call_node(node, ctx);
-        ctx.predicates_allowed = prev_predicates_allowed;
-        ctx.predicate_arg_type = prev_predicate_arg_type;
-        result
-    }
-
-    fn resolve_function_call_node(
-        node: syntax_nodes::FunctionCallExpression,
-        ctx: &mut LookupCtx,
-    ) -> Expression {
         let mut arguments = Vec::new();
 
         let mut sub_expr = node.Expression();
@@ -1591,8 +1574,29 @@ impl Expression {
             }
             return Self::Invalid;
         };
-        // Convert the arguments once the parameter types are known, so a bare color/enum
-        // literal in argument position resolves against its parameter type.
+        // For `.any(predicate)` / `.all(predicate)` the closure's argument type is
+        // structurally derived from the base array's element type. Compute it here
+        // so we can hand it to the closure when resolving that specific argument.
+        let expected_closure_arg_type = match &function {
+            Some(LookupResult::Callable(LookupResultCallable::MemberFunction {
+                base,
+                member,
+                ..
+            })) if matches!(
+                **member,
+                LookupResultCallable::Callable(Callable::Builtin(
+                    BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll
+                ))
+            ) =>
+            {
+                let Type::Array(elem_ty) = base.ty() else { unreachable!() };
+                Some((*elem_ty).clone())
+            }
+            _ => None,
+        };
+
+        // Convert the arguments once the parameter types are known, so type-directed
+        // literals resolve against the parameter type at their exact argument position.
         let arg_nodes = sub_expr.collect::<Vec<_>>();
         let convert_args = |ctx: &mut LookupCtx, expected: &[Type]| {
             arg_nodes
@@ -1600,39 +1604,30 @@ impl Expression {
                 .enumerate()
                 .map(|(i, n)| {
                     let ty = expected.get(i).cloned().unwrap_or(Type::Invalid);
-                    let e = ctx.with_expected_type(ty, |ctx| {
-                        Self::from_expression_node((*n).clone(), ctx)
+                    let expression = ctx.with_expected_type(ty, |ctx| {
+                        Self::from_argument_expression_node(
+                            (*n).clone(),
+                            ctx,
+                            &expected_closure_arg_type,
+                        )
                     });
-                    (e, Some(NodeOrToken::from((**n).clone())))
+                    (expression, Some(NodeOrToken::from((**n).clone())))
                 })
                 .collect::<Vec<_>>()
         };
+
         let Some(function) = function else {
-            // Check sub expressions anyway
+            // Check sub-expressions anyway.
             convert_args(ctx, &[]);
             assert!(ctx.diag.has_errors());
             return Self::Invalid;
         };
         let LookupResult::Callable(function) = function else {
-            // Check sub expressions anyway
+            // Check sub-expressions anyway.
             convert_args(ctx, &[]);
             ctx.diag.push_error("The expression is not a function".into(), &node);
             return Self::Invalid;
         };
-
-        // For array `.any()` / `.all()`, arrange to accept the predicate's element type
-        // for the upcoming argument resolution.
-        if let LookupResultCallable::MemberFunction { base, member, .. } = &function {
-            if let LookupResultCallable::Callable(Callable::Builtin(
-                BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll,
-            )) = **member
-            {
-                // These member functions are only available when the base is an array.
-                let Type::Array(elem_ty) = base.ty() else { unreachable!() };
-                ctx.predicates_allowed = true;
-                ctx.predicate_arg_type = Some((*elem_ty).clone());
-            }
-        }
 
         let mut adjust_arg_count = 0;
         let function = match function {
@@ -1648,7 +1643,7 @@ impl Expression {
                 );
             }
             LookupResultCallable::MemberFunction { member, base, source_node } => {
-                arguments.push((base.clone(), source_node));
+                arguments.push((base, source_node));
                 adjust_arg_count = 1;
                 match *member {
                     LookupResultCallable::Callable(c) => c,
@@ -2037,66 +2032,73 @@ impl Expression {
         Expression::Array { element_ty, values }
     }
 
-    fn from_predicate_node(node: syntax_nodes::Predicate, ctx: &mut LookupCtx) -> Expression {
-        if !ctx.predicates_allowed {
-            ctx.diag.push_error(
-                "Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`"
-                    .to_string(),
-                &node,
-            );
-            return Expression::Invalid;
-        }
-
-        // `.take()` so a nested function call inside the predicate body sees `None`
-        // and doesn't accidentally inherit the outer predicate's element type.
-        // Once we've descended past this predicate node, no further predicates should be
-        // resolved against this type.
-        let Some(ty) = ctx.predicate_arg_type.take() else {
-            // The caller (from_function_call_node) sets this for ArrayAny/ArrayAll. Reaching
-            // here without it means the resolver enabled predicates outside that path.
-            ctx.diag.push_error(
-                "Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`"
-                    .to_string(),
-                &node,
-            );
-            return Expression::Invalid;
-        };
-
+    /// Resolve a closure expression. `arg_type` is `Some` only when the closure appears in a
+    /// position whose callee constrains the argument's type (currently `.any` / `.all`); in
+    /// that case the body is also required to evaluate to `bool`. When `arg_type` is `None`
+    /// the closure is still a valid expression of type [`Type::Closure`], but its body cannot
+    /// be meaningfully typed and any later type-conversion error will be reported at the
+    /// position that consumes it.
+    fn from_closure_node(
+        node: syntax_nodes::Closure,
+        ctx: &mut LookupCtx,
+        arg_type: Option<Type>,
+    ) -> Expression {
+        let has_expected_arg_type = arg_type.is_some();
+        let ty = arg_type.unwrap_or(Type::Invalid);
         let arg_name = node.DeclaredIdentifier().to_smolstr();
-        let internal_arg_name = Self::unique_internal_predicate_name(ctx);
+        let internal_arg_name: SmolStr = format!("local_{arg_name}").into();
 
-        ctx.predicate_arguments.push((arg_name, internal_arg_name.clone(), ty));
-        let expression = Expression::from_expression_node(node.Expression(), ctx);
-        ctx.predicate_arguments.pop();
+        ctx.local_variables.push(vec![(internal_arg_name.clone(), ty)]);
+        let body_expected_type = if has_expected_arg_type { Type::Bool } else { Type::Invalid };
+        let expression = ctx.with_expected_type(body_expected_type, |ctx| {
+            Expression::from_expression_node(node.Expression(), ctx)
+        });
+        ctx.local_variables.pop();
 
         let body_ty = expression.ty();
-        if body_ty != Type::Bool && body_ty != Type::Invalid {
+        if has_expected_arg_type && body_ty != Type::Bool && body_ty != Type::Invalid {
             ctx.diag.push_error(
-                format!("Predicate expression must be of type bool, but is {body_ty}"),
+                format!("Closure body must be of type bool, but is {body_ty}"),
                 &node.Expression(),
             );
             return Expression::Invalid;
         }
 
-        Expression::Predicate { arg_name: internal_arg_name, expression: Box::new(expression) }
+        Expression::Closure { arg_name: internal_arg_name, expression: Box::new(expression) }
     }
 
-    fn unique_internal_predicate_name(ctx: &LookupCtx) -> SmolStr {
-        let conflicts = |candidate: &SmolStr| {
-            ctx.local_variables.iter().flatten().any(|(name, _)| name == candidate)
-                || ctx.predicate_arguments.iter().any(|(source_name, internal_name, _)| {
-                    source_name == candidate || internal_name == candidate
-                })
-        };
-
-        let mut index = ctx.predicate_arguments.len();
-        loop {
-            let candidate = format_smolstr!("slint_predicate_arg_{index}");
-            if !conflicts(&candidate) {
-                return candidate;
+    /// Resolve a function call argument. If the argument is a closure expression (possibly
+    /// nested in zero or more parenthesizing `Expression` wrappers), dispatch directly to
+    /// `from_closure_node` with the expected argument type. Otherwise fall back to the
+    /// generic expression resolver, in which case any closure encountered inside has no
+    /// expected argument type.
+    fn from_argument_expression_node(
+        node: syntax_nodes::Expression,
+        ctx: &mut LookupCtx,
+        expected_closure_arg_type: &Option<Type>,
+    ) -> Expression {
+        if expected_closure_arg_type.is_some() {
+            let mut current = node.clone();
+            loop {
+                let first_meaningful_child = current
+                    .children()
+                    .find(|n| matches!(n.kind(), SyntaxKind::Expression | SyntaxKind::Closure));
+                match first_meaningful_child {
+                    Some(child) if child.kind() == SyntaxKind::Closure => {
+                        return Self::from_closure_node(
+                            child.into(),
+                            ctx,
+                            expected_closure_arg_type.clone(),
+                        );
+                    }
+                    Some(child) if child.kind() == SyntaxKind::Expression => {
+                        current = child.into();
+                    }
+                    _ => break,
+                }
             }
-            index += 1;
         }
+        Self::from_expression_node(node, ctx)
     }
 
     fn from_string_template_node(
@@ -2704,9 +2706,6 @@ fn resolve_two_way_bindings_for_element(
                 type_loader: None,
                 current_token: Some(node.clone().into()),
                 local_variables: Vec::new(),
-                predicate_arguments: vec![],
-                predicate_arg_type: None,
-                predicates_allowed: false,
             };
 
             // Only the alias-only case stores the two-way binding in the expression slot;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -20,7 +20,7 @@ use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
 use core::num::IntErrorKind;
 use smol_str::{SmolStr, ToSmolStr};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Arc;
 use unicode_segmentation::UnicodeSegmentation;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -19,8 +19,8 @@ use crate::parser::{NodeOrToken, SyntaxKind, SyntaxNode, identifier_text, syntax
 use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
 use core::num::IntErrorKind;
-use smol_str::{SmolStr, ToSmolStr};
-use std::collections::BTreeMap;
+use smol_str::{SmolStr, ToSmolStr, format_smolstr};
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use std::sync::Arc;
 use unicode_segmentation::UnicodeSegmentation;
@@ -55,6 +55,9 @@ fn resolve_expression(
             type_loader: Some(type_loader),
             current_token: None,
             local_variables: Vec::new(),
+            predicate_arguments: vec![],
+            predicate_arg_type: None,
+            predicates_allowed: false,
         };
         lookup_ctx.expected_type = lookup_ctx.return_type().clone();
 
@@ -541,6 +544,9 @@ impl Expression {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("String interpolation expressions are", &node);
                         return Self::from_string_template_node(node.into(), ctx);
+                    }
+                    SyntaxKind::Predicate => {
+                        return Self::from_predicate_node(node.into(), ctx);
                     }
                     _ => {}
                 },
@@ -1549,6 +1555,20 @@ impl Expression {
         node: syntax_nodes::FunctionCallExpression,
         ctx: &mut LookupCtx,
     ) -> Expression {
+        // Save state so nested calls (or function calls inside a predicate body) can't leak
+        // their settings out into the enclosing scope. Restore on every exit path.
+        let prev_predicates_allowed = std::mem::replace(&mut ctx.predicates_allowed, false);
+        let prev_predicate_arg_type = ctx.predicate_arg_type.take();
+        let result = Self::resolve_function_call_node(node, ctx);
+        ctx.predicates_allowed = prev_predicates_allowed;
+        ctx.predicate_arg_type = prev_predicate_arg_type;
+        result
+    }
+
+    fn resolve_function_call_node(
+        node: syntax_nodes::FunctionCallExpression,
+        ctx: &mut LookupCtx,
+    ) -> Expression {
         let mut arguments = Vec::new();
 
         let mut sub_expr = node.Expression();
@@ -1600,6 +1620,20 @@ impl Expression {
             return Self::Invalid;
         };
 
+        // For array `.any()` / `.all()`, arrange to accept the predicate's element type
+        // for the upcoming argument resolution.
+        if let LookupResultCallable::MemberFunction { base, member, .. } = &function {
+            if let LookupResultCallable::Callable(Callable::Builtin(
+                BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll,
+            )) = **member
+            {
+                // These member functions are only available when the base is an array.
+                let Type::Array(elem_ty) = base.ty() else { unreachable!() };
+                ctx.predicates_allowed = true;
+                ctx.predicate_arg_type = Some((*elem_ty).clone());
+            }
+        }
+
         let mut adjust_arg_count = 0;
         let function = match function {
             LookupResultCallable::Callable(c) => c,
@@ -1613,8 +1647,8 @@ impl Expression {
                     &ctx.symbol_counters,
                 );
             }
-            LookupResultCallable::MemberFunction { member, base, base_node } => {
-                arguments.push((base, base_node));
+            LookupResultCallable::MemberFunction { member, base, source_node } => {
+                arguments.push((base.clone(), source_node));
                 adjust_arg_count = 1;
                 match *member {
                     LookupResultCallable::Callable(c) => c,
@@ -2001,6 +2035,68 @@ impl Expression {
         }
 
         Expression::Array { element_ty, values }
+    }
+
+    fn from_predicate_node(node: syntax_nodes::Predicate, ctx: &mut LookupCtx) -> Expression {
+        if !ctx.predicates_allowed {
+            ctx.diag.push_error(
+                "Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`"
+                    .to_string(),
+                &node,
+            );
+            return Expression::Invalid;
+        }
+
+        // `.take()` so a nested function call inside the predicate body sees `None`
+        // and doesn't accidentally inherit the outer predicate's element type.
+        // Once we've descended past this predicate node, no further predicates should be
+        // resolved against this type.
+        let Some(ty) = ctx.predicate_arg_type.take() else {
+            // The caller (from_function_call_node) sets this for ArrayAny/ArrayAll. Reaching
+            // here without it means the resolver enabled predicates outside that path.
+            ctx.diag.push_error(
+                "Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`"
+                    .to_string(),
+                &node,
+            );
+            return Expression::Invalid;
+        };
+
+        let arg_name = node.DeclaredIdentifier().to_smolstr();
+        let internal_arg_name = Self::unique_internal_predicate_name(ctx);
+
+        ctx.predicate_arguments.push((arg_name, internal_arg_name.clone(), ty));
+        let expression = Expression::from_expression_node(node.Expression(), ctx);
+        ctx.predicate_arguments.pop();
+
+        let body_ty = expression.ty();
+        if body_ty != Type::Bool && body_ty != Type::Invalid {
+            ctx.diag.push_error(
+                format!("Predicate expression must be of type bool, but is {body_ty}"),
+                &node.Expression(),
+            );
+            return Expression::Invalid;
+        }
+
+        Expression::Predicate { arg_name: internal_arg_name, expression: Box::new(expression) }
+    }
+
+    fn unique_internal_predicate_name(ctx: &LookupCtx) -> SmolStr {
+        let conflicts = |candidate: &SmolStr| {
+            ctx.local_variables.iter().flatten().any(|(name, _)| name == candidate)
+                || ctx.predicate_arguments.iter().any(|(source_name, internal_name, _)| {
+                    source_name == candidate || internal_name == candidate
+                })
+        };
+
+        let mut index = ctx.predicate_arguments.len();
+        loop {
+            let candidate = format_smolstr!("slint_predicate_arg_{index}");
+            if !conflicts(&candidate) {
+                return candidate;
+            }
+            index += 1;
+        }
     }
 
     fn from_string_template_node(
@@ -2442,7 +2538,7 @@ fn continue_lookup_within_element(
         if matches!(fun.args.first(), Some(Type::ElementReference)) {
             LookupResult::Callable(LookupResultCallable::MemberFunction {
                 base: Expression::ElementReference(Rc::downgrade(elem)),
-                base_node: Some(NodeOrToken::Node(node.into())),
+                source_node: Some(NodeOrToken::Node(node.into())),
                 member: Box::new(LookupResultCallable::Callable(callable)),
             })
             .into()
@@ -2608,6 +2704,9 @@ fn resolve_two_way_bindings_for_element(
                 type_loader: None,
                 current_token: Some(node.clone().into()),
                 local_variables: Vec::new(),
+                predicate_arguments: vec![],
+                predicate_arg_type: None,
+                predicates_allowed: false,
             };
 
             // Only the alias-only case stores the two-way binding in the expression slot;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2075,6 +2075,11 @@ impl Expression {
     /// `from_closure_node` with the expected argument type. Otherwise fall back to the
     /// generic expression resolver, in which case any closure encountered inside has no
     /// expected argument type.
+    ///
+    /// A closure-typed argument that is not written inline (for example a local variable
+    /// holding a closure) is rejected: the code generators and the interpreter evaluate
+    /// the closure body directly at the call site, so they require the argument to be a
+    /// literal [`Expression::Closure`].
     fn from_argument_expression_node(
         node: syntax_nodes::Expression,
         ctx: &mut LookupCtx,
@@ -2101,7 +2106,18 @@ impl Expression {
                 }
             }
         }
-        Self::from_expression_node(node, ctx)
+        let expression = Self::from_expression_node(node.clone(), ctx);
+        if expected_closure_arg_type.is_some()
+            && expression.ty() == Type::Closure
+            && !matches!(expression, Expression::Closure { .. })
+        {
+            ctx.diag.push_error(
+                "Closures must be written inline as the argument of 'any' or 'all'".into(),
+                &node,
+            );
+            return Expression::Invalid;
+        }
+        expression
     }
 
     fn from_string_template_node(

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2043,6 +2043,9 @@ impl Expression {
         ctx: &mut LookupCtx,
         arg_type: Option<Type>,
     ) -> Expression {
+        if crate::reject_experimental_feature(ctx.diag, ctx.type_register, "closures", &node) {
+            return Expression::Invalid;
+        }
         let has_expected_arg_type = arg_type.is_some();
         let ty = arg_type.unwrap_or(Type::Invalid);
         let arg_name = node.DeclaredIdentifier().to_smolstr();

--- a/internal/compiler/passes/resolving/remove_noop.rs
+++ b/internal/compiler/passes/resolving/remove_noop.rs
@@ -127,6 +127,6 @@ fn without_side_effects(expression: &Expression) -> bool {
         Expression::DebugHook { .. } => false,
         Expression::EmptyComponentFactory => false,
         Expression::EmptyDataTransfer => false,
-        Expression::Predicate { expression, .. } => without_side_effects(expression),
+        Expression::Closure { expression, .. } => without_side_effects(expression),
     }
 }

--- a/internal/compiler/passes/resolving/remove_noop.rs
+++ b/internal/compiler/passes/resolving/remove_noop.rs
@@ -127,5 +127,6 @@ fn without_side_effects(expression: &Expression) -> bool {
         Expression::DebugHook { .. } => false,
         Expression::EmptyComponentFactory => false,
         Expression::EmptyDataTransfer => false,
+        Expression::Predicate { expression, .. } => without_side_effects(expression),
     }
 }

--- a/internal/compiler/passes/resolving/remove_noop.rs
+++ b/internal/compiler/passes/resolving/remove_noop.rs
@@ -127,6 +127,7 @@ fn without_side_effects(expression: &Expression) -> bool {
         Expression::DebugHook { .. } => false,
         Expression::EmptyComponentFactory => false,
         Expression::EmptyDataTransfer => false,
-        Expression::Closure { expression, .. } => without_side_effects(expression),
+        // A closure that is not called has no side effect, regardless of what its body does.
+        Expression::Closure { .. } => true,
     }
 }

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -7,43 +7,56 @@ export component Test inherits Window {
     function takes-bool(value: bool) -> bool { return value; }
 
     if x => x > 0 : Rectangle {}
-//     >         <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+//     >         <error{Cannot convert closure to bool}
 
     init => {
         ints.any(1);
-//               ^error{Cannot convert float to predicate}
+//               ^error{Cannot convert float to closure}
         ints.all(1);
-//               ^error{Cannot convert float to predicate}
+//               ^error{Cannot convert float to closure}
 
         ints.any(x => 1);
-//                    ^error{Predicate expression must be of type bool, but is float}
+//                    ^error{Closure body must be of type bool, but is float}
         ints.all(x => 1);
-//                    ^error{Predicate expression must be of type bool, but is float}
+//                    ^error{Closure body must be of type bool, but is float}
 
         ints.any(x => x);
-//                    ^error{Predicate expression must be of type bool, but is int}
+//                    ^error{Closure body must be of type bool, but is int}
         ints.all(x => x);
-//                    ^error{Predicate expression must be of type bool, but is int}
+//                    ^error{Closure body must be of type bool, but is int}
         debug(x);
 //            ^error{Unknown unqualified identifier 'x'. Did you mean 'self.x'?}
 
         takes-int(x => true);
-//                >       <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+//                >       <error{Cannot convert closure to int}
 
         debug(x => x > 0);
-//            >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+//            >        <error{Cannot debug this expression}
 
         y => y > 0;
-//      >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+//      >        <warning{Expression has no effect!}
 
-        // A predicate must not be accepted as an argument to a non-array function call
-        // that is itself nested inside a legitimate predicate body.
+        // A closure must not be accepted as an argument to a non-array function call
+        // that is itself nested inside a legitimate closure body.
         ints.any(x => takes-bool(y => y > 0));
-//                               >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+//                               >        <error{Cannot convert closure to bool}
+
+        // Closures are first-class expressions of type `closure`; using one in a position
+        // that doesn't constrain the argument's type produces an unusable value but no
+        // error. The body is *not* type-checked for `bool` here — only call sites that
+        // structurally know what the argument should be (currently `.any`/`.all`) enforce
+        // that. Reading `useless` later would emit "Cannot convert closure to …".
+        let useless = x => x + 1;
+        // Closure as a regular sub-expression: same story, body is unconstrained.
+        let still-useless = (y => y);
     }
+
+    // Closure as the right-hand side of a non-array property still produces a single
+    // conversion error at the property's binding, not a cascade inside the closure body.
+    property <int> rejected: x => x + 1;
+//                           >         <error{Cannot convert closure to int}
 
     TouchArea {
         clicked => x => x > 0;
-//                 >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
     }
 }

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -1,0 +1,49 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test inherits Window {
+    property <[int]> ints: [1, 2, 3, 4, 5];
+    function takes-int(value: int) -> int { return value; }
+    function takes-bool(value: bool) -> bool { return value; }
+
+    if x => x > 0 : Rectangle {}
+//     >         <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+
+    init => {
+        ints.any(1);
+//               ^error{Cannot convert float to predicate}
+        ints.all(1);
+//               ^error{Cannot convert float to predicate}
+
+        ints.any(x => 1);
+//                    ^error{Predicate expression must be of type bool, but is float}
+        ints.all(x => 1);
+//                    ^error{Predicate expression must be of type bool, but is float}
+
+        ints.any(x => x);
+//                    ^error{Predicate expression must be of type bool, but is int}
+        ints.all(x => x);
+//                    ^error{Predicate expression must be of type bool, but is int}
+        debug(x);
+//            ^error{Unknown unqualified identifier 'x'. Did you mean 'self.x'?}
+
+        takes-int(x => true);
+//                >       <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+
+        debug(x => x > 0);
+//            >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+
+        y => y > 0;
+//      >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+
+        // A predicate must not be accepted as an argument to a non-array function call
+        // that is itself nested inside a legitimate predicate body.
+        ints.any(x => takes-bool(y => y > 0));
+//                               >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+    }
+
+    TouchArea {
+        clicked => x => x > 0;
+//                 >        <error{Predicates (`x => ...`) can only appear as arguments to `.any()` or `.all()`}
+    }
+}

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -6,8 +6,8 @@ export component Test inherits Window {
     function takes-int(value: int) -> int { return value; }
     function takes-bool(value: bool) -> bool { return value; }
 
-    if x => x > 0 : Rectangle {}
-//     >         <error{Cannot convert closure to bool}
+    if ((x) => x > 0) : Rectangle {}
+//     >             <error{Cannot convert closure to bool}
 
     init => {
         ints.any(1);
@@ -15,48 +15,48 @@ export component Test inherits Window {
         ints.all(1);
 //               ^error{Cannot convert float to closure}
 
-        ints.any(x => 1);
-//                    ^error{Closure body must be of type bool, but is float}
-        ints.all(x => 1);
-//                    ^error{Closure body must be of type bool, but is float}
+        ints.any((x) => 1);
+//                      ^error{Closure body must be of type bool, but is float}
+        ints.all((x) => 1);
+//                      ^error{Closure body must be of type bool, but is float}
 
-        ints.any(x => x);
-//                    ^error{Closure body must be of type bool, but is int}
-        ints.all(x => x);
-//                    ^error{Closure body must be of type bool, but is int}
+        ints.any((x) => x);
+//                      ^error{Closure body must be of type bool, but is int}
+        ints.all((x) => x);
+//                      ^error{Closure body must be of type bool, but is int}
         debug(x);
 //            ^error{Unknown unqualified identifier 'x'. Did you mean 'self.x'?}
 
-        takes-int(x => true);
-//                >       <error{Cannot convert closure to int}
+        takes-int((x) => true);
+//                >         <error{Cannot convert closure to int}
 
-        debug(x => x > 0);
-//            >        <error{Cannot debug this expression}
+        debug((x) => x > 0);
+//            >          <error{Cannot debug this expression}
 
-        y => y > 0;
-//      >        <warning{Expression has no effect!}
+        (y) => y > 0;
+//      >          <warning{Expression has no effect!}
 
         // A closure must not be accepted as an argument to a non-array function call
         // that is itself nested inside a legitimate closure body.
-        ints.any(x => takes-bool(y => y > 0));
-//                               >        <error{Cannot convert closure to bool}
+        ints.any((x) => takes-bool((y) => y > 0));
+//                                 >          <error{Cannot convert closure to bool}
 
         // Closures are first-class expressions of type `closure`; using one in a position
         // that doesn't constrain the argument's type produces an unusable value but no
         // error. The body is *not* type-checked for `bool` here — only call sites that
         // structurally know what the argument should be (currently `.any`/`.all`) enforce
         // that. Reading `useless` later would emit "Cannot convert closure to …".
-        let useless = x => x + 1;
+        let useless = (x) => x + 1;
         // Closure as a regular sub-expression: same story, body is unconstrained.
-        let still-useless = (y => y);
+        let still-useless = ((y) => y);
     }
 
     // Closure as the right-hand side of a non-array property still produces a single
     // conversion error at the property's binding, not a cascade inside the closure body.
-    property <int> rejected: x => x + 1;
-//                           >         <error{Cannot convert closure to int}
+    property <int> rejected: (x) => x + 1;
+//                           >           <error{Cannot convert closure to int}
 
     TouchArea {
-        clicked => x => x > 0;
+        clicked => (x) => x > 0;
     }
 }

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -49,6 +49,15 @@ export component Test inherits Window {
         let useless = (x) => x + 1;
         // Closure as a regular sub-expression: same story, body is unconstrained.
         let still-useless = ((y) => y);
+
+        // A stored closure cannot be passed to `any`/`all`: the code generators and the
+        // interpreter evaluate the closure body at the call site, so the argument must
+        // be a closure written inline.
+        let not-useless = (x) => x == 3;
+        debug(ints.any(not-useless));
+//                     >         <error{Closures must be written inline as the argument of 'any' or 'all'}
+        ints.all((not-useless));
+//               >           <error{Closures must be written inline as the argument of 'any' or 'all'}
     }
 
     // Closure as the right-hand side of a non-array property still produces a single

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -342,6 +342,28 @@ pub trait ModelExt: Model {
 
 impl<T: Model> ModelExt for T {}
 
+pub fn model_any<T: Default>(
+    model: &dyn Model<Data = T>,
+    mut predicate: impl FnMut(T) -> bool,
+) -> bool {
+    model.model_tracker().track_row_count_changes();
+    (0..model.row_count()).any(|index| {
+        model.model_tracker().track_row_data_changes(index);
+        predicate(model.row_data(index).unwrap_or_default())
+    })
+}
+
+pub fn model_all<T: Default>(
+    model: &dyn Model<Data = T>,
+    mut predicate: impl FnMut(T) -> bool,
+) -> bool {
+    model.model_tracker().track_row_count_changes();
+    (0..model.row_count()).all(|index| {
+        model.model_tracker().track_row_data_changes(index);
+        predicate(model.row_data(index).unwrap_or_default())
+    })
+}
+
 /// An iterator over the elements of a model.
 /// This struct is created by the [`Model::iter()`] trait function.
 pub struct ModelIterator<'a, T> {

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1315,7 +1315,7 @@ pub(crate) fn generate_item_tree<'id>(
             | Type::PathData
             | Type::UnitProduct(_)
             | Type::ElementReference
-            | Type::Predicate => panic!("bad type {ty:?} for property {name}"),
+            | Type::Closure => panic!("bad type {ty:?} for property {name}"),
         })
     }
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1314,7 +1314,8 @@ pub(crate) fn generate_item_tree<'id>(
             | Type::Model
             | Type::PathData
             | Type::UnitProduct(_)
-            | Type::ElementReference => panic!("bad type {ty:?} for property {name}"),
+            | Type::ElementReference
+            | Type::Predicate => panic!("bad type {ty:?} for property {name}"),
         })
     }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -739,8 +739,8 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
 
             eval_expression(expression, local_context)
         }
-        Expression::Predicate { .. } => unreachable!(
-            "predicates are only valid as direct arguments to ArrayAny/ArrayAll, which dispatch them without going through eval_expression"
+        Expression::Closure { .. } => unreachable!(
+            "closures are dispatched by their consuming builtin and should not go through eval_expression"
         ),
     }
 }
@@ -1975,10 +1975,12 @@ fn call_builtin_function(
             let is_all = matches!(f, BuiltinFunction::ArrayAll);
             let model: ModelRc<Value> =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let Expression::Predicate { arg_name, expression } = &arguments[1] else {
-                panic!("internal error: Array.any/all expects a predicate as second argument")
+            let Expression::Closure { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: Array.any/all expects a closure as second argument")
             };
-            for x in model.iter() {
+            model.model_tracker().track_row_count_changes();
+            for row in 0..model.row_count() {
+                let x = model.row_data_tracked(row).unwrap_or_default();
                 let previous = local_context.local_variables.insert(arg_name.clone(), x);
                 let result: bool = eval_expression(expression, local_context).try_into().unwrap();
                 match previous {
@@ -2296,7 +2298,7 @@ fn check_value_type(value: &mut Value, ty: &Type) -> bool {
         | Type::Callback { .. }
         | Type::Function { .. }
         | Type::ElementReference
-        | Type::Predicate => panic!("not valid property type"),
+        | Type::Closure => panic!("not valid property type"),
         Type::Float32 => matches!(value, Value::Number(_)),
         Type::Int32 => matches!(value, Value::Number(_)),
         Type::String => matches!(value, Value::String(_)),
@@ -2699,7 +2701,7 @@ pub fn default_value_for_type(ty: &Type) -> Value {
         | Type::InferredCallback
         | Type::ElementReference
         | Type::Function { .. }
-        | Type::Predicate => {
+        | Type::Closure => {
             panic!("There can't be such property")
         }
         Type::StyledText => Value::StyledText(Default::default()),

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -739,6 +739,9 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
 
             eval_expression(expression, local_context)
         }
+        Expression::Predicate { .. } => unreachable!(
+            "predicates are only valid as direct arguments to ArrayAny/ArrayAll, which dispatch them without going through eval_expression"
+        ),
     }
 }
 
@@ -1968,6 +1971,31 @@ fn call_builtin_function(
                 panic!("internal error: argument to PathAngleAt must be an element")
             }
         }
+        BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => {
+            let is_all = matches!(f, BuiltinFunction::ArrayAll);
+            let model: ModelRc<Value> =
+                eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let Expression::Predicate { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: Array.any/all expects a predicate as second argument")
+            };
+            for x in model.iter() {
+                let previous = local_context.local_variables.insert(arg_name.clone(), x);
+                let result: bool = eval_expression(expression, local_context).try_into().unwrap();
+                match previous {
+                    Some(prev) => {
+                        local_context.local_variables.insert(arg_name.clone(), prev);
+                    }
+                    None => {
+                        local_context.local_variables.remove(arg_name);
+                    }
+                }
+                // `all` short-circuits on false, `any` short-circuits on true.
+                if result != is_all {
+                    return Value::Bool(!is_all);
+                }
+            }
+            Value::Bool(is_all)
+        }
     }
 }
 
@@ -2267,7 +2295,8 @@ fn check_value_type(value: &mut Value, ty: &Type) -> bool {
         | Type::InferredCallback
         | Type::Callback { .. }
         | Type::Function { .. }
-        | Type::ElementReference => panic!("not valid property type"),
+        | Type::ElementReference
+        | Type::Predicate => panic!("not valid property type"),
         Type::Float32 => matches!(value, Value::Number(_)),
         Type::Int32 => matches!(value, Value::Number(_)),
         Type::String => matches!(value, Value::String(_)),
@@ -2669,7 +2698,8 @@ pub fn default_value_for_type(ty: &Type) -> Value {
         Type::InferredProperty
         | Type::InferredCallback
         | Type::ElementReference
-        | Type::Function { .. } => {
+        | Type::Function { .. }
+        | Type::Predicate => {
             panic!("There can't be such property")
         }
         Type::StyledText => Value::StyledText(Default::default()),

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -7,7 +7,8 @@ struct Person {
 }
 
 export component TestCase {
-    property <[int]> ints: [1, 2, 3, 4, 5];
+    in-out property <[int]> ints: [1, 2, 3, 4, 5];
+    in-out property <int> threshold: 3;
     property <[int]> empty-ints: [];
     property <[string]> strings: ["hello", "world", "foo", "bar"];
     property <[Person]> people: [
@@ -22,63 +23,76 @@ export component TestCase {
         [{ name: "Evan", age: 22 }, { name: "Fiona", age: 27 }]
     ];
 
-    out property <bool> test: {
-        // test that predicate args shadow outer variables regardless of type
+    out property <bool> has-zero: ints.any(x => x == 0);
+    out property <bool> all-positive: ints.all(x => x > 0);
+    out property <bool> any-above-threshold: ints.any(x => x > threshold);
+    out property <bool> all-above-threshold: ints.all(x => x > threshold);
+
+    out property <bool> ints-all-positive: ints.all(x => x > 0);
+    out property <bool> ints-not-all-gt-one: !ints.all(x => x > 1);
+    out property <bool> ints-no-zero: !ints.any(x => x == 0);
+    out property <bool> ints-any-five: ints.any(x => x == 5);
+    out property <bool> ints-any-under-five: ints.any(x => x < 5);
+
+    out property <bool> strings-all-nonempty: strings.all(s => s.character-count > 0);
+    out property <bool> strings-not-all-empty: !strings.all(s => s.is-empty);
+    out property <bool> strings-any-hello: strings.any(s => s == "hello");
+    out property <bool> strings-no-test: !strings.any(s => s == "test");
+    out property <bool> strings-no-empty: !strings.any(s => s.is-empty);
+
+    out property <bool> people-all-adults: people.all(p => p.age > 20);
+    out property <bool> people-not-all-under-thirty: !people.all(p => p.age < 30);
+    out property <bool> people-any-alice: people.any(p => p.name == "Alice");
+    out property <bool> people-no-evan: !people.any(p => p.name == "Evan");
+    out property <bool> people-any-under-thirty: people.any(p => p.age < 30);
+
+    out property <bool> groups-all-over-twenty: groups.all(group => group.all(person => person.age > 20));
+    out property <bool> groups-not-all-under-thirty: !groups.all(group => group.all(person => person.age < 30));
+    out property <bool> groups-all-have-adult: groups.all(group => group.any(person => person.age >= 25));
+    out property <bool> groups-no-all-alice: !groups.any(group => group.all(person => person.name == "Alice"));
+    out property <bool> groups-any-all-long-name: groups.any(group => group.all(person => person.name.character-count > 4));
+    out property <bool> groups-any-seven-letter-name: groups.any(group => group.any(person => person.name.character-count == 7));
+
+    out property <bool> nested-finds-alice: groups.any(group => group.length == 2 && group.any(person => person.name == "Alice"));
+    out property <bool> nested-all-have-age-twenty-five: groups.all(group => group.any(person => person.age >= 25));
+    out property <bool> nested-no-all-alice: !groups.any(group => group.all(person => person.name == "Alice"));
+
+    out property <bool> precedence-and: ints.any(x => x > 0 && x < 2);
+    out property <bool> precedence-or: !ints.any(x => x > 10 || x < 0);
+    out property <bool> precedence-all: ints.all(x => x > 0 && x < 10);
+
+    out property <bool> empty-any-false: !empty-ints.any(x => x == 0);
+    out property <bool> empty-all-true: empty-ints.all(x => x == 0);
+
+    out property <bool> closure-arg-shadows-local: {
         let x = "hello world";
-        let s = 42;
-        let p = 42px;
-        let slint_predicate_arg_0 = 99;
-
-        let ints = self.ints.all(x
-
-        => x > 0
-        ) && !self.ints.all(x => x > 1
-        ) && !self.ints.any(x => x == 0
-        ) && self.ints.any(x => x == 5
-        ) && self.ints.any(x => x < 5
-        );
-
-        let strings = self.strings.all(s => s.character-count > 0
-        ) && !self.strings.all(s => s.is-empty
-        ) && self.strings.any(s => s == "hello"
-        ) && !self.strings.any(s => s == "test"
-        ) && !self.strings.any(s => s.is-empty
-        );
-
-        let people = self.people.all(p => p.age > 20
-        ) && !self.people.all(p => p.age < 30
-        ) && self.people.any(p => p.name == "Alice"
-        ) && !self.people.any(p => p.name == "Evan"
-        ) && self.people.any(p => p.age < 30
-        );
-
-        let groups = self.groups.all(p => p.all(p
-        => p.age > 20)) && !self.groups.all(p => p.all(p
-        => p.age < 30)) && self.groups.all(p => p.any(p
-        => p.age >= 25)) && !self.groups.any(p => p.all(p
-        => p.name == "Alice")) && self.groups.any(p => p.all(p
-        => p.name.character-count > 4)) && self.groups.any(p => p.any(p
-        => p.name.character-count == 7));
-
-        let nested_named = self.groups.any(group => group.length == 2 && group.any(person
-        => person.name == "Alice")) && self.groups.all(group => group.any(person
-        => person.age >= 25)) && !self.groups.any(group => group.all(person
-        => person.name == "Alice"));
-
-        let precedence = self.ints.any(x => x > 0 && x < 2
-        ) && !self.ints.any(x => x > 10 || x < 0
-        ) && self.ints.all(x => x > 0 && x < 10);
-
-        let empty = !self.empty-ints.any(x => x == 0) && self.empty-ints.all(x => x == 0);
-
-        let internal_name_shadowing = self.ints.any(x => x == 1 && slint_predicate_arg_0 == 99);
-
-        let shadowing = x == "hello world" && s == 42 && p == 42px;
-
-        ints && strings && people && groups && nested_named && precedence && empty && internal_name_shadowing && shadowing
+        self.ints.any(x => x == 1) && x == "hello world"
     }
 
-    // with the groups here we are also testing arg shadowing when nested predicate args have the same and different names
+    // Same-name, same-type shadowing: the outer `x: int` must be hidden by the closure's
+    // `x: int` for the duration of the predicate body, and re-exposed after.
+    out property <bool> closure-arg-shadows-same-type-local: {
+        let x = 5;
+        self.ints.any(x => x == 2) && x == 5
+    }
+
+    out property <bool> nested-closure-arg-shadows: {
+        let person = "outer";
+        self.groups.any(person => person.any(person => person.name == "Alice")) && person == "outer"
+    }
+
+    out property <bool> test:
+        ints-all-positive && ints-not-all-gt-one && ints-no-zero && ints-any-five
+        && ints-any-under-five && strings-all-nonempty && strings-not-all-empty
+        && strings-any-hello && strings-no-test && strings-no-empty && people-all-adults
+        && people-not-all-under-thirty && people-any-alice && people-no-evan
+        && people-any-under-thirty && groups-all-over-twenty && groups-not-all-under-thirty
+        && groups-all-have-adult && groups-no-all-alice && groups-any-all-long-name
+        && groups-any-seven-letter-name && nested-finds-alice && nested-all-have-age-twenty-five
+        && nested-no-all-alice && precedence-and && precedence-or && precedence-all
+        && empty-any-false && empty-all-true && closure-arg-shadows-local
+        && closure-arg-shadows-same-type-local
+        && nested-closure-arg-shadows;
 }
 
 /*
@@ -86,19 +100,144 @@ export component TestCase {
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 
-assert(instance.get_test());
+assert(instance.get_ints_all_positive());
+assert(instance.get_ints_not_all_gt_one());
+assert(instance.get_ints_no_zero());
+assert(instance.get_ints_any_five());
+assert(instance.get_ints_any_under_five());
+assert(instance.get_strings_all_nonempty());
+assert(instance.get_strings_not_all_empty());
+assert(instance.get_strings_any_hello());
+assert(instance.get_strings_no_test());
+assert(instance.get_strings_no_empty());
+assert(instance.get_people_all_adults());
+assert(instance.get_people_not_all_under_thirty());
+assert(instance.get_people_any_alice());
+assert(instance.get_people_no_evan());
+assert(instance.get_people_any_under_thirty());
+assert(instance.get_groups_all_over_twenty());
+assert(instance.get_groups_not_all_under_thirty());
+assert(instance.get_groups_all_have_adult());
+assert(instance.get_groups_no_all_alice());
+assert(instance.get_groups_any_all_long_name());
+assert(instance.get_groups_any_seven_letter_name());
+assert(instance.get_nested_finds_alice());
+assert(instance.get_nested_all_have_age_twenty_five());
+assert(instance.get_nested_no_all_alice());
+assert(instance.get_precedence_and());
+assert(instance.get_precedence_or());
+assert(instance.get_precedence_all());
+assert(instance.get_empty_any_false());
+assert(instance.get_empty_all_true());
+assert(instance.get_closure_arg_shadows_local());
+assert(instance.get_closure_arg_shadows_same_type_local());
+assert(instance.get_nested_closure_arg_shadows());
 ```
 
-
 ```rust
+use slint::Model;
+
 let instance = TestCase::new().unwrap();
 
-assert!(instance.get_test());
+assert!(instance.get_ints_all_positive());
+assert!(instance.get_ints_not_all_gt_one());
+assert!(instance.get_ints_no_zero());
+assert!(instance.get_ints_any_five());
+assert!(instance.get_ints_any_under_five());
+assert!(instance.get_strings_all_nonempty());
+assert!(instance.get_strings_not_all_empty());
+assert!(instance.get_strings_any_hello());
+assert!(instance.get_strings_no_test());
+assert!(instance.get_strings_no_empty());
+assert!(instance.get_people_all_adults());
+assert!(instance.get_people_not_all_under_thirty());
+assert!(instance.get_people_any_alice());
+assert!(instance.get_people_no_evan());
+assert!(instance.get_people_any_under_thirty());
+assert!(instance.get_groups_all_over_twenty());
+assert!(instance.get_groups_not_all_under_thirty());
+assert!(instance.get_groups_all_have_adult());
+assert!(instance.get_groups_no_all_alice());
+assert!(instance.get_groups_any_all_long_name());
+assert!(instance.get_groups_any_seven_letter_name());
+assert!(instance.get_nested_finds_alice());
+assert!(instance.get_nested_all_have_age_twenty_five());
+assert!(instance.get_nested_no_all_alice());
+assert!(instance.get_precedence_and());
+assert!(instance.get_precedence_or());
+assert!(instance.get_precedence_all());
+assert!(instance.get_empty_any_false());
+assert!(instance.get_empty_all_true());
+assert!(instance.get_closure_arg_shadows_local());
+assert!(instance.get_closure_arg_shadows_same_type_local());
+assert!(instance.get_nested_closure_arg_shadows());
+
+let model: std::rc::Rc<slint::VecModel<i32>> = std::rc::Rc::new(vec![1, 2, 3].into());
+instance.set_ints(slint::ModelRc::from(model.clone()));
+assert!(!instance.get_has_zero());
+assert!(instance.get_all_positive());
+assert!(!instance.get_any_above_threshold());
+assert!(!instance.get_all_above_threshold());
+
+instance.set_threshold(1);
+assert!(instance.get_any_above_threshold());
+assert!(!instance.get_all_above_threshold());
+
+model.set_row_data(0, 3);
+assert!(instance.get_all_above_threshold());
+
+model.set_row_data(1, 0);
+assert!(instance.get_has_zero());
+assert!(!instance.get_all_positive());
+assert!(instance.get_any_above_threshold());
+assert!(!instance.get_all_above_threshold());
+
+model.set_row_data(1, 4);
+assert!(!instance.get_has_zero());
+assert!(instance.get_all_positive());
+assert!(instance.get_any_above_threshold());
+assert!(instance.get_all_above_threshold());
+
+model.push(0);
+assert!(instance.get_has_zero());
+assert!(!instance.get_all_positive());
+assert!(!instance.get_all_above_threshold());
 ```
 
 ```js
 var instance = new slint.TestCase();
 
-assert(instance.test);
+assert(instance.ints_all_positive);
+assert(instance.ints_not_all_gt_one);
+assert(instance.ints_no_zero);
+assert(instance.ints_any_five);
+assert(instance.ints_any_under_five);
+assert(instance.strings_all_nonempty);
+assert(instance.strings_not_all_empty);
+assert(instance.strings_any_hello);
+assert(instance.strings_no_test);
+assert(instance.strings_no_empty);
+assert(instance.people_all_adults);
+assert(instance.people_not_all_under_thirty);
+assert(instance.people_any_alice);
+assert(instance.people_no_evan);
+assert(instance.people_any_under_thirty);
+assert(instance.groups_all_over_twenty);
+assert(instance.groups_not_all_under_thirty);
+assert(instance.groups_all_have_adult);
+assert(instance.groups_no_all_alice);
+assert(instance.groups_any_all_long_name);
+assert(instance.groups_any_seven_letter_name);
+assert(instance.nested_finds_alice);
+assert(instance.nested_all_have_age_twenty_five);
+assert(instance.nested_no_all_alice);
+assert(instance.precedence_and);
+assert(instance.precedence_or);
+assert(instance.precedence_all);
+assert(instance.empty_any_false);
+assert(instance.empty_all_true);
+assert(instance.closure_arg_shadows_local);
+assert(instance.closure_arg_shadows_same_type_local);
+assert(instance.nested_closure_arg_shadows);
 ```
 */

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -1,0 +1,104 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+struct Person {
+    name: string,
+    age: int,
+}
+
+export component TestCase {
+    property <[int]> ints: [1, 2, 3, 4, 5];
+    property <[int]> empty-ints: [];
+    property <[string]> strings: ["hello", "world", "foo", "bar"];
+    property <[Person]> people: [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 },
+        { name: "Charlie", age: 35 },
+        { name: "Diana", age: 28 }
+    ];
+    property <[[Person]]> groups: [
+        [{ name: "Alice", age: 30 }, { name: "Bob", age: 25 }],
+        [{ name: "Charlie", age: 35 }, { name: "Diana", age: 28 }],
+        [{ name: "Evan", age: 22 }, { name: "Fiona", age: 27 }]
+    ];
+
+    out property <bool> test: {
+        // test that predicate args shadow outer variables regardless of type
+        let x = "hello world";
+        let s = 42;
+        let p = 42px;
+        let slint_predicate_arg_0 = 99;
+
+        let ints = self.ints.all(x
+
+        => x > 0
+        ) && !self.ints.all(x => x > 1
+        ) && !self.ints.any(x => x == 0
+        ) && self.ints.any(x => x == 5
+        ) && self.ints.any(x => x < 5
+        );
+
+        let strings = self.strings.all(s => s.character-count > 0
+        ) && !self.strings.all(s => s.is-empty
+        ) && self.strings.any(s => s == "hello"
+        ) && !self.strings.any(s => s == "test"
+        ) && !self.strings.any(s => s.is-empty
+        );
+
+        let people = self.people.all(p => p.age > 20
+        ) && !self.people.all(p => p.age < 30
+        ) && self.people.any(p => p.name == "Alice"
+        ) && !self.people.any(p => p.name == "Evan"
+        ) && self.people.any(p => p.age < 30
+        );
+
+        let groups = self.groups.all(p => p.all(p
+        => p.age > 20)) && !self.groups.all(p => p.all(p
+        => p.age < 30)) && self.groups.all(p => p.any(p
+        => p.age >= 25)) && !self.groups.any(p => p.all(p
+        => p.name == "Alice")) && self.groups.any(p => p.all(p
+        => p.name.character-count > 4)) && self.groups.any(p => p.any(p
+        => p.name.character-count == 7));
+
+        let nested_named = self.groups.any(group => group.length == 2 && group.any(person
+        => person.name == "Alice")) && self.groups.all(group => group.any(person
+        => person.age >= 25)) && !self.groups.any(group => group.all(person
+        => person.name == "Alice"));
+
+        let precedence = self.ints.any(x => x > 0 && x < 2
+        ) && !self.ints.any(x => x > 10 || x < 0
+        ) && self.ints.all(x => x > 0 && x < 10);
+
+        let empty = !self.empty-ints.any(x => x == 0) && self.empty-ints.all(x => x == 0);
+
+        let internal_name_shadowing = self.ints.any(x => x == 1 && slint_predicate_arg_0 == 99);
+
+        let shadowing = x == "hello world" && s == 42 && p == 42px;
+
+        ints && strings && people && groups && nested_named && precedence && empty && internal_name_shadowing && shadowing
+    }
+
+    // with the groups here we are also testing arg shadowing when nested predicate args have the same and different names
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+
+assert(instance.test);
+```
+*/

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -23,62 +23,62 @@ export component TestCase {
         [{ name: "Evan", age: 22 }, { name: "Fiona", age: 27 }]
     ];
 
-    out property <bool> has-zero: ints.any(x => x == 0);
-    out property <bool> all-positive: ints.all(x => x > 0);
-    out property <bool> any-above-threshold: ints.any(x => x > threshold);
-    out property <bool> all-above-threshold: ints.all(x => x > threshold);
+    out property <bool> has-zero: ints.any((x) => x == 0);
+    out property <bool> all-positive: ints.all((x) => x > 0);
+    out property <bool> any-above-threshold: ints.any((x) => x > threshold);
+    out property <bool> all-above-threshold: ints.all((x) => x > threshold);
 
-    out property <bool> ints-all-positive: ints.all(x => x > 0);
-    out property <bool> ints-not-all-gt-one: !ints.all(x => x > 1);
-    out property <bool> ints-no-zero: !ints.any(x => x == 0);
-    out property <bool> ints-any-five: ints.any(x => x == 5);
-    out property <bool> ints-any-under-five: ints.any(x => x < 5);
+    out property <bool> ints-all-positive: ints.all((x) => x > 0);
+    out property <bool> ints-not-all-gt-one: !ints.all((x) => x > 1);
+    out property <bool> ints-no-zero: !ints.any((x) => x == 0);
+    out property <bool> ints-any-five: ints.any((x) => x == 5);
+    out property <bool> ints-any-under-five: ints.any((x) => x < 5);
 
-    out property <bool> strings-all-nonempty: strings.all(s => s.character-count > 0);
-    out property <bool> strings-not-all-empty: !strings.all(s => s.is-empty);
-    out property <bool> strings-any-hello: strings.any(s => s == "hello");
-    out property <bool> strings-no-test: !strings.any(s => s == "test");
-    out property <bool> strings-no-empty: !strings.any(s => s.is-empty);
+    out property <bool> strings-all-nonempty: strings.all((s) => s.character-count > 0);
+    out property <bool> strings-not-all-empty: !strings.all((s) => s.is-empty);
+    out property <bool> strings-any-hello: strings.any((s) => s == "hello");
+    out property <bool> strings-no-test: !strings.any((s) => s == "test");
+    out property <bool> strings-no-empty: !strings.any((s) => s.is-empty);
 
-    out property <bool> people-all-adults: people.all(p => p.age > 20);
-    out property <bool> people-not-all-under-thirty: !people.all(p => p.age < 30);
-    out property <bool> people-any-alice: people.any(p => p.name == "Alice");
-    out property <bool> people-no-evan: !people.any(p => p.name == "Evan");
-    out property <bool> people-any-under-thirty: people.any(p => p.age < 30);
+    out property <bool> people-all-adults: people.all((p) => p.age > 20);
+    out property <bool> people-not-all-under-thirty: !people.all((p) => p.age < 30);
+    out property <bool> people-any-alice: people.any((p) => p.name == "Alice");
+    out property <bool> people-no-evan: !people.any((p) => p.name == "Evan");
+    out property <bool> people-any-under-thirty: people.any((p) => p.age < 30);
 
-    out property <bool> groups-all-over-twenty: groups.all(group => group.all(person => person.age > 20));
-    out property <bool> groups-not-all-under-thirty: !groups.all(group => group.all(person => person.age < 30));
-    out property <bool> groups-all-have-adult: groups.all(group => group.any(person => person.age >= 25));
-    out property <bool> groups-no-all-alice: !groups.any(group => group.all(person => person.name == "Alice"));
-    out property <bool> groups-any-all-long-name: groups.any(group => group.all(person => person.name.character-count > 4));
-    out property <bool> groups-any-seven-letter-name: groups.any(group => group.any(person => person.name.character-count == 7));
+    out property <bool> groups-all-over-twenty: groups.all((group) => group.all((person) => person.age > 20));
+    out property <bool> groups-not-all-under-thirty: !groups.all((group) => group.all((person) => person.age < 30));
+    out property <bool> groups-all-have-adult: groups.all((group) => group.any((person) => person.age >= 25));
+    out property <bool> groups-no-all-alice: !groups.any((group) => group.all((person) => person.name == "Alice"));
+    out property <bool> groups-any-all-long-name: groups.any((group) => group.all((person) => person.name.character-count > 4));
+    out property <bool> groups-any-seven-letter-name: groups.any((group) => group.any((person) => person.name.character-count == 7));
 
-    out property <bool> nested-finds-alice: groups.any(group => group.length == 2 && group.any(person => person.name == "Alice"));
-    out property <bool> nested-all-have-age-twenty-five: groups.all(group => group.any(person => person.age >= 25));
-    out property <bool> nested-no-all-alice: !groups.any(group => group.all(person => person.name == "Alice"));
+    out property <bool> nested-finds-alice: groups.any((group) => group.length == 2 && group.any((person) => person.name == "Alice"));
+    out property <bool> nested-all-have-age-twenty-five: groups.all((group) => group.any((person) => person.age >= 25));
+    out property <bool> nested-no-all-alice: !groups.any((group) => group.all((person) => person.name == "Alice"));
 
-    out property <bool> precedence-and: ints.any(x => x > 0 && x < 2);
-    out property <bool> precedence-or: !ints.any(x => x > 10 || x < 0);
-    out property <bool> precedence-all: ints.all(x => x > 0 && x < 10);
+    out property <bool> precedence-and: ints.any((x) => x > 0 && x < 2);
+    out property <bool> precedence-or: !ints.any((x) => x > 10 || x < 0);
+    out property <bool> precedence-all: ints.all((x) => x > 0 && x < 10);
 
-    out property <bool> empty-any-false: !empty-ints.any(x => x == 0);
-    out property <bool> empty-all-true: empty-ints.all(x => x == 0);
+    out property <bool> empty-any-false: !empty-ints.any((x) => x == 0);
+    out property <bool> empty-all-true: empty-ints.all((x) => x == 0);
 
     out property <bool> closure-arg-shadows-local: {
         let x = "hello world";
-        self.ints.any(x => x == 1) && x == "hello world"
+        self.ints.any((x) => x == 1) && x == "hello world"
     }
 
     // Same-name, same-type shadowing: the outer `x: int` must be hidden by the closure's
     // `x: int` for the duration of the predicate body, and re-exposed after.
     out property <bool> closure-arg-shadows-same-type-local: {
         let x = 5;
-        self.ints.any(x => x == 2) && x == 5
+        self.ints.any((x) => x == 2) && x == 5
     }
 
     out property <bool> nested-closure-arg-shadows: {
         let person = "outer";
-        self.groups.any(person => person.any(person => person.name == "Alice")) && person == "outer"
+        self.groups.any((person) => person.any((person) => person.name == "Alice")) && person == "outer"
     }
 
     out property <bool> test:

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -3590,11 +3590,11 @@ export component MainWindow2 inherits Rectangle {
     #[test]
     fn closure() {
         assert_formatting(
-            "component X { property <[int]> arr: [1, 2, 3, 4, 5]; function foo() { arr.any(x\n     =>   x         ==  1     ); } }",
+            "component X { property <[int]> arr: [1, 2, 3, 4, 5]; function foo() { arr.any((x)\n     =>   x         ==  1     ); } }",
             r#"component X {
     property <[int]> arr: [1, 2, 3, 4, 5];
     function foo() {
-        arr.any(x => x == 1);
+        arr.any((x) => x == 1);
     }
 }
 "#,
@@ -3819,19 +3819,19 @@ export component MainWindow2 inherits Rectangle {
     #[test]
     fn nested_closure() {
         assert_formatting(
-            "component X { property <[[int]]> arr: [[1, 2, 3, 4, 5]]; function foo() { arr.any(x     =>   x.all(y   => y   ==  7     )      ); } }",
+            "component X { property <[[int]]> arr: [[1, 2, 3, 4, 5]]; function foo() { arr.any((x)     =>   x.all((y)   => y   ==  7     )      ); } }",
             r#"component X {
     property <[[int]]> arr: [[1, 2, 3, 4, 5]];
-    function foo() { arr.any(x => x.all(y => y == 7)); }
+    function foo() { arr.any((x) => x.all((y) => y == 7)); }
 }
 "#,
         );
 
         assert_formatting(
-            "component X { property <[[{age: int}]]> groups: []; function foo() { groups.any(group     =>   group.any(person   => person.age   >  20     ) && group.length == 2      ); } }",
+            "component X { property <[[{age: int}]]> groups: []; function foo() { groups.any((group)     =>   group.any((person)   => person.age   >  20     ) && group.length == 2      ); } }",
             r#"component X {
     property <[[{age: int}]]> groups: [];
-    function foo() { groups.any(group => group.any(person => person.age > 20) && group.length == 2); }
+    function foo() { groups.any((group) => group.any((person) => person.age > 20) && group.length == 2); }
 }
 "#,
         );

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -212,8 +212,8 @@ fn format_node(
         SyntaxKind::ImportSpecifier => {
             return format_import_specifier(node, writer, state);
         }
-        SyntaxKind::Predicate => {
-            return format_predicate(node, writer, state);
+        SyntaxKind::Closure => {
+            return format_closure(node, writer, state);
         }
         _ => (),
     }
@@ -2185,7 +2185,7 @@ fn format_import_specifier(
     Ok(())
 }
 
-fn format_predicate(
+fn format_closure(
     node: &SyntaxNode,
     writer: &mut impl TokenWriter,
     state: &mut FormatState,
@@ -3588,7 +3588,7 @@ export component MainWindow2 inherits Rectangle {
     }
 
     #[test]
-    fn predicate() {
+    fn closure() {
         assert_formatting(
             "component X { property <[int]> arr: [1, 2, 3, 4, 5]; function foo() { arr.any(x\n     =>   x         ==  1     ); } }",
             r#"component X {
@@ -3817,7 +3817,7 @@ export component MainWindow2 inherits Rectangle {
     }
 
     #[test]
-    fn nested_predicate() {
+    fn nested_closure() {
         assert_formatting(
             "component X { property <[[int]]> arr: [[1, 2, 3, 4, 5]]; function foo() { arr.any(x     =>   x.all(y   => y   ==  7     )      ); } }",
             r#"component X {

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -212,6 +212,9 @@ fn format_node(
         SyntaxKind::ImportSpecifier => {
             return format_import_specifier(node, writer, state);
         }
+        SyntaxKind::Predicate => {
+            return format_predicate(node, writer, state);
+        }
         _ => (),
     }
 
@@ -822,24 +825,6 @@ fn format_qualified_name(
         state.skip_all_whitespace = true;
         fold(n, writer, state)?;
     }
-    /*if !node
-        .last_token()
-        .and_then(|x| x.next_token())
-        .map(|x| {
-            matches!(
-                x.kind(),
-                SyntaxKind::LParent
-                    | SyntaxKind::RParent
-                    | SyntaxKind::Semicolon
-                    | SyntaxKind::Comma
-            )
-        })
-        .unwrap_or(false)
-    {
-        state.insert_whitespace(" ");
-    } else {
-        state.skip_all_whitespace = true;
-    }*/
     Ok(())
 }
 
@@ -2194,6 +2179,26 @@ fn format_import_specifier(
             _ => {
                 fold(n, writer, state)?;
             }
+        }
+    }
+
+    Ok(())
+}
+
+fn format_predicate(
+    node: &SyntaxNode,
+    writer: &mut impl TokenWriter,
+    state: &mut FormatState,
+) -> Result<(), std::io::Error> {
+    for s in node.children_with_tokens() {
+        state.skip_all_whitespace = true;
+        match s.kind() {
+            SyntaxKind::FatArrow => {
+                state.insert_whitespace(" ");
+                fold(s, writer, state)?;
+                state.insert_whitespace(" ");
+            }
+            _ => fold(s, writer, state)?,
         }
     }
 
@@ -3582,6 +3587,20 @@ export component MainWindow2 inherits Rectangle {
         );
     }
 
+    #[test]
+    fn predicate() {
+        assert_formatting(
+            "component X { property <[int]> arr: [1, 2, 3, 4, 5]; function foo() { arr.any(x\n     =>   x         ==  1     ); } }",
+            r#"component X {
+    property <[int]> arr: [1, 2, 3, 4, 5];
+    function foo() {
+        arr.any(x => x == 1);
+    }
+}
+"#,
+        );
+    }
+
     // cspell:disable
     #[test]
     fn import_line_too_long() {
@@ -3794,6 +3813,27 @@ export component MainWindow2 inherits Rectangle {
     Tar,
     Jar,
 } from "./here.slint";"#,
+        );
+    }
+
+    #[test]
+    fn nested_predicate() {
+        assert_formatting(
+            "component X { property <[[int]]> arr: [[1, 2, 3, 4, 5]]; function foo() { arr.any(x     =>   x.all(y   => y   ==  7     )      ); } }",
+            r#"component X {
+    property <[[int]]> arr: [[1, 2, 3, 4, 5]];
+    function foo() { arr.any(x => x.all(y => y == 7)); }
+}
+"#,
+        );
+
+        assert_formatting(
+            "component X { property <[[{age: int}]]> groups: []; function foo() { groups.any(group     =>   group.any(person   => person.age   >  20     ) && group.length == 2      ); } }",
+            r#"component X {
+    property <[[{age: int}]]> groups: [];
+    function foo() { groups.any(group => group.any(person => person.age > 20) && group.length == 2); }
+}
+"#,
         );
     }
 }


### PR DESCRIPTION
This continues and rebases the array predicate work originally started by Avery Townsend (@codeshaunted) in https://github.com/slint-ui/slint/pull/8941.

The branch adds `array.any(name => condition)` and `array.all(name => condition)` support for Slint arrays/models, including compiler lowering, Rust/C++ code generation, interpreter evaluation, formatter support, docs, and tests.

I checked the discussion and inline review comments on #8941 before opening this PR. The branch addresses the requested follow-ups:

- Uses JS-style predicate syntax (`x => ...`).
- Adds syntax/error tests for predicates in invalid contexts, non-predicate arguments, and non-bool predicate bodies.
- Covers nested predicates and argument shadowing.
- Includes interpreter support.
- Avoids generated-code name collisions by resolving predicate arguments to internal local names.
- Keeps the existing `expanded` spelling in `parser.rs`.
- Adds a regression test and fix for stale bindings when model rows or row counts change.

Tests run:

- `SLINT_TEST_FILTER=array_predicates cargo test -p test-driver-rust`
- `SLINT_TEST_FILTER=array_predicates cargo test -p test-driver-interpreter`
- `cargo test -p i-slint-compiler --features display-diagnostics --test syntax_tests`
- `cargo clippy -p i-slint-compiler -p slint-interpreter --tests`
