### PR TITLE
c++: Fix warning when compiling with the Skia renderer enabled

### DIFF
--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -911,7 +911,10 @@ pub mod skia {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_skia_renderer_render(r: SkiaRendererOpaque) {
         let r = unsafe { &*(r as *const SkiaRenderer) };
-        r.render().unwrap();
+        // There's now way right now of instantiating the Skia Renderer in C++
+        // with wgpu to produce the DrawOutput that'll require the caller to act,
+        // so ignore the Ok result.
+        let _ = r.render().unwrap();
     }
 
     #[unsafe(no_mangle)]


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
