### PR TITLE
parser: suggest `let` when seeing `foo := ...` in a statement

### DIFF
--- a/internal/compiler/parser/statements.rs
+++ b/internal/compiler/parser/statements.rs
@@ -60,6 +60,28 @@ pub fn parse_statement(p: &mut impl Parser) -> bool {
         return true;
     }
 
+    if p.nth(0).kind() == SyntaxKind::Identifier && p.nth(1).kind() == SyntaxKind::ColonEqual {
+        let name = p.nth(0).as_str().to_string();
+        // `foo := Identifier {` likely means a '}' is missing earlier; let the outer parser recover the element.
+        if p.nth(2).kind() == SyntaxKind::Identifier && p.nth(3).kind() == SyntaxKind::LBrace {
+            p.error("':=' is not valid in statements");
+            return false;
+        }
+        // Otherwise the user probably meant to declare a local variable.
+        p.error(format!(
+            "':=' is not valid in statements. Use 'let {name} = <expression>;' to declare a local variable"
+        ));
+        let mut p = p.start_node_at(checkpoint, SyntaxKind::LetStatement);
+        {
+            let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+            p.expect(SyntaxKind::Identifier);
+        }
+        p.expect(SyntaxKind::ColonEqual);
+        parse_expression(&mut *p);
+        p.test(SyntaxKind::Semicolon);
+        return true;
+    }
+
     parse_expression(p);
     if matches!(
         p.nth(0).kind(),

--- a/internal/compiler/tests/syntax/functions/local_variable_colon_equal.slint
+++ b/internal/compiler/tests/syntax/functions/local_variable_colon_equal.slint
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Foo {
+    function compute() -> int {
+        x := 42;
+//      ^error{':=' is not valid in statements. Use 'let x = <expression>;' to declare a local variable}
+        return x;
+    }
+
+    function nested() -> int {
+        sum := 1 + 2;
+//      > <error{':=' is not valid in statements. Use 'let sum = <expression>;' to declare a local variable}
+        return sum;
+    }
+
+    function branches(cond: bool) -> int {
+        if (cond) {
+            a := 1;
+//          ^error{':=' is not valid in statements. Use 'let a = <expression>;' to declare a local variable}
+            return a;
+        } else {
+            b := 2;
+//          ^error{':=' is not valid in statements. Use 'let b = <expression>;' to declare a local variable}
+            return b;
+        }
+    }
+
+    function missing_brace() {
+        bar := Rectangle {
+//      > <error{':=' is not valid in statements}
+//      > <^error{Syntax error: expected '}'}
+            width: 10px;
+        }
+    }
+  }
+//^error{Parse error: expected a top-level item such as a component, a struct, or a global}


### PR DESCRIPTION
When `:=` is used in statement position (e.g. inside a function body), emit a helpful error pointing the user to `let foo = <expr>;`.

If the right-hand side looks like an element declaration (`foo := Identifier {`), suggest that a `}` may be missing earlier and let the outer parser recover the sub-element.
