### PR TITLE
Add `pathdata` type and `@pathdata` macro

### DIFF
--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -367,6 +367,20 @@ See <Link type="DragAndDrop" /> for an end-to-end example.
 
 </SlintProperty>
 
+## Paths
+### pathdata
+<SlintProperty propName="pathdata" typeName="pathdata" defaultValue='empty pathdata'>
+
+The `pathdata` type is a reference to a SVG path commands.
+
+A `pathdata` value can be constructed from a string literal with the `@pathdata("...")` construct.
+
+For example: `@pathdata("M 19 4 L 10 4 M 14 20 L 5 20 M 15 4 L 9 20")`.
+
+See also the <Link type="Path" label="Path element"/>.
+
+</SlintProperty>
+
 ## Animation
 ### easing
 <SlintProperty propName="easing" typeName="easing" defaultValue='linear'>

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -369,11 +369,10 @@ See <Link type="DragAndDrop" /> for an end-to-end example.
 
 ## Paths
 ### pathdata
-<SlintProperty propName="pathdata" typeName="pathdata" defaultValue='empty pathdata'>
+<SlintProperty propName="pathdata" typeName="pathdata" defaultValue='an empty pathdata'>
+A `pathdata` value is a compiled series of SVG path commands.
 
-The `pathdata` type is a reference to a SVG path commands.
-
-A `pathdata` value can be constructed from a string literal with the `@pathdata("...")` construct.
+It can be constructed at compile-time with the `@pathdata("...")` macro, or you can implicitly cast from a string to construct it at runtime.
 
 For example: `@pathdata("M 19 4 L 10 4 M 14 20 L 5 20 M 15 4 L 9 20")`.
 

--- a/docs/common/src/utils/utils.ts
+++ b/docs/common/src/utils/utils.ts
@@ -29,6 +29,7 @@ export type KnownType =
     | "int"
     | "keys"
     | "length"
+    | "pathdata"
     | "percent"
     | "physical-length"
     | "Edges"
@@ -118,6 +119,11 @@ export function getTypeInfo(typeName: KnownType): TypeInfo {
             return {
                 href: linkMap.length.href,
                 defaultValue: "0px",
+            };
+        case "pathdata":
+            return {
+                href: linkMap.pathdata.href,
+                defaultValue: "an empty pathdata",
             };
         case "percent":
             return {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2275,9 +2275,10 @@ component Close {
 ///
 /// When not part of a layout, its width or height defaults to 100% of the parent element when not specified.
 ///
-/// A path can be defined in two different ways:
+/// A path can be defined in three different ways:
 ///
 /// -   Using SVG path commands as a string
+/// -   Using SVG path commands inside `@pathdata` macro as a pathdata
 /// -   Using path command elements in `.slint` markup.
 ///
 /// The coordinates used in the geometric commands are within the imaginary coordinate system of the path.
@@ -2372,8 +2373,21 @@ export component Path {
     //! The commands are provided in a property:
     //!
     //! ### Commands
-    //! <SlintProperty propName="commands" typeName="string">
+    //! <SlintProperty propName="commands" typeName="pathdata">
     //! A string providing the commands according to the SVG path specification.
+    //! ```slint
+    //! export component Example inherits Path {
+    //!     commands: "M5 12h14";
+    //! }
+    //! ```
+    //!
+    //! Alternatively, the commands can be provided using the `@pathdata` macro, which allows it to be compiled ahead of time.
+    //! Most suitable for `no_std` environments, where string commands parsing is not available.
+    //! ```slint
+    //! export component Example inherits Path {
+    //!     commands: @pathdata("M5 12h14");
+    //! }
+    //! ```
     //! This property can only be set in a binding and cannot be accessed in an expression.
     //! </SlintProperty>
     //!

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2278,7 +2278,7 @@ component Close {
 /// A path can be defined in three different ways:
 ///
 /// -   Using SVG path commands as a string
-/// -   Using SVG path commands inside `@pathdata` macro as a [pathdata](../../primitive-types/#pathdata)
+/// -   Using SVG path commands inside the <Link type="pathdata" label="`@pathdata` macro" />
 /// -   Using path command elements in `.slint` markup.
 ///
 /// The coordinates used in the geometric commands are within the imaginary coordinate system of the path.
@@ -2381,7 +2381,7 @@ export component Path {
     //! }
     //! ```
     //!
-    //! Alternatively, the commands can be provided using the [`@pathdata`](../primitive-types/#pathdata) macro, which allows it to be compiled ahead of time.
+    //! Alternatively, the commands can be provided using the <Link type="pathdata" label="`@pathdata` macro" />, which allows it to be compiled ahead of time.
     //! Most suitable for `no_std` environments, where string commands parsing is not available.
     //! ```slint
     //! export component Example inherits Path {
@@ -2390,7 +2390,7 @@ export component Path {
     //! ```
     //! This property can only be set in a binding and cannot be accessed in an expression.
     //!
-    //! See also [`pathdata`](../primitive-types/#pathdata).
+    //! See also <Link type="pathdata" />.
     //! </SlintProperty>
     //!
     //! ## Path Using SVG Path Elements

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2332,7 +2332,7 @@ export component Path {
     //!
     //! If the `viewbox-width` or `viewbox-height` is less or equal than zero, the viewbox properties are
     //! ignored and instead the bounding rectangle of all path elements is used to define the view port.
-    in property <pathdata> commands;  // 'fake' hardcoded in typeregister.rs
+    in property <pathdata> commands;
     in property <float> viewbox-x;
     in property <float> viewbox-y;
     in property <float> viewbox-width;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2331,7 +2331,7 @@ export component Path {
     //!
     //! If the `viewbox-width` or `viewbox-height` is less or equal than zero, the viewbox properties are
     //! ignored and instead the bounding rectangle of all path elements is used to define the view port.
-    in property <string> commands;  // 'fake' hardcoded in typeregister.rs
+    in property <pathdata> commands;  // 'fake' hardcoded in typeregister.rs
     in property <float> viewbox-x;
     in property <float> viewbox-y;
     in property <float> viewbox-width;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2278,7 +2278,7 @@ component Close {
 /// A path can be defined in three different ways:
 ///
 /// -   Using SVG path commands as a string
-/// -   Using SVG path commands inside `@pathdata` macro as a pathdata
+/// -   Using SVG path commands inside `@pathdata` macro as a [pathdata](../../primitive-types/#pathdata)
 /// -   Using path command elements in `.slint` markup.
 ///
 /// The coordinates used in the geometric commands are within the imaginary coordinate system of the path.
@@ -2381,7 +2381,7 @@ export component Path {
     //! }
     //! ```
     //!
-    //! Alternatively, the commands can be provided using the `@pathdata` macro, which allows it to be compiled ahead of time.
+    //! Alternatively, the commands can be provided using the [`@pathdata`](../primitive-types/#pathdata) macro, which allows it to be compiled ahead of time.
     //! Most suitable for `no_std` environments, where string commands parsing is not available.
     //! ```slint
     //! export component Example inherits Path {
@@ -2389,6 +2389,8 @@ export component Path {
     //! }
     //! ```
     //! This property can only be set in a binding and cannot be accessed in an expression.
+    //!
+    //! See also [`pathdata`](../primitive-types/#pathdata).
     //! </SlintProperty>
     //!
     //! ## Path Using SVG Path Elements

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -226,6 +226,7 @@ impl Type {
                 | Self::Enumeration(_)
                 | Self::Keys
                 | Self::DataTransfer
+                | Self::PathData
                 | Self::ElementReference
                 | Self::Struct { .. }
                 | Self::Array(_)
@@ -285,7 +286,8 @@ impl Type {
             | (Type::PhysicalLength, Type::Rem)
             | (Type::Percent, Type::Float32)
             | (Type::Brush, Type::Color)
-            | (Type::Color, Type::Brush) => true,
+            | (Type::Color, Type::Brush)
+            | (Type::String, Type::PathData) => true,
             (Type::Array(a), Type::Model) if a.is_property_type() => true,
             (Type::Struct(a), Type::Struct(b)) => can_convert_struct(&a.fields, &b.fields),
             (Type::UnitProduct(u), o) => match o.as_unit_product() {

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -375,12 +375,14 @@ declare_syntax! {
         // FIXME: the test should test that as alternative rather than several of them (but it can also be a literal)
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
-                       ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
+                       ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtPathData, ?AtGradient, ?AtTr,
                        ?MemberAccess, ?AtKeys ],
         /// Concatenate the children Expressions and StringLiteral to make a string
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
         AtImageUrl -> [],
+        /// `@pathdata("M5 12h14")`
+        AtPathData -> [],
         /// `@linear-gradient(...)` or `@radial-gradient(...)`
         AtGradient -> [*Expression],
         /// `@tr("foo", ...)`  // the string is a StringLiteral

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -768,7 +768,7 @@ fn parse_path_data(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::AtPathData);
     p.expect(SyntaxKind::At);
     debug_assert_eq!(p.peek().as_str(), "pathdata");
-    p.expect(SyntaxKind::Identifier); // "pathdata"  
+    p.expect(SyntaxKind::Identifier); // "pathdata"
     p.expect(SyntaxKind::LParent);
 
     let peek = p.peek();

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -243,6 +243,9 @@ fn parse_at_keyword(p: &mut impl Parser) {
         "image-url" | "image_url" => {
             parse_image_url(p);
         }
+        "pathdata" => {
+            parse_path_data(p);
+        }
         "linear-gradient" | "linear_gradient" => {
             parse_gradient(p);
         }
@@ -755,4 +758,28 @@ fn parse_image_url(p: &mut impl Parser) {
     if !p.expect(SyntaxKind::RParent) {
         p.until(SyntaxKind::RParent);
     }
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,AtPathData
+/// @pathdata("M5 12h14")
+/// ```
+fn parse_path_data(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::AtPathData);
+    p.expect(SyntaxKind::At);
+    debug_assert_eq!(p.peek().as_str(), "pathdata");
+    p.expect(SyntaxKind::Identifier); // "pathdata"  
+    p.expect(SyntaxKind::LParent);
+
+    let peek = p.peek();
+    if peek.kind() != SyntaxKind::StringLiteral
+        || !peek.as_str().starts_with('"')
+        || !peek.as_str().ends_with('"')
+    {
+        p.error("@pathdata requires a plain string literal");
+        return;
+    }
+    p.expect(SyntaxKind::StringLiteral);
+
+    p.expect(SyntaxKind::RParent);
 }

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -63,6 +63,25 @@ pub fn compile_paths(
                         }
                     }
                 }
+                Expression::Cast { from, to: Type::PathData } if from.ty() == Type::String => {
+                    if let Expression::StringLiteral(commands) = from.as_ref() {
+                        match compile_path_from_string_literal(commands) {
+                            Ok(binding) => binding,
+                            Err(e) => {
+                                diag.push_error(
+                                    format!("Error parsing SVG commands ({e})"),
+                                    &commands_expr,
+                                );
+                                return;
+                            }
+                        }
+                    } else {
+                        Expression::PathData(crate::expression_tree::Path::Commands(Box::new(
+                            (**from).clone(),
+                        )))
+                    }
+                }
+                expr if expr.ty() == Type::PathData => commands_expr.expression,
                 expr if expr.ty() == Type::String => {
                     #[cfg(feature = "software-renderer")]
                     if _embed_resources == EmbedResourcesKind::EmbedTextures {
@@ -75,7 +94,6 @@ pub fn compile_paths(
                     Expression::PathData(crate::expression_tree::Path::Commands(Box::new(
                         commands_expr.expression,
                     )))
-                    .into()
                 }
                 _ => {
                     diag.push_error(
@@ -136,19 +154,19 @@ pub fn compile_paths(
                 }
             }
 
-            Expression::PathData(crate::expression_tree::Path::Elements(path_data)).into()
+            Expression::PathData(crate::expression_tree::Path::Elements(path_data))
         };
 
         elem_
             .borrow_mut()
             .bindings
-            .insert(SmolStr::new_static("elements"), RefCell::new(path_data_binding));
+            .insert(SmolStr::new_static("elements"), RefCell::new(path_data_binding.into()));
     });
 }
 
-fn compile_path_from_string_literal(
+pub fn compile_path_from_string_literal(
     commands: &str,
-) -> Result<BindingExpression, lyon_extra::parser::ParseError> {
+) -> Result<Expression, lyon_extra::parser::ParseError> {
     let mut builder = lyon_path::Path::builder();
     let mut parser = lyon_extra::parser::PathParser::new();
     parser.parse(
@@ -220,5 +238,5 @@ fn compile_path_from_string_literal(
         })
         .collect();
 
-    Ok(Expression::PathData(Path::Events(events, points)).into())
+    Ok(Expression::PathData(Path::Events(events, points)))
 }

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -139,7 +139,7 @@ pub fn compile_paths(
                 }
             }
 
-            if elem.is_binding_set("elements", false) {
+            if elem.is_binding_set("commands", false) {
                 if path_data.is_empty() {
                     // Just Path subclass that had elements declared earlier, since path_data is empty we should retain the
                     // existing elements
@@ -160,7 +160,7 @@ pub fn compile_paths(
         elem_
             .borrow_mut()
             .bindings
-            .insert(SmolStr::new_static("elements"), RefCell::new(path_data_binding.into()));
+            .insert(SmolStr::new_static("commands"), RefCell::new(path_data_binding.into()));
     });
 }
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -378,6 +378,11 @@ impl Expression {
                         ctx.diag.slint_sc_error("@image-url() expressions are", &node);
                         Some(Self::from_at_image_url_node(node.into(), ctx))
                     }
+                    SyntaxKind::AtPathData => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("@pathdata() expressions are", &node);
+                        Some(Self::from_at_path_data_node(node.into(), ctx))
+                    }
                     SyntaxKind::AtGradient => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("@gradient expressions are", &node);
@@ -586,6 +591,23 @@ impl Expression {
             resource_ref,
             source_location: Some(node.to_source_location()),
             nine_slice,
+        }
+    }
+
+    fn from_at_path_data_node(node: syntax_nodes::AtPathData, ctx: &mut LookupCtx) -> Self {
+        let Some(string_token) = node.child_token(SyntaxKind::StringLiteral) else {
+            return Expression::Invalid;
+        };
+
+        let s = string_token.text();
+        let commands_str = &s[1..s.len() - 1];
+
+        match super::compile_paths::compile_path_from_string_literal(commands_str) {
+            Ok(binding) => binding,
+            Err(e) => {
+                ctx.diag.push_error(format!("Error parsing SVG path commands ({e})"), &node);
+                Expression::Invalid
+            }
         }
     }
 

--- a/internal/compiler/tests/syntax/basic/path_commands.slint
+++ b/internal/compiler/tests/syntax/basic/path_commands.slint
@@ -29,18 +29,14 @@ export TestCase := Rectangle {
     p := Path {
         width: 640px;
         height: 480px;
-        commands: "M 0 0 M -100 0 A 100 100 0 1 0 0 A 100 100 0 1 0 100 0 Z";
-//                >                                                         <error{Error parsing SVG commands (Line 0 Column 33: Expected number, got "".)}
+        commands: "M 22 12 C 22 17.523 17.523 22 12 22 C 6.477 22 2 17.523 2 12 C 2 6.477 6.477 2 12 2 C 17.523 2 22 6.477 22 12";
     }
 
     TouchArea {
         clicked => {
-            p.commands = "M 0 0 M -100 0 A 100 100 0 1 0 100 0 A 100 100 0 1 0 100 0 Z";
-//            >      <error{This special property can only be used to make a binding and cannot be accessed}
+            p.commands = "M 22 12 C 22 17.523 17.523 22 12 22 C 6.477 22 2 17.523 2 12 C 2 6.477 6.477 2 12 2 C 17.523 2 22 6.477 22 12 M 12 8 L 12 12 M 12 16 L 12.01 16";
         }
     }
-    Text { text: p.commands; }
-//                 >      <error{This special property can only be used to make a binding and cannot be accessed}
 
     Test2 {}
 

--- a/internal/compiler/tests/syntax/basic/pathdata.slint
+++ b/internal/compiler/tests/syntax/basic/pathdata.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export TestCase := Rectangle {
+//              ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
+    p := Path {
+        commands: @pathdata("M 14 12 L 18 16 L 22 12 M 18 16 L 18 7 M 2 16 L 6.039 6.31 C 6.116658 6.1237254 6.298686 6.0024 6.5005 6.0024 C 6.702314 6.0024 6.884342 6.1237254 6.962 6.31 L 11 16 M 3.304 13 L 9.696 13");
+    }
+
+    property <pathdata> pd1: p.commands;
+
+    Path {
+        commands: pd1;
+    }
+
+    property <string> pd2str: pd1;
+//                            >  <error{Cannot convert pathdata to string}
+
+    property <pathdata> pd2: pd1;
+}

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -645,7 +645,7 @@ impl TypeRegister {
             ElementType::Builtin(b) => {
                 let path = Rc::get_mut(b).unwrap();
                 path.properties.get_mut("commands").unwrap().property_visibility =
-                    PropertyVisibility::Fake;
+                    PropertyVisibility::InOut;
             }
 
             _ => unreachable!(),

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -477,6 +477,7 @@ impl TypeRegister {
         register.insert_type(Type::ComponentFactory);
         register.insert_type(Type::Duration);
         register.insert_type(Type::Image);
+        register.insert_type(Type::PathData);
         register.insert_type(Type::Bool);
         register.insert_type(Type::Model);
         register.insert_type(Type::Percent);

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -161,6 +161,9 @@
     "Path": {
         "href": "reference/elements/path/"
     },
+    "pathdata": {
+        "href": "reference/primitive-types/#pathdata"
+    },
     "percent": {
         "href": "reference/primitive-types/#percent"
     },

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -38,7 +38,7 @@ use i_slint_core_macros::*;
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 pub struct Path {
-    pub elements: Property<PathData>,
+    pub commands: Property<PathData>,
     pub fill: Property<Brush>,
     pub fill_rule: Property<FillRule>,
     pub stroke: Property<Brush>,
@@ -162,7 +162,7 @@ impl Path {
         self: Pin<&Self>,
         self_rc: &ItemRc,
     ) -> Option<(LogicalVector, PathDataIterator)> {
-        let mut elements_iter = self.elements().iter()?;
+        let mut elements_iter = self.commands().iter()?;
 
         let stroke_width = self.stroke_width();
         let geometry = self_rc.geometry();

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -37,7 +37,7 @@ use i_slint_core::slice::Slice;
 use i_slint_core::styled_text::StyledText;
 use i_slint_core::timers::Timer;
 use i_slint_core::window::{WindowAdapterRc, WindowInner, WindowKind};
-use i_slint_core::{Brush, Color, DataTransfer, Property, SharedString, SharedVector};
+use i_slint_core::{Brush, Color, DataTransfer, PathData, Property, SharedString, SharedVector};
 #[cfg(feature = "internal")]
 use itertools::Either;
 use once_cell::unsync::{Lazy, OnceCell};
@@ -1297,13 +1297,13 @@ pub(crate) fn generate_item_tree<'id>(
             Type::ArrayOfU16 => property_info::<SharedVector<u16>>(),
             Type::Function { .. } | Type::Callback { .. } => return None,
             Type::StyledText => property_info::<StyledText>(),
+            Type::PathData => property_info::<PathData>(),
             // These can't be used in properties
             Type::Invalid
             | Type::Void
             | Type::InferredProperty
             | Type::InferredCallback
             | Type::Model
-            | Type::PathData
             | Type::UnitProduct(_)
             | Type::ElementReference => panic!("bad type {ty:?} for property {name}"),
         })

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -260,6 +260,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 (Value::Number(n), Type::String) => {
                     Value::String(i_slint_core::string::shared_string_from_number(n))
                 }
+                (Value::String(s), Type::PathData) => Value::PathData(PathData::Commands(s)),
                 (Value::Number(n), Type::Color) => Color::from_argb_encoded(n as u32).into(),
                 (Value::Brush(brush), Type::Color) => brush.color().into(),
                 (Value::EnumerationValue(_, val), Type::String) => Value::String(val.into()),

--- a/tests/cases/elements/path_at_path_data.slint
+++ b/tests/cases/elements/path_at_path_data.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Path {
+    stroke: white;
+    stroke-width: 10px;
+    commands: @pathdata("M 19 4 L 10 4 M 14 20 L 5 20 M 15 4 L 9 20");
+}

--- a/tests/cases/elements/path_string_commands.slint
+++ b/tests/cases/elements/path_string_commands.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Path {
+    stroke: white;
+    stroke-width: 10px;
+    commands: "M 19 4 L 10 4 M 14 20 L 5 20 M 15 4 L 9 20";
+}


### PR DESCRIPTION
This PR provides an improved implementation for **#12053**, shifting the path parsing logic from runtime to build-time via a new `@pathdata` macro.

#### **Changes made in this PR:**

1. **Type Registration:** Introduced the `pathdata` type to language types, implemented the type conversion from `String` to `PathData`, and registered `PathData` in the `type_register`.
2. **Parser & Name Resolution:** Implemented the `@pathdata` macro syntax which accepts a string literal and processes it during the resolution pass.
3. **Path Compilation:** Updated the path compilation pipeline to check for pre-compiled `PathData` and use it directly if present. Exposed `compile_path_from_string_literal` as public and refactored its return type to enhance reusability.
4. **Interpreter:** Added support for casting `String` to `PathData`.
5. **Tests:** Added two new test cases for the `Path` element—one verifying standard runtime string commands and another verifying build-time optimization via the `@pathdata` macro.
6. **Documentation:** Updated relevant docs.

Syntax highlighting support for the new macro will be added in a follow-up once this PR makes sufficient progress.

Thanks!

cc [#4](https://github.com/cnlancehu/lucide-slint/issues/4)