### PR TITLE
node: fix npm packaging on Windows by spawning through a shell

### DIFF
--- a/api/node/scripts/packaging.mts
+++ b/api/node/scripts/packaging.mts
@@ -54,6 +54,10 @@ export async function run(
         const { stdout, stderr } = await execFileAsync(cmd, args, {
             encoding: "utf8",
             maxBuffer: 64 * 1024 * 1024,
+            // npm/npx/pnpm are .cmd shims on Windows, which execFile cannot launch
+            // directly; run through the shell there. (The args below are package
+            // names and ./-relative paths, so no extra quoting is needed.)
+            shell: process.platform === "win32",
             ...opts,
         });
         return { stdout, stderr };


### PR DESCRIPTION
The shared packaging module runs npm/npx/pnpm via child_process.execFile, which on Windows fails with ENOENT: there these are .cmd shims that cannot be launched directly (Node also refuses to exec .cmd/.bat without a shell). Pass shell:true on Windows so the publish workflow's pack-binary/publish steps work; Linux and macOS keep spawning directly, as the in-process Verdaccio e2e relies on.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
