### PR TITLE
node: fix the publish-gate e2e auth against the local registry

### DIFF
--- a/api/node/__test__/registry/e2e.test.mts
+++ b/api/node/__test__/registry/e2e.test.mts
@@ -71,7 +71,20 @@ let registry = "";
 let server: Server | undefined;
 
 function npmEnv(): NodeJS.ProcessEnv {
-    return { ...process.env, npm_config_userconfig: join(work, ".npmrc") };
+    // setup-node (in the publish workflow) exports NPM_CONFIG_USERCONFIG pointing
+    // at its own .npmrc (npmjs auth, always-auth=true). npm/pnpm lowercase env
+    // keys when reading config, so that would collide with — and shadow — the
+    // npm_config_userconfig we set here, and publishing to the local registry
+    // would fail with ENEEDAUTH. Drop any case variant of the inherited value and
+    // point npm/pnpm only at our throwaway .npmrc.
+    const env: NodeJS.ProcessEnv = {};
+    for (const [key, value] of Object.entries(process.env)) {
+        if (key.toLowerCase() !== "npm_config_userconfig") {
+            env[key] = value;
+        }
+    }
+    env.npm_config_userconfig = join(work, ".npmrc");
+    return env;
 }
 
 before(async () => {


### PR DESCRIPTION
In the publish workflow, actions/setup-node exports NPM_CONFIG_USERCONFIG pointing at its own .npmrc (npmjs auth, always-auth=true). npm and pnpm lowercase environment keys when reading config, so it collided with and shadowed the npm_config_userconfig the test sets, and publishing the tarballs to the in-process Verdaccio failed with ENEEDAUTH. Drop any case variant of the inherited userconfig so npm/pnpm read only the test's throwaway .npmrc, which carries the local registry's auth token.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
