### PR TITLE
docs: restore GFM tables in Starlight MDX pages

### DIFF
--- a/docs/common/src/utils/starlight-site-defaults.ts
+++ b/docs/common/src/utils/starlight-site-defaults.ts
@@ -8,11 +8,21 @@ import { rehypeExternalLinksSlint } from "./rehype-external-links-preset";
 export const SLINT_STARLIGHT_TRAILING_SLASH = "always" as const;
 
 /**
- * Default Astro `markdown.rehypePlugins` for Starlight sites (Slint external-link preset only).
- * Sites with extra rehype plugins should import {@link rehypeExternalLinksSlint} and compose locally.
+ * Default Astro `markdown` config for Starlight sites: the Slint external-link
+ * rehype preset plus GitHub-Flavored Markdown.
+ *
+ * `gfm` is set explicitly because once an Astro site provides a `markdown`
+ * object, the `@astrojs/mdx` pipeline no longer picks up the `gfm: true`
+ * default, which silently disables GFM tables (and the rest of GFM) inside
+ * `.mdx` pages. Keeping it here means every site that uses this helper renders
+ * markdown tables instead of raw `|`-delimited text.
+ *
+ * Sites with extra rehype plugins should import {@link rehypeExternalLinksSlint}
+ * and compose locally (and set `gfm: true` themselves).
  */
 export function slintStarlightMarkdownRehypeExternalLinksOnly() {
     return {
+        gfm: true,
         rehypePlugins: [rehypeExternalLinksSlint],
     };
 }


### PR DESCRIPTION
Setting a markdown config object stops @astrojs/mdx from applying the gfm: true default, which silently disabled tables in .mdx pages; the C++ and Python type mapping tables, for example, were misrendered as raw text. Set gfm explicitly.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
