### PR TITLE
Pick up the default font size on Linux, Android, Windows, ~and macOS~

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -226,6 +226,7 @@ class SlintInputView extends View {
         super.onConfigurationChanged(newConfig);
         int currentNightMode = newConfig.uiMode & Configuration.UI_MODE_NIGHT_MASK;
         SlintAndroidJavaHelper.setNightMode(currentNightMode);
+        SlintAndroidJavaHelper.setFontScale(newConfig.fontScale);
     }
 
     private InputHandle mCursorHandle;
@@ -526,6 +527,8 @@ public class SlintAndroidJavaHelper {
 
     static public native void setNightMode(int nightMode);
 
+    static public native void setFontScale(float fontScale);
+
     static public native void moveCursorHandle(int id, int pos_x, int pos_y);
 
     static public native void popupMenuAction(int id);
@@ -570,6 +573,10 @@ public class SlintAndroidJavaHelper {
     public int color_scheme() {
         int nightModeFlags = mActivity.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
         return nightModeFlags;
+    }
+
+    public float font_scale() {
+        return mActivity.getResources().getConfiguration().fontScale;
     }
 
     public int accent_color() {

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore dalvik jboolean jint
+// cSpell: ignore dalvik jboolean jfloat jint
 use super::*;
 use i_slint_common::unicode_utils::{
     byte_offset_to_utf16_offset, utf16_offset_to_byte_offset_clamped,
@@ -12,13 +12,19 @@ use i_slint_core::graphics::{Color, euclid};
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType};
 use i_slint_core::item_rendering::HasFont;
 use i_slint_core::items::{ColorScheme, InputType};
-use i_slint_core::lengths::PhysicalEdges;
+use i_slint_core::lengths::{LogicalLength, PhysicalEdges};
 use i_slint_core::platform::WindowAdapter;
 use jni::objects::{JClass, JClassLoader, JString, LoaderContext};
-use jni::sys::jint;
+use jni::sys::{jfloat, jint};
 use jni::{Env, JavaVM, bind_java_type};
 use std::sync::OnceLock;
 use std::time::Duration;
+
+/// Maps an Android `Configuration.fontScale` to a Slint default font size.
+/// 14 LP = Material Design body-text size at `fontScale = 1.0`.
+pub(crate) fn font_scale_to_logical_length(font_scale: f32) -> Option<LogicalLength> {
+    (font_scale.is_finite() && font_scale > 0.0).then(|| LogicalLength::new(14.0 * font_scale))
+}
 
 const DEX_DATA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/classes.dex"));
 
@@ -39,6 +45,10 @@ bind_java_type! {
         fn color_scheme {
             name = "color_scheme",
             sig = () -> jint,
+        },
+        fn font_scale {
+            name = "font_scale",
+            sig = () -> jfloat,
         },
         fn get_clipboard {
             name = "get_clipboard",
@@ -120,6 +130,10 @@ bind_java_type! {
         pub static fn set_night_mode {
             sig = (night_mode: jint) -> (),
             fn = callback_set_night_mode,
+        },
+        pub static fn set_font_scale {
+            sig = (font_scale: jfloat) -> (),
+            fn = callback_set_font_scale,
         },
         pub static fn update_text {
             sig = (
@@ -429,6 +443,10 @@ impl JavaHelper {
         self.with_jni_env(|env, helper| helper.color_scheme(env))
     }
 
+    pub fn font_scale(&self) -> Result<f32, jni::errors::Error> {
+        self.with_jni_env(|env, helper| helper.font_scale(env))
+    }
+
     pub fn accent_color(&self) -> Result<Color, jni::errors::Error> {
         self.with_jni_env(|env, helper| {
             Ok(Color::from_argb_encoded(helper.accent_color(env)? as u32))
@@ -559,6 +577,25 @@ fn callback_set_night_mode<'local>(
             if let Ok(accent) = w.java_helper.accent_color() {
                 ctx.set_accent_color(accent);
             }
+        }
+    })
+    .unwrap();
+    Ok(())
+}
+
+fn callback_set_font_scale<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    font_scale: jfloat,
+) -> Result<(), jni::errors::Error> {
+    // Skip rather than clobber: an OEM/ROM that hands us 0.0 or NaN during a
+    // transient configuration change must not zero out the value `bind_context`
+    // already set.
+    let Some(size) = font_scale_to_logical_length(font_scale) else { return Ok(()) };
+    i_slint_core::api::invoke_from_event_loop(move || {
+        if let Some(w) = CURRENT_WINDOW.with_borrow(|x| x.upgrade()) {
+            let ctx = i_slint_core::window::WindowInner::from_pub(&w.window).context();
+            ctx.set_platform_default_font_size(Some(size));
         }
     })
     .unwrap();

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -173,6 +173,11 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
         if let Ok(accent) = self.window.java_helper.accent_color() {
             ctx.set_accent_color(accent);
         }
+        if let Ok(scale) = self.window.java_helper.font_scale()
+            && let Some(size) = javahelper::font_scale_to_logical_length(scale)
+        {
+            ctx.set_platform_default_font_size(Some(size));
+        }
     }
 
     fn long_press_interval(&self, _: i_slint_core::InternalToken) -> Duration {

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -136,7 +136,7 @@ objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["
 block2 = "0.6.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { workspace = true, features = ["Win32_UI_WindowsAndMessaging", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm"] }
+windows = { workspace = true, features = ["Win32_UI_WindowsAndMessaging", "Win32_UI_HiDpi", "Win32_Graphics_Gdi", "Win32_Graphics_Dwm"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore binfmt testui
+// cSpell: ignore binfmt GETNONCLIENTMETRICS NONCLIENTMETRICSW testui
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 #![warn(missing_docs)]
@@ -700,6 +700,35 @@ impl i_slint_core::platform::Platform for Backend {
                 }
             }) {
                 *self.xdg_watcher.borrow_mut() = Some(handle);
+            }
+        }
+        #[cfg(target_os = "windows")]
+        if let Some(ctx) = _ctx.upgrade() {
+            use windows::Win32::UI::HiDpi::SystemParametersInfoForDpi;
+            use windows::Win32::UI::WindowsAndMessaging::{
+                NONCLIENTMETRICSW, SPI_GETNONCLIENTMETRICS,
+            };
+            let mut metrics = NONCLIENTMETRICSW {
+                cbSize: core::mem::size_of::<NONCLIENTMETRICSW>() as u32,
+                ..NONCLIENTMETRICSW::default()
+            };
+            let ok = unsafe {
+                SystemParametersInfoForDpi(
+                    SPI_GETNONCLIENTMETRICS.0,
+                    metrics.cbSize,
+                    Some(&mut metrics as *mut _ as *mut core::ffi::c_void),
+                    0,
+                    96,
+                )
+            }
+            .is_ok();
+            // `lfMessageFont.lfHeight` is in pixels at 96 DPI = Slint logical pixels;
+            // negative means em height, positive means cell height — magnitude is fine here.
+            let height = metrics.lfMessageFont.lfHeight.unsigned_abs();
+            if ok && height > 0 {
+                ctx.set_platform_default_font_size(Some(
+                    i_slint_core::lengths::LogicalLength::new(height as f32),
+                ));
             }
         }
     }

--- a/internal/backends/winit/xdg_desktop_settings.rs
+++ b/internal/backends/winit/xdg_desktop_settings.rs
@@ -6,8 +6,24 @@ use std::rc::Weak;
 use i_slint_core::SlintContextWeak;
 use i_slint_core::graphics::Color;
 use i_slint_core::items::ColorScheme;
+use i_slint_core::lengths::LogicalLength;
 
 use crate::SharedBackendData;
+
+/// Parses the trailing point size from a GNOME font description such as
+/// `"Helvetica 11"` or `"Sans Bold 10.5"`.
+fn parse_font_points(font_name: &str) -> Option<f32> {
+    let last = font_name.split_whitespace().next_back()?;
+    last.parse::<f32>().ok().filter(|p| p.is_finite() && *p > 0.0)
+}
+
+fn apply_font_name(ctx_weak: &SlintContextWeak, font_name: &str) {
+    let Some(points) = parse_font_points(font_name) else { return };
+    let size = LogicalLength::new(points * 96.0 / 72.0);
+    if let Some(ctx) = ctx_weak.upgrade() {
+        ctx.set_platform_default_font_size(Some(size));
+    }
+}
 
 fn xdg_color_scheme_to_slint(value: zbus::zvariant::OwnedValue) -> ColorScheme {
     match value.downcast_ref::<u32>() {
@@ -103,16 +119,24 @@ pub async fn watch(
         shared.cursor_blink_interval.set(interval);
     }
 
+    let font_name_result: zbus::Result<zbus::zvariant::OwnedValue> =
+        settings_proxy.call("ReadOne", &("org.gnome.desktop.interface", "font-name")).await;
+    if let Ok(value) = font_name_result
+        && let Ok(name) = value.downcast_ref::<&str>()
+    {
+        apply_font_name(&ctx_weak, name);
+    }
+
     use futures::stream::StreamExt;
 
-    let mut settings_stream =
-        settings_proxy.receive_signal("SettingChanged").await?.map(|message| {
-            let (namespace, key, value): (String, String, zbus::zvariant::OwnedValue) =
-                message.body().deserialize().ok()?;
-            Some((namespace, key, value))
-        });
+    let mut settings_stream = settings_proxy.receive_signal("SettingChanged").await?;
 
-    while let Some(Some((namespace, key, value))) = settings_stream.next().await {
+    while let Some(message) = settings_stream.next().await {
+        let Ok((namespace, key, value)) =
+            message.body().deserialize::<(String, String, zbus::zvariant::OwnedValue)>()
+        else {
+            continue;
+        };
         match (namespace.as_str(), key.as_str()) {
             ("org.freedesktop.appearance", "color-scheme") => {
                 apply_color_scheme(&ctx_weak, &shared_data_weak, xdg_color_scheme_to_slint(value));
@@ -144,6 +168,11 @@ pub async fn watch(
                     && let Some(shared) = shared_data_weak.upgrade()
                 {
                     shared.cursor_blink_interval.set(core::time::Duration::from_millis(ms as u64));
+                }
+            }
+            ("org.gnome.desktop.interface", "font-name") => {
+                if let Ok(name) = value.downcast_ref::<&str>() {
+                    apply_font_name(&ctx_weak, name);
                 }
             }
             _ => {}


### PR DESCRIPTION
Follow-up to the iOS work (#10039): each backend now reports the
system's default font size to SlintContext, so Slint apps match
their host platform's text size out of the box.

Tested on Linux and Android. **Windows and macOS are untested.**

Windows and macOs don't update dynamically, but the normal case of following the font size when the app is run is already worth it.

**Update:** Mac was removed from the PR

Part of #11980
