### PR TITLE
doctests: scan indented code fences

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -50,6 +50,8 @@ docs_build:
  - 'helper_crates/**'
  - 'tools/lsp/**'
  - 'tests/doctests/**'
+ # The doctests compile the slint snippets in the skill files
+ - 'skills/**'
  - *js_config
  - *ci_config
 

--- a/docs/astro/src/content/docs/guide/tooling/figma-inspector.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/figma-inspector.mdx
@@ -68,18 +68,18 @@ The inspector currently has 2 functions.  One is to inspect individual Figma obj
 ## Design-Token File Structure
 
 1. **Import**
-    ```slint
+    ```slint no-test
     // If separate files:
     import { Colors } from "colors.slint";
     import { Spacing } from "spacing.slint";
     ```
-    ```slint
+    ```slint no-test
     // If single file:
     import { Colors, Spacing } from "design-tokens.slint";
     ```
 
 2. **Use variables**
-    ```slint
+    ```slint no-test
     // Use the tokens:
     MyComponent := Rectangle {
         background: Colors.current.background.primary; // Access via .current for mode switching
@@ -90,7 +90,7 @@ The inspector currently has 2 functions.  One is to inspect individual Figma obj
 3.  **Mode Switching:** (For multi-mode collections)
    Modify the `current-mode` property of the imported global:
 
-    ```slint
+    ```slint no-test
     // Example: In your main component's logic
     init => {
         // Set initial mode

--- a/examples/servo/README.md
+++ b/examples/servo/README.md
@@ -17,7 +17,7 @@ Integrate [Servo](https://github.com/servo/servo) Web Engine as WebView Componen
 - Copy `webview.slint` from [src](https://github.com/slint-ui/slint/tree/master/examples/servo/src) and paste it in your project.
 - Use `Webview` to your `.slint` file.
 
-    ```slint
+    ```slint no-test
     import { Webview } from "webview.slint";
 
     export component MyApp inherits Window {

--- a/skills/slint/reference/icons-and-theming.md
+++ b/skills/slint/reference/icons-and-theming.md
@@ -24,10 +24,9 @@ brush, so a single monochrome asset works in both color schemes.
 - `Palette.color-scheme` (from `std-widgets.slint`) reflects the OS light/dark
   setting and updates live; it's also settable to force a scheme for native
   widgets.
-- A clean pattern: one `export global Theme` holding every color/length token as
-  `out property`s selected by a `dark` bool, e.g.
-  `out property <brush> bg: dark ? #1e2025 : #ffffff;` Bind `dark` to the palette
-  with an optional user override:
+- A clean pattern: one `export global Theme` holding every color/length token
+  as `out property`s selected by a `dark` bool, bound to the palette with an
+  optional user override:
   ```slint
   import { Palette } from "std-widgets.slint";
 
@@ -39,6 +38,11 @@ brush, so a single monochrome asset works in both color schemes.
           preference == ThemePreference.dark ? true
           : preference == ThemePreference.light ? false
           : Palette.color-scheme == ColorScheme.dark;
+      out property <brush> bg: dark ? #1e2025 : #ffffff;
+  }
+
+  export component Card inherits Rectangle {
+      background: Theme.bg;   // reacts to scheme and preference changes
   }
   ```
-  Every component then reads `Theme.bg` etc., so theme switching is automatic.
+  Every component reads `Theme.bg` etc., so theme switching is automatic.

--- a/tests/doctests/build.rs
+++ b/tests/doctests/build.rs
@@ -24,8 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let file = std::fs::read_to_string(path)?;
         let file = file.replace('\r', ""); // Remove \r, because Windows.
 
-        const BEGIN_MARKER: &str = "\n```slint";
-        if !file.contains(BEGIN_MARKER) {
+        if !file.contains("```slint") {
             continue;
         }
 
@@ -39,32 +38,42 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         writeln!(tests_file, "\nmod {stem} {{")?;
 
-        let mut rest = file.as_str();
-        let mut line = 1;
-
-        while let Some(begin) = rest.find(BEGIN_MARKER) {
-            line += rest[..begin].bytes().filter(|&c| c == b'\n').count() + 1;
-            rest = rest[begin..].strip_prefix(BEGIN_MARKER).unwrap();
-
-            // Permit `slint,no-preview` and `slint,no-auto-preview` but skip `slint,ignore` and others.
-            rest = match rest.split_once('\n') {
-                Some((",ignore", _)) => continue,
-                Some((x, _)) if x.contains("no-test") => continue,
-                Some((_, rest)) => rest,
-                _ => continue,
+        let mut lines = file.lines().enumerate();
+        while let Some((n, opening)) = lines.next() {
+            let trimmed = opening.trim_start();
+            let Some(info) = trimmed.strip_prefix("```slint") else {
+                continue;
             };
+            // Permit `slint,no-preview` and `slint,no-auto-preview` but skip `slint,ignore` and others.
+            if info == ",ignore" || info.contains("no-test") {
+                continue;
+            }
 
-            let end = rest.find("\n```\n").ok_or_else(|| {
-                format!("Could not find the end of a code snippet in {}", path.display())
-            })?;
-            let snippet = &rest[..end];
+            // The fence can be indented (e.g. inside a list item); strip the
+            // same indentation from the snippet lines.
+            let indent = &opening[..opening.len() - trimmed.len()];
+            let mut snippet_lines = Vec::new();
+            loop {
+                match lines.next() {
+                    None => {
+                        return Err(format!(
+                            "Could not find the end of a code snippet in {}",
+                            path.display()
+                        )
+                        .into());
+                    }
+                    Some((_, l)) if l.trim_start() == "```" => break,
+                    Some((_, l)) => {
+                        snippet_lines.push(l.strip_prefix(indent).unwrap_or(l.trim_start()));
+                    }
+                }
+            }
+            let snippet = snippet_lines.join("\n");
 
             if snippet.starts_with("{{#include") {
                 // Skip non literal slint text
                 continue;
             }
-
-            rest = &rest[end..];
 
             write!(
                 tests_file,
@@ -75,12 +84,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }}
 
                 "##,
-                line,
+                n + 1,
                 snippet.escape_default(),
                 path.to_string_lossy().escape_default()
             )?;
-
-            line += snippet.bytes().filter(|&c| c == b'\n').count() + 1;
         }
         writeln!(tests_file, "}}")?;
         println!("cargo:rerun-if-changed={}", path.display());

--- a/tests/doctests/main.rs
+++ b/tests/doctests/main.rs
@@ -26,9 +26,9 @@ fn do_test(snippet: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> 
     let code = if must_wrap {
         format!(
             "import {{
-                Button, CheckBox, ComboBox, DatePickerPopup, LineEdit, ProgressIndicator, ScrollView,
-                Slider, SpinBox, Spinner, StandardButton, StandardListView, StandardTableView,
-                RadioGroup,
+                Button, CheckBox, ComboBox, DatePickerPopup, LineEdit, Palette, ProgressIndicator,
+                ScrollView, Slider, SpinBox, Spinner, StandardButton, StandardListView,
+                StandardTableView, RadioGroup,
                 Switch, TabWidget, TextEdit, TimePickerPopup}} from\"std-widgets.slint\";
             component Example {{\n{snippet}\n}}"
         )


### PR DESCRIPTION
The scanner only matched fences at the start of a line, so slint snippets indented inside list items were never tested. Scan line by line, strip the fence's indentation from the snippet, and use the exact fence line in the test name (skipped snippets used to shift it).

Newly scanned snippets that don't compile: mark the illustrative fragments in the figma-inspector guide and the servo README as no-test (they import generated files that don't exist in the repo), and export a component from the skill's theme snippet (a file exporting only a global hits a deprecation fallback).

Also import Palette in the snippet wrapper so fragments can use palette colors, and include skills/ in the docs_build path filter so the doctests run when the skill files change.
