### PR TITLE
Allow shadowing newly added builtin members with a warning

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -526,6 +526,7 @@ serde
 setattr
 SETFL
 Shaderiv
+shadowable
 sharedfontique
 sharedstring
 sharedvector

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -18,6 +18,15 @@
    another properties. These binding will be then set by the compiler.
    `output` property mean that the property can be modified by the native Item,
    otherwise it is assumed the native item don't write to that property.
+
+   A property, callback, or function can be preceded by a `//-shadowable` comment.
+   Components may declare a member with the same name as a shadowable member: this is
+   a warning instead of an error, and the declaration shadows the builtin member.
+   Members added to an already released element must be marked shadowable, so that
+   older code that already declares a member with that name keeps compiling.
+   This only works for members that the compiler itself never accesses by name —
+   no default binding, and no compiler pass that looks the name up on user elements —
+   as such accesses would resolve to the shadowing declaration and generate wrong code.
  */
 
  component Empty {
@@ -1500,8 +1509,10 @@ component WindowItem {
     /// \default true if 'SLINT_FULLSCREEN' environment variable is set, otherwise false
     in-out property <bool> full-screen;
     /// Whether the window is minimized. Setting this to true minimizes the window.
+    //-shadowable
     in-out property <bool> minimized;
     /// Whether the window is maximized. Setting this to true maximizes the window.
+    //-shadowable
     in-out property <bool> maximized;
     /// The background brush of the `Window`.
     /// \default depends on the style
@@ -1536,10 +1547,12 @@ component WindowItem {
     /// Request that the window be closed. This triggers the `close-requested` callback,
     /// giving the application a chance to cancel the close. Returns `true` if the close
     /// was dispatched, or `false` if the application declined.
+    //-shadowable
     function close() -> bool {
     }
     /// Hide this window. This also drops the strong reference on the window, so if this was
     /// the last reference, the event loop will quit.
+    //-shadowable
     function hide() {
     }
 }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -384,6 +384,13 @@ pub struct BuiltinPropertyInfo {
     pub property_visibility: PropertyVisibility,
     /// Raw `///` doc comment from builtins.slint, if any.
     pub docs: Option<String>,
+    /// True when a component may declare a member of the same name, shadowing this one
+    /// (`//-shadowable` annotation in builtins.slint).
+    /// Members added to a builtin element after its initial release should be marked
+    /// shadowable so that older code that already declares the name keeps compiling —
+    /// unless a compiler pass accesses the member by name, in which case shadowing
+    /// would generate wrong code and the member must not be marked.
+    pub shadowable: bool,
 }
 
 impl BuiltinPropertyInfo {
@@ -393,6 +400,7 @@ impl BuiltinPropertyInfo {
             default_value: BuiltinPropertyDefault::None,
             property_visibility: PropertyVisibility::InOut,
             docs: None,
+            shadowable: false,
         }
     }
 
@@ -408,6 +416,7 @@ impl From<BuiltinFunction> for BuiltinPropertyInfo {
             default_value: BuiltinPropertyDefault::BuiltinFunction(function),
             property_visibility: PropertyVisibility::Public,
             docs: None,
+            shadowable: false,
         }
     }
 }
@@ -470,6 +479,7 @@ impl ElementType {
                         declared_pure: None,
                         is_local_to_component: false,
                         is_in_direct_base: false,
+                        is_shadowable: p.shadowable,
                         builtin_function: match &p.default_value {
                             BuiltinPropertyDefault::BuiltinFunction(f) => Some(f.clone()),
                             _ => None,
@@ -492,6 +502,7 @@ impl ElementType {
                     declared_pure: None,
                     is_local_to_component: false,
                     is_in_direct_base: false,
+                    is_shadowable: false,
                     builtin_function: None,
                 }
             }
@@ -877,6 +888,9 @@ pub struct PropertyLookupResult<'a> {
     pub is_local_to_component: bool,
     /// True if the property in the direct base of the component (for protected visibility purposes)
     pub is_in_direct_base: bool,
+    /// True if a local declaration may shadow this member. Only builtin element
+    /// members marked `//-shadowable` in builtins.slint are shadowable.
+    pub is_shadowable: bool,
 
     /// If the property is a builtin function
     pub builtin_function: Option<BuiltinFunction>,
@@ -905,6 +919,7 @@ impl<'a> PropertyLookupResult<'a> {
             declared_pure: None,
             is_local_to_component: false,
             is_in_direct_base: false,
+            is_shadowable: false,
             builtin_function: None,
         }
     }

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -94,8 +94,10 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                     }
 
                     info.docs = docs::doc_comment(&p);
+                    info.shadowable = has_shadowable_annotation(&p);
 
                     if let Some(e) = p.BindingExpression() {
+                        assert!(!info.shadowable, "shadowable property {id}::{prop_name} can't have a default value as it would end up on the shadowing declaration");
                         let ty = info.ty.clone();
                         info.default_value = BuiltinPropertyDefault::Expr(compiled(e, register, ty));
                     }
@@ -123,6 +125,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                             .collect()
                     })));
                     info.docs = docs::doc_comment(&s);
+                    info.shadowable = has_shadowable_annotation(&s);
                     (identifier_text(&s.DeclaredIdentifier()).unwrap(), info)
                 }))
         );
@@ -178,6 +181,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                 Function { return_type, args, arg_names }.into(),
             ));
             info.docs = docs::doc_comment(&f);
+            info.shadowable = has_shadowable_annotation(&f);
             (name, info)
         }));
 
@@ -283,6 +287,26 @@ fn compiled(
         panic!("Error parsing the builtin elements: {vec:?}");
     }
     e
+}
+
+/// Check for a `//-shadowable` annotation in the comments immediately before a
+/// member declaration. Marks members that a component may shadow with a local
+/// declaration of the same name.
+fn has_shadowable_annotation(node: &SyntaxNode) -> bool {
+    let mut cursor = node.node.prev_sibling_or_token();
+    while let Some(cur) = cursor {
+        match cur.kind() {
+            SyntaxKind::Whitespace => {}
+            SyntaxKind::Comment => {
+                if cur.as_token().unwrap().text().trim_end() == "//-shadowable" {
+                    return true;
+                }
+            }
+            _ => return false,
+        }
+        cursor = cur.prev_sibling_or_token();
+    }
+    false
 }
 
 /// Find out if there are comments that starts with `//-key` and returns `None`

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -642,6 +642,9 @@ pub struct PropertyDeclaration {
     pub visibility: PropertyVisibility,
     /// For function or callback: whether it is declared as `pure` (None for private function for which this has to be deduced)
     pub pure: Option<bool>,
+    /// Whether the declaration shadows a builtin element member of the same name
+    /// (diagnosed by the check_builtin_shadowing pass)
+    pub shadows_builtin: bool,
 }
 
 impl PropertyDeclaration {
@@ -1256,9 +1259,15 @@ impl Element {
             let PropertyLookupResult {
                 resolved_name: prop_name,
                 property_type: maybe_existing_prop_type,
+                is_shadowable,
                 ..
             } = r.lookup_property(&unresolved_prop_name);
+            let shadows_builtin = maybe_existing_prop_type != Type::Invalid && is_shadowable;
             match maybe_existing_prop_type {
+                Type::Invalid => {} // Ok to proceed with a new declaration
+                // The declaration shadows a shadowable builtin member;
+                // the check_builtin_shadowing pass emits the diagnostic
+                _ if shadows_builtin => {}
                 Type::Callback { .. } => {
                     diag.push_error(
                         format!("Cannot declare property '{prop_name}' when a callback with the same name exists"),
@@ -1273,7 +1282,6 @@ impl Element {
                     );
                     continue;
                 }
-                Type::Invalid => {} // Ok to proceed with a new declaration
                 _ => {
                     diag.push_error(
                         format!("Cannot override property '{unresolved_prop_name}'"),
@@ -1322,19 +1330,22 @@ impl Element {
                 );
             }
 
+            // Use the name as declared, not the resolved name: when the declaration
+            // shadows a builtin member, the resolved name may be a native alias.
             r.property_declarations.insert(
-                prop_name.clone().into(),
+                unresolved_prop_name.clone(),
                 PropertyDeclaration {
                     property_type: prop_type,
                     node: Some(prop_decl.clone().into()),
                     visibility,
+                    shadows_builtin,
                     ..Default::default()
                 },
             );
 
             if let Some(csn) = prop_decl.BindingExpression() {
                 property_bindings.push((
-                    prop_name.clone().into(),
+                    unresolved_prop_name.clone(),
                     csn,
                     prop_decl.DeclaredIdentifier(),
                 ));
@@ -1343,7 +1354,7 @@ impl Element {
             if let Some(csn) = prop_decl.TwoWayBinding() {
                 #[cfg(feature = "slint-sc")]
                 diag.slint_sc_error("Two-way bindings are", &csn);
-                two_way_bindings.push((prop_name.into(), csn, prop_decl.DeclaredIdentifier()));
+                two_way_bindings.push((unresolved_prop_name, csn, prop_decl.DeclaredIdentifier()));
             }
         }
 
@@ -1399,9 +1410,13 @@ impl Element {
             let PropertyLookupResult {
                 resolved_name: existing_name,
                 property_type: maybe_existing_prop_type,
+                is_shadowable,
                 ..
             } = r.lookup_property(&name);
-            if !matches!(maybe_existing_prop_type, Type::Invalid) {
+            // When the declaration shadows a shadowable builtin member, proceed;
+            // the check_builtin_shadowing pass emits the diagnostic
+            let shadows_builtin = !matches!(maybe_existing_prop_type, Type::Invalid);
+            if shadows_builtin && !is_shadowable {
                 if matches!(maybe_existing_prop_type, Type::Callback { .. }) {
                     if r.property_declarations.contains_key(&name) {
                         diag.push_error(
@@ -1436,6 +1451,7 @@ impl Element {
                         node: Some(sig_decl.into()),
                         visibility: PropertyVisibility::InOut,
                         pure,
+                        shadows_builtin,
                         ..Default::default()
                     },
                 );
@@ -1469,6 +1485,7 @@ impl Element {
                     node: Some(sig_decl.into()),
                     visibility: PropertyVisibility::InOut,
                     pure,
+                    shadows_builtin,
                     ..Default::default()
                 },
             );
@@ -1485,9 +1502,13 @@ impl Element {
             let PropertyLookupResult {
                 resolved_name: existing_name,
                 property_type: maybe_existing_prop_type,
+                is_shadowable,
                 ..
             } = r.lookup_property(&name);
-            if !matches!(maybe_existing_prop_type, Type::Invalid) {
+            // When the declaration shadows a shadowable builtin member, proceed;
+            // the check_builtin_shadowing pass emits the diagnostic
+            let shadows_builtin = !matches!(maybe_existing_prop_type, Type::Invalid);
+            if shadows_builtin && !is_shadowable {
                 if matches!(maybe_existing_prop_type, Type::Callback { .. } | Type::Function { .. })
                 {
                     diag.push_error(
@@ -1553,6 +1574,7 @@ impl Element {
                 node: Some(func.clone().into()),
                 visibility,
                 pure,
+                shadows_builtin,
                 ..Default::default()
             };
 
@@ -2041,6 +2063,7 @@ impl Element {
                 declared_pure: p.pure,
                 is_local_to_component: true,
                 is_in_direct_base: false,
+                is_shadowable: false,
                 builtin_function: None,
             },
         )

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -4,6 +4,7 @@
 mod apply_default_properties_from_style;
 mod binding_analysis;
 mod border_radius;
+mod check_builtin_shadowing;
 mod check_drag_area;
 mod check_expressions;
 mod check_public_api;
@@ -336,6 +337,7 @@ pub fn run_import_passes(
     purity_check::purity_check(doc, diag);
     focus_handling::replace_forward_focus_bindings_with_focus_functions(doc, diag);
     check_expressions::check_expressions(doc, diag);
+    check_builtin_shadowing::check_builtin_shadowing(doc, diag);
     windows::warn_about_child_windows(doc, diag);
     unique_id::check_unique_id(doc, diag);
 }

--- a/internal/compiler/passes/check_builtin_shadowing.rs
+++ b/internal/compiler/passes/check_builtin_shadowing.rs
@@ -1,0 +1,77 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Diagnose declarations that shadow a builtin element member.
+//!
+//! A declaration may shadow a shadowable builtin member with a warning, but only as
+//! long as no base component uses that member: inlining merges a base component's root
+//! element into the inheriting element, and since references are looked up by name, the
+//! base component's references to the builtin member would silently resolve to the
+//! shadowing declaration instead. In that case, report an error.
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::langtype::{ElementType, Type};
+use crate::object_tree::{Component, Document, recurse_elem};
+use crate::parser::SyntaxKind;
+use std::rc::Rc;
+
+pub fn check_builtin_shadowing(doc: &Document, diag: &mut BuildDiagnostics) {
+    for component in &doc.inner_components {
+        recurse_elem(&component.root_element, &(), &mut |elem, _| {
+            let elem = elem.borrow();
+            for (name, decl) in &elem.property_declarations {
+                if !decl.shadows_builtin {
+                    continue;
+                }
+                let Some(node) = &decl.node else { continue };
+                let span =
+                    node.child_node(SyntaxKind::DeclaredIdentifier).unwrap_or_else(|| node.clone());
+                let builtin_kind = member_kind(&elem.base_type.lookup_property(name).property_type);
+
+                // Look for a base component that uses the builtin member
+                let mut base = elem.base_type.clone();
+                let conflicting_base = loop {
+                    let ElementType::Component(c) = base else { break None };
+                    base = c.root_element.borrow().base_type.clone();
+                    if uses_member_on_root(&c, name) {
+                        break Some(c);
+                    }
+                };
+
+                if let Some(c) = conflicting_base {
+                    diag.push_error(
+                        format!(
+                            "Cannot shadow the builtin {builtin_kind} '{name}' because it is used by the base component '{}'",
+                            c.id
+                        ),
+                        &span,
+                    );
+                } else {
+                    diag.push_warning(
+                        format!("'{name}' shadows the builtin {builtin_kind} of the same name"),
+                        &span,
+                    );
+                }
+            }
+        });
+    }
+}
+
+/// True if the component's own code uses `name` on its root element
+fn uses_member_on_root(component: &Rc<Component>, name: &str) -> bool {
+    let root = component.root_element.borrow();
+    // bindings and change callbacks refer to the property by name,
+    // everything else goes through a NamedReference
+    root.named_references.is_referenced(name)
+        || root.bindings.contains_key(name)
+        || root.change_callbacks.contains_key(name)
+}
+
+/// The kind of element member that a type represents, for use in diagnostics
+fn member_kind(ty: &Type) -> &'static str {
+    match ty {
+        Type::Callback { .. } => "callback",
+        Type::Function { .. } => "function",
+        _ => "property",
+    }
+}

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1674,6 +1674,7 @@ fn lower_dialog_layout(
                                         )),
                                         visibility: PropertyVisibility::InOut,
                                         pure: None,
+                                        shadows_builtin: false,
                                     });
                             }
                         }

--- a/internal/compiler/tests/syntax/basic/override_builtin.slint
+++ b/internal/compiler/tests/syntax/basic/override_builtin.slint
@@ -1,0 +1,82 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Builtin members marked `//-shadowable` in builtins.slint can be shadowed by a local
+// declaration with a warning instead of an error, so that code written before the
+// builtin member was added keeps compiling.
+
+export component Test inherits Window {
+    // shadows the builtin bool property with a different type
+    in-out property <string> maximized: "shadowed";
+//                           >       <warning{'maximized' shadows the builtin property of the same name}
+
+    in-out property <int> minimized: 42;
+//                        >       <warning{'minimized' shadows the builtin property of the same name}
+
+    // shadows the builtin `close() -> bool` function
+    callback close(string) -> string;
+//           >   <warning{'close' shadows the builtin function of the same name}
+    close(s) => { s + "!" }
+
+    // shadows the builtin `hide()` function
+    function hide() -> string { "shadowed" }
+//           >  <warning{'hide' shadows the builtin function of the same name}
+
+    // builtin members that are not marked shadowable can still not be overridden
+    property <string> width;
+//                    >   <error{Cannot override property 'width'}
+    TouchArea {
+        callback clicked(int);
+//               >     <error{Cannot override callback 'clicked'}
+    }
+
+    // neither can reserved properties that exist on every element
+    property <int> x;
+//                 ^error{Cannot override property 'x'}
+    function focus() {}
+//           >   <error{Cannot override 'focus'}
+}
+
+// A shadowable member can still not be shadowed when a base component uses it,
+// because the shadowing declaration would hijack the base component's references.
+component UsesWindowMembers inherits Window {
+    out property <string> status: self.minimized ? "minimized" : "normal";
+    public function request-close() { if (!self.maximized) { self.close(); } }
+}
+
+export component Test2 inherits UsesWindowMembers {
+    in-out property <string> minimized;
+//                           >       <error{Cannot shadow the builtin property 'minimized' because it is used by the base component 'UsesWindowMembers'}
+    callback maximized(int) -> int;
+//           >       <error{Cannot shadow the builtin property 'maximized' because it is used by the base component 'UsesWindowMembers'}
+    in-out property <string> close: "abc";
+//                           >   <error{Cannot shadow the builtin function 'close' because it is used by the base component 'UsesWindowMembers'}
+}
+
+// Bindings and change callbacks in the base component also count as uses
+component BindsWindowMembers inherits Window {
+    maximized: true;
+    changed minimized => { }
+}
+
+export component Test3 inherits BindsWindowMembers {
+    in-out property <string> maximized;
+//                           >       <error{Cannot shadow the builtin property 'maximized' because it is used by the base component 'BindsWindowMembers'}
+    in-out property <string> minimized;
+//                           >       <error{Cannot shadow the builtin property 'minimized' because it is used by the base component 'BindsWindowMembers'}
+}
+
+// Assignments in the base component also count as uses
+component AssignsWindowMembers inherits Window {
+    public function minimize() { self.minimized = true; }
+    TouchArea {
+        clicked => { root.maximized = false; }
+    }
+}
+
+export component Test4 inherits AssignsWindowMembers {
+    in-out property <string> minimized;
+//                           >       <error{Cannot shadow the builtin property 'minimized' because it is used by the base component 'AssignsWindowMembers'}
+    in-out property <string> maximized;
+//                           >       <error{Cannot shadow the builtin property 'maximized' because it is used by the base component 'AssignsWindowMembers'}
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -542,6 +542,7 @@ impl Snapshotter {
                     is_alias: v.is_alias.as_ref().map(|a| a.snapshot(self)),
                     visibility: v.visibility,
                     pure: v.pure,
+                    shadows_builtin: v.shadows_builtin,
                 };
                 (k.clone(), decl)
             })

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -368,6 +368,7 @@ pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResul
             resolved_name: name,
             is_local_to_component: false,
             is_in_direct_base: false,
+            is_shadowable: false,
             property_visibility: visibility,
             declared_pure: None,
             builtin_function,
@@ -386,6 +387,7 @@ pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResul
                         resolved_name: format!("{pre}-{suf}").into(),
                         is_local_to_component: false,
                         is_in_direct_base: false,
+                        is_shadowable: false,
                         property_visibility: crate::object_tree::PropertyVisibility::InOut,
                         declared_pure: None,
                         builtin_function: None,
@@ -587,7 +589,6 @@ impl TypeRegister {
         }
 
         let font_metrics_prop = crate::langtype::BuiltinPropertyInfo {
-            ty: font_metrics_type(),
             property_visibility: PropertyVisibility::Output,
             default_value: BuiltinPropertyDefault::WithElement(|elem| {
                 crate::expression_tree::Expression::FunctionCall {
@@ -598,7 +599,7 @@ impl TypeRegister {
                     source_location: None,
                 }
             }),
-            docs: None,
+            ..crate::langtype::BuiltinPropertyInfo::new(font_metrics_type())
         };
 
         match &mut register.elements.get_mut("TextInput").unwrap() {

--- a/tests/cases/properties/override_builtin.slint
+++ b/tests/cases/properties/override_builtin.slint
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Declarations that collide with a shadowable member of a builtin element are only a
+// warning: the declaration shadows the builtin member, even with a different type.
+// This keeps code compiling when a new Slint version adds members to builtin elements.
+
+// The base component doesn't use the builtin members, so the derived component may
+// shadow them.
+component Base inherits Window {
+    width: 300px;
+    height: 200px;
+}
+
+export component TestCase inherits Base {
+    // shadows the builtin bool properties with different types
+    in-out property <string> maximized: "shadowed";
+    in-out property <int> minimized: 42;
+
+    // shadows the builtin `close() -> bool` function
+    pure callback close(string) -> string;
+    close(s) => { s + "!" }
+
+    out property <bool> test: maximized == "shadowed" && minimized == 42 && close("a") == "a!";
+}
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.set_maximized("changed".into());
+instance.set_minimized(-1);
+assert_eq!(instance.get_maximized(), slint::SharedString::from("changed"));
+assert_eq!(instance.get_minimized(), -1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+instance.set_maximized("changed");
+instance.set_minimized(-1);
+assert_eq(instance.get_maximized(), "changed");
+assert_eq(instance.get_minimized(), -1);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+instance.maximized = "changed";
+instance.minimized = -1;
+assert.equal(instance.maximized, "changed");
+assert.equal(instance.minimized, -1);
+```
+*/


### PR DESCRIPTION
New members on builtin elements broke code that already declared a property or callback with the same name (in 1.17: `minimized`, `maximized`, `close()`, and `hide()` on Window).

Members marked `//-shadowable` in builtins.slint can now be shadowed by a local declaration: the conflict is a warning instead of an error and the declaration shadows the builtin member, even with a different type.

Shadowing stays an error when a base component uses the builtin member, because inlining merges the base's root element into the inheriting element and the base's by-name references would silently resolve to the shadowing declaration.

Shadowable members must not be otherwise accessed by name in the compiler, as such accesses would also resolve to the shadowing declaration. An assert in load_builtins enforces this for default bindings.

Allowing any shadowing would be a big undertaking as every NamedReference is just a string lookup that we would need to change to a precise component path.
That's https://github.com/slint-ui/slint/issues/1937  and somehow https://github.com/slint-ui/slint/issues/1461