### PR TITLE
Improved API for the logging hook

### DIFF
--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -113,7 +113,11 @@ pub fn set_callback_handler<
 }
 
 pub fn debug(s: SharedString) {
-    i_slint_core::debug_log!("{s}");
+    i_slint_core::debug_log::log_message(i_slint_core::debug_log::LogMessage::new(
+        i_slint_core::debug_log::LogMessageSource::SlintCode,
+        None,
+        format_args!("{s}"),
+    ));
 }
 
 pub fn ensure_backend() -> Result<(), crate::PlatformError> {

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -243,7 +243,7 @@ impl i_slint_core::platform::Platform for TestingBackend {
 
     fn debug_log(&self, arguments: core::fmt::Arguments) {
         self.debug_logs.borrow_mut().push(arguments.to_string());
-        i_slint_core::debug_log::default_debug_log(arguments);
+        i_slint_core::debug_log::default_log_message(arguments);
     }
 }
 

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -89,7 +89,7 @@ pub(crate) struct SlintContextInner {
     pub(crate) window_shown_hook:
         core::cell::RefCell<Option<Box<dyn FnMut(&Rc<dyn crate::platform::WindowAdapter>)>>>,
     pub(crate) window_event_hook: core::cell::RefCell<Option<WindowEventHook>>,
-    pub(crate) debug_handler: RefCell<Option<crate::debug_log::DebugLogHandler>>,
+    pub(crate) log_message_handler: RefCell<Option<crate::debug_log::LogMessageHandler>>,
     #[cfg(all(unix, not(target_os = "macos")))]
     xdg_app_id: core::cell::RefCell<Option<crate::SharedString>>,
     #[cfg(feature = "shared-parley")]
@@ -132,7 +132,7 @@ impl SlintContext {
             ),
             window_shown_hook: Default::default(),
             window_event_hook: Default::default(),
-            debug_handler: Default::default(),
+            log_message_handler: Default::default(),
             #[cfg(all(unix, not(target_os = "macos")))]
             xdg_app_id: Default::default(),
             #[cfg(feature = "shared-parley")]
@@ -240,24 +240,20 @@ impl SlintContext {
     }
 
     #[doc(hidden)]
-    pub fn dispatch_debug_log(
-        &self,
-        location: Option<&crate::debug_log::DebugLogLocation>,
-        arguments: core::fmt::Arguments<'_>,
-    ) {
-        if let Some(handler) = self.0.debug_handler.borrow().as_ref() {
-            handler(location, arguments);
+    pub fn dispatch_log_message(&self, message: crate::debug_log::LogMessage<'_>) {
+        if let Some(handler) = self.0.log_message_handler.borrow().as_ref() {
+            handler(message);
         } else {
-            self.0.platform.debug_log(arguments);
+            self.0.platform.debug_log(message.message_arguments());
         }
     }
 
     #[doc(hidden)]
-    pub fn set_debug_handler(
+    pub fn set_log_message_handler(
         &self,
-        handler: Option<crate::debug_log::DebugLogHandler>,
-    ) -> Option<crate::debug_log::DebugLogHandler> {
-        let mut slot = self.0.debug_handler.borrow_mut();
+        handler: Option<crate::debug_log::LogMessageHandler>,
+    ) -> Option<crate::debug_log::LogMessageHandler> {
+        let mut slot = self.0.log_message_handler.borrow_mut();
         core::mem::replace(&mut *slot, handler)
     }
 

--- a/internal/core/debug_log.rs
+++ b/internal/core/debug_log.rs
@@ -1,13 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use crate::SharedString;
-
 /// Location information attached to a log message.
 #[derive(Clone, Debug)]
-pub struct LogMessageLocation {
+pub struct LogMessageLocation<'a> {
     /// The file path of the source that emitted the log message
-    pub path: SharedString,
+    pub path: &'a str,
     /// the line number of the call that emitted the log message (1-based)
     pub line: usize,
     /// The column of the call that emitted the log message (1-based)
@@ -28,14 +26,14 @@ pub enum LogMessageSource {
 /// Opaque log message, emitted by [`crate::debug_log!`] as well as the Slint `debug()` function.
 pub struct LogMessage<'a> {
     source: LogMessageSource,
-    location: Option<&'a LogMessageLocation>,
+    location: Option<LogMessageLocation<'a>>,
     arguments: core::fmt::Arguments<'a>,
 }
 
 impl<'a> LogMessage<'a> {
     pub fn new(
         source: LogMessageSource,
-        location: Option<&'a LogMessageLocation>,
+        location: Option<LogMessageLocation<'a>>,
         arguments: core::fmt::Arguments<'a>,
     ) -> Self {
         Self { source, location, arguments }
@@ -45,8 +43,8 @@ impl<'a> LogMessage<'a> {
         self.source
     }
 
-    pub fn location(&self) -> Option<&LogMessageLocation> {
-        self.location
+    pub fn location(&self) -> Option<LogMessageLocation<'_>> {
+        self.location.clone()
     }
 
     pub fn message_arguments(&self) -> core::fmt::Arguments<'a> {
@@ -99,11 +97,7 @@ macro_rules! debug_log {
     ($($t:tt)*) => ($crate::debug_log::log_message(
         $crate::debug_log::LogMessage::new(
             $crate::debug_log::LogMessageSource::Runtime,
-            Some(&$crate::debug_log::LogMessageLocation {
-                path: ::core::file!().into(),
-                line: ::core::line!() as usize,
-                column: ::core::column!() as usize,
-            }),
+            None,
             format_args!($($t)*),
         )
     ))

--- a/internal/core/debug_log.rs
+++ b/internal/core/debug_log.rs
@@ -3,38 +3,70 @@
 
 use crate::SharedString;
 
-/// Location information attached to a debug message.
+/// Location information attached to a log message.
 #[derive(Clone, Debug)]
-pub struct DebugLogLocation {
+pub struct LogMessageLocation {
+    /// The file path of the source that emitted the log message
     pub path: SharedString,
+    /// the line number of the call that emitted the log message (1-based)
     pub line: usize,
+    /// The column of the call that emitted the log message (1-based)
     pub column: usize,
 }
 
-/// Debug handler type stored in a [`crate::SlintContext`].
-pub type DebugLogHandler = alloc::boxed::Box<
-    dyn for<'a> Fn(Option<&DebugLogLocation>, core::fmt::Arguments<'a>) + 'static,
->;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum LogMessageSource {
+    /// The message originates from Slint source code (e.g. the `debug()` function in Slint)
+    SlintCode,
+    /// The message originates from the Slint runtime crates
+    ///
+    /// For example if a file path could not be resolved at runtime.
+    Runtime,
+}
 
-/// implementation details for debug_log()
+/// Opaque log message, emitted by [`crate::debug_log!`] as well as the Slint `debug()` function.
+pub struct LogMessage<'a> {
+    source: LogMessageSource,
+    location: Option<&'a LogMessageLocation>,
+    arguments: core::fmt::Arguments<'a>,
+}
+
+impl<'a> LogMessage<'a> {
+    pub fn new(
+        source: LogMessageSource,
+        location: Option<&'a LogMessageLocation>,
+        arguments: core::fmt::Arguments<'a>,
+    ) -> Self {
+        Self { source, location, arguments }
+    }
+
+    pub fn source(&self) -> LogMessageSource {
+        self.source
+    }
+
+    pub fn location(&self) -> Option<&LogMessageLocation> {
+        self.location
+    }
+
+    pub fn message_arguments(&self) -> core::fmt::Arguments<'a> {
+        self.arguments
+    }
+}
+
+/// Log message handler type stored in a [`crate::SlintContext`].
+pub type LogMessageHandler = alloc::boxed::Box<dyn for<'a> Fn(LogMessage<'a>) + 'static>;
+
 #[doc(hidden)]
-pub fn debug_log_impl(args: core::fmt::Arguments) {
+pub fn log_message(message: LogMessage) {
     crate::context::GLOBAL_CONTEXT.with(|p| match p.get() {
-        Some(ctx) => ctx.dispatch_debug_log(None, args),
-        None => default_debug_log(args),
+        Some(ctx) => ctx.dispatch_log_message(message),
+        None => default_log_message(message.arguments),
     });
 }
 
 #[doc(hidden)]
-pub fn debug_log_with_location(location: Option<&DebugLogLocation>, args: core::fmt::Arguments) {
-    crate::context::GLOBAL_CONTEXT.with(|p| match p.get() {
-        Some(ctx) => ctx.dispatch_debug_log(location, args),
-        None => default_debug_log(args),
-    });
-}
-
-#[doc(hidden)]
-pub fn default_debug_log(_arguments: core::fmt::Arguments) {
+pub fn default_log_message(_arguments: core::fmt::Arguments) {
     cfg_if::cfg_if! {
         if #[cfg(feature = "log")] {
             log::debug!("{_arguments}");
@@ -64,5 +96,15 @@ pub fn default_debug_log(_arguments: core::fmt::Arguments) {
 /// This macro allows producing debug output that will appear on stderr in regular builds
 /// and in the console log for wasm builds.
 macro_rules! debug_log {
-    ($($t:tt)*) => ($crate::debug_log::debug_log_impl(format_args!($($t)*)))
+    ($($t:tt)*) => ($crate::debug_log::log_message(
+        $crate::debug_log::LogMessage::new(
+            $crate::debug_log::LogMessageSource::Runtime,
+            Some(&$crate::debug_log::LogMessageLocation {
+                path: ::core::file!().into(),
+                line: ::core::line!() as usize,
+                column: ::core::column!() as usize,
+            }),
+            format_args!($($t)*),
+        )
+    ))
 }

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -150,7 +150,7 @@ pub trait Platform {
     /// should direct the output to some developer visible terminal. The default implementation
     /// uses stderr if available, or `console.log` when targeting wasm.
     fn debug_log(&self, _arguments: core::fmt::Arguments) {
-        crate::debug_log::default_debug_log(_arguments);
+        crate::debug_log::default_log_message(_arguments);
     }
 
     /// Opens the given URL in an external browser.

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -734,6 +734,8 @@ fn call_builtin_function(
             Value::Number(i_slint_core::animations::animation_tick() as f64)
         }
         BuiltinFunction::Debug => {
+            use corelib::debug_log::*;
+
             let to_print: SharedString =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
             let location = source_location.as_ref().and_then(|location| {
@@ -742,7 +744,7 @@ fn call_builtin_function(
                         location.span.offset,
                         i_slint_compiler::diagnostics::ByteFormat::Utf8,
                     );
-                    corelib::debug_log::DebugLogLocation {
+                    LogMessageLocation {
                         path: file.path().to_string_lossy().to_shared_string(),
                         line,
                         column,
@@ -754,12 +756,17 @@ fn call_builtin_function(
             if let Some(root) = root_weak.upgrade()
                 && let Some(ctx) = corelib::window::context_for_root(&root)
             {
-                ctx.dispatch_debug_log(location.as_ref(), format_args!("{to_print}"));
-            } else {
-                corelib::debug_log::debug_log_with_location(
+                ctx.dispatch_log_message(LogMessage::new(
+                    LogMessageSource::SlintCode,
                     location.as_ref(),
                     format_args!("{to_print}"),
-                );
+                ));
+            } else {
+                log_message(LogMessage::new(
+                    corelib::debug_log::LogMessageSource::SlintCode,
+                    location.as_ref(),
+                    format_args!("{to_print}"),
+                ));
             }
             Value::Void
         }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -744,12 +744,14 @@ fn call_builtin_function(
                         location.span.offset,
                         i_slint_compiler::diagnostics::ByteFormat::Utf8,
                     );
-                    LogMessageLocation {
-                        path: file.path().to_string_lossy().to_shared_string(),
-                        line,
-                        column,
-                    }
+                    let path = file.path().to_string_lossy();
+                    (line, column, path)
                 })
+            });
+            let location = location.as_ref().map(|(line, column, path)| LogMessageLocation {
+                path,
+                line: *line,
+                column: *column,
             });
             let root_weak =
                 vtable::VWeak::into_dyn(local_context.component_instance.root_weak().clone());
@@ -758,13 +760,13 @@ fn call_builtin_function(
             {
                 ctx.dispatch_log_message(LogMessage::new(
                     LogMessageSource::SlintCode,
-                    location.as_ref(),
+                    location,
                     format_args!("{to_print}"),
                 ));
             } else {
                 log_message(LogMessage::new(
-                    corelib::debug_log::LogMessageSource::SlintCode,
-                    location.as_ref(),
+                    LogMessageSource::SlintCode,
+                    location,
                     format_args!("{to_print}"),
                 ));
             }

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -3,10 +3,11 @@
 
 use i_slint_core::api::ComponentHandle;
 
-fn set_global_debug_handler(
-    handler: Option<i_slint_core::debug_log::DebugLogHandler>,
-) -> Option<i_slint_core::debug_log::DebugLogHandler> {
-    i_slint_backend_selector::with_global_context(|ctx| ctx.set_debug_handler(handler)).unwrap()
+fn set_global_log_message_handler(
+    handler: Option<i_slint_core::debug_log::LogMessageHandler>,
+) -> Option<i_slint_core::debug_log::LogMessageHandler> {
+    i_slint_backend_selector::with_global_context(|ctx| ctx.set_log_message_handler(handler))
+        .unwrap()
 }
 
 #[test]
@@ -60,11 +61,10 @@ fn context_debug_handler_overrides_platform() {
     use std::rc::Rc;
 
     let captured = Rc::new(RefCell::new(Vec::new()));
-    let previous = set_global_debug_handler(Some(Box::new({
+    let previous = set_global_log_message_handler(Some(Box::new({
         let captured = captured.clone();
-        move |_location: Option<&i_slint_core::debug_log::DebugLogLocation>,
-              arguments: core::fmt::Arguments<'_>| {
-            captured.borrow_mut().push(arguments.to_string());
+        move |message: i_slint_core::debug_log::LogMessage<'_>| {
+            captured.borrow_mut().push(message.message_arguments().to_string());
         }
     })));
 
@@ -89,7 +89,7 @@ fn context_debug_handler_overrides_platform() {
         .is_empty()
     );
 
-    set_global_debug_handler(previous);
+    set_global_log_message_handler(previous);
 }
 
 #[test]
@@ -126,11 +126,10 @@ fn global_debug_messages_use_context_handler() {
     use std::rc::Rc;
 
     let captured = Rc::new(RefCell::new(Vec::new()));
-    let previous = set_global_debug_handler(Some(Box::new({
+    let previous = set_global_log_message_handler(Some(Box::new({
         let captured = captured.clone();
-        move |_location: Option<&i_slint_core::debug_log::DebugLogLocation>,
-              arguments: core::fmt::Arguments<'_>| {
-            captured.borrow_mut().push(arguments.to_string());
+        move |message: i_slint_core::debug_log::LogMessage<'_>| {
+            captured.borrow_mut().push(message.message_arguments().to_string());
         }
     })));
 
@@ -164,7 +163,7 @@ fn global_debug_messages_use_context_handler() {
         .is_empty()
     );
 
-    set_global_debug_handler(previous);
+    set_global_log_message_handler(previous);
 }
 
 #[test]

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -116,9 +116,9 @@ pub trait PreviewToLsp {
     }
 }
 
-/// Converts a debug message from the preview to a string to be logged by the LSP
+/// Converts a log message from the preview to a string to be logged by the LSP
 #[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
-pub fn preview_debug_message_to_string(
+pub fn preview_log_message_to_string(
     location: &Option<(std::path::PathBuf, usize, usize)>,
     message: &str,
 ) -> String {

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -95,8 +95,13 @@ pub trait PreviewToLsp {
         selection: lsp_types::Range,
         take_focus: bool,
     ) -> Result<()> {
-        let file = lsp_types::Url::from_file_path(file)
-            .map_err(|_| "Failed to convert URL".to_string())?;
+        let file = match lsp_types::Url::from_file_path(file) {
+            Ok(file) => file,
+            Err(()) => {
+                tracing::error!("Failed to convert file path to URL for ShowDocument: {file}");
+                return Err("Failed to convert file path to URL".to_string().into());
+            }
+        };
         if selection.start.character == 0 || selection.end.character == 0 {
             return Ok(());
         }
@@ -112,7 +117,11 @@ pub trait PreviewToLsp {
             }
             object
         };
-        self.send(&PreviewToLspMessage::TelemetryEvent(object))
+        if let Err(err) = self.send(&PreviewToLspMessage::TelemetryEvent(object)) {
+            tracing::error!("Failed to send telemetry event: {err}");
+            return Err(err);
+        }
+        Ok(())
     }
 }
 

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -399,7 +399,7 @@ fn handle_preview_message(msg: PreviewToLspMessage, ctx: &language::Context) {
             };
         }
         DebugMessage { location, message } => {
-            eprintln!("{}", common::preview_debug_message_to_string(location, message));
+            eprintln!("{}", common::preview_log_message_to_string(location, message));
         }
 
         Diagnostics { .. }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -714,7 +714,7 @@ async fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Conte
             )?
         }
         M::DebugMessage { location, message } => {
-            eprintln!("{}", common::preview_debug_message_to_string(&location, &message));
+            eprintln!("{}", common::preview_log_message_to_string(&location, &message));
         }
         M::ConnectRemote { addresses, port } => {
             tracing::debug!("Preview asked to connect remote at {addresses:?}:{port}");

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -23,7 +23,7 @@ use i_slint_live_preview::protocol::{
     PreviewComponent, PreviewConfig, PreviewToLspMessage, SourceFileVersion, VersionedUrl,
 };
 use lsp_types::Url;
-use slint::{PlatformError, SharedString};
+use slint::{PlatformError, SharedString, ToSharedString};
 use slint_interpreter::{ComponentDefinition, ComponentHandle, ComponentInstance};
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
@@ -1575,23 +1575,28 @@ fn set_preview_factory(
         .context()
         .set_log_message_handler(Some(Box::new(|log_message| {
             let message = log_message.message_arguments().to_string();
-            let location = log_message
-                .location()
-                .map(|location| (location.path.clone(), location.line, location.column));
+            let location = log_message.location();
             PREVIEW_STATE.with_borrow_mut(|state| {
                 let to_lsp = state.to_lsp.try_borrow();
                 let Some(to_lsp) = to_lsp.ok() else { return };
                 if let Some(to_lsp) = &*to_lsp {
                     to_lsp
                         .send(&PreviewToLspMessage::DebugMessage {
-                            location: location.as_ref().map(|(path, line, column)| {
-                                (std::path::PathBuf::from(path.as_str()), *line, *column)
+                            location: location.as_ref().map(|location| {
+                                (
+                                    std::path::PathBuf::from(location.path),
+                                    location.line,
+                                    location.column,
+                                )
                             }),
                             message: message.clone(),
                         })
                         .ok();
                 }
             });
+            let location = location
+                .as_ref()
+                .map(|location| (location.path.to_shared_string(), location.line, location.column));
             let _ = slint::invoke_from_event_loop(move || {
                 PREVIEW_STATE.with_borrow(|preview_state| {
                     if let Some(api) = preview_state.api.upgrade() {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -63,7 +63,7 @@ pub fn run(
             "type".to_string(),
             serde_json::to_value("preview_opened").unwrap(),
         )])
-        .unwrap();
+        .ok();
     app_window.window().set_fullscreen(fullscreen);
 
     tracing::debug!("Preview: requesting state from LSP");
@@ -573,7 +573,7 @@ fn set_code_binding(
         "type".to_string(),
         serde_json::to_value("property_changed").unwrap(),
     )])
-    .unwrap();
+    .ok();
 
     set_binding(
         element_url,
@@ -690,7 +690,7 @@ fn show_component(name: slint::SharedString, url: slint::SharedString) {
         lsp_types::Range::new(start, start),
         false,
     )
-    .unwrap();
+    .ok();
 }
 
 fn show_document_offset_range(url: slint::SharedString, start: i32, end: i32, take_focus: bool) {
@@ -730,7 +730,7 @@ fn show_document_offset_range(url: slint::SharedString, start: i32, end: i32, ta
             lsp_types::Range::new(s, e),
             take_focus,
         )
-        .unwrap();
+        .ok();
     }
 }
 
@@ -1378,7 +1378,7 @@ async fn reload_timer_function() {
                 lsp_types::Range::new(pos, pos),
                 false,
             )
-            .unwrap();
+            .ok();
         }
     }
 }
@@ -1877,7 +1877,7 @@ fn set_selected_element(
             lsp_types::Range::new(pos, pos),
             false,
         )
-        .unwrap();
+        .ok();
     }
 }
 

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1573,10 +1573,11 @@ fn set_preview_factory(
 
     let _ = i_slint_core::window::WindowInner::from_pub(app_window.window())
         .context()
-        .set_debug_handler(Some(Box::new(|location, arguments| {
-            let message = arguments.to_string();
-            let location =
-                location.map(|location| (location.path.clone(), location.line, location.column));
+        .set_log_message_handler(Some(Box::new(|log_message| {
+            let message = log_message.message_arguments().to_string();
+            let location = log_message
+                .location()
+                .map(|location| (location.path.clone(), location.line, location.column));
             PREVIEW_STATE.with_borrow_mut(|state| {
                 let to_lsp = state.to_lsp.try_borrow();
                 let Some(to_lsp) = to_lsp.ok() else { return };

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -174,9 +174,7 @@ fn select_element_node(
 
     if let Some(document_position) = lsp_element_node_position(selected_element, format) {
         let to_lsp = preview::PREVIEW_STATE.with_borrow(|ps| ps.to_lsp.borrow().clone().unwrap());
-        to_lsp
-            .ask_editor_to_show_document(&document_position.0, document_position.1, false)
-            .unwrap();
+        to_lsp.ask_editor_to_show_document(&document_position.0, document_position.1, false).ok();
     }
 }
 

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -144,7 +144,7 @@ pub fn create_ui(
     api.on_show_document(move |file, line, column| {
         use lsp_types::{Position, Range};
         let pos = Position::new((line as u32).saturating_sub(1), (column as u32).saturating_sub(1));
-        lsp.ask_editor_to_show_document(&file, Range::new(pos, pos), false).unwrap();
+        lsp.ask_editor_to_show_document(&file, Range::new(pos, pos), false).ok();
     });
     api.on_show_document_offset_range(super::show_document_offset_range);
     api.on_show_preview_for(super::show_preview_for);
@@ -190,7 +190,7 @@ pub fn create_ui(
             "type".to_string(),
             serde_json::to_value("component_dropped").unwrap(),
         )])
-        .unwrap();
+        .ok();
         super::drop_component(data, x, y)
     });
     api.on_selected_element_resize(super::resize_selected_element);
@@ -217,7 +217,7 @@ pub fn create_ui(
                 "type".to_string(),
                 serde_json::to_value("data_json_changed").unwrap(),
             )])
-            .unwrap();
+            .ok();
         }
         set_json_preview_data(container, property_name, json_string)
     });

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -385,7 +385,7 @@ impl SlintServer {
                     );
             }
             M::DebugMessage { location, message } => {
-                log(&common::preview_debug_message_to_string(&location, &message));
+                log(&common::preview_log_message_to_string(&location, &message));
             }
             M::ConnectRemote { .. } | M::DisconnectRemote => {
                 tracing::debug!("Ignoring remote-preview control message in WASM LSP");

--- a/tools/viewer/debug.rs
+++ b/tools/viewer/debug.rs
@@ -9,7 +9,7 @@ pub fn log_message_handler(
     let arguments = message.message_arguments();
     let location = message
         .location()
-        .map(|location| (PathBuf::from(location.path.as_str()), location.line, location.column));
+        .map(|location| (PathBuf::from(location.path), location.line, location.column));
     if let Some((file, line, column)) = &location {
         tracing::info!("DEBUG {file}:{line}:{column}> {arguments}", file = file.display());
     } else {

--- a/tools/viewer/debug.rs
+++ b/tools/viewer/debug.rs
@@ -3,11 +3,12 @@
 
 use std::path::PathBuf;
 
-pub fn debug_handler(
-    location: Option<&i_slint_core::debug_log::DebugLogLocation>,
-    arguments: core::fmt::Arguments,
+pub fn log_message_handler(
+    message: &i_slint_core::debug_log::LogMessage<'_>,
 ) -> Option<(PathBuf, usize, usize)> {
-    let location = location
+    let arguments = message.message_arguments();
+    let location = message
+        .location()
         .map(|location| (PathBuf::from(location.path.as_str()), location.line, location.column));
     if let Some((file, line, column)) = &location {
         tracing::info!("DEBUG {file}:{line}:{column}> {arguments}", file = file.display());

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -222,7 +222,7 @@ fn main() -> Result<()> {
 
     if args.auto_reload {
         select_backend(args.backend.as_deref())?;
-        install_debug_handler()?;
+        install_log_message_handler()?;
 
         let live = i_slint_live_preview::live_component::LiveReloadingComponent::new(
             compiler,
@@ -259,7 +259,7 @@ fn main() -> Result<()> {
         };
 
         select_backend(args.backend.as_deref())?;
-        install_debug_handler()?;
+        install_log_message_handler()?;
 
         let component = c.create()?;
         setup_instance(&component, &args.on, args.load_data.as_deref())?;
@@ -283,10 +283,10 @@ fn select_backend(backend: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn install_debug_handler() -> Result<()> {
+fn install_log_message_handler() -> Result<()> {
     let _ = i_slint_backend_selector::with_global_context(|ctx| {
-        ctx.set_debug_handler(Some(Box::new(move |location, arguments| {
-            debug::debug_handler(location, arguments);
+        ctx.set_log_message_handler(Some(Box::new(move |message| {
+            debug::log_message_handler(&message);
         })))
     })?;
     Ok(())

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -55,8 +55,8 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     // Slint Viewer itself only displays the previewed app, so it has no UI of its own to show debug messages in.
     let connection_weak = Rc::downgrade(&connection);
     let _ = i_slint_backend_selector::with_global_context(|ctx| {
-        ctx.set_debug_handler(Some(Box::new(move |location, arguments| {
-            let location = crate::debug::debug_handler(location, arguments);
+        ctx.set_log_message_handler(Some(Box::new(move |message| {
+            let location = crate::debug::log_message_handler(&message);
             let Some(connection) = connection_weak.upgrade() else {
                 return;
             };
@@ -64,7 +64,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
             connection
                 .send(PreviewToLspMessage::DebugMessage {
                     location,
-                    message: arguments.to_string(),
+                    message: message.message_arguments().to_string(),
                 })
                 .ok();
         })))


### PR DESCRIPTION
The hook is now no longer called the debug handler, but the log handler,
because it may also contain other kinds of log messages in the future.

It now also takes a log message as argument, which is an opaque type
that can contain more details about the log message. At the moment it
contains the location of the log message as a file path, as well as the
log message source, which identifies whether the message comes from
Slint code or from the runtime.

Note that the location for the debug log macro might now point to Slint
internal file paths, which may not be something we want.

Related to #3616

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
