### PR TITLE
CI: publish Android demos under demos/android/ with an index

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -473,6 +473,17 @@ jobs:
                 mkdir -p $output_path/demos/android
                 cp -a ../android/* $output_path/demos/android/
 
+                # A directory listing so the published folder is browsable.
+                {
+                  echo '<!DOCTYPE html><meta charset="utf-8"><title>Slint Android demos</title>'
+                  echo '<h1>Slint Android demos</h1>'
+                  echo '<p>Install an APK on a device, or use the AAB for Play Store uploads.</p><ul>'
+                  for f in $(cd $output_path/demos/android && ls *.apk *.aab 2>/dev/null); do
+                    echo "<li><a href=\"$f\">$f</a></li>"
+                  done
+                  echo '</ul>'
+                } > $output_path/demos/android/index.html
+
                 rm -rf $output_path/wasm-interpreter
                 mkdir -p $output_path/wasm-interpreter
                 cp -a ../api/wasm-interpreter/pkg/* ./$output_path/wasm-interpreter/
@@ -772,7 +783,7 @@ jobs:
               run: |
                   curl --fail -L -o bundletool.jar https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar
                   java -jar bundletool.jar build-apks --mode=universal \
-                      --bundle=tools/viewer/android-aab/app/build/outputs/bundle/release/app-release.aab \
+                      --bundle=tools/viewer/android-aab/app/build/outputs/bundle/release/slint-viewer.aab \
                       --output=slint-viewer.apks \
                       --ks="$CARGO_APK_RELEASE_KEYSTORE" \
                       --ks-pass="pass:$ANDROID_KEYSTORE_PASSWORD" \
@@ -780,17 +791,16 @@ jobs:
                   mkdir -p target/release/apk
                   unzip -p slint-viewer.apks universal.apk > target/release/apk/slint-viewer.apk
 
-            # Upload whatever built so a Gradle failure doesn't drop the APKs.
+            # Flatten into one directory so the artifact holds bare files.
+            - name: Collect Android artifacts
+              if: always()
+              run: |
+                  mkdir -p android-demo
+                  cp -a target/release/apk/*.apk android-demo/ || true
+                  cp -a tools/viewer/android-aab/app/build/outputs/bundle/release/slint-viewer.aab android-demo/ || true
             - name: "upload APK artifact"
               if: always()
               uses: actions/upload-artifact@v7
               with:
                   name: android-demo
-                  path: |
-                    target/release/apk/energy-monitor.apk
-                    target/release/apk/todo_lib.apk
-                    target/release/apk/weather_demo.apk
-                    target/release/apk/usecases_lib.apk
-                    target/release/apk/home_automation_lib.apk
-                    target/release/apk/slint-viewer.apk
-                    tools/viewer/android-aab/app/build/outputs/bundle/release/app-release.aab
+                  path: android-demo/

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -405,7 +405,7 @@ jobs:
                   name: wasm_demo
             - uses: actions/download-artifact@v8
               with:
-                  name: android-demo
+                  name: android-demos
                   path: android
 
             - uses: actions/checkout@v6
@@ -475,8 +475,8 @@ jobs:
 
                 # A directory listing so the published folder is browsable.
                 {
-                  echo '<!DOCTYPE html><meta charset="utf-8"><title>Slint Android demos</title>'
-                  echo '<h1>Slint Android demos</h1>'
+                  echo '<!DOCTYPE html><meta charset="utf-8"><title>Slint Android Demos</title>'
+                  echo '<h1>Slint Android Demos</h1>'
                   echo '<p>Install an APK on a device, or use the AAB for Play Store uploads.</p><ul>'
                   for f in $(cd $output_path/demos/android && ls *.apk *.aab 2>/dev/null); do
                     echo "<li><a href=\"$f\">$f</a></li>"
@@ -795,12 +795,12 @@ jobs:
             - name: Collect Android artifacts
               if: always()
               run: |
-                  mkdir -p android-demo
-                  cp -a target/release/apk/*.apk android-demo/ || true
-                  cp -a tools/viewer/android-aab/app/build/outputs/bundle/release/slint-viewer.aab android-demo/ || true
+                  mkdir -p android-demos
+                  cp -a target/release/apk/*.apk android-demos/ || true
+                  cp -a tools/viewer/android-aab/app/build/outputs/bundle/release/slint-viewer.aab android-demos/ || true
             - name: "upload APK artifact"
               if: always()
               uses: actions/upload-artifact@v7
               with:
-                  name: android-demo
-                  path: android-demo/
+                  name: android-demos
+                  path: android-demos/

--- a/docs/nightly-release-notes.md
+++ b/docs/nightly-release-notes.md
@@ -67,3 +67,4 @@ Alternatively, download the binary from "Assets" section below.
  - Documentation: https://slint.dev/snapshots/{feature}/docs
  - SlintPad: https://slint.dev/snapshots/{feature}/editor
  - Demos: links from https://github.com/slint-ui/slint/tree/master/examples
+ - Android demos (APK / AAB): https://snapshots.slint.dev/{feature}/demos/android/

--- a/docs/nightly-release-notes.md
+++ b/docs/nightly-release-notes.md
@@ -67,4 +67,4 @@ Alternatively, download the binary from "Assets" section below.
  - Documentation: https://slint.dev/snapshots/{feature}/docs
  - SlintPad: https://slint.dev/snapshots/{feature}/editor
  - Demos: links from https://github.com/slint-ui/slint/tree/master/examples
- - Android demos (APK / AAB): https://snapshots.slint.dev/{feature}/demos/android/
+ - Android Demos (APK / AAB): https://snapshots.slint.dev/{feature}/demos/android/

--- a/tools/viewer/android-aab/build-aab.sh
+++ b/tools/viewer/android-aab/build-aab.sh
@@ -17,7 +17,7 @@
 # set; gradle 8.9+ on PATH (AGP 8.7); JDK 17; the three Android rust targets
 # (rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android).
 #
-# Output: app/build/outputs/bundle/release/app-release.aab
+# Output: app/build/outputs/bundle/release/slint-viewer.aab
 
 set -euo pipefail
 
@@ -77,4 +77,8 @@ cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 --platform 26 -o "$JNI_DIR" \
 cd "$PROJECT_DIR"
 gradle --no-daemon bundleRelease
 
-echo "AAB built at: $PROJECT_DIR/app/build/outputs/bundle/release/app-release.aab"
+# Gradle names the bundle app-release.aab; rename it to the app.
+BUNDLE_DIR="$PROJECT_DIR/app/build/outputs/bundle/release"
+mv -f "$BUNDLE_DIR/app-release.aab" "$BUNDLE_DIR/slint-viewer.aab"
+
+echo "AAB built at: $BUNDLE_DIR/slint-viewer.aab"

--- a/tools/viewer/android-aab/install-aab.sh
+++ b/tools/viewer/android-aab/install-aab.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
-AAB="${1:-$PROJECT_DIR/app/build/outputs/bundle/release/app-release.aab}"
+AAB="${1:-$PROJECT_DIR/app/build/outputs/bundle/release/slint-viewer.aab}"
 [ -f "$AAB" ] || { echo "AAB not found at $AAB; run build-aab.sh first" >&2; exit 1; }
 
 [ -n "${ANDROID_KEYSTORE_PATH:-}" ] || { echo "set ANDROID_KEYSTORE_PATH for signing" >&2; exit 1; }


### PR DESCRIPTION
The AAB upload added a path outside target/release/apk/, which pushed the artifact's common ancestor to the repo root, so the files landed in demos/android/target/release/apk/. Flatten the APKs and AAB into one directory before upload to publish them under demos/android/ again.

Also add a browsable index.html linked from the nightly release notes, and rename the bundle from app-release.aab to slint-viewer.aab.

