### PR TITLE
docs: improve the documentation of conversions between numbers and strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to this project are documented in this file.
  - TextInput: allow setting the accessibility value
  - Add landmark accessible roles to `AccessibleRole` (#11831)
  - `animate`: Added `enabled` boolean to toggle animations on/off (defaults to `true`). (#9604)
+ - Conversions between `float` and `string` now use the locale's decimal separator,
+   which is exposed as `Platform.decimal-separator`. (#10857)
 
 ### Widgets
 

--- a/docs/astro/src/content/docs/guide/development/translations.mdx
+++ b/docs/astro/src/content/docs/guide/development/translations.mdx
@@ -305,7 +305,16 @@ Use the <LangRefLink lang="python" relpath="api/functions/init_translations/">`s
 Make sure the `gettext` feature was enabled when building slint-viewer.
 Use the `--translation-domain` and `--translation-dir` command line options to load translations for preview.
 
-## Selecting the decimal separator
+## Selecting the Decimal Separator
 
-The current used decimal separator can be read with <Link type="Platform.decimal-separator" label="decimal-separator" />. As default the dot `.` is used as decimal separator.
-When bundling the languages, the decimal separator will be determined during compile time and bundled into the software, otherwise it will be determined from the system locale
+Conversions between `float` and `string` use the locale's decimal separator,
+for example the comma (`,`) in a German locale.
+See <Link type="NumberStringConversion" label="Converting Between Numbers and Strings" /> for the conversion rules.
+
+Read the currently used separator from <Link type="Platform.decimal-separator" label="Platform.decimal-separator" />.
+It defaults to the dot (`.`).
+
+When bundling translations, the decimal separator of each language is determined at compile time
+and bundled with the application:
+selecting a translation also selects its decimal separator.
+When the `gettext` feature is enabled, the decimal separator is determined from the system locale.

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -44,8 +44,13 @@ Anything else following an unescaped `\` is an error.
   The `\{...}` syntax is not valid within the `slint!` macro in Rust.
 :::
 
+</SlintProperty>
 
-`is-empty` property is true when `string` doesn't contain anything.
+Strings have the following properties and member functions:
+
+#### is-empty
+
+`true` when the string doesn't contain anything, `false` otherwise.
 
 ```slint
 export component LengthOfString {
@@ -54,7 +59,9 @@ export component LengthOfString {
 }
 ```
 
-`character-count` property returns the number of [grapheme clusters](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries).
+#### character-count
+
+The number of [grapheme clusters](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) in the string.
 
 ```slint
 export component CharacterCountOfString {
@@ -70,28 +77,50 @@ export component CharacterCountOfString {
 }
 ```
 
-The `to-lowercase` and `to-uppercase` methods convert `string` to lowercase or uppercase according to the [Unicode Character Property](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-4/#G124722).
+#### to-lowercase() -> string
+
+Returns the string converted to lowercase,
+according to the [Unicode Character Property](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-4/#G124722).
 
 ```slint
-export component ChangeCaseOfString {
+export component StringToLowercase {
     property<string> hello: "HELLO".to-lowercase(); // "hello"
-    property<string> bye: "tschüß".to-uppercase(); // "TSCHÜSS"
     property<string> odysseus: "ὈΔΥΣΣΕΎΣ".to-lowercase(); // "ὀδυσσεύς"
-    property<string> new_year: "农历新年".to-uppercase(); // "农历新年"
 }
 ```
 
-The `to-float` method can be used to convert `string` to a `float`. It returns 0 if the string isn’t a valid number. You can check with `is-float` if the string contains a valid number.
+#### to-uppercase() -> string
+
+Returns the string converted to uppercase,
+according to the [Unicode Character Property](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-4/#G124722).
+
+```slint
+export component StringToUppercase {
+    property<string> bye: "tschüß".to-uppercase(); // "TSCHÜSS"
+    property<string> new-year: "农历新年".to-uppercase(); // "农历新年"
+}
+```
+
+#### to-float() -> float
+
+Returns the number contained in the string, or 0 if the string isn't a valid number.
+Use `is-float()` to tell a string holding the number 0 apart from a string that isn't a valid number.
+
+The string is parsed using the decimal separator of the current locale.
+See [Converting Between Numbers and Strings](#converting-between-numbers-and-strings).
+
+#### is-float() -> bool
+
+Returns `true` if the string contains a valid number, `false` otherwise.
+Like `to-float()`, it uses the decimal separator of the current locale.
 
 ```slint
 export component StringToFloat {
     property<float> hello: "hello".to-float(); // 0
     property<bool> goodbye: "goodbye".is-float(); // false
-    property<float> value: "1.5".to-float(); // 1.5
+    property<float> value: "1.5".to-float(); // 1.5 if the decimal separator is "."
 }
 ```
-
-</SlintProperty>
 
 ### styled-text
 <SlintProperty propName="styled-text" typeName="styled-text" defaultValue='""'>
@@ -130,6 +159,32 @@ Type for the duration of animations. A suffix like `ms` (millisecond) or `s` (se
 <SlintProperty propName="float" typeName="float" defaultValue='0'>
 Signed, 32-bit floating point number. Numbers with a `%` suffix are automatically divided by 100, so for example `30%` is the same as `0.30`.
 </SlintProperty>
+
+`float` and `int` values have the following member functions:
+
+#### to-fixed(digits: int) -> string
+
+Returns a string representation of the number with `digits` digits after the decimal point.
+It behaves like JavaScript's [`toFixed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed).
+
+#### to-precision(digits: int) -> string
+
+Returns a string representation of the number with `digits` significant digits.
+It behaves like JavaScript's [`toPrecision()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision).
+
+Both functions format the number using the decimal separator of the current locale.
+See [Converting Between Numbers and Strings](#converting-between-numbers-and-strings).
+
+```slint
+export component FloatToString {
+    property<float> pi: 3.14159;
+    property<string> fixed: pi.to-fixed(2); // "3.14"
+    property<string> precision: pi.to-precision(4); // "3.142"
+}
+```
+
+In addition, call the <Link type="MathRef" label="math functions"/> in postfix style on any numeric value,
+for example `(-10).abs()` or `x.round()`.
 
 ### int
 <SlintProperty propName="int" typeName="int" defaultValue='0'>
@@ -180,9 +235,13 @@ This is the primitive type used to detect if a KeyEvent should trigger a given k
 
 Key bindings in Slint are based on **logical keys** — the character a key produces on the current keyboard layout — not the physical position of a key on the keyboard.
 See <Link type="KeyBindingOverview" label="Key Bindings" /> for details.
+</SlintProperty>
 
-Use the `to-string` function to convert a `keys` instance to `string`.
-It returns a platform-native description of the key combination.
+`keys` values have the following member function:
+
+#### to-string() -> string
+
+Returns a platform-native description of the key combination.
 
 ```slint
 export component KeysToString inherits FocusScope {
@@ -199,9 +258,6 @@ export component KeysToString inherits FocusScope {
 }
 
 ```
-
-
-</SlintProperty>
 
 ## Images
 ### image
@@ -225,8 +281,6 @@ For example: `@image-url("data:image/png;base64,iVBORw0KGgo...")`.
 Supported format are SVG, and formats supported by the [`image` crate](https://crates.io/crates/image):
 AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
 
-For Rust applications, not all formats are enabled by default. Enable them with the `image-default-formats` Cargo feature.
-
 <Tabs syncKey="dev-language">
 <TabItem label="C++">
 In C++, properties or struct fields of the image type are mapped to <LangRefLink lang="cpp" relpath="api/slint/image/">`slint::Image`</LangRefLink>.
@@ -234,7 +288,9 @@ In C++, properties or struct fields of the image type are mapped to <LangRefLink
 <TabItem label="Rust">
 In Rust, properties or struct fields of the image type are mapped to <LangRefLink lang="rust-slint" relpath="struct.Image">`slint::Image`</LangRefLink>.
 :::note[Note]
-Some image formats can be disabled using cargo features to reduce binary size and speed up compilation.
+By default, only PNG, JPEG, and SVG are supported.
+Enable the `image-default-formats` Cargo feature to support the other formats listed above,
+at the cost of a bigger binary and longer compilation.
 :::
 </TabItem>
 <TabItem label="NodeJS" >
@@ -246,29 +302,6 @@ In Python, properties or struct fields of the image type are mapped to <LangRefL
 </TabItem>
 
 </Tabs>
-
-Access an `image`'s dimension using its `width` and `height` properties.
-
-```slint
-export component Example inherits Window {
-    preferred-width: 150px;
-    preferred-height: 50px;
-
-    // Note: http URL only work on the web version.
-    in property <image> some_image: @image-url("https://slint.dev/logo/slint-logo-full-light.svg");
-
-    HorizontalLayout {
-        Text {
-            text: "The image is " + some_image.width + "x" + some_image.height;
-        }
-
-        // Check the size to find out if the image is empty.
-        if some_image.width > 0 : Image {
-            source: some_image;
-        }
-    }
-}
-```
 
 It is also possible to load images supporting [9 slice scaling](https://en.wikipedia.org/wiki/9-slice_scaling) (also called nine patch or border images)
 by adding a  `nine-slice(...)` argument. The argument can have either one, two, or four numbers that specifies the size of the edges.
@@ -290,6 +323,37 @@ export component Example inherits Window {
 See also the <Link type="Image" label="Image element"/>.
 
 </SlintProperty>
+
+Images have the following properties:
+
+#### width
+
+The width of the image in pixels, as an `int`. An empty image has a width of 0.
+
+#### height
+
+The height of the image in pixels, as an `int`. An empty image has a height of 0.
+
+```slint
+export component Example inherits Window {
+    preferred-width: 150px;
+    preferred-height: 50px;
+
+    // Note: http URL only work on the web version.
+    in property <image> some_image: @image-url("https://slint.dev/logo/slint-logo-full-light.svg");
+
+    HorizontalLayout {
+        Text {
+            text: "The image is " + some_image.width + "x" + some_image.height;
+        }
+
+        // Check the size to find out if the image is empty.
+        if some_image.width > 0 : Image {
+            source: some_image;
+        }
+    }
+}
+```
 
 ### data-transfer
 <SlintProperty propName="data" typeName="data-transfer" defaultValue='an empty data-transfer'>
@@ -378,7 +442,9 @@ The following conversions are possible:
 
 -   `int` can be converted implicitly to `float` and vice-versa.
      When converting from `float` to `int`, the value is truncated.
--   `int` and `float` can be converted implicitly to `string`
+-   `int` and `float` can be converted implicitly to `string`,
+    and `string` can be converted to `float` with the `to-float()` member function.
+    See [Converting Between Numbers and Strings](#converting-between-numbers-and-strings).
 -   `physical-length`, `relative-font-size`, and `length` can be converted implicitly to each other only in
     context where the pixel ratio is known.
 -   the units type (`length`, `physical-length`, `duration`, ...) can't be converted to numbers (`float` or `int`)
@@ -388,12 +454,6 @@ The following conversions are possible:
 -   Struct types convert with another struct type if they have the same property names and their types can be converted.
     The source struct can have either missing properties, or extra properties. But not both.
 -   Arrays generally don't convert between each other. Array literals can be converted if the element types are convertible.
--   String can be converted to float by using the `to-float` function. That function returns 0 if the string isn't
-    a valid number. You can check with `is-float()` if the string contains a valid number
--   `float` can be converted to a formatted `string` using `to-fixed` and `to-precision` which can be passed the
-    number of digits after the decimal point and and the number of significant digits respectively. They behave like their
-    JavaScript counterparts [`toFixed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)
-    and [`toPrecision()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision).
 
 ```slint
 export component Example {
@@ -412,3 +472,24 @@ export component Example {
     property<int> xxx3: 45.8; // 45
 }
 ```
+
+### Converting Between Numbers and Strings
+
+`int` and `float` convert implicitly to `string`.
+To control how many digits appear in the result, use the [`to-fixed()` and `to-precision()`](#to-fixeddigits-int---string)
+member functions instead of the implicit conversion.
+
+For the other direction, convert a `string` to a number with the [`to-float()`](#to-float---float) member function,
+and check whether a string holds a valid number with `is-float()`.
+
+All these conversions use the decimal separator of the current locale,
+which is exposed as <Link type="Platform.decimal-separator" label="Platform.decimal-separator" /> and defaults to the dot (`.`).
+For example, in a German locale the decimal separator is the comma (`,`):
+
+-   The `float` value `1.5` converts to the string `"1,5"`.
+-   `"1,5".to-float()` returns `1.5`.
+-   `"1.5".is-float()` returns `false` and `"1.5".to-float()` returns `0`:
+    only the locale's decimal separator is recognized when parsing.
+
+Number literals in `.slint` files always use the dot, regardless of the locale.
+See the <Link type="translations" label="translations guide"/> for how the decimal separator is determined.

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -290,7 +290,7 @@ In Rust, properties or struct fields of the image type are mapped to <LangRefLin
 :::note[Note]
 By default, only PNG, JPEG, and SVG are supported.
 Enable the `image-default-formats` Cargo feature to support the other formats listed above,
-at the cost of a bigger binary and longer compilation.
+which comes at a cost of increased binary size and compilation time.
 :::
 </TabItem>
 <TabItem label="NodeJS" >

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -335,7 +335,8 @@ macro_rules! for_each_enums {
                 Password,
                 /// This will only accept and render number characters (0-9)
                 Number,
-                /// This will accept and render characters if it's valid part of a decimal
+                /// This will accept and render characters if it's valid part of a decimal,
+                /// using the decimal separator of the current locale
                 Decimal,
                 /// This identifies the input field as a search box. Characters are rendered normally,
                 /// but assistive technologies are informed that the field is used for searching or

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2837,6 +2837,10 @@ export global Platform {
     /// style name without the suffix. Use <Link type="Palette" label="Palette"/>'s `color-scheme` to
     /// determine the currently used scheme.
     out property <string> style-name;
+    /// The decimal separator used when converting between `float` and `string`.
+    /// It defaults to the dot (`.`) and is determined by the locale.
+    /// See the <Link type="translations" label="translations guide"/> for details.
+    out property <string> decimal-separator;
     /// Opens the specified URL in an external browser. This function invokes the platform's URL opening mechanism.
     /// Returns `true` on success, or `false` if the platform doesn't support opening URLs or the operation failed.
     ///
@@ -2862,9 +2866,6 @@ export global Platform {
     ///
     /// This corresponds to the standard macOS **Window › Bring All to Front** menu item.
     function macos-bring-all-windows-to-front() { }
-    /// The decimal separator currently used for localized float to string and vice versa conversions
-    /// For more information about localization and how to change the decimal separator see <Link type="translations" label="translations page"/>.
-    out property <string> decimal-separator;
 }
 
 export component NativeButton {

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -149,6 +149,9 @@
     "Models": {
         "href": "guide/language/coding/repetition-and-data-models/#models"
     },
+    "MathRef": {
+        "href": "reference/global-functions/math/"
+    },
     "NumericTypes": {
         "href": "reference/primitive-types/#numeric-types"
     },
@@ -238,6 +241,9 @@
     },
     "Types": {
         "href": "reference/primitive-types/"
+    },
+    "NumberStringConversion": {
+        "href": "reference/primitive-types/#converting-between-numbers-and-strings"
     },
     "VerticalBox": {
         "href": "reference/std-widgets/layouts/verticalbox/"


### PR DESCRIPTION
Give the member functions of string, float, image, and keys their own sections in the primitive types documentation, like in colors & brushes. Document that conversions between float and string use the locale's decimal separator.

Move the Platform.decimal-separator declaration before the functions so it appears under Properties in the generated documentation.
