### PR TITLE
compiler: report redundant default property bindings

### DIFF
--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -98,6 +98,16 @@ impl JsComponentCompiler {
         self.internal.style().cloned()
     }
 
+    #[napi(setter)]
+    pub fn set_warn_redundant_default_properties(&mut self, warn: bool) {
+        self.internal.set_warn_redundant_default_properties(warn);
+    }
+
+    #[napi(getter)]
+    pub fn warn_redundant_default_properties(&self) -> bool {
+        self.internal.warn_redundant_default_properties()
+    }
+
     #[napi(getter)]
     pub fn diagnostics(&self) -> Vec<JsDiagnostic> {
         self.diagnostics.iter().map(|d| JsDiagnostic::from(d.clone())).collect()

--- a/api/node/rust/interpreter/diagnostic.rs
+++ b/api/node/rust/interpreter/diagnostic.rs
@@ -12,6 +12,9 @@ pub enum JsDiagnosticLevel {
     /// The diagnostic found is a warning.
     Warning,
 
+    /// The diagnostic found is informational.
+    Info,
+
     /// The diagnostic is a note to further help with the error or warning.
     Note,
 }
@@ -21,6 +24,7 @@ impl From<DiagnosticLevel> for JsDiagnosticLevel {
         match diagnostic_level {
             DiagnosticLevel::Error => JsDiagnosticLevel::Error,
             DiagnosticLevel::Warning => JsDiagnosticLevel::Warning,
+            DiagnosticLevel::Info => JsDiagnosticLevel::Info,
             DiagnosticLevel::Note => JsDiagnosticLevel::Note,
             _ => unimplemented!(),
         }

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -313,12 +313,20 @@ function loadSlint(loadData: LoadData): Object {
     const diagnostics = compiler.diagnostics;
 
     if (diagnostics.length > 0) {
+        const infos = diagnostics.filter(
+            (d) => d.level === napi.DiagnosticLevel.Info,
+        );
         const warnings = diagnostics.filter(
             (d) => d.level === napi.DiagnosticLevel.Warning,
         );
+        const notes = diagnostics.filter(
+            (d) => d.level === napi.DiagnosticLevel.Note,
+        );
 
         if (typeof options !== "undefined" && options.quiet !== true) {
+            infos.forEach((i) => console.info("Info: " + i));
             warnings.forEach((w) => console.warn("Warning: " + w));
+            notes.forEach((n) => console.info("Note: " + n));
         }
 
         const errors = diagnostics.filter(

--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -68,6 +68,16 @@ impl Compiler {
         self.compiler.set_library_paths(libraries)
     }
 
+    #[getter]
+    fn get_warn_redundant_default_properties(&self) -> PyResult<bool> {
+        Ok(self.compiler.warn_redundant_default_properties())
+    }
+
+    #[setter]
+    fn set_warn_redundant_default_properties(&mut self, warn: bool) {
+        self.compiler.set_warn_redundant_default_properties(warn)
+    }
+
     #[setter]
     fn set_translation_domain(&mut self, domain: String) {
         self.compiler.set_translation_domain(domain)
@@ -100,6 +110,7 @@ impl PyDiagnostic {
         match self.0.level() {
             slint_interpreter::DiagnosticLevel::Error => PyDiagnosticLevel::Error,
             slint_interpreter::DiagnosticLevel::Warning => PyDiagnosticLevel::Warning,
+            slint_interpreter::DiagnosticLevel::Info => PyDiagnosticLevel::Info,
             slint_interpreter::DiagnosticLevel::Note => PyDiagnosticLevel::Note,
             _ => unimplemented!(),
         }
@@ -135,6 +146,7 @@ impl PyDiagnostic {
 pub enum PyDiagnosticLevel {
     Error,
     Warning,
+    Info,
     Note,
 }
 

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -57,7 +57,7 @@ use std::env;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::diagnostics::{BuildDiagnostics, DiagnosticLevel};
 
 /// Argument of [`CompilerConfiguration::with_default_translation_context()`]
 ///
@@ -577,8 +577,8 @@ pub fn compile_with_output_path(
     let (doc, diag, loader) =
         spin_on::spin_on(i_slint_compiler::compile_syntax_node(syntax_node, diag, compiler_config));
 
-    if diag.has_errors()
-        || (!diag.is_empty() && std::env::var("SLINT_COMPILER_DENY_WARNINGS").is_ok())
+    let has_warnings = diag.iter().any(|diag| matches!(diag.level(), DiagnosticLevel::Warning));
+    if diag.has_errors() || (has_warnings && std::env::var("SLINT_COMPILER_DENY_WARNINGS").is_ok())
     {
         let vec = diag.to_string_vec();
         diag.print();
@@ -599,12 +599,11 @@ pub fn compile_with_output_path(
         }
     }
 
-    // print warnings
-    diag.diagnostics_as_string().lines().for_each(|w| {
-        if !w.is_empty() {
-            println!("cargo:warning={}", w.strip_prefix("warning: ").unwrap_or(w))
-        }
-    });
+    // Cargo build scripts only have a warning channel. Keep informational
+    // diagnostics out of it so they remain non-fatal under denied warnings.
+    for diagnostic in diag.iter().filter(|diag| matches!(diag.level(), DiagnosticLevel::Warning)) {
+        println!("cargo:warning={diagnostic}");
+    }
 
     write!(code_formatter, "{generated}").map_err(CompileError::SaveError)?;
     dependencies.push(input_slint_file_path.as_ref().to_path_buf());

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -8,7 +8,7 @@
 
 extern crate proc_macro;
 
-use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::diagnostics::{BuildDiagnostics, DiagnosticLevel};
 use i_slint_compiler::parser::SyntaxKind;
 use i_slint_compiler::*;
 use proc_macro::{Spacing, TokenStream, TokenTree};
@@ -422,7 +422,7 @@ pub fn slint(stream: TokenStream) -> TokenStream {
     result.extend(quote! {const _ : ::core::option::Option<&'static str> = ::core::option_env!("SLINT_STYLE");});
 
     let mut result = TokenStream::from(result);
-    if !diag.is_empty() {
+    if diag.iter().any(|diag| !matches!(diag.level(), DiagnosticLevel::Info)) {
         result.extend(diag.report_macro_diagnostic(&tokens));
     }
     result

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -258,6 +258,8 @@ pub enum DiagnosticLevel {
     Error,
     /// The diagnostic found is a warning.
     Warning,
+    /// The diagnostic found is informational.
+    Info,
     /// The diagnostic is an note to further help with the error or warning
     Note,
 }
@@ -408,6 +410,12 @@ impl BuildDiagnostics {
     pub fn push_warning(&mut self, message: String, source: &dyn Spanned) {
         self.push_warning_with_span(message, source.to_source_location());
     }
+    pub fn push_info_with_span(&mut self, message: String, span: SourceLocation) {
+        self.push_diagnostic_with_span(message, span, DiagnosticLevel::Info)
+    }
+    pub fn push_info(&mut self, message: String, source: &dyn Spanned) {
+        self.push_info_with_span(message, source.to_source_location());
+    }
     pub fn push_note_with_span(&mut self, message: String, span: SourceLocation) {
         self.push_diagnostic_with_span(message, span, DiagnosticLevel::Note)
     }
@@ -475,6 +483,7 @@ impl BuildDiagnostics {
                 let annotate_snippets_level = match d.level {
                     DiagnosticLevel::Error => annotate_snippets::Level::ERROR,
                     DiagnosticLevel::Warning => annotate_snippets::Level::WARNING,
+                    DiagnosticLevel::Info => annotate_snippets::Level::INFO,
                     DiagnosticLevel::Note => annotate_snippets::Level::NOTE,
                 };
                 let message = annotate_snippets_level.primary_title(d.message());
@@ -568,7 +577,13 @@ impl BuildDiagnostics {
                         result.extend(proc_macro::TokenStream::from(
                             quote::quote_spanned!(span => const _ : () = { #[deprecated(note = #message)] const WARNING: () = (); WARNING };)
                         ));
-                    },
+                    }
+                    DiagnosticLevel::Info => {
+                        let message = format!("info: {message}");
+                        result.extend(proc_macro::TokenStream::from(
+                            quote::quote_spanned!(span => const _ : () = { #[deprecated(note = #message)] const INFO: () = (); INFO };)
+                        ));
+                    }
                     DiagnosticLevel::Note => {
                         // TODO: Notes are not (yet) supported in proc-macros, we'll just print them as warnings for now.
                         // We can fix this once proc-macro diagnostics support notes
@@ -576,7 +591,7 @@ impl BuildDiagnostics {
                         result.extend(proc_macro::TokenStream::from(
                             quote::quote_spanned!(span => const _ : () = { #[deprecated(note = #message)] const NOTE: () = (); NOTE };)
                         ));
-                    },
+                    }
                 }
             }),
         );

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -187,6 +187,13 @@ pub struct CompilerConfiguration {
     /// Generate debug hooks to inspect/override properties.
     pub debug_hooks: Option<std::hash::RandomState>,
 
+    /// Emit warnings when a property binding explicitly sets the same value
+    /// the compiler would use by default.
+    ///
+    /// This is on by default so tooling can surface redundant defaults, but
+    /// can be disabled for compatibility-sensitive integrations.
+    pub warn_redundant_default_properties: bool,
+
     pub components_to_generate: ComponentSelection,
 
     /// The name of the library when compiling as a library.
@@ -249,6 +256,17 @@ impl CompilerConfiguration {
 
         let debug_info = std::env::var_os("SLINT_EMIT_DEBUG_INFO").is_some();
 
+        let warn_redundant_default_properties = match std::env::var(
+            "SLINT_WARN_REDUNDANT_DEFAULT_PROPERTIES",
+        ) {
+            Ok(var) => var.parse::<bool>().unwrap_or_else(|_| {
+                panic!(
+                    "SLINT_WARN_REDUNDANT_DEFAULT_PROPERTIES has incorrect value. Must be either unset, 'true' or 'false'"
+                )
+            }),
+            Err(_) => true,
+        };
+
         #[cfg(feature = "slint-sc")]
         let slint_sc = matches!(output_format, OutputFormat::SlintSc);
 
@@ -281,6 +299,7 @@ impl CompilerConfiguration {
             error_on_binding_loop_with_window_layout: false,
             debug_info,
             debug_hooks: None,
+            warn_redundant_default_properties,
             components_to_generate: ComponentSelection::ExportedWindows,
             #[cfg(all(feature = "software-renderer", feature = "sdf-fonts"))]
             use_sdf_fonts: false,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -50,6 +50,7 @@ pub mod materialize_fake_properties;
 pub mod move_declarations;
 mod optimize_useless_rectangles;
 mod purity_check;
+mod redundant_default_properties;
 mod remove_aliases;
 mod remove_return;
 mod remove_unused_properties;
@@ -159,6 +160,9 @@ pub async fn run_passes(
         deprecated_rotation_origin::handle_rotation_origin(component, diag);
         flickable::handle_flickable(component, &global_type_registry.borrow());
         lower_layout::lower_layouts(component, type_loader, &style_metrics, diag);
+        if type_loader.compiler_config.warn_redundant_default_properties {
+            redundant_default_properties::warn_redundant_default_properties(component, diag);
+        }
         default_geometry::default_geometry(component, diag);
         lower_layout::synthesize_layoutinfo_v_with_constraint(component);
         lower_layout::synthesize_layoutinfo_h_with_constraint(component);

--- a/internal/compiler/passes/redundant_default_properties.rs
+++ b/internal/compiler/passes/redundant_default_properties.rs
@@ -1,0 +1,500 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::rc::Rc;
+
+use smol_str::{SmolStr, ToSmolStr};
+
+use crate::diagnostics::{BuildDiagnostics, Spanned};
+use crate::expression_tree::{BindingExpression, Callable, Expression, ImageReference, Unit};
+use crate::langtype::{DefaultSizeBinding, ElementType, Type};
+use crate::namedreference::NamedReference;
+use crate::object_tree::{Component, ElementRc};
+
+pub fn warn_redundant_default_properties(
+    root_component: &Rc<Component>,
+    diag: &mut BuildDiagnostics,
+) {
+    crate::object_tree::recurse_elem_including_sub_components(
+        root_component,
+        &None,
+        &mut |elem: &ElementRc, parent: &Option<ElementRc>| {
+            let explicit_bindings = collect_explicit_bindings(elem);
+            for (property_name, binding) in explicit_bindings {
+                if base_has_explicit_binding(elem, &property_name) {
+                    continue;
+                }
+
+                let builtin_default =
+                    builtin_default_expression(elem, &property_name).is_some_and(|default_expr| {
+                        same_expression(
+                            super::ignore_debug_hooks(&binding.expression),
+                            &default_expr,
+                        )
+                    });
+
+                let geometry_default = parent.as_ref().is_some_and(|parent| {
+                    redundant_geometry_binding(
+                        elem,
+                        parent,
+                        &property_name,
+                        super::ignore_debug_hooks(&binding.expression),
+                    )
+                });
+
+                if builtin_default || geometry_default {
+                    diag.push_info_with_span(
+                        format!(
+                            "Property '{}' is explicitly set to its default value and can be removed",
+                            property_name
+                        ),
+                        binding.span.unwrap_or_default(),
+                    );
+                }
+            }
+            Some(elem.clone())
+        },
+    );
+}
+
+fn collect_explicit_bindings(elem: &ElementRc) -> Vec<(SmolStr, BindingExpression)> {
+    elem.borrow()
+        .bindings
+        .iter()
+        .filter_map(|(property_name, binding)| {
+            let binding = binding.borrow();
+            let span = binding.span.as_ref()?;
+            if binding.priority <= 0
+                || !binding.two_way_bindings.is_empty()
+                || binding.animation.is_some()
+                || span
+                    .source_file()
+                    .is_some_and(|sf| sf.path().to_string_lossy().starts_with("builtin:/"))
+            {
+                return None;
+            }
+            Some((property_name.clone(), binding.clone()))
+        })
+        .collect()
+}
+
+fn base_has_explicit_binding(elem: &ElementRc, property_name: &str) -> bool {
+    let mut base_type = elem.borrow().base_type.clone();
+    while let ElementType::Component(base) = base_type {
+        let base_root = base.root_element.borrow();
+        if base_root.bindings.get(property_name).is_some_and(|binding| {
+            let binding = binding.borrow();
+            binding.priority > 0 && binding.has_binding()
+        }) {
+            return true;
+        }
+        base_type = base_root.base_type.clone();
+    }
+    false
+}
+
+fn builtin_default_expression(elem: &ElementRc, property_name: &str) -> Option<Expression> {
+    let builtin = elem.borrow().builtin_type()?;
+    let info = builtin.properties.get(property_name)?;
+    Some(
+        info.default_value
+            .expr(elem)
+            .unwrap_or_else(|| Expression::default_value_for_type(&info.ty)),
+    )
+}
+
+fn redundant_geometry_binding(
+    elem: &ElementRc,
+    parent: &ElementRc,
+    property_name: &str,
+    expression: &Expression,
+) -> bool {
+    let elem_borrow = elem.borrow();
+    let Some(builtin) = elem_borrow.builtin_type() else { return false };
+
+    match property_name {
+        "width" | "height"
+            if builtin.default_size_binding == DefaultSizeBinding::ExpandsToParentGeometry
+                && !elem_borrow.child_of_layout =>
+        {
+            let parent_prop = NamedReference::new(parent, property_name.to_smolstr());
+            is_fill_parent_expression(expression, &parent_prop)
+        }
+        "x" | "y"
+            if !elem_borrow.child_of_layout
+                && !elem_borrow.is_legacy_syntax
+                && builtin.name != "Window"
+                && !axis_fills_parent(elem, parent, property_name) =>
+        {
+            is_center_in_parent_expression(elem, parent, property_name, expression)
+        }
+        _ => false,
+    }
+}
+
+fn axis_fills_parent(elem: &ElementRc, parent: &ElementRc, property_name: &str) -> bool {
+    let size_prop = match property_name {
+        "x" => "width",
+        "y" => "height",
+        _ => return false,
+    };
+
+    if let Some(binding) = elem.borrow().bindings.get(size_prop) {
+        return is_fill_parent_expression(
+            super::ignore_debug_hooks(&binding.borrow().expression),
+            &NamedReference::new(parent, size_prop.to_smolstr()),
+        );
+    }
+
+    let Some(builtin) = elem.borrow().builtin_type() else { return false };
+    builtin.default_size_binding == DefaultSizeBinding::ExpandsToParentGeometry
+}
+
+fn is_fill_parent_expression(expression: &Expression, parent_prop: &NamedReference) -> bool {
+    if expression.ty() == Type::Percent && is_scalar_one(expression) {
+        return true;
+    }
+
+    match expression {
+        Expression::PropertyReference(nr) => nr == parent_prop,
+        Expression::BinaryExpression { lhs, rhs, op: '*' } => {
+            (is_scalar_one(lhs) && matches_property_reference(rhs, parent_prop))
+                || (is_scalar_one(rhs) && matches_property_reference(lhs, parent_prop))
+        }
+        _ => false,
+    }
+}
+
+fn is_center_in_parent_expression(
+    elem: &ElementRc,
+    parent: &ElementRc,
+    property_name: &str,
+    expression: &Expression,
+) -> bool {
+    let size_prop = match property_name {
+        "x" => "width",
+        "y" => "height",
+        _ => return false,
+    };
+
+    let expected = Expression::BinaryExpression {
+        lhs: Box::new(Expression::BinaryExpression {
+            lhs: Box::new(Expression::PropertyReference(NamedReference::new(
+                parent,
+                SmolStr::new_static(size_prop),
+            ))),
+            rhs: Box::new(Expression::PropertyReference(NamedReference::new(
+                elem,
+                SmolStr::new_static(size_prop),
+            ))),
+            op: '-',
+        }),
+        rhs: Box::new(Expression::NumberLiteral(2., Unit::None)),
+        op: '/',
+    };
+
+    same_expression(expression, &expected)
+}
+
+fn is_scalar_one(expression: &Expression) -> bool {
+    scalar_value(expression).is_some_and(|value| (value - 1.).abs() < 0.001)
+}
+
+fn scalar_value(expression: &Expression) -> Option<f64> {
+    match expression {
+        Expression::NumberLiteral(value, Unit::None) => Some(*value),
+        Expression::NumberLiteral(value, Unit::Percent) => Some(*value * 0.01),
+        Expression::Cast { from, .. } => scalar_value(from),
+        Expression::UnaryOp { sub, op: '+' } => scalar_value(sub),
+        Expression::UnaryOp { sub, op: '-' } => scalar_value(sub).map(|value| -value),
+        Expression::BinaryExpression { lhs, rhs, op: '*' } => {
+            Some(scalar_value(lhs)? * scalar_value(rhs)?)
+        }
+        Expression::BinaryExpression { lhs, rhs, op: '/' } => {
+            let rhs = scalar_value(rhs)?;
+            if rhs.abs() < 0.001 { None } else { Some(scalar_value(lhs)? / rhs) }
+        }
+        _ => None,
+    }
+}
+
+fn matches_property_reference(expression: &Expression, expected: &NamedReference) -> bool {
+    matches!(expression, Expression::PropertyReference(actual) if actual == expected)
+}
+
+fn same_expression(lhs: &Expression, rhs: &Expression) -> bool {
+    match (lhs, rhs) {
+        (Expression::Invalid, Expression::Invalid) => true,
+        (Expression::StringLiteral(lhs), Expression::StringLiteral(rhs)) => lhs == rhs,
+        (
+            Expression::NumberLiteral(lhs_value, lhs_unit),
+            Expression::NumberLiteral(rhs_value, rhs_unit),
+        ) => lhs_unit == rhs_unit && (lhs_value - rhs_value).abs() < 0.001,
+        (Expression::BoolLiteral(lhs), Expression::BoolLiteral(rhs)) => lhs == rhs,
+        (Expression::PropertyReference(lhs), Expression::PropertyReference(rhs)) => lhs == rhs,
+        (
+            Expression::Cast { from: lhs_from, to: lhs_to },
+            Expression::Cast { from: rhs_from, to: rhs_to },
+        ) => lhs_to == rhs_to && same_expression(lhs_from, rhs_from),
+        (
+            Expression::BinaryExpression { lhs: lhs_lhs, rhs: lhs_rhs, op: lhs_op },
+            Expression::BinaryExpression { lhs: rhs_lhs, rhs: rhs_rhs, op: rhs_op },
+        ) => {
+            lhs_op == rhs_op
+                && same_expression(lhs_lhs, rhs_lhs)
+                && same_expression(lhs_rhs, rhs_rhs)
+        }
+        (
+            Expression::UnaryOp { sub: lhs_sub, op: lhs_op },
+            Expression::UnaryOp { sub: rhs_sub, op: rhs_op },
+        ) => lhs_op == rhs_op && same_expression(lhs_sub, rhs_sub),
+        (Expression::EnumerationValue(lhs), Expression::EnumerationValue(rhs)) => lhs == rhs,
+        (
+            Expression::FunctionCall {
+                function: Callable::Builtin(lhs_function),
+                arguments: lhs_arguments,
+                ..
+            },
+            Expression::FunctionCall {
+                function: Callable::Builtin(rhs_function),
+                arguments: rhs_arguments,
+                ..
+            },
+        ) => {
+            lhs_function == rhs_function
+                && lhs_arguments.len() == rhs_arguments.len()
+                && lhs_arguments
+                    .iter()
+                    .zip(rhs_arguments)
+                    .all(|(lhs, rhs)| same_expression(lhs, rhs))
+        }
+        (
+            Expression::Struct { ty: lhs_ty, values: lhs_values },
+            Expression::Struct { ty: rhs_ty, values: rhs_values },
+        ) => {
+            lhs_ty.name == rhs_ty.name
+                && lhs_ty.fields == rhs_ty.fields
+                && lhs_values.len() == rhs_values.len()
+                && lhs_values.iter().all(|(name, lhs_value)| {
+                    rhs_values
+                        .get(name)
+                        .is_some_and(|rhs_value| same_expression(lhs_value, rhs_value))
+                })
+        }
+        (
+            Expression::Array { element_ty: lhs_ty, values: lhs_values },
+            Expression::Array { element_ty: rhs_ty, values: rhs_values },
+        ) => {
+            lhs_ty == rhs_ty
+                && lhs_values.len() == rhs_values.len()
+                && lhs_values.iter().zip(rhs_values).all(|(lhs, rhs)| same_expression(lhs, rhs))
+        }
+        (
+            Expression::ImageReference { resource_ref: lhs_ref, .. },
+            Expression::ImageReference { resource_ref: rhs_ref, .. },
+        ) => same_image_reference(lhs_ref, rhs_ref),
+        _ => false,
+    }
+}
+
+fn same_image_reference(lhs: &ImageReference, rhs: &ImageReference) -> bool {
+    match (lhs, rhs) {
+        (ImageReference::None, ImageReference::None) => true,
+        (ImageReference::AbsolutePath(lhs), ImageReference::AbsolutePath(rhs)) => lhs == rhs,
+        (
+            ImageReference::EmbeddedData { resource_id: lhs_id, extension: lhs_extension },
+            ImageReference::EmbeddedData { resource_id: rhs_id, extension: rhs_extension },
+        ) => lhs_id == rhs_id && lhs_extension == rhs_extension,
+        (
+            ImageReference::EmbeddedTexture { resource_id: lhs_id },
+            ImageReference::EmbeddedTexture { resource_id: rhs_id },
+        ) => lhs_id == rhs_id,
+        _ => false,
+    }
+}
+
+#[test]
+fn warns_for_builtin_defaults_when_enabled() {
+    let mut compiler_config =
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.warn_redundant_default_properties = true;
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+        export component Test inherits Window {
+            TouchArea {
+                enabled: true;
+                mouse-cursor: MouseCursor.default;
+            }
+        }
+"#
+        .into(),
+        Some(std::path::Path::new("test.slint")),
+        &mut test_diags,
+    );
+    let (_, diag, _) =
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+    assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
+
+    let warnings = diag
+        .iter()
+        .filter(|diag| matches!(diag.level(), crate::diagnostics::DiagnosticLevel::Info))
+        .map(|diag| diag.message().to_owned())
+        .collect::<Vec<_>>();
+    let mut warnings = warnings;
+    warnings.sort();
+
+    assert_eq!(
+        warnings,
+        vec![
+            "Property 'enabled' is explicitly set to its default value and can be removed",
+            "Property 'mouse-cursor' is explicitly set to its default value and can be removed",
+        ]
+    );
+}
+
+#[test]
+fn warns_for_geometry_defaults_when_enabled() {
+    let mut compiler_config =
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.warn_redundant_default_properties = true;
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+        export component Test inherits Window {
+            TouchArea {
+                width: 100%;
+                height: parent.height;
+            }
+
+            Rectangle {
+                width: 100px;
+                height: 50px;
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+            }
+        }
+"#
+        .into(),
+        Some(std::path::Path::new("test.slint")),
+        &mut test_diags,
+    );
+    let (_, diag, _) =
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+    assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
+
+    let warnings = diag
+        .iter()
+        .filter(|diag| matches!(diag.level(), crate::diagnostics::DiagnosticLevel::Info))
+        .map(|diag| diag.message().to_owned())
+        .collect::<Vec<_>>();
+    let mut warnings = warnings;
+    warnings.sort();
+
+    assert_eq!(
+        warnings,
+        vec![
+            "Property 'height' is explicitly set to its default value and can be removed",
+            "Property 'width' is explicitly set to its default value and can be removed",
+            "Property 'x' is explicitly set to its default value and can be removed",
+            "Property 'y' is explicitly set to its default value and can be removed",
+        ]
+    );
+}
+
+#[test]
+fn does_not_warn_when_restoring_a_base_override() {
+    let mut compiler_config =
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.warn_redundant_default_properties = true;
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+        component BaseTouchArea inherits TouchArea {
+            enabled: false;
+        }
+
+        export component Test inherits Window {
+            BaseTouchArea {
+                enabled: true;
+            }
+        }
+"#
+        .into(),
+        Some(std::path::Path::new("test.slint")),
+        &mut test_diags,
+    );
+    let (_, diag, _) =
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+    assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
+    assert!(
+        diag.iter().all(|diag| !matches!(diag.level(), crate::diagnostics::DiagnosticLevel::Info)),
+        "{:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn warns_for_equivalent_fill_parent_expression() {
+    let mut compiler_config =
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.warn_redundant_default_properties = true;
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+        export component Test inherits Window {
+            TouchArea {
+                width: 1 * parent.width;
+            }
+        }
+"#
+        .into(),
+        Some(std::path::Path::new("test.slint")),
+        &mut test_diags,
+    );
+    let (_, diag, _) =
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+    assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
+
+    let infos = diag
+        .iter()
+        .filter(|diag| matches!(diag.level(), crate::diagnostics::DiagnosticLevel::Info))
+        .map(|diag| diag.message().to_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        infos,
+        vec!["Property 'width' is explicitly set to its default value and can be removed"]
+    );
+}
+
+#[test]
+fn does_not_warn_for_layout_managed_geometry() {
+    let mut compiler_config =
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.warn_redundant_default_properties = true;
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+        export component Test inherits Window {
+            HorizontalLayout {
+                TouchArea {
+                    width: 100%;
+                    height: 20px;
+                }
+            }
+        }
+"#
+        .into(),
+        Some(std::path::Path::new("test.slint")),
+        &mut test_diags,
+    );
+    let (_, diag, _) =
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+    assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
+    assert!(
+        diag.iter().all(|diag| !matches!(diag.level(), crate::diagnostics::DiagnosticLevel::Info)),
+        "{:?}",
+        diag.to_string_vec()
+    );
+}

--- a/internal/compiler/tests/syntax/analysis/redundant_default_properties.slint
+++ b/internal/compiler/tests/syntax/analysis/redundant_default_properties.slint
@@ -1,0 +1,32 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component BaseTouchArea inherits TouchArea {
+    enabled: false;
+}
+
+export component Test inherits Window {
+    TouchArea {
+        enabled: true;
+//               >   <info{Property 'enabled' is explicitly set to its default value and can be removed}
+        mouse-cursor: MouseCursor.default;
+//                    >                  <info{Property 'mouse-cursor' is explicitly set to its default value and can be removed}
+        width: 100%;
+//             >   <info{Property 'width' is explicitly set to its default value and can be removed}
+        height: parent.height;
+//              >            <info{Property 'height' is explicitly set to its default value and can be removed}
+    }
+
+    Rectangle {
+        width: 100px;
+        height: 50px;
+        x: (parent.width - self.width) / 2;
+//         >                              <info{Property 'x' is explicitly set to its default value and can be removed}
+        y: (parent.height - self.height) / 2;
+//         >                                <info{Property 'y' is explicitly set to its default value and can be removed}
+    }
+
+    BaseTouchArea {
+        enabled: true;
+    }
+}

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -23,7 +23,8 @@
 //! should be an additional character to the left, which is useful if the diagnostic starts or ends
 //! in the first or second column, where otherwise the `//` is located.
 //!
-//! Warnings with `> <warning{expected_message}` are also supported.
+//! Warnings with `> <warning{expected_message}` and info diagnostics with
+//! `> <info{expected_message}` are also supported.
 //!
 //! The newlines are replaced by `↵` in the error message. Also the manifest dir (CARGO_MANIFEST_DIR) is replaced by `📂`.
 //!
@@ -125,7 +126,7 @@ fn extract_expected_diags(source: &str) -> Vec<ExpectedDiagnostic> {
     // carets refers to the number of lines to go back. This is useful when one line of code produces multiple
     // errors or warnings.
     let re = regex::Regex::new(
-        r"\n *//[^\n\^\|<>]*((\^)|(\|)|((>)?( *<)?))(\^*)(<*)(error|warning|note)\{([^\n]*)\}",
+        r"\n *//[^\n\^\|<>]*((\^)|(\|)|((>)?( *<)?))(\^*)(<*)(error|warning|info|note)\{([^\n]*)\}",
     )
     .unwrap();
 
@@ -193,6 +194,7 @@ fn extract_expected_diags(source: &str) -> Vec<ExpectedDiagnostic> {
         let expected_diag_level = match warning_or_error {
             "warning" => DiagnosticLevel::Warning,
             "error" => DiagnosticLevel::Error,
+            "info" => DiagnosticLevel::Info,
             "note" => DiagnosticLevel::Note,
             _ => panic!("Unsupported diagnostic level {warning_or_error}"),
         };
@@ -360,6 +362,7 @@ fn update(
             let level = match d.level() {
                 DiagnosticLevel::Error => "error",
                 DiagnosticLevel::Warning => "warning",
+                DiagnosticLevel::Info => "info",
                 DiagnosticLevel::Note => "note",
                 _ => todo!(),
             };
@@ -445,6 +448,9 @@ fn process_file_source(
     .collect();
     compiler_config.embed_resources = i_slint_compiler::EmbedResourcesKind::OnlyBuiltinResources;
     compiler_config.enable_experimental = true;
+    if source.contains("config:no_warn_redundant_default_properties") {
+        compiler_config.warn_redundant_default_properties = false;
+    }
     compiler_config.style = Some("fluent".into());
     compiler_config.components_to_generate =
         if source.contains("config:generate_all_exported_windows") {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -736,6 +736,16 @@ impl ComponentCompiler {
         self.config.style.as_ref()
     }
 
+    /// Enables or disables diagnostics for redundant default property bindings.
+    pub fn set_warn_redundant_default_properties(&mut self, warn: bool) {
+        self.config.warn_redundant_default_properties = warn;
+    }
+
+    /// Returns whether diagnostics for redundant default property bindings are enabled.
+    pub fn warn_redundant_default_properties(&self) -> bool {
+        self.config.warn_redundant_default_properties
+    }
+
     /// The domain used for translations
     pub fn set_translation_domain(&mut self, domain: String) {
         self.config.translation_domain = Some(domain);
@@ -904,6 +914,16 @@ impl Compiler {
     /// Returns the widget style the compiler is currently using when compiling .slint files.
     pub fn style(&self) -> Option<&String> {
         self.config.style.as_ref()
+    }
+
+    /// Enables or disables diagnostics for redundant default property bindings.
+    pub fn set_warn_redundant_default_properties(&mut self, warn: bool) {
+        self.config.warn_redundant_default_properties = warn;
+    }
+
+    /// Returns whether diagnostics for redundant default property bindings are enabled.
+    pub fn warn_redundant_default_properties(&self) -> bool {
+        self.config.warn_redundant_default_properties
     }
 
     /// The domain used for translations

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -689,6 +689,8 @@ pub enum DiagnosticLevel {
     Error,
     /// The diagnostic belongs to a warning.
     Warning,
+    /// The diagnostic is informational.
+    Info,
     /// The diagnostic is a note
     Note,
 }
@@ -815,6 +817,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_get_diagnostics(
             level: match diagnostic.level() {
                 i_slint_compiler::diagnostics::DiagnosticLevel::Error => DiagnosticLevel::Error,
                 i_slint_compiler::diagnostics::DiagnosticLevel::Warning => DiagnosticLevel::Warning,
+                i_slint_compiler::diagnostics::DiagnosticLevel::Info => DiagnosticLevel::Info,
                 i_slint_compiler::diagnostics::DiagnosticLevel::Note => DiagnosticLevel::Note,
                 _ => DiagnosticLevel::Warning,
             },

--- a/internal/live-preview/protocol/diagnostics_adapter.rs
+++ b/internal/live-preview/protocol/diagnostics_adapter.rs
@@ -34,6 +34,7 @@ fn to_severity(level: DiagnosticLevel) -> lsp_types::DiagnosticSeverity {
     match level {
         DiagnosticLevel::Error => DiagnosticSeverity::ERROR,
         DiagnosticLevel::Warning => DiagnosticSeverity::WARNING,
+        DiagnosticLevel::Info => DiagnosticSeverity::INFORMATION,
         DiagnosticLevel::Note => DiagnosticSeverity::HINT,
         _ => DiagnosticSeverity::INFORMATION,
     }

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -275,6 +275,7 @@ pub fn set_diagnostics(api: &Api<'_>, diagnostics: &[slint_interpreter::Diagnost
             let level = match d.level() {
                 DiagnosticLevel::Error => LogMessageLevel::Error,
                 DiagnosticLevel::Warning => LogMessageLevel::Warning,
+                DiagnosticLevel::Info => LogMessageLevel::Info,
                 DiagnosticLevel::Note => LogMessageLevel::Note,
                 _ => LogMessageLevel::Debug,
             };
@@ -286,6 +287,7 @@ pub fn set_diagnostics(api: &Api<'_>, diagnostics: &[slint_interpreter::Diagnost
                 (_, DiagnosticLevel::Error) => DiagnosticSummary::Errors,
                 (DiagnosticSummary::Errors, DiagnosticLevel::Warning) => DiagnosticSummary::Errors,
                 (_, DiagnosticLevel::Warning) => DiagnosticSummary::Warnings,
+                (acc, DiagnosticLevel::Info) => acc,
                 // Ignore Note level diagnostics for the summary.
                 // If there is only a note, that's not relevant enough to bother the user.
                 (acc, DiagnosticLevel::Note) => acc,

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -261,6 +261,7 @@ export struct PaletteEntry {
 
 export enum LogMessageLevel {
     Debug,
+    Info,
     Warning,
     Error,
     Note,


### PR DESCRIPTION
Add an `Infolevel` compiler diagnostic for bindings that explicitly repeat the default value and enable the diagnostic by default
Fixes #11994
