### PR TITLE
Fix constant float to string conversions ignoring the decimal separator 

### DIFF
--- a/internal/common/lib.rs
+++ b/internal/common/lib.rs
@@ -32,7 +32,11 @@ impl core::fmt::Display for FormattedNumber {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Number from which the increment of f32 is 1, so that we print enough precision
         // to be able to represent all integers
-        if self.0 < 16777216. { write!(f, "{}", self.0 as f32) } else { write!(f, "{}", self.0) }
+        if self.0.abs() < 16777216. {
+            write!(f, "{}", self.0 as f32)
+        } else {
+            write!(f, "{}", self.0)
+        }
     }
 }
 
@@ -125,9 +129,9 @@ fn test_formatted_number() {
     assert_eq!(format(0.), "0");
     assert_eq!(format(16777216.), "16777216");
     assert_eq!(format(16777217.), "16777217");
-    // Negative numbers take the f32 path, which can't represent -16777217 exactly
-    assert_eq!(format(-16777217.), "-16777216");
+    assert_eq!(format(-16777217.), "-16777217");
     assert_eq!(format(16777215.5), "16777216");
+    assert_eq!(format(-16777215.5), "-16777216");
     assert_eq!(format(f64::NAN), "NaN");
 }
 

--- a/internal/common/lib.rs
+++ b/internal/common/lib.rs
@@ -21,6 +21,21 @@ pub mod unicode_utils;
 
 pub const DEFAULT_DECIMAL_SEPARATOR: char = '.';
 
+/// Formats a float the way Slint converts it to a string, before the locale's
+/// decimal separator is substituted.
+///
+/// Both the runtime conversion and the compiler's constant folding use this,
+/// so they can't diverge.
+pub struct FormattedNumber(pub f64);
+
+impl core::fmt::Display for FormattedNumber {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Number from which the increment of f32 is 1, so that we print enough precision
+        // to be able to represent all integers
+        if self.0 < 16777216. { write!(f, "{}", self.0 as f32) } else { write!(f, "{}", self.0) }
+    }
+}
+
 #[derive(Clone)]
 pub struct TranslationsBundled {
     pub language: &'static str,
@@ -100,6 +115,21 @@ pub const MENU_SEPARATOR_PLACEHOLDER_TITLE: &str = "\u{E001}⸺";
 /// Use the value 65536, so it's outside u16 range and not as likely as -1
 /// (we can catch it as a literal at compile time, but not if it's a runtime value)
 pub const ROW_COL_AUTO: f32 = u16::MAX as f32 + 1.;
+
+#[test]
+fn test_formatted_number() {
+    let format = |n: f64| alloc::format!("{}", FormattedNumber(n));
+    assert_eq!(format(45.), "45");
+    assert_eq!(format(45.12), "45.12");
+    assert_eq!(format(-1325466.), "-1325466");
+    assert_eq!(format(0.), "0");
+    assert_eq!(format(16777216.), "16777216");
+    assert_eq!(format(16777217.), "16777217");
+    // Negative numbers take the f32 path, which can't represent -16777217 exactly
+    assert_eq!(format(-16777217.), "-16777216");
+    assert_eq!(format(16777215.5), "16777216");
+    assert_eq!(format(f64::NAN), "NaN");
+}
 
 #[cfg(all(test, feature = "locale-decimal-separator"))]
 mod tests {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -368,9 +368,14 @@ impl BuiltinFunction {
             | BuiltinFunction::Pow
             | BuiltinFunction::Exp
             | BuiltinFunction::ATan
-            | BuiltinFunction::ATan2
-            | BuiltinFunction::ToFixed
-            | BuiltinFunction::ToPrecision => true,
+            | BuiltinFunction::ATan2 => true,
+            // The result depends on the locale's decimal separator, like DecimalSeparator.
+            // The constant propagation folds the locale-independent cases and promotes
+            // their binding back to constant.
+            BuiltinFunction::ToFixed
+            | BuiltinFunction::ToPrecision
+            | BuiltinFunction::StringToFloat
+            | BuiltinFunction::StringIsFloat => false,
             BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => false,
             BuiltinFunction::ShowPopupWindow
             | BuiltinFunction::ClosePopupWindow
@@ -378,9 +383,7 @@ impl BuiltinFunction {
             | BuiltinFunction::ShowPopupMenuInternal => false,
             BuiltinFunction::SetSelectionOffsets => false,
             BuiltinFunction::ItemFontMetrics => false, // depends also on Window's font properties
-            BuiltinFunction::StringToFloat
-            | BuiltinFunction::StringIsFloat
-            | BuiltinFunction::StringIsEmpty
+            BuiltinFunction::StringIsEmpty
             | BuiltinFunction::StringCharacterCount
             | BuiltinFunction::StringToLowercase
             | BuiltinFunction::StringToUppercase
@@ -1335,7 +1338,20 @@ impl Expression {
             Expression::ArrayIndex { array, index } => {
                 array.is_constant(ga) && index.is_constant(ga)
             }
-            Expression::Cast { from, .. } => from.is_constant(ga),
+            Expression::Cast { from, to } => {
+                // Converting a float to string depends on the locale's decimal separator,
+                // unless the result contains none, like for integer literals.
+                // The constant propagation folds the remaining constant cases and
+                // promotes their binding back to constant.
+                if *to == Type::String
+                    && from.ty() == Type::Float32
+                    && !matches!(&**from, Expression::NumberLiteral(n, Unit::None)
+                        if locale_independent_number_to_string(*n).is_some())
+                {
+                    return false;
+                }
+                from.is_constant(ga)
+            }
             // This is conservative: the return value is the last expression in the block, but
             // we kind of mean "pure" here too, so ensure the whole body is OK.
             Expression::CodeBlock(sub) => sub.iter().all(|s| s.is_constant(ga)),
@@ -1746,6 +1762,13 @@ fn model_inner_type(model: &Expression) -> Type {
             _ => Type::Invalid,
         },
     }
+}
+
+/// Converts a float to a string when the result contains no decimal separator,
+/// and is therefore the same in every locale.
+pub fn locale_independent_number_to_string(n: f64) -> Option<SmolStr> {
+    let string = format_smolstr!("{}", i_slint_common::FormattedNumber(n));
+    (!string.contains('.')).then_some(string)
 }
 
 /// The right hand side of a two way binding

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -10,7 +10,7 @@ use crate::expression_tree::*;
 use crate::langtype::{BuiltinStruct, ElementType, StructName, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
-use smol_str::{ToSmolStr, format_smolstr};
+use smol_str::format_smolstr;
 
 type ConstPropCache = HashMap<NamedReference, Option<Expression>>;
 
@@ -21,6 +21,25 @@ pub fn const_propagation(component: &Component, global_analysis: &GlobalAnalysis
             return;
         }
         simplify_expression(expr, global_analysis, &mut cache);
+    });
+
+    // The binding analysis classifies conversions such as float to string as non-constant
+    // because their result depends on the locale's decimal separator. When the
+    // simplification folded the conversion away, the binding is constant after all:
+    // promote it back.
+    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+        for binding in elem.borrow().bindings.values() {
+            let Ok(mut binding) = binding.try_borrow_mut() else { continue };
+            let Some(analysis) = binding.analysis.as_ref() else { continue };
+            if analysis.is_const || matches!(binding.expression, Expression::Invalid) {
+                continue;
+            }
+            if binding.expression.is_constant(Some(global_analysis))
+                && binding.two_way_bindings.iter().all(|tw| tw.is_constant())
+            {
+                binding.analysis.as_mut().unwrap().is_const = true;
+            }
+        }
     });
 }
 
@@ -162,7 +181,7 @@ fn simplify_expression(
             } else {
                 match (&**from, to) {
                     (Expression::NumberLiteral(x, Unit::None), Type::String) => {
-                        Some(Expression::StringLiteral(x.to_smolstr()))
+                        locale_independent_number_to_string(*x).map(Expression::StringLiteral)
                     }
                     (Expression::Struct { values, .. }, Type::Struct(ty)) => {
                         Some(Expression::Struct { ty: ty.clone(), values: values.clone() })
@@ -375,6 +394,21 @@ fn try_inline_builtin_function(
         BuiltinFunction::Ceil => num(a(0)?.ceil()),
         BuiltinFunction::Floor => num(a(0)?.floor()),
         BuiltinFunction::Abs => num(a(0)?.abs()),
+        BuiltinFunction::StringToFloat | BuiltinFunction::StringIsFloat => {
+            let Some(Expression::StringLiteral(s)) = args.first() else { return None };
+            // Only fold when the string can't contain the decimal separator of any locale,
+            // so that parsing gives the same result regardless of the locale.
+            if !s.chars().all(|c| c.is_ascii_digit() || matches!(c, '+' | '-' | 'e' | 'E')) {
+                return None;
+            }
+            let value = s.parse::<f32>().ok();
+            Some(match b {
+                BuiltinFunction::StringToFloat => {
+                    Expression::NumberLiteral(value.unwrap_or(0.) as f64, Unit::None)
+                }
+                _ => Expression::BoolLiteral(value.is_some()),
+            })
+        }
         _ => None,
     }
 }
@@ -441,6 +475,64 @@ export component Foo {
         },
         _ => panic!("not code block: {out3_binding:?}"),
     };
+}
+
+#[test]
+fn test_locale_dependent_string_conversion() {
+    let mut compiler_config =
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+export component Foo {
+    out property <string> int-str: "n=" + 42;
+    out property <string> calc-str: "n=" + (6 * 7);
+    out property <string> float-str: "n=" + 4.5;
+    out property <float> int-float: "42".to-float();
+    out property <bool> int-is-float: "42".is-float();
+    out property <float> frac-float: "4,2".to-float();
+}
+"#
+        .into(),
+        Some(std::path::Path::new("HELLO")),
+        &mut test_diags,
+    );
+    let (doc, diag, _) =
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+    assert!(!diag.has_errors(), "slint compile error {:#?}", diag.to_string_vec());
+
+    let bindings = &doc.inner_components.last().unwrap().root_element.borrow().bindings;
+    let binding = |name: &str| bindings.get(name).unwrap().borrow().clone();
+    let is_const =
+        |name: &str| bindings.get(name).unwrap().borrow().analysis.as_ref().unwrap().is_const;
+
+    // Conversions whose result contains no decimal separator are folded and stay constant
+    assert!(
+        matches!(&binding("int-str").expression, Expression::StringLiteral(s) if s == "n=42"),
+        "{:?}",
+        binding("int-str").expression
+    );
+    assert!(is_const("int-str"));
+    assert!(matches!(&binding("calc-str").expression, Expression::StringLiteral(s) if s == "n=42"));
+    assert!(is_const("calc-str"));
+    assert!(
+        matches!(&binding("int-float").expression, Expression::NumberLiteral(n, _) if *n == 42.)
+    );
+    assert!(is_const("int-float"));
+    assert!(matches!(&binding("int-is-float").expression, Expression::BoolLiteral(true)));
+    assert!(is_const("int-is-float"));
+
+    // Locale-dependent conversions are not folded and their bindings are no longer constant,
+    // so that they are re-evaluated when the locale changes at runtime
+    assert!(
+        !matches!(&binding("float-str").expression, Expression::StringLiteral(_)),
+        "{:?}",
+        binding("float-str").expression
+    );
+    assert!(!is_const("float-str"));
+    assert!(matches!(&binding("frac-float").expression, Expression::FunctionCall { .. }));
+    assert!(!is_const("frac-float"));
 }
 
 #[test]

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -344,9 +344,7 @@ where
 /// Convert a f64 to a SharedString
 pub fn shared_string_from_number(n: f64) -> SharedString {
     crate::context::GLOBAL_CONTEXT.with(|ctx| {
-        // Number from which the increment of f32 is 1, so that we print enough precision to be able to represent all integers
-        let mut result =
-            if n < 16777216. { crate::format!("{}", n as f32) } else { crate::format!("{}", n) };
+        let mut result = crate::format!("{}", i_slint_common::FormattedNumber(n));
 
         if let Some(ctx) = ctx.get() {
             let pinned = ctx.0.as_ref().project_ref();

--- a/tests/cases/expr/float_to_string.slint
+++ b/tests/cases/expr/float_to_string.slint
@@ -1,0 +1,55 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Verify that converting a float to string gives the same result for compile-time
+// constants and for runtime values, in particular around 16777216 where the
+// formatting switches from f32 to f64 precision.
+
+export component TestCase {
+    in-out property <float> v1: 16777216;
+    in-out property <float> v2: 16777218;
+    in-out property <float> v3: -16777217;
+    in-out property <float> v4: 16777215.5;
+    in-out property <float> v5: 4.25;
+    in-out property <float> v6: 42;
+
+    // Converted from a constant
+    out property <string> c1: 16777216;
+    out property <string> c2: 16777218;
+    out property <string> c3: -16777217;
+    out property <string> c4: 16777215.5;
+    out property <string> c5: 4.25;
+    out property <string> c6: 42;
+
+    // Converted at runtime
+    out property <string> r1: v1;
+    out property <string> r2: v2;
+    out property <string> r3: v3;
+    out property <string> r4: v4;
+    out property <string> r5: v5;
+    out property <string> r6: v6;
+
+    out property <bool> test:
+        c1 == r1 && c2 == r2 && c3 == r3 && c4 == r4 && c5 == r5 && c6 == r6
+        && c1 == "16777216" && c2 == "16777218" && c3 == "-16777216"
+        && c4 == "16777216" && c5 == "4.25" && c6 == "42";
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/

--- a/tests/cases/expr/float_to_string.slint
+++ b/tests/cases/expr/float_to_string.slint
@@ -8,7 +8,7 @@
 export component TestCase {
     in-out property <float> v1: 16777216;
     in-out property <float> v2: 16777218;
-    in-out property <float> v3: -16777217;
+    in-out property <float> v3: -16777218;
     in-out property <float> v4: 16777215.5;
     in-out property <float> v5: 4.25;
     in-out property <float> v6: 42;
@@ -16,7 +16,7 @@ export component TestCase {
     // Converted from a constant
     out property <string> c1: 16777216;
     out property <string> c2: 16777218;
-    out property <string> c3: -16777217;
+    out property <string> c3: -16777218;
     out property <string> c4: 16777215.5;
     out property <string> c5: 4.25;
     out property <string> c6: 42;
@@ -31,7 +31,7 @@ export component TestCase {
 
     out property <bool> test:
         c1 == r1 && c2 == r2 && c3 == r3 && c4 == r4 && c5 == r5 && c6 == r6
-        && c1 == "16777216" && c2 == "16777218" && c3 == "-16777216"
+        && c1 == "16777216" && c2 == "16777218" && c3 == "-16777218"
         && c4 == "16777216" && c5 == "4.25" && c6 == "42";
 }
 

--- a/tests/cases/translations/decimal_separator.slint
+++ b/tests/cases/translations/decimal_separator.slint
@@ -18,6 +18,13 @@ export component TestCase {
     // \{ cannot be in a slint macro, so we add it here, because we wanna execute the Test with
     // compiled source (otherwise bundling translations is not possible)
     out property <string> same_or_diff: "\{the-decimal-separator}";
+
+    // Conversions of constant expressions must use the same locale-dependent rules as
+    // conversions of runtime values, and update when the locale changes
+    out property <string> const_float_as_string: 1.5;
+    out property <string> const_int_as_string: 42;
+    out property <string> const_to_fixed: 1.5.to-fixed(2);
+    out property <bool> const_is_float: "1,5".is-float();
 }
 
 /*
@@ -25,11 +32,19 @@ export component TestCase {
 ```rust
 let instance = TestCase::new().unwrap();
 assert_eq!(instance.get_the_decimal_separator(), "."); // We didn't set any decimal separator yet
+assert_eq!(instance.get_const_float_as_string(), "1.5");
+assert_eq!(instance.get_const_int_as_string(), "42");
+assert_eq!(instance.get_const_to_fixed(), "1.50");
+assert_eq!(instance.get_const_is_float(), false);
 
 assert!(slint::select_bundled_translation("fr").is_ok());
 assert_eq!(instance.get_the_decimal_separator(), ",");
 instance.set_value(-5.5);
 assert_eq!(instance.get_float_as_string(), "-5,5");
+assert_eq!(instance.get_const_float_as_string(), "1,5");
+assert_eq!(instance.get_const_int_as_string(), "42");
+assert_eq!(instance.get_const_to_fixed(), "1,50");
+assert_eq!(instance.get_const_is_float(), true);
 
 instance.set_value_string("5.5".into());
 assert_eq!(instance.get_is_float(), false);
@@ -42,6 +57,9 @@ assert!(slint::select_bundled_translation("en").is_ok());
 assert_eq!(instance.get_the_decimal_separator(), ".");
 instance.set_value(7.123);
 assert_eq!(instance.get_float_as_string(), "7.123");
+assert_eq!(instance.get_const_float_as_string(), "1.5");
+assert_eq!(instance.get_const_to_fixed(), "1.50");
+assert_eq!(instance.get_const_is_float(), false);
 
 instance.set_value_string("5,5".into());
 assert_eq!(instance.get_is_float(), false);
@@ -58,11 +76,19 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 
 assert_eq(instance.get_the_decimal_separator(), ".");
+assert_eq(instance.get_const_float_as_string(), "1.5");
+assert_eq(instance.get_const_int_as_string(), "42");
+assert_eq(instance.get_const_to_fixed(), "1.50");
+assert_eq(instance.get_const_is_float(), false);
 
 assert(slint::select_bundled_translation("fr"));
 assert_eq(instance.get_the_decimal_separator(), ",");
 instance.set_value(-5.5);
 assert_eq(instance.get_float_as_string(), "-5,5");
+assert_eq(instance.get_const_float_as_string(), "1,5");
+assert_eq(instance.get_const_int_as_string(), "42");
+assert_eq(instance.get_const_to_fixed(), "1,50");
+assert_eq(instance.get_const_is_float(), true);
 
 instance.set_value_string("5.5");
 assert_eq(instance.get_is_float(), false);
@@ -75,6 +101,9 @@ assert(slint::select_bundled_translation("en"));
 assert_eq(instance.get_the_decimal_separator(), ".");
 instance.set_value(7.123);
 assert_eq(instance.get_float_as_string(), "7.123");
+assert_eq(instance.get_const_float_as_string(), "1.5");
+assert_eq(instance.get_const_to_fixed(), "1.50");
+assert_eq(instance.get_const_is_float(), false);
 
 instance.set_value_string("5,5");
 assert_eq(instance.get_is_float(), false);


### PR DESCRIPTION
The constant propagation folded float to string casts with Rust's
default formatting: the result used '.' even in locales with another
decimal separator, and f64 formatting where the runtime uses f32 below
16777216.

Fold the conversion only when the result contains no decimal separator,
using the same formatting as the runtime. The binding analysis now
classifies locale-dependent conversions (float to string, to-fixed,
to-precision, to-float, and is-float) as non-constant, so that they are
re-evaluated when the locale changes at runtime, like
Platform.decimal-separator. The constant propagation promotes bindings
back to constant when it folded the conversion away.
to-float and is-float of strings that can't contain a decimal separator
are also folded at compile time.