### PR TITLE
Better error messages for misplaced child elements

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -539,8 +539,9 @@ impl ElementType {
                     None => {
                         let base_type = component.root_element.borrow().base_type.clone();
                         if base_type == tr.empty_type() {
-                            if Self::can_be_special_child_element(name, tr) {
-                                return tr.lookup_element(name);
+                            let element = tr.lookup_element(name)?;
+                            if matches!(&element, ElementType::Builtin(b) if b.can_be_declared_without_children_slot) {
+                                return Ok(element);
                             }
                             return Err(format!("'{}' cannot have children. Only components with @children can have children", component.id));
                         }
@@ -550,8 +551,11 @@ impl ElementType {
                 base_type.lookup_type_for_child_element(name, tr)
             }
             Self::Builtin(builtin) => {
-                if Self::can_be_special_child_element(name, tr) {
-                    return tr.lookup_element(name);
+                let looked_up = tr.lookup_element(name);
+                if let Ok(ElementType::Builtin(b)) = &looked_up
+                    && b.can_be_declared_without_children_slot
+                {
+                    return Ok(ElementType::Builtin(b.clone()));
                 }
                 if builtin.disallow_global_types_as_child_elements {
                     if let Some(child_type) = builtin.additional_accepted_child_types.get(name) {
@@ -567,6 +571,8 @@ impl ElementType {
                     valid_children.sort();
 
                     let err = if valid_children.is_empty() {
+                        // No whitelist to suggest from; prefer "Unknown element" for typos.
+                        looked_up?;
                         format!("{} cannot have children elements", builtin.native_class.class_name,)
                     } else {
                         format!(
@@ -578,7 +584,7 @@ impl ElementType {
                     };
                     return Err(err);
                 }
-                let err = match tr.lookup_element(name) {
+                let err = match looked_up {
                     Err(e) => e,
                     Ok(t) => {
                         if !tr.expose_internal_types
@@ -608,14 +614,6 @@ impl ElementType {
                 }
             })
         }
-    }
-
-    fn can_be_special_child_element(name: &str, tr: &TypeRegister) -> bool {
-        let is_special_builtin = matches!(
-            tr.lookup_element(name),
-            Ok(ElementType::Builtin(b)) if b.can_be_declared_without_children_slot
-        );
-        is_special_builtin
     }
 
     /// Assume this is a builtin type, panic if it isn't

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -112,9 +112,9 @@ pub async fn run_passes(
 
     collect_libraries::collect_libraries(doc);
     collect_subcomponents::collect_subcomponents(doc);
+    lower_tooltips::lower_tooltips(doc, type_loader, diag).await;
     lower_tabwidget::lower_tabwidget(doc, type_loader, diag).await;
     lower_radiogroup::lower_radiogroup(doc, type_loader, diag).await;
-    lower_tooltips::lower_tooltips(doc, type_loader, diag).await;
     lower_menus::lower_menus(doc, type_loader, diag).await;
     lower_component_container::lower_component_container(doc, type_loader, diag);
     collect_subcomponents::collect_subcomponents(doc);

--- a/internal/compiler/passes/lower_tooltips.rs
+++ b/internal/compiler/passes/lower_tooltips.rs
@@ -330,18 +330,22 @@ fn lower_tooltips_in_component(
             );
             return;
         }
-        if elem.borrow().builtin_type().is_some_and(|builtin| {
-            LAYOUT_ELEMENTS_DISALLOWING_TOOLTIP.contains(&builtin.name.as_str())
-        }) {
+        let parent_name = elem.borrow().builtin_type().map(|b| b.name.clone());
+        if parent_name
+            .as_ref()
+            .is_some_and(|name| LAYOUT_ELEMENTS_DISALLOWING_TOOLTIP.contains(&name.as_str()))
+        {
             diag.push_error(
-                "Tooltip cannot be used inside layout elements".into(),
+                format!("Tooltip cannot be added to {}", parent_name.as_ref().unwrap()),
                 &*tooltip_candidate.borrow(),
             );
             return;
         }
-        if elem.borrow().builtin_type().is_some_and(|builtin| builtin.is_non_item_type) {
+        if elem.borrow().builtin_type().is_some_and(|builtin| {
+            builtin.is_non_item_type || builtin.disallow_global_types_as_child_elements
+        }) {
             diag.push_error(
-                "Tooltip cannot be used inside non-item elements".into(),
+                format!("Tooltip cannot be added to {}", parent_name.as_ref().unwrap()),
                 &*tooltip_candidate.borrow(),
             );
             return;

--- a/internal/compiler/tests/syntax/elements/contextmenu2.slint
+++ b/internal/compiler/tests/syntax/elements/contextmenu2.slint
@@ -36,7 +36,7 @@ export component A  {
                 width: 45px;
 //              >   <error{Unknown property width in MenuSeparator}
                 MenuItem {}
-//              >       <error{MenuSeparator cannot have children elements}
+//              >       <error{Unknown element 'MenuItem'}
                 Rectangle {}
 //              >        <error{MenuSeparator cannot have children elements}
             }

--- a/internal/compiler/tests/syntax/elements/contextmenu2.slint
+++ b/internal/compiler/tests/syntax/elements/contextmenu2.slint
@@ -36,16 +36,16 @@ export component A  {
                 width: 45px;
 //              >   <error{Unknown property width in MenuSeparator}
                 MenuItem {}
-//              >       <error{Unknown element 'MenuItem'}
+//              >       <error{MenuItem can only be within a Menu element}
                 Rectangle {}
 //              >        <error{MenuSeparator cannot have children elements}
             }
         }
         MenuItem {}
-//      >       <error{Unknown element 'MenuItem'}
+//      >       <error{MenuItem can only be within a Menu element}
 
         MenuSeparator {}
-//      >            <error{Unknown element 'MenuSeparator'}
+//      >            <error{MenuSeparator can only be within a Menu element}
     }
 
     TouchArea {

--- a/internal/compiler/tests/syntax/elements/menubar2.slint
+++ b/internal/compiler/tests/syntax/elements/menubar2.slint
@@ -57,13 +57,13 @@ export component A inherits Window {
         }
 
         MenuItem {
-//      >       <error{Unknown element 'MenuItem'}
+//      >       <error{MenuItem can only be within a Menu element}
             Menu {}
-//          >   <error{Menu can only be within the following elements: ContextMenuArea, SystemTrayIcon}
+//          >   <error{Menu can only be within the following elements: ContextMenuArea, Menu, MenuBar, SystemTrayIcon}
         }
 
         Menu {}
-//      >   <error{Menu can only be within the following elements: ContextMenuArea, SystemTrayIcon}
+//      >   <error{Menu can only be within the following elements: ContextMenuArea, Menu, MenuBar, SystemTrayIcon}
     }
 }
 

--- a/internal/compiler/tests/syntax/elements/tabwidget.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget.slint
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { TabWidget  } from "std-widgets.slint";
-export Test1 := Rectangle {
-//           ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
+export component Test1 inherits Rectangle {
     TabWidget {
         Rectangle {}
 //      >        <error{Rectangle is not allowed within TabWidget. Only Tab are valid children}
+        Tablet {}
+//      >     <error{Tablet is not allowed within TabWidget. Only Tab are valid children}
         Tab {
             Tab {}
 //          >  <error{Tab can only be within a TabWidget element}

--- a/internal/compiler/tests/syntax/elements/timer.slint
+++ b/internal/compiler/tests/syntax/elements/timer.slint
@@ -6,6 +6,8 @@ export component Def {
         interval: 100ms;
         Rectangle {}
 //      >        <error{Timer cannot have children elements}
+        Error {}
+//      >    <error{Unknown element 'Error'}
     }
 
     Timer {

--- a/internal/compiler/tests/syntax/elements/tooltip_in_layout.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_layout.slint
@@ -4,7 +4,7 @@
 export component Test inherits Window {
     HorizontalLayout {
         Tooltip {
-//      >      <error{Tooltip cannot be used inside layout elements}
+//      >      <error{Tooltip cannot be added to HorizontalLayout}
             text: @markdown("Not allowed directly inside layout");
         }
     }

--- a/internal/compiler/tests/syntax/elements/tooltip_in_menu.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_menu.slint
@@ -6,7 +6,7 @@ export component Test inherits Window {
         Menu {
             title: "File";
             Tooltip {
-//          >      <error{Tooltip cannot be used inside non-item elements}
+//          >      <error{Tooltip cannot be added to Menu}
                 text: @markdown("No tooltip here");
             }
         }

--- a/internal/compiler/tests/syntax/elements/tooltip_in_timer.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_in_timer.slint
@@ -1,11 +1,27 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import { TabWidget } from "std-widgets.slint";
+
 export component Test inherits Window {
     Timer {
         interval: 200ms;
         Tooltip {
-//      >      <error{Tooltip cannot be used inside non-item elements}
+//      >      <error{Tooltip cannot be added to Timer}
+            text: @markdown("No tooltip here");
+        }
+    }
+
+    TabWidget {
+        Tooltip {
+//      >      <error{Tooltip cannot be added to TabWidget}
+            text: @markdown("No tooltip here");
+        }
+    }
+
+    Path {
+        Tooltip {
+//      >      <error{Tooltip cannot be added to Path}
             text: @markdown("No tooltip here");
         }
     }

--- a/internal/compiler/tests/syntax/elements/tooltip_nested.slint
+++ b/internal/compiler/tests/syntax/elements/tooltip_nested.slint
@@ -7,7 +7,7 @@ export component Test inherits Window {
 //      >      <error{Tooltip cannot have both text and custom content}
             text: @markdown("Outer");
             Tooltip {
-//          >      <error{Tooltip cannot be used inside non-item elements}
+//          >      <error{Tooltip cannot be added to Tooltip}
                 text: @markdown("Nested");
             }
         }

--- a/internal/compiler/tests/syntax/new_syntax/new_component.slint
+++ b/internal/compiler/tests/syntax/new_syntax/new_component.slint
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore Rectangel
 
 component Foo {
     background: 0;
@@ -14,9 +15,21 @@ component Bar {
 //      >        <error{'Foo' cannot have children. Only components with @children can have children}
     }
     Foo {
+        Rectangel { }
+//      >        <error{Unknown element 'Rectangel'}
+    }
+    Foo {
         background: 0;
 //      >        <error{Unknown property background in Foo}
         height: self.width;
+    }
+    Foo {
+        // Tooltip is allowed even though Foo has no `@children`.
+        Tooltip { }
+    }
+    Foo {
+        Row { }
+//      >  <error{Row can only be within a GridLayout element}
     }
 
     @children

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -512,22 +512,33 @@ impl TypeRegister {
 
         crate::load_builtins::load_builtins(&mut register);
 
-        for e in register.elements.values() {
-            if let ElementType::Builtin(b) = e {
-                for accepted_child_type_name in b.additional_accepted_child_types.keys() {
-                    register
-                        .context_restricted_types
-                        .entry(accepted_child_type_name.clone())
-                        .or_default()
-                        .insert(b.native_class.class_name.clone());
-                }
-                if b.additional_accept_self {
-                    register
-                        .context_restricted_types
-                        .entry(b.native_class.class_name.clone())
-                        .or_default()
-                        .insert(b.native_class.class_name.clone());
-                }
+        // Walk every builtin reachable from an exported one and register each
+        // accepted child as context-restricted to its parent, so internal types
+        // like `MenuItem` report "can only be within Menu" instead of "Unknown".
+        let mut visited: HashSet<SmolStr> = HashSet::new();
+        let mut to_visit: Vec<Rc<BuiltinElement>> = register
+            .elements
+            .values()
+            .filter_map(|e| match e {
+                ElementType::Builtin(b) => Some(b.clone()),
+                _ => None,
+            })
+            .collect();
+        while let Some(b) = to_visit.pop() {
+            let parent = b.native_class.class_name.clone();
+            if !visited.insert(parent.clone()) {
+                continue;
+            }
+            for (child_name, child_type) in &b.additional_accepted_child_types {
+                register
+                    .context_restricted_types
+                    .entry(child_name.clone())
+                    .or_default()
+                    .insert(parent.clone());
+                to_visit.push(child_type.clone());
+            }
+            if b.additional_accept_self {
+                register.context_restricted_types.entry(parent.clone()).or_default().insert(parent);
             }
         }
 


### PR DESCRIPTION
  - Report "Unknown element 'Foo'" when the child of an element is itself
    unknown, instead of the misleading "X cannot have children" error.
  - Reject Tooltip inside elements that restrict their children
    (TabWidget, Path, RadioGroup, ...). Previously this either panicked
    or silently compiled.
  - Reword Tooltip placement errors to name the parent
    ("Tooltip cannot be added to X") instead of using the internal
    "non-item element" jargon.

  Fixes: #11990
