### PR TITLE
Fix division by zero in core/animations.rs

### DIFF
--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -418,7 +418,7 @@ pub fn update_animations() {
         let mut duration = Instant::duration_since_start().as_millis() as u64;
         #[cfg(feature = "std")]
         if let Ok(val) = std::env::var("SLINT_SLOW_ANIMATIONS") {
-            let factor = val.parse().unwrap_or(2);
+            let factor = val.parse().unwrap_or(2).max(1);
             duration /= factor;
         };
         driver.update_animations(Instant(duration))


### PR DESCRIPTION
Steps to reproduce `SLINT_SLOW_ANIMATIONS=0 cargo run`

```
thread 'main' (1523964) panicked at /home/rafal/test/slint/internal/core/animations.rs:422:13:
attempt to divide by zero
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```