### PR TITLE
Disambiguate window and element handles via distinct MCP schema descr…

### DIFF
--- a/docs/development/mcp-server.md
+++ b/docs/development/mcp-server.md
@@ -60,6 +60,8 @@ Both transports use `generational_arena::Index` internally. The proto `Handle` t
 
 Handles are generational: if an element is evicted and its arena slot reused, stale handles are detected because the generation won't match.
 
+Window handles and element handles share the same `{index, generation}` shape, so clients (especially LLM agents) easily confuse them. To disambiguate, `tool_definitions()` gives the `windowHandle` and `elementHandle` parameters distinct `description`s, and the `initialize` instructions spell out that the two kinds are not interchangeable and where each one comes from.
+
 ### FIFO Eviction
 
 The element arena is capped at 10,000 entries (`ELEMENT_HANDLE_CAP`). When the cap is exceeded, the oldest handles are evicted (FIFO order), with one exception: root element handles for tracked windows are never evicted — they are pushed to the back of the queue instead.

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -128,6 +128,41 @@ const TOOLS: &[ToolDef] = &[
     },
 ];
 
+/// Human-readable description for a handle-typed input field. Window and element
+/// handles are structurally identical (`{index, generation}` objects), so without
+/// these descriptions their input schemas would be byte-for-byte identical and
+/// agents routinely confuse the two. The text spells out where each kind of
+/// handle comes from and that they are not interchangeable.
+fn handle_field_description(field_name: &str) -> Option<&'static str> {
+    match field_name {
+        "windowHandle" => Some(
+            "A window handle (NOT an element handle). Obtain it from list_windows. \
+             Window and element handles look identical but are not interchangeable: \
+             passing an element handle here is incorrect.",
+        ),
+        "elementHandle" => Some(
+            "An element handle (NOT a window handle). Obtain it from get_element_tree, \
+             find_elements_by_id, query_element_descendants, or a window's rootElementHandle \
+             (from get_window_properties). Window and element handles look identical but are \
+             not interchangeable: passing a window handle here is incorrect.",
+        ),
+        _ => None,
+    }
+}
+
+/// Annotate handle-typed properties of an input schema with a `description` so
+/// `windowHandle` and `elementHandle` read differently to the client.
+fn annotate_handle_fields(schema: &mut Value) {
+    let Some(props) = schema.get_mut("properties").and_then(|p| p.as_object_mut()) else {
+        return;
+    };
+    for (name, prop) in props.iter_mut() {
+        if let (Some(desc), Some(obj)) = (handle_field_description(name), prop.as_object_mut()) {
+            obj.insert("description".to_string(), Value::String(desc.to_string()));
+        }
+    }
+}
+
 fn tool_definitions() -> Value {
     let tools: Vec<Value> = TOOLS
         .iter()
@@ -136,6 +171,8 @@ fn tool_definitions() -> Value {
                 mcp_schemas::proto_input_schema(def.request_type).unwrap_or_else(|| {
                     panic!("no proto schema for {}", def.request_type);
                 });
+
+            annotate_handle_fields(&mut schema);
 
             // Add "required" array: all fields except those listed as optional
             if let Some(all_fields) = mcp_schemas::proto_field_names(def.request_type) {
@@ -464,6 +501,13 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "Values are uint64 encoded as strings (protobuf JSON convention). ",
                     "Zero-valued fields may be omitted by the serializer, so {} means {\"index\": \"0\", \"generation\": \"0\"}. ",
                     "When sending handles back, you may omit zero fields or include them — both work.\n\n",
+
+                    "IMPORTANT: window handles and element handles are SEPARATE, NON-INTERCHANGEABLE kinds, ",
+                    "even though they share this {index, generation} shape. ",
+                    "Window handles come from list_windows (use them for windowHandle parameters). ",
+                    "Element handles come from get_element_tree, find_elements_by_id, query_element_descendants, ",
+                    "or a window's rootElementHandle (use them for elementHandle parameters). ",
+                    "Do not reuse a window handle as an element handle or vice versa — they are not interchangeable.\n\n",
 
                     "# Enum values\n\n",
                     "Enum fields accept PascalCase strings:\n",
@@ -1071,6 +1115,30 @@ mod tests {
         ));
         let resp = resp.unwrap();
         assert_eq!(resp["error"]["code"], -32600);
+    }
+
+    #[test]
+    fn test_handle_field_schemas_are_distinct() {
+        // The window and element handle schemas would otherwise be byte-identical
+        // {index, generation} objects. Verify the disambiguating descriptions are
+        // present and differ, so clients can tell the two kinds apart.
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().unwrap();
+        let find = |name: &str| tools.iter().find(|t| t["name"] == name).unwrap().clone();
+
+        let window_tool = find("get_window_properties");
+        let window_desc = window_tool["inputSchema"]["properties"]["windowHandle"]["description"]
+            .as_str()
+            .expect("windowHandle should have a description");
+        let element_tool = find("get_element_properties");
+        let element_desc =
+            element_tool["inputSchema"]["properties"]["elementHandle"]["description"]
+                .as_str()
+                .expect("elementHandle should have a description");
+
+        assert!(window_desc.contains("window handle"));
+        assert!(element_desc.contains("element handle"));
+        assert_ne!(window_desc, element_desc);
     }
 
     #[test]


### PR DESCRIPTION
…iptions

Window handles and element handles share the same {index, generation} wire shape, so the generated MCP input schemas for the windowHandle and elementHandle parameters were byte-for-byte identical, giving agents nothing to tell the two kinds apart — they frequently pass one where the other is expected.

Attach a distinct description to each windowHandle/elementHandle property in the tool schemas, and spell out in the initialize instructions that the two kinds are not interchangeable and where each one comes from.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
