### PR TITLE
Run the C++ live-preview test-driver in CI and fix builtin enum conversion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,6 +209,10 @@ jobs:
                   target: i686-unknown-linux-gnu
             - name: Run tests
               run: cargo test -p test-driver-cpp --target i686-unknown-linux-gnu --no-default-features
+            - name: Run tests with live-preview
+              env:
+                  SLINT_LIVE_PREVIEW: 1
+              run: cargo test -p test-driver-cpp --target i686-unknown-linux-gnu --no-default-features --features live-preview
 
     cpp_cmake_matrix:
         needs: files-changed

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -29,30 +29,12 @@ fn enums(path: &Path) -> anyhow::Result<()> {
     // can come first, with the source-compat aliases referring back to it.
     let mut lang_section: Vec<u8> = Vec::new();
     let mut slint_compat: Vec<u8> = Vec::new();
-    let mut slint_other: Vec<u8> = Vec::new();
-
-    // For PrivateEnum entries whose body must NOT live in `slint::cbindgen_private`
-    // (historical C++ public surface that isn't part of `slint::language`).
-    // Returns the optional sub-namespace under `slint::`.
-    macro_rules! priv_routing {
-        (Orientation) => {
-            Some(None)
-        };
-        (AccessibleLiveness) => {
-            Some(None)
-        };
-        ($_:ident) => {
-            None
-        };
-    }
 
     macro_rules! print_enums {
          ($( $(#[doc = $enum_doc:literal])* $(#[non_exhaustive])? $vis:vis enum $Name:ident { $( $(#[doc = $value_doc:literal])* $Value:ident,)* })*) => {
              $({
-                #[allow(unused_assignments)]
-                let mut sub_namespace: Option<&'static str> = None;
-                let target: &mut dyn Write = match (stringify!($vis), stringify!($Name)) {
-                    ("pub", _) => {
+                let target: &mut dyn Write = match stringify!($vis) {
+                    "pub" => {
                         // body lives in `slint::language`; alias into `cbindgen_private`,
                         // and (for enums that historically lived in `slint::`) also into `slint::`.
                         writeln!(enums_priv, "using slint::language::{};", stringify!($Name))?;
@@ -61,27 +43,8 @@ fn enums(path: &Path) -> anyhow::Result<()> {
                         }
                         &mut lang_section
                     }
-                    ("", _) => {
-                        // Private enums mostly live in `cbindgen_private`. A handful keep their
-                        // historical `slint::` (or `slint::testing`) home for source compatibility.
-                        match priv_routing!($Name) {
-                            Some(ns) => {
-                                sub_namespace = ns;
-                                let qualified = match ns {
-                                    Some(ns) => format!("slint::{}::{}", ns, stringify!($Name)),
-                                    None => format!("slint::{}", stringify!($Name)),
-                                };
-                                writeln!(enums_priv, "using {};", qualified)?;
-                                &mut slint_other
-                            }
-                            None => &mut enums_priv as &mut dyn Write,
-                        }
-                    }
-                    _ => unreachable!(),
+                    _ => &mut enums_priv as &mut dyn Write,
                 };
-                if let Some(ns) = sub_namespace {
-                    writeln!(target, "namespace {} {{", ns)?;
-                }
                 $(writeln!(target, "///{}", $enum_doc)?;)*
                 writeln!(target, "enum class {} {{", stringify!($Name))?;
                 $(
@@ -89,9 +52,6 @@ fn enums(path: &Path) -> anyhow::Result<()> {
                     writeln!(target, "    {},", stringify!($Value).trim_start_matches("r#"))?;
                 )*
                 writeln!(target, "}};")?;
-                if sub_namespace.is_some() {
-                    writeln!(target, "}}")?;
-                }
              })*
          }
     }
@@ -101,7 +61,6 @@ fn enums(path: &Path) -> anyhow::Result<()> {
     enums_pub.write_all(&lang_section)?;
     writeln!(enums_pub, "}} // namespace language")?;
     enums_pub.write_all(&slint_compat)?;
-    enums_pub.write_all(&slint_other)?;
     writeln!(enums_pub, "}}")?;
     writeln!(enums_priv, "}}")?;
 
@@ -242,10 +201,10 @@ fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
     macro_rules! collect_enums {
         ($( $(#[doc = $enum_doc:literal])* $(#[non_exhaustive])? $vis:vis enum $Name:ident { $( $(#[doc = $value_doc:literal])* $Value:ident,)* })*) => {
             $({
-                let namespace = match (stringify!($vis), stringify!($Name)) {
-                    ("pub", _) => "slint::language",
-                    (_, "Orientation") | (_, "AccessibleLiveness") => "slint",
-                    _ => "slint::cbindgen_private",
+                let namespace = if stringify!($vis) == "pub" {
+                    "slint::language"
+                } else {
+                    "slint::cbindgen_private"
                 };
                 enums.push((
                     namespace,
@@ -261,7 +220,7 @@ fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
     }
     i_slint_common::for_each_enums!(collect_enums);
 
-    for target_namespace in ["slint", "slint::language", "slint::cbindgen_private"] {
+    for target_namespace in ["slint::language", "slint::cbindgen_private"] {
         writeln!(file, "namespace {target_namespace} {{")?;
         for (_, ty, enum_name, values) in enums.iter().filter(|e| e.0 == target_namespace) {
             writeln!(

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -255,7 +255,7 @@ fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
     }
 
     // The public builtin structs (in slint::language) converted field by field, in their namespace
-    // so ADL finds them. StandardListViewItem is hand-written; DropEvent needs DataTransfer.
+    // so ADL finds them. StandardListViewItem is hand-written.
     let mut structs: Vec<(String, Vec<String>)> = Vec::new();
     macro_rules! collect_structs {
         ($( $(#[$attr:meta])* $vis:vis struct $Name:ident {
@@ -263,7 +263,7 @@ fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
         })*) => {
             $(
                 if stringify!($vis) == "pub"
-                    && !matches!(stringify!($Name), "StandardListViewItem" | "DropEvent")
+                    && !matches!(stringify!($Name), "StandardListViewItem")
                 {
                     structs.push((
                         stringify!($Name).to_string(),

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -210,6 +210,94 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Generate the live-preview `into_slint_value`/`from_slint_value` for the builtin enums (which
+/// aren't in any document), each in its enum's namespace so ADL finds it.
+fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
+    let mut file = BufWriter::new(
+        std::fs::File::create(path.join("slint_live_preview_enums.h"))
+            .context("Error creating slint_live_preview_enums.h file")?,
+    );
+    writeln!(file, "#pragma once")?;
+    writeln!(file, "// This file is auto-generated from {}", file!())?;
+
+    // must match the enums' runtime `strum` kebab-case serialization
+    fn to_kebab_case(value: &str) -> String {
+        let mut result = String::with_capacity(value.len());
+        for c in value.chars() {
+            if c.is_ascii_uppercase() {
+                if !result.is_empty() {
+                    result.push('-');
+                }
+                result.push(c.to_ascii_lowercase());
+            } else {
+                result.push(c);
+            }
+        }
+        result
+    }
+
+    // (namespace, type, interpreter name, [(variant, value)]); namespace mirrors enums() for ADL
+    #[allow(clippy::type_complexity)]
+    let mut enums: Vec<(&str, String, String, Vec<(String, String)>)> = Vec::new();
+    macro_rules! collect_enums {
+        ($( $(#[doc = $enum_doc:literal])* $(#[non_exhaustive])? $vis:vis enum $Name:ident { $( $(#[doc = $value_doc:literal])* $Value:ident,)* })*) => {
+            $({
+                let namespace = match (stringify!($vis), stringify!($Name)) {
+                    ("pub", _) => "slint::language",
+                    (_, "Orientation") | (_, "AccessibleLiveness") => "slint",
+                    _ => "slint::cbindgen_private",
+                };
+                enums.push((
+                    namespace,
+                    format!("slint::cbindgen_private::{}", stringify!($Name)),
+                    stringify!($Name).replace('_', "-"),
+                    vec![$({
+                        let variant = stringify!($Value).trim_start_matches("r#");
+                        (variant.to_string(), to_kebab_case(variant))
+                    }),*],
+                ));
+            })*
+        };
+    }
+    i_slint_common::for_each_enums!(collect_enums);
+
+    for target_namespace in ["slint", "slint::language", "slint::cbindgen_private"] {
+        writeln!(file, "namespace {target_namespace} {{")?;
+        for (_, ty, enum_name, values) in enums.iter().filter(|e| e.0 == target_namespace) {
+            writeln!(
+                file,
+                "inline slint::interpreter::Value into_slint_value([[maybe_unused]] const {ty} &self) {{"
+            )?;
+            writeln!(file, "    switch (self) {{")?;
+            for (variant, value_str) in values {
+                writeln!(
+                    file,
+                    "    case {ty}::{variant}: return slint::private_api::live_preview::LiveReloadingComponent::value_from_enum(\"{enum_name}\", \"{value_str}\");"
+                )?;
+            }
+            writeln!(file, "    }}")?;
+            writeln!(file, "    return {{}};")?;
+            writeln!(file, "}}")?;
+            writeln!(
+                file,
+                "inline {ty} from_slint_value(const slint::interpreter::Value &val, const {ty} *) {{"
+            )?;
+            writeln!(
+                file,
+                "    auto value_str = slint::private_api::live_preview::LiveReloadingComponent::get_enum_value(val);"
+            )?;
+            for (variant, value_str) in values {
+                writeln!(file, "    if (value_str == \"{value_str}\") return {ty}::{variant};")?;
+            }
+            writeln!(file, "    return {{}};")?;
+            writeln!(file, "}}")?;
+        }
+        writeln!(file, "}} // namespace {target_namespace}")?;
+    }
+    file.flush()?;
+    Ok(())
+}
+
 fn ensure_cargo_rerun_for_crate(
     crate_dir: &Path,
     dependencies: &mut Vec<PathBuf>,
@@ -1161,6 +1249,9 @@ pub fn gen_all(
     }
     if enabled_features.interpreter {
         gen_interpreter(root_dir, &gen_dir, &mut deps)?;
+    }
+    if enabled_features.live_preview {
+        live_preview_enums(&gen_dir)?;
     }
     Ok(deps)
 }

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -169,8 +169,8 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Generate the live-preview `into_slint_value`/`from_slint_value` for the builtin enums (which
-/// aren't in any document), each in its enum's namespace so ADL finds it.
+/// Generate the live-preview `into_slint_value`/`from_slint_value` for the builtin enums and
+/// structs (which aren't in any document), each in its type's namespace so ADL finds it.
 fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
     let mut file = BufWriter::new(
         std::fs::File::create(path.join("slint_live_preview_enums.h"))
@@ -253,6 +253,56 @@ fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
         }
         writeln!(file, "}} // namespace {target_namespace}")?;
     }
+
+    // The public builtin structs (in slint::language) converted field by field, in their namespace
+    // so ADL finds them. StandardListViewItem is hand-written; DropEvent needs DataTransfer.
+    let mut structs: Vec<(String, Vec<String>)> = Vec::new();
+    macro_rules! collect_structs {
+        ($( $(#[$attr:meta])* $vis:vis struct $Name:ident {
+            $( $(#[$field_attr:meta])* $field:ident : $ty:ty,)*
+        })*) => {
+            $(
+                if stringify!($vis) == "pub"
+                    && !matches!(stringify!($Name), "StandardListViewItem" | "DropEvent")
+                {
+                    structs.push((
+                        stringify!($Name).to_string(),
+                        vec![$(stringify!($field).to_string()),*],
+                    ));
+                }
+            )*
+        };
+    }
+    i_slint_common::for_each_builtin_structs!(collect_structs);
+
+    writeln!(file, "namespace slint::language {{")?;
+    for (name, fields) in &structs {
+        let ty = format!("slint::language::{name}");
+        writeln!(file, "inline slint::interpreter::Value into_slint_value(const {ty} &self) {{")?;
+        writeln!(file, "    using slint::private_api::live_preview::into_slint_value;")?;
+        writeln!(file, "    slint::interpreter::Struct s;")?;
+        for field in fields {
+            writeln!(file, "    s.set_field(\"{field}\", into_slint_value(self.{field}));")?;
+        }
+        writeln!(file, "    return s;")?;
+        writeln!(file, "}}")?;
+        writeln!(
+            file,
+            "inline {ty} from_slint_value(const slint::interpreter::Value &val, const {ty} *) {{"
+        )?;
+        writeln!(file, "    auto s = val.to_struct().value();")?;
+        writeln!(file, "    {ty} r;")?;
+        for field in fields {
+            writeln!(
+                file,
+                "    r.{field} = slint::private_api::live_preview::from_slint_value<std::decay_t<decltype(r.{field})>>(s.get_field(\"{field}\").value());"
+            )?;
+        }
+        writeln!(file, "    return r;")?;
+        writeln!(file, "}}")?;
+    }
+    writeln!(file, "}} // namespace slint::language")?;
+
     file.flush()?;
     Ok(())
 }

--- a/api/cpp/include/private/slint_live_preview.h
+++ b/api/cpp/include/private/slint_live_preview.h
@@ -234,6 +234,43 @@ public:
         slint::cbindgen_private::slint_interpreter_value_enum_to_string(value.inner, &result);
         return result;
     }
+
+    // Conversions for the dedicated Value variants, which abuse the friend on Value
+    static slint::interpreter::Value value_from_data_transfer(const slint::DataTransfer &data)
+    {
+        return slint::interpreter::Value(
+                cbindgen_private::slint_interpreter_value_new_data_transfer(&data));
+    }
+    static slint::DataTransfer data_transfer_from_value(const slint::interpreter::Value &value)
+    {
+        if (auto *p = cbindgen_private::slint_interpreter_value_to_data_transfer(value.inner)) {
+            return *p;
+        }
+        return {};
+    }
+    static slint::interpreter::Value value_from_keys(const slint::Keys &keys)
+    {
+        return slint::interpreter::Value(cbindgen_private::slint_interpreter_value_new_keys(&keys));
+    }
+    static slint::Keys keys_from_value(const slint::interpreter::Value &value)
+    {
+        if (auto *p = cbindgen_private::slint_interpreter_value_to_keys(value.inner)) {
+            return *p;
+        }
+        return {};
+    }
+    static slint::interpreter::Value value_from_styled_text(const slint::StyledText &text)
+    {
+        return slint::interpreter::Value(
+                cbindgen_private::slint_interpreter_value_new_styled_text(&text));
+    }
+    static slint::StyledText styled_text_from_value(const slint::interpreter::Value &value)
+    {
+        if (auto *p = cbindgen_private::slint_interpreter_value_to_styled_text(value.inner)) {
+            return *p;
+        }
+        return {};
+    }
 };
 
 class LiveReloadModelWrapperBase : public private_api::ModelChangeListener
@@ -397,6 +434,37 @@ from_slint_value(const slint::interpreter::Value &value,
 }
 
 } // namespace slint::private_api::live_preview
+
+// Conversions for the dedicated Value variants, in slint:: so ADL finds them; after
+// LiveReloadingComponent, whose friend accessors they call into.
+namespace slint {
+inline slint::interpreter::Value into_slint_value(const slint::DataTransfer &val)
+{
+    return private_api::live_preview::LiveReloadingComponent::value_from_data_transfer(val);
+}
+inline slint::DataTransfer from_slint_value(const slint::interpreter::Value &val,
+                                            const slint::DataTransfer *)
+{
+    return private_api::live_preview::LiveReloadingComponent::data_transfer_from_value(val);
+}
+inline slint::interpreter::Value into_slint_value(const slint::Keys &val)
+{
+    return private_api::live_preview::LiveReloadingComponent::value_from_keys(val);
+}
+inline slint::Keys from_slint_value(const slint::interpreter::Value &val, const slint::Keys *)
+{
+    return private_api::live_preview::LiveReloadingComponent::keys_from_value(val);
+}
+inline slint::interpreter::Value into_slint_value(const slint::StyledText &val)
+{
+    return private_api::live_preview::LiveReloadingComponent::value_from_styled_text(val);
+}
+inline slint::StyledText from_slint_value(const slint::interpreter::Value &val,
+                                          const slint::StyledText *)
+{
+    return private_api::live_preview::LiveReloadingComponent::styled_text_from_value(val);
+}
+} // namespace slint
 
 // Builtin enum conversions (generated); after LiveReloadingComponent, which they call into.
 #    include "private/slint_live_preview_enums.h"

--- a/api/cpp/include/private/slint_live_preview.h
+++ b/api/cpp/include/private/slint_live_preview.h
@@ -398,4 +398,7 @@ from_slint_value(const slint::interpreter::Value &value,
 
 } // namespace slint::private_api::live_preview
 
+// Builtin enum conversions (generated); after LiveReloadingComponent, which they call into.
+#    include "private/slint_live_preview_enums.h"
+
 #endif // SLINT_FEATURE_LIVE_PREVIEW

--- a/api/cpp/include/private/slint_live_preview.h
+++ b/api/cpp/include/private/slint_live_preview.h
@@ -185,9 +185,9 @@ public:
     {
         assert_main_thread();
         std::array<interpreter::Value, sizeof...(Args)> args_values { into_slint_value(args)... };
-        cbindgen_private::Slice<cbindgen_private::Value *> args_slice {
-            reinterpret_cast<cbindgen_private::Value **>(args_values.data()), args_values.size()
-        };
+        auto args_slice = slint::private_api::make_slice(
+                reinterpret_cast<cbindgen_private::Value **>(args_values.data()),
+                args_values.size());
         interpreter::Value val(cbindgen_private::slint_live_preview_invoke(
                 inner, string_to_slice(name), args_slice));
         return val;

--- a/api/cpp/include/private/slint_live_preview.h
+++ b/api/cpp/include/private/slint_live_preview.h
@@ -72,11 +72,11 @@ inline slint::Image from_slint_value(const slint::interpreter::Value &val, const
     return val.to_image().value();
 }
 /// duration
-inline long int from_slint_value(const slint::interpreter::Value &val, const long int *)
+inline std::int64_t from_slint_value(const slint::interpreter::Value &val, const std::int64_t *)
 {
     return val.to_number().value();
 }
-inline interpreter::Value into_slint_value(const long int &val)
+inline interpreter::Value into_slint_value(const std::int64_t &val)
 {
     return double(val);
 }

--- a/api/cpp/include/private/slint_live_preview.h
+++ b/api/cpp/include/private/slint_live_preview.h
@@ -217,8 +217,8 @@ public:
 
     slint::Window &window() const
     {
-        const cbindgen_private::WindowAdapterRcOpaque *win_ptr = nullptr;
-        cbindgen_private::slint_live_preview_window(inner, &win_ptr);
+        const cbindgen_private::WindowAdapterRcOpaque *win_ptr =
+                cbindgen_private::slint_live_preview_window(inner);
         return const_cast<slint::Window &>(*reinterpret_cast<const slint::Window *>(win_ptr));
     }
 

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -378,8 +378,9 @@ public:
     }
 
     /// Returns the accessible-orientation of that element, if any.
-    std::optional<Orientation> accessible_orientation() const
+    std::optional<slint::language::Orientation> accessible_orientation() const
     {
+        using slint::language::Orientation;
         if (auto str = get_accessible_string_property(
                     cbindgen_private::AccessibleStringProperty::Orientation)) {
             if (*str == "horizontal")
@@ -391,8 +392,9 @@ public:
     }
 
     /// Returns the accessible-live-region of that element, if any.
-    std::optional<AccessibleLiveness> accessible_live_region() const
+    std::optional<slint::language::AccessibleLiveness> accessible_live_region() const
     {
+        using slint::language::AccessibleLiveness;
         if (auto str = get_accessible_string_property(
                     cbindgen_private::AccessibleStringProperty::LiveRegion)) {
             if (*str == "off")

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -38,6 +38,9 @@ pub use i_slint_backend_testing;
 #[cfg(feature = "slint-interpreter")]
 pub use slint_interpreter;
 
+#[cfg(feature = "live-preview")]
+pub use i_slint_live_preview;
+
 #[cfg(target_os = "android")]
 mod android {
     unsafe extern "C" {

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -540,7 +540,7 @@ macro_rules! for_each_enums {
             /// It indicates that an element is a live region whose content changes should be
             /// announced by assistive technologies.
             #[non_exhaustive]
-            enum AccessibleLiveness {
+            pub enum AccessibleLiveness {
                 /// Use in regions that present information that is of low-importance to the user.
                 /// Assistive technologies are expected to not announce changes unless the user explicitly asks for it.
                 Off,
@@ -568,7 +568,7 @@ macro_rules! for_each_enums {
 
             /// Represents the orientation of an element or widget such as the `Slider`.
             // (on purpose not #[non_exhaustive])
-            enum Orientation {
+            pub enum Orientation {
                 /// Element is oriented horizontally.
                 Horizontal,
                 /// Element is oriented vertically.

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -129,7 +129,7 @@ fn generate_public_component(
             "{{ nullptr, nullptr, nullptr, nullptr, \
                 nullptr, nullptr, nullptr, nullptr, nullptr, \
                 nullptr, nullptr, nullptr, nullptr, \
-                nullptr, nullptr, nullptr, \
+                nullptr, nullptr, nullptr, nullptr, \
                 slint::private_api::drop_in_place<{component_id}>, slint::private_api::dealloc }}"
         )),
         ..Default::default()

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -180,6 +180,58 @@ pub extern "C" fn slint_interpreter_value_to_image(val: &Value) -> Option<&Image
     }
 }
 
+/// Construct a new Value containing a DataTransfer
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_interpreter_value_new_data_transfer(
+    data: &i_slint_core::data_transfer::DataTransfer,
+) -> Box<Value> {
+    Box::new(Value::DataTransfer(data.clone()))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_interpreter_value_to_data_transfer(
+    val: &Value,
+) -> Option<&i_slint_core::data_transfer::DataTransfer> {
+    match val {
+        Value::DataTransfer(data) => Some(data),
+        _ => None,
+    }
+}
+
+/// Construct a new Value containing a Keys
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_interpreter_value_new_keys(keys: &i_slint_core::input::Keys) -> Box<Value> {
+    Box::new(Value::Keys(keys.clone()))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_interpreter_value_to_keys(
+    val: &Value,
+) -> Option<&i_slint_core::input::Keys> {
+    match val {
+        Value::Keys(keys) => Some(keys),
+        _ => None,
+    }
+}
+
+/// Construct a new Value containing a StyledText
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_interpreter_value_new_styled_text(
+    text: &i_slint_core::styled_text::StyledText,
+) -> Box<Value> {
+    Box::new(Value::StyledText(text.clone()))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn slint_interpreter_value_to_styled_text(
+    val: &Value,
+) -> Option<&i_slint_core::styled_text::StyledText> {
+    match val {
+        Value::StyledText(text) => Some(text),
+        _ => None,
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_enum_to_string(
     val: &Value,

--- a/internal/live-preview/live_component.rs
+++ b/internal/live-preview/live_component.rs
@@ -20,6 +20,8 @@ pub use slint_interpreter::{Compiler, ComponentInstance, DefaultTranslationConte
 pub struct LiveReloadingComponent {
     // because new_cyclic cannot return error, we need to initialize the instance after
     instance: Option<ComponentInstance>,
+    // Kept so the FFI can return a stable reference; the window is reused across reloads.
+    window_adapter: Option<Rc<dyn i_slint_core::window::WindowAdapter>>,
     watcher: Arc<Mutex<Watcher>>,
     compiler: Compiler,
     file_name: PathBuf,
@@ -43,6 +45,7 @@ impl LiveReloadingComponent {
             let watcher = Watcher::new(self_weak.clone());
             RefCell::new(Self {
                 instance: None,
+                window_adapter: None,
                 watcher,
                 compiler,
                 file_name,
@@ -65,6 +68,8 @@ impl LiveReloadingComponent {
         );
         let definition = self_mut.find_component(&result).expect("Cannot open component");
         let instance = definition.create()?;
+        self_mut.window_adapter =
+            Some(i_slint_core::window::WindowInner::from_pub(instance.window()).window_adapter());
         self_mut.instance = Some(instance);
         drop(self_mut);
         Ok(self_rc)
@@ -456,19 +461,17 @@ mod ffi {
         }
     }
 
-    /// Same precondition as slint_interpreter_component_instance_window
+    /// Return a borrowed pointer to the component's window adapter (valid while the component lives).
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_live_preview_window(
+    pub extern "C" fn slint_live_preview_window(
         component: &LiveReloadingComponentInner,
-        out: *mut *const i_slint_core::window::ffi::WindowAdapterRcOpaque,
-    ) {
+    ) -> *const i_slint_core::window::ffi::WindowAdapterRcOpaque {
         assert_eq!(
             core::mem::size_of::<Rc<dyn WindowAdapter>>(),
             core::mem::size_of::<i_slint_core::window::ffi::WindowAdapterRcOpaque>()
         );
         let borrow = component.borrow();
-        let adapter = i_slint_core::window::WindowInner::from_pub(borrow.instance().window())
-            .window_adapter();
-        unsafe { core::ptr::write(out as *mut *const Rc<dyn WindowAdapter>, &adapter as *const _) };
+        let adapter = borrow.window_adapter.as_ref().unwrap();
+        (adapter as *const Rc<dyn WindowAdapter>).cast()
     }
 }

--- a/tests/cases/accessibility/accessible_id.slint
+++ b/tests/cases/accessibility/accessible_id.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 // Test the accessible-id property for uniquely identifying widgets for automation
 
 export component TestCase inherits Rectangle {

--- a/tests/cases/accessibility/actions.slint
+++ b/tests/cases/accessibility/actions.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 component Button {
     callback clicked();
     accessible-role: button;

--- a/tests/cases/accessibility/live.slint
+++ b/tests/cases/accessibility/live.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 // Test the accessible-live-region property.
 
 export component TestCase inherits Window {

--- a/tests/cases/accessibility/live.slint
+++ b/tests/cases/accessibility/live.slint
@@ -44,7 +44,7 @@ export component TestCase inherits Window {
 /*
 
 ```rust
-use slint_testing::AccessibleLiveness;
+use slint::language::AccessibleLiveness;
 
 let instance = TestCase::new().unwrap();
 
@@ -74,21 +74,21 @@ const TestCase &instance = *handle;
 auto off = slint::testing::ElementHandle::find_by_accessible_label(handle, "off-region");
 assert_eq(off.size(), 1);
 assert(off[0].accessible_live_region().has_value());
-assert(*off[0].accessible_live_region() == slint::AccessibleLiveness::Off);
+assert(*off[0].accessible_live_region() == slint::language::AccessibleLiveness::Off);
 
 auto polite = slint::testing::ElementHandle::find_by_accessible_label(handle, "polite-region");
 assert_eq(polite.size(), 1);
-assert(*polite[0].accessible_live_region() == slint::AccessibleLiveness::Polite);
+assert(*polite[0].accessible_live_region() == slint::language::AccessibleLiveness::Polite);
 
 auto assertive = slint::testing::ElementHandle::find_by_accessible_label(handle, "assertive-region");
 assert_eq(assertive.size(), 1);
-assert(*assertive[0].accessible_live_region() == slint::AccessibleLiveness::Assertive);
+assert(*assertive[0].accessible_live_region() == slint::language::AccessibleLiveness::Assertive);
 
 auto d = slint::testing::ElementHandle::find_by_accessible_label(handle, "dynamic-region");
 assert_eq(d.size(), 1);
-assert(*d[0].accessible_live_region() == slint::AccessibleLiveness::Polite);
-instance.set_status_live(slint::AccessibleLiveness::Assertive);
-assert(*d[0].accessible_live_region() == slint::AccessibleLiveness::Assertive);
+assert(*d[0].accessible_live_region() == slint::language::AccessibleLiveness::Polite);
+instance.set_status_live(slint::language::AccessibleLiveness::Assertive);
+assert(*d[0].accessible_live_region() == slint::language::AccessibleLiveness::Assertive);
 
 auto none = slint::testing::ElementHandle::find_by_accessible_label(handle, "no-live");
 assert_eq(none.size(), 1);

--- a/tests/cases/accessibility/orientation.slint
+++ b/tests/cases/accessibility/orientation.slint
@@ -39,7 +39,7 @@ export component TestCase inherits Window {
 /*
 
 ```rust
-use slint_testing::Orientation;
+use slint::language::Orientation;
 
 let instance = TestCase::new().unwrap();
 
@@ -66,18 +66,18 @@ const TestCase &instance = *handle;
 auto h = slint::testing::ElementHandle::find_by_accessible_label(handle, "horizontal-slider");
 assert_eq(h.size(), 1);
 assert(h[0].accessible_orientation().has_value());
-assert(*h[0].accessible_orientation() == slint::Orientation::Horizontal);
+assert(*h[0].accessible_orientation() == slint::language::Orientation::Horizontal);
 
 auto v = slint::testing::ElementHandle::find_by_accessible_label(handle, "vertical-slider");
 assert_eq(v.size(), 1);
 assert(v[0].accessible_orientation().has_value());
-assert(*v[0].accessible_orientation() == slint::Orientation::Vertical);
+assert(*v[0].accessible_orientation() == slint::language::Orientation::Vertical);
 
 auto d = slint::testing::ElementHandle::find_by_accessible_label(handle, "dynamic-slider");
 assert_eq(d.size(), 1);
-assert(*d[0].accessible_orientation() == slint::Orientation::Horizontal);
-instance.set_slider_orientation(slint::Orientation::Vertical);
-assert(*d[0].accessible_orientation() == slint::Orientation::Vertical);
+assert(*d[0].accessible_orientation() == slint::language::Orientation::Horizontal);
+instance.set_slider_orientation(slint::language::Orientation::Vertical);
+assert(*d[0].accessible_orientation() == slint::language::Orientation::Vertical);
 
 auto b = slint::testing::ElementHandle::find_by_accessible_label(handle, "no-orientation");
 assert_eq(b.size(), 1);

--- a/tests/cases/accessibility/orientation.slint
+++ b/tests/cases/accessibility/orientation.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 // Test the accessible-orientation property.
 
 export component TestCase inherits Window {

--- a/tests/cases/bindings/two_way_binding_model.slint
+++ b/tests/cases/bindings/two_way_binding_model.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: interpreted models don't write back
+//ignore: cpp-live-preview
 
 import { ListView } from "std-widgets.slint";
 struct ModelItem {

--- a/tests/cases/bindings/two_way_binding_model_length.slint
+++ b/tests/cases/bindings/two_way_binding_model_length.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: interpreted models don't write back
+//ignore: cpp-live-preview
+
 // Verify that two-way bindings to a struct field of `length` type in a model
 // row apply the LogicalLength <-> f32 conversion correctly. This exercises the
 // `set_primitive_property_value` / `primitive_value_from_property_value` path

--- a/tests/cases/bindings/two_way_binding_model_nested.slint
+++ b/tests/cases/bindings/two_way_binding_model_nested.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: interpreted models don't write back
+//ignore: cpp-live-preview
+
 // Verify that two-way bindings to a model row work when the binding lives
 // inside an element that's nested *under* the for-loop body. This exercises
 // the `parent_level > 0` codegen path in the Rust generator and the

--- a/tests/cases/elements/dragarea_actions.slint
+++ b/tests/cases/elements/dragarea_actions.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// C++ live preview: no DataTransfer conversion
-//ignore: cpp-live-preview
-
 export global Api {
     pure callback make-data() -> data-transfer;
     in property <DragAction> next-action: DragAction.move;

--- a/tests/cases/elements/dragarea_actions.slint
+++ b/tests/cases/elements/dragarea_actions.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no DataTransfer conversion
+//ignore: cpp-live-preview
+
 export global Api {
     pure callback make-data() -> data-transfer;
     in property <DragAction> next-action: DragAction.move;

--- a/tests/cases/elements/dragarea_droparea.slint
+++ b/tests/cases/elements/dragarea_droparea.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no DataTransfer conversion
+//ignore: cpp-live-preview
+
 export global Api {
     pure callback string-to-transfer(string) -> data-transfer;
     pure callback image-to-transfer(image) -> data-transfer;

--- a/tests/cases/elements/dragarea_droparea.slint
+++ b/tests/cases/elements/dragarea_droparea.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// C++ live preview: no DataTransfer conversion
-//ignore: cpp-live-preview
-
 export global Api {
     pure callback string-to-transfer(string) -> data-transfer;
     pure callback image-to-transfer(image) -> data-transfer;

--- a/tests/cases/elements/dragarea_image.slint
+++ b/tests/cases/elements/dragarea_image.slint
@@ -1,5 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// C++ live preview: no DataTransfer conversion
+//ignore: cpp-live-preview
+
 //
 // Exercises the `drag-image` / `drag-image-offset-*` properties on `DragArea`.
 // The rendering side (an overlay drawn under the cursor) requires a real renderer to

--- a/tests/cases/elements/dragarea_image.slint
+++ b/tests/cases/elements/dragarea_image.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// C++ live preview: no DataTransfer conversion
-//ignore: cpp-live-preview
-
 //
 // Exercises the `drag-image` / `drag-image-offset-*` properties on `DragArea`.
 // The rendering side (an overlay drawn under the cursor) requires a real renderer to

--- a/tests/cases/elements/dragarea_modifiers.slint
+++ b/tests/cases/elements/dragarea_modifiers.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// C++ live preview: no DataTransfer conversion
-//ignore: cpp-live-preview
-
 //
 // Verifies that pressing modifier keys mid-drag updates `event.proposed-action`
 // and therefore the target's chosen `current-action`, even without mouse motion.

--- a/tests/cases/elements/dragarea_modifiers.slint
+++ b/tests/cases/elements/dragarea_modifiers.slint
@@ -1,5 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// C++ live preview: no DataTransfer conversion
+//ignore: cpp-live-preview
+
 //
 // Verifies that pressing modifier keys mid-drag updates `event.proposed-action`
 // and therefore the target's chosen `current-action`, even without mouse motion.

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 //include_path: ../../../demos/printerdemo/ui/images/
 
 component TestCase inherits Rectangle {

--- a/tests/cases/elements/key_binding.slint
+++ b/tests/cases/elements/key_binding.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no Keys conversion
+//ignore: cpp-live-preview
+
 export component TestCase inherits Window {
     in-out property <int> matches: 0;
     in-out property <bool> condition: false;

--- a/tests/cases/elements/key_binding_from_parts.slint
+++ b/tests/cases/elements/key_binding_from_parts.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no Keys conversion
+//ignore: cpp-live-preview
+
 // Test that `Keys` values created from backend code via `from_parts` work
 // correctly with `KeyBinding` elements: construction, property assignment,
 // and actual key-event matching.

--- a/tests/cases/elements/menubar_shortcut.slint
+++ b/tests/cases/elements/menubar_shortcut.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no Keys conversion
+//ignore: cpp-live-preview
+
 export component TestCase inherits Window {
     in-out property <string> result;
     in-out property <bool> show-open: false;

--- a/tests/cases/elements/systemtray_menu.slint
+++ b/tests/cases/elements/systemtray_menu.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: always exposes window(), forbidden for SystemTrayIcon roots
+//ignore: cpp-live-preview
+
 // cSpell: ignore SFINAE
 // Exercises lowering + code generation for a SystemTrayIcon with a Menu child,
 // including a separator and a nested sub-menu. At runtime the tray has no

--- a/tests/cases/expr/debug.slint
+++ b/tests/cases/expr/debug.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no anonymous-struct (tuple) conversion
+//ignore: cpp-live-preview
+
 enum MyEnum { alpha, beta, gamma }
 
 struct MyStruct {

--- a/tests/cases/expr/return3.slint
+++ b/tests/cases/expr/return3.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no KeyEvent conversion
+//ignore: cpp-live-preview
 
 component BackgroundExpr inherits Rectangle {
     in property <bool> cond;

--- a/tests/cases/expr/return3.slint
+++ b/tests/cases/expr/return3.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// C++ live preview: no KeyEvent conversion
-//ignore: cpp-live-preview
-
 component BackgroundExpr inherits Rectangle {
     in property <bool> cond;
     // conversion from color to brush do a Cast expression and this should work even when there is a return

--- a/tests/cases/models/delete_from_clicked.slint
+++ b/tests/cases/models/delete_from_clicked.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: interpreted models don't write back
+//ignore: cpp-live-preview
+
 export global Glob {
     in-out property <[string]> model: ["Hello", "World"];
     in-out property <bool> condition: true;

--- a/tests/cases/models/write_to_model.slint
+++ b/tests/cases/models/write_to_model.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: interpreted models don't write back
+//ignore: cpp-live-preview
 
 component TestCase inherits Rectangle {
     width: 300phx;

--- a/tests/cases/testing/dynamic_components.slint
+++ b/tests/cases/testing/dynamic_components.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 // cSpell:ignore testlabel newvalue
 
 export component TestCase {

--- a/tests/cases/testing/find_by_element_id_or_type.slint
+++ b/tests/cases/testing/find_by_element_id_or_type.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 component ButtonBase inherits Text { }
 
 component Button inherits ButtonBase {

--- a/tests/cases/translations/bundle.slint
+++ b/tests/cases/translations/bundle.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no bundled translations
+//ignore: cpp-live-preview
+
 // cSpell: ignore dans fichier fichiers Floup Même Plouf
 //bundle-translations
 

--- a/tests/cases/translations/bundle_no_context.slint
+++ b/tests/cases/translations/bundle_no_context.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no bundled translations
+//ignore: cpp-live-preview
+
 //bundle-translations
 //no-default-translation-context
 

--- a/tests/cases/translations/decimal_separator.slint
+++ b/tests/cases/translations/decimal_separator.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no bundled translations
+//ignore: cpp-live-preview
+
 // Check that the correct decimal separator is used when specifying a locale
 
 // Include this keyword to bundle the translations

--- a/tests/cases/types/builtin_enum_property.slint
+++ b/tests/cases/types/builtin_enum_property.slint
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A builtin enum exposed as a public property must convert to and from the interpreter Value,
+// for enums in different namespaces and for multi-word values.
+
+component TestCase inherits Rectangle {
+    in-out property <ColorScheme> scheme: dark;
+    in-out property <Orientation> orientation: horizontal;
+    in-out property <MouseCursor> cursor: no-drop;
+    in-out property <AccessibleRole> role: list-item;
+    out property <bool> test: scheme == ColorScheme.dark && orientation == Orientation.horizontal
+        && cursor == MouseCursor.no-drop && role == AccessibleRole.list-item;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+assert(instance.get_scheme() == slint::cbindgen_private::ColorScheme::Dark);
+assert(instance.get_orientation() == slint::cbindgen_private::Orientation::Horizontal);
+assert(instance.get_cursor() == slint::cbindgen_private::MouseCursor::NoDrop);
+assert(instance.get_role() == slint::cbindgen_private::AccessibleRole::ListItem);
+instance.set_cursor(slint::cbindgen_private::MouseCursor::ColResize);
+assert(instance.get_cursor() == slint::cbindgen_private::MouseCursor::ColResize);
+instance.set_role(slint::cbindgen_private::AccessibleRole::RadioButton);
+assert(instance.get_role() == slint::cbindgen_private::AccessibleRole::RadioButton);
+assert(!instance.get_test());
+```
+
+```rust
+use slint::private_unstable_api::re_exports as sp;
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(instance.get_scheme(), sp::ColorScheme::Dark);
+assert_eq!(instance.get_orientation(), sp::Orientation::Horizontal);
+assert_eq!(instance.get_cursor(), sp::MouseCursor::NoDrop);
+assert_eq!(instance.get_role(), sp::AccessibleRole::ListItem);
+instance.set_cursor(sp::MouseCursor::ColResize);
+assert_eq!(instance.get_cursor(), sp::MouseCursor::ColResize);
+instance.set_role(sp::AccessibleRole::RadioButton);
+assert_eq!(instance.get_role(), sp::AccessibleRole::RadioButton);
+assert!(!instance.get_test());
+```
+*/

--- a/tests/cases/types/keys.slint
+++ b/tests/cases/types/keys.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// C++ live preview: no Keys conversion
-//ignore: cpp-live-preview
-
 // Open me with the live-preview to see the logged keyboard events
 export component TestCase inherits Window {
     in-out property <[keys]> shortcuts: [

--- a/tests/cases/types/keys.slint
+++ b/tests/cases/types/keys.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no Keys conversion
+//ignore: cpp-live-preview
+
 // Open me with the live-preview to see the logged keyboard events
 export component TestCase inherits Window {
     in-out property <[keys]> shortcuts: [

--- a/tests/cases/types/logical_geometry.slint
+++ b/tests/cases/types/logical_geometry.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no LogicalSize conversion
+//ignore: cpp-live-preview
+
 export component TestCase inherits Window {
     in-out property <Point> p: { x: 1px, y: 2px };
     in-out property <Size> s: { width: 3px, height: 4px };

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no StyledText conversion
+//ignore: cpp-live-preview
+
 // cSpell: ignore ello
 
 export struct TestStruct {

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// C++ live preview: no StyledText conversion
-//ignore: cpp-live-preview
-
 // cSpell: ignore ello
 
 export struct TestStruct {

--- a/tests/cases/widgets/button.slint
+++ b/tests/cases/widgets/button.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 import { ComboBox, Button } from "std-widgets.slint";
 export component TestCase inherits Window {
 

--- a/tests/cases/widgets/checkbox.slint
+++ b/tests/cases/widgets/checkbox.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 import { CheckBox } from "std-widgets.slint";
 export component TestCase inherits Window {
 

--- a/tests/cases/widgets/radiogroup_for.slint
+++ b/tests/cases/widgets/radiogroup_for.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 import { RadioGroup } from "std-widgets.slint";
 
 export component TestCase inherits Window {

--- a/tests/cases/widgets/spinbox_default_value.slint
+++ b/tests/cases/widgets/spinbox_default_value.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
 
 import { SpinBox } from "std-widgets.slint";
 export component TestCase inherits Window {

--- a/tests/cases/widgets/switch.slint
+++ b/tests/cases/widgets/switch.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 import { Switch } from "std-widgets.slint";
 export component TestCase inherits Window {
 

--- a/tests/cases/widgets/timepicker.slint
+++ b/tests/cases/widgets/timepicker.slint
@@ -1,6 +1,9 @@
  // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 import { TimePickerPopup, Time, Button } from "std-widgets.slint";
 export { Time }
 

--- a/tests/driver/cpp/Cargo.toml
+++ b/tests/driver/cpp/Cargo.toml
@@ -35,3 +35,4 @@ test_driver_lib = { path = "../driverlib" }
 [features]
 default = ["backend-qt"]
 backend-qt = ["slint-cpp/backend-qt"]
+live-preview = ["slint-cpp/live-preview"]

--- a/tests/driver/cpp/build.rs
+++ b/tests/driver/cpp/build.rs
@@ -42,9 +42,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tests_file = BufWriter::new(std::fs::File::create(&tests_file_path)?);
 
+    let live_preview = std::env::var("SLINT_LIVE_PREVIEW").is_ok();
+    println!("cargo::rerun-if-env-changed=SLINT_LIVE_PREVIEW");
+
     for testcase in test_driver_lib::collect_test_cases("cases")? {
         let test_function_name = testcase.identifier();
-        let ignored = testcase.is_ignored("cpp");
+        let ignored = if testcase.is_ignored("cpp") {
+            "#[ignore = \"testcase ignored for cpp\"]"
+        } else if live_preview
+            && (testcase.is_ignored("live-preview") || testcase.is_ignored("cpp-live-preview"))
+        {
+            "#[ignore = \"testcase ignored in live-preview mode\"]"
+        } else {
+            ""
+        };
 
         write!(
             tests_file,
@@ -60,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }}
 
         "##,
-            ignore = if ignored { "#[ignore]" } else { "" },
+            ignore = ignored,
             function_name = test_function_name,
             absolute_path = testcase.absolute_path.to_string_lossy(),
             relative_path = testcase.relative_path.to_string_lossy(),


### PR DESCRIPTION
The Rust live-preview is exercised by the test-driver in CI, but the C++ one
wasn't because many cases failed. This enables it and fixes what was needed to
get a passing baseline.

Fixes #12095: builtin enums exposed as a public property
made the generated C++ live-preview code fail to compile, because no
`into_slint_value`/`from_slint_value` overload was generated for them. 
They're now generated once by cbindgen, each in the namespace where its enum is
declared so argument-dependent lookup finds it.

Along the way, several C++ live-preview FFI/codegen bugs are fixed:
- generated item-tree vtable was missing the `window_adapter` slot
- `slint_live_preview_window` returned a dangling pointer
- zero-argument `invoke` passed a null `Slice`
- the live-preview FFI symbols weren't linked into the cdylib

Cases that don't work yet in the C++ live-preview (element search, missing
builtin *struct* conversions, model write-back, bundled translations) are
skipped with a `cpp-live-preview` ignore that carries a one-line reason and
doesn't affect the Rust live-preview run.

Includes a follow-up moving `Orientation` and `AccessibleLiveness` to the
`slint::language` module — they're new public language enums but were
mistakenly generated under `slint::`.