### PR TITLE
docs(safety): add per-page .md endpoint (parity with other docs sites)

### DIFF
--- a/docs/safety/src/pages/[...slug].md.ts
+++ b/docs/safety/src/pages/[...slug].md.ts
@@ -1,0 +1,33 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// Serves a plain-markdown sibling for every doc page so AI agents can fetch
+// docs without paying the HTML/JS overhead. Example:
+//   …/docs/safety/reference/   -> rendered HTML page
+//   …/docs/safety/reference.md -> this endpoint, raw markdown
+//
+// Mirrors the other docs sites' endpoints; see
+// docs/common/src/utils/markdown-endpoint.ts. The safety manual uses the
+// in-prose <Link> component (but no `?raw` code imports), so it passes the
+// linkMap + its own base path and omits projectRoot.
+
+import type { APIRoute, GetStaticPaths } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+import {
+    markdownStaticPaths,
+    renderMarkdownResponse,
+} from "@slint/common-files/src/utils/markdown-endpoint";
+import { linkMap } from "@slint/common-files/src/utils/utils";
+import { SAFETY_DOCS_BASE_PATH } from "../safety-site-config.mjs";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+    return markdownStaticPaths(await getCollection("docs"));
+};
+
+type Props = { entry: CollectionEntry<"docs"> };
+
+export const GET: APIRoute<Props> = ({ props }) =>
+    renderMarkdownResponse(props.entry, {
+        basePath: SAFETY_DOCS_BASE_PATH,
+        linkMap,
+    });


### PR DESCRIPTION
## What

Adds the per-page **`.md` endpoint** (`src/pages/[...slug].md.ts`) to the **safety** docs site — the only one of the five docs sites that was missing it.

## Why

The other four sites (slint/astro, cpp, nodejs, python) already serve a plain-markdown sibling for every doc page via the shared [`markdown-endpoint.ts`](docs/common/src/utils/markdown-endpoint.ts) util, e.g.:

```
…/docs/slint/guide/…/properties/      -> HTML page
…/docs/slint/guide/…/properties.md    -> raw markdown (frontmatter + body)
```

These give AI agents (and the docs-MCP) clean, per-page markdown with real slugs — no HTML/JS overhead, no heuristic reconstruction. `safety` had a `docs` collection but no such route, so it was the lone gap.

## How

Mirrors the existing routes via `markdownStaticPaths` + `renderMarkdownResponse`. The safety manual uses the in-prose `<Link>` component (but no `?raw` code imports), so it passes the shared `linkMap` + its own `SAFETY_DOCS_BASE_PATH` and omits `projectRoot` (matching how the astro site wires it).

## Verified locally

`pnpm -C docs/safety build` → **29 `.md` files** emitted, all internal links valid. The single `<Link type="MenuBar" />` resolves to a real markdown link (`[MenuBar](…/reference/window/window.md#menubar)`); **0 raw `<Link>` tags** leak into any `.md`. biome + cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
