### PR TITLE
C++: fix crash when calling focus() in init with a repeater present

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -1173,6 +1173,8 @@ public:
     uint64_t visit(TraversalOrder order, private_api::ItemVisitorRefMut visitor) const
     {
         track_model_changes();
+        if (!inner)
+            return std::numeric_limits<uint64_t>::max();
         for (std::size_t i = 0; i < inner->data.size(); ++i) {
             auto index = order == TraversalOrder::BackToFront ? i : inner->data.size() - 1 - i;
             if (!inner->data[index].ptr)
@@ -1188,6 +1190,8 @@ public:
 
     vtable::VWeak<private_api::ItemTreeVTable> instance_at(std::size_t i) const
     {
+        if (!inner)
+            return {};
         const auto offset = inner->layout_state.offset;
         if (i < offset || i - offset >= inner->data.size()) {
             return {};
@@ -1200,6 +1204,8 @@ public:
 
     private_api::IndexRange index_range() const
     {
+        if (!inner)
+            return private_api::IndexRange { 0, 0 };
         const auto offset = inner->layout_state.offset;
         return private_api::IndexRange { offset, offset + inner->data.size() };
     }

--- a/tests/cases/focus/disabled_focus_in_init_repeater.slint
+++ b/tests/cases/focus/disabled_focus_in_init_repeater.slint
@@ -1,0 +1,34 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Calling focus() in the init callback of a disabled FocusScope used to crash
+// when a repeater (`for`) was present, because the focus walk stepped into the
+// not-yet-instantiated repeater subtree.
+
+component TestCase inherits Window {
+    property <[int]> model;
+    for item in model: Rectangle { }
+    fs := FocusScope {
+        enabled: false;
+        init => { self.focus(); }
+    }
+    out property<bool> test: !fs.has-focus;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
The Repeater's inner state is only allocated by refresh_model(), which runs from ensure_updated(). The focus walk reaches index_range() and instance_at() through get_subtree_range/get_subtree before that pass runs (e.g. from focus() in an init callback), so inner was still null and got dereferenced. Guard inner like len() already does.

Fixes: #12109
