### PR TITLE
remote preview: reconnect automatically when the connection drops 

### DIFF
--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -59,6 +59,11 @@ pub enum LspToPreviewMessage {
         error: Option<String>,
     },
     Quit,
+    /// Keepalive probe; the viewer answers with [`super::PreviewToLspMessage::Pong`].
+    /// Never sent to local previews.
+    /// A protocol message because the LSP's browser-compatible WebSocket layer
+    /// doesn't expose frame-level pings.
+    Ping,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -47,4 +47,7 @@ pub enum PreviewToLspMessage {
     ConnectRemote { addresses: Vec<String>, port: u16 },
     /// The preview UI asked to disconnect the remote viewer.
     DisconnectRemote,
+    /// Answer to [`super::LspToPreviewMessage::Ping`], consumed by the LSP's
+    /// WebSocket connector.
+    Pong,
 }

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -140,6 +140,16 @@ pub struct Connection {
     device_name: Mutex<String>,
 }
 
+/// Serialize a message into the wire format and queue it on the write half.
+fn encode_and_send(
+    sender: &UnboundedSender<Message>,
+    message: &impl Serialize,
+) -> anyhow::Result<()> {
+    let data: Vec<u8> = postcard::to_allocvec(message)?;
+    sender.send(Message::Binary(data.into()))?;
+    Ok(())
+}
+
 /// Whether the connection can act on this URL. The remote preview protocol only handles
 /// `file://` URLs; the LSP can legitimately produce others (e.g. `vscode-remote://`), but
 /// they're silently ignored on this side.
@@ -420,6 +430,13 @@ impl Connection {
                                         LspToPreviewMessage::Quit => {
                                             break 'outer;
                                         }
+                                        LspToPreviewMessage::Ping => {
+                                            encode_and_send(
+                                                &message_sender,
+                                                &PreviewToLspMessage::Pong,
+                                            )
+                                            .ok();
+                                        }
                                         // Internal LSP↔local-preview control message;
                                         // never legitimately reaches a remote viewer.
                                         LspToPreviewMessage::RemoteConnectionState { .. } => {
@@ -466,10 +483,7 @@ impl Connection {
     }
 
     pub fn send(&self, data: impl Serialize) -> anyhow::Result<()> {
-        let data: Vec<u8> = postcard::to_allocvec(&data)?;
-        self.message_sender.send(Message::Binary(data.into()))?;
-
-        Ok(())
+        encode_and_send(&self.message_sender, &data)
     }
 
     pub async fn request_file(&self, url: Url) -> std::io::Result<VersionedFileContent> {
@@ -702,6 +716,47 @@ mod tests {
     fn sanitize_falls_back_for_empty_or_all_invalid() {
         assert_eq!(sanitize_dns_label(""), "slint-viewer");
         assert_eq!(sanitize_dns_label("@@@"), "slint-viewer");
+    }
+}
+
+#[cfg(test)]
+mod keepalive_tests {
+    use super::Connection;
+    use crate::protocol::{LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PreviewToLspMessage};
+    use futures_util::{SinkExt as _, StreamExt as _};
+    use tokio_tungstenite::tungstenite::{
+        client::IntoClientRequest as _,
+        http::{HeaderValue, header::SEC_WEBSOCKET_PROTOCOL},
+    };
+
+    #[tokio::test]
+    async fn ping_is_answered_with_pong() {
+        let connection =
+            Connection::listen(Some(std::net::SocketAddr::from(([127, 0, 0, 1], 0))), None, |_| {})
+                .await
+                .unwrap();
+
+        let mut request =
+            format!("ws://127.0.0.1:{}", connection.local_port()).into_client_request().unwrap();
+        request
+            .headers_mut()
+            .insert(SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_static(PROTOCOL_SUBPROTOCOL));
+        let (mut stream, _) = tokio_tungstenite::connect_async(request).await.unwrap();
+
+        let ping = postcard::to_allocvec(&LspToPreviewMessage::Ping).unwrap();
+        stream.send(tokio_tungstenite::tungstenite::Message::Binary(ping.into())).await.unwrap();
+
+        let pong = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let msg = stream.next().await.expect("stream ended without a pong").unwrap();
+                if let tokio_tungstenite::tungstenite::Message::Binary(bytes) = msg {
+                    return postcard::from_bytes::<PreviewToLspMessage>(&bytes).unwrap();
+                }
+            }
+        })
+        .await
+        .expect("no pong within 5 seconds");
+        assert!(matches!(pong, PreviewToLspMessage::Pong));
     }
 }
 

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -148,6 +148,8 @@ tokio = { version = "1.50.0", features = ["rt", "sync", "macros"] }
 [dev-dependencies]
 i-slint-backend-testing = { path = "../../internal/backends/testing" }
 spin_on = { workspace = true }
+# The remote connector tests talk to the real viewer-side connection.
+i-slint-live-preview = { path = "../../internal/live-preview", features = ["remote"] }
 
 [build-dependencies]
 slint-build = { workspace = true, features = ["default"], optional = true }

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -211,22 +211,18 @@ fn start_lsp_thread(
 
 fn bridge_crossbeam_to_tokio(
     from_preview: crossbeam_channel::Receiver<PreviewToLspMessage>,
-) -> (
-    tokio::sync::mpsc::UnboundedSender<PreviewToLspMessage>,
-    tokio::sync::mpsc::UnboundedReceiver<PreviewToLspMessage>,
-) {
+) -> tokio::sync::mpsc::UnboundedReceiver<PreviewToLspMessage> {
     let (from_preview_tx, from_preview_rx) =
         tokio::sync::mpsc::unbounded_channel::<PreviewToLspMessage>();
-    let inner_from_preview_tx = from_preview_tx.clone();
     std::thread::spawn(move || {
         while let Ok(msg) = from_preview.recv() {
-            if inner_from_preview_tx.send(msg).is_err() {
+            if from_preview_tx.send(msg).is_err() {
                 break;
             }
         }
         tracing::debug!("Preview->LSP crossbeam adapter thread exited");
     });
-    (from_preview_tx, from_preview_rx)
+    from_preview_rx
 }
 
 async fn lsp_main(
@@ -237,7 +233,7 @@ async fn lsp_main(
 ) -> Result<()> {
     use crate::common::document_cache::CompilerConfiguration;
 
-    let (from_preview_tx, mut from_preview_rx) = bridge_crossbeam_to_tokio(from_preview);
+    let mut from_preview_rx = bridge_crossbeam_to_tokio(from_preview);
     let (file_watcher_tx, mut file_watcher_rx) = tokio::sync::mpsc::unbounded_channel();
     let mut file_watcher = FileWatcher::start(
         move |event| {
@@ -296,7 +292,6 @@ async fn lsp_main(
         open_urls: Default::default(),
         to_preview,
         pending_recompile: Default::default(),
-        preview_to_lsp_sender: from_preview_tx,
     };
 
     // Load the initial document through the compiler. This triggers the import

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -425,7 +425,8 @@ fn handle_preview_message(msg: PreviewToLspMessage, ctx: &language::Context) {
         | PreviewTypeChanged { .. }
         | TelemetryEvent(..)
         | ConnectRemote { .. }
-        | DisconnectRemote => {
+        | DisconnectRemote
+        | Pong => {
             tracing::debug!("Ignoring message from preview: {msg:?}");
         }
         SendWorkspaceEdit { .. } => {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -27,9 +27,7 @@ use i_slint_compiler::{diagnostics::BuildDiagnostics, langtype::Type};
 use i_slint_live_preview::protocol::PreviewComponent;
 use i_slint_live_preview::{
     file_watcher::FileChangeKind,
-    protocol::{
-        LspToPreviewMessage, PreviewConfig, PreviewToLspMessage, SourceFileVersion, VersionedUrl,
-    },
+    protocol::{LspToPreviewMessage, PreviewConfig, SourceFileVersion, VersionedUrl},
 };
 
 use itertools::Itertools;
@@ -216,8 +214,6 @@ pub struct Context {
     /// Files to recompile after all other operations are done
     /// (i.e. recompilations triggered by updates to unopened files)
     pub pending_recompile: HashSet<lsp_types::Url>,
-    #[cfg_attr(not(feature = "preview-remote"), allow(dead_code))]
-    pub preview_to_lsp_sender: tokio::sync::mpsc::UnboundedSender<PreviewToLspMessage>,
 }
 
 /// An error from a LSP request

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -201,7 +201,6 @@ fn test_goto_definition_multi_files() {
         open_urls: Default::default(),
         to_preview: crate::common::LspToPreviews::with_one(common::DummyLspToPreview::default()),
         pending_recompile: Default::default(),
-        preview_to_lsp_sender: tokio::sync::mpsc::unbounded_channel().0,
     };
     let (extra_files, diag) = spin_on::spin_on(crate::language::load_document_impl(
         &mut ctx,

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -36,7 +36,6 @@ pub fn mock_context() -> Context {
         open_urls: HashSet::new(),
         to_preview: LspToPreviews::with_one(common::DummyLspToPreview::default()),
         pending_recompile: Default::default(),
-        preview_to_lsp_sender: tokio::sync::mpsc::unbounded_channel().0,
     }
 }
 
@@ -80,7 +79,6 @@ pub fn loaded_document_cache_with_file_name(
         open_urls: Default::default(),
         to_preview: LspToPreviews::with_one(common::DummyLspToPreview::default()),
         pending_recompile: Default::default(),
-        preview_to_lsp_sender: tokio::sync::mpsc::unbounded_channel().0,
     };
     let (extra_files, diag) =
         spin_on::spin_on(load_document_impl(&mut ctx, content, url.clone(), Some(42)));

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -378,7 +378,6 @@ async fn main_loop(
         cli_args,
         request_queue,
         server_notifier,
-        preview_to_lsp_sender,
         preview_to_lsp_receiver,
         to_preview.clone(),
     )
@@ -472,7 +471,6 @@ async fn run_main_loop(
     cli_args: Cli,
     request_queue: OutgoingRequestQueue,
     server_notifier: ServerNotifier,
-    preview_to_lsp_sender: mpsc::UnboundedSender<PreviewToLspMessage>,
     #[cfg_attr(not(feature = "preview-engine"), allow(unused_mut))]
     mut preview_to_lsp_receiver: mpsc::UnboundedReceiver<PreviewToLspMessage>,
     to_preview: Rc<LspToPreviews>,
@@ -537,7 +535,6 @@ async fn run_main_loop(
         open_urls: Default::default(),
         to_preview,
         pending_recompile: Default::default(),
-        preview_to_lsp_sender,
     };
 
     let connection = Arc::new(connection);
@@ -860,16 +857,9 @@ async fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Conte
             tracing::debug!("Preview asked to connect remote at {addresses:?}:{port}");
             #[cfg(feature = "preview-remote")]
             if let Some(remote) = ctx.to_preview.remote() {
-                // `connect()` emits Connecting / Connected / Failed itself and
-                // rejects empty `addresses` up front.
-                let preview_to_lsp_sender = ctx.preview_to_lsp_sender.clone();
-                let future = remote.connect(addresses.clone(), port);
-                crate::common::spawn_local(async move {
-                    if future.await.is_ok() {
-                        let _ = preview_to_lsp_sender
-                            .send(PreviewToLspMessage::RequestState { files: Vec::new() });
-                    }
-                });
+                // `connect()` owns the dialog state and has the preview
+                // state pushed once connected.
+                crate::common::spawn_local(remote.connect(addresses, port));
             }
         }
         M::DisconnectRemote => {

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -879,6 +879,10 @@ async fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Conte
                 crate::common::spawn_local(remote.disconnect());
             }
         }
+        M::Pong => {
+            // The remote connector consumes pongs; local previews never send them.
+            tracing::debug!("Ignoring unexpected Pong message from a local preview");
+        }
     }
     Ok(())
 }

--- a/tools/lsp/preview/connector.rs
+++ b/tools/lsp/preview/connector.rs
@@ -49,5 +49,8 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
             #[cfg(not(target_arch = "wasm32"))]
             let _ = slint::quit_event_loop();
         }
+        M::Ping => {
+            // Keepalive for the remote-preview WebSocket; local previews never see it.
+        }
     }
 }

--- a/tools/lsp/preview/connector/remote.rs
+++ b/tools/lsp/preview/connector/remote.rs
@@ -1,13 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore backgrounded
+
 //! LSP-server side of the remote-preview connection: owns the WebSocket.
 //! Discovery and the dialog live in the preview process; see
 //! [`crate::preview::remote`].
 
-use std::rc::Weak;
+use std::cell::Cell;
+use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use futures_util::{
     SinkExt as _,
@@ -23,6 +27,19 @@ use tokio_tungstenite_wasm::{Message, WebSocketStream};
 
 use crate::common::LspToPreviews;
 
+/// How often the keepalive probes the remote viewer.
+const PING_INTERVAL: Duration = Duration::from_secs(5);
+/// Without a pong for this long, the connection counts as dead.
+/// Mobile devices abort a backgrounded app's connections without notifying
+/// the peer, so the socket alone can't tell us.
+const PONG_TIMEOUT: Duration = Duration::from_secs(15);
+/// Pause between reconnect attempts.
+const RECONNECT_DELAY: Duration = Duration::from_secs(3);
+/// Cap on a single connection attempt.
+/// A device that blocks network for a backgrounded viewer can swallow
+/// packets; an uncapped dial would then hang for minutes on TCP retransmissions.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 struct RemoteLspConnection {
     sender: SplitSink<WebSocketStream, Message>,
     task: tokio::task::JoinHandle<()>,
@@ -32,13 +49,36 @@ struct RemoteLspConnection {
     replaced: Arc<AtomicBool>,
 }
 
-pub struct RemoteLspToPreview {
+/// State shared between the connector and its spawned tasks.
+/// Everything runs on the LSP's `LocalSet` thread.
+#[derive(Clone)]
+struct SharedState {
     connection: Arc<Mutex<Option<RemoteLspConnection>>>,
     preview_to_lsp_sender: mpsc::UnboundedSender<PreviewToLspMessage>,
     /// Back-reference to the owning [`LspToPreviews`]. Used to forward
     /// `RemoteConnectionState` updates to the dialog. `Weak` so it can
     /// be stored inside the owner without forming an `Rc` cycle.
     to_previews: Weak<LspToPreviews>,
+    /// Bumped on every user-driven connect or disconnect.
+    /// Tasks spawned for an older generation stand down.
+    generation: Rc<Cell<u64>>,
+}
+
+impl SharedState {
+    fn bump_generation(&self) -> u64 {
+        let generation = self.generation.get() + 1;
+        self.generation.set(generation);
+        generation
+    }
+
+    /// Forward a connection-state transition to the local preview dialog.
+    fn emit_state(&self, state: RemoteConnectionState, target: String, error: Option<String>) {
+        RemoteLspToPreview::emit_state(&self.to_previews, state, target, error);
+    }
+}
+
+pub struct RemoteLspToPreview {
+    shared: SharedState,
 }
 
 impl RemoteLspToPreview {
@@ -46,7 +86,14 @@ impl RemoteLspToPreview {
         preview_to_lsp_sender: mpsc::UnboundedSender<PreviewToLspMessage>,
         to_previews: Weak<LspToPreviews>,
     ) -> Self {
-        Self { connection: Arc::default(), preview_to_lsp_sender, to_previews }
+        Self {
+            shared: SharedState {
+                connection: Arc::default(),
+                preview_to_lsp_sender,
+                to_previews,
+                generation: Rc::default(),
+            },
+        }
     }
 
     /// Forward a connection-state transition to the local preview dialog.
@@ -70,7 +117,7 @@ impl RemoteLspToPreview {
     /// failure — this is called from the LSP's hot send path.
     pub fn send(&self, message: &LspToPreviewMessage) {
         tracing::debug!("Sending websocket message {message:?}");
-        let connection = Arc::downgrade(&self.connection);
+        let connection = Arc::downgrade(&self.shared.connection);
         let message = match postcard::to_allocvec(message) {
             Ok(bytes) => bytes,
             Err(err) => {
@@ -98,106 +145,230 @@ impl RemoteLspToPreview {
         port: u16,
     ) -> impl Future<Output = crate::common::Result<()>> + 'static {
         tracing::debug!("RemoteLspToPreview::connect");
-        let connection = self.connection.clone();
+        let shared = self.shared.clone();
         let addresses = addresses.into_iter().map(Into::into).collect::<Vec<_>>();
-        let preview_to_lsp_sender = self.preview_to_lsp_sender.clone();
-        let to_previews = self.to_previews.clone();
         async move {
             // First address identifies the connection in the state notifications.
-            let Some(first_address) = addresses.first().cloned() else {
+            let Some(first_address) = addresses.first() else {
                 return Err("No address to connect to".into());
             };
             let target = format!("{first_address}:{port}");
-            Self::emit_state(&to_previews, RemoteConnectionState::Connecting, target.clone(), None);
-
-            let addresses = &mut addresses.into_iter();
-            let mut last_error: Option<String> = None;
-            let (stream, address, port) = loop {
-                let Some(address) = addresses.next() else {
-                    let reason =
-                        last_error.unwrap_or_else(|| "Unable to connect to remote viewer".into());
+            let generation = shared.bump_generation();
+            shared.emit_state(RemoteConnectionState::Connecting, target.clone(), None);
+            if let Err(reason) = Self::connect_impl(&shared, &addresses, port, generation).await {
+                // A superseded attempt no longer owns the dialog state.
+                if shared.generation.get() == generation {
                     // Don't flip the UI to `Failed` if a live peer is still routing;
                     // that would contradict Connected and disable the Disconnect button.
-                    let previous_still_alive = connection.lock().await.is_some();
-                    if previous_still_alive {
+                    if shared.connection.lock().await.is_some() {
                         tracing::warn!(
                             "Connect attempt to {target} failed but previous remote connection is still active: {reason}"
                         );
                     } else {
-                        Self::emit_state(
-                            &to_previews,
+                        shared.emit_state(
                             RemoteConnectionState::Failed,
                             target,
-                            Some(reason.clone()),
+                            Some(reason.to_string()),
                         );
-                    }
-                    return Err(reason.into());
-                };
-                tracing::info!(
-                    "Attempting to connect to remote preview server at {address}:{port}"
-                );
-                let url = format!("ws://{address}:{port}");
-                let connect_future =
-                    tokio_tungstenite_wasm::connect_with_protocols(&url, &[PROTOCOL_SUBPROTOCOL]);
-                match connect_future.await {
-                    Ok(stream) => {
-                        tracing::info!("Connected to remote preview server at {address}:{port}");
-                        break (stream, address, port);
-                    }
-                    Err(err) => {
-                        let mismatch = describe_version_mismatch(&err);
-                        tracing::debug!(
-                            "Failed connecting to remote viewer, trying next address: {err}"
-                        );
-                        if mismatch.is_some() {
-                            last_error = mismatch;
-                        } else if last_error.is_none() {
-                            last_error = Some(format!("{err}"));
-                        }
                     }
                 }
-            };
+                return Err(reason);
+            }
+            Ok(())
+        }
+    }
 
-            let (socket_sender, socket_receiver) = stream.split();
-            let replaced = Arc::new(AtomicBool::new(false));
-            #[allow(clippy::disallowed_methods)]
-            let Some(mut old) = connection.lock().await.replace(RemoteLspConnection {
-                sender: socket_sender,
-                task: tokio::task::spawn_local(Self::receive_task(
-                    socket_receiver,
-                    preview_to_lsp_sender,
-                    to_previews.clone(),
-                    address,
-                    port,
-                    replaced.clone(),
-                )),
-                replaced,
-            }) else {
-                return Ok(());
-            };
+    /// Dial `addresses` in order and install the resulting session.
+    /// The callers own the dialog state updates.
+    async fn connect_impl(
+        shared: &SharedState,
+        addresses: &[String],
+        port: u16,
+        generation: u64,
+    ) -> crate::common::Result<()> {
+        let mut last_error: Option<String> = None;
+        let mut connected = None;
+        for address in addresses {
+            tracing::info!("Attempting to connect to remote preview server at {address}:{port}");
+            let url = format!("ws://{address}:{port}");
+            let connect_future =
+                tokio_tungstenite_wasm::connect_with_protocols(&url, &[PROTOCOL_SUBPROTOCOL]);
+            match tokio::time::timeout(CONNECT_TIMEOUT, connect_future).await {
+                Ok(Ok(stream)) => {
+                    tracing::info!("Connected to remote preview server at {address}:{port}");
+                    connected = Some((stream, address.clone()));
+                    break;
+                }
+                Ok(Err(err)) => {
+                    let mismatch = describe_version_mismatch(&err);
+                    tracing::debug!(
+                        "Failed connecting to remote viewer, trying next address: {err}"
+                    );
+                    if mismatch.is_some() {
+                        last_error = mismatch;
+                    } else if last_error.is_none() {
+                        last_error = Some(format!("{err}"));
+                    }
+                }
+                Err(_) => {
+                    tracing::debug!("Connection attempt to {address}:{port} timed out");
+                    if last_error.is_none() {
+                        last_error = Some(format!("Connection attempt to {address} timed out"));
+                    }
+                }
+            }
+        }
+        let Some((stream, address)) = connected else {
+            return Err(last_error
+                .unwrap_or_else(|| "Unable to connect to remote viewer".into())
+                .into());
+        };
 
+        if shared.generation.get() != generation {
+            // The user disconnected or connected elsewhere while we dialed.
+            tracing::info!("Discarding connection to {address}:{port}: superseded");
+            return Err("Connection superseded".into());
+        }
+
+        let (socket_sender, socket_receiver) = stream.split();
+        let replaced = Arc::new(AtomicBool::new(false));
+        #[allow(clippy::disallowed_methods)]
+        let task = tokio::task::spawn_local(Self::run_session(
+            shared.clone(),
+            socket_receiver,
+            addresses.to_vec(),
+            address,
+            port,
+            replaced.clone(),
+            generation,
+        ));
+        if let Some(mut old) = shared.connection.lock().await.replace(RemoteLspConnection {
+            sender: socket_sender,
+            task,
+            replaced,
+        }) {
             tracing::info!("Closing previous connection to remote preview server");
             old.replaced.store(true, Ordering::Relaxed);
             // Close handshake so the old viewer sees a clean end of session
             // instead of a connection reset.
             old.sender.close().await.ok();
             old.task.abort();
+        }
 
-            Ok(())
+        // Have the LSP push configuration, file contents, and the previewed
+        // component, so the viewer leaves its idle screen on its own.
+        let _ = shared
+            .preview_to_lsp_sender
+            .send(PreviewToLspMessage::RequestState { files: Vec::new() });
+
+        Ok(())
+    }
+
+    /// Drive one established connection.
+    /// When the session ends on its own (peer closed, socket error, missing
+    /// pongs), reconnect; user-driven disconnects and replacements abort
+    /// this task instead.
+    async fn run_session(
+        shared: SharedState,
+        socket_receiver: SplitStream<WebSocketStream>,
+        addresses: Vec<String>,
+        connected_address: String,
+        port: u16,
+        replaced: Arc<AtomicBool>,
+        generation: u64,
+    ) {
+        let last_pong = Cell::new(Instant::now());
+        let receive = Self::receive_task(
+            &shared,
+            socket_receiver,
+            connected_address,
+            port,
+            replaced,
+            &last_pong,
+        );
+        let keepalive = Self::keepalive_task(&shared, &last_pong);
+        tokio::select! {
+            _ = receive => {}
+            _ = keepalive => {}
+        }
+        Self::reconnect_loop(&shared, &addresses, port, generation).await;
+    }
+
+    /// Ping the viewer every [`PING_INTERVAL`] and return — ending the
+    /// session — when pongs stay out for [`PONG_TIMEOUT`] or sending fails.
+    async fn keepalive_task(shared: &SharedState, last_pong: &Cell<Instant>) {
+        let Ok(ping) = postcard::to_allocvec(&LspToPreviewMessage::Ping) else { return };
+        let ping = Message::binary(ping);
+        loop {
+            tokio::time::sleep(PING_INTERVAL).await;
+            if last_pong.get().elapsed() > PONG_TIMEOUT {
+                tracing::warn!(
+                    "Remote viewer answered no ping for {PONG_TIMEOUT:?}; treating the connection as dead"
+                );
+                return;
+            }
+            let mut guard = shared.connection.lock().await;
+            let Some(connection) = guard.as_mut() else { return };
+            // Bound the send: it holds the connection lock, which would
+            // otherwise block all LSP→viewer sends behind a stalled socket.
+            match tokio::time::timeout(PONG_TIMEOUT, connection.sender.send(ping.clone())).await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    tracing::warn!("Failed sending keepalive ping to remote viewer: {err}");
+                    return;
+                }
+                Err(_) => {
+                    tracing::warn!("Keepalive ping send stalled; treating the connection as dead");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Redial a dropped connection every [`RECONNECT_DELAY`] until it
+    /// succeeds or a generation bump tells us to stand down.
+    async fn reconnect_loop(
+        shared: &SharedState,
+        addresses: &[String],
+        port: u16,
+        generation: u64,
+    ) {
+        if shared.generation.get() != generation {
+            return;
+        }
+        // Drop the dead connection's write half; its task is this very task.
+        drop(shared.connection.lock().await.take());
+        let target =
+            format!("{}:{port}", addresses.first().map(String::as_str).unwrap_or_default());
+        tracing::info!("Connection to remote viewer lost; reconnecting to {target}");
+        shared.emit_state(RemoteConnectionState::Connecting, target.clone(), None);
+        loop {
+            match Self::connect_impl(shared, addresses, port, generation).await {
+                Ok(()) => {
+                    tracing::info!("Reconnected to remote viewer at {target}");
+                    return;
+                }
+                Err(err) => {
+                    tracing::debug!("Reconnect attempt to {target} failed: {err}");
+                }
+            }
+            tokio::time::sleep(RECONNECT_DELAY).await;
+            if shared.generation.get() != generation {
+                return;
+            }
         }
     }
 
     async fn receive_task(
+        shared: &SharedState,
         mut socket_receiver: SplitStream<WebSocketStream>,
-        preview_to_lsp_sender: mpsc::UnboundedSender<PreviewToLspMessage>,
-        to_previews: Weak<LspToPreviews>,
         address: String,
         port: u16,
         replaced: Arc<AtomicBool>,
+        last_pong: &Cell<Instant>,
     ) {
         let mut connection_state_handle =
-            ConnectionStateHandle::new(to_previews, address, port, replaced);
-        // TODO: implement a timer to send a ping every once in a while, and close the connection if we don't receive a pong in time
+            ConnectionStateHandle::new(shared.to_previews.clone(), address, port, replaced);
         while let Some(msg) = socket_receiver.next().await {
             match msg {
                 Ok(msg) => {
@@ -210,8 +381,11 @@ impl RemoteLspToPreview {
                         }
                         Message::Binary(bytes) => {
                             match postcard::from_bytes::<PreviewToLspMessage>(&bytes) {
+                                Ok(PreviewToLspMessage::Pong) => {
+                                    last_pong.set(Instant::now());
+                                }
                                 Ok(msg) => {
-                                    preview_to_lsp_sender.send(msg).unwrap_or_else(|err| {
+                                    shared.preview_to_lsp_sender.send(msg).unwrap_or_else(|err| {
                                         tracing::error!(
                                             "Failed sending message from remote preview server to LSP server: {err}"
                                         );
@@ -256,9 +430,10 @@ impl RemoteLspToPreview {
     }
 
     pub fn disconnect(&self) -> impl Future<Output = ()> + 'static {
-        let connection = self.connection.clone();
+        let shared = self.shared.clone();
         async move {
-            if let Some(mut connection) = connection.lock().await.take() {
+            shared.bump_generation();
+            if let Some(mut connection) = shared.connection.lock().await.take() {
                 // Close handshake so the viewer sees a clean end of session
                 // instead of a connection reset.
                 connection.sender.close().await.ok();
@@ -309,10 +484,12 @@ impl Drop for ConnectionStateHandle {
 
 impl Drop for RemoteLspToPreview {
     fn drop(&mut self) {
+        // Stop any reconnect loop that is between attempts.
+        self.shared.bump_generation();
         // Best-effort: an in-flight future may hold the lock, in which case
         // LocalSet teardown aborts the receive task. Panicking here would
         // abort the LSP.
-        if let Some(mut guard) = self.connection.try_lock()
+        if let Some(mut guard) = self.shared.connection.try_lock()
             && let Some(connection) = guard.take()
         {
             tracing::info!("Closing connection to remote preview server");
@@ -350,5 +527,94 @@ fn describe_version_mismatch(err: &tokio_tungstenite_wasm::Error) -> Option<Stri
             "Version mismatch: viewer does not speak {PROTOCOL_SUBPROTOCOL} (this LSP is Slint {SLINT_VERSION})",
         )),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use i_slint_live_preview::remote::{Connection, ConnectionMessage};
+
+    async fn listen(port: u16) -> (Connection, mpsc::UnboundedReceiver<ConnectionMessage>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let connection = Connection::listen(
+            Some(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
+            None,
+            move |msg| {
+                let _ = tx.send(msg);
+            },
+        )
+        .await
+        .unwrap();
+        (connection, rx)
+    }
+
+    /// Wait until `rx` yields a message matching `pred`.
+    async fn expect_message<T>(
+        rx: &mut mpsc::UnboundedReceiver<T>,
+        pred: impl Fn(&T) -> bool,
+        what: &str,
+    ) {
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                let msg = rx.recv().await.expect("message channel closed");
+                if pred(&msg) {
+                    return;
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
+    }
+
+    #[tokio::test]
+    async fn reconnects_after_connection_loss() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+                connector.connect(["127.0.0.1"], port).await.unwrap();
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Connected { .. }),
+                    "viewer connection",
+                )
+                .await;
+                // Consume the initial state push, so the wait below can only
+                // match the reconnect's.
+                expect_message(
+                    &mut to_lsp_rx,
+                    |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
+                    "RequestState after connecting",
+                )
+                .await;
+
+                // Replace the viewer on the same port, like an app whose
+                // connection the OS cut while backgrounded.
+                drop(viewer);
+                drop(viewer_rx);
+                let (_viewer, mut viewer_rx) = listen(port).await;
+
+                // The connector reconnects on its own ...
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Connected { .. }),
+                    "viewer reconnection",
+                )
+                .await;
+                // ... and asks the LSP to re-push the preview state.
+                expect_message(
+                    &mut to_lsp_rx,
+                    |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
+                    "RequestState after reconnecting",
+                )
+                .await;
+
+                connector.disconnect().await;
+            })
+            .await;
     }
 }

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -614,7 +614,6 @@ export component Main { }
                     crate::common::DummyLspToPreview::default(),
                 ),
                 pending_recompile: Default::default(),
-                preview_to_lsp_sender: tokio::sync::mpsc::unbounded_channel().0,
             };
             let (url, _) = crate::language::test::load(
                 &mut ctx,

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -390,7 +390,7 @@ impl SlintServer {
             M::DebugMessage { location, message } => {
                 log(&common::preview_log_message_to_string(&location, &message));
             }
-            M::ConnectRemote { .. } | M::DisconnectRemote => {
+            M::ConnectRemote { .. } | M::DisconnectRemote | M::Pong => {
                 tracing::debug!("Ignoring remote-preview control message in WASM LSP");
             }
         }

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -284,8 +284,6 @@ pub fn create(
     let mut rh = RequestHandler::default();
     language::register_request_handlers(&mut rh);
 
-    let (preview_to_lsp_sender, _preview_to_lsp_receiver) = tokio::sync::mpsc::unbounded_channel();
-
     Ok(SlintServer {
         ctx: ReentryGuard::new(Context {
             document_cache,
@@ -296,7 +294,6 @@ pub fn create(
             open_urls: Default::default(),
             to_preview,
             pending_recompile: Default::default(),
-            preview_to_lsp_sender,
         }),
         rh: Rc::new(rh),
     })


### PR DESCRIPTION
Android cuts the viewer's TCP connection a few seconds after the app
goes to the background, while the app and its listening socket keep
running. Coming back to the viewer left the editor disconnected until
the user reconnected by hand.

The LSP now pings the viewer every 5 seconds and treats the connection
as dead after 15 seconds without a pong. When a session ends on its
own, the LSP redials the last target every 3 seconds until it succeeds
or the user disconnects, then re-pushes the preview state so the
viewer shows the previewed component again without user interaction.

Each dial attempt is capped at 5 seconds: a device that blocks network
for a backgrounded app can swallow SYN packets, and an uncapped
attempt would hang on TCP retransmissions long after the viewer is
reachable again.