### PR TITLE
Polish remote UI and viewer for release

### DIFF
--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -62,10 +62,8 @@ component PhonePreview {
 
 export component RemotePreviewView inherits Rectangle {
     background: Palette.background;
-    min-width: 640px;
-    min-height: 420px;
-    preferred-width: 900px;
-    preferred-height: 620px;
+    width: 840px;
+    height: 600px;
     clip: true;
 
     property <int> selected-index: -1;

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -172,6 +172,7 @@ export component RemotePreviewView inherits Rectangle {
                         inner-shadow-color: black.with-alpha(0.1);
                         inner-shadow-offset-x: 5px;
                         inner-shadow-offset-y: 5px;
+                        clip: true;
 
                         if Api.remote-discovered-viewers.length == 0: VerticalLayout {
                             alignment: center;

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -210,13 +210,14 @@ export component RemotePreviewView inherits Rectangle {
                                     spacing: EditorSpaceSettings.default-spacing;
                                     VerticalLayout {
                                         horizontal-stretch: 1;
-                                        Text {
+                                        if device.name != "": Text {
                                             text: device.name;
+                                            font-size: 14px;
                                             color: i == root.selected-index ? Palette.accent-foreground : Palette.foreground;
                                             font-weight: FontWeight.bold;
                                         }
 
-                                        Text {
+                                        if device.name == "": Text {
                                             text: (device.addresses.length > 0 ? device.addresses[0] : device.host) + ":" + device.port;
                                             color: i == root.selected-index ? Palette.accent-foreground : Palette.foreground;
                                             opacity: 0.7;

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -9,11 +9,11 @@ component PhonePreview {
     property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
     in property <image> background-image;
 
-    width: 190px;
-    height: 380px;
+    width: 150px;
+    height: 300px;
 
     Rectangle {
-        border-radius: 34px;
+        border-radius: 27px;
         background: root.dark-color-scheme ? @linear-gradient(180deg, #1C1C1C, black) : @linear-gradient(0deg, #D7D9DD, white);
         drop-shadow-blur: 10px;
         drop-shadow-color: black.with-alpha(0.5);
@@ -27,25 +27,25 @@ component PhonePreview {
 
         Rectangle {
             x: (parent.width - self.width) / 2;
-            y: 10px;
-            width: 62px;
-            height: 18px;
-            border-radius: 9px;
+            y: 8px;
+            width: 49px;
+            height: 14px;
+            border-radius: 7px;
             background: #111111;
         }
 
         VerticalLayout {
-            padding-left: 20px;
-            padding-right: 20px;
-            padding-top: 92px;
-            padding-bottom: 24px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 72px;
+            padding-bottom: 19px;
             alignment: space-between;
 
             VerticalLayout {
                 spacing: 6px;
                 Text {
                     text: @tr("Slint Viewer");
-                    font-size: 16px;
+                    font-size: 13px;
                     font-weight: FontWeight.extra-bold;
                     color: root.dark-color-scheme ? #eeeeee : #333333;
                 }
@@ -62,7 +62,7 @@ component PhonePreview {
 
 export component RemotePreviewView inherits Rectangle {
     background: Palette.background;
-    width: 840px;
+    width: 740px;
     height: 600px;
     clip: true;
 
@@ -123,7 +123,11 @@ export component RemotePreviewView inherits Rectangle {
                 }
 
                 Text {
-                    text: @tr("Open Slint Viewer on your phone and ensure it is on the same Wi-Fi.");
+                    text: Api.remote-connection-state == RemoteConnectionState.Connected
+                        ? @tr("Live preview is running on the connected device.")
+                        : (Api.remote-discovered-viewers.length > 0
+                        ? @tr("Select a discovered device to connect.")
+                        : @tr("Open Slint Viewer on your phone; it will appear below."));
                     wrap: word-wrap;
                     color: Palette.foreground;
                     opacity: 0.72;
@@ -174,15 +178,26 @@ export component RemotePreviewView inherits Rectangle {
                         inner-shadow-offset-y: 5px;
                         clip: true;
 
-                        if Api.remote-discovered-viewers.length == 0: VerticalLayout {
-                            alignment: center;
-                            spacing: EditorSpaceSettings.default-spacing;
-                            Text {
-                                text: @tr("Searching the local network…");
-                                horizontal-alignment: center;
-                                font-weight: FontWeight.bold;
-                                color: Palette.foreground;
-                                font-size: 12px;
+                        if Api.remote-discovered-viewers.length == 0: HorizontalLayout {
+                            alignment: start;
+                            spacing: EditorSpaceSettings.default-spacing * 2;
+                            padding: EditorSpaceSettings.default-padding * 2;
+
+                            PhonePreview {
+                                background-image: background-image;
+                            }
+
+                            VerticalLayout {
+                                padding: EditorSpaceSettings.default-padding * 2;
+                                Text {
+                                    text: @tr("Start Slint Viewer on your device using the same Wi-Fi.");
+                                    wrap: word-wrap;
+                                    color: Palette.foreground;
+                                    opacity: 0.80;
+                                    font-size: 14px;
+                                    width: 200px;
+                                    horizontal-alignment: left;
+                                }
                             }
                         }
 
@@ -287,30 +302,6 @@ export component RemotePreviewView inherits Rectangle {
                                 }
                             }
                         }
-                    }
-                }
-            }
-
-            Rectangle {
-                width: 260px;
-                vertical-stretch: 1;
-
-                VerticalLayout {
-                    alignment: center;
-                    spacing: EditorSpaceSettings.default-spacing * 2;
-                    cross-axis-alignment: center;
-
-                    PhonePreview {
-                        background-image: background-image;
-                    }
-
-                    Text {
-                        text: @tr("Start Slint Viewer on your device using the same Wi-Fi.");
-                        horizontal-alignment: left;
-                        wrap: word-wrap;
-                        color: Palette.foreground;
-                        opacity: 0.80;
-                        font-size: 14px;
                     }
                 }
             }

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -118,7 +118,8 @@ export component RemotePreviewView inherits Rectangle {
                 Text {
                     text: Api.remote-connection-state == RemoteConnectionState.Connected
                         ? @tr("Connected to {}.", best-device-name)
-                        : @tr("Searching for a device…");
+                        : (Api.remote-discovered-viewers.length > 0 ? @tr("Select a discovered device to connect.")
+                        : @tr("Searching for a device…"));
                     font-size: 24px;
                     font-weight: FontWeight.bold;
                     color: Palette.foreground;
@@ -127,9 +128,7 @@ export component RemotePreviewView inherits Rectangle {
                 Text {
                     text: Api.remote-connection-state == RemoteConnectionState.Connected
                         ? @tr("Live preview is running on the connected device.")
-                        : (Api.remote-discovered-viewers.length > 0
-                        ? @tr("Select a discovered device to connect.")
-                        : @tr("Open Slint Viewer on your phone; it will appear below."));
+                        : "";
                     wrap: word-wrap;
                     color: Palette.foreground;
                     opacity: 0.72;
@@ -210,6 +209,12 @@ export component RemotePreviewView inherits Rectangle {
                                     ? Palette.accent-background
                                     : (touch.has-hover ? Palette.alternate-background : transparent);
 
+                                Rectangle {
+                                    y: parent.height - self.height;
+                                    height: 1px;
+                                    background: Palette.border.with-alpha(0.2);
+                                }
+
                                 touch := TouchArea {
                                     clicked => {
                                         root.selected-index = i;
@@ -231,7 +236,6 @@ export component RemotePreviewView inherits Rectangle {
                                             text: device.name;
                                             font-size: 14px;
                                             color: i == root.selected-index ? Palette.accent-foreground : Palette.foreground;
-                                            font-weight: FontWeight.bold;
                                         }
 
                                         if device.name == "": Text {

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -89,6 +89,8 @@ export component RemotePreviewView inherits Rectangle {
     }
     property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
     property <image> background-image: root.dark-color-scheme ? @image-url("../../../viewer/remote/assets/bg-frame.svg") : @image-url("../../../viewer/remote/assets/bg-frame-light.svg");
+    property <string> best-device-name: Api.remote-discovered-viewers[selected-index].name != "" ? Api.remote-discovered-viewers[selected-index].name
+        : Api.remote-connection-target;
 
     Rectangle {
         background: root.dark-color-scheme ? @linear-gradient(180deg, #1C1C1C, black) : @linear-gradient(0deg, #D7D9DD, white);
@@ -115,7 +117,7 @@ export component RemotePreviewView inherits Rectangle {
                 spacing: 6px;
                 Text {
                     text: Api.remote-connection-state == RemoteConnectionState.Connected
-                        ? @tr("Previewing on {}.", Api.remote-connection-target)
+                        ? @tr("Connected to {}.", best-device-name)
                         : @tr("Searching for a device…");
                     font-size: 24px;
                     font-weight: FontWeight.bold;
@@ -272,11 +274,6 @@ export component RemotePreviewView inherits Rectangle {
                     if root.connecting: Text {
                         text: @tr("Connecting to {}…", Api.remote-connection-target);
                         color: Palette.foreground;
-                    }
-                    if Api.remote-connection-state == RemoteConnectionState.Connected: Text {
-                        text: @tr("Connected to {}. Switch to Local to disconnect.", Api.remote-connection-target);
-                        color: #2a2;
-                        font-weight: FontWeight.bold;
                     }
                     if Api.remote-connection-state == RemoteConnectionState.Failed: Text {
                         text: Api.remote-connection-error != ""

--- a/tools/viewer/.gitignore
+++ b/tools/viewer/.gitignore
@@ -7,3 +7,4 @@
 
 # App icon asset catalog generated at build time by scripts/render_ios_app_icon.bash
 /Assets.xcassets/
+remote/assets/slint-logo-small-light.svg

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -68,6 +68,7 @@ export component RemoteViewerWindow inherits Window {
         enabled: root.state != RemoteViewerState.preview-error;
 
         clicked => {
+            root.showing-name = !root.showing-name;
             root.copy-to-clipboard(root.address, @tr("IP copied to clipboard"));
         }
     }

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -117,6 +117,7 @@ export component RemoteViewerWindow inherits Window {
                 text: root.showing-name && root.has-name ? name : address;
                 font-size: 1.41rem;
                 font-weight: 400;
+                wrap: word-wrap;
             }
         }
 

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -46,6 +46,7 @@ export component RemoteViewerWindow inherits Window {
     TouchArea {
         y: 0;
         height: root.safe-area-insets.top + 246px;
+        enabled: root.state != RemoteViewerState.preview-error;
 
         clicked => {
             hidden-input.select-all();
@@ -75,6 +76,7 @@ export component RemoteViewerWindow inherits Window {
         padding-left: 24px;
         padding-top: root.safe-area-insets.top + 146px;
         padding-bottom: root.safe-area-insets.bottom;
+        visible: root.state != RemoteViewerState.preview-error;
         VerticalLayout {
             alignment: start;
             spacing: 8px;
@@ -148,10 +150,10 @@ export component RemoteViewerWindow inherits Window {
         padding-top: root.safe-area-insets.top;
         padding-bottom: root.safe-area-insets.bottom;
 
-        if message != "": Text {
+        if root.state == RemoteViewerState.preview-error && message != "": Text {
             text: message;
             horizontal-alignment: center;
-            font-weight: 400;
+            wrap: word-wrap;
         }
     }
 }

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -26,11 +26,30 @@ export component RemoteViewerWindow inherits Window {
     property <bool> showing-name: true;
 
     property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
+    property <string> toast-message;
 
     hidden-input := TextInput {
         enabled: false;
         visible: false;
         text: root.address;
+    }
+
+    function show-toast(message: string) {
+        root.toast-message = message;
+        if hide-toast-timer.running == false {
+            hide-toast-timer.start();
+        } else {
+            hide-toast-timer.restart();
+        }
+
+        toast.opacity = 1;
+    }
+
+    function copy-to-clipboard(text: string, toast-message: string) {
+        hidden-input.text = text;
+        hidden-input.select-all();
+        hidden-input.copy();
+        root.show-toast(toast-message);
     }
 
     Rectangle {
@@ -49,15 +68,15 @@ export component RemoteViewerWindow inherits Window {
         enabled: root.state != RemoteViewerState.preview-error;
 
         clicked => {
-            hidden-input.select-all();
-            hidden-input.copy();
-            if hide-toast-timer.running == false {
-                hide-toast-timer.start();
-            } else {
-                hide-toast-timer.restart();
-            }
+            root.copy-to-clipboard(root.address, @tr("IP copied to clipboard"));
+        }
+    }
 
-            toast.opacity = 1;
+    TouchArea {
+        enabled: root.state == RemoteViewerState.preview-error && root.message != "";
+
+        clicked => {
+            root.copy-to-clipboard(root.message, @tr("Error copied to clipboard"));
         }
     }
 
@@ -136,7 +155,7 @@ export component RemoteViewerWindow inherits Window {
             border-radius: parent.border-radius;
             background: root.dark-color-scheme ? #212121 : #f6f7f8;
             Text {
-                text: @tr("IP copied to clipboard");
+                text: root.toast-message;
                 font-weight: 400;
             }
         }


### PR DESCRIPTION
Fix window size issue and performance.
Don't show helper phone/text once devices are found.
Stop repeating a lot of helper text.
Show errors better on remote viewer.
Allow errors to be copied to clipboard on phone.