### PR TITLE
Rename AccessibleLiveRegion to AccessibleLiveness

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -38,7 +38,7 @@ fn enums(path: &Path) -> anyhow::Result<()> {
         (Orientation) => {
             Some(None)
         };
-        (AccessibleLiveRegion) => {
+        (AccessibleLiveness) => {
             Some(None)
         };
         ($_:ident) => {

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -391,16 +391,16 @@ public:
     }
 
     /// Returns the accessible-live-region of that element, if any.
-    std::optional<AccessibleLiveRegion> accessible_live_region() const
+    std::optional<AccessibleLiveness> accessible_live_region() const
     {
         if (auto str = get_accessible_string_property(
                     cbindgen_private::AccessibleStringProperty::LiveRegion)) {
             if (*str == "off")
-                return AccessibleLiveRegion::Off;
+                return AccessibleLiveness::Off;
             if (*str == "polite")
-                return AccessibleLiveRegion::Polite;
+                return AccessibleLiveness::Polite;
             if (*str == "assertive")
-                return AccessibleLiveRegion::Assertive;
+                return AccessibleLiveness::Assertive;
         }
         return std::nullopt;
     }

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -142,4 +142,4 @@ pub fn configure_test_fonts() {
     .unwrap();
 }
 
-pub use i_slint_core::items::{AccessibleLiveRegion, AccessibleRole, Orientation};
+pub use i_slint_core::items::{AccessibleLiveness, AccessibleRole, Orientation};

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -832,7 +832,7 @@ impl ElementHandle {
     }
 
     /// Returns the value of the `accessible-live-region` property, if present.
-    pub fn accessible_live_region(&self) -> Option<crate::AccessibleLiveRegion> {
+    pub fn accessible_live_region(&self) -> Option<crate::AccessibleLiveness> {
         if self.element_index != 0 {
             return None;
         }

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -690,12 +690,12 @@ impl NodeCollection {
 
         if let Some(live) = item
             .accessible_string_property(AccessibleStringProperty::LiveRegion)
-            .and_then(|s| s.parse::<i_slint_core::items::AccessibleLiveRegion>().ok())
+            .and_then(|s| s.parse::<i_slint_core::items::AccessibleLiveness>().ok())
         {
             node.set_live(match live {
-                i_slint_core::items::AccessibleLiveRegion::Off => Live::Off,
-                i_slint_core::items::AccessibleLiveRegion::Polite => Live::Polite,
-                i_slint_core::items::AccessibleLiveRegion::Assertive => Live::Assertive,
+                i_slint_core::items::AccessibleLiveness::Off => Live::Off,
+                i_slint_core::items::AccessibleLiveness::Polite => Live::Polite,
+                i_slint_core::items::AccessibleLiveness::Assertive => Live::Assertive,
                 _ => Live::Off,
             });
         }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -539,7 +539,7 @@ macro_rules! for_each_enums {
             /// It indicates that an element is a live region whose content changes should be
             /// announced by assistive technologies.
             #[non_exhaustive]
-            enum AccessibleLiveRegion {
+            enum AccessibleLiveness {
                 /// The element is not a live region.
                 Off,
                 /// Updates are announced when the user is idle.

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -542,9 +542,11 @@ macro_rules! for_each_enums {
             enum AccessibleLiveness {
                 /// The element is not a live region.
                 Off,
-                /// Updates are announced when the user is idle.
+                /// Use in regions that present new information to users.
+                /// Assistive technology is expected to not interrupt the user to inform of changes to the live region.
                 Polite,
-                /// Updates are announced as soon as possible.
+                /// Use in regions that present information that a user should know about right away.
+                /// Assistive technology is expected to announce to the user as soon as possible.
                 Assertive,
             }
 

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -540,13 +540,14 @@ macro_rules! for_each_enums {
             /// announced by assistive technologies.
             #[non_exhaustive]
             enum AccessibleLiveness {
-                /// The element is not a live region.
+                /// Use in regions that present information that is of low-importance to the user.
+                /// Assistive technologies are expected to not announce changes unless the user explicitly asks for it.
                 Off,
                 /// Use in regions that present new information to users.
-                /// Assistive technology is expected to not interrupt the user to inform of changes to the live region.
+                /// Assistive technologies are expected to not interrupt the user to inform of changes to the live region.
                 Polite,
                 /// Use in regions that present information that a user should know about right away.
-                /// Assistive technology is expected to announce to the user as soon as possible.
+                /// Assistive technologies are expected to announce to the user as soon as possible.
                 Assertive,
             }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2506,7 +2506,7 @@ export component PopupWindow {
     /// Use this read-only property to style the element that opened the popup, for example
     /// to rotate a ComboBox's arrow while the dropdown is open.
     /// `true` while the popup is shown on the screen, and `false` once it is closed, for example
-    /// when dismissed by a click, by a selection, or by a programmatic `close()`. 
+    /// when dismissed by a click, by a selection, or by a programmatic `close()`.
     out property <bool> is-open;
     //! ## Functions
     //!

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -347,7 +347,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
             ),
             (
                 "accessible-live-region",
-                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleLiveRegion.clone())),
+                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleLiveness.clone())),
                 PropertyVisibility::Input,
             ),
         ]))

--- a/tests/cases/accessibility/live.slint
+++ b/tests/cases/accessibility/live.slint
@@ -7,23 +7,23 @@ export component TestCase inherits Window {
     width: 300phx;
     height: 300phx;
 
-    in-out property <AccessibleLiveRegion> status-live: AccessibleLiveRegion.polite;
+    in-out property <AccessibleLiveness> status-live: AccessibleLiveness.polite;
 
     VerticalLayout {
         Rectangle {
             accessible-role: text;
             accessible-label: "off-region";
-            accessible-live-region: AccessibleLiveRegion.off;
+            accessible-live-region: AccessibleLiveness.off;
         }
         Rectangle {
             accessible-role: text;
             accessible-label: "polite-region";
-            accessible-live-region: AccessibleLiveRegion.polite;
+            accessible-live-region: AccessibleLiveness.polite;
         }
         Rectangle {
             accessible-role: text;
             accessible-label: "assertive-region";
-            accessible-live-region: AccessibleLiveRegion.assertive;
+            accessible-live-region: AccessibleLiveness.assertive;
         }
         Rectangle {
             accessible-role: text;
@@ -41,23 +41,23 @@ export component TestCase inherits Window {
 /*
 
 ```rust
-use slint_testing::AccessibleLiveRegion;
+use slint_testing::AccessibleLiveness;
 
 let instance = TestCase::new().unwrap();
 
 let off = slint_testing::ElementHandle::find_by_accessible_label(&instance, "off-region").next().unwrap();
-assert_eq!(off.accessible_live_region(), Some(AccessibleLiveRegion::Off));
+assert_eq!(off.accessible_live_region(), Some(AccessibleLiveness::Off));
 
 let polite = slint_testing::ElementHandle::find_by_accessible_label(&instance, "polite-region").next().unwrap();
-assert_eq!(polite.accessible_live_region(), Some(AccessibleLiveRegion::Polite));
+assert_eq!(polite.accessible_live_region(), Some(AccessibleLiveness::Polite));
 
 let assertive = slint_testing::ElementHandle::find_by_accessible_label(&instance, "assertive-region").next().unwrap();
-assert_eq!(assertive.accessible_live_region(), Some(AccessibleLiveRegion::Assertive));
+assert_eq!(assertive.accessible_live_region(), Some(AccessibleLiveness::Assertive));
 
 let d = slint_testing::ElementHandle::find_by_accessible_label(&instance, "dynamic-region").next().unwrap();
-assert_eq!(d.accessible_live_region(), Some(AccessibleLiveRegion::Polite));
-instance.set_status_live(AccessibleLiveRegion::Assertive);
-assert_eq!(d.accessible_live_region(), Some(AccessibleLiveRegion::Assertive));
+assert_eq!(d.accessible_live_region(), Some(AccessibleLiveness::Polite));
+instance.set_status_live(AccessibleLiveness::Assertive);
+assert_eq!(d.accessible_live_region(), Some(AccessibleLiveness::Assertive));
 
 let none = slint_testing::ElementHandle::find_by_accessible_label(&instance, "no-live").next().unwrap();
 // Element has no accessible-live-region binding, so the property is not exposed.
@@ -71,21 +71,21 @@ const TestCase &instance = *handle;
 auto off = slint::testing::ElementHandle::find_by_accessible_label(handle, "off-region");
 assert_eq(off.size(), 1);
 assert(off[0].accessible_live_region().has_value());
-assert(*off[0].accessible_live_region() == slint::AccessibleLiveRegion::Off);
+assert(*off[0].accessible_live_region() == slint::AccessibleLiveness::Off);
 
 auto polite = slint::testing::ElementHandle::find_by_accessible_label(handle, "polite-region");
 assert_eq(polite.size(), 1);
-assert(*polite[0].accessible_live_region() == slint::AccessibleLiveRegion::Polite);
+assert(*polite[0].accessible_live_region() == slint::AccessibleLiveness::Polite);
 
 auto assertive = slint::testing::ElementHandle::find_by_accessible_label(handle, "assertive-region");
 assert_eq(assertive.size(), 1);
-assert(*assertive[0].accessible_live_region() == slint::AccessibleLiveRegion::Assertive);
+assert(*assertive[0].accessible_live_region() == slint::AccessibleLiveness::Assertive);
 
 auto d = slint::testing::ElementHandle::find_by_accessible_label(handle, "dynamic-region");
 assert_eq(d.size(), 1);
-assert(*d[0].accessible_live_region() == slint::AccessibleLiveRegion::Polite);
-instance.set_status_live(slint::AccessibleLiveRegion::Assertive);
-assert(*d[0].accessible_live_region() == slint::AccessibleLiveRegion::Assertive);
+assert(*d[0].accessible_live_region() == slint::AccessibleLiveness::Polite);
+instance.set_status_live(slint::AccessibleLiveness::Assertive);
+assert(*d[0].accessible_live_region() == slint::AccessibleLiveness::Assertive);
 
 auto none = slint::testing::ElementHandle::find_by_accessible_label(handle, "no-live");
 assert_eq(none.size(), 1);


### PR DESCRIPTION
As discussed with Leon and Olivier, this presents a compromise where "live" is what connects the property and the enum, but each of their own have an expressive name.

cc #11921

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
