### PR TITLE
 feat: expose undo() and redo() as public functions on TextInput

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1709,6 +1709,12 @@ export component TextInput {
     /// Pastes the text content of the clipboard at the cursor position.
     function paste() {
     }
+    /// Undoes the last text operation.
+    function undo() {
+    }
+    /// Redoes the last undone text operation.
+    function redo() {
+    }
     //! ### focus()
     //! Call this function to focus the text input and make it receive future keyboard events.
     //!

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -2087,7 +2087,7 @@ impl TextInput {
         self.undo_items.set(items);
     }
 
-    fn undo(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>, self_rc: &ItemRc) {
+    pub fn undo(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>, self_rc: &ItemRc) {
         let mut items = self.undo_items.take();
         let Some(last) = items.pop() else {
             return;
@@ -2132,7 +2132,7 @@ impl TextInput {
         Self::FIELD_OFFSETS.edited().apply_pin(self).call(&());
     }
 
-    fn redo(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>, self_rc: &ItemRc) {
+    pub fn redo(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>, self_rc: &ItemRc) {
         let mut items = self.redo_items.take();
         let Some(last) = items.pop() else {
             return;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -2355,6 +2355,36 @@ pub unsafe extern "C" fn slint_textinput_paste(
     }
 }
 
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_textinput_undo(
+    text_input: Pin<&TextInput>,
+    window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
+    self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
+    self_index: u32,
+) {
+    unsafe {
+        let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
+        let self_rc = ItemRc::new(self_component.clone(), self_index);
+        text_input.undo(window_adapter, &self_rc);
+    }
+}
+
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_textinput_redo(
+    text_input: Pin<&TextInput>,
+    window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
+    self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
+    self_index: u32,
+) {
+    unsafe {
+        let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
+        let self_rc = ItemRc::new(self_component.clone(), self_index);
+        text_input.redo(window_adapter, &self_rc);
+    }
+}
+
 pub fn slint_text_item_fontmetrics(
     window_adapter: &Rc<dyn WindowAdapter>,
     item_ref: Pin<ItemRef<'_>>,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1841,6 +1841,8 @@ fn call_item_member_function(nr: &NamedReference, local_context: &mut EvalLocalC
             "cut" => textinput.cut(&window_adapter, &item_rc),
             "copy" => textinput.copy(&window_adapter, &item_rc),
             "paste" => textinput.paste(&window_adapter, &item_rc),
+            "undo" => textinput.undo(&window_adapter, &item_rc),
+            "redo" => textinput.redo(&window_adapter, &item_rc),
             _ => panic!("internal: Unknown member function {name} called on TextInput"),
         }
     } else if let Some(s) = ItemRef::downcast_pin::<corelib::items::SwipeGestureHandler>(item_ref) {

--- a/tests/cases/text/undo_redo.slint
+++ b/tests/cases/text/undo_redo.slint
@@ -1,21 +1,35 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-component TestCase inherits TextInput {
+export component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
-    single-line: false;
-    in-out property<string> test_text: self.text;
-    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
-    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
+
+    forward-focus: ti;
+
+    ti := TextInput {
+        single-line: false;
+    }
+
+    in-out property<string> test_text <=> ti.text;
+    in-out property<int> test_cursor_pos: ti.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: ti.anchor_position_byte_offset;
     in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    in-out property<bool> input_focused: self.has_focus;
+    in-out property<bool> input_focused: ti.has_focus;
+
+    callback do_undo();
+    do_undo => { ti.undo(); }
+
+    callback do_redo();
+    do_redo => { ti.redo(); }
+
+    callback do_select_all();
+    do_select_all => { ti.select_all(); }
 }
 
 /*
 ```rust
-
-const BACK_CODE: char = '\u{0008}'; // backspace \b
+const BACK_CODE: char = '\u{0008}';
 
 fn ctrl_key(instance: &TestCase, key: &str, shift: bool) {
     slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
@@ -23,55 +37,111 @@ fn ctrl_key(instance: &TestCase, key: &str, shift: bool) {
         slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
     }
     slint_testing::send_keyboard_string_sequence(instance, key);
-
-    // release
     slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
     if shift {
         slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
     }
 }
 
-fn undo(instance: &TestCase) {
-    ctrl_key(instance, "z", false);
-}
-
-fn redo(instance: &TestCase) {
-    ctrl_key(instance, "z", true);
-    ctrl_key(instance, "y", false); // for windows
-}
-
 let instance = TestCase::new().unwrap();
-assert!(instance.get_input_focused());
-assert_eq!(instance.get_test_text(), "");
-
 slint_testing::send_keyboard_string_sequence(&instance, "First line\nSecond line");
 assert_eq!(instance.get_test_text(), "First line\nSecond line");
 
-// undo
-undo(&instance);
+// --- undo/redo via public functions ---
+
+instance.invoke_do_undo();
 assert_eq!(instance.get_test_text(), "First line\n");
-undo(&instance);
+instance.invoke_do_undo();
 assert_eq!(instance.get_test_text(), "First line");
-undo(&instance);
+instance.invoke_do_undo();
 assert_eq!(instance.get_test_text(), "");
 
-// redo
-redo(&instance);
+instance.invoke_do_redo();
 assert_eq!(instance.get_test_text(), "First line");
-redo(&instance);
+instance.invoke_do_redo();
 assert_eq!(instance.get_test_text(), "First line\n");
-redo(&instance);
+instance.invoke_do_redo();
 assert_eq!(instance.get_test_text(), "First line\nSecond line");
 
-// CASE: select all -> remove -> undo -> should restore original text + selection
-ctrl_key(&instance, "a", /*shift=*/false);
-
+// select all -> delete -> undo should restore text + selection
+instance.invoke_do_select_all();
 assert!(instance.get_has_selection());
+
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
-assert_eq!(instance.get_test_text(), ""); // empty
-assert!(!instance.get_has_selection()); // no selection
-undo(&instance);
-assert_eq!(instance.get_test_text(), "First line\nSecond line"); // restored
-assert!(instance.get_has_selection()); // selection should be there
+assert_eq!(instance.get_test_text(), "");
+assert!(!instance.get_has_selection());
+
+instance.invoke_do_undo();
+assert_eq!(instance.get_test_text(), "First line\nSecond line");
+assert!(instance.get_has_selection());
+
+// --- undo/redo via Ctrl+Z / Ctrl+Shift+Z keyboard shortcuts ---
+
+// clear and type fresh text
+instance.invoke_do_select_all();
+slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+assert_eq!(instance.get_test_text(), "");
+// undo the delete + select to get back to clean slate
+ctrl_key(&instance, "z", false);
+ctrl_key(&instance, "z", false);
+ctrl_key(&instance, "z", false);
+ctrl_key(&instance, "z", false);
+ctrl_key(&instance, "z", false);
+ctrl_key(&instance, "z", false);
+assert_eq!(instance.get_test_text(), "");
+
+slint_testing::send_keyboard_string_sequence(&instance, "Hello\nWorld");
+assert_eq!(instance.get_test_text(), "Hello\nWorld");
+
+ctrl_key(&instance, "z", false);
+assert_eq!(instance.get_test_text(), "Hello\n");
+ctrl_key(&instance, "z", false);
+assert_eq!(instance.get_test_text(), "Hello");
+ctrl_key(&instance, "z", false);
+assert_eq!(instance.get_test_text(), "");
+
+ctrl_key(&instance, "z", true);
+assert_eq!(instance.get_test_text(), "Hello");
+ctrl_key(&instance, "z", true);
+assert_eq!(instance.get_test_text(), "Hello\n");
+ctrl_key(&instance, "z", true);
+assert_eq!(instance.get_test_text(), "Hello\nWorld");
+```
+*/
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_keyboard_string_sequence(&instance, "First line\nSecond line");
+assert_eq(instance.get_test_text(), "First line\nSecond line");
+
+// --- undo/redo via public functions ---
+
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "First line\n");
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "First line");
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "");
+
+instance.invoke_do_redo();
+assert_eq(instance.get_test_text(), "First line");
+instance.invoke_do_redo();
+assert_eq(instance.get_test_text(), "First line\n");
+instance.invoke_do_redo();
+assert_eq(instance.get_test_text(), "First line\nSecond line");
+
+// select all -> delete -> undo should restore text + selection
+instance.invoke_do_select_all();
+assert(instance.get_has_selection());
+
+slint_testing::send_keyboard_string_sequence(&instance, "\x08");
+assert_eq(instance.get_test_text(), "");
+assert(!instance.get_has_selection());
+
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "First line\nSecond line");
+assert(instance.get_has_selection());
 ```
 */

--- a/tests/cases/text/undo_redo.slint
+++ b/tests/cases/text/undo_redo.slint
@@ -1,35 +1,29 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export component TestCase inherits Window {
+component TestCase inherits TextInput {
     width: 100phx;
     height: 100phx;
-
-    forward-focus: ti;
-
-    ti := TextInput {
-        single-line: false;
-    }
-
-    in-out property<string> test_text <=> ti.text;
-    in-out property<int> test_cursor_pos: ti.cursor_position_byte_offset;
-    in-out property<int> test_anchor_pos: ti.anchor_position_byte_offset;
+    single-line: false;
+    in-out property<string> test_text: self.text;
+    in-out property<int> test_cursor_pos: self.cursor_position_byte_offset;
+    in-out property<int> test_anchor_pos: self.anchor_position_byte_offset;
     in-out property<bool> has_selection: self.test_cursor_pos != self.test_anchor_pos;
-    in-out property<bool> input_focused: ti.has_focus;
+    in-out property<bool> input_focused: self.has_focus;
 
     callback do_undo();
-    do_undo => { ti.undo(); }
+    do_undo => { self.undo(); }
 
     callback do_redo();
-    do_redo => { ti.redo(); }
+    do_redo => { self.redo(); }
 
     callback do_select_all();
-    do_select_all => { ti.select_all(); }
+    do_select_all => { self.select_all(); }
 }
 
 /*
 ```rust
-const BACK_CODE: char = '\u{0008}';
+const BACK_CODE: char = '\u{0008}'; // backspace \b
 
 fn ctrl_key(instance: &TestCase, key: &str, shift: bool) {
     slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
@@ -37,6 +31,8 @@ fn ctrl_key(instance: &TestCase, key: &str, shift: bool) {
         slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
     }
     slint_testing::send_keyboard_string_sequence(instance, key);
+
+    // release
     slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
     if shift {
         slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
@@ -100,11 +96,15 @@ assert_eq!(instance.get_test_text(), "Hello");
 ctrl_key(&instance, "z", false);
 assert_eq!(instance.get_test_text(), "");
 
+// Ctrl+Shift+Z (Linux/macOS) + Ctrl+Y (Windows)
 ctrl_key(&instance, "z", true);
+ctrl_key(&instance, "y", false);
 assert_eq!(instance.get_test_text(), "Hello");
 ctrl_key(&instance, "z", true);
+ctrl_key(&instance, "y", false);
 assert_eq!(instance.get_test_text(), "Hello\n");
 ctrl_key(&instance, "z", true);
+ctrl_key(&instance, "y", false);
 assert_eq!(instance.get_test_text(), "Hello\nWorld");
 ```
 */


### PR DESCRIPTION
  Make the existing undo/redo implementation callable from Slint DSL,
  matching the already-public copy(), cut(), paste(), and select-all().
  This enables custom context menus with Undo/Redo support.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
