### PR TITLE
nightly: let private builds still publish docs, and add 1.17 pre-release

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -15,7 +15,7 @@ on:
                 options:
                     - release       # Publish a versioned release: a draft GitHub release and a non-nightly extension.
                     - full-nightly  # Publish the website snapshot, plus the VS Code extension and the `nightly` release tag.
-                    - snapshot      # Publish the website snapshot (docs, demos, editor) only.
+                    - website-only  # Publish the website snapshot (docs, demos, editor) only.
                     - test          # Build everything, publish nothing.
 
 env:

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -7,21 +7,16 @@ name: Nightly snapshot
 on:
     workflow_dispatch:
         inputs:
-            private:
-                type: boolean
-                default: true
+            mode:
+                type: choice
+                default: test
                 required: false
-                description: "Private build? True means artifacts are only built. False means the artefacts are published (docs, vscode extension) to the web/marketplace"
-            snapshots_only:
-                type: boolean
-                default: false
-                required: false
-                description: "Only publish the website snapshots (docs, demos, editor). True skips the VS Code extension and the `nightly` release tag, so a single branch can own them. Ignored for private builds."
-            release:
-                type: boolean
-                default: false
-                required: false
-                description: "Release? Enable options for building binaries for a release (i.e. don't have a -nightly suffix for the extension)"
+                description: "What to build and publish"
+                options:
+                    - release       # Publish a versioned release: a draft GitHub release and a non-nightly extension.
+                    - full-nightly  # Publish the website snapshot, plus the VS Code extension and the `nightly` release tag.
+                    - snapshot      # Publish the website snapshot (docs, demos, editor) only.
+                    - test          # Build everything, publish nothing.
 
 env:
     # Keep in sync with features in slint_tool_binary.yaml, cpp_package.yaml, api/node/Cargo.toml, and api/python/slint/Cargo.toml
@@ -56,7 +51,7 @@ jobs:
         uses: ./.github/workflows/build_docs.yaml
         secrets: inherit
         with:
-          release: ${{ github.event.inputs.release }}
+          release: ${{ github.event.inputs.mode == 'release' }}
           app-id: ${{ vars.READ_WRITE_APP_ID }}
 
     wasm_demo:
@@ -68,7 +63,7 @@ jobs:
     cpp_package:
         uses: ./.github/workflows/cpp_package.yaml
         with:
-            extra_cmake_flags: ${{ github.event.inputs.release != 'true' && '-DCPACK_PACKAGE_VERSION=nightly' || '' }}
+            extra_cmake_flags: ${{ github.event.inputs.mode != 'release' && '-DCPACK_PACKAGE_VERSION=nightly' || '' }}
 
     check-for-secrets:
         runs-on: ubuntu-latest
@@ -279,7 +274,7 @@ jobs:
               run: chmod 755 editors/vscode/bin/* editors/vscode/bin/*.app/Contents/MacOS/*
             - name: "Prepare meta-data files for nightly package"
               env:
-                  RELEASE_INPUT: ${{ github.event.inputs.release }}
+                  RELEASE_INPUT: ${{ github.event.inputs.mode == 'release' }}
               working-directory: editors/vscode
               run: |
                   if grep -q 'lines below this marker are stripped from the release' README.md; then
@@ -303,12 +298,12 @@ jobs:
               with:
                   pat: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
                   registryUrl: https://marketplace.visualstudio.com
-                  dryRun: ${{ github.event.inputs.private == 'true' || github.event.inputs.snapshots_only == 'true' }}
+                  dryRun: ${{ github.event.inputs.mode != 'full-nightly' && github.event.inputs.mode != 'release' }}
                   packagePath: editors/vscode
                   dependencies: false
             - name: Publish to Open VSX Registry
               continue-on-error: true
-              if: ${{ github.event.inputs.private != 'true' && github.event.inputs.snapshots_only != 'true' }}
+              if: ${{ github.event.inputs.mode == 'full-nightly' || github.event.inputs.mode == 'release' }}
               uses: HaaLeo/publish-vscode-extension@v2
               with:
                   pat: ${{ secrets.OPENVSX_PAT }}
@@ -352,7 +347,7 @@ jobs:
                   path: tools/figma-inspector/zip
 
     #  publish_tree_sitter:
-    #    if: github.event.inputs.private != 'true'
+    #    if: github.event.inputs.mode != 'test'
     #    runs-on: ubuntu-22.04
     #    steps:
     #      - uses: actions/checkout@v6
@@ -363,7 +358,7 @@ jobs:
     #            path: editors/tree-sitter-slint
 
     publish_artifacts:
-        if: ${{ github.event.inputs.private != 'true' }}
+        if: ${{ github.event.inputs.mode != 'test' }}
         needs: [docs, wasm_demo, wasm, check-for-secrets, android]
         runs-on: ubuntu-22.04
         steps:
@@ -437,7 +432,7 @@ jobs:
 
             - name: Clone www-releases/releases and slintpad directory
               uses: actions/checkout@v6
-              if: ${{ github.event.inputs.release  == 'true' }}
+              if: ${{ github.event.inputs.mode == 'release' }}
               with:
                 repository: slint-ui/www-releases
                 path: www-releases
@@ -448,7 +443,7 @@ jobs:
 
             - name: Clone www-releases/snapshots directory
               uses: actions/checkout@v6
-              if: ${{ github.event.inputs.release  != 'true' }}
+              if: ${{ github.event.inputs.mode != 'release' }}
               with:
                 repository: slint-ui/www-releases
                 path: www-releases
@@ -459,7 +454,7 @@ jobs:
             - name: Publish Docs and Demos
               working-directory: ./www-releases
               run: |
-                if [[ "${{ github.event.inputs.release }}" == "true" ]]; then
+                if [[ "${{ github.event.inputs.mode == 'release' }}" == "true" ]]; then
                   output_path="releases/${{ steps.version.outputs.VERSION }}"
                 else
                   output_path="snapshots/${GITHUB_REF##*/}"
@@ -497,7 +492,7 @@ jobs:
                 mkdir -p $output_path/editor
                 cp -a ../slintpad/* $output_path/editor/
 
-                if [[ "${{ github.event.inputs.release }}" == "true" ]]; then
+                if [[ "${{ github.event.inputs.mode == 'release' }}" == "true" ]]; then
                   version="${{ steps.version.outputs.VERSION }}"
                 else
                   version="development snapshot"
@@ -511,26 +506,26 @@ jobs:
                 sed -i "s!https://slint.dev/releases/.*/docs/!../../!" $output_path/docs/rust/slint/*.html
 
             - name: Adjust redirections
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               run: |
                 sed -i "/1.0.2/! s,[0-9]*\.[0-9]*\.[0-9]*/\(.*\),${{ steps.version.outputs.VERSION }}/\1," www-releases/releases/_redirects
 
             - name: Adjust slintpad default tag
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               run: sed -i "s,XXXX_DEFAULT_TAG_XXXX,v${{ steps.version.outputs.VERSION }}," www-releases/releases/${{ steps.version.outputs.VERSION }}/editor/assets/*.js
 
             - name: Update versions.txt
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               working-directory: www-releases/releases
               run: ls -1d */ | cut -f1 -d'/' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort --version-sort -r > versions.txt
 
             - name: Print contents before update
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               working-directory: www-releases/releases
               run: cat versions.json
 
             - name: Update version in versions.json
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               working-directory: www-releases/releases
               run: |
                   sed -i '/"name": "development snapshot"/,/"preferred": true,/c\
@@ -545,12 +540,12 @@ jobs:
                       {' versions.json
 
             - name: Print contents before update
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               working-directory: www-releases/releases
               run: cat versions.json
 
             - name: Update SlintPad
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               run: |
                 rm -rf www-releases/slintpad
                 cp -r www-releases/releases/${{ steps.version.outputs.VERSION }}/editor www-releases/slintpad
@@ -583,7 +578,7 @@ jobs:
                 git push
 
     prepare_release:
-        if: github.event.inputs.private != 'true' && (github.event.inputs.snapshots_only != 'true' || github.event.inputs.release == 'true')
+        if: github.event.inputs.mode == 'full-nightly' || github.event.inputs.mode == 'release'
         needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin]
         runs-on: ubuntu-22.04
         permissions:
@@ -637,7 +632,7 @@ jobs:
             - name: prepare release notes
               id: version
               env:
-                   RELEASE_INPUT: ${{ github.event.inputs.release }}
+                   RELEASE_INPUT: ${{ github.event.inputs.mode == 'release' }}
               run: |
                   if [ "$RELEASE_INPUT" != "true" ]; then
                     notes_file=slint-src/docs/nightly-release-notes.md
@@ -668,7 +663,7 @@ jobs:
 
             - name: generate STM32 template packages
               env:
-                RELEASE_INPUT: ${{ github.event.inputs.release }}
+                RELEASE_INPUT: ${{ github.event.inputs.mode == 'release' }}
               run: |
                 git clone https://github.com/slint-ui/slint-cpp-templates-stm32 --depth 1
                 cd slint-cpp-templates-stm32
@@ -681,7 +676,7 @@ jobs:
                 done
 
             - uses: ncipollo/release-action@v1
-              if: github.event.inputs.release == 'true'
+              if: github.event.inputs.mode == 'release'
               with:
                   draft: true
                   artifacts: "artifacts/*"
@@ -690,7 +685,7 @@ jobs:
                   tag: v${{ steps.version.outputs.VERSION }}
                   commit: ${{ github.sha }}
             - uses: ncipollo/release-action@v1
-              if: github.event.inputs.release != 'true' && github.event.inputs.private != 'true'
+              if: github.event.inputs.mode == 'full-nightly'
               with:
                   allowUpdates: true
                   prerelease: true
@@ -702,7 +697,7 @@ jobs:
                   tag: nightly
                   commit: ${{ github.sha }}
             - name: trigger stm32 build
-              if: github.event.inputs.private != 'true'
+              if: github.event.inputs.mode == 'full-nightly' || github.event.inputs.mode == 'release'
               run: |
                 curl -L \
                 -X POST \

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -12,6 +12,11 @@ on:
                 default: true
                 required: false
                 description: "Private build? True means artifacts are only built. False means the artefacts are published (docs, vscode extension) to the web/marketplace"
+            snapshots_only:
+                type: boolean
+                default: false
+                required: false
+                description: "Only publish the website snapshots (docs, demos, editor). True skips the VS Code extension and the `nightly` release tag, so a single branch can own them. Ignored for private builds."
             release:
                 type: boolean
                 default: false
@@ -298,12 +303,12 @@ jobs:
               with:
                   pat: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
                   registryUrl: https://marketplace.visualstudio.com
-                  dryRun: ${{ github.event.inputs.private == 'true' || (github.ref != 'refs/heads/master' && github.event.inputs.release != 'true') }}
+                  dryRun: ${{ github.event.inputs.private == 'true' || github.event.inputs.snapshots_only == 'true' }}
                   packagePath: editors/vscode
                   dependencies: false
             - name: Publish to Open VSX Registry
               continue-on-error: true
-              if: ${{ github.event.inputs.private != 'true' && (github.ref == 'refs/heads/master' || github.event.inputs.release == 'true') }}
+              if: ${{ github.event.inputs.private != 'true' && github.event.inputs.snapshots_only != 'true' }}
               uses: HaaLeo/publish-vscode-extension@v2
               with:
                   pat: ${{ secrets.OPENVSX_PAT }}
@@ -578,7 +583,7 @@ jobs:
                 git push
 
     prepare_release:
-        if: github.event.inputs.private != 'true'
+        if: github.event.inputs.private != 'true' && (github.event.inputs.snapshots_only != 'true' || github.event.inputs.release == 'true')
         needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin]
         runs-on: ubuntu-22.04
         permissions:
@@ -685,7 +690,7 @@ jobs:
                   tag: v${{ steps.version.outputs.VERSION }}
                   commit: ${{ github.sha }}
             - uses: ncipollo/release-action@v1
-              if: github.event.inputs.release != 'true' && github.ref == 'refs/heads/master'
+              if: github.event.inputs.release != 'true' && github.event.inputs.private != 'true'
               with:
                   allowUpdates: true
                   prerelease: true
@@ -697,7 +702,7 @@ jobs:
                   tag: nightly
                   commit: ${{ github.sha }}
             - name: trigger stm32 build
-              if: github.ref == 'refs/heads/master'
+              if: github.event.inputs.private != 'true'
               run: |
                 curl -L \
                 -X POST \

--- a/.github/workflows/schedule_nightly_snapshot.yaml
+++ b/.github/workflows/schedule_nightly_snapshot.yaml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Exactly one branch has `snapshots_only: false`: it owns the `nightly` tag and the VS Code extension.
+        # Exactly one branch uses `mode: full-nightly`: it owns the `nightly` tag and the VS Code extension.
         include:
           - branch: pre-release/1.17
-            snapshots_only: false
+            mode: full-nightly
           - branch: master
-            snapshots_only: true
+            mode: snapshot
 
     steps:
       - uses: actions/checkout@v6
@@ -40,4 +40,4 @@ jobs:
         if: steps.recent.outputs.has_commits == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run "Nightly snapshot" --ref ${{ matrix.branch }} --repo ${{ github.repository }} -f private=false -f snapshots_only=${{ matrix.snapshots_only }}
+        run: gh workflow run "Nightly snapshot" --ref ${{ matrix.branch }} --repo ${{ github.repository }} -f mode=${{ matrix.mode }}

--- a/.github/workflows/schedule_nightly_snapshot.yaml
+++ b/.github/workflows/schedule_nightly_snapshot.yaml
@@ -19,7 +19,7 @@ jobs:
           - branch: pre-release/1.17
             mode: full-nightly
           - branch: master
-            mode: snapshot
+            mode: website-only
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/schedule_nightly_snapshot.yaml
+++ b/.github/workflows/schedule_nightly_snapshot.yaml
@@ -14,9 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch:
-          - pre-release/1.16
-          - master
+        # Exactly one branch has `snapshots_only: false`: it owns the `nightly` tag and the VS Code extension.
+        include:
+          - branch: pre-release/1.17
+            snapshots_only: false
+          - branch: master
+            snapshots_only: true
 
     steps:
       - uses: actions/checkout@v6
@@ -37,4 +40,4 @@ jobs:
         if: steps.recent.outputs.has_commits == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run "Nightly snapshot" --ref ${{ matrix.branch }} --repo ${{ github.repository }} -f private=false
+        run: gh workflow run "Nightly snapshot" --ref ${{ matrix.branch }} --repo ${{ github.repository }} -f private=false -f snapshots_only=${{ matrix.snapshots_only }}

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -33,8 +33,8 @@ Use this branch to collect fixes and run testing (apply cherry-picks here).
     ```
 
  2. Change .github/workflows/schedule_nightly_snapshot.yaml to include that pre-release branch in the matrix
-    with `snapshots_only: false`, and switch `master` to `snapshots_only: true`.
-    Exactly one branch has `snapshots_only: false`: it owns the `nightly` tag and the VS Code extension.
+    with `mode: full-nightly`, and switch `master` to `mode: snapshot`.
+    Exactly one branch uses `mode: full-nightly`: it owns the `nightly` tag and the VS Code extension.
     This commit needs to be done in the `master` branch.
 
  3. Send a discussion in the ["Show And Tell" category](https://github.com/slint-ui/slint/discussions/categories/show-and-tell)
@@ -70,7 +70,7 @@ In the mean time, the version in the master branch can be updated
  - Check that the CI is green for the top of the branch commit
 
  - **Trigger a build of binary artifacts** (docs, demos, etc.) on https://github.com/slint-ui/slint/actions/workflows/nightly_snapshot.yaml
-    Select the right `pre-release/x.y` branch, and choose false for private and true for release.
+    Select the right `pre-release/x.y` branch, and choose `release` for the mode.
     As a result artifacts will be built and made available for download and a new VS code extension be built and uploaded to the market places (open-vsx.org and microsoft).
 
  - **Publish to crates.io** using the `./scripts/publish.sh`.
@@ -144,8 +144,8 @@ In the mean time, the version in the master branch can be updated
 
 * [Update tree-sitter configurations for editors](https://github.com/slint-ui/wiki/blob/309a3b0327731ba2cfb229595e0fa7209ba868c6/infrastructure/release_checklist.md?plain=1#L91)
 
-* In `.github/workflows/schedule_nightly_snapshot.yaml` (on `master`), give the `snapshots_only: false` slot back to
-  `master`: set the released branch to `snapshots_only: true` and `master` to `snapshots_only: false`.
+* In `.github/workflows/schedule_nightly_snapshot.yaml` (on `master`), give the `mode: full-nightly` slot back to
+  `master`: set the released branch to `mode: snapshot` and `master` to `mode: full-nightly`.
 
 ## Patch Releases
 

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -33,7 +33,7 @@ Use this branch to collect fixes and run testing (apply cherry-picks here).
     ```
 
  2. Change .github/workflows/schedule_nightly_snapshot.yaml to include that pre-release branch in the matrix
-    with `mode: full-nightly`, and switch `master` to `mode: snapshot`.
+    with `mode: full-nightly`, and switch `master` to `mode: website-only`.
     Exactly one branch uses `mode: full-nightly`: it owns the `nightly` tag and the VS Code extension.
     This commit needs to be done in the `master` branch.
 
@@ -145,7 +145,7 @@ In the mean time, the version in the master branch can be updated
 * [Update tree-sitter configurations for editors](https://github.com/slint-ui/wiki/blob/309a3b0327731ba2cfb229595e0fa7209ba868c6/infrastructure/release_checklist.md?plain=1#L91)
 
 * In `.github/workflows/schedule_nightly_snapshot.yaml` (on `master`), give the `mode: full-nightly` slot back to
-  `master`: set the released branch to `mode: snapshot` and `master` to `mode: full-nightly`.
+  `master`: set the released branch to `mode: website-only` and `master` to `mode: full-nightly`.
 
 ## Patch Releases
 

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -32,7 +32,9 @@ Use this branch to collect fixes and run testing (apply cherry-picks here).
     git push origin origin/master:pre-release/<major.minor>
     ```
 
- 2. Change .github/workflows/schedule_nightly_snapshot.yaml to include that pre-release branch in the matrix.
+ 2. Change .github/workflows/schedule_nightly_snapshot.yaml to include that pre-release branch in the matrix
+    with `snapshots_only: false`, and switch `master` to `snapshots_only: true`.
+    Exactly one branch has `snapshots_only: false`: it owns the `nightly` tag and the VS Code extension.
     This commit needs to be done in the `master` branch.
 
  3. Send a discussion in the ["Show And Tell" category](https://github.com/slint-ui/slint/discussions/categories/show-and-tell)
@@ -141,6 +143,9 @@ In the mean time, the version in the master branch can be updated
 * Notify Torizon guys to update the base images that contain Slint or create PR for https://github.com/commontorizon/Containerfiles
 
 * [Update tree-sitter configurations for editors](https://github.com/slint-ui/wiki/blob/309a3b0327731ba2cfb229595e0fa7209ba868c6/infrastructure/release_checklist.md?plain=1#L91)
+
+* In `.github/workflows/schedule_nightly_snapshot.yaml` (on `master`), give the `snapshots_only: false` slot back to
+  `master`: set the released branch to `snapshots_only: true` and `master` to `snapshots_only: false`.
 
 ## Patch Releases
 


### PR DESCRIPTION
The nightly tag and the vscode extension can only have one release, so they must come from a single branch. Make the private input only gate publishing to the store and the nightly tag; docs and demos still go to the website snapshots. Schedule master as private and let the pre-release branch publish the nightly tag and the extension.
