### PR TITLE
Fix crash with a GridLayout with repeated rows in a sub-component

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -611,6 +611,27 @@ fn fixup_reference(nr: &mut NamedReference, mapping: &Mapping) {
     }
 }
 
+/// Remap all the element references stored in a grid layout (the cell items and
+/// the repeated-row child templates) through the inlining `mapping`.
+fn fixup_grid_layout(layout: &mut crate::layout::GridLayout, fxe: &impl Fn(&mut ElementRc)) {
+    for e in &mut layout.elems {
+        fxe(&mut e.item.element);
+    }
+    // Break the cell Rc sharing with the original before remapping the elements
+    // stored inside the repeated-row cells.
+    layout.clone_cells();
+    for elem in &mut layout.elems {
+        let mut cell = elem.cell.borrow_mut();
+        let Some(child_items) = &mut cell.child_items else { continue };
+        for child in child_items.iter_mut() {
+            fxe(&mut child.layout_item_mut().element);
+            if let crate::layout::RowChildTemplate::Repeated { repeated_element, .. } = child {
+                fxe(repeated_element);
+            }
+        }
+    }
+}
+
 fn fixup_element_references(expr: &mut Expression, mapping: &Mapping) {
     let fx = |element: &mut std::rc::Weak<RefCell<Element>>| {
         if let Some(e) = element.upgrade().and_then(|e| mapping.get(&element_key(e))) {
@@ -638,16 +659,10 @@ fn fixup_element_references(expr: &mut Expression, mapping: &Mapping) {
             }
         }
         Expression::SolveGridLayout { layout, .. } | Expression::OrganizeGridLayout(layout) => {
-            for e in &mut layout.elems {
-                fxe(&mut e.item.element);
-            }
-            layout.clone_cells();
+            fixup_grid_layout(layout, &fxe);
         }
         Expression::ComputeGridLayoutInfo { layout, cross_axis_size, .. } => {
-            for e in &mut layout.elems {
-                fxe(&mut e.item.element);
-            }
-            layout.clone_cells();
+            fixup_grid_layout(layout, &fxe);
             if let Some(cas) = cross_axis_size {
                 fixup_element_references(cas, mapping);
             }

--- a/tests/cases/layout/grid_repeated_row_in_subcomponent.slint
+++ b/tests/cases/layout/grid_repeated_row_in_subcomponent.slint
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #12123: a GridLayout containing a repeated Row used to
+// crash with "Item not found" when its component was instantiated (and thus
+// inlined) into another component. Inlining cloned the grid cells but did not
+// remap the element references stored inside the repeated-row child templates.
+
+component Inner {
+    in property <[length]> heights: [30phx, 40phx, 50phx];
+    GridLayout {
+        spacing: 0phx;
+        padding: 0phx;
+        for h in heights: Row {
+            Rectangle {
+                min-height: h;
+                max-height: h;
+            }
+        }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200phx;
+    height: 200phx;
+
+    inner := Inner { }
+
+    out property <length> inner-min-height: inner.min-height;
+    out property <bool> test: inner.min-height == 120phx;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+assert_eq(instance.get_inner_min_height(), 120.);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(instance.get_inner_min_height(), 120.);
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+assert.equal(instance.inner_min_height, 120.);
+```
+
+*/

--- a/tests/cases/layout/grid_repeated_row_in_subcomponent.slint
+++ b/tests/cases/layout/grid_repeated_row_in_subcomponent.slint
@@ -35,20 +35,20 @@ export component TestCase inherits Window {
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-assert(instance.get_test());
 assert_eq(instance.get_inner_min_height(), 120.);
+assert(instance.get_test());
 ```
 
 ```rust
 let instance = TestCase::new().unwrap();
-assert!(instance.get_test());
 assert_eq!(instance.get_inner_min_height(), 120.);
+assert!(instance.get_test());
 ```
 
 ```js
 var instance = new slint.TestCase();
-assert(instance.test);
 assert.equal(instance.inner_min_height, 120.);
+assert(instance.test);
 ```
 
 */


### PR DESCRIPTION
When inlining a component, the element references stored in the repeated-row cells of a GridLayout were not remapped to the inlined copies, leading to a panic when computing the layout info.

Fixes: #12123
