### PR TITLE
fix(wgpu): drop Suboptimal surface texture before reconfiguring (femtovg + skia, Wayland first-frame panic)

### DIFF
--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -195,9 +195,17 @@ impl GraphicsBackend for WGPUBackend {
             wgpu::CurrentSurfaceTexture::Validation => {
                 return Err("WGPU surface validation error in get_current_texture".into());
             }
-            wgpu::CurrentSurfaceTexture::Outdated
+            stale @ (wgpu::CurrentSurfaceTexture::Outdated
             | wgpu::CurrentSurfaceTexture::Suboptimal(_)
-            | wgpu::CurrentSurfaceTexture::Lost => {
+            | wgpu::CurrentSurfaceTexture::Lost) => {
+                // `Suboptimal` carries a live `SurfaceTexture`; matched with `_` it is not bound,
+                // so the temporary returned by `get_current_texture()` keeps it alive for the
+                // whole arm — i.e. across the `surface.configure()` below. wgpu forbids
+                // reconfiguring a surface while an acquired surface texture is still alive and
+                // panics with "`SurfaceOutput` must be dropped before a new `Surface` is made".
+                // Drop it first. This is the common FIRST-frame status on Wayland, so without the
+                // drop the renderer panics on startup. (`Outdated`/`Lost` carry nothing → no-op.)
+                drop(stale);
                 let mut device = self.device.borrow_mut();
                 let device = device.as_mut().unwrap();
                 surface.configure(device, self.surface_config.borrow().as_ref().unwrap());


### PR DESCRIPTION
## Problem

`WGPUBackend::begin_surface_rendering` (FemtoVG + WGPU) panics in `Surface::configure` on the **first frame on Wayland**:

```
wgpu error: Validation Error
  In Surface::configure: `SurfaceOutput` must be dropped before a new `Surface` is made
```

`CurrentSurfaceTexture::Suboptimal(SurfaceTexture)` carries a **live** surface texture. In the `Outdated | Suboptimal(_) | Lost` arm it is matched with `_`, so the `match surface.get_current_texture()` scrutinee keeps that texture alive across the `surface.configure()` call — which wgpu forbids. Wayland compositors commonly return `Suboptimal` on the first acquire, so the renderer panics on startup (reliably in debug builds; release sometimes wins the timing race).

Fixes #12098.

## Fix

Bind the stale `CurrentSurfaceTexture` with `stale @ (...)` and `drop(stale)` before reconfiguring, so no acquired surface texture is alive when `configure()` runs. `Outdated`/`Lost` carry no texture, so dropping them is a no-op; behaviour is otherwise unchanged.

```rust
stale @ (wgpu::CurrentSurfaceTexture::Outdated
    | wgpu::CurrentSurfaceTexture::Suboptimal(_)
    | wgpu::CurrentSurfaceTexture::Lost) => {
    drop(stale); // release the (possibly Suboptimal) texture before reconfigure
    let mut device = self.device.borrow_mut();
    let device = device.as_mut().unwrap();
    surface.configure(device, self.surface_config.borrow().as_ref().unwrap());
    // ...
}
```

## Testing

- `cargo check -p i-slint-renderer-femtovg --features wgpu-29` — clean.
- Root cause confirmed against the live panic: on a real winit + FemtoVG + WGPU app on Wayland, the crash backtrace runs `begin_surface_rendering → Surface::configure`, and the first-frame `get_current_texture()` returns `Suboptimal` (which holds the texture alive across `configure`). A full before/after runtime run against that app is in progress and I'll confirm here.
