### PR TITLE
Encourage AI to display Slint screenshots inline

### DIFF
--- a/skills/slint/SKILL.md
+++ b/skills/slint/SKILL.md
@@ -20,7 +20,10 @@ a declarative GUI toolkit for desktop, embedded, mobile, and web.
 3. Never declare UI work done without looking at a render — a screenshot for
    appearance, the MCP server for interactions. Review against
    [polish.md](reference/polish.md).
-4. Offer to run `slint-viewer --auto-reload ui/main.slint` so the user watches
+4. Share the render when the host supports it: inline the screenshot in chat
+   apps, or print its absolute path and summarize the visual checks in CLI-only
+   environments.
+5. Offer to run `slint-viewer --auto-reload ui/main.slint` so the user watches
    changes live while you edit.
 
 Most "won't compile" / "won't fill" / "padding ignored" questions are answered

--- a/skills/slint/reference/debugging-and-mcp.md
+++ b/skills/slint/reference/debugging-and-mcp.md
@@ -56,6 +56,10 @@ slint-viewer --screenshot out.png --load-data props.json ui/main.slint
 Rule of thumb: **viewer** for previewing components/layout/theme; **MCP
 server** for the running app with real data and interactions.
 
+When the assistant host can display local images inline, include the rendered
+screenshot in the chat. In CLI-only hosts, print the absolute image path and
+summarize what was visually checked.
+
 ## MCP Server for AI-Assisted Debugging
 
 Slint **1.17+** ships an embedded MCP server: walk the UI tree, read


### PR DESCRIPTION
Apps like Claude code, Codex and Cursor and show screenshots inline. But
they need some extra hints to do so.