### PR TITLE
Docs: fix type mapping tables

### DIFF
--- a/api/python/slint/README.md
+++ b/api/python/slint/README.md
@@ -213,28 +213,9 @@ singleton.
 
 ### Type Mappings
 
-Each type used for properties in the Slint Language translates to a specific type in Python. The following table summarizes
-the mapping:
-
-| `.slint` Type | Python Type | Notes |
-| ------------- | ----------- | ----- |
-| `int`         | `int`       |       |
-| `float`       | `float`     |       |
-| `bool`        | `bool`      |       |
-| `string`      | `str`       |       |
-| `color`       | `slint.Color` |     |
-| `brush`       | `slint.Brush` |     |
-| `image`       | `slint.Image` |     |
-| `styled-text` | `slint.StyledText` | |
-| `data-transfer` | `slint.DataTransfer` | |
-| `length`      | `float`     |       |
-| `physical_length` | `float` |       |
-| `duration`    | `float`     | The number of milliseconds |
-| `angle`       | `float`     | The angle in degrees |
-| `relative-font-size` | `float` | Relative font size factor that is multiplied with the window's default font size. |
-| structure     | `dict`/`Struct` | When reading, structures are mapped to data classes, when writing dicts are also accepted. |
-| array         | `slint.Model` |     |
-| `Point`       | `slint.LogicalPosition` | A struct with `x` and `y` fields, representing logical coordinates. |
+Each type used for properties in the Slint Language translates to a specific type in Python. See the
+[type mappings table](https://docs.slint.dev/latest/docs/python/#type-mappings) in the Slint Python documentation for the
+complete list.
 
 ### Arrays and Models
 

--- a/api/python/slint/README.md
+++ b/api/python/slint/README.md
@@ -220,6 +220,7 @@ the mapping:
 | ------------- | ----------- | ----- |
 | `int`         | `int`       |       |
 | `float`       | `float`     |       |
+| `bool`        | `bool`      |       |
 | `string`      | `str`       |       |
 | `color`       | `slint.Color` |     |
 | `brush`       | `slint.Brush` |     |
@@ -230,8 +231,10 @@ the mapping:
 | `physical_length` | `float` |       |
 | `duration`    | `float`     | The number of milliseconds |
 | `angle`       | `float`     | The angle in degrees |
+| `relative-font-size` | `float` | Relative font size factor that is multiplied with the window's default font size. |
 | structure     | `dict`/`Struct` | When reading, structures are mapped to data classes, when writing dicts are also accepted. |
 | array         | `slint.Model` |     |
+| `Point`       | `slint.LogicalPosition` | A struct with `x` and `y` fields, representing logical coordinates. |
 
 ### Arrays and Models
 

--- a/docs/nodejs/src/content/docs/index.md
+++ b/docs/nodejs/src/content/docs/index.md
@@ -309,6 +309,8 @@ The types used for properties in .slint design markup each translate to specific
 | `brush` | `Brush` | |
 | `keys` | `Keys` | |
 | `image` | `ImageData` | |
+| `styled-text` | `StyledText` | Styled text parsed from markdown or plain text. Use `StyledText.fromMarkdown()` or `StyledText.fromPlainText()` to create instances. |
+| `data-transfer` | `DataTransfer` | Data associated with a drag-drop transfer. |
 | `length` | `Number` | |
 | `physical_length` | `Number` | |
 | `duration` | `Number` | The number of milliseconds |
@@ -316,6 +318,7 @@ The types used for properties in .slint design markup each translate to specific
 | `relative-font-size` | `Number` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | structure | `Object` | Structures are mapped to JavaScript objects where each structure field is a property. |
 | array | `Model` | |
+| `Point` | `{ x: number; y: number }` | A two-dimensional point with `x` and `y` coordinates. |
 
 ### Arrays and Models
 

--- a/docs/python/src/content/docs/index.mdx
+++ b/docs/python/src/content/docs/index.mdx
@@ -141,15 +141,17 @@ Python type:
 | --- | --- |
 | <SlintRef type="int" /> | `int` |
 | <SlintRef type="float" /> | `float` |
+| <SlintRef type="bool" /> | `bool` |
 | <SlintRef type="StringType" label="string" /> | `str` |
 | <SlintRef type="color" /> | <XRef to="Color" /> |
 | <SlintRef type="brush" /> | <XRef to="Brush" /> |
 | <SlintRef type="ImageType" label="image" /> | <XRef to="Image" /> |
 | <SlintRef type="styled_text" label="styled-text" /> | <XRef to="StyledText" /> |
 | <SlintRef type="data_transfer" label="data-transfer" /> | <XRef to="DataTransfer" /> |
-| `length`, `physical-length`, `duration`, `angle` | `float` |
+| `length`, `physical-length`, `duration`, `angle`, `relative-font-size` | `float` |
 | structure | `dict` / `Struct` |
 | array | <XRef to="Model" /> |
+| <SlintRef type="Point" /> | <XRef to="LogicalPosition" /> |
 
 For the full set of classes and module-level functions, see the **API**
 section in the sidebar.


### PR DESCRIPTION
Node.js and Python have gaps:)
