### PR TITLE
CI: Scope the Windows LLVM 19.1.7 downgrade to windows-2022 runners

### DIFF
--- a/.github/actions/install-skia-dependencies/action.yaml
+++ b/.github/actions/install-skia-dependencies/action.yaml
@@ -8,9 +8,17 @@ description: Set up dependencies needed to build Skia
 runs:
     using: composite
     steps:
-        - name: Upgrade LLVM for Skia build on Windows
+        # libclang must not be newer than the clang bundled with Visual Studio,
+        # otherwise bindgen ends up parsing VS's older clang resource headers
+        # (mmintrin.h & friends) with a libclang that no longer knows their
+        # builtins. VS 2022 bundles clang 19; newer images bundle clang >= 20
+        # and work with the LLVM preinstalled on the image.
+        - name: Pin LLVM to match the Visual Studio 2022 bundled clang
           if: runner.os == 'Windows'
-          run: choco upgrade llvm --version "19.1.7" --allow-downgrade
+          run: |
+              if [ "$ImageOS" = "win22" ]; then
+                  choco upgrade llvm --version "19.1.7" --allow-downgrade
+              fi
           shell: bash
         # See https://github.com/ilammy/msvc-dev-cmd?tab=readme-ov-file#caveats
         - name: Remove GNU link.exe from GH actions


### PR DESCRIPTION
The windows-latest runner image now ships Visual Studio 18 (2026) with MSVC 14.51, whose STL headers statically assert that any Clang parsing them is version 20 or newer. The unconditional LLVM 19.1.7 downgrade from commit 4823ffa490 therefore made bindgen fail in the mozangle build of the servo example:

    yvals_core.h:533:58: error: static assertion failed: error STL1000:
    Unexpected compiler version, expected Clang 20 or newer.

The downgrade is still needed on windows-2022 runners: VS 2022 bundles clang 19, and a newer libclang fails to parse its resource headers because the MMX builtins used by mmintrin.h were removed in clang 20:

    VC\Tools\Llvm\x64\lib\clang\19\include\mmintrin.h:56:19:
    error: use of undeclared identifier '__builtin_ia32_vec_init_v2si'

(This only shows when the skia-bindings prebuilt binary download misses and it builds from source, e.g. in the nightly cargo-update job right after a skia-bindings release.)

So key the downgrade on ImageOS=win22: LLVM 19.1.7 there to match the VS-bundled clang, the image's preinstalled LLVM (currently 22.1.2) everywhere else.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
