### PR TITLE
viewer: keep remote UI clear of the notch in landscape

### DIFF
--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -93,7 +93,8 @@ export component RemoteViewerWindow inherits Window {
 
     VerticalLayout {
         alignment: space-between;
-        padding-left: 24px;
+        padding-left: max(root.safe-area-insets.left, 24px);
+        padding-right: max(root.safe-area-insets.right, 24px);
         padding-top: root.safe-area-insets.top + 146px;
         padding-bottom: root.safe-area-insets.bottom;
         visible: root.state != RemoteViewerState.preview-error;
@@ -166,8 +167,8 @@ export component RemoteViewerWindow inherits Window {
 
     VerticalLayout {
         alignment: center;
-        padding-left: 24px;
-        padding-right: 24px;
+        padding-left: max(root.safe-area-insets.left, 24px);
+        padding-right: max(root.safe-area-insets.right, 24px);
         padding-top: root.safe-area-insets.top;
         padding-bottom: root.safe-area-insets.bottom;
 


### PR DESCRIPTION
The placeholder UI only compensated for the top safe-area inset, so after rotating to landscape the "Connect Live Preview to" label ended up underneath the notch. Fold the left and right insets into the horizontal padding of the content and error layouts.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
