### PR TITLE
Update tree-sitter to v0.26.9 and the zed grammar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -439,7 +439,7 @@ jobs:
         uses: ./.github/workflows/tree_sitter.yaml
         with:
             latest: false
-            tag: "v0.26.5"
+            tag: "v0.26.9"
 
     # Test that the formater don't introduce slint compilation error
     fmt_test:

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -15,4 +15,4 @@ language = "Slint"
 
 [grammars.slint]
 repository = "https://github.com/slint-ui/tree-sitter-slint.git"
-commit = "68b25244cec6eb9d7f8f790ef781c29c822d8f84"
+commit = "5043d26717bcfcd5c26f8bf0fed4cff0f07aabeb"


### PR DESCRIPTION
Release housekeeping for the tree-sitter related pins:
                                                                                                                                             
- Bump the `tag` of the `tree-sitter` CI job to v0.26.9, the latest release.
- Update the `grammars.slint` commit in the zed extension to the head of the
  tree-sitter-slint nightly branch (built with tree-sitter 0.26.7).
