### PR TITLE
Fix name collisions in generated code

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2506,7 +2506,7 @@ export component PopupWindow {
     /// Use this read-only property to style the element that opened the popup, for example
     /// to rotate a ComboBox's arrow while the dropdown is open.
     /// `true` while the popup is shown on the screen, and `false` once it is closed, for example
-    /// when dismissed by a click, by a selection, or by a programmatic `close()`. 
+    /// when dismissed by a click, by a selection, or by a programmatic `close()`.
     out property <bool> is-open;
     //! ## Functions
     //!

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -643,8 +643,8 @@ fn generate_model_two_way_binding(
     field_access: &[SmolStr],
 ) -> String {
     let body_sc = &ctx.compilation_unit.sub_components[info.body_sub_component];
-    let data_prop_name = ident(&body_sc.properties[info.data_prop].name);
-    let index_prop_name = ident(&body_sc.properties[info.index_prop].name);
+    let data_prop_name = field_name(&body_sc.properties[info.data_prop].name);
+    let index_prop_name = field_name(&body_sc.properties[info.index_prop].name);
     let repeater_index = usize::from(info.repeater_index);
 
     // Determine the C++ class name of `self` so we can cast back from
@@ -1460,7 +1460,7 @@ fn generate_public_component(
                 "SystemTrayIcon",
                 "TopLevelComponentType::SystemTrayIcon expects the root item to be a SystemTrayIcon"
             );
-            let tray_field = ident(&tray_item.name);
+            let tray_field = field_name(&tray_item.name);
             (
                 format!("{tray_field}.visible.set(true);"),
                 format!("{tray_field}.visible.set(false);"),
@@ -1605,7 +1605,8 @@ fn generate_item_tree(
                 let mut compo_offset = String::new();
                 let mut sub_component = &root.sub_components[sub_tree.root];
                 for i in &node.sub_component_path {
-                    let next_sub_component_name = ident(&sub_component.sub_components[*i].name);
+                    let next_sub_component_name =
+                        field_name(&sub_component.sub_components[*i].name);
                     write!(
                         compo_offset,
                         "offsetof({}, {}) + ",
@@ -1634,7 +1635,7 @@ fn generate_item_tree(
                     item.ty.cpp_vtable_getter,
                     compo_offset,
                     &ident(&sub_component.name),
-                    ident(&item.name),
+                    field_name(&item.name),
                 ));
             }
         }
@@ -2228,7 +2229,7 @@ fn generate_sub_component(
     }
 
     for property in component.properties.iter() {
-        let cpp_name = ident(&property.name);
+        let cpp_name = field_name(&property.name);
         let ty =
             format_smolstr!("slint::private_api::Property<{}>", property.ty.cpp_type().unwrap());
         target_struct.members.push((
@@ -2237,7 +2238,7 @@ fn generate_sub_component(
         ));
     }
     for callback in component.callbacks.iter() {
-        let cpp_name = ident(&callback.name);
+        let cpp_name = field_name(&callback.name);
         let param_types = callback.args.iter().map(|t| t.cpp_type().unwrap()).collect::<Vec<_>>();
         let ty = format_smolstr!(
             "slint::private_api::Callback<{}({})>",
@@ -2280,7 +2281,7 @@ fn generate_sub_component(
     let mut ensure_instantiated_stmts: Vec<String> = Vec::new();
 
     for sub in &component.sub_components {
-        let field_name = ident(&sub.name);
+        let sub_field = field_name(&sub.name);
         let sub_sc = &root.sub_components[sub.ty];
         let local_tree_index: u32 = sub.index_in_tree as _;
         let local_index_of_first_child: u32 = sub.index_of_first_child_in_tree as _;
@@ -2299,9 +2300,9 @@ fn generate_sub_component(
         };
 
         init.push(format!(
-            "this->{field_name}.init(globals, self_weak.into_dyn(), {global_index}, {global_children});"
+            "this->{sub_field}.init(globals, self_weak.into_dyn(), {global_index}, {global_children});"
         ));
-        user_init.push(format!("this->{field_name}.user_init();"));
+        user_init.push(format!("this->{sub_field}.user_init();"));
 
         let sub_component_repeater_count = sub_sc.repeater_count(root);
         if sub_component_repeater_count > 0 {
@@ -2314,29 +2315,29 @@ fn generate_sub_component(
 
             children_visitor_cases.push(format!(
                 "\n        {case_code} {{
-                        return self->{field_name}.visit_dynamic_children(dyn_index - {repeater_offset}, order, visitor);
+                        return self->{sub_field}.visit_dynamic_children(dyn_index - {repeater_offset}, order, visitor);
                     }}",
             ));
             subtrees_ranges_cases.push(format!(
                 "\n        {case_code} {{
-                        return self->{field_name}.subtree_range(dyn_index - {repeater_offset});
+                        return self->{sub_field}.subtree_range(dyn_index - {repeater_offset});
                     }}",
             ));
             subtrees_components_cases.push(format!(
                 "\n        {case_code} {{
-                        self->{field_name}.subtree_component(dyn_index - {repeater_offset}, subtree_index, result);
+                        self->{sub_field}.subtree_component(dyn_index - {repeater_offset}, subtree_index, result);
                         return;
                     }}",
             ));
             ensure_instantiated_stmts
-                .push(format!("_changed |= self->{field_name}.ensure_instantiated();"));
+                .push(format!("_changed |= self->{sub_field}.ensure_instantiated();"));
         }
 
         target_struct.members.push((
             field_access,
             Declaration::Var(Var {
                 ty: ident(&sub_sc.name),
-                name: field_name,
+                name: sub_field,
                 ..Default::default()
             }),
         ));
@@ -2391,7 +2392,7 @@ fn generate_sub_component(
             field_access,
             Declaration::Var(Var {
                 ty: format_smolstr!("slint::cbindgen_private::{}", ident(&item.ty.class_name)),
-                name: ident(&item.name),
+                name: field_name(&item.name),
                 init: Some("{}".to_owned()),
                 ..Default::default()
             }),
@@ -2563,49 +2564,50 @@ fn generate_sub_component(
         }),
     ));
 
-    let mut dispatch_item_function = |name: &str,
-                                      signature: &str,
-                                      forward_args: &str,
-                                      code: Vec<String>| {
-        let mut code = ["[[maybe_unused]] auto self = this;".into()]
-            .into_iter()
-            .chain(code)
-            .collect::<Vec<_>>();
+    let mut dispatch_item_function =
+        |name: &str, signature: &str, forward_args: &str, code: Vec<String>| {
+            let mut code = ["[[maybe_unused]] auto self = this;".into()]
+                .into_iter()
+                .chain(code)
+                .collect::<Vec<_>>();
 
-        let mut else_ = "";
-        for sub in &component.sub_components {
-            let sub_sc = &ctx.compilation_unit.sub_components[sub.ty];
-            let sub_items_count = sub_sc.child_item_count(ctx.compilation_unit);
-            code.push(format!("{else_}if (index == {}) {{", sub.index_in_tree,));
-            code.push(format!("    return self->{}.{name}(0{forward_args});", ident(&sub.name)));
-            if sub_items_count > 1 {
+            let mut else_ = "";
+            for sub in &component.sub_components {
+                let sub_sc = &ctx.compilation_unit.sub_components[sub.ty];
+                let sub_items_count = sub_sc.child_item_count(ctx.compilation_unit);
+                code.push(format!("{else_}if (index == {}) {{", sub.index_in_tree,));
                 code.push(format!(
-                    "}} else if (index >= {} && index < {}) {{",
-                    sub.index_of_first_child_in_tree,
-                    sub.index_of_first_child_in_tree + sub_items_count - 1
-                        + sub_sc.repeater_count(ctx.compilation_unit)
+                    "    return self->{}.{name}(0{forward_args});",
+                    field_name(&sub.name)
                 ));
-                code.push(format!(
-                    "    return self->{}.{name}(index - {}{forward_args});",
-                    ident(&sub.name),
-                    sub.index_of_first_child_in_tree - 1
-                ));
+                if sub_items_count > 1 {
+                    code.push(format!(
+                        "}} else if (index >= {} && index < {}) {{",
+                        sub.index_of_first_child_in_tree,
+                        sub.index_of_first_child_in_tree + sub_items_count - 1
+                            + sub_sc.repeater_count(ctx.compilation_unit)
+                    ));
+                    code.push(format!(
+                        "    return self->{}.{name}(index - {}{forward_args});",
+                        field_name(&sub.name),
+                        sub.index_of_first_child_in_tree - 1
+                    ));
+                }
+                else_ = "} else ";
             }
-            else_ = "} else ";
-        }
-        let ret =
-            if signature.contains("->") && !signature.contains("-> void") { "{}" } else { "" };
-        code.push(format!("{else_}return {ret};"));
-        target_struct.members.push((
-            field_access,
-            Declaration::Function(Function {
-                name: name.into(),
-                signature: signature.into(),
-                statements: Some(code),
-                ..Default::default()
-            }),
-        ));
-    };
+            let ret =
+                if signature.contains("->") && !signature.contains("-> void") { "{}" } else { "" };
+            code.push(format!("{else_}return {ret};"));
+            target_struct.members.push((
+                field_access,
+                Declaration::Function(Function {
+                    name: name.into(),
+                    signature: signature.into(),
+                    statements: Some(code),
+                    ..Default::default()
+                }),
+            ));
+        };
 
     let mut item_geometry_cases = vec!["switch (index) {".to_string()];
     item_geometry_cases.extend(
@@ -3115,7 +3117,7 @@ fn generate_global(
     let mut global_struct = Struct { name: ident(&global.name), ..Default::default() };
 
     for property in global.properties.iter() {
-        let cpp_name = ident(&property.name);
+        let cpp_name = field_name(&property.name);
         let ty =
             format_smolstr!("slint::private_api::Property<{}>", property.ty.cpp_type().unwrap());
         global_struct.members.push((
@@ -3127,7 +3129,7 @@ fn generate_global(
         ));
     }
     for callback in global.callbacks.iter().filter(|p| p.use_count.get() > 0) {
-        let cpp_name = ident(&callback.name);
+        let cpp_name = field_name(&callback.name);
         let param_types = callback.args.iter().map(|t| t.cpp_type().unwrap()).collect::<Vec<_>>();
         let ty = format_smolstr!(
             "slint::private_api::Callback<{}({})>",
@@ -3501,7 +3503,7 @@ fn follow_sub_component_path<'a>(
     let mut compo_path = String::new();
     let mut sub_component = &compilation_unit.sub_components[root];
     for i in sub_component_path {
-        let sub_component_name = ident(&sub_component.sub_components[*i].name);
+        let sub_component_name = field_name(&sub_component.sub_components[*i].name);
         write!(compo_path, "{sub_component_name}.").unwrap();
         sub_component = &compilation_unit.sub_components[sub_component.sub_components[*i].ty];
     }
@@ -3528,11 +3530,13 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                 );
                 match &local_reference.reference {
                     llr::LocalMemberIndex::Property(property_index) => {
-                        let property_name = ident(&sub_component.properties[*property_index].name);
+                        let property_name =
+                            field_name(&sub_component.properties[*property_index].name);
                         path.with_member(format!("->{compo_path}{property_name}"))
                     }
                     llr::LocalMemberIndex::Callback(callback_index) => {
-                        let callback_name = ident(&sub_component.callbacks[*callback_index].name);
+                        let callback_name =
+                            field_name(&sub_component.callbacks[*callback_index].name);
                         path.with_member(format!("->{compo_path}{callback_name}"))
                     }
                     llr::LocalMemberIndex::Function(function_index) => {
@@ -3540,7 +3544,7 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                         path.with_member(format!("->{compo_path}fn_{function_name}"))
                     }
                     llr::LocalMemberIndex::Native { item_index, prop_name } => {
-                        let item_name = ident(&sub_component.items[*item_index].name);
+                        let item_name = field_name(&sub_component.items[*item_index].name);
                         if prop_name.is_empty()
                             || matches!(
                                 sub_component.items[*item_index].ty.lookup_property(prop_name),
@@ -3559,7 +3563,8 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
             } else if let Some(current_global) = ctx.current_global() {
                 match &local_reference.reference {
                     llr::LocalMemberIndex::Property(property_index) => {
-                        let property_name = ident(&current_global.properties[*property_index].name);
+                        let property_name =
+                            field_name(&current_global.properties[*property_index].name);
                         MemberAccess::Direct(format!("this->{property_name}"))
                     }
                     llr::LocalMemberIndex::Function(function_index) => {
@@ -3567,7 +3572,8 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                         MemberAccess::Direct(format!("this->fn_{function_name}"))
                     }
                     llr::LocalMemberIndex::Callback(callback_index) => {
-                        let callback_name = ident(&current_global.callbacks[*callback_index].name);
+                        let callback_name =
+                            field_name(&current_global.callbacks[*callback_index].name);
                         MemberAccess::Direct(format!("this->{callback_name}"))
                     }
                     _ => unreachable!(),
@@ -3578,17 +3584,19 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
         }
         llr::MemberReference::Global { global_index, member } => {
             let global = &ctx.compilation_unit.globals[*global_index];
+            // Builtin globals are structs from the C++ runtime library whose fields keep
+            // the declared names
+            let field = |name| if global.is_builtin { ident(name) } else { field_name(name) };
             let name = match member {
-                llr::LocalMemberIndex::Property(property_index) => ident(
-                    &ctx.compilation_unit.globals[*global_index].properties[*property_index].name,
-                ),
-                llr::LocalMemberIndex::Callback(callback_index) => ident(
-                    &ctx.compilation_unit.globals[*global_index].callbacks[*callback_index].name,
-                ),
-                llr::LocalMemberIndex::Function(function_index) => ident(&format!(
-                    "fn_{}",
-                    &ctx.compilation_unit.globals[*global_index].functions[*function_index].name,
-                )),
+                llr::LocalMemberIndex::Property(property_index) => {
+                    field(&global.properties[*property_index].name)
+                }
+                llr::LocalMemberIndex::Callback(callback_index) => {
+                    field(&global.callbacks[*callback_index].name)
+                }
+                llr::LocalMemberIndex::Function(function_index) => {
+                    ident(&format!("fn_{}", &global.functions[*function_index].name))
+                }
                 _ => unreachable!(),
             };
             if matches!(ctx.current_scope, EvaluationScope::Global(i) if i == *global_index) {
@@ -3613,6 +3621,15 @@ fn access_local_member(reference: &llr::LocalMemberReference, ctx: &EvaluationCo
 /// Returns the C++ field name for the change-tracker property of a callback.
 fn callback_tracker_name(callback_name: &str) -> SmolStr {
     format_smolstr!("callback_tracker_{}", callback_name.replace('-', "_"))
+}
+
+/// Returns the name of the C++ field holding a property, callback, item, or sub-component
+/// instance.
+/// The prefix keeps the field apart from generated member functions
+/// (e.g. a callback named `set-foo` and the `set_foo` setter of a property `foo`)
+/// and from reserved members such as `repeater_0` or `self_weak`.
+fn field_name(name: &str) -> SmolStr {
+    format_smolstr!("field_{}", concatenate_ident(name))
 }
 
 /// Returns the C++ code to access the change-tracker `Property<uint8_t>` for an exported callback.

--- a/internal/compiler/passes/move_declarations.rs
+++ b/internal/compiler/passes/move_declarations.rs
@@ -3,13 +3,23 @@
 
 //! This pass moves all declaration of properties or callback to the root
 
+#![allow(clippy::mutable_key_type)] // ByAddress<ElementRc> keys rely on Rc identity semantics
+
 use crate::expression_tree::{Expression, NamedReference};
 use crate::langtype::ElementType;
 use crate::object_tree::*;
+use by_address::ByAddress;
 use core::cell::RefCell;
 use smol_str::{SmolStr, format_smolstr};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
+
+/// The root-level name of each declaration that is going to be moved, keyed by the
+/// declaring element and the declared name.
+/// Concatenating the element id and the declared name alone can give the same name to two
+/// different declarations: the ids `a-2` and `a-2-b-4` with the properties `b-4-c` and `c`
+/// both concatenate to `a-2-b-4-c`.
+type RenameMap = HashMap<(ByAddress<ElementRc>, SmolStr), SmolStr>;
 
 struct Declarations {
     property_declarations: BTreeMap<SmolStr, PropertyDeclaration>,
@@ -22,24 +32,63 @@ impl Declarations {
 
 pub fn move_declarations(component: &Rc<Component>) {
     simplify_optimized_items_recursive(component);
-    do_move_declarations(component);
+    let mut renames = RenameMap::new();
+    collect_renames(component, &mut renames);
+    do_move_declarations(component, &renames);
 }
 
-fn do_move_declarations(component: &Rc<Component>) {
+/// Pick a unique root-level name for every declaration that `do_move_declarations` moves
+fn collect_renames(component: &Rc<Component>, renames: &mut RenameMap) {
+    let mut elements = Vec::new();
+    recurse_elem(&component.root_element, &(), &mut |elem, _| {
+        if elem.borrow().repeated.is_some() {
+            if let ElementType::Component(base) = &elem.borrow().base_type {
+                collect_renames(base, renames);
+            }
+        } else if !Rc::ptr_eq(elem, &component.root_element) {
+            elements.push(elem.clone());
+        }
+    });
+    elements.extend(component.optimized_elements.borrow().iter().cloned());
+
+    let mut used: HashSet<SmolStr> =
+        component.root_element.borrow().property_declarations.keys().cloned().collect();
+    for elem in elements {
+        for prop in elem.borrow().property_declarations.keys() {
+            let base = map_name(&elem, prop);
+            let mut name = base.clone();
+            let mut suffix = 1;
+            while !used.insert(name.clone()) {
+                name = format_smolstr!("{base}-{suffix}");
+                suffix += 1;
+            }
+            renames.insert((ByAddress(elem.clone()), prop.clone()), name);
+        }
+    }
+
+    component.popup_windows.borrow().iter().for_each(|p| collect_renames(&p.component, renames));
+    component.menu_item_tree.borrow().iter().for_each(|c| collect_renames(c, renames));
+}
+
+fn do_move_declarations(component: &Rc<Component>, renames: &RenameMap) {
     let mut decl = Declarations::take_from_element(&mut component.root_element.borrow_mut());
-    component.popup_windows.borrow().iter().for_each(|f| do_move_declarations(&f.component));
-    component.menu_item_tree.borrow().iter().for_each(do_move_declarations);
+    component
+        .popup_windows
+        .borrow()
+        .iter()
+        .for_each(|f| do_move_declarations(&f.component, renames));
+    component.menu_item_tree.borrow().iter().for_each(|c| do_move_declarations(c, renames));
 
     let mut new_root_bindings = HashMap::new();
     let mut new_root_change_callbacks = HashMap::new();
     let mut new_root_property_analysis = BTreeMap::new();
 
     let move_bindings_and_animations = &mut |elem: &ElementRc| {
-        visit_all_named_references_in_element(elem, fixup_reference);
+        visit_all_named_references_in_element(elem, |nr| fixup_reference(nr, renames));
 
         if elem.borrow().repeated.is_some() {
             if let ElementType::Component(base) = &elem.borrow().base_type {
-                do_move_declarations(base);
+                do_move_declarations(base, renames);
             } else {
                 panic!(
                     "Repeated element should have a component as base because of the repeater_component.rs pass"
@@ -58,7 +107,7 @@ fn do_move_declarations(component: &Rc<Component>) {
         for (k, e) in bindings {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&k);
             if will_be_moved {
-                new_root_bindings.insert(map_name(elem, &k), e);
+                new_root_bindings.insert(moved_name(renames, elem, &k), e);
             } else {
                 new_bindings.insert(k, e);
             }
@@ -70,7 +119,7 @@ fn do_move_declarations(component: &Rc<Component>) {
         for (prop, a) in property_analysis {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&prop);
             if will_be_moved {
-                new_root_property_analysis.insert(map_name(elem, &prop), a);
+                new_root_property_analysis.insert(moved_name(renames, elem, &prop), a);
             } else {
                 new_property_analysis.insert(prop, a);
             }
@@ -83,7 +132,7 @@ fn do_move_declarations(component: &Rc<Component>) {
         for (k, e) in change_callbacks {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&k);
             if will_be_moved {
-                new_root_change_callbacks.insert(map_name(elem, &k), e);
+                new_root_change_callbacks.insert(moved_name(renames, elem, &k), e);
             } else {
                 new_change_callbacks.insert(k, e);
             }
@@ -94,37 +143,45 @@ fn do_move_declarations(component: &Rc<Component>) {
     component.optimized_elements.borrow().iter().for_each(&mut *move_bindings_and_animations);
     recurse_elem(&component.root_element, &(), &mut |e, _| move_bindings_and_animations(e));
 
-    component.root_constraints.borrow_mut().visit_named_references(&mut fixup_reference);
+    component
+        .root_constraints
+        .borrow_mut()
+        .visit_named_references(&mut |nr| fixup_reference(nr, renames));
     component.popup_windows.borrow_mut().iter_mut().for_each(|p| {
-        fixup_reference(&mut p.x);
-        fixup_reference(&mut p.y);
+        fixup_reference(&mut p.x, renames);
+        fixup_reference(&mut p.y, renames);
         // `is_open` references the synthesized property on this (the parent) component; it must be
         // remapped to the moved-to-root property just like `x`/`y`, otherwise the runtime setter
         // (see the interpreter's `show_popup`) cannot find it once the declaration is hoisted.
         if let Some(is_open) = &mut p.is_open {
-            fixup_reference(is_open);
+            fixup_reference(is_open, renames);
         }
-        visit_all_named_references(&p.component, &mut fixup_reference)
+        visit_all_named_references(&p.component, &mut |nr| fixup_reference(nr, renames))
     });
     component.timers.borrow_mut().iter_mut().for_each(|t| {
-        fixup_reference(&mut t.interval);
-        fixup_reference(&mut t.running);
-        fixup_reference(&mut t.triggered);
+        fixup_reference(&mut t.interval, renames);
+        fixup_reference(&mut t.running, renames);
+        fixup_reference(&mut t.triggered, renames);
     });
     component.menu_item_tree.borrow_mut().iter_mut().for_each(|c| {
-        visit_all_named_references(c, &mut fixup_reference);
+        visit_all_named_references(c, &mut |nr| fixup_reference(nr, renames));
     });
     component.init_code.borrow_mut().iter_mut().for_each(|expr| {
-        visit_named_references_in_expression(expr, &mut fixup_reference);
+        visit_named_references_in_expression(expr, &mut |nr| fixup_reference(nr, renames));
     });
     for pd in decl.property_declarations.values_mut() {
-        pd.is_alias.as_mut().map(fixup_reference);
+        if let Some(nr) = pd.is_alias.as_mut() {
+            fixup_reference(nr, renames)
+        }
     }
 
     let move_properties = &mut |elem: &ElementRc| {
         let elem_decl = Declarations::take_from_element(&mut elem.borrow_mut());
         decl.property_declarations.extend(
-            elem_decl.property_declarations.into_iter().map(|(p, d)| (map_name(elem, &p), d)),
+            elem_decl
+                .property_declarations
+                .into_iter()
+                .map(|(p, d)| (moved_name(renames, elem, &p), d)),
         );
     };
 
@@ -142,18 +199,23 @@ fn do_move_declarations(component: &Rc<Component>) {
 }
 
 /// Map the reference to the previous properties to the new moved property at the root
-fn fixup_reference(nr: &mut NamedReference) {
+fn fixup_reference(nr: &mut NamedReference, renames: &RenameMap) {
     let e = nr.element();
     let parent_component = e.borrow().enclosing_component.upgrade().unwrap();
     if !Rc::ptr_eq(&e, &parent_component.root_element)
         && e.borrow().property_declarations.contains_key(nr.name())
     {
-        *nr = NamedReference::new(&parent_component.root_element, map_name(&e, nr.name()));
+        *nr =
+            NamedReference::new(&parent_component.root_element, moved_name(renames, &e, nr.name()));
     }
 }
 
 fn map_name(e: &ElementRc, s: &SmolStr) -> SmolStr {
     format_smolstr!("{}-{}", e.borrow().id, s)
+}
+
+fn moved_name(renames: &RenameMap, e: &ElementRc, s: &SmolStr) -> SmolStr {
+    renames.get(&(ByAddress(e.clone()), s.clone())).cloned().unwrap_or_else(|| map_name(e, s))
 }
 
 fn simplify_optimized_items_recursive(component: &Rc<Component>) {

--- a/tests/cases/crashes/moved_declaration_name_clash.slint
+++ b/tests/cases/crashes/moved_declaration_name_clash.slint
@@ -1,0 +1,53 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Element-local property declarations are moved to the component root under a name made
+// of the unique element id and the property name. That concatenation alone can be
+// ambiguous: element ids are made unique with a global counter, so `a` becomes `a-2` and
+// `a-2-b` becomes `a-2-b-4`, and with the properties below both declarations would
+// concatenate to `a-2-b-4-c`. The two properties must stay distinct.
+
+export component TestCase inherits Window {
+    a := Rectangle {
+        property <int> b-4-c: 1;
+    }
+    x := Rectangle { }
+    a-2-b := Rectangle {
+        property <int> c: 2;
+    }
+    callback poke;
+    poke => {
+        a.b-4-c += 1;
+        a-2-b.c += 10;
+    }
+    out property <int> r1: a.b-4-c;
+    out property <int> r2: a-2-b.c;
+    out property <bool> test: r1 == 1 && r2 == 2;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.invoke_poke();
+assert_eq!(instance.get_r1(), 2);
+assert_eq!(instance.get_r2(), 12);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+instance.invoke_poke();
+assert_eq(instance.get_r1(), 2);
+assert_eq(instance.get_r2(), 12);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+instance.poke();
+assert.equal(instance.r1, 2);
+assert.equal(instance.r2, 12);
+```
+*/

--- a/tests/cases/globals/accessor_name_collision.slint
+++ b/tests/cases/globals/accessor_name_collision.slint
@@ -1,0 +1,74 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A callback named `set-xxx` or `get-xxx` must not clash with the generated accessor
+// functions of a property named `xxx`, and a property named `on-xxx` must not clash
+// with the generated `on_xxx` function of a callback named `xxx`.
+
+export global State {
+    in-out property <int> sort-dir: 1;
+    callback set-sort-dir(int);
+    set-sort-dir(v) => { self.sort-dir = v; }
+
+    out property <int> value: 10;
+    pure callback get-value() -> int;
+    get-value() => { return self.value; }
+
+    in-out property <bool> on-toggle;
+    callback toggle();
+    toggle() => { self.on-toggle = !self.on-toggle; }
+}
+
+export component TestCase inherits Window {
+    in-out property <int> sort-dir <=> State.sort-dir;
+    callback set-sort-dir <=> State.set-sort-dir;
+
+    out property <bool> test: State.sort-dir == 1 && State.get-value() == 10;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.invoke_set_sort_dir(2);
+assert_eq!(instance.get_sort_dir(), 2);
+instance.set_sort_dir(3);
+assert_eq!(instance.global::<State<'_>>().get_sort_dir(), 3);
+assert_eq!(instance.global::<State<'_>>().invoke_get_value(), 10);
+instance.global::<State<'_>>().invoke_set_sort_dir(4);
+assert_eq!(instance.get_sort_dir(), 4);
+assert!(!instance.global::<State<'_>>().get_on_toggle());
+instance.global::<State<'_>>().invoke_toggle();
+assert!(instance.global::<State<'_>>().get_on_toggle());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+instance.invoke_set_sort_dir(2);
+assert_eq(instance.get_sort_dir(), 2);
+instance.set_sort_dir(3);
+assert_eq(instance.global<State>().get_sort_dir(), 3);
+assert_eq(instance.global<State>().invoke_get_value(), 10);
+instance.global<State>().invoke_set_sort_dir(4);
+assert_eq(instance.get_sort_dir(), 4);
+assert(!instance.global<State>().get_on_toggle());
+instance.global<State>().invoke_toggle();
+assert(instance.global<State>().get_on_toggle());
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+instance.set_sort_dir(2);
+assert.equal(instance.sort_dir, 2);
+instance.sort_dir = 3;
+assert.equal(instance.State.sort_dir, 3);
+assert.equal(instance.State.get_value(), 10);
+instance.State.set_sort_dir(4);
+assert.equal(instance.sort_dir, 4);
+instance.State.toggle();
+assert(instance.State.on_toggle);
+```
+*/


### PR DESCRIPTION
Two different declarations could end up with the same generated name:

 
- The move_declarations pass names a moved property by concatenating the element id and the property name. Two declarations can produce the same name (e.g. ids a-2 / a-2-b-4 with properties b-4-c / c). One then silently overwrote the other and both references resolved to a single merged property, in every language backend.
Now a suffix is added when the name is already taken.

- In generated C++, the fields holding properties and callbacks shared the struct with the public accessor functions. A callback named set-foo collided with the generated setter of a property foo and caused a confusing C++ compile error. All fields named after source identifiers now get a field_ prefix, so they can't clash with member functions or reserved members.

