### PR TITLE
interpreter: keep component alive during callback invocation

### DIFF
--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -2146,6 +2146,14 @@ pub(crate) fn invoke_callback(
     generativity::make_guard!(guard);
     match enclosing_component_instance_for_element(element, component_instance, guard) {
         ComponentInstance::InstanceRef(enclosing_component) => {
+            // Keep the component alive while the callback runs: the callback may close the popup
+            // that owns this callback, and Callback::call() restores the handler after returning.
+            let _component_guard = enclosing_component
+                .self_weak()
+                .get()
+                .expect("component self weak must be initialized before invoking callbacks")
+                .upgrade()
+                .expect("component must be alive while invoking callbacks");
             let description = enclosing_component.description;
             let element = element.borrow();
             if element.id == element.enclosing_component.upgrade().unwrap().root_element.borrow().id
@@ -2242,6 +2250,14 @@ pub(crate) fn call_function(
     generativity::make_guard!(guard);
     match enclosing_component_instance_for_element(element, component_instance, guard) {
         ComponentInstance::InstanceRef(c) => {
+            // Keep the component alive while the function runs: the function may close the popup
+            // that owns this function or callbacks it invokes.
+            let _component_guard = c
+                .self_weak()
+                .get()
+                .expect("component self weak must be initialized before invoking functions")
+                .upgrade()
+                .expect("component must be alive while invoking functions");
             let mut ctx = EvalLocalContext::from_function_arguments(c, args);
             eval_expression(
                 &element.borrow().bindings.get(function_name)?.borrow().expression,

--- a/tests/cases/widgets/menubar.slint
+++ b/tests/cases/widgets/menubar.slint
@@ -186,4 +186,55 @@ assert(instance.get_checkable_menu_item_checked());
 
 ```
 
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+
+// click on the file menu
+slintlib.private_api.send_mouse_click(instance, 10., 16.);
+// navigate using the keys to the "Open Recent" menu item
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F703}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F700}");
+assert.equal(instance.result, "");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
+assert.equal(instance.result, "Recent 3");
+
+instance.result = "";
+//click on the file menu
+slintlib.private_api.send_mouse_click(instance, 10., 16.);
+assert.equal(instance.result, "");
+// click on the first entry (new)  (this value seems to work with all styles)
+slintlib.private_api.send_mouse_click(instance, 30., 49.);
+assert.equal(instance.result, "New");
+
+instance.result = "";
+// click on the file menu
+slintlib.private_api.send_mouse_click(instance, 10., 16.);
+// arrow should skip the separators before "save"
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}"); // New
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}"); // Open
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}"); // Open Recent
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}"); // Checkable
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}"); // Save (skipped the separator)
+assert.equal(instance.result, "");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
+assert.equal(instance.result, "Save");
+
+// verify that the checked menu item is not checked
+assert(!instance.checkable_menu_item_checked);
+// click on the file menu
+slintlib.private_api.send_mouse_click(instance, 10., 16.);
+// navigate using the keys to the "Checked" menu item and toggle it
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
+// verify that the checked menu item is checked
+assert(instance.checkable_menu_item_checked);
+```
+
 */

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -117,8 +117,6 @@ fn main() -> std::io::Result<()> {
             "#[ignore = \"testcase ignored in live-preview mode\"]"
         } else if live_preview && source.contains("#3464") {
             "#[ignore = \"issue #3464 not fixed with the interpreter\"]"
-        } else if live_preview && module_name.contains("widgets_menubar") {
-            "#[ignore = \"issue #8454 causes crashes\"]"
         } else if live_preview && module_name.contains("write_to_model") {
             "#[ignore = \"Interpreted model don't forward to underlying models for anonymous structs\"]"
         } else {


### PR DESCRIPTION
Fixes #8454, hopefully.

Menu activation in the interpreter can close the popup that owns the currently executing callback. `Callback::call()` temporarily takes the handler, invokes it, and then restores it afterwards. If the callback closes and drops the popup item tree synchronously, restoring the handler can access freed memory.

Keep a strong reference to the enclosing component for the duration of `invoke_callback()` so popup close can detach the component but not deallocate it while callback dispatch is still unwinding.

I could not reproduce the original Linux/winit crash locally, but the change matches the reported Valgrind/backtrace: the popup is dropped from `close_popup()` while callback dispatch is still on the stack.

Tested:
- `cargo test -p test-driver-interpreter test_interpreter_widgets_menubar -- --nocapture`
- `cargo test -p test-driver-interpreter test_interpreter_elements_menubar -- --nocapture`
- `cargo test -p test-driver-interpreter issue_9722_popup_panic -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

Feedback wanted:
- Can someone who reproduced #8454 on Linux/winit confirm this fixes the crash?
- Is `invoke_callback()` the right ownership boundary, or should this guard live closer to popup/menu callback dispatch?