### PR TITLE
MCP server: make take_screenshot work headlessly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,6 +5274,8 @@ dependencies = [
  "i-slint-common",
  "i-slint-core",
  "i-slint-core-macros",
+ "i-slint-renderer-skia",
+ "i-slint-renderer-software",
  "image",
  "include_dir",
  "pbjson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5269,6 +5269,7 @@ dependencies = [
  "async-net",
  "base64 0.22.1",
  "byteorder",
+ "cfg_aliases",
  "futures-lite",
  "httparse",
  "i-slint-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5248,6 +5248,7 @@ name = "i-slint-backend-selector"
 version = "1.17.0"
 dependencies = [
  "cfg-if",
+ "cfg_aliases",
  "i-slint-backend-android-activity",
  "i-slint-backend-linuxkms",
  "i-slint-backend-qt",

--- a/api/rs/slint/tests/spawn_local.rs
+++ b/api/rs/slint/tests/spawn_local.rs
@@ -86,7 +86,11 @@ fn main() {
 fn with_context() {
     use i_slint_core::SlintContext;
     let ctx = SlintContext::new(Box::new(i_slint_backend_testing::TestingBackend::new(
-        i_slint_backend_testing::TestingBackendOptions { mock_time: true, threading: true },
+        i_slint_backend_testing::TestingBackendOptions {
+            mock_time: true,
+            threading: true,
+            ..Default::default()
+        },
     )));
     let handle = ctx.spawn_local(async { String::from("Hello") }).unwrap();
     ctx.spawn_local(async move { panic!("Aborted task") }).unwrap().abort();

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -5481,6 +5481,7 @@ name = "i-slint-backend-selector"
 version = "1.17.0"
 dependencies = [
  "cfg-if",
+ "cfg_aliases",
  "i-slint-backend-linuxkms",
  "i-slint-backend-testing",
  "i-slint-backend-winit",

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -219,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
 ]
@@ -231,7 +231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
 dependencies = [
  "alsa-sys",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
 ]
@@ -253,7 +253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cc",
  "jni 0.22.4",
  "libc",
@@ -909,7 +909,7 @@ dependencies = [
  "bevy_reflect 0.18.1",
  "bevy_tasks 0.18.1",
  "bevy_utils 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "blake3",
  "crossbeam-channel",
  "derive_more",
@@ -952,7 +952,7 @@ dependencies = [
  "bevy_reflect 0.19.0-rc.2",
  "bevy_tasks 0.19.0-rc.2",
  "bevy_utils 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "blake3",
  "crossbeam-channel",
  "derive_more",
@@ -1153,7 +1153,7 @@ dependencies = [
  "bevy_transform 0.18.1",
  "bevy_utils 0.18.1",
  "bevy_window 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "nonmax",
  "radsort",
  "smallvec",
@@ -1185,7 +1185,7 @@ dependencies = [
  "bevy_transform 0.19.0-rc.2",
  "bevy_utils 0.19.0-rc.2",
  "bevy_window 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap",
  "nonmax",
 ]
@@ -1322,7 +1322,7 @@ dependencies = [
  "bevy_reflect 0.18.1",
  "bevy_tasks 0.18.1",
  "bevy_utils 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bumpalo",
  "concurrent-queue",
  "derive_more",
@@ -1350,7 +1350,7 @@ dependencies = [
  "bevy_reflect 0.19.0-rc.2",
  "bevy_tasks 0.19.0-rc.2",
  "bevy_utils 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bumpalo",
  "concurrent-queue",
  "derive_more",
@@ -1721,7 +1721,7 @@ dependencies = [
  "bevy_platform 0.18.1",
  "bevy_reflect 0.18.1",
  "bevy_utils 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "futures-lite",
  "guillotiere",
@@ -1750,7 +1750,7 @@ dependencies = [
  "bevy_platform 0.19.0-rc.2",
  "bevy_reflect 0.19.0-rc.2",
  "bevy_utils 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "futures-lite",
  "guillotiere",
@@ -2144,7 +2144,7 @@ dependencies = [
  "bevy_platform 0.18.1",
  "bevy_reflect 0.18.1",
  "bevy_transform 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "hexasphere 16.0.0",
@@ -2169,7 +2169,7 @@ dependencies = [
  "bevy_platform 0.19.0-rc.2",
  "bevy_reflect 0.19.0-rc.2",
  "bevy_transform 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "encase",
@@ -2218,7 +2218,7 @@ dependencies = [
  "bevy_shader 0.18.1",
  "bevy_transform 0.18.1",
  "bevy_utils 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -2259,7 +2259,7 @@ dependencies = [
  "bevy_tasks 0.19.0-rc.2",
  "bevy_transform 0.19.0-rc.2",
  "bevy_utils 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -2385,7 +2385,7 @@ dependencies = [
  "bevy_transform 0.18.1",
  "bevy_utils 0.18.1",
  "bevy_window 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "nonmax",
  "radsort",
  "smallvec",
@@ -2543,7 +2543,7 @@ dependencies = [
  "bevy_transform 0.18.1",
  "bevy_utils 0.18.1",
  "bevy_window 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "downcast-rs 2.0.2",
@@ -2596,7 +2596,7 @@ dependencies = [
  "bevy_transform 0.19.0-rc.2",
  "bevy_utils 0.19.0-rc.2",
  "bevy_window 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "downcast-rs 2.0.2",
@@ -2810,7 +2810,7 @@ dependencies = [
  "bevy_text 0.18.1",
  "bevy_transform 0.18.1",
  "bevy_utils 0.18.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -2843,7 +2843,7 @@ dependencies = [
  "bevy_text 0.19.0-rc.2",
  "bevy_transform 0.19.0-rc.2",
  "bevy_utils 0.19.0-rc.2",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -3410,7 +3410,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -3462,9 +3462,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "bytemuck",
  "serde_core",
@@ -3587,7 +3587,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -3601,7 +3601,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -3682,9 +3682,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -3912,7 +3912,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -3953,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
 dependencies = [
  "bindgen",
 ]
@@ -3966,7 +3966,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cadaea21e24c49c0c82116f2b465ae6a49d63c90e428b0f8d9ae1f638ac91f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fontdb",
  "harfrust 0.4.1",
  "linebender_resource_handle",
@@ -4187,7 +4187,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -4252,7 +4252,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
@@ -4449,7 +4449,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43d05da42e81724c16d34a150fb7fda53d3f786e5a94673ee526ff8602f0f6a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "fnv",
  "glow 0.17.0",
@@ -4776,7 +4776,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "drm",
  "drm-fourcc",
  "gbm-sys",
@@ -5000,7 +5000,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -5066,7 +5066,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "gpu-alloc-types",
 ]
 
@@ -5076,7 +5076,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5111,7 +5111,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -5122,7 +5122,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5179,7 +5179,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0caaee032384c10dd597af4579c67dee16650d862a9ccbe1233ff1a379abc07"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "read-fonts 0.36.0",
@@ -5192,7 +5192,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551ed25397e4b444e89686602877d5cf3a7f6e3d548dcac37a8357d1e195f4df"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "read-fonts 0.39.2",
@@ -5205,7 +5205,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "read-fonts 0.39.2",
  "smallvec",
@@ -5328,9 +5328,9 @@ checksum = "48ce8546b993eaf241d69ded33b1be6d205dd9857ec879d9d18bd05d3676e144"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -5482,12 +5482,24 @@ version = "1.17.0"
 dependencies = [
  "cfg-if",
  "i-slint-backend-linuxkms",
+ "i-slint-backend-testing",
  "i-slint-backend-winit",
  "i-slint-common",
  "i-slint-core",
  "i-slint-core-macros",
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
+]
+
+[[package]]
+name = "i-slint-backend-testing"
+version = "1.17.0"
+dependencies = [
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-renderer-skia",
+ "i-slint-renderer-software",
+ "vtable",
 ]
 
 [[package]]
@@ -5580,7 +5592,7 @@ version = "1.17.0"
 dependencies = [
  "async-channel",
  "auto_enums",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "chrono",
  "clru",
@@ -5966,9 +5978,9 @@ checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "imgref"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -5994,7 +6006,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -6014,7 +6026,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "input-sys",
  "libc",
  "log",
@@ -6172,13 +6184,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -6188,7 +6199,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -6234,7 +6245,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff7f53bdf698e7aa7ec916411bbdc8078135da11b66db5182675b2227f6c0d07"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6243,7 +6254,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d50be8a24c37debdf3170be6ca396d5b5b165f37f94837891adac735ca416b8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6309,7 +6320,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.8.1",
@@ -6387,9 +6398,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lyon_algorithms"
@@ -6498,7 +6509,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block",
  "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
@@ -6577,7 +6588,7 @@ checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting 0.12.0",
@@ -6604,7 +6615,7 @@ checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting 0.13.1",
@@ -6680,7 +6691,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
@@ -6694,7 +6705,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
@@ -6733,7 +6744,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6745,7 +6756,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6898,7 +6909,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -6914,7 +6925,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -6935,7 +6946,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "objc2 0.6.4",
  "objc2-core-audio",
@@ -6960,7 +6971,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -6973,7 +6984,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -7008,7 +7019,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
 ]
 
@@ -7018,7 +7029,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -7030,7 +7041,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -7041,7 +7052,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "libc",
@@ -7054,7 +7065,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -7101,7 +7112,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -7113,7 +7124,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -7132,7 +7143,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -7145,7 +7156,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -7158,7 +7169,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "objc2-core-foundation",
 ]
@@ -7169,7 +7180,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -7192,7 +7203,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -7204,7 +7215,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -7216,7 +7227,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -7229,7 +7240,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -7252,7 +7263,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit 0.2.2",
@@ -7273,7 +7284,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -7298,7 +7309,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -7363,7 +7374,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -7687,7 +7698,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -7810,7 +7821,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -7980,16 +7991,6 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
-dependencies = [
- "bytemuck",
- "font-types 0.11.3",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
@@ -8019,7 +8020,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8028,7 +8029,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8179,7 +8180,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -8241,7 +8242,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -8254,7 +8255,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -8306,7 +8307,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -8388,7 +8389,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -8589,7 +8590,7 @@ version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "skia-bindings",
  "windows 0.62.2",
 ]
@@ -8602,16 +8603,6 @@ checksum = "9c9eb0b904a04d09bd68c65d946617b8ff733009999050f3b851c32fb3cfb60e"
 dependencies = [
  "bytemuck",
  "read-fonts 0.36.0",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts 0.37.0",
 ]
 
 [[package]]
@@ -8683,7 +8674,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -8708,7 +8699,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -8842,7 +8833,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8851,7 +8842,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8929,11 +8920,11 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
+checksum = "d1804632b66a35ca2b1d277eb0a138e10f46cb365b9a6d297e876b69ef79de43"
 dependencies = [
- "skrifa 0.40.0",
+ "skrifa 0.42.1",
  "yazi",
  "zeno",
 ]
@@ -9015,7 +9006,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -9372,7 +9363,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -9679,9 +9670,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -9788,9 +9779,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9801,9 +9792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9811,9 +9802,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9821,9 +9812,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9834,9 +9825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -9882,7 +9873,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -9908,7 +9899,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -9920,7 +9911,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -9942,7 +9933,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -9954,7 +9945,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9967,7 +9958,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9980,7 +9971,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9993,7 +9984,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -10031,9 +10022,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10090,7 +10081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -10117,7 +10108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -10149,7 +10140,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -10181,7 +10172,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bit-vec 0.9.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -10279,7 +10270,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.8.0",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block",
  "bytemuck",
  "cfg-if",
@@ -10328,7 +10319,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.9.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
  "cfg-if",
@@ -10388,7 +10379,7 @@ version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -10403,7 +10394,7 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -11052,7 +11043,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
@@ -11177,7 +11168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -11301,7 +11292,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",
@@ -11345,9 +11336,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -5495,6 +5495,7 @@ dependencies = [
 name = "i-slint-backend-testing"
 version = "1.17.0"
 dependencies = [
+ "cfg_aliases",
  "i-slint-common",
  "i-slint-core",
  "i-slint-renderer-skia",

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -44,13 +44,11 @@ renderer-skia = [
 renderer-skia-opengl = [
   "i-slint-backend-winit?/renderer-skia-opengl",
   "i-slint-backend-linuxkms?/renderer-skia-opengl",
-  "i-slint-backend-testing?/renderer-skia-opengl",
   "i-slint-renderer-skia/opengl",
 ]
 renderer-skia-vulkan = [
   "i-slint-backend-winit?/renderer-skia-vulkan",
   "i-slint-backend-linuxkms?/renderer-skia-vulkan",
-  "i-slint-backend-testing?/renderer-skia-vulkan",
   "i-slint-renderer-skia/vulkan",
 ]
 renderer-software = [

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -39,26 +39,33 @@ renderer-skia = [
   "dep:i-slint-renderer-skia",
   "i-slint-backend-winit?/renderer-skia",
   "i-slint-backend-linuxkms?/renderer-skia",
+  "i-slint-backend-testing?/renderer-skia",
 ]
 renderer-skia-opengl = [
   "i-slint-backend-winit?/renderer-skia-opengl",
   "i-slint-backend-linuxkms?/renderer-skia-opengl",
+  "i-slint-backend-testing?/renderer-skia-opengl",
   "i-slint-renderer-skia/opengl",
 ]
 renderer-skia-vulkan = [
   "i-slint-backend-winit?/renderer-skia-vulkan",
   "i-slint-backend-linuxkms?/renderer-skia-vulkan",
+  "i-slint-backend-testing?/renderer-skia-vulkan",
   "i-slint-renderer-skia/vulkan",
 ]
-renderer-software = ["i-slint-backend-winit?/renderer-software", "i-slint-backend-linuxkms?/renderer-software"]
+renderer-software = [
+  "i-slint-backend-winit?/renderer-software",
+  "i-slint-backend-linuxkms?/renderer-software",
+  "i-slint-backend-testing?/renderer-software",
+]
 
 rtti = ["i-slint-core/rtti", "i-slint-backend-qt?/rtti"]
 accessibility = ["i-slint-backend-winit?/accessibility"]
 
 raw-window-handle-06 = ["i-slint-core/raw-window-handle-06", "i-slint-backend-winit?/raw-window-handle-06"]
 
-system-testing = ["i-slint-backend-testing/system-testing"]
-mcp = ["i-slint-backend-testing/mcp"]
+system-testing = ["renderer-software", "i-slint-backend-testing/system-testing"]
+mcp = ["renderer-software", "i-slint-backend-testing/mcp"]
 
 unstable-wgpu-28 = [
   "i-slint-core/unstable-wgpu-28",

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -110,6 +110,7 @@ i-slint-backend-linuxkms = { workspace = true, features = ["default"], optional 
 input = { workspace = true, optional = true }
 
 [build-dependencies]
+cfg_aliases = { workspace = true }
 i-slint-common = { workspace = true }
 
 [dev-dependencies]

--- a/internal/backends/selector/build.rs
+++ b/internal/backends/selector/build.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(no_qt)");
 
     cfg_aliases::cfg_aliases! {
-        headless: { any(feature = "renderer-software", feature = "renderer-skia") },
+        supports_headless: { any(feature = "renderer-software", feature = "renderer-skia") },
     }
 
     // This is part code tries to detect automatically what default style to use and tries to

--- a/internal/backends/selector/build.rs
+++ b/internal/backends/selector/build.rs
@@ -7,6 +7,10 @@ use std::path::Path;
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(no_qt)");
 
+    cfg_aliases::cfg_aliases! {
+        headless: { any(feature = "renderer-software", feature = "renderer-skia") },
+    }
+
     // This is part code tries to detect automatically what default style to use and tries to
     // use the native style automatically if Qt is available.
     //

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -35,13 +35,13 @@ fn create_linuxkms_backend() -> Result<Box<dyn Platform + 'static>, PlatformErro
     Ok(Box::new(i_slint_backend_linuxkms::BackendBuilder::default().build()?))
 }
 
-#[cfg(all(feature = "mcp", headless))]
-fn create_headless_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
+#[cfg(all(feature = "mcp", supports_headless))]
+fn create_headless_backend(renderer: &str) -> Result<Box<dyn Platform + 'static>, PlatformError> {
     Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
         i_slint_backend_testing::TestingBackendOptions {
             mock_time: false,
             threading: true,
-            renderer_name: Some(Default::default()),
+            renderer_name: Some(renderer.into()),
         },
     )))
 }
@@ -79,12 +79,10 @@ cfg_if::cfg_if! {
                 ("Winit", create_winit_backend as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
                 #[cfg(all(feature = "i-slint-backend-linuxkms", target_os = "linux"))]
                 ("LinuxKMS", create_linuxkms_backend as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
-                // Last-resort headless fallback when MCP is enabled — lets the
-                // MCP server keep working in environments where no display is
-                // available. Only kicks in if every graphical backend above
-                // failed to initialize.
-                #[cfg(all(feature = "mcp", headless))]
-                ("Headless", create_headless_backend as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
+                // Last-resort headless fallback so the MCP server keeps
+                // working when no display is available.
+                #[cfg(all(feature = "mcp", supports_headless))]
+                ("Headless", (|| create_headless_backend("")) as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
                 ("", || Err(PlatformError::NoPlatform)),
             ];
 
@@ -129,14 +127,8 @@ cfg_if::cfg_if! {
                 "testing" => return Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
                     i_slint_backend_testing::TestingBackendOptions { mock_time: false, threading: true, ..Default::default() },
                 ))),
-                #[cfg(all(feature = "mcp", headless))]
-                "headless" => return Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
-                    i_slint_backend_testing::TestingBackendOptions {
-                        mock_time: false,
-                        threading: true,
-                        renderer_name: Some(_renderer.into()),
-                    },
-                ))),
+                #[cfg(all(feature = "mcp", supports_headless))]
+                "headless" => return create_headless_backend(_renderer),
                 _ => {},
             }
 

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -41,7 +41,7 @@ fn create_headless_backend() -> Result<Box<dyn Platform + 'static>, PlatformErro
         i_slint_backend_testing::TestingBackendOptions {
             mock_time: false,
             threading: true,
-            ..Default::default()
+            renderer_name: Some(Default::default()),
         },
     )))
 }
@@ -134,7 +134,7 @@ cfg_if::cfg_if! {
                     i_slint_backend_testing::TestingBackendOptions {
                         mock_time: false,
                         threading: true,
-                        renderer_name: (!_renderer.is_empty()).then(|| _renderer.into()),
+                        renderer_name: Some(_renderer.into()),
                     },
                 ))),
                 _ => {},

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -35,6 +35,17 @@ fn create_linuxkms_backend() -> Result<Box<dyn Platform + 'static>, PlatformErro
     Ok(Box::new(i_slint_backend_linuxkms::BackendBuilder::default().build()?))
 }
 
+#[cfg(all(feature = "mcp", any(feature = "renderer-software", feature = "renderer-skia")))]
+fn create_headless_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
+    Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
+        i_slint_backend_testing::TestingBackendOptions {
+            mock_time: false,
+            threading: true,
+            ..Default::default()
+        },
+    )))
+}
+
 cfg_if::cfg_if! {
     if #[cfg(target_os = "android")] {
         const DEFAULT_BACKEND_NAME: &str = "";
@@ -68,6 +79,12 @@ cfg_if::cfg_if! {
                 ("Winit", create_winit_backend as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
                 #[cfg(all(feature = "i-slint-backend-linuxkms", target_os = "linux"))]
                 ("LinuxKMS", create_linuxkms_backend as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
+                // Last-resort headless fallback when MCP is enabled — lets the
+                // MCP server keep working in environments where no display is
+                // available. Only kicks in if every graphical backend above
+                // failed to initialize.
+                #[cfg(all(feature = "mcp", any(feature = "renderer-software", feature = "renderer-skia")))]
+                ("Headless", create_headless_backend as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
                 ("", || Err(PlatformError::NoPlatform)),
             ];
 
@@ -110,7 +127,15 @@ cfg_if::cfg_if! {
                 },
                 #[cfg(feature = "backend-testing")]
                 "testing" => return Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
-                    i_slint_backend_testing::TestingBackendOptions { mock_time: false, threading: true },
+                    i_slint_backend_testing::TestingBackendOptions { mock_time: false, threading: true, ..Default::default() },
+                ))),
+                #[cfg(all(feature = "mcp", any(feature = "renderer-software", feature = "renderer-skia")))]
+                "headless" => return Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
+                    i_slint_backend_testing::TestingBackendOptions {
+                        mock_time: false,
+                        threading: true,
+                        renderer_name: (!_renderer.is_empty()).then(|| _renderer.into()),
+                    },
                 ))),
                 _ => {},
             }

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -35,7 +35,7 @@ fn create_linuxkms_backend() -> Result<Box<dyn Platform + 'static>, PlatformErro
     Ok(Box::new(i_slint_backend_linuxkms::BackendBuilder::default().build()?))
 }
 
-#[cfg(all(feature = "mcp", any(feature = "renderer-software", feature = "renderer-skia")))]
+#[cfg(all(feature = "mcp", headless))]
 fn create_headless_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
     Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
         i_slint_backend_testing::TestingBackendOptions {
@@ -83,7 +83,7 @@ cfg_if::cfg_if! {
                 // MCP server keep working in environments where no display is
                 // available. Only kicks in if every graphical backend above
                 // failed to initialize.
-                #[cfg(all(feature = "mcp", any(feature = "renderer-software", feature = "renderer-skia")))]
+                #[cfg(all(feature = "mcp", headless))]
                 ("Headless", create_headless_backend as fn() -> Result<Box<(dyn Platform + 'static)>, PlatformError>),
                 ("", || Err(PlatformError::NoPlatform)),
             ];
@@ -129,7 +129,7 @@ cfg_if::cfg_if! {
                 "testing" => return Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
                     i_slint_backend_testing::TestingBackendOptions { mock_time: false, threading: true, ..Default::default() },
                 ))),
-                #[cfg(all(feature = "mcp", any(feature = "renderer-software", feature = "renderer-skia")))]
+                #[cfg(all(feature = "mcp", headless))]
                 "headless" => return Ok(Box::new(i_slint_backend_testing::TestingBackend::new(
                     i_slint_backend_testing::TestingBackendOptions {
                         mock_time: false,

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -24,8 +24,6 @@ internal = ["include_dir"]
 ffi = []
 renderer-software = ["dep:i-slint-renderer-software", "i-slint-renderer-software/std"]
 renderer-skia = ["dep:i-slint-renderer-skia"]
-renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
-renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]
 system-testing = [
   "prost",
   "pbjson",

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -74,7 +74,7 @@ byteorder = { version = "1.5.0", optional = true }
 image = { workspace = true, optional = true, features = ["png"] }
 include_dir = { version = "0.7", optional = true }
 i-slint-renderer-software = { workspace = true, optional = true }
-i-slint-renderer-skia = { workspace = true, features = ["software"], optional = true }
+i-slint-renderer-skia = { workspace = true, default-features = false, optional = true }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -22,7 +22,6 @@ path = "lib.rs"
 internal = ["include_dir"]
 # ffi for C++ bindings
 ffi = []
-# Rasterizers usable for headless screenshots (take_snapshot).
 renderer-software = ["dep:i-slint-renderer-software", "i-slint-renderer-software/std"]
 renderer-skia = ["dep:i-slint-renderer-skia"]
 renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -74,7 +74,7 @@ byteorder = { version = "1.5.0", optional = true }
 image = { workspace = true, optional = true, features = ["png"] }
 include_dir = { version = "0.7", optional = true }
 i-slint-renderer-software = { workspace = true, optional = true }
-i-slint-renderer-skia = { workspace = true, features = ["default"], optional = true }
+i-slint-renderer-skia = { workspace = true, features = ["software"], optional = true }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -77,6 +77,7 @@ i-slint-renderer-software = { workspace = true, optional = true }
 i-slint-renderer-skia = { workspace = true, features = ["default"], optional = true }
 
 [build-dependencies]
+cfg_aliases = { workspace = true }
 prost = { version = "0.14", optional = true }
 prost-build = { version = "0.14", optional = true }
 prost-types = { version = "0.14", optional = true }

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -22,6 +22,11 @@ path = "lib.rs"
 internal = ["include_dir"]
 # ffi for C++ bindings
 ffi = []
+# Rasterizers usable for headless screenshots (take_snapshot).
+renderer-software = ["dep:i-slint-renderer-software", "i-slint-renderer-software/std"]
+renderer-skia = ["dep:i-slint-renderer-skia"]
+renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
+renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]
 system-testing = [
   "prost",
   "pbjson",
@@ -35,6 +40,7 @@ system-testing = [
   "prost-types",
   "pbjson-build",
   "protox",
+  "renderer-software",
 ]
 mcp = [
   "prost",
@@ -51,6 +57,7 @@ mcp = [
   "prost-types",
   "pbjson-build",
   "protox",
+  "renderer-software",
 ]
 
 [dependencies]
@@ -69,6 +76,8 @@ futures-lite = { version = "2.3.0", optional = true }
 byteorder = { version = "1.5.0", optional = true }
 image = { workspace = true, optional = true, features = ["png"] }
 include_dir = { version = "0.7", optional = true }
+i-slint-renderer-software = { workspace = true, optional = true }
+i-slint-renderer-skia = { workspace = true, features = ["default"], optional = true }
 
 [build-dependencies]
 prost = { version = "0.14", optional = true }

--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -227,7 +227,7 @@ flag on the command line instead.
 ### Running Without a Display
 
 On a machine with no display server (CI, container, agent sandbox) the regular
-backend can't open a window, so `take_screenshot` and the other tools would not
+backend can't open a window, so `take_screenshot` and the other tools won't
 work. Set `SLINT_BACKEND=headless` to run the app under a windowless,
 software-rasterized backend instead:
 
@@ -240,8 +240,8 @@ The headless backend uses Skia's software rasterizer when `slint/renderer-skia`
 is enabled, otherwise the built-in software renderer. Suffix the value
 (`headless-software`, `headless-skia`) to force a specific rasterizer. If
 `SLINT_BACKEND` is unset and the configured graphical backend fails to
-initialize (for example because no display is available), the headless backend
-is used as a fallback automatically.
+initialize (for example because no display is available), Slint falls back to
+the headless backend automatically.
 
 This is an unstable, MCP-oriented entry point — the exact value of
 `SLINT_BACKEND` may change between Slint releases. Use it from automation, not

--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -224,6 +224,29 @@ If `SLINT_MCP_PORT` is not set, no server is started and there is no runtime ove
 Do not add `mcp` to the `[features]` section of your `Cargo.toml` — use the `--features`
 flag on the command line instead.
 
+### Running Without a Display
+
+On a machine with no display server (CI, container, agent sandbox) the regular
+backend can't open a window, so `take_screenshot` and the other tools would not
+work. Set `SLINT_BACKEND=headless` to run the app under a windowless,
+software-rasterized backend instead:
+
+```sh
+SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=8080 SLINT_BACKEND=headless \
+    cargo run -p my-slint-app --features slint/mcp
+```
+
+The headless backend uses Skia's software rasterizer when `slint/renderer-skia`
+is enabled, otherwise the built-in software renderer. Suffix the value
+(`headless-software`, `headless-skia`) to force a specific rasterizer. If
+`SLINT_BACKEND` is unset and the configured graphical backend fails to
+initialize (for example because no display is available), the headless backend
+is used as a fallback automatically.
+
+This is an unstable, MCP-oriented entry point — the exact value of
+`SLINT_BACKEND` may change between Slint releases. Use it from automation, not
+from production code.
+
 ### Usage with AI Agents
 
 The simplest approach is to tell the agent to run the application with both environment variables

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -3,6 +3,10 @@
 
 // cSpell: ignore rsplit Sfixed
 fn main() {
+    cfg_aliases::cfg_aliases! {
+        headless: { any(feature = "renderer-software", feature = "renderer-skia") },
+    }
+
     #[cfg(any(feature = "system-testing", feature = "mcp"))]
     {
         use prost::Message;

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -4,7 +4,9 @@
 // cSpell: ignore rsplit Sfixed
 fn main() {
     cfg_aliases::cfg_aliases! {
-        headless: { any(feature = "renderer-software", feature = "renderer-skia") },
+        supports_headless: { any(feature = "renderer-software", feature = "renderer-skia") },
+        // Skia's software rasterizer is not built on Android.
+        skia_headless: { all(feature = "renderer-skia", not(target_os = "android")) },
     }
 
     #[cfg(any(feature = "system-testing", feature = "mcp"))]

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -38,7 +38,11 @@ pub mod systest;
 /// Instead, use [`mock_elapsed_time()`] to advance the simulate (mock) time Slint uses.
 pub fn init_no_event_loop() {
     i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
-        testing_backend::TestingBackendOptions { mock_time: true, threading: false, ..Default::default() },
+        testing_backend::TestingBackendOptions {
+            mock_time: true,
+            threading: false,
+            ..Default::default()
+        },
     )))
     .expect("platform already initialized");
 }
@@ -53,7 +57,11 @@ pub fn init_no_event_loop() {
 /// Instead, use [`mock_elapsed_time()`] to advance the simulate (mock) time Slint uses.
 pub fn init_integration_test_with_mock_time() {
     i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
-        testing_backend::TestingBackendOptions { mock_time: true, threading: true, ..Default::default() },
+        testing_backend::TestingBackendOptions {
+            mock_time: true,
+            threading: true,
+            ..Default::default()
+        },
     )))
     .expect("platform already initialized");
 }
@@ -65,7 +73,11 @@ pub fn init_integration_test_with_mock_time() {
 /// Calling it when the rendering backend is already initialized will panic.
 pub fn init_integration_test_with_system_time() {
     i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
-        testing_backend::TestingBackendOptions { mock_time: false, threading: true, ..Default::default() },
+        testing_backend::TestingBackendOptions {
+            mock_time: false,
+            threading: true,
+            ..Default::default()
+        },
     )))
     .expect("platform already initialized");
 }

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -12,10 +12,8 @@ mod internal_tests;
 pub use internal_tests::*;
 pub mod testing_backend;
 pub use testing_backend::get_mocked_time;
-// `TestingBackend` and `TestingBackendOptions` are part of the public API
-// because the backend selector instantiates them for `SLINT_BACKEND=headless`.
-// The deeper-internal surface (`TestingWindow`, the raw-millisecond
-// `mock_elapsed_time`, the `internal_tests` helpers) stays gated.
+// Exported unconditionally so the backend selector can instantiate the
+// headless backend.
 pub use testing_backend::{TestingBackend, TestingBackendOptions};
 #[cfg(feature = "internal")]
 pub use testing_backend::{TestingWindow, mock_elapsed_time};

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -12,10 +12,13 @@ mod internal_tests;
 pub use internal_tests::*;
 pub mod testing_backend;
 pub use testing_backend::get_mocked_time;
+// `TestingBackend` and `TestingBackendOptions` are part of the public API
+// because the backend selector instantiates them for `SLINT_BACKEND=headless`.
+// The deeper-internal surface (`TestingWindow`, the raw-millisecond
+// `mock_elapsed_time`, the `internal_tests` helpers) stays gated.
+pub use testing_backend::{TestingBackend, TestingBackendOptions};
 #[cfg(feature = "internal")]
-pub use testing_backend::{
-    TestingBackend, TestingBackendOptions, TestingWindow, mock_elapsed_time,
-};
+pub use testing_backend::{TestingWindow, mock_elapsed_time};
 #[cfg(all(feature = "ffi", not(test)))]
 mod ffi;
 #[cfg(any(feature = "system-testing", feature = "mcp"))]
@@ -35,7 +38,7 @@ pub mod systest;
 /// Instead, use [`mock_elapsed_time()`] to advance the simulate (mock) time Slint uses.
 pub fn init_no_event_loop() {
     i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
-        testing_backend::TestingBackendOptions { mock_time: true, threading: false },
+        testing_backend::TestingBackendOptions { mock_time: true, threading: false, ..Default::default() },
     )))
     .expect("platform already initialized");
 }
@@ -50,7 +53,7 @@ pub fn init_no_event_loop() {
 /// Instead, use [`mock_elapsed_time()`] to advance the simulate (mock) time Slint uses.
 pub fn init_integration_test_with_mock_time() {
     i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
-        testing_backend::TestingBackendOptions { mock_time: true, threading: true },
+        testing_backend::TestingBackendOptions { mock_time: true, threading: true, ..Default::default() },
     )))
     .expect("platform already initialized");
 }
@@ -62,7 +65,7 @@ pub fn init_integration_test_with_mock_time() {
 /// Calling it when the rendering backend is already initialized will panic.
 pub fn init_integration_test_with_system_time() {
     i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
-        testing_backend::TestingBackendOptions { mock_time: false, threading: true },
+        testing_backend::TestingBackendOptions { mock_time: false, threading: true, ..Default::default() },
     )))
     .expect("platform already initialized");
 }

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -142,6 +142,13 @@ fn is_fixed_test_font(family: &Option<SharedString>) -> bool {
 pub struct TestingBackendOptions {
     pub mock_time: bool,
     pub threading: bool,
+    /// Selects the rasterizer used for headless screenshots (`take_snapshot`).
+    /// `None` keeps the stub renderer; `Some("software")` / `Some("skia")` /
+    /// `Some("skia-software")` request a real rasterizer (when the matching
+    /// feature is compiled in). Other strings produce an error at window
+    /// creation time.
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    pub renderer_name: Option<SharedString>,
 }
 
 pub struct TestingBackend {
@@ -150,6 +157,8 @@ pub struct TestingBackend {
     mock_time: bool,
     pub open_url: Rc<RefCell<Option<SharedString>>>,
     pub debug_logs: Rc<RefCell<Vec<String>>>,
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    renderer_name: Option<SharedString>,
 }
 
 impl TestingBackend {
@@ -160,6 +169,8 @@ impl TestingBackend {
             mock_time: options.mock_time,
             open_url: Default::default(),
             debug_logs: Default::default(),
+            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            renderer_name: options.renderer_name,
         }
     }
 }
@@ -168,6 +179,8 @@ impl i_slint_core::platform::Platform for TestingBackend {
     fn create_window_adapter(
         &self,
     ) -> Result<Rc<dyn WindowAdapter>, i_slint_core::platform::PlatformError> {
+        #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+        let renderer = create_headless_renderer(self.renderer_name.as_deref())?;
         let window = Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
             size: Default::default(),
@@ -177,6 +190,10 @@ impl i_slint_core::platform::Platform for TestingBackend {
             open_url: self.open_url.clone(),
             debug_logs: self.debug_logs.clone(),
             native_popup: Cell::new(false),
+            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            renderer_name: self.renderer_name.clone(),
+            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            renderer,
         });
         ALL_TESTING_WINDOWS.with(|list| list.borrow_mut().push(Rc::downgrade(&window)));
         Ok(window)
@@ -271,6 +288,15 @@ pub struct TestingWindow {
     pub open_url: Rc<RefCell<Option<SharedString>>>,
     pub debug_logs: Rc<RefCell<Vec<String>>>,
     native_popup: Cell<bool>,
+    /// Remembered for child popups, so they pick the same rasterizer.
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    renderer_name: Option<SharedString>,
+    /// Real rasterizer driving `take_snapshot`. The text-measurement and
+    /// font paths of [`RendererSealed`] are still served by `TestingWindow`
+    /// itself (the fixed-test-font fixture relies on that); only the
+    /// screenshot delegates here.
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    renderer: Box<dyn Renderer>,
 }
 
 impl TestingWindow {
@@ -323,6 +349,8 @@ impl WindowAdapterInternal for TestingWindow {
 
     fn create_child_window_adapter(&self, _kind: WindowKind) -> Option<Rc<dyn WindowAdapter>> {
         if self.native_popup.get() {
+            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            let renderer = create_headless_renderer(self.renderer_name.as_deref()).ok()?;
             let window = Rc::new_cyclic(|self_weak| TestingWindow {
                 window: i_slint_core::api::Window::new(self_weak.clone() as _),
                 size: Default::default(),
@@ -332,6 +360,10 @@ impl WindowAdapterInternal for TestingWindow {
                 open_url: self.open_url.clone(),
                 debug_logs: self.debug_logs.clone(),
                 native_popup: self.native_popup.clone(),
+                #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+                renderer_name: self.renderer_name.clone(),
+                #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+                renderer,
             });
             Some(window)
         } else {
@@ -516,7 +548,13 @@ impl RendererSealed for TestingWindow {
     }
 
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
-        // No-op since TestingWindow is also the WindowAdapter
+        // TestingWindow is itself the WindowAdapter, so no need to remember it
+        // here. However, the embedded rasterizer (used for `take_snapshot`)
+        // does need its weak window-adapter reference set, since the
+        // framework only forwards `set_window_adapter` to whatever
+        // `WindowAdapter::renderer()` returns.
+        #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+        self.renderer.set_window_adapter(_window_adapter);
     }
 
     fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
@@ -525,6 +563,81 @@ impl RendererSealed for TestingWindow {
 
     fn supports_transformations(&self) -> bool {
         true
+    }
+
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    fn take_snapshot(
+        &self,
+    ) -> Result<
+        i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+        PlatformError,
+    > {
+        self.renderer.take_snapshot()
+    }
+
+    // The remaining overrides forward lifecycle notifications that the
+    // wrapped rasterizer needs to keep its caches consistent. Without them,
+    // bitmap fonts baked at compile time would be silently dropped, and
+    // per-component caches in the held renderer would grow without bound.
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    fn register_bitmap_font(&self, font_data: &'static i_slint_core::graphics::BitmapFont) {
+        self.renderer.register_bitmap_font(font_data);
+    }
+
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    fn free_graphics_resources(
+        &self,
+        component: i_slint_core::item_tree::ItemTreeRef,
+        items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
+    ) -> Result<(), PlatformError> {
+        self.renderer.free_graphics_resources(component, items)
+    }
+
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    fn mark_dirty_region(&self, region: i_slint_core::partial_renderer::DirtyRegion) {
+        self.renderer.mark_dirty_region(region);
+    }
+
+    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    fn resize(&self, size: PhysicalSize) -> Result<(), PlatformError> {
+        self.renderer.resize(size)
+    }
+}
+
+/// Build a rasterizer suitable for headless `take_snapshot` based on the
+/// renderer name parsed from `SLINT_BACKEND=headless-<name>`. `None` /
+/// empty / `"default"` selects the best available (Skia software when
+/// compiled in, otherwise the built-in software renderer).
+#[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+fn create_headless_renderer(name: Option<&str>) -> Result<Box<dyn Renderer>, PlatformError> {
+    // Skia's software rasterizer is unavailable on Android (see
+    // `internal/renderers/skia/build.rs`'s `skia_backend_software` cfg-alias).
+    // When the Skia arm is gated out for Android, the software arms below
+    // pick up `""`/`"default"` so the headless backend still has a fallback.
+    match name.unwrap_or("") {
+        #[cfg(all(feature = "renderer-skia", not(target_os = "android")))]
+        "" | "default" | "skia" | "skia-software" => {
+            Ok(Box::new(i_slint_renderer_skia::SkiaRenderer::default_software(
+                &i_slint_renderer_skia::SkiaSharedContext::default(),
+            )))
+        }
+        #[cfg(all(
+            feature = "renderer-software",
+            any(not(feature = "renderer-skia"), target_os = "android")
+        ))]
+        "" | "default" => Ok(Box::new(i_slint_renderer_software::SoftwareRenderer::new())),
+        #[cfg(feature = "renderer-software")]
+        "sw" | "software" => Ok(Box::new(i_slint_renderer_software::SoftwareRenderer::new())),
+        other => Err(PlatformError::Other(format!(
+            "Unknown headless renderer {other:?} (available: \
+             {software}{skia})",
+            software = if cfg!(feature = "renderer-software") { "software" } else { "" },
+            skia = if cfg!(all(feature = "renderer-skia", not(target_os = "android"))) {
+                if cfg!(feature = "renderer-software") { ", skia" } else { "skia" }
+            } else {
+                ""
+            },
+        ))),
     }
 }
 

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -142,8 +142,11 @@ fn is_fixed_test_font(family: &Option<SharedString>) -> bool {
 pub struct TestingBackendOptions {
     pub mock_time: bool,
     pub threading: bool,
-    /// Headless renderer choice. Recognized names: `software`, `skia`.
-    /// `None` or empty picks the best available.
+    /// When set, windows embed a real rasterizer so headless rendering
+    /// (e.g. `Window::take_snapshot`) works. Recognized names: `software`,
+    /// `skia`; an empty string or `default` picks the best available.
+    /// When `None`, the backend keeps its mock renderer with fixed font
+    /// metrics, as the test drivers expect.
     #[cfg(headless)]
     pub renderer_name: Option<SharedString>,
 }
@@ -177,7 +180,8 @@ impl i_slint_core::platform::Platform for TestingBackend {
         &self,
     ) -> Result<Rc<dyn WindowAdapter>, i_slint_core::platform::PlatformError> {
         #[cfg(headless)]
-        let renderer = create_headless_renderer(self.renderer_name.as_deref())?;
+        let renderer =
+            self.renderer_name.as_ref().map(|name| create_headless_renderer(name)).transpose()?;
         let window = Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
             size: Default::default(),
@@ -288,10 +292,11 @@ pub struct TestingWindow {
     /// Remembered for child popups, so they pick the same rasterizer.
     #[cfg(headless)]
     renderer_name: Option<SharedString>,
-    /// Rasterizer returned by `WindowAdapter::renderer` when headless is on,
-    /// so every `RendererSealed` call routes through it.
+    /// Rasterizer returned by `WindowAdapter::renderer` when headless
+    /// rendering was requested, so every `RendererSealed` call routes through
+    /// it. `None` keeps the mock renderer with its fixed test font metrics.
     #[cfg(headless)]
-    renderer: Box<dyn Renderer>,
+    renderer: Option<Box<dyn Renderer>>,
 }
 
 impl TestingWindow {
@@ -345,7 +350,10 @@ impl WindowAdapterInternal for TestingWindow {
     fn create_child_window_adapter(&self, _kind: WindowKind) -> Option<Rc<dyn WindowAdapter>> {
         if self.native_popup.get() {
             #[cfg(headless)]
-            let renderer = create_headless_renderer(self.renderer_name.as_deref()).ok()?;
+            let renderer = match &self.renderer_name {
+                Some(name) => Some(create_headless_renderer(name).ok()?),
+                None => None,
+            };
             let window = Rc::new_cyclic(|self_weak| TestingWindow {
                 window: i_slint_core::api::Window::new(self_weak.clone() as _),
                 size: Default::default(),
@@ -385,9 +393,10 @@ impl WindowAdapter for TestingWindow {
 
     fn renderer(&self) -> &dyn Renderer {
         #[cfg(headless)]
-        return &*self.renderer;
-        #[cfg(not(headless))]
-        return self;
+        if let Some(renderer) = &self.renderer {
+            return &**renderer;
+        }
+        self
     }
 
     fn update_window_properties(&self, properties: i_slint_core::window::WindowProperties<'_>) {
@@ -560,13 +569,13 @@ impl RendererSealed for TestingWindow {
 }
 
 /// Pick the rasterizer for the headless backend.
-/// `None` / `""` / `"default"` picks Skia software when compiled in, else the
+/// `""` / `"default"` picks Skia software when compiled in, else the
 /// built-in software renderer.
 #[cfg(headless)]
-fn create_headless_renderer(name: Option<&str>) -> Result<Box<dyn Renderer>, PlatformError> {
+fn create_headless_renderer(name: &str) -> Result<Box<dyn Renderer>, PlatformError> {
     // `SkiaRenderer::default_software` isn't built on Android; fall through
     // to the software renderer there.
-    match name.unwrap_or("") {
+    match name {
         #[cfg(all(feature = "renderer-skia", not(target_os = "android")))]
         "" | "default" | "skia" | "skia-software" => {
             Ok(Box::new(i_slint_renderer_skia::SkiaRenderer::default_software(

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -142,12 +142,9 @@ fn is_fixed_test_font(family: &Option<SharedString>) -> bool {
 pub struct TestingBackendOptions {
     pub mock_time: bool,
     pub threading: bool,
-    /// Selects the rasterizer used for headless screenshots (`take_snapshot`).
-    /// `None` keeps the stub renderer; `Some("software")` / `Some("skia")` /
-    /// `Some("skia-software")` request a real rasterizer (when the matching
-    /// feature is compiled in). Other strings produce an error at window
-    /// creation time.
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    /// Headless renderer choice. Recognized names: `software`, `skia`.
+    /// `None` or empty picks the best available.
+    #[cfg(headless)]
     pub renderer_name: Option<SharedString>,
 }
 
@@ -157,7 +154,7 @@ pub struct TestingBackend {
     mock_time: bool,
     pub open_url: Rc<RefCell<Option<SharedString>>>,
     pub debug_logs: Rc<RefCell<Vec<String>>>,
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    #[cfg(headless)]
     renderer_name: Option<SharedString>,
 }
 
@@ -169,7 +166,7 @@ impl TestingBackend {
             mock_time: options.mock_time,
             open_url: Default::default(),
             debug_logs: Default::default(),
-            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            #[cfg(headless)]
             renderer_name: options.renderer_name,
         }
     }
@@ -179,7 +176,7 @@ impl i_slint_core::platform::Platform for TestingBackend {
     fn create_window_adapter(
         &self,
     ) -> Result<Rc<dyn WindowAdapter>, i_slint_core::platform::PlatformError> {
-        #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+        #[cfg(headless)]
         let renderer = create_headless_renderer(self.renderer_name.as_deref())?;
         let window = Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
@@ -190,9 +187,9 @@ impl i_slint_core::platform::Platform for TestingBackend {
             open_url: self.open_url.clone(),
             debug_logs: self.debug_logs.clone(),
             native_popup: Cell::new(false),
-            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            #[cfg(headless)]
             renderer_name: self.renderer_name.clone(),
-            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            #[cfg(headless)]
             renderer,
         });
         ALL_TESTING_WINDOWS.with(|list| list.borrow_mut().push(Rc::downgrade(&window)));
@@ -289,13 +286,11 @@ pub struct TestingWindow {
     pub debug_logs: Rc<RefCell<Vec<String>>>,
     native_popup: Cell<bool>,
     /// Remembered for child popups, so they pick the same rasterizer.
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    #[cfg(headless)]
     renderer_name: Option<SharedString>,
-    /// Real rasterizer driving `take_snapshot`. The text-measurement and
-    /// font paths of [`RendererSealed`] are still served by `TestingWindow`
-    /// itself (the fixed-test-font fixture relies on that); only the
-    /// screenshot delegates here.
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+    /// Rasterizer returned by `WindowAdapter::renderer` when headless is on,
+    /// so every `RendererSealed` call routes through it.
+    #[cfg(headless)]
     renderer: Box<dyn Renderer>,
 }
 
@@ -349,7 +344,7 @@ impl WindowAdapterInternal for TestingWindow {
 
     fn create_child_window_adapter(&self, _kind: WindowKind) -> Option<Rc<dyn WindowAdapter>> {
         if self.native_popup.get() {
-            #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+            #[cfg(headless)]
             let renderer = create_headless_renderer(self.renderer_name.as_deref()).ok()?;
             let window = Rc::new_cyclic(|self_weak| TestingWindow {
                 window: i_slint_core::api::Window::new(self_weak.clone() as _),
@@ -360,9 +355,9 @@ impl WindowAdapterInternal for TestingWindow {
                 open_url: self.open_url.clone(),
                 debug_logs: self.debug_logs.clone(),
                 native_popup: self.native_popup.clone(),
-                #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+                #[cfg(headless)]
                 renderer_name: self.renderer_name.clone(),
-                #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+                #[cfg(headless)]
                 renderer,
             });
             Some(window)
@@ -389,7 +384,10 @@ impl WindowAdapter for TestingWindow {
     }
 
     fn renderer(&self) -> &dyn Renderer {
-        self
+        #[cfg(headless)]
+        return &*self.renderer;
+        #[cfg(not(headless))]
+        return self;
     }
 
     fn update_window_properties(&self, properties: i_slint_core::window::WindowProperties<'_>) {
@@ -548,13 +546,8 @@ impl RendererSealed for TestingWindow {
     }
 
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
-        // TestingWindow is itself the WindowAdapter, so no need to remember it
-        // here. However, the embedded rasterizer (used for `take_snapshot`)
-        // does need its weak window-adapter reference set, since the
-        // framework only forwards `set_window_adapter` to whatever
-        // `WindowAdapter::renderer()` returns.
-        #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
-        self.renderer.set_window_adapter(_window_adapter);
+        // No-op. When headless is on, the framework reaches the held
+        // rasterizer via `renderer()` instead.
     }
 
     fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
@@ -564,56 +557,15 @@ impl RendererSealed for TestingWindow {
     fn supports_transformations(&self) -> bool {
         true
     }
-
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
-    fn take_snapshot(
-        &self,
-    ) -> Result<
-        i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
-        PlatformError,
-    > {
-        self.renderer.take_snapshot()
-    }
-
-    // The remaining overrides forward lifecycle notifications that the
-    // wrapped rasterizer needs to keep its caches consistent. Without them,
-    // bitmap fonts baked at compile time would be silently dropped, and
-    // per-component caches in the held renderer would grow without bound.
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
-    fn register_bitmap_font(&self, font_data: &'static i_slint_core::graphics::BitmapFont) {
-        self.renderer.register_bitmap_font(font_data);
-    }
-
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
-    fn free_graphics_resources(
-        &self,
-        component: i_slint_core::item_tree::ItemTreeRef,
-        items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
-    ) -> Result<(), PlatformError> {
-        self.renderer.free_graphics_resources(component, items)
-    }
-
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
-    fn mark_dirty_region(&self, region: i_slint_core::partial_renderer::DirtyRegion) {
-        self.renderer.mark_dirty_region(region);
-    }
-
-    #[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
-    fn resize(&self, size: PhysicalSize) -> Result<(), PlatformError> {
-        self.renderer.resize(size)
-    }
 }
 
-/// Build a rasterizer suitable for headless `take_snapshot` based on the
-/// renderer name parsed from `SLINT_BACKEND=headless-<name>`. `None` /
-/// empty / `"default"` selects the best available (Skia software when
-/// compiled in, otherwise the built-in software renderer).
-#[cfg(any(feature = "renderer-software", feature = "renderer-skia"))]
+/// Pick the rasterizer for the headless backend.
+/// `None` / `""` / `"default"` picks Skia software when compiled in, else the
+/// built-in software renderer.
+#[cfg(headless)]
 fn create_headless_renderer(name: Option<&str>) -> Result<Box<dyn Renderer>, PlatformError> {
-    // Skia's software rasterizer is unavailable on Android (see
-    // `internal/renderers/skia/build.rs`'s `skia_backend_software` cfg-alias).
-    // When the Skia arm is gated out for Android, the software arms below
-    // pick up `""`/`"default"` so the headless backend still has a fallback.
+    // `SkiaRenderer::default_software` isn't built on Android; fall through
+    // to the software renderer there.
     match name.unwrap_or("") {
         #[cfg(all(feature = "renderer-skia", not(target_os = "android")))]
         "" | "default" | "skia" | "skia-software" => {

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -146,8 +146,8 @@ pub struct TestingBackendOptions {
     /// (e.g. `Window::take_snapshot`) works. Recognized names: `software`,
     /// `skia`; an empty string or `default` picks the best available.
     /// When `None`, the backend keeps its mock renderer with fixed font
-    /// metrics, as the test drivers expect.
-    #[cfg(headless)]
+    /// metrics.
+    #[cfg(supports_headless)]
     pub renderer_name: Option<SharedString>,
 }
 
@@ -157,7 +157,7 @@ pub struct TestingBackend {
     mock_time: bool,
     pub open_url: Rc<RefCell<Option<SharedString>>>,
     pub debug_logs: Rc<RefCell<Vec<String>>>,
-    #[cfg(headless)]
+    #[cfg(supports_headless)]
     renderer_name: Option<SharedString>,
 }
 
@@ -169,7 +169,7 @@ impl TestingBackend {
             mock_time: options.mock_time,
             open_url: Default::default(),
             debug_logs: Default::default(),
-            #[cfg(headless)]
+            #[cfg(supports_headless)]
             renderer_name: options.renderer_name,
         }
     }
@@ -179,7 +179,7 @@ impl i_slint_core::platform::Platform for TestingBackend {
     fn create_window_adapter(
         &self,
     ) -> Result<Rc<dyn WindowAdapter>, i_slint_core::platform::PlatformError> {
-        #[cfg(headless)]
+        #[cfg(supports_headless)]
         let renderer =
             self.renderer_name.as_ref().map(|name| create_headless_renderer(name)).transpose()?;
         let window = Rc::new_cyclic(|self_weak| TestingWindow {
@@ -191,9 +191,9 @@ impl i_slint_core::platform::Platform for TestingBackend {
             open_url: self.open_url.clone(),
             debug_logs: self.debug_logs.clone(),
             native_popup: Cell::new(false),
-            #[cfg(headless)]
+            #[cfg(supports_headless)]
             renderer_name: self.renderer_name.clone(),
-            #[cfg(headless)]
+            #[cfg(supports_headless)]
             renderer,
         });
         ALL_TESTING_WINDOWS.with(|list| list.borrow_mut().push(Rc::downgrade(&window)));
@@ -290,12 +290,12 @@ pub struct TestingWindow {
     pub debug_logs: Rc<RefCell<Vec<String>>>,
     native_popup: Cell<bool>,
     /// Remembered for child popups, so they pick the same rasterizer.
-    #[cfg(headless)]
+    #[cfg(supports_headless)]
     renderer_name: Option<SharedString>,
     /// Rasterizer returned by `WindowAdapter::renderer` when headless
     /// rendering was requested, so every `RendererSealed` call routes through
     /// it. `None` keeps the mock renderer with its fixed test font metrics.
-    #[cfg(headless)]
+    #[cfg(supports_headless)]
     renderer: Option<Box<dyn Renderer>>,
 }
 
@@ -349,11 +349,13 @@ impl WindowAdapterInternal for TestingWindow {
 
     fn create_child_window_adapter(&self, _kind: WindowKind) -> Option<Rc<dyn WindowAdapter>> {
         if self.native_popup.get() {
-            #[cfg(headless)]
-            let renderer = match &self.renderer_name {
-                Some(name) => Some(create_headless_renderer(name).ok()?),
-                None => None,
-            };
+            #[cfg(supports_headless)]
+            let renderer = self
+                .renderer_name
+                .as_ref()
+                .map(|name| create_headless_renderer(name))
+                .transpose()
+                .ok()?;
             let window = Rc::new_cyclic(|self_weak| TestingWindow {
                 window: i_slint_core::api::Window::new(self_weak.clone() as _),
                 size: Default::default(),
@@ -363,9 +365,9 @@ impl WindowAdapterInternal for TestingWindow {
                 open_url: self.open_url.clone(),
                 debug_logs: self.debug_logs.clone(),
                 native_popup: self.native_popup.clone(),
-                #[cfg(headless)]
+                #[cfg(supports_headless)]
                 renderer_name: self.renderer_name.clone(),
-                #[cfg(headless)]
+                #[cfg(supports_headless)]
                 renderer,
             });
             Some(window)
@@ -392,7 +394,7 @@ impl WindowAdapter for TestingWindow {
     }
 
     fn renderer(&self) -> &dyn Renderer {
-        #[cfg(headless)]
+        #[cfg(supports_headless)]
         if let Some(renderer) = &self.renderer {
             return &**renderer;
         }
@@ -555,8 +557,7 @@ impl RendererSealed for TestingWindow {
     }
 
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
-        // No-op. When headless is on, the framework reaches the held
-        // rasterizer via `renderer()` instead.
+        // No-op since TestingWindow is also the WindowAdapter
     }
 
     fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
@@ -571,34 +572,36 @@ impl RendererSealed for TestingWindow {
 /// Pick the rasterizer for the headless backend.
 /// `""` / `"default"` picks Skia software when compiled in, else the
 /// built-in software renderer.
-#[cfg(headless)]
+#[cfg(supports_headless)]
 fn create_headless_renderer(name: &str) -> Result<Box<dyn Renderer>, PlatformError> {
-    // `SkiaRenderer::default_software` isn't built on Android; fall through
-    // to the software renderer there.
     match name {
-        #[cfg(all(feature = "renderer-skia", not(target_os = "android")))]
+        #[cfg(skia_headless)]
         "" | "default" | "skia" | "skia-software" => {
-            Ok(Box::new(i_slint_renderer_skia::SkiaRenderer::default_software(
-                &i_slint_renderer_skia::SkiaSharedContext::default(),
-            )))
+            std::thread_local! {
+                /// Shared across all windows so they reuse Skia resources.
+                static SHARED_CONTEXT: i_slint_renderer_skia::SkiaSharedContext =
+                    Default::default();
+            }
+            SHARED_CONTEXT.with(|context| {
+                Ok(Box::new(i_slint_renderer_skia::SkiaRenderer::default_software(context)) as _)
+            })
         }
-        #[cfg(all(
-            feature = "renderer-software",
-            any(not(feature = "renderer-skia"), target_os = "android")
-        ))]
+        #[cfg(all(feature = "renderer-software", not(skia_headless)))]
         "" | "default" => Ok(Box::new(i_slint_renderer_software::SoftwareRenderer::new())),
         #[cfg(feature = "renderer-software")]
         "sw" | "software" => Ok(Box::new(i_slint_renderer_software::SoftwareRenderer::new())),
-        other => Err(PlatformError::Other(format!(
-            "Unknown headless renderer {other:?} (available: \
-             {software}{skia})",
-            software = if cfg!(feature = "renderer-software") { "software" } else { "" },
-            skia = if cfg!(all(feature = "renderer-skia", not(target_os = "android"))) {
-                if cfg!(feature = "renderer-software") { ", skia" } else { "skia" }
-            } else {
-                ""
-            },
-        ))),
+        other => {
+            let available: &[&str] = &[
+                #[cfg(feature = "renderer-software")]
+                "software",
+                #[cfg(skia_headless)]
+                "skia",
+            ];
+            Err(PlatformError::Other(format!(
+                "Unknown headless renderer {other:?} (available: {})",
+                available.join(", ")
+            )))
+        }
     }
 }
 

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -39,11 +39,7 @@ wgpu-28 = [
 unstable-wgpu-28 = ["i-slint-core/unstable-wgpu-28", "wgpu-28"]
 wgpu-29 = ["i-slint-core/wgpu-29", "dep:wgpu-29", "dep:spin_on", "dep:ash", "dep:windows-core"]
 unstable-wgpu-29 = ["i-slint-core/unstable-wgpu-29", "wgpu-29"]
-# Enables `SkiaRenderer::default_software`. The default surface uses
-# softbuffer; the headless `take_snapshot` path uses `wrap_pixels` instead
-# and never instantiates it.
-software = ["softbuffer"]
-default = ["software"]
+default = ["softbuffer"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["default", "box-shadow-cache", "shared-parley"] }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -39,7 +39,11 @@ wgpu-28 = [
 unstable-wgpu-28 = ["i-slint-core/unstable-wgpu-28", "wgpu-28"]
 wgpu-29 = ["i-slint-core/wgpu-29", "dep:wgpu-29", "dep:spin_on", "dep:ash", "dep:windows-core"]
 unstable-wgpu-29 = ["i-slint-core/unstable-wgpu-29", "wgpu-29"]
-default = ["softbuffer"]
+# Enables `SkiaRenderer::default_software`. The default surface uses
+# softbuffer; the headless `take_snapshot` path uses `wrap_pixels` instead
+# and never instantiates it.
+software = ["softbuffer"]
+default = ["software"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["default", "box-shadow-cache", "shared-parley"] }

--- a/internal/renderers/skia/build.rs
+++ b/internal/renderers/skia/build.rs
@@ -10,6 +10,8 @@ fn main() {
        skia_backend_metal: { all(target_vendor = "apple", not(feature = "opengl")) },
        skia_backend_vulkan: { feature = "vulkan" },
        skia_backend_software: { not(target_os = "android") },
+       skia_backend_softbuffer: { all(skia_backend_software, feature = "softbuffer") },
+       skia_windowed: { any(skia_backend_vulkan, skia_backend_opengl, skia_backend_metal, skia_backend_softbuffer) },
     }
 
     println!("cargo:rustc-check-cfg=cfg(slint_nightly_test)");

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -44,7 +44,7 @@ mod cached_image;
 mod font_cache;
 mod itemrenderer;
 
-#[cfg(skia_backend_software)]
+#[cfg(skia_backend_softbuffer)]
 pub mod software_surface;
 
 #[cfg(target_vendor = "apple")]
@@ -79,11 +79,12 @@ cfg_if::cfg_if! {
         type DefaultSurface = opengl_surface::OpenGLSurface;
     } else if #[cfg(skia_backend_metal)] {
         type DefaultSurface = metal_surface::MetalSurface;
-    } else if #[cfg(skia_backend_software)] {
+    } else if #[cfg(skia_backend_softbuffer)] {
         type DefaultSurface = software_surface::SoftwareSurface;
     }
 }
 
+#[cfg(skia_windowed)]
 fn create_default_surface(
     context: &SkiaSharedContext,
     window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Sync + Send>,
@@ -99,7 +100,7 @@ fn create_default_surface(
         requested_graphics_api,
     ) {
         Ok(gpu_surface) => Ok(Box::new(gpu_surface) as Box<dyn Surface>),
-        #[cfg(skia_backend_software)]
+        #[cfg(skia_backend_softbuffer)]
         Err(err) => {
             i_slint_core::debug_log!(
                 "Failed to initialize Skia GPU renderer: {} . Falling back to software rendering",
@@ -114,7 +115,7 @@ fn create_default_surface(
             )
             .map(|r| Box::new(r) as Box<dyn Surface>)
         }
-        #[cfg(not(skia_backend_software))]
+        #[cfg(not(skia_backend_softbuffer))]
         Err(err) => Err(err),
     }
 }
@@ -190,6 +191,7 @@ pub struct SkiaRenderer {
 }
 
 impl SkiaRenderer {
+    #[cfg(skia_windowed)]
     pub fn default(context: &SkiaSharedContext) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
@@ -223,19 +225,26 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                software_surface::SoftwareSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
+            surface_factory: |_context,
+                              _window_handle,
+                              _display_handle,
+                              _size,
+                              _requested_graphics_api| {
+                #[cfg(skia_backend_softbuffer)]
+                {
+                    software_surface::SoftwareSurface::new(
+                        _context,
+                        _window_handle,
+                        _display_handle,
+                        _size,
+                        _requested_graphics_api,
+                    )
+                    .map(|r| Box::new(r) as Box<dyn Surface>)
+                }
+                #[cfg(not(skia_backend_softbuffer))]
+                Err(PlatformError::Other(
+                    "Skia software rendering needs the 'softbuffer' feature".into(),
+                ))
             },
             pre_present_callback: Default::default(),
             partial_rendering_state: PartialRenderingState::default().into(),

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -44,7 +44,7 @@ mod cached_image;
 mod font_cache;
 mod itemrenderer;
 
-#[cfg(skia_backend_softbuffer)]
+#[cfg(skia_backend_software)]
 pub mod software_surface;
 
 #[cfg(target_vendor = "apple")]
@@ -225,26 +225,19 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: |_context,
-                              _window_handle,
-                              _display_handle,
-                              _size,
-                              _requested_graphics_api| {
-                #[cfg(skia_backend_softbuffer)]
-                {
-                    software_surface::SoftwareSurface::new(
-                        _context,
-                        _window_handle,
-                        _display_handle,
-                        _size,
-                        _requested_graphics_api,
-                    )
-                    .map(|r| Box::new(r) as Box<dyn Surface>)
-                }
-                #[cfg(not(skia_backend_softbuffer))]
-                Err(PlatformError::Other(
-                    "Skia software rendering needs the 'softbuffer' feature".into(),
-                ))
+            surface_factory: |context,
+                              window_handle,
+                              display_handle,
+                              size,
+                              requested_graphics_api| {
+                software_surface::SoftwareSurface::new(
+                    context,
+                    window_handle,
+                    display_handle,
+                    size,
+                    requested_graphics_api,
+                )
+                .map(|r| Box::new(r) as Box<dyn Surface>)
             },
             pre_present_callback: Default::default(),
             partial_rendering_state: PartialRenderingState::default().into(),

--- a/skills/slint/SKILL.md
+++ b/skills/slint/SKILL.md
@@ -136,7 +136,7 @@ SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 cargo run -p my-app --features slint
 Do not add `mcp` to the `[features]` section of your `Cargo.toml` — use the `--features` flag on the command line instead.
 
 On a machine with no display server (CI, container, agent sandbox), also set `SLINT_BACKEND=headless` so `take_screenshot` works without Xvfb or a GPU.
-Suffix the value (`headless-software`, `headless-skia`) to force a specific rasterizer; the default picks Skia software when `renderer-skia` is enabled, otherwise the built-in software renderer.
+Suffix the value (`headless-software`, `headless-skia`) to force a specific rasterizer.
 If `SLINT_BACKEND` is unset and the regular backend fails to initialize, the headless backend kicks in as a fallback.
 This is an MCP-oriented entry point; the exact value may change between Slint releases.
 

--- a/skills/slint/SKILL.md
+++ b/skills/slint/SKILL.md
@@ -135,13 +135,10 @@ SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 cargo run -p my-app --features slint
 
 Do not add `mcp` to the `[features]` section of your `Cargo.toml` — use the `--features` flag on the command line instead.
 
-If you are running on a machine with no display server (CI, container, agent sandbox), also set `SLINT_BACKEND=headless` so the app runs under a windowless, software-rasterized backend and `take_screenshot` works without Xvfb or a GPU:
-
-```sh
-SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 SLINT_BACKEND=headless cargo run -p my-app --features slint/mcp
-```
-
-Suffix the value (`headless-software`, `headless-skia`) to force a specific rasterizer; the default picks Skia software when `renderer-skia` is enabled, otherwise the built-in software renderer. If `SLINT_BACKEND` is unset and the regular backend fails to initialize (e.g. no display), the headless backend is used as a fallback automatically. This is an MCP-oriented entry point; the exact value may change between Slint releases — do not rely on it from production code.
+On a machine with no display server (CI, container, agent sandbox), also set `SLINT_BACKEND=headless` so `take_screenshot` works without Xvfb or a GPU.
+Suffix the value (`headless-software`, `headless-skia`) to force a specific rasterizer; the default picks Skia software when `renderer-skia` is enabled, otherwise the built-in software renderer.
+If `SLINT_BACKEND` is unset and the regular backend fails to initialize, the headless backend kicks in as a fallback.
+This is an MCP-oriented entry point; the exact value may change between Slint releases.
 
 **Step 2**: Connect to the running application's MCP server at `http://localhost:9315/mcp` using Streamable HTTP transport and use the available tools to inspect and interact with the UI.
 

--- a/skills/slint/SKILL.md
+++ b/skills/slint/SKILL.md
@@ -135,6 +135,14 @@ SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 cargo run -p my-app --features slint
 
 Do not add `mcp` to the `[features]` section of your `Cargo.toml` — use the `--features` flag on the command line instead.
 
+If you are running on a machine with no display server (CI, container, agent sandbox), also set `SLINT_BACKEND=headless` so the app runs under a windowless, software-rasterized backend and `take_screenshot` works without Xvfb or a GPU:
+
+```sh
+SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 SLINT_BACKEND=headless cargo run -p my-app --features slint/mcp
+```
+
+Suffix the value (`headless-software`, `headless-skia`) to force a specific rasterizer; the default picks Skia software when `renderer-skia` is enabled, otherwise the built-in software renderer. If `SLINT_BACKEND` is unset and the regular backend fails to initialize (e.g. no display), the headless backend is used as a fallback automatically. This is an MCP-oriented entry point; the exact value may change between Slint releases — do not rely on it from production code.
+
 **Step 2**: Connect to the running application's MCP server at `http://localhost:9315/mcp` using Streamable HTTP transport and use the available tools to inspect and interact with the UI.
 
 When scripting or verifying the server from the command line, use `curl` — it is the most reliable approach for raw JSON-RPC. Prefer `curl` over built-in HTTP fetch tools, which agents sometimes reach for but which are less predictable for this use case:


### PR DESCRIPTION
Today the MCP server's `take_screenshot` tool needs a real display                                                                                    
because the testing backend (where the MCP server lives) has a stub
renderer.

This PR embeds a software rasterizer in the testing backend so
`take_screenshot` returns a real PNG of the running app, with no
display, Xvfb, or GPU.

Set `SLINT_BACKEND=headless` to opt in.

```
SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 SLINT_BACKEND=headless \                                                                                  
    cargo run --features slint/mcp
```
