### PR TITLE
TextInput: add password-character property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project are documented in this file.
 
 ### Slint language
 
+ - Added `password-character` property to `TextInput`, to override the glyph used to mask
+   password input when the active font lacks the default one.
  - Added `is-open` output property to `PopupWindow`, reflecting whether the popup is currently shown.
    It can be used to style the element that opened the popup, such as a ComboBox's arrow. (#456)
  - Added new `SystemTrayIcon` element.

--- a/internal/backends/qt/qt_widgets/stylemetrics.rs
+++ b/internal/backends/qt/qt_widgets/stylemetrics.rs
@@ -33,6 +33,7 @@ pub struct NativeStyleMetrics {
     pub layout_spacing: Property<LogicalLength>,
     pub layout_padding: Property<LogicalLength>,
     pub text_cursor_width: Property<LogicalLength>,
+    pub password_character: Property<SharedString>,
     pub window_background: Property<Color>,
     pub default_text_color: Property<Color>,
     pub textedit_background: Property<Color>,
@@ -65,6 +66,7 @@ impl NativeStyleMetrics {
             layout_spacing: Default::default(),
             layout_padding: Default::default(),
             text_cursor_width: Default::default(),
+            password_character: Default::default(),
             window_background: Default::default(),
             default_text_color: Default::default(),
             textedit_background: Default::default(),
@@ -116,6 +118,11 @@ impl NativeStyleMetrics {
             return qApp->style()->pixelMetric(QStyle::PM_TextCursorWidth);
         });
         self.text_cursor_width.set(LogicalLength::new(text_cursor_width.max(0.0)));
+        let password_character = cpp!(unsafe [] -> i32 as "int" {
+            return qApp->style()->styleHint(QStyle::SH_LineEdit_PasswordCharacter, nullptr, nullptr);
+        });
+        let password_character = char::from_u32(password_character as u32).unwrap_or('\u{25cf}');
+        self.password_character.set(password_character.to_string().into());
         let window_background = cpp!(unsafe[] -> u32 as "QRgb" {
             return qApp->palette().color(QPalette::Window).rgba();
         });

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -897,7 +897,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
     ) {
         self.save_state();
         self.pixel_align_origin();
-        sharedparley::draw_text_input(self, text_input, self_rc, size, Some(qt_password_character));
+        sharedparley::draw_text_input(self, text_input, self_rc, size);
         self.restore_state();
     }
 
@@ -2874,11 +2874,4 @@ pub(crate) mod ffi {
                 win.widget_ptr().cast::<c_void>().as_ptr()
             })
     }
-}
-
-fn qt_password_character() -> char {
-    char::from_u32(cpp! { unsafe [] -> i32 as "int" {
-        return qApp->style()->styleHint(QStyle::SH_LineEdit_PasswordCharacter, nullptr, nullptr);
-    }} as u32)
-    .unwrap_or('●')
 }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1678,6 +1678,9 @@ export component TextInput {
     ///  Use this to configure `TextInput` for editing special input, such as password fields.
     /// \default text
     in property <InputType> input-type;
+    /// The glyph that masks each character in a `password` input; first character only, empty keeps the default.
+    /// \default provided at run-time by the selected widget style
+    in property <string> password-character;
     // Internal, undocumented property, only exposed for tests.
     out property <int> cursor-position_byte-offset;
     // Internal, undocumented property, only exposed for tests.
@@ -3042,6 +3045,7 @@ export global NativeStyleMetrics {
     out property <length> layout-spacing;
     out property <length> layout-padding;
     out property <length> text-cursor-width;
+    out property <string> password-character;
     out property <color> window-background;
     out property <color> default-text-color;
     out property <color> textedit-background;

--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -34,6 +34,12 @@ pub fn apply_default_properties_from_style(
                             SmolStr::new_static("text-cursor-width"),
                         ))
                     });
+                    elem.set_binding_if_not_set("password-character".into(), || {
+                        Expression::PropertyReference(NamedReference::new(
+                            &style_metrics.root_element,
+                            SmolStr::new_static("password-character"),
+                        ))
+                    });
                     elem.set_binding_if_not_set("color".into(), || {
                         Expression::PropertyReference(NamedReference::new(
                             &palette.root_element,

--- a/internal/compiler/widgets/cosmic/style-base.slint
+++ b/internal/compiler/widgets/cosmic/style-base.slint
@@ -10,6 +10,7 @@ export global StyleMetrics {
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;
+    out property <string> password-character: "\u{25cf}";
     out property <color> window-background: CosmicPalette.background;
     out property <color> default-text-color: CosmicPalette.foreground;
     out property <color> textedit-background: CosmicPalette.background;

--- a/internal/compiler/widgets/cupertino/style-base.slint
+++ b/internal/compiler/widgets/cupertino/style-base.slint
@@ -10,6 +10,7 @@ export global StyleMetrics {
     out property <length> layout-spacing: 10px;
     out property <length> layout-padding: 12px;
     out property <length> text-cursor-width: 1px;
+    out property <string> password-character: "\u{25cf}";
     out property <color> window-background: CupertinoPalette.background;
     out property <color> default-text-color: CupertinoPalette.foreground;
     out property <color> textedit-background: CupertinoPalette.alternate-background;

--- a/internal/compiler/widgets/fluent/style-base.slint
+++ b/internal/compiler/widgets/fluent/style-base.slint
@@ -10,6 +10,7 @@ export global StyleMetrics {
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;
+    out property <string> password-character: "\u{25cf}";
     out property <color> window-background: FluentPalette.background;
     out property <color> default-text-color: FluentPalette.foreground;
     out property <color> textedit-background: FluentPalette.background;

--- a/internal/compiler/widgets/material/style-base.slint
+++ b/internal/compiler/widgets/material/style-base.slint
@@ -10,6 +10,7 @@ export global StyleMetrics {
     out property <length> layout-spacing: 16px;
     out property <length> layout-padding: 16px;
     out property <length> text-cursor-width: 2px;
+    out property <string> password-character: "\u{25cf}";
 
     out property <color> default-text-color: MaterialPalette.foreground;
     out property <color> textedit-background: transparent;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -743,6 +743,8 @@ pub struct TextInput {
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub wrap: Property<TextWrap>,
     pub input_type: Property<InputType>,
+    /// Mask glyph for password input; empty keeps the style default. First char only.
+    pub password_character: Property<SharedString>,
     pub letter_spacing: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
@@ -1277,7 +1279,7 @@ impl HasFont for TextInput {
 
 impl RenderString for TextInput {
     fn text(self: Pin<&Self>) -> PlainOrStyledText {
-        PlainOrStyledText::Plain(self.as_ref().visual_representation(None).text.clone())
+        PlainOrStyledText::Plain(self.as_ref().visual_representation().text.clone())
     }
 }
 
@@ -1377,17 +1379,15 @@ pub struct TextInputVisualRepresentation {
 impl TextInputVisualRepresentation {
     /// If the given `TextInput` renders a password, then all characters in this `TextInputVisualRepresentation` are replaced
     /// with the password character and the selection/preedit-ranges/cursor position are adjusted.
-    /// If `password_character_fn` is Some, it is called lazily to query the password character, otherwise a default is used.
-    fn apply_password_character_substitution(
-        &mut self,
-        text_input: Pin<&TextInput>,
-        password_character_fn: Option<fn() -> char>,
-    ) {
+    fn apply_password_character_substitution(&mut self, text_input: Pin<&TextInput>) {
         if !matches!(text_input.input_type(), InputType::Password) {
             return;
         }
 
-        let password_character = password_character_fn.map_or('●', |f| f());
+        // The `password-character` property carries the style default (injected from
+        // StyleMetrics) or a caller override; fall back only if it is unset.
+        let password_character =
+            text_input.password_character().chars().next().unwrap_or('\u{25cf}');
 
         let text = &mut self.text;
         let fixup_range = |r: &mut core::ops::Range<usize>| {
@@ -1949,10 +1949,7 @@ impl TextInput {
     /// Returns a [`TextInputVisualRepresentation`] struct that contains all the fields necessary for rendering the text input,
     /// after making adjustments such as applying a substitution of characters for password input fields, or making sure
     /// that the selection start is always less or equal than the selection end.
-    pub fn visual_representation(
-        self: Pin<&Self>,
-        password_character_fn: Option<fn() -> char>,
-    ) -> TextInputVisualRepresentation {
+    pub fn visual_representation(self: Pin<&Self>) -> TextInputVisualRepresentation {
         let mut text = self.text();
 
         let preedit_text = self.preedit_text();
@@ -2007,7 +2004,7 @@ impl TextInput {
             text_color,
             cursor_color,
         };
-        repr.apply_password_character_substitution(self, password_character_fn);
+        repr.apply_password_character_substitution(self);
         repr
     }
 

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1256,7 +1256,6 @@ pub fn draw_text_input(
     text_input: Pin<&crate::items::TextInput>,
     item_rc: &crate::item_tree::ItemRc,
     size: LogicalSize,
-    password_character: Option<fn() -> char>,
 ) {
     let width = size.width_length();
     let height = size.height_length();
@@ -1264,7 +1263,7 @@ pub fn draw_text_input(
         return;
     }
 
-    let visual_representation = text_input.visual_representation(password_character);
+    let visual_representation = text_input.visual_representation();
 
     let Some(platform_fill_brush) =
         item_renderer.platform_text_fill_brush(visual_representation.text_color, size)
@@ -1498,7 +1497,7 @@ pub fn text_input_byte_offset_for_position(
         None,
         scale_factor,
     );
-    let visual_representation = text_input.visual_representation(None);
+    let visual_representation = text_input.visual_representation();
 
     let Some(ctx) = renderer.slint_context() else {
         return 0;
@@ -1550,7 +1549,7 @@ pub fn text_input_cursor_rect_for_byte_offset(
         );
     }
 
-    let visual_representation = text_input.visual_representation(None);
+    let visual_representation = text_input.visual_representation();
     let cursor_width = text_input.text_cursor_width() * scale_factor;
 
     let Some(ctx) = renderer.slint_context() else {

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -355,7 +355,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
             return;
         }
 
-        sharedparley::draw_text_input(self, text_input, self_rc, size, None);
+        sharedparley::draw_text_input(self, text_input, self_rc, size);
     }
 
     fn draw_path(&mut self, path: Pin<&items::Path>, item_rc: &ItemRc, _size: LogicalSize) {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -695,7 +695,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
         size: LogicalSize,
     ) {
         let restore = self.save_canvas_and_pixel_align_origin();
-        sharedparley::draw_text_input(self, text_input, self_rc, size, None);
+        sharedparley::draw_text_input(self, text_input, self_rc, size);
         if restore {
             self.canvas.restore();
         }

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -992,7 +992,7 @@ impl RendererSealed for SoftwareRenderer {
             }
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(vf), true) => {
-                let visual_representation = text_input.visual_representation(None);
+                let visual_representation = text_input.visual_representation();
 
                 let width = (text_input.width().cast() * scale_factor).cast();
                 let height = (text_input.height().cast() * scale_factor).cast();
@@ -1020,7 +1020,7 @@ impl RendererSealed for SoftwareRenderer {
                 )
             }
             (fonts::Font::PixelFont(pf), _) => {
-                let visual_representation = text_input.visual_representation(None);
+                let visual_representation = text_input.visual_representation();
 
                 let width = (text_input.width().cast() * scale_factor).cast();
                 let height = (text_input.height().cast() * scale_factor).cast();
@@ -1087,7 +1087,7 @@ impl RendererSealed for SoftwareRenderer {
             }
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(vf), true) => {
-                let visual_representation = text_input.visual_representation(None);
+                let visual_representation = text_input.visual_representation();
 
                 let width = (text_input.width().cast() * scale_factor).cast();
                 let height = (text_input.height().cast() * scale_factor).cast();
@@ -1121,7 +1121,7 @@ impl RendererSealed for SoftwareRenderer {
                     .cast()
             }
             (fonts::Font::PixelFont(pf), _) => {
-                let visual_representation = text_input.visual_representation(None);
+                let visual_representation = text_input.visual_representation();
 
                 let width = (text_input.width().cast() * scale_factor).cast();
                 let height = (text_input.height().cast() * scale_factor).cast();
@@ -2828,7 +2828,7 @@ impl<T: ProcessScene> i_slint_core::item_rendering::ItemRenderer for SceneBuilde
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
                 drop(font_ctx);
-                sharedparley::draw_text_input(self, text_input, self_rc, size, None);
+                sharedparley::draw_text_input(self, text_input, self_rc, size);
             }
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(vf), true) => {
@@ -2850,7 +2850,7 @@ impl<T: ProcessScene> i_slint_core::item_rendering::ItemRenderer for SceneBuilde
                     };
                 let offset = self.current_state.offset.to_vector().cast() * self.scale_factor;
 
-                let text_visual_representation = text_input.visual_representation(None);
+                let text_visual_representation = text_input.visual_representation();
                 let color = self.alpha_color(text_visual_representation.text_color.color());
 
                 let selection = (!text_visual_representation.selection_range.is_empty()).then_some(
@@ -2934,7 +2934,7 @@ impl<T: ProcessScene> i_slint_core::item_rendering::ItemRenderer for SceneBuilde
                     };
                 let offset = self.current_state.offset.to_vector().cast() * self.scale_factor;
 
-                let text_visual_representation = text_input.visual_representation(None);
+                let text_visual_representation = text_input.visual_representation();
                 let color = self.alpha_color(text_visual_representation.text_color.color());
 
                 let selection = (!text_visual_representation.selection_range.is_empty()).then_some(


### PR DESCRIPTION
The password mask glyph in `TextInput` was hardcoded to U+25CF (`●`) - queried natively on Qt via `SH_LineEdit_PasswordCharacter`, fixed everywhere else. When the active font has no glyph for it, masked input renders as tofu, and there is no way to override it.

This follows the same path as `text-cursor-width`: `password-character` becomes a `StyleMetrics` property injected as the `TextInput` default by `apply_default_properties_from_style`, each style declares it, and the Qt style sources it natively (so Qt is unchanged). Setting the property on a `TextInput` overrides the glyph; an empty value keeps the style default. The old per-renderer `password_character_fn` hook is removed in favour of this single path.

I hit this in an app whose login field uses Noto Sans (no `●` glyph); setting `password-character: "•"` fixes the masking.