### PR TITLE
slint-viewer: add --check and JSON diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10916,6 +10916,7 @@ dependencies = [
  "itertools 0.14.0",
  "jni 0.22.4",
  "mdns-sd 0.17.2",
+ "serde",
  "serde_json",
  "shlex",
  "slint",

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -82,6 +82,7 @@ clap = { workspace = true }
 shlex = "1"
 image = { workspace = true }
 itertools = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 smol_str = { workspace = true }
 tokio = { version = "1.48.0", optional = true }

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -45,6 +45,9 @@ slint-viewer path/to/myfile.slint
    Set `SLINT_SCALE_FACTOR` to override the default scale factor of 1.
  - `--check`: Compile the file, print any diagnostics, and exit without opening a window.
    Exit status is 1 on errors, 0 otherwise (warnings still print).
+ - `--diagnostics-format <human|json>`: Format for compiler diagnostics.
+   `human` (default) prints colored output to stderr;
+   `json` emits a single array on stdout for tooling.
 
 Instead of a path to a file, one can use `-` for the standard input or the standard output.
 
@@ -86,7 +89,7 @@ the dialog if no callback was set on the button.
 The program returns with the following error code:
  - If the command line argument parsing or argument validation fails, the exit code will be *2*
  - If the .slint compilation fails, the compilation error will be printed to stderr and the exit code
-   will be *-1*
+   will be *-1*, except for `--check` and `--screenshot` which exit with *1*
  - If a Window is closed, the exit code will be *0*
  - If a Dialog is closed with the "Ok" or "Closed" or "Yes" button, the exit code will be *0*
  - If a Dialog is closed with the "Cancel" or "No" button, or using the close button in the window

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -85,7 +85,7 @@ the dialog if no callback was set on the button.
 ## Result code
 
 The program returns with the following error code:
- - If the command line argument parsing fails, the exit code will be *1*
+ - If the command line argument parsing or argument validation fails, the exit code will be *2*
  - If the .slint compilation fails, the compilation error will be printed to stderr and the exit code
    will be *-1*
  - If a Window is closed, the exit code will be *0*

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -40,12 +40,11 @@ slint-viewer path/to/myfile.slint
  - `--backend <backend>`: Override the Slint rendering backend
  - `--on <callback> <handler>`: Set a callback handler, see [callback handler](#callback-handlers)
  - `--component <name>`: Load the component with the given name. If not specified, load the last exported component
- - `--screenshot <file>`: Render the component to an image file and exit instead of opening a window.
-   The file format is inferred from the extension (e.g. `.png`, `.jpg`). Use `-` to write a PNG to
-   standard output. The component is rendered at its preferred size with a headless renderer (Skia's
-   software rasterizer when the `renderer-skia` feature is enabled, otherwise Slint's software
-   renderer), unless `--backend` is also given. Set `SLINT_SCALE_FACTOR` to override the default
-   scale factor of 1. This option is incompatible with `--auto-reload`.
+ - `--screenshot <file>`: Render the component to an image and exit.
+   The format follows the extension (e.g. `.png`, `.jpg`); use `-` to write a PNG to standard output.
+   Set `SLINT_SCALE_FACTOR` to override the default scale factor of 1.
+ - `--check`: Compile the file, print any diagnostics, and exit without opening a window.
+   Exit status is 1 on errors, 0 otherwise (warnings still print).
 
 Instead of a path to a file, one can use `-` for the standard input or the standard output.
 

--- a/tools/viewer/build.rs
+++ b/tools/viewer/build.rs
@@ -4,6 +4,7 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_REMOTE");
+    println!("cargo:rustc-check-cfg=cfg(slint_nightly_test)");
     // The slint!{} macro in remote.rs needs the experimental
     // new_with_existing_window constructor.
     if std::env::var_os("CARGO_FEATURE_REMOTE").is_some() {

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #![doc = include_str!("README.md")]
+#![cfg_attr(slint_nightly_test, feature(non_exhaustive_omitted_patterns_lint))]
+#![cfg_attr(slint_nightly_test, warn(non_exhaustive_omitted_patterns))]
 
 mod debug;
+mod print_diagnostics;
 mod screenshot;
 
 #[cfg(feature = "remote")]
@@ -119,6 +122,11 @@ struct Cli {
     )]
     check: bool,
 
+    /// Format for compiler diagnostics: `human` (colored, to stderr) or `json`
+    /// (a single array on stdout).
+    #[arg(long, value_name = "format", default_value = "human")]
+    diagnostics_format: print_diagnostics::DiagnosticsFormat,
+
     /// Specify callbacks handler.
     /// The first argument is the callback name, and the second argument is a string that is going
     /// to be passed to the shell to be executed. Occurrences of `$1` will be replaced by the first argument,
@@ -188,6 +196,28 @@ fn main() -> Result<()> {
         }
     }
 
+    // JSON goes to stdout, so reject other flags that claim stdout. Auto-reload
+    // uses its own diagnostic renderer that doesn't honor the format.
+    if args.diagnostics_format == print_diagnostics::DiagnosticsFormat::Json {
+        let is_stdout = |p: &std::path::Path| p == std::path::Path::new("-");
+        if args.screenshot.as_deref().is_some_and(is_stdout) {
+            eprintln!(
+                "--diagnostics-format json conflicts with --screenshot - (both write to stdout)"
+            );
+            std::process::exit(2);
+        }
+        if args.save_data.as_deref().is_some_and(is_stdout) {
+            eprintln!(
+                "--diagnostics-format json conflicts with --save-data - (both write to stdout)"
+            );
+            std::process::exit(2);
+        }
+        if args.auto_reload {
+            eprintln!("--diagnostics-format json is not supported with --auto-reload");
+            std::process::exit(2);
+        }
+    }
+
     if args.remote {
         #[cfg(feature = "remote")]
         {
@@ -227,7 +257,7 @@ fn main() -> Result<()> {
 
     if args.check {
         let result = poll_ready(compiler.build_from_path(args.path()));
-        result.print_diagnostics();
+        print_diagnostics::print_diagnostics(&result, args.diagnostics_format);
         std::process::exit(if result.has_errors() { 1 } else { 0 });
     }
 
@@ -261,7 +291,7 @@ fn main() -> Result<()> {
         instance.run()?;
     } else {
         let result = poll_ready(compiler.build_from_path(args.path()));
-        result.print_diagnostics();
+        print_diagnostics::print_diagnostics(&result, args.diagnostics_format);
         if result.has_errors() {
             std::process::exit(-1);
         }
@@ -554,6 +584,7 @@ fn execute_cmd(cmd: &str, callback_args: &[Value]) -> Result<()> {
     let callback_args = callback_args
         .iter()
         .map(|v| {
+            #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
             Ok(match v {
                 Value::Number(x) => x.to_string(),
                 Value::String(x) => x.to_string(),

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -170,16 +170,16 @@ fn main() -> Result<()> {
     if args.screenshot.is_some() {
         if args.auto_reload {
             eprintln!("Cannot pass both --auto-reload and --screenshot");
-            std::process::exit(-1);
+            std::process::exit(2);
         }
         if args.save_data.is_some() {
             eprintln!("Cannot pass both --save-data and --screenshot");
-            std::process::exit(-1);
+            std::process::exit(2);
         }
         #[cfg(feature = "remote")]
         if args.remote {
             eprintln!("Cannot pass both --remote and --screenshot");
-            std::process::exit(-1);
+            std::process::exit(2);
         }
     }
 
@@ -200,7 +200,7 @@ fn main() -> Result<()> {
 
     if args.auto_reload && args.save_data.is_some() {
         eprintln!("Cannot pass both --auto-reload and --save-data");
-        std::process::exit(-1);
+        std::process::exit(2);
     }
 
     #[cfg(feature = "gettext")]

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -104,15 +104,20 @@ struct Cli {
     #[arg(long, value_name = "json file", action)]
     save_data: Option<std::path::PathBuf>,
 
-    /// Render the component to an image file and exit instead of opening a window.
-    /// The file format is inferred from the extension (e.g. .png, .jpg).
-    /// Use `-` to write a PNG to standard output. The component is rendered at its
-    /// preferred size with a headless renderer (Skia's software rasterizer when the
-    /// `renderer-skia` feature is enabled, otherwise Slint's software renderer); pass
-    /// `--backend` to pick another renderer. Set `SLINT_SCALE_FACTOR` to override the
-    /// default scale factor of 1. Incompatible with `--auto-reload` and `--remote`.
+    /// Render the component to an image and exit.
+    /// The format follows the extension (e.g. `.png`, `.jpg`);
+    /// use `-` to write a PNG to standard output.
     #[arg(long, value_name = "image file", action)]
     screenshot: Option<std::path::PathBuf>,
+
+    /// Compile, print any diagnostics, and exit without opening a window.
+    /// Exit status is 1 on errors, 0 otherwise (warnings still print).
+    #[arg(
+        long,
+        action,
+        conflicts_with_all = ["auto_reload", "screenshot", "save_data", "load_data", "on", "remote"],
+    )]
+    check: bool,
 
     /// Specify callbacks handler.
     /// The first argument is the callback name, and the second argument is a string that is going
@@ -219,6 +224,12 @@ fn main() -> Result<()> {
     }
 
     let compiler = init_compiler(&args);
+
+    if args.check {
+        let result = poll_ready(compiler.build_from_path(args.path()));
+        result.print_diagnostics();
+        std::process::exit(if result.has_errors() { 1 } else { 0 });
+    }
 
     if args.auto_reload {
         select_backend(args.backend.as_deref())?;

--- a/tools/viewer/print_diagnostics.rs
+++ b/tools/viewer/print_diagnostics.rs
@@ -1,0 +1,83 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Diagnostic output for `slint-viewer`: human (stderr) or JSON (stdout).
+
+use i_slint_compiler::diagnostics::{
+    ByteFormat, DiagnosticLevel, diagnostic_end_line_column_with_format,
+};
+use serde::Serialize;
+use slint_interpreter::Diagnostic;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, clap::ValueEnum)]
+pub enum DiagnosticsFormat {
+    /// Colored, human-readable output on stderr.
+    #[default]
+    Human,
+    /// One JSON array of diagnostic objects on stdout.
+    Json,
+}
+
+/// Print `result`'s diagnostics in the chosen format.
+pub fn print_diagnostics(result: &slint_interpreter::CompilationResult, format: DiagnosticsFormat) {
+    match format {
+        DiagnosticsFormat::Human => result.print_diagnostics(),
+        DiagnosticsFormat::Json => {
+            let diagnostics: Vec<Diagnostic> = result.diagnostics().collect();
+            println!("{}", format_diagnostics_json(&diagnostics));
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct JsonDiagnostic<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<std::borrow::Cow<'a, str>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    column: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_column: Option<usize>,
+    level: &'static str,
+    message: &'a str,
+}
+
+fn level_str(level: DiagnosticLevel) -> &'static str {
+    match level {
+        DiagnosticLevel::Error => "error",
+        DiagnosticLevel::Warning => "warning",
+        DiagnosticLevel::Note => "note",
+        _ => "unknown",
+    }
+}
+
+/// `(0, 0)` is the sentinel for a missing or invalid span.
+fn valid_position(line: usize, column: usize) -> (Option<usize>, Option<usize>) {
+    if line == 0 { (None, None) } else { (Some(line), Some(column)) }
+}
+
+pub fn format_diagnostics_json(diagnostics: &[Diagnostic]) -> String {
+    let entries: Vec<JsonDiagnostic<'_>> = diagnostics
+        .iter()
+        .map(|d| {
+            let (start_line, start_col) = d.line_column();
+            let (end_line_raw, end_col_raw) =
+                diagnostic_end_line_column_with_format(d, ByteFormat::Utf8);
+            let (line, column) = valid_position(start_line, start_col);
+            let (end_line, end_column) = valid_position(end_line_raw, end_col_raw);
+            JsonDiagnostic {
+                file: d.source_file().map(|p| p.to_string_lossy()),
+                line,
+                column,
+                end_line,
+                end_column,
+                level: level_str(d.level()),
+                message: d.message(),
+            }
+        })
+        .collect();
+    serde_json::to_string_pretty(&entries).expect("serializing diagnostics")
+}

--- a/tools/viewer/screenshot.rs
+++ b/tools/viewer/screenshot.rs
@@ -53,12 +53,12 @@ pub fn take_screenshot(args: &Cli) -> Result<()> {
 
     let compiler = init_compiler(args);
     let result = poll_ready(compiler.build_from_path(args.path()));
-    result.print_diagnostics();
+    crate::print_diagnostics::print_diagnostics(&result, args.diagnostics_format);
     if result.has_errors() {
-        std::process::exit(-1);
+        std::process::exit(1);
     }
     let Some(c) = extract_component(&result, args) else {
-        std::process::exit(-1);
+        std::process::exit(1);
     };
 
     let component = c.create()?;

--- a/tools/viewer/tests/cli.rs
+++ b/tools/viewer/tests/cli.rs
@@ -126,7 +126,7 @@ fn syntax_error_is_reported() {
     let out = tmp.path().join("out.png");
     let (code, _stdout, stderr) =
         run(&["--screenshot", out.to_str().unwrap(), f.path().to_str().unwrap()]);
-    assert_eq!(code, COMPILE_ERROR_EXIT);
+    assert_eq!(code, 1);
     assert!(stderr.contains("Parse error"), "stderr was:\n{stderr}");
     assert!(!out.exists(), "screenshot file should not have been written");
 }
@@ -138,7 +138,7 @@ fn file_with_no_component_is_reported() {
     let out = tmp.path().join("out.png");
     let (code, _stdout, stderr) =
         run(&["--screenshot", out.to_str().unwrap(), f.path().to_str().unwrap()]);
-    assert_eq!(code, COMPILE_ERROR_EXIT);
+    assert_eq!(code, 1);
     assert!(stderr.contains("No component found"), "stderr was:\n{stderr}");
     assert!(!out.exists(), "screenshot file should not have been written");
 }
@@ -180,6 +180,116 @@ fn check_conflicts_with_screenshot() {
         run(&["--check", "--screenshot", out.to_str().unwrap(), f.path().to_str().unwrap()]);
     assert_eq!(code, 2);
     assert!(stderr.contains("--check") && stderr.contains("--screenshot"), "stderr was:\n{stderr}");
+}
+
+// --- JSON diagnostics format -------------------------------------------
+
+#[test]
+fn check_json_error_is_valid_json() {
+    let f = write_slint("export component Bad { Text { letter-spacing: 1em; } }\n");
+    let (code, stdout, _stderr) =
+        run(&["--check", "--diagnostics-format", "json", f.path().to_str().unwrap()]);
+    assert_eq!(code, 1);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is JSON");
+    let array = parsed.as_array().expect("top-level is an array");
+    assert_eq!(array.len(), 1);
+    let entry = &array[0];
+    assert_eq!(entry["level"], "error");
+    assert!(entry["message"].as_str().unwrap().contains("Invalid unit 'em'"));
+    assert!(entry["line"].as_u64().unwrap() >= 1);
+    assert!(entry["column"].as_u64().unwrap() >= 1);
+    assert_eq!(entry["file"].as_str().unwrap(), f.path().to_str().unwrap());
+}
+
+#[test]
+fn check_json_valid_file_is_empty_array() {
+    let f = write_slint("export component Ok { Text { text: \"hi\"; } }\n");
+    let (code, stdout, stderr) =
+        run(&["--check", "--diagnostics-format", "json", f.path().to_str().unwrap()]);
+    assert_eq!(code, 0, "stderr was:\n{stderr}");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is JSON");
+    assert!(parsed.as_array().unwrap().is_empty());
+}
+
+#[test]
+fn check_warning_only_exits_zero() {
+    let f = write_slint("export Test := Rectangle { background: blue; }\n");
+    let (code, stdout, _stderr) =
+        run(&["--check", "--diagnostics-format", "json", f.path().to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is JSON");
+    let array = parsed.as_array().unwrap();
+    assert_eq!(array.len(), 1);
+    assert_eq!(array[0]["level"], "warning");
+}
+
+#[test]
+fn diagnostics_format_json_applies_on_screenshot_errors() {
+    let f = write_slint("export component Bad { Text { letter-spacing: 1em; } }\n");
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("out.png");
+    let (code, stdout, _stderr) = run(&[
+        "--screenshot",
+        out.to_str().unwrap(),
+        "--diagnostics-format",
+        "json",
+        f.path().to_str().unwrap(),
+    ]);
+    assert_eq!(code, 1);
+    assert!(!out.exists(), "screenshot should not be written on error");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is JSON");
+    assert_eq!(parsed.as_array().unwrap()[0]["level"], "error");
+}
+
+#[test]
+fn diagnostics_format_json_applies_on_run_path_errors() {
+    // Without `--check`, the viewer still prints diagnostics for compilation
+    // errors before attempting to run, and `--diagnostics-format json`
+    // controls how they're emitted.
+    let f = write_slint("export component Bad { Text { letter-spacing: 1em; } }\n");
+    let (code, stdout, _stderr) =
+        run(&["--diagnostics-format", "json", f.path().to_str().unwrap()]);
+    assert_eq!(code, COMPILE_ERROR_EXIT);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is JSON");
+    let array = parsed.as_array().expect("top-level is an array");
+    assert_eq!(array.len(), 1);
+    assert_eq!(array[0]["level"], "error");
+}
+
+#[test]
+fn json_conflicts_with_auto_reload() {
+    let f = write_slint("export component Ok { }\n");
+    let (code, _stdout, stderr) =
+        run(&["--auto-reload", "--diagnostics-format", "json", f.path().to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("--diagnostics-format json") && stderr.contains("--auto-reload"),
+        "stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn json_conflicts_with_screenshot_stdout() {
+    let f = write_slint("export component Ok { }\n");
+    let (code, _stdout, stderr) =
+        run(&["--screenshot", "-", "--diagnostics-format", "json", f.path().to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("--diagnostics-format json") && stderr.contains("--screenshot -"),
+        "stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn json_conflicts_with_save_data_stdout() {
+    let f = write_slint("export component Ok { }\n");
+    let (code, _stdout, stderr) =
+        run(&["--save-data", "-", "--diagnostics-format", "json", f.path().to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("--diagnostics-format json") && stderr.contains("--save-data -"),
+        "stderr was:\n{stderr}"
+    );
 }
 
 // --- Screenshot rendering ----------------------------------------------

--- a/tools/viewer/tests/cli.rs
+++ b/tools/viewer/tests/cli.rs
@@ -9,6 +9,10 @@ use std::process::Command;
 
 const BIN: &str = env!("CARGO_BIN_EXE_slint-viewer");
 
+/// Exit code returned by the plain run path on compile failure. `exit(-1)`
+/// surfaces as `-1` on Windows and as `255` (the low byte) on Unix.
+const COMPILE_ERROR_EXIT: i32 = if cfg!(windows) { -1 } else { 255 };
+
 fn run(args: &[&str]) -> (i32, String, String) {
     let out = Command::new(BIN).args(args).output().expect("failed to spawn slint-viewer");
     (
@@ -30,7 +34,7 @@ fn write_slint(content: &str) -> tempfile::NamedTempFile {
 #[test]
 fn unknown_argument_is_rejected() {
     let (code, _stdout, stderr) = run(&["--definitely-not-a-real-flag"]);
-    assert_ne!(code, 0);
+    assert_eq!(code, 2);
     assert!(
         stderr.contains("unexpected argument") || stderr.contains("unrecognized"),
         "stderr was:\n{stderr}"
@@ -40,7 +44,7 @@ fn unknown_argument_is_rejected() {
 #[test]
 fn missing_value_for_screenshot() {
     let (code, _stdout, stderr) = run(&["--screenshot"]);
-    assert_ne!(code, 0);
+    assert_eq!(code, 2);
     assert!(stderr.contains("a value is required"), "stderr was:\n{stderr}");
 }
 
@@ -48,7 +52,7 @@ fn missing_value_for_screenshot() {
 fn missing_path_argument() {
     // Without `--remote`, a path is required.
     let (code, _stdout, stderr) = run(&[]);
-    assert_ne!(code, 0);
+    assert_eq!(code, 2);
     assert!(stderr.contains("required") || stderr.contains("Usage"), "stderr was:\n{stderr}");
 }
 
@@ -58,7 +62,7 @@ fn screenshot_and_auto_reload_conflict() {
     let out = tmp.path().join("out.png");
     let (code, _stdout, stderr) =
         run(&["--screenshot", out.to_str().unwrap(), "--auto-reload", "x.slint"]);
-    assert_ne!(code, 0);
+    assert_eq!(code, 2);
     assert!(
         stderr.contains("Cannot pass both --auto-reload and --screenshot"),
         "stderr was:\n{stderr}"
@@ -72,7 +76,7 @@ fn screenshot_and_save_data_conflict() {
     let out = tmp.path().join("out.png");
     let (code, _stdout, stderr) =
         run(&["--screenshot", out.to_str().unwrap(), "--save-data", "x.json", "x.slint"]);
-    assert_ne!(code, 0);
+    assert_eq!(code, 2);
     assert!(
         stderr.contains("Cannot pass both --save-data and --screenshot"),
         "stderr was:\n{stderr}"
@@ -86,7 +90,7 @@ fn screenshot_and_remote_conflict() {
     let tmp = tempfile::tempdir().unwrap();
     let out = tmp.path().join("out.png");
     let (code, _stdout, stderr) = run(&["--screenshot", out.to_str().unwrap(), "--remote"]);
-    assert_ne!(code, 0);
+    assert_eq!(code, 2);
     assert!(stderr.contains("Cannot pass both --remote and --screenshot"), "stderr was:\n{stderr}");
     assert!(!out.exists(), "screenshot file should not have been written");
 }
@@ -94,7 +98,7 @@ fn screenshot_and_remote_conflict() {
 #[test]
 fn auto_reload_and_save_data_conflict() {
     let (code, _stdout, stderr) = run(&["--auto-reload", "--save-data", "x.json", "x.slint"]);
-    assert_ne!(code, 0);
+    assert_eq!(code, 2);
     assert!(
         stderr.contains("Cannot pass both --auto-reload and --save-data"),
         "stderr was:\n{stderr}"
@@ -108,7 +112,7 @@ fn nonexistent_file_is_reported() {
     let tmp = tempfile::tempdir().unwrap();
     let missing = tmp.path().join("does_not_exist.slint");
     let (code, _stdout, stderr) = run(&[missing.to_str().unwrap()]);
-    assert_ne!(code, 0);
+    assert_eq!(code, COMPILE_ERROR_EXIT);
     assert!(
         stderr.contains("Could not load") || stderr.contains("No such file"),
         "stderr was:\n{stderr}"
@@ -122,7 +126,7 @@ fn syntax_error_is_reported() {
     let out = tmp.path().join("out.png");
     let (code, _stdout, stderr) =
         run(&["--screenshot", out.to_str().unwrap(), f.path().to_str().unwrap()]);
-    assert_ne!(code, 0);
+    assert_eq!(code, COMPILE_ERROR_EXIT);
     assert!(stderr.contains("Parse error"), "stderr was:\n{stderr}");
     assert!(!out.exists(), "screenshot file should not have been written");
 }
@@ -134,7 +138,7 @@ fn file_with_no_component_is_reported() {
     let out = tmp.path().join("out.png");
     let (code, _stdout, stderr) =
         run(&["--screenshot", out.to_str().unwrap(), f.path().to_str().unwrap()]);
-    assert_ne!(code, 0);
+    assert_eq!(code, COMPILE_ERROR_EXIT);
     assert!(stderr.contains("No component found"), "stderr was:\n{stderr}");
     assert!(!out.exists(), "screenshot file should not have been written");
 }

--- a/tools/viewer/tests/cli.rs
+++ b/tools/viewer/tests/cli.rs
@@ -143,6 +143,45 @@ fn file_with_no_component_is_reported() {
     assert!(!out.exists(), "screenshot file should not have been written");
 }
 
+// --- Check mode --------------------------------------------------------
+
+#[test]
+fn check_valid_file_exits_zero() {
+    let f = write_slint("export component Ok { Text { text: \"hi\"; } }\n");
+    let (code, _stdout, stderr) = run(&["--check", f.path().to_str().unwrap()]);
+    assert_eq!(code, 0, "stderr was:\n{stderr}");
+}
+
+#[test]
+fn check_syntax_error_exits_one() {
+    let f = write_slint("export component Bad { Text { letter-spacing: 1em; } }\n");
+    let (code, _stdout, stderr) = run(&["--check", f.path().to_str().unwrap()]);
+    assert_eq!(code, 1, "stderr was:\n{stderr}");
+    assert!(stderr.contains("Invalid unit 'em'"), "stderr was:\n{stderr}");
+}
+
+#[test]
+fn check_conflicts_with_auto_reload() {
+    let f = write_slint("export component Ok { }\n");
+    let (code, _stdout, stderr) = run(&["--check", "--auto-reload", f.path().to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(
+        stderr.contains("--check") && stderr.contains("--auto-reload"),
+        "stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn check_conflicts_with_screenshot() {
+    let f = write_slint("export component Ok { }\n");
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("out.png");
+    let (code, _stdout, stderr) =
+        run(&["--check", "--screenshot", out.to_str().unwrap(), f.path().to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("--check") && stderr.contains("--screenshot"), "stderr was:\n{stderr}");
+}
+
 // --- Screenshot rendering ----------------------------------------------
 
 // Cases known to produce the same RGB output as their reference under both


### PR DESCRIPTION
The viewer can now validate `.slint` files without opening a window:

  * `--check` compiles the file, prints any diagnostics, and exits.
    Status `1` on errors, `0` otherwise.
  * `--diagnostics-format json` prints diagnostics as a single JSON array on
    stdout, suitable for scripts and AI agents. Works with `--check` and
    with `--screenshot`. 
    (default is `human`)

  Useful when you want quick static feedback on a `.slint` file from a
  script or coding agent, without launching the LSP or running a full
  `cargo build`.

  Example:  

  ```sh
  slint-viewer --check --diagnostics-format json ui/main.slint                                                                               

  [
    {                                                                                                                                        
      "file": "ui/main.slint",
      "line": 12,
      "column": 5,
      "end_line": 12,
      "end_column": 8,
      "level": "error",
      "message": "Invalid unit 'em'. Valid units are: %, phx, px, ..."
    }
  ]
  ```
                            
  Exit code changes:

  - Invalid argument combinations now exit 2 (matching clap and the
  README, was inconsistent).
  - --screenshot exits 1 on compile failure (was -1), matching                                                                               
  --check. The plain run path still exits -1.

