### PR TITLE
ci: Make aws-lc-sys cross-compile in the win32 build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -753,9 +753,10 @@ jobs:
                   key: x-win32
             # The runner image ships versioned LLVM binaries, but cc-rs invokes the unversioned
             # llvm-lib when archiving C code (e.g. for the ring crate); the llvm meta package
-            # provides the unversioned tool names.
-            - name: Install LLVM tools
-              run: sudo apt-get update && sudo apt-get install -y llvm
+            # provides the unversioned tool names. nasm assembles aws-lc-sys' x86 assembly
+            # (pulled in via rustls/aws-lc-rs, e.g. by the servo example and live-preview).
+            - name: Install LLVM tools and nasm
+              run: sudo apt-get update && sudo apt-get install -y llvm nasm
             - uses: baptiste0928/cargo-install@v3
               with:
                   crate: cargo-xwin
@@ -771,6 +772,12 @@ jobs:
                   # cargo-xwin defaults to splatting only x86_64 and aarch64 CRT/SDK libraries;
                   # request the 32-bit ones instead.
                   XWIN_ARCH: x86
+                  # aws-lc-sys' x86 C sources guard against assembly without SSE2 and only key
+                  # off __SSE2__, which clang-cl's /arch:SSE2 does not define. Enable SSE2 (the
+                  # baseline for 32-bit Windows anyway) via -msse2; cargo-xwin appends $CFLAGS to
+                  # the target's CFLAGS, so this augments rather than replaces its include flags.
+                  CFLAGS: -msse2
+                  CXXFLAGS: -msse2
               run: cargo xwin build --target i686-pc-windows-msvc --locked --workspace --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --exclude slint-sc --exclude ffmpeg --exclude gstreamer-player --exclude material-gallery --exclude test-driver-screenshots --exclude slint-doc-generator --exclude i-slint-renderer-skia
 
     qa-tree-sitter-latest:


### PR DESCRIPTION
The 32-bit Windows cross build pulls in aws-lc-sys via rustls/aws-lc-rs (e.g. the servo example's direct rustls dependency and live-preview's tokio-tungstenite). Two things were missing to build it for i686-pc-windows-msvc with cargo-xwin/clang-cl:

- nasm, to assemble its x86 assembly sources.
- SSE2: aws-lc-sys' C sources reject x86 assembly unless __SSE2__ is defined, but clang-cl's /arch:SSE2 doesn't define it. Pass -msse2 (SSE2 is the 32-bit Windows baseline) via $CFLAGS/$CXXFLAGS, which cargo-xwin appends to the target CFLAGS without dropping its include flags.

Install nasm and set those flags so the whole workspace builds.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
