### PR TITLE
fix: system tray compilation on 32-bit Windows

### DIFF
--- a/internal/core/items/system_tray/windows.rs
+++ b/internal/core/items/system_tray/windows.rs
@@ -165,7 +165,7 @@ impl PlatformTray {
             hmenu: Cell::new(None),
             tip: RefCell::new(tip),
         });
-        unsafe { SetWindowLongPtrW(inner.hwnd, GWLP_USERDATA, &*inner as *const Inner as isize) };
+        unsafe { SetWindowLongPtrW(inner.hwnd, GWLP_USERDATA, &*inner as *const Inner as _) };
 
         Ok(Self { inner })
     }
@@ -263,7 +263,7 @@ impl Drop for PlatformTray {
 
             // Detach from the window before destroying it so any pending messages
             // resolve through DefWindowProc.
-            SetWindowLongPtrW(self.inner.hwnd, GWLP_USERDATA, 0);
+            SetWindowLongPtrW(self.inner.hwnd, GWLP_USERDATA, 0 as _);
             if let Some(m) = self.inner.hmenu.take() {
                 let _ = DestroyMenu(m);
             }


### PR DESCRIPTION
  On Win32, SetWindowLongPtrW is a macro that maps to SetWindowLongW,
  which takes i32 instead of isize. Use *as _* to let the compiler
  infer the correct integer type on both 32-bit and 64-bit targets.

fixes #12062
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
