### PR TITLE
fix(skia-wgpu): drop Suboptimal surface texture before reconfiguring

### DIFF
--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -206,9 +206,15 @@ impl crate::Surface for WGPUSurface {
             wgpu::CurrentSurfaceTexture::Validation => {
                 return Err("WGPU surface validation error in get_current_texture".into());
             }
-            wgpu::CurrentSurfaceTexture::Outdated
+            stale @ (wgpu::CurrentSurfaceTexture::Outdated
             | wgpu::CurrentSurfaceTexture::Suboptimal(_)
-            | wgpu::CurrentSurfaceTexture::Lost => {
+            | wgpu::CurrentSurfaceTexture::Lost) => {
+                // `Suboptimal` carries a live `SurfaceTexture`; matched with `_` it is not bound,
+                // so the value returned by `get_current_texture()` keeps it alive across the
+                // `surface.configure()` below — which wgpu forbids ("`SurfaceOutput` must be
+                // dropped before a new `Surface` is made"), panicking on the first frame on
+                // Wayland. Drop it first. (`Outdated`/`Lost` carry nothing → no-op.)
+                drop(stale);
                 surface.configure(&self.device, surface_config);
                 match surface.get_current_texture() {
                     wgpu::CurrentSurfaceTexture::Success(t) => t,


### PR DESCRIPTION
Companion to #12099 (merged) — applies the same fix to the Skia renderer, as requested by @tronical.

`WGPUSurface::render` in `internal/renderers/skia/wgpu_29_surface.rs` has the same bug the femtovg-wgpu renderer had: the `Outdated | Suboptimal(_) | Lost` arm calls `surface.configure()` while the live `SurfaceTexture` carried by `Suboptimal(_)` is still held by the value returned from `get_current_texture()`, so wgpu panics on the first frame on Wayland (`"SurfaceOutput must be dropped before a new Surface is made"`). Bind it and drop it before `configure()`.

`wgpu_28_surface.rs` is intentionally left unchanged: it uses the older `Result<SurfaceTexture, SurfaceError>` API where a suboptimal acquire is a flag on the `Ok(texture)` (used directly) and the `Err(_)` reconfigure arm carries no `SurfaceTexture` — nothing to drop.

> Note: I couldn't compile-check the skia crate locally — `cargo check -p i-slint-renderer-skia --features wgpu-29` fails building the `softbuffer` dep in my environment, unrelated to this change — so I'm relying on CI for the skia build. The edit mirrors the merged femtovg fix (#12099) exactly.
