### PR TITLE
viewer: fix iOS crash after a network change while backgrounded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5534,7 +5534,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tracing",
- "zeroconf-tokio",
 ]
 
 [[package]]
@@ -10880,6 +10879,7 @@ version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-compat",
+ "block2 0.6.2",
  "clap",
  "i-slint-backend-android-activity",
  "i-slint-backend-selector",
@@ -10892,6 +10892,8 @@ dependencies = [
  "itertools 0.14.0",
  "jni 0.22.4",
  "mdns-sd",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "serde_json",
  "shlex 2.0.1",
  "slint",
@@ -10903,7 +10905,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "zeroconf-tokio",
+ "zeroconf",
 ]
 
 [[package]]
@@ -14638,18 +14640,6 @@ checksum = "5b52318880bad5d5a081f7ac4251b5144e73dfa859cbcd10562d9433eeed6b72"
 dependencies = [
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zeroconf-tokio"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7eebfa4a31245de0d62ec17bdbd767575560743fd7c8237cac776dd420587f"
-dependencies = [
- "log",
- "tokio",
- "tokio-util",
- "zeroconf",
 ]
 
 [[package]]

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -40,9 +40,6 @@ anyhow = { version = "1.0.100", optional = true }
 [target.'cfg(not(any(target_vendor = "apple", target_arch = "wasm32")))'.dependencies]
 mdns-sd = { version = "0.20.0", default-features = false, features = ["async"], optional = true }
 
-[target.'cfg(target_vendor = "apple")'.dependencies]
-zeroconf-tokio = { version = "0.3.2", optional = true }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 getifs = { version = "0.6.1", optional = true }
 
@@ -69,7 +66,6 @@ remote = [
   "dep:base64",
   "dep:hostname",
   "dep:mdns-sd",
-  "dep:zeroconf-tokio",
   "dep:getifs",
   "slint-interpreter/accessibility",
   "slint-interpreter/image-default-formats",

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -58,7 +58,10 @@ remote = [
   "dep:async-compat",
   "dep:anyhow",
   "dep:mdns-sd",
-  "dep:zeroconf-tokio",
+  "dep:zeroconf",
+  "dep:objc2-foundation",
+  "dep:objc2-ui-kit",
+  "dep:block2",
   "dep:i-slint-backend-android-activity",
   "i-slint-backend-android-activity?/native-activity",
   "i-slint-backend-android-activity?/aa-06",
@@ -94,11 +97,24 @@ tracing-log = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 
+# On the choice of mdns-sd vs zeroconf:
+#
+# - zeroconf uses bonjour on Apple platforms. That's the right choice.
+# - zeroconf uses bonjour on Windows. That's not a good choice, because it means the users need to have bonjour installed on Windows.
+# - zeroconf uses avahi on the other platforms. That in turn requires the avahi dev packages (headers and .so file) to be available.
+# - mdns-sd is a pure Rust implementation that works on all platforms, but it doesn't integrate with the system's mDNSResponder on Apple platforms.
+#
+# That's why we chose zeroconf for Apple platforms and mdns-sd for the other platforms.
 [target.'cfg(not(any(target_vendor = "apple", target_arch = "wasm32")))'.dependencies]
 mdns-sd = { version = "0.20.0", default-features = false, features = ["async"], optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-zeroconf-tokio = { version = "0.3.2", optional = true }
+zeroconf = { version = "0.18", optional = true }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSNotification", "NSString", "NSOperation", "block2"], optional = true }
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIApplication"], optional = true }
+block2 = { version = "0.6", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-backend-android-activity = { workspace = true, optional = true }

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -28,6 +28,24 @@ fn build_info() -> SharedString {
     }
 }
 
+/// Events driving the remote main loop: messages from the editor connection plus, on
+/// iOS, app lifecycle notifications.
+enum Event {
+    Connection(ConnectionMessage),
+    /// The app returned to the foreground after having been suspended: re-announce
+    /// the mDNS service (see [`announce_mdns`] for why the old announcement may be
+    /// dead). Only iOS has the lifecycle observers that send this.
+    #[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+    Resumed,
+}
+
+#[cfg(target_vendor = "apple")]
+mod apple;
+#[cfg(target_vendor = "apple")]
+use apple::announce_mdns;
+#[cfg(target_os = "ios")]
+use apple::observe_foregrounding;
+
 pub fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Result<()> {
     slint_interpreter::spawn_local(async_compat::Compat::new(async move {
         if let Err(err) = run_async(address, enable_mdns).await {
@@ -40,11 +58,14 @@ pub fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Result<()>
 }
 
 async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Result<()> {
-    let (message_sender, mut message_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let (event_sender, mut event_receiver) = tokio::sync::mpsc::unbounded_channel();
+
+    #[cfg(target_os = "ios")]
+    observe_foregrounding(event_sender.clone());
 
     let connection = Rc::new(
         Connection::listen(address, device_name_override(), move |msg| {
-            let _ = message_sender.send(msg);
+            let _ = event_sender.send(Event::Connection(msg));
         })
         .await?,
     );
@@ -81,49 +102,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
         mdns.as_ref().map(|mdns| mdns.register(service)).transpose()?;
     }
     #[cfg(target_vendor = "apple")]
-    let mut mdns = enable_mdns
-        .then(|| {
-            use zeroconf_tokio::prelude::{TMdnsService as _, TTxtRecord as _};
-
-            let mut service = zeroconf_tokio::MdnsService::new(
-                zeroconf_tokio::ServiceType::new(
-                    i_slint_live_preview::protocol::SERVICE_TYPE_NAME,
-                    i_slint_live_preview::protocol::SERVICE_TYPE_PROTOCOL,
-                )?,
-                connection.local_port(),
-            );
-            // Deliberately don't set a name: with a NULL/empty instance name Bonjour
-            // substitutes the system default service name, which is the user-assigned
-            // device name (e.g. "Simon's iPhone" on iOS, the computer name on macOS).
-            // This is the friendly name we want to show in the editor.
-            let mut txt = zeroconf_tokio::TxtRecord::new();
-            txt.insert(
-                i_slint_live_preview::protocol::TXT_PROTOCOLS_KEY,
-                i_slint_live_preview::protocol::PROTOCOL_SUBPROTOCOL,
-            )?;
-            txt.insert(
-                i_slint_live_preview::protocol::TXT_SLINT_VERSION_KEY,
-                i_slint_live_preview::protocol::SLINT_VERSION,
-            )?;
-            service.set_txt_record(txt);
-            zeroconf_tokio::MdnsServiceAsync::new(service)
-        })
-        .transpose()
-        .inspect_err(|err| tracing::error!("Failed to initialize mDNS: {err}"))
-        .ok()
-        .flatten();
-
-    #[cfg(target_vendor = "apple")]
-    if let Some(mdns) = &mut mdns {
-        match mdns.start().await {
-            Ok(registration) => connection.set_device_name(registration.name().to_owned()),
-            Err(err) => tracing::error!("Failed to announce service: {err}"),
-        }
-    }
-    // Snapshot after the Apple Bonjour overwrite above so the UI label matches the
-    // advertised mDNS instance. Re-read `connection.device_name()` here (not at the
-    // set_property sites) if a future change starts mutating the name post-registration.
-    let device_name = connection.device_name();
+    let mut mdns = if enable_mdns { announce_mdns(&connection).await } else { None };
 
     let local_port = connection.local_port();
     let local_ip_str: Vec<String> = connection
@@ -139,7 +118,9 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     let address = local_ip_str.join("\n");
 
     placeholder.set_address(SharedString::from(address.as_str()));
-    placeholder.set_name(SharedString::from(device_name.as_str()));
+    // Read after the Apple Bonjour overwrite above so the UI label matches the
+    // advertised mDNS instance.
+    placeholder.set_name(SharedString::from(connection.device_name().as_str()));
     placeholder.set_slint_version(SharedString::from(SLINT_VERSION));
     placeholder.set_build_info(build_info());
     placeholder.show()?;
@@ -147,7 +128,21 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     let mut last_connection = None;
     let mut user_instance: Option<slint_interpreter::ComponentInstance> = None;
     let mut current_preview: Option<PreviewComponent> = None;
-    while let Some(msg) = message_receiver.recv().await {
+    while let Some(event) = event_receiver.recv().await {
+        let msg = match event {
+            Event::Connection(msg) => msg,
+            Event::Resumed => {
+                #[cfg(target_vendor = "apple")]
+                if enable_mdns {
+                    // Withdraw the old announcement first: re-registering while it is
+                    // still alive would trigger Bonjour's conflict rename.
+                    drop(mdns.take());
+                    mdns = announce_mdns(&connection).await;
+                    placeholder.set_name(SharedString::from(connection.device_name().as_str()));
+                }
+                continue;
+            }
+        };
         match msg {
             ConnectionMessage::SetConfiguration { config } => {
                 compiler.set_style(config.style);
@@ -162,7 +157,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     &mut user_instance,
                     &connection,
                     &address,
-                    &device_name,
+                    &connection.device_name(),
                 )
                 .await?;
                 current_preview = Some(preview_component);
@@ -176,7 +171,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     &mut user_instance,
                     &connection,
                     &address,
-                    &device_name,
+                    &connection.device_name(),
                 )
                 .await?;
             }
@@ -195,7 +190,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                         &mut placeholder,
                         &mut user_instance,
                         &address,
-                        &device_name,
+                        &connection.device_name(),
                         "",
                         RemoteViewerState::WaitingForConnection,
                     )?;
@@ -208,6 +203,10 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     mdns.map(|mdns| mdns.shutdown())
         .transpose()
         .inspect_err(|err| tracing::error!("mdns shutdown: {err}"))?;
+
+    // Keep the Bonjour announcement alive until the message loop ends.
+    #[cfg(target_vendor = "apple")]
+    drop(mdns);
 
     Ok(())
 }

--- a/tools/viewer/remote/apple.rs
+++ b/tools/viewer/remote/apple.rs
@@ -1,0 +1,159 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! mDNS announcement on Apple platforms and, on iOS, the app lifecycle observation
+//! that keeps the announcement alive across network changes.
+//!
+//! This pumps the Bonjour socket with its own bounded polling loop on top of the
+//! synchronous zeroconf crate instead of using zeroconf-tokio: the viewer only needs
+//! the socket pumped until the one registration callback has arrived, and
+//! zeroconf-tokio's perpetual event processor aborts the process when polling fails,
+//! which is exactly what happens once iOS tears down the daemon connection (airplane
+//! mode, network switch) while the app is in the background. See
+//! https://github.com/windy1/zeroconf-tokio/issues/15 and
+//! https://github.com/slint-ui/slint/issues/12043.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use i_slint_live_preview::remote::Connection;
+use zeroconf::prelude::{TEventLoop as _, TMdnsService as _, TTxtRecord as _};
+
+/// How long to wait for the registration result before giving up, so that a wedged
+/// daemon cannot stall viewer startup indefinitely. The local daemon normally answers
+/// within milliseconds.
+const REGISTRATION_TIMEOUT: Duration = Duration::from_secs(10);
+/// The `select()` timeout of a single poll iteration. `poll()` returns early when
+/// daemon data arrives, so this adds no latency to the registration; it only sets how
+/// promptly the deadline above is noticed.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Announce the live-preview service over Bonjour and report the advertised instance
+/// name to `connection`. The announcement stays active for as long as the returned
+/// service handle is alive: the daemon maintains it without any participation from
+/// the app.
+///
+/// The Bonjour socket is only polled until the registration result is in; afterwards
+/// nothing reads it.
+pub(super) async fn announce_mdns(connection: &Connection) -> Option<zeroconf::MdnsService> {
+    let registration_result: Arc<Mutex<Option<zeroconf::Result<zeroconf::ServiceRegistration>>>> =
+        Arc::default();
+
+    let (service, event_loop) = (|| {
+        let mut service = zeroconf::MdnsService::new(
+            zeroconf::ServiceType::new(
+                i_slint_live_preview::protocol::SERVICE_TYPE_NAME,
+                i_slint_live_preview::protocol::SERVICE_TYPE_PROTOCOL,
+            )?,
+            connection.local_port(),
+        );
+        // Deliberately don't set a name: with a NULL/empty instance name Bonjour
+        // substitutes the system default service name, which is the user-assigned
+        // device name (e.g. "Simon's iPhone" on iOS, the computer name on macOS).
+        // This is the friendly name we want to show in the editor.
+        let mut txt = zeroconf::TxtRecord::new();
+        txt.insert(
+            i_slint_live_preview::protocol::TXT_PROTOCOLS_KEY,
+            i_slint_live_preview::protocol::PROTOCOL_SUBPROTOCOL,
+        )?;
+        txt.insert(
+            i_slint_live_preview::protocol::TXT_SLINT_VERSION_KEY,
+            i_slint_live_preview::protocol::SLINT_VERSION,
+        )?;
+        service.set_txt_record(txt);
+        service.set_registered_callback(Box::new({
+            let registration_result = registration_result.clone();
+            move |result, _context| {
+                *registration_result.lock().unwrap_or_else(|e| e.into_inner()) = Some(result);
+            }
+        }));
+        let event_loop = service.register()?;
+        Ok::<_, zeroconf::error::Error>((service, event_loop))
+    })()
+    .inspect_err(|err| tracing::error!("Failed to initialize mDNS: {err}"))
+    .ok()?;
+
+    // The callback is only ever invoked from within poll(), on this blocking thread.
+    let registration = tokio::task::spawn_blocking({
+        let registration_result = registration_result.clone();
+        move || {
+            let deadline = Instant::now() + REGISTRATION_TIMEOUT;
+            loop {
+                event_loop.poll(POLL_INTERVAL)?;
+                if let Some(result) =
+                    registration_result.lock().unwrap_or_else(|e| e.into_inner()).take()
+                {
+                    return result;
+                }
+                if Instant::now() >= deadline {
+                    return Err("timed out waiting for the registration result".into());
+                }
+            }
+        }
+    })
+    .await
+    // spawn_blocking only fails if the closure panicked, which in this panic=abort
+    // binary would have ended the process already.
+    .expect("the mDNS registration task cannot panic");
+
+    match registration {
+        Ok(registration) => {
+            connection.set_device_name(registration.name().to_owned());
+            Some(service)
+        }
+        Err(err) => {
+            tracing::error!("Failed to announce service: {err}");
+            None
+        }
+    }
+}
+
+/// Sends [`super::Event::Resumed`] whenever the app returns to the foreground after
+/// having been suspended, by observing the `UIApplication` lifecycle notifications.
+/// The observers live for the rest of the process: `NSNotificationCenter` holds
+/// block-based observers strongly until `removeObserver:`, which is never called.
+///
+/// Sending only when a suspension preceded the activation makes the notification
+/// accompanying app startup a non-event by construction, and it is while suspended
+/// that the announcement typically dies (network change tearing down the daemon
+/// connection).
+#[cfg(target_os = "ios")]
+pub(super) fn observe_foregrounding(sender: tokio::sync::mpsc::UnboundedSender<super::Event>) {
+    use objc2_foundation::{
+        NSNotification, NSNotificationCenter, NSNotificationName, NSOperationQueue,
+    };
+    use std::ptr::NonNull;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let center = NSNotificationCenter::defaultCenter();
+    let main_queue = NSOperationQueue::mainQueue();
+    let suspended = Arc::new(AtomicBool::new(false));
+
+    let add_observer =
+        |name: &NSNotificationName, block: block2::RcBlock<dyn Fn(NonNull<NSNotification>)>| {
+            // Safety: the observed object is NULL, delivery happens on the main queue,
+            // and the blocks are sendable: they only capture an atomic flag and a
+            // channel sender.
+            let _ = unsafe {
+                center.addObserverForName_object_queue_usingBlock(
+                    Some(name),
+                    None,
+                    Some(&main_queue),
+                    &block,
+                )
+            };
+        };
+
+    add_observer(unsafe { objc2_ui_kit::UIApplicationWillResignActiveNotification }, {
+        let suspended = suspended.clone();
+        block2::RcBlock::new(move |_| suspended.store(true, Ordering::Relaxed))
+    });
+    add_observer(
+        unsafe { objc2_ui_kit::UIApplicationDidBecomeActiveNotification },
+        block2::RcBlock::new(move |_| {
+            if suspended.swap(false, Ordering::Relaxed) {
+                let _ = sender.send(super::Event::Resumed);
+            }
+        }),
+    );
+}


### PR DESCRIPTION
zeroconf-tokio polls the Bonjour daemon socket on a perpetual thread and unwraps every poll result. When iOS tears down the daemon connection while the app is backgrounded (airplane mode, Wi-Fi switch), the thread reads the dead socket on the next foregrounding, DNSServiceProcessResult returns kDNSServiceErr_ServiceNotRunning, and the expect() aborts this panic=abort binary.

Replace zeroconf-tokio with the synchronous zeroconf crate and a bounded polling loop that pumps the socket only until the registration result is in, handling poll errors instead of unwrapping them. The daemon maintains the announcement without any participation from the app, so afterwards nothing reads the socket and a daemon connection death cannot hurt us.

The announcement still silently dies with the daemon connection, so on iOS observe UIApplicationWillResignActive/DidBecomeActive and re-announce when the app returns to the foreground after a suspension.

Also drop the unused zeroconf-tokio dependency of i-slint-live-preview.

Fixes #12043

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
