### PR TITLE
docs: inline ?raw code imports in the served markdown

### DIFF
--- a/docs/astro/src/pages/[...slug].md.ts
+++ b/docs/astro/src/pages/[...slug].md.ts
@@ -6,7 +6,9 @@
 //   /docs/guide/language/coding/properties/      -> rendered HTML page
 //   /docs/guide/language/coding/properties.md    -> this endpoint, raw markdown
 
+import { fileURLToPath } from "node:url";
 import type { APIRoute, GetStaticPaths } from "astro";
+import { root } from "astro:config/server";
 import { getCollection, type CollectionEntry } from "astro:content";
 import {
     markdownStaticPaths,
@@ -21,5 +23,12 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 type Props = { entry: CollectionEntry<"docs"> };
 
+// Project root for resolving `?raw` code imports.
+const projectRoot = fileURLToPath(root);
+
 export const GET: APIRoute<Props> = ({ props }) =>
-    renderMarkdownResponse(props.entry, { basePath: BASE_PATH, linkMap });
+    renderMarkdownResponse(props.entry, {
+        basePath: BASE_PATH,
+        linkMap,
+        projectRoot,
+    });

--- a/docs/common/src/utils/markdown-endpoint.ts
+++ b/docs/common/src/utils/markdown-endpoint.ts
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
 /** Minimal structural shape of an `astro:content` collection entry. */
 export interface MarkdownDocEntry {
     /** Collection id; the root index page has an empty id. */
@@ -9,6 +12,11 @@ export interface MarkdownDocEntry {
     data: Record<string, unknown>;
     /** Raw markdown body. */
     body?: string;
+    /**
+     * Source file path relative to the project root (Astro's
+     * `entry.filePath`). Needed to resolve relative `?raw` imports.
+     */
+    filePath?: string;
 }
 
 /** A `linkMap` entry: the in-prose `<Link>` component resolves a `type` to an href. */
@@ -28,6 +36,12 @@ export interface MarkdownEndpointOptions {
      * (the generated C++/Python/Node API references) omit this.
      */
     linkMap?: Record<string, MarkdownLinkTarget>;
+    /**
+     * Absolute path of the Astro project root. When set, `?raw` imports and
+     * the `<Code>` components consuming them are inlined as fenced code
+     * blocks. Sites whose pages don't import code from files omit this.
+     */
+    projectRoot?: string;
 }
 
 /**
@@ -48,6 +62,9 @@ export function renderMarkdownResponse(
 ): Response {
     const data = entry.data;
     let body = entry.body ?? "";
+    if (options.projectRoot) {
+        body = inlineRawCodeImports(body, options.projectRoot, entry.filePath);
+    }
     if (options.linkMap) {
         body = resolveLinkComponents(
             body,
@@ -107,6 +124,80 @@ function resolveLinkComponents(
         const label = parsed.label ?? type;
         return `[${label}](${basePath}${toMarkdownHref(linkMap[type].href)})`;
     });
+}
+
+// Pages include code examples via Vite raw imports —
+// `import name from "…?raw"` hands the file's text to a `<Code>` component at
+// build time. The served markdown is the unprocessed MDX, so without help the
+// reader sees the import line where the HTML page shows code. Inline the file
+// content as a fenced code block and drop the consumed import. Components
+// whose source can't be resolved are left as-is so the regular build checks
+// surface the problem.
+const RAW_IMPORT_RE =
+    /^import\s+(\w+)\s+from\s+["']([^"']+)\?raw["'];?[ \t]*\n?/gm;
+const CODE_COMPONENT_RE = /<Code\s([^>]*?)\/>/g;
+// Mirrors `extractLines()` from utils.ts: a 1-based inclusive line range.
+const EXTRACT_LINES_RE =
+    /^\s*extractLines\(\s*(\w+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/;
+
+function inlineRawCodeImports(
+    body: string,
+    projectRoot: string,
+    entryFilePath?: string,
+): string {
+    // The imported files: binding name -> file content.
+    const sources = new Map<string, string>();
+    for (const [, name, importPath] of body.matchAll(RAW_IMPORT_RE)) {
+        // Project-absolute imports (`/src/…`) resolve against the project
+        // root; relative ones against the page's own directory.
+        const resolved = importPath.startsWith("/")
+            ? join(projectRoot, importPath)
+            : entryFilePath
+              ? join(projectRoot, dirname(entryFilePath), importPath)
+              : undefined;
+        try {
+            if (resolved) {
+                sources.set(name, readFileSync(resolved, "utf-8"));
+            }
+        } catch {
+            // Unreadable file: keep the import and its <Code> usage verbatim.
+        }
+    }
+    if (sources.size === 0) {
+        return body;
+    }
+
+    const inlined = new Set<string>();
+    const out = body.replace(CODE_COMPONENT_RE, (whole, attrs: string) => {
+        const codeExpr = /\bcode=\{([^}]*)\}/.exec(attrs)?.[1] ?? "";
+        const sliced = EXTRACT_LINES_RE.exec(codeExpr);
+        const name = sliced?.[1] ?? codeExpr.trim();
+        let content = sources.get(name);
+        if (content === undefined) {
+            return whole;
+        }
+        if (sliced) {
+            content = content
+                .split("\n")
+                .slice(Number(sliced[2]) - 1, Number(sliced[3]))
+                .join("\n");
+        }
+        inlined.add(name);
+        const lang = /\blang="([^"]*)"/.exec(attrs)?.[1] ?? "";
+        const title = /\btitle="([^"]*)"/.exec(attrs)?.[1];
+        // A fence must be longer than any backtick run in the content.
+        let fence = "```";
+        while (content.includes(fence)) {
+            fence += "`";
+        }
+        const info = lang + (title ? ` title="${title}"` : "");
+        return `${fence}${info}\n${content.replace(/\n+$/, "")}\n${fence}`;
+    });
+
+    // Drop the import lines whose code is now inlined.
+    return out.replace(RAW_IMPORT_RE, (whole, name) =>
+        inlined.has(name) ? "" : whole,
+    );
 }
 
 // Convert an HTML page href like "reference/common/#anchor" into the

--- a/docs/common/src/utils/markdown-endpoint.ts
+++ b/docs/common/src/utils/markdown-endpoint.ts
@@ -130,9 +130,10 @@ function resolveLinkComponents(
 // `import name from "…?raw"` hands the file's text to a `<Code>` component at
 // build time. The served markdown is the unprocessed MDX, so without help the
 // reader sees the import line where the HTML page shows code. Inline the file
-// content as a fenced code block and drop the consumed import. Components
-// whose source can't be resolved are left as-is so the regular build checks
-// surface the problem.
+// content as a fenced code block and drop the consumed import. Anything that
+// doesn't parse fails the build: a silent pass-through would let a syntax
+// change (a new Astro major, a new authoring pattern) quietly degrade the
+// served markdown again.
 const RAW_IMPORT_RE =
     /^import\s+(\w+)\s+from\s+["']([^"']+)\?raw["'];?[ \t]*\n?/gm;
 const CODE_COMPONENT_RE = /<Code\s([^>]*?)\/>/g;
@@ -145,6 +146,7 @@ function inlineRawCodeImports(
     projectRoot: string,
     entryFilePath?: string,
 ): string {
+    const page = entryFilePath ?? "<unknown page>";
     // The imported files: binding name -> file content.
     const sources = new Map<string, string>();
     for (const [, name, importPath] of body.matchAll(RAW_IMPORT_RE)) {
@@ -155,16 +157,20 @@ function inlineRawCodeImports(
             : entryFilePath
               ? join(projectRoot, dirname(entryFilePath), importPath)
               : undefined;
-        try {
-            if (resolved) {
-                sources.set(name, readFileSync(resolved, "utf-8"));
-            }
-        } catch {
-            // Unreadable file: keep the import and its <Code> usage verbatim.
+        if (resolved === undefined) {
+            throw new Error(
+                `${page}: cannot resolve the relative import "${importPath}?raw" without the entry's filePath`,
+            );
         }
-    }
-    if (sources.size === 0) {
-        return body;
+        try {
+            sources.set(name, readFileSync(resolved, "utf-8"));
+        } catch {
+            // Astro itself resolves the import during the build, so a read
+            // failure here means this endpoint resolved the path differently.
+            throw new Error(
+                `${page}: cannot read "${importPath}?raw" (resolved to ${resolved}) — fix the path resolution in the markdown endpoint`,
+            );
+        }
     }
 
     const inlined = new Set<string>();
@@ -174,7 +180,9 @@ function inlineRawCodeImports(
         const name = sliced?.[1] ?? codeExpr.trim();
         let content = sources.get(name);
         if (content === undefined) {
-            return whole;
+            throw new Error(
+                `${page}: \`${whole}\` does not reference a ?raw import — teach the markdown endpoint this syntax`,
+            );
         }
         if (sliced) {
             content = content
@@ -194,10 +202,15 @@ function inlineRawCodeImports(
         return `${fence}${info}\n${content.replace(/\n+$/, "")}\n${fence}`;
     });
 
-    // Drop the import lines whose code is now inlined.
-    return out.replace(RAW_IMPORT_RE, (whole, name) =>
-        inlined.has(name) ? "" : whole,
-    );
+    for (const name of sources.keys()) {
+        if (!inlined.has(name)) {
+            throw new Error(
+                `${page}: the ?raw import "${name}" feeds no <Code …/> the markdown endpoint recognizes — teach it the new syntax`,
+            );
+        }
+    }
+    // Every import is consumed at this point; drop the import lines.
+    return out.replace(RAW_IMPORT_RE, "");
 }
 
 // Convert an HTML page href like "reference/common/#anchor" into the

--- a/docs/common/tests/markdown-endpoint.test.ts
+++ b/docs/common/tests/markdown-endpoint.test.ts
@@ -165,16 +165,36 @@ test("relative ?raw imports resolve against the page's directory", async () => {
     assert.match(text, /```bash\nmake\n```/);
 });
 
-test("unresolvable code imports leave the MDX untouched", async () => {
+test("an unreadable ?raw import fails the build", () => {
     const projectRoot = projectRootWith({});
     const body = [
         "import gone from '/src/content/code/missing.cpp?raw'",
         '<Code code={gone} lang="cpp" />',
     ].join("\n");
-    const res = renderMarkdownResponse(entry({ body }), { projectRoot });
-    const text = await res.text();
-    assert.match(text, /import gone from/);
-    assert.match(text, /<Code code=\{gone\} lang="cpp" \/>/);
+    assert.throws(
+        () => renderMarkdownResponse(entry({ body }), { projectRoot }),
+        /cannot read "\/src\/content\/code\/missing\.cpp\?raw"/,
+    );
+});
+
+test("a <Code> expression that is not a ?raw import fails the build", () => {
+    const projectRoot = projectRootWith({});
+    const body = '<Code code={someNewHelper(x)} lang="cpp" />';
+    assert.throws(
+        () => renderMarkdownResponse(entry({ body }), { projectRoot }),
+        /does not reference a \?raw import/,
+    );
+});
+
+test("a ?raw import that no recognized <Code> consumes fails the build", () => {
+    const projectRoot = projectRootWith({
+        "src/content/code/hello.sh": "echo hello\n",
+    });
+    const body = "import script from '/src/content/code/hello.sh?raw'";
+    assert.throws(
+        () => renderMarkdownResponse(entry({ body }), { projectRoot }),
+        /feeds no <Code/,
+    );
 });
 
 test("without projectRoot, code imports are left as-is", async () => {

--- a/docs/common/tests/markdown-endpoint.test.ts
+++ b/docs/common/tests/markdown-endpoint.test.ts
@@ -6,6 +6,9 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
     markdownStaticPaths,
     renderMarkdownResponse,
@@ -14,6 +17,17 @@ import {
 
 function entry(over: Partial<MarkdownDocEntry>): MarkdownDocEntry {
     return { id: "", data: {}, body: "", ...over };
+}
+
+// A fake project root holding code files that `?raw` imports resolve to.
+function projectRootWith(files: Record<string, string>): string {
+    const root = mkdtempSync(join(tmpdir(), "md-endpoint-test-"));
+    for (const [path, content] of Object.entries(files)) {
+        const abs = join(root, path);
+        mkdirSync(join(abs, ".."), { recursive: true });
+        writeFileSync(abs, content);
+    }
+    return root;
 }
 
 test("root index (empty id) maps to the index.md slug", () => {
@@ -94,4 +108,78 @@ test("unknown link types are passed through unchanged", async () => {
     );
     const text = await res.text();
     assert.match(text, /<Link type="Nope" \/>/);
+});
+
+test("a ?raw import feeding <Code> becomes a fenced block", async () => {
+    const projectRoot = projectRootWith({
+        "src/content/code/hello.sh": "echo hello\n",
+    });
+    const res = renderMarkdownResponse(
+        entry({
+            body: [
+                "import script from '/src/content/code/hello.sh?raw'",
+                "",
+                '<Code code={script} lang="bash" />',
+            ].join("\n"),
+        }),
+        { projectRoot },
+    );
+    const text = await res.text();
+    assert.match(text, /```bash\necho hello\n```/);
+    // The consumed import line is gone.
+    assert.doesNotMatch(text, /import script/);
+});
+
+test("extractLines() slices a 1-based inclusive range and title is kept", async () => {
+    const projectRoot = projectRootWith({
+        "src/content/code/app.slint": "l1\nl2\nl3\nl4\nl5\n",
+    });
+    const res = renderMarkdownResponse(
+        entry({
+            body: [
+                'import appWindow from "/src/content/code/app.slint?raw"',
+                '<Code code={extractLines(appWindow, 2 ,4)} lang="slint" title="app.slint" />',
+            ].join("\n"),
+        }),
+        { projectRoot },
+    );
+    const text = await res.text();
+    assert.match(text, /```slint title="app\.slint"\nl2\nl3\nl4\n```/);
+});
+
+test("relative ?raw imports resolve against the page's directory", async () => {
+    const projectRoot = projectRootWith({
+        "scripts/build.sh": "make\n",
+    });
+    const res = renderMarkdownResponse(
+        entry({
+            filePath: "src/content/docs/guide/page.mdx",
+            body: [
+                "import script from './../../../../scripts/build.sh?raw'",
+                '<Code code={script} lang="bash" />',
+            ].join("\n"),
+        }),
+        { projectRoot },
+    );
+    const text = await res.text();
+    assert.match(text, /```bash\nmake\n```/);
+});
+
+test("unresolvable code imports leave the MDX untouched", async () => {
+    const projectRoot = projectRootWith({});
+    const body = [
+        "import gone from '/src/content/code/missing.cpp?raw'",
+        '<Code code={gone} lang="cpp" />',
+    ].join("\n");
+    const res = renderMarkdownResponse(entry({ body }), { projectRoot });
+    const text = await res.text();
+    assert.match(text, /import gone from/);
+    assert.match(text, /<Code code=\{gone\} lang="cpp" \/>/);
+});
+
+test("without projectRoot, code imports are left as-is", async () => {
+    const body = "import script from '/src/content/code/x.sh?raw'";
+    const res = renderMarkdownResponse(entry({ body }));
+    const text = await res.text();
+    assert.match(text, /import script from/);
 });


### PR DESCRIPTION
Every docs page serves a .md sibling so AI agents can read the docs without parsing HTML. But that endpoint serves the unprocessed MDX, and many pages pull their code examples from files via Vite ?raw imports rendered by <Code>. Agents reading such a page got the prose but an import statement where the HTML shows code.

Resolve those imports when rendering the markdown response and inline the file content as a fenced code block, mirroring extractLines() for line ranges. Unresolvable imports stay untouched so build validation still catches mistakes.
