### PR TITLE
Add `@commands` macro

### DIFF
--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -303,6 +303,20 @@ See <Link type="DragAndDrop" /> for an end-to-end example.
 
 </SlintProperty>
 
+## Paths
+### pathdata
+<SlintProperty propName="pathdata" typeName="pathdata" defaultValue='empty pathdata'>
+
+The `pathdata` type is a reference to a SVG path commands.
+
+A `pathdata` value can be constructed from a string literal with the `@commands("...")` construct.
+
+For example: `@commands("M 19 4 L 10 4 M 14 20 L 5 20 M 15 4 L 9 20")`.
+
+See also the <Link type="Path" label="Path element"/>.
+
+</SlintProperty>
+
 ## Animation
 ### easing
 <SlintProperty propName="easing" typeName="easing" defaultValue='linear'>

--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -632,7 +632,7 @@
                     "include": "#boolean"
                 },
                 {
-                    "begin": "(@(tr|linear-gradient|radial-gradient|conic-gradient|image-url))\\s*(\\()",
+                    "begin": "(@(tr|linear-gradient|radial-gradient|conic-gradient|image-url|commands))\\s*(\\()",
                     "end": "(\\))",
                     "beginCaptures": {
                         "1": {

--- a/editors/kate/slint.ksyntaxhighlighter.xml
+++ b/editors/kate/slint.ksyntaxhighlighter.xml
@@ -45,6 +45,7 @@
       <item>@tr</item>
       <item>@children</item>
       <item>@image-url</item>
+      <item>@commands</item>
       <item>@linear-gradient</item>
       <item>@radial-gradient</item>
       <item>@conic-gradient</item>

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -333,6 +333,7 @@ module.exports = grammar({
           $.value,
           $.gradient_call,
           $.image_call,
+          $.commands_call,
           $.reference_identifier,
           $.simple_identifier,
           $.function_call,
@@ -597,6 +598,14 @@ module.exports = grammar({
         optional(seq(",", "nine-slice", "(", repeat($._int_number), ")")),
         ")",
       ),
+
+    commands_call: ($) =>
+        seq(
+            field("name", "@commands"),
+            "(",
+            field("commands", $.string_value),
+            ")"
+        ),
 
     typed_identifier: ($) =>
       seq(field("name", $.simple_identifier), ":", field("type", $.type)),

--- a/editors/zed/languages/slint/highlights.scm
+++ b/editors/zed/languages/slint/highlights.scm
@@ -183,6 +183,9 @@
 (image_call
   "@image-url" @attribute)
 
+(commands
+  "@commands" @attribute)
+
 (tr
   "@tr" @attribute)
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2248,9 +2248,10 @@ component Close {
 ///
 /// When not part of a layout, its width or height defaults to 100% of the parent element when not specified.
 ///
-/// A path can be defined in two different ways:
+/// A path can be defined in three different ways:
 ///
 /// -   Using SVG path commands as a string
+/// -   Using SVG path commands inside `@commands` macro as a pathdata
 /// -   Using path command elements in `.slint` markup.
 ///
 /// The coordinates used in the geometric commands are within the imaginary coordinate system of the path.
@@ -2347,6 +2348,15 @@ export component Path {
     //! ### Commands
     //! <SlintProperty propName="commands" typeName="string">
     //! A string providing the commands according to the SVG path specification.
+    //! ```slint
+    //! commands: "M5 12h14";
+    //! ```
+    //!
+    //! Alternatively, the commands can be provided using the `@commands` macro, which allows it to be compiled ahead of time.
+    //! Most suitable for `no_std` environments, where string commands parsing is not available.
+    //! ```slint
+    //! commands: @commands("M5 12h14");
+    //! ```
     //! This property can only be set in a binding and cannot be accessed in an expression.
     //! </SlintProperty>
     //!

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2349,13 +2349,17 @@ export component Path {
     //! <SlintProperty propName="commands" typeName="string">
     //! A string providing the commands according to the SVG path specification.
     //! ```slint
-    //! commands: "M5 12h14";
+    //! export component Example inherits Path {
+    //!     commands: "M5 12h14";
+    //! }
     //! ```
     //!
     //! Alternatively, the commands can be provided using the `@commands` macro, which allows it to be compiled ahead of time.
     //! Most suitable for `no_std` environments, where string commands parsing is not available.
     //! ```slint
-    //! commands: @commands("M5 12h14");
+    //! export component Example inherits Path {
+    //!     commands: @commands("M5 12h14");
+    //! }
     //! ```
     //! This property can only be set in a binding and cannot be accessed in an expression.
     //! </SlintProperty>
@@ -2839,7 +2843,8 @@ export global Platform {
     /// to the top of the window stack. On other platforms this function is a no-op.
     ///
     /// This corresponds to the standard macOS **Window › Bring All to Front** menu item.
-    function macos-bring-all-windows-to-front() { }
+    function macos-bring-all-windows-to-front() {
+    }
     /// The decimal separator currently used for localized float to string and vice versa conversions
     /// For more information about localization and how to change the decimal separator see <Link type="translations" label="translations page"/>.
     out property <string> decimal-separator;

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -375,12 +375,14 @@ declare_syntax! {
         // FIXME: the test should test that as alternative rather than several of them (but it can also be a literal)
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
-                       ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
+                       ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtCommands,?AtGradient, ?AtTr,
                        ?MemberAccess, ?AtKeys ],
         /// Concatenate the children Expressions and StringLiteral to make a string
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
         AtImageUrl -> [],
+        /// `@commands("M 20 4 L 9 15 M 21 19 L 3 19 M 9 15 L 4 10")`
+        AtCommands -> [],
         /// `@linear-gradient(...)` or `@radial-gradient(...)`
         AtGradient -> [*Expression],
         /// `@tr("foo", ...)`  // the string is a StringLiteral

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -261,6 +261,9 @@ fn parse_at_keyword(p: &mut impl Parser) {
         "keys" => {
             parse_keys(p);
         }
+        "commands" => {
+            parse_commands(p);
+        }
         _ => {
             p.consume();
             p.test(SyntaxKind::Identifier); // consume the identifier, so that autocomplete works
@@ -755,4 +758,29 @@ fn parse_image_url(p: &mut impl Parser) {
     if !p.expect(SyntaxKind::RParent) {
         p.until(SyntaxKind::RParent);
     }
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,AtCommands
+/// @commands("M 20 4 L 9 15 M 21 19 L 3 19 M 9 15 L 4 10")
+/// ```
+fn parse_commands(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::AtCommands);
+    p.expect(SyntaxKind::At);
+    debug_assert_eq!(p.peek().as_str(), "commands");
+    p.expect(SyntaxKind::Identifier); // "commands"
+    p.expect(SyntaxKind::LParent);
+
+    let peek = p.peek();
+    if peek.kind() != SyntaxKind::StringLiteral
+        || !peek.as_str().starts_with('"')
+        || !peek.as_str().ends_with('"')
+    {
+        p.error("@commands requires a plain string literal (no string templates)");
+        p.until(SyntaxKind::RParent);
+        return;
+    }
+    p.consume();
+
+    p.expect(SyntaxKind::RParent);
 }

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -77,9 +77,7 @@ pub fn compile_paths(
                     )))
                     .into()
                 }
-                expr if expr.ty() == Type::PathData => {
-                    commands_expr.into()
-                }
+                expr if expr.ty() == Type::PathData => commands_expr,
                 _ => {
                     diag.push_error(
                         "The commands property only accepts strings".into(),

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -77,6 +77,9 @@ pub fn compile_paths(
                     )))
                     .into()
                 }
+                expr if expr.ty() == Type::PathData => {
+                    commands_expr.into()
+                }
                 _ => {
                     diag.push_error(
                         "The commands property only accepts strings".into(),
@@ -146,7 +149,7 @@ pub fn compile_paths(
     });
 }
 
-fn compile_path_from_string_literal(
+pub fn compile_path_from_string_literal(
     commands: &str,
 ) -> Result<BindingExpression, lyon_extra::parser::ParseError> {
     let mut builder = lyon_path::Path::builder();

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -212,7 +212,15 @@ impl Expression {
             }
         };
         if !matches!(ctx.property_type, Type::Callback { .. } | Type::Function { .. }) {
-            e.maybe_convert_to(ctx.property_type.clone(), &node, ctx.diag)
+            // Skip type checking for Path with @commands
+            if e.ty() == Type::PathData
+                && ctx.property_type == Type::String
+                && ctx.property_name == Some("commands")
+            {
+                e
+            } else {
+                e.maybe_convert_to(ctx.property_type.clone(), &node, ctx.diag)
+            }
         } else {
             // Binding to a callback or function shouldn't happen
             assert!(ctx.diag.has_errors());
@@ -377,6 +385,11 @@ impl Expression {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("@image-url() expressions are", &node);
                         Some(Self::from_at_image_url_node(node.into(), ctx))
+                    }
+                    SyntaxKind::AtCommands => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("@commands() expressions are", &node);
+                        Some(Self::from_at_commands_node(node.into(), ctx))
                     }
                     SyntaxKind::AtGradient => {
                         #[cfg(feature = "slint-sc")]
@@ -586,6 +599,22 @@ impl Expression {
             resource_ref,
             source_location: Some(node.to_source_location()),
             nine_slice,
+        }
+    }
+    fn from_at_commands_node(node: syntax_nodes::AtCommands, ctx: &mut LookupCtx) -> Self {
+        let Some(string_token) = node.child_token(SyntaxKind::StringLiteral) else {
+            return Expression::Invalid;
+        };
+
+        let s = string_token.text();
+        let commands_str = &s[1..s.len() - 1];
+
+        match super::compile_paths::compile_path_from_string_literal(commands_str) {
+            Ok(binding) => binding.expression, // ?
+            Err(e) => {
+                ctx.diag.push_error(format!("Error parsing SVG path commands ({e})"), &node);
+                Expression::Invalid
+            }
         }
     }
 

--- a/tests/cases/elements/path_at_commands.slint
+++ b/tests/cases/elements/path_at_commands.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Path {
+    stroke: white;
+    stroke-width: 10px;
+    commands: @commands("M 19 4 L 10 4 M 14 20 L 5 20 M 15 4 L 9 20");
+}

--- a/tests/cases/elements/path_string_commands.slint
+++ b/tests/cases/elements/path_string_commands.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Path {
+    stroke: white;
+    stroke-width: 10px;
+    commands: "M 19 4 L 10 4 M 14 20 L 5 20 M 15 4 L 9 20";
+}


### PR DESCRIPTION
This PR introduces a `@commands` macro that enables SVG path commands to be compiled at build-time rather than parsed at runtime. This is particularly beneficial for `no_std` environments where runtime string parsing is not available.

```slint
export component Example inherits Path {
    commands: @commands("M 19 4 L 10");
}
```

### Key Benefits

* **`no_std` friendly:** Brings the convenience of string commands to `no_std` targets, offering a much cleaner syntax compared to verbose `Path Element` trees.
* **Performance gains:** Eliminates runtime decoding overhead for static paths.


#### **Changes made in this PR:**

1. **Parser (`compiler/parser.rs`):** Added `parse_commands` to handle and parse the `@commands` macro syntax.
2. **Name Resolution (`compiler/passes/resolving.rs`):** Modified the resolution pass to allow the `Path` element to accept both compiled path data (returned by `@commands`) and traditional string commands.
3. **Tests:** Added two new test cases for the `Path` element—one verifying standard string commands and another verifying commands processed via the `@commands` macro.
4. **Documentation**
5. **Editor grammars**
