### PR TITLE
cspell: Always ignore the `target` and `node_modules` directories

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -335,7 +335,9 @@
         "**/*.gltf",
         "**/*.po",
         "**/*.pot",
-        "**/*.svg"
+        "**/*.svg",
+        "target/**",
+        "**/node_modules/**"
     ],
     "overrides": [
         {


### PR DESCRIPTION
The spell check CI step is configured with:

```yaml
uses: streetsidesoftware/cspell-action@v8
with:
  incremental_files_only: true
```

The `incremental_files_only` flag means that cspell should

> Limit the files checked to the ones in the pull request or push.

However, when we run it on a branch on a fork cspell is unable to determine which files change:

```text
cspell-action
Warning: Unable to determine which files have changed, checking files: **
```

https://github.com/0x6e/slint/actions/runs/27280419563/job/80573081226#step:6:25

The CI run then fails because it goes on to check files in the target and node_modules directories.

This commit attempts to fix that by explicitly adding these directories to the cspell `ignorePaths` configuration.

The autofix job now passes with this change when run on a branch: https://github.com/0x6e/slint/actions/runs/27283432202/job/80583973814#step:6:25
