### PR TITLE
compiler: don't panic on interface property with invalid type

### DIFF
--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -256,6 +256,13 @@ fn apply_interface_property_declaration(
     interface_name: &SmolStr,
     diag: &mut BuildDiagnostics,
 ) {
+    if matches!(prop_decl.property_type, Type::Invalid) {
+        // The interface's own declaration is invalid (e.g. an unknown property type). A diagnostic
+        // was already emitted when the interface was parsed, so there is nothing meaningful to apply
+        // or conflict-check here.
+        return;
+    }
+
     let lookup_result = e.lookup_property(unresolved_prop_name);
 
     fn find_conflicting_node(
@@ -268,12 +275,10 @@ fn apply_interface_property_declaration(
     if lookup_result.property_type != Type::Invalid {
         if lookup_result.is_local_to_component {
             let property_type_name = match prop_decl.property_type {
-                Type::Invalid => Err(()),
-                Type::Callback { .. } => Ok("callback"),
-                Type::Function { .. } => Ok("function"),
-                _ => Ok("property"),
-            }
-            .expect("Expected valid property type");
+                Type::Callback { .. } => "callback",
+                Type::Function { .. } => "function",
+                _ => "property",
+            };
 
             let local_property_node = find_conflicting_node(e, unresolved_prop_name)
                 .expect("Expected local property to have a syntax node");

--- a/internal/compiler/tests/syntax/interfaces/interface_invalid_property_type.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_invalid_property_type.slint
@@ -1,0 +1,22 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// An interface that declares a property with an unknown type used to crash the
+// compiler when an implementing component had a conflicting local declaration of
+// the same name (the invalid type hit a match arm guarded by `.expect()`). See
+// the `Unknown type` diagnostic below: the invalid interface property is simply
+// skipped, so compilation reports the error instead of panicking.
+
+export interface InvalidPropertyTypeInterface {
+    in-out property <inv> value;
+//                   > <error{Unknown type 'inv'}
+    callback speak();
+}
+
+export component Impl {
+    in-out property <int> value: 0;
+    callback speak();
+    @children
+}
+
+export component ComponentImplementsInterface implements InvalidPropertyTypeInterface inherits Impl { }


### PR DESCRIPTION
An interface declaring a property with an unknown type (e.g.
`property <inv> value;`) gets a PropertyDeclaration with Type::Invalid
after the 'Unknown type' diagnostic is emitted. When an implementing
component also declared a local property of the same name, the conflict
path in apply_interface_property_declaration matched Type::Invalid to
Err(()) and .expect()ed it, panicking.

Skip interface properties whose declaration type is already invalid:
the user has already been told the type is unknown, so there is nothing
meaningful to apply or conflict-check. This also lets the type-name
match become total, so the .expect() is gone.

Found by the compiler_fuzzing fuzz target.