### PR TITLE
Remote viewer: expose the viewer state to the UI and polish the connection

### DIFF
--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -206,11 +206,15 @@ impl Connection {
                                         Ok(stream) => {
                                             tracing::info!("Websocket established with {addr:?}");
                                             if let Some((_old_sink, old_handle)) = current_session.take() {
-                                                tracing::error!(
-                                                    "Second connection while we were already connected, dropping old connection"
-                                                );
-                                                old_handle.abort();
-                                                // The aborted task can't run its end-of-loop
+                                                // A finished handle is just a stale session left
+                                                // behind by an earlier disconnect, not a takeover.
+                                                if !old_handle.is_finished() {
+                                                    tracing::warn!(
+                                                        "Second connection while we were already connected, dropping old connection"
+                                                    );
+                                                    old_handle.abort();
+                                                }
+                                                // An aborted task can't run its end-of-loop
                                                 // cleanup, so reset the shared state here so
                                                 // the new client starts from a clean cache.
                                                 inner_file_cache.clear();
@@ -438,6 +442,14 @@ impl Connection {
                             break;
                         }
                         Ok(Message::Frame(_)) => unreachable!(),
+                        Err(tokio_tungstenite::tungstenite::Error::Protocol(
+                            tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+                        )) => {
+                            // The peer vanished without a close handshake (process killed,
+                            // network drop) — a normal way for a session to end.
+                            tracing::info!("Connection lost");
+                            break;
+                        }
                         Err(err) => {
                             tracing::error!("WebSocket error: {err}");
                             break;

--- a/tools/lsp/preview/connector/remote.rs
+++ b/tools/lsp/preview/connector/remote.rs
@@ -161,7 +161,7 @@ impl RemoteLspToPreview {
             let (socket_sender, socket_receiver) = stream.split();
             let replaced = Arc::new(AtomicBool::new(false));
             #[allow(clippy::disallowed_methods)]
-            let Some(old) = connection.lock().await.replace(RemoteLspConnection {
+            let Some(mut old) = connection.lock().await.replace(RemoteLspConnection {
                 sender: socket_sender,
                 task: tokio::task::spawn_local(Self::receive_task(
                     socket_receiver,
@@ -178,6 +178,9 @@ impl RemoteLspToPreview {
 
             tracing::info!("Closing previous connection to remote preview server");
             old.replaced.store(true, Ordering::Relaxed);
+            // Close handshake so the old viewer sees a clean end of session
+            // instead of a connection reset.
+            old.sender.close().await.ok();
             old.task.abort();
 
             Ok(())
@@ -237,6 +240,14 @@ impl RemoteLspToPreview {
                     connection_state_handle.error = Some(format!("I/O error: {err}"));
                     return;
                 }
+                Err(tokio_tungstenite_wasm::Error::Protocol(
+                    tokio_tungstenite_wasm::error::ProtocolError::ResetWithoutClosingHandshake,
+                )) => {
+                    // The viewer vanished without a close handshake (app killed,
+                    // network drop) — a normal way for a session to end.
+                    tracing::info!("Connection to remote viewer lost");
+                    return;
+                }
                 Err(err) => {
                     tracing::error!("WebSocket error: {err}");
                 }
@@ -247,7 +258,10 @@ impl RemoteLspToPreview {
     pub fn disconnect(&self) -> impl Future<Output = ()> + 'static {
         let connection = self.connection.clone();
         async move {
-            if let Some(connection) = connection.lock().await.take() {
+            if let Some(mut connection) = connection.lock().await.take() {
+                // Close handshake so the viewer sees a clean end of session
+                // instead of a connection reset.
+                connection.sender.close().await.ok();
                 connection.task.abort();
             }
         }

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -77,6 +77,18 @@ export component RemotePreviewView inherits Rectangle {
         && Api.remote-discovered-viewers[selected-index].compatible;
 
     property <bool> connecting: Api.remote-connection-state == RemoteConnectionState.Connecting;
+
+    function connect-to-device(index: int) {
+        if !root.connecting
+            && index >= 0
+            && index < Api.remote-discovered-viewers.length
+            && Api.remote-discovered-viewers[index].compatible
+            && Api.remote-discovered-viewers[index].addresses.length > 0 {
+            Api.remote-connect(
+                Api.remote-discovered-viewers[index].addresses,
+                Api.remote-discovered-viewers[index].port);
+        }
+    }
     property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
     property <image> background-image: root.dark-color-scheme ? @image-url("../../../viewer/remote/assets/bg-frame.svg") : @image-url("../../../viewer/remote/assets/bg-frame-light.svg");
 
@@ -187,6 +199,11 @@ export component RemotePreviewView inherits Rectangle {
                                         root.selected-index = i;
                                         root.manual-entry = "";
                                     }
+                                    double-clicked => {
+                                        root.selected-index = i;
+                                        root.manual-entry = "";
+                                        root.connect-to-device(i);
+                                    }
                                 }
 
                                 device-layout := HorizontalLayout {
@@ -265,13 +282,8 @@ export component RemotePreviewView inherits Rectangle {
                             clicked => {
                                 if root.manual-entry != "" {
                                     Api.remote-connect-manual(root.manual-entry);
-                                } else if root.selected-index >= 0
-                                    && root.selected-index < Api.remote-discovered-viewers.length
-                                    && Api.remote-discovered-viewers[root.selected-index].compatible
-                                    && Api.remote-discovered-viewers[root.selected-index].addresses.length > 0 {
-                                    Api.remote-connect(
-                                        Api.remote-discovered-viewers[root.selected-index].addresses,
-                                        Api.remote-discovered-viewers[root.selected-index].port);
+                                } else {
+                                    root.connect-to-device(root.selected-index);
                                 }
                             }
                         }

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -10,7 +10,7 @@ use i_slint_live_preview::remote::{Connection, ConnectionMessage, init_compiler}
 use slint::ComponentHandle as _;
 
 slint::slint! {
-    export { EmptyWindow } from "remote/main.slint";
+    export { RemoteViewerWindow, RemoteViewerState } from "remote/main.slint";
 }
 
 // CARGO_PKG_VERSION tracks the workspace version, so it is the Slint version.
@@ -70,7 +70,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
         })))
     })?;
 
-    let mut placeholder = EmptyWindow::new()?;
+    let mut placeholder = RemoteViewerWindow::new()?;
 
     #[cfg(not(target_vendor = "apple"))]
     let mdns = enable_mdns.then(mdns_sd::ServiceDaemon::new).transpose()?;
@@ -183,6 +183,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
             ConnectionMessage::HighlightFromEditor { .. } => {}
             ConnectionMessage::Connected { remote_addr } => {
                 placeholder.set_message(SharedString::from(format!("Connected to {remote_addr}")));
+                placeholder.set_state(RemoteViewerState::Connected);
                 last_connection = Some(remote_addr);
             }
             ConnectionMessage::Disconnected { remote_addr } => {
@@ -196,6 +197,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                         &address,
                         &device_name,
                         "",
+                        RemoteViewerState::WaitingForConnection,
                     )?;
                 }
             }
@@ -215,7 +217,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
 async fn build_and_show(
     compiler: &slint_interpreter::Compiler,
     preview_component: &PreviewComponent,
-    placeholder: &mut EmptyWindow,
+    placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
     connection: &Rc<Connection>,
     address: &str,
@@ -253,7 +255,14 @@ async fn build_and_show(
             .map(|d| d.to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        swap_to_placeholder(placeholder, user_instance, address, name, &message)?;
+        swap_to_placeholder(
+            placeholder,
+            user_instance,
+            address,
+            name,
+            &message,
+            RemoteViewerState::PreviewError,
+        )?;
         return Ok(());
     }
 
@@ -266,7 +275,14 @@ async fn build_and_show(
         // No compile errors but no component — skip send_diagnostics so we don't clobber
         // unrelated LSP diagnostics for this URI.
         tracing::error!("Component not found");
-        swap_to_placeholder(placeholder, user_instance, address, name, "Component not found")?;
+        swap_to_placeholder(
+            placeholder,
+            user_instance,
+            address,
+            name,
+            "Component not found",
+            RemoteViewerState::PreviewError,
+        )?;
         return Ok(());
     };
 
@@ -279,24 +295,28 @@ async fn build_and_show(
 
     new_instance.show().map_err(|err| anyhow::anyhow!("Cannot show component: {err}"))?;
     *user_instance = Some(new_instance);
+    // The placeholder is hidden now, but keep its state property truthful.
+    placeholder.set_state(RemoteViewerState::Previewing);
     Ok(())
 }
 
 /// Reinstall a fresh placeholder onto the existing window and drop the user instance.
 fn swap_to_placeholder(
-    placeholder: &mut EmptyWindow,
+    placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
     address: &str,
     name: &str,
     message: &str,
+    state: RemoteViewerState,
 ) -> anyhow::Result<()> {
-    let fresh = EmptyWindow::new_with_existing_window(placeholder.window())
+    let fresh = RemoteViewerWindow::new_with_existing_window(placeholder.window())
         .map_err(|err| anyhow::anyhow!("Cannot create placeholder: {err}"))?;
     fresh.set_address(SharedString::from(address));
     fresh.set_name(SharedString::from(name));
     fresh.set_message(SharedString::from(message));
     fresh.set_slint_version(SharedString::from(SLINT_VERSION));
     fresh.set_build_info(build_info());
+    fresh.set_state(state);
     fresh.show().map_err(|err| anyhow::anyhow!("Cannot show placeholder: {err}"))?;
     *placeholder = fresh;
     *user_instance = None;

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -3,12 +3,24 @@
 
 import { Palette, Button } from "std-widgets.slint";
 
-export component EmptyWindow inherits Window {
+export enum RemoteViewerState {
+    /// No editor is connected (startup, and after a disconnect).
+    waiting-for-connection,
+    /// An editor is connected but no preview has been requested yet.
+    connected,
+    /// A user component is shown; this window is hidden.
+    previewing,
+    /// The last build failed; `message` holds the error text.
+    preview-error,
+}
+
+export component RemoteViewerWindow inherits Window {
     in property <string> name;
     in property <string> address;
     in property <string> message;
     in property <string> slint-version;
     in property <string> build-info;
+    in property <RemoteViewerState> state;
 
     property <bool> has-name: name != "";
     property <bool> showing-name: true;


### PR DESCRIPTION
  - Rename `EmptyWindow` to `RemoteViewerWindow` and add a `RemoteViewerState`
    enum property (`waiting-for-connection`, `connected`, `previewing`,
    `preview-error`) so the placeholder UI can react to the viewer's state.
  - Stop logging errors on a normal disconnect: the LSP now performs a proper
    WebSocket close handshake, a connection reset is logged as a normal end of
    session, and a reconnect no longer warns about a stale "second connection".
  - Double-clicking a device in the remote preview dialog connects to it.
