### PR TITLE
system testing: Remove accidental event recording

### DIFF
--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -223,7 +223,6 @@ impl TestingClient {
 pub fn init() -> Result<(), EventLoopError> {
     introspection::ensure_window_tracking()?;
     let state = introspection::shared_state();
-    state.start_recording();
 
     let Some(client) = TestingClient::new(state) else {
         return Ok(());


### PR DESCRIPTION
There's no API for that (yet), so don't unconditionally start recording events. That eats up (little) memory :)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
