### PR TITLE
Fix wasm demo build by bumping getrandom to 0.4

### DIFF
--- a/examples/memory/Cargo.toml
+++ b/examples/memory/Cargo.toml
@@ -32,4 +32,4 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# wasm-bindgen = { version = "0.2" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
-#wasm# getrandom = { version = "0.3.4", features = ["wasm_js"] }
+#wasm# getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/examples/slide_puzzle/Cargo.toml
+++ b/examples/slide_puzzle/Cargo.toml
@@ -32,4 +32,4 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# wasm-bindgen = { version = "0.2" }
 #wasm# web-sys = { version = "0.3", features=["console", "Element", "HtmlCollection"] }
 #wasm# console_error_panic_hook = "0.1.5"
-#wasm# getrandom = { version = "0.3.4", features = ["wasm_js"] }
+#wasm# getrandom = { version = "0.4", features = ["wasm_js"] }


### PR DESCRIPTION
The dependency update in b318552 bumped rand from 0.9 to 0.10, which pulls in getrandom 0.4 transitively. The wasm-only getrandom dependency was still pinned to 0.3.4, so the "wasm_js" feature was enabled on an orphaned version while the getrandom 0.4 used by rand built without it, breaking the wasm32-unknown-unknown build for the slide_puzzle and memory demos.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
