### PR TITLE
Fix the nightly Android App Bundle signing, and simplify the Android CI

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -706,18 +706,21 @@ jobs:
             - uses: ./.github/actions/install-linux-dependencies
             - name: Install Android API platforms
               run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-30" "platforms;android-35" "build-tools;35.0.1"
-            - name: Cache cargo-apk
-              id: cargo-apk-cache
+            - name: Cache cargo-apk, cargo-ndk and resvg
+              id: cargo-tools-cache
               uses: actions/cache@v5
               with:
-                  path: ~/.cargo/bin/cargo-apk
-                  key: cargo-apk-cache
-            # Only build cargo-apk if not cached
+                  path: |
+                      ~/.cargo/bin/cargo-apk
+                      ~/.cargo/bin/cargo-ndk
+                      ~/.cargo/bin/resvg
+                  key: android-cargo-tools-cache
+            # Only build the tools if not cached
             - uses: dtolnay/rust-toolchain@stable
-              if: steps.cargo-apk-cache.outputs.cache-hit != 'true'
-            - name: Install cargo-apk
-              if: steps.cargo-apk-cache.outputs.cache-hit != 'true'
-              run: cargo install cargo-apk
+              if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
+            - name: Install cargo-apk, cargo-ndk and resvg
+              if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
+              run: cargo install --locked cargo-apk cargo-ndk resvg
 
             - uses: ./.github/actions/setup-rust
               with:
@@ -756,11 +759,6 @@ jobs:
               with:
                   # Installs Gradle on PATH; the AAB project has no wrapper jar.
                   gradle-version: "8.10.2"
-            # Split so a failure of one install doesn't mask the other's diagnostic.
-            - name: Install cargo-ndk
-              run: cargo install cargo-ndk --locked
-            - name: Install resvg
-              run: cargo install resvg --locked
             - name: Build slint-viewer AAB
               env:
                   ANDROID_KEYSTORE_PATH: ${{ env.CARGO_APK_RELEASE_KEYSTORE }}

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -744,11 +744,10 @@ jobs:
               run: cargo apk build -p usecases --target aarch64-linux-android --lib --release
             - name: Build home automation demo
               run: cargo apk build -p home-automation --target aarch64-linux-android --lib --release
-            - name: Build slint-viewer
-              run: cargo apk build -p slint-viewer --target aarch64-linux-android --lib --release --features remote
 
-            # Play Store accepts only AABs for new submissions, so build one
-            # alongside the APK.
+            # Play Store accepts only AABs for new submissions. Build the
+            # bundle, then derive the nightly slint-viewer APK from it so the
+            # viewer is only compiled once.
             - name: Set up JDK 17 for Android Gradle Plugin
               uses: actions/setup-java@v5
               with:
@@ -765,6 +764,21 @@ jobs:
                   ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
                   ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
               run: tools/viewer/android-aab/build-aab.sh
+            # A universal APK works on every ABI the bundle carries.
+            - name: Build slint-viewer APK from the AAB
+              env:
+                  ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+                  ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
+              run: |
+                  curl --fail -L -o bundletool.jar https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar
+                  java -jar bundletool.jar build-apks --mode=universal \
+                      --bundle=tools/viewer/android-aab/app/build/outputs/bundle/release/app-release.aab \
+                      --output=slint-viewer.apks \
+                      --ks="$CARGO_APK_RELEASE_KEYSTORE" \
+                      --ks-pass="pass:$ANDROID_KEYSTORE_PASSWORD" \
+                      --ks-key-alias="$ANDROID_KEYSTORE_ALIAS"
+                  mkdir -p target/release/apk
+                  unzip -p slint-viewer.apks universal.apk > target/release/apk/slint-viewer.apk
 
             # Upload whatever built so a Gradle failure doesn't drop the APKs.
             - name: "upload APK artifact"

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -765,6 +765,7 @@ jobs:
               env:
                   ANDROID_KEYSTORE_PATH: ${{ env.CARGO_APK_RELEASE_KEYSTORE }}
                   ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+                  ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
               run: tools/viewer/android-aab/build-aab.sh
 
             # Upload whatever built so a Gradle failure doesn't drop the APKs.

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -791,7 +791,6 @@ jobs:
                     target/release/apk/todo_lib.apk
                     target/release/apk/weather_demo.apk
                     target/release/apk/usecases_lib.apk
-                    target/release/apk/usecases_lib.apk
                     target/release/apk/home_automation_lib.apk
                     target/release/apk/slint-viewer.apk
                     tools/viewer/android-aab/app/build/outputs/bundle/release/app-release.aab

--- a/scripts/render_android_app_icon.bash
+++ b/scripts/render_android_app_icon.bash
@@ -5,8 +5,8 @@
 
 # Render the slint-viewer Android launcher icons from the Slint logo SVG.
 # The legacy ic_launcher.png is 192px on a white background; the adaptive
-# foreground is 432px with the symbol inside Android's 66dp/108dp safe zone
-# so launcher masks don't clip it. Sibling of render_ios_app_icon.bash.
+# foreground is a full-bleed 432px render that ic_launcher.xml insets into
+# the 66dp/108dp safe zone. Sibling of render_ios_app_icon.bash.
 #
 # Requires resvg (cargo install resvg --locked).
 
@@ -24,13 +24,6 @@ command -v resvg >/dev/null 2>&1 \
 mkdir -p "$RES"
 
 resvg --background=white -w 192 -h 192 "$SVG" "$RES/ic_launcher.png"
-
-# Nest the source SVG at (84,84) with a 264x264 envelope so it fits inside the
-# 66dp/108dp safe zone. The sed extraction needs the opening tag on line 1 and
-# the closing tag as the last </svg>. Fail loudly if either changes.
-head -1 "$SVG" | grep -qE '^<svg[^>]*>$' \
-    || { echo "expected single-line <svg> opener in $SVG" >&2; exit 1; }
-PADDED_SVG="<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"432\" height=\"432\" viewBox=\"0 0 432 432\"><svg x=\"84\" y=\"84\" width=\"264\" height=\"264\" viewBox=\"0 0 64 64\">$(sed -n '2,$p' "$SVG" | sed '$s|</svg>||')</svg></svg>"
-resvg -w 432 -h 432 - "$RES/ic_launcher_foreground.png" <<<"$PADDED_SVG"
+resvg -w 432 -h 432 "$SVG" "$RES/ic_launcher_foreground.png"
 
 echo "Rendered Android app icons under $RES/"

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -129,6 +129,3 @@ label = "Slint Viewer"
 
 [[package.metadata.android.uses_permission]]
 name = "android.permission.INTERNET"
-
-[[package.metadata.android.uses_permission]]
-name = "android.permission.CHANGE_WIFI_MULTICAST_STATE"

--- a/tools/viewer/android-aab/app/build.gradle.kts
+++ b/tools/viewer/android-aab/app/build.gradle.kts
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
-// cSpell: ignore getenv androidkey
+// cSpell: ignore getenv
 
 plugins {
     id("com.android.application")
@@ -30,9 +30,8 @@ android {
             create("release") {
                 storeFile = file(keystorePath)
                 storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
-                keyAlias = System.getenv("ANDROID_KEY_ALIAS") ?: "androidkey"
-                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
-                    ?: System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEYSTORE_ALIAS")
+                keyPassword = storePassword
             }
         }
     }

--- a/tools/viewer/android-aab/app/src/main/AndroidManifest.xml
+++ b/tools/viewer/android-aab/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <application
         android:label="Slint Viewer"

--- a/tools/viewer/android-aab/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/tools/viewer/android-aab/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -5,5 +5,9 @@
 -->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <!-- Inset the full-bleed render into the 66dp/108dp safe zone so
+         launcher masks don't clip the logo: (1 - 66/108) / 2 per side. -->
+    <foreground>
+        <inset android:drawable="@mipmap/ic_launcher_foreground" android:inset="19.44%" />
+    </foreground>
 </adaptive-icon>

--- a/tools/viewer/android-aab/build-aab.sh
+++ b/tools/viewer/android-aab/build-aab.sh
@@ -1,18 +1,17 @@
 #!/bin/bash
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
-# cSpell: ignore androidkey xxxhdpi jniLibs
+# cSpell: ignore xxxhdpi jniLibs
 #
 # Build the slint-viewer Android App Bundle for Play Store upload.
 #
 # Defaults: SLINT_VERSION from the workspace Cargo.toml, SLINT_BUILD_NUMBER
 # from the git commit count. Override either as env vars.
 #
-# Signing (omit for an unsigned local bundle):
+# Signing (omit all three for an unsigned local bundle):
 #   ANDROID_KEYSTORE_PATH      upload keystore path
-#   ANDROID_KEYSTORE_PASSWORD  upload keystore password
-#   ANDROID_KEY_ALIAS          key alias, defaults to "androidkey"
-#   ANDROID_KEY_PASSWORD       key password, defaults to keystore password
+#   ANDROID_KEYSTORE_PASSWORD  upload keystore password, also unlocks the key
+#   ANDROID_KEYSTORE_ALIAS     alias of the signing key in the keystore
 #
 # Requires: cargo-ndk; Android SDK + NDK with ANDROID_HOME / ANDROID_NDK_HOME
 # set; gradle 8.9+ on PATH (AGP 8.7); JDK 17; the three Android rust targets
@@ -26,6 +25,12 @@ PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$PROJECT_DIR/../../.." && pwd)"
 
 [ -n "${ANDROID_HOME:-}" ] || { echo "set ANDROID_HOME to your Android SDK" >&2; exit 1; }
+
+# Check the signing setup before the long Rust build so it fails fast.
+if [ -n "${ANDROID_KEYSTORE_PATH:-}" ]; then
+    [ -n "${ANDROID_KEYSTORE_PASSWORD:-}" ] || { echo "set ANDROID_KEYSTORE_PASSWORD" >&2; exit 1; }
+    [ -n "${ANDROID_KEYSTORE_ALIAS:-}" ] || { echo "set ANDROID_KEYSTORE_ALIAS" >&2; exit 1; }
+fi
 
 if [ -z "${SLINT_VERSION:-}" ]; then
     SLINT_VERSION=$(awk -F'"' '/^version = / { print $2; exit }' "$REPO_ROOT/Cargo.toml")

--- a/tools/viewer/android-aab/install-aab.sh
+++ b/tools/viewer/android-aab/install-aab.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
-# cSpell: ignore bundletool BUNDLETOOL androidkey apks APKS
+# cSpell: ignore bundletool BUNDLETOOL apks APKS
 #
 # Build APKs from the slint-viewer AAB with bundletool and install them on a
 # connected device. Hand-test the same bundle Play would receive without
@@ -12,8 +12,8 @@
 # Required:
 #   bundletool on PATH (or $BUNDLETOOL pointing at the jar)
 #   adb on PATH; device authorized for USB debugging
-#   ANDROID_KEYSTORE_PATH / ANDROID_KEYSTORE_PASSWORD (and optionally
-#   ANDROID_KEY_ALIAS / ANDROID_KEY_PASSWORD) — Android refuses unsigned APKs.
+#   ANDROID_KEYSTORE_PATH / ANDROID_KEYSTORE_PASSWORD / ANDROID_KEYSTORE_ALIAS
+#   for signing — Android refuses unsigned APKs.
 
 set -euo pipefail
 
@@ -23,8 +23,7 @@ AAB="${1:-$PROJECT_DIR/app/build/outputs/bundle/release/app-release.aab}"
 
 [ -n "${ANDROID_KEYSTORE_PATH:-}" ] || { echo "set ANDROID_KEYSTORE_PATH for signing" >&2; exit 1; }
 [ -n "${ANDROID_KEYSTORE_PASSWORD:-}" ] || { echo "set ANDROID_KEYSTORE_PASSWORD" >&2; exit 1; }
-KEY_ALIAS="${ANDROID_KEY_ALIAS:-androidkey}"
-KEY_PASSWORD="${ANDROID_KEY_PASSWORD:-$ANDROID_KEYSTORE_PASSWORD}"
+[ -n "${ANDROID_KEYSTORE_ALIAS:-}" ] || { echo "set ANDROID_KEYSTORE_ALIAS" >&2; exit 1; }
 
 # bundletool ships as a jar; honor a BUNDLETOOL override for it.
 if [ -n "${BUNDLETOOL:-}" ] && [[ "$BUNDLETOOL" == *.jar ]]; then
@@ -62,8 +61,7 @@ bt build-apks \
     "${MODE_FLAG[@]}" \
     --ks="$ANDROID_KEYSTORE_PATH" \
     --ks-pass="pass:$ANDROID_KEYSTORE_PASSWORD" \
-    --ks-key-alias="$KEY_ALIAS" \
-    --key-pass="pass:$KEY_PASSWORD"
+    --ks-key-alias="$ANDROID_KEYSTORE_ALIAS"
 
 if [ "$ADB_STATE" = "device" ]; then
     bt install-apks --apks="$OUT_APKS"


### PR DESCRIPTION
The nightly failed to sign the slint-viewer AAB because the key alias was guessed as "androidkey". The alias now comes from the new ANDROID_KEYSTORE_ALIAS secret, 
and the keystore password also unlocks the key, like the APK signing already does.

The rest cleans up the Android part of the nightly:
  - Cache cargo-ndk and resvg instead of compiling them on every run
  - Build slint-viewer only once: the nightly APK is now extracted from the AAB with bundletool
  - Drop the WiFi multicast permission; nothing uses it
  - Let an InsetDrawable in ic_launcher.xml pad the adaptive icon, instead of assembling a padded SVG with sed

 