### PR TITLE
FlexboxLayout: don't stretch wrapped column items to the full container width

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -252,7 +252,14 @@ pub(super) fn solve_box_layout(
     ctx: &mut ExpressionLoweringCtx,
 ) -> llr_Expression {
     let (padding, spacing) = generate_layout_padding_and_spacing(&layout.geometry, o, ctx);
-    let bld = box_layout_data(layout, o, ctx, None);
+    // For a horizontal layout's main (width) pass, feed each width-for-height
+    // child the layout's real cross size (its content height) instead of the
+    // `f32::MAX` "assume infinite height" fallback, so the width reserved for the
+    // child matches the height it will actually be given.
+    let cross_override = (o == layout.orientation && o == Orientation::Horizontal)
+        .then(|| layout_cross_content_size(layout))
+        .flatten();
+    let bld = box_layout_data(layout, o, ctx, cross_override.as_ref());
     let size = layout_geometry_size(&layout.geometry.rect, o, ctx);
     let (data, function) = if o == layout.orientation {
         let data = make_struct(
@@ -331,8 +338,8 @@ pub(super) fn solve_flexbox_layout(
         generate_layout_padding_and_spacing(&layout.geometry, Orientation::Vertical, ctx);
     // At solve time, the container width is known (set by our parent).
     // For column-direction flex (vertical main axis), each cell is
-    // stretched to the container's width, so it's the correct width to
-    // supply as the cross-axis constraint to height-for-width children.
+    // at most as wide as the container (per-column when wrapped), an upper
+    // bound to supply as the cross-axis constraint to height-for-width children.
     let container_width_for_cells = if matches!(
         layout.axis_relation(Orientation::Vertical),
         crate::layout::FlexboxAxisRelation::MainAxis
@@ -1429,6 +1436,29 @@ fn default_cross_axis_constraint(elem: &ElementRc) -> Option<crate::expression_t
         base: Box::new(expr),
         name: "preferred".into(),
     })
+}
+
+/// Build an expression for the layout's cross-axis *content* size
+/// (`self.height` minus top/bottom padding, for a horizontal layout).
+fn layout_cross_content_size(
+    layout: &crate::layout::BoxLayout,
+) -> Option<crate::expression_tree::Expression> {
+    use crate::expression_tree::Expression;
+    let cross = layout.orientation.orthogonal();
+    let size_nr = layout.geometry.rect.size_reference(cross)?.clone();
+    let mut expr = Expression::PropertyReference(size_nr);
+    let pads = match cross {
+        Orientation::Horizontal => [&layout.geometry.padding.left, &layout.geometry.padding.right],
+        Orientation::Vertical => [&layout.geometry.padding.top, &layout.geometry.padding.bottom],
+    };
+    for p in pads.into_iter().flatten() {
+        expr = Expression::BinaryExpression {
+            lhs: Box::new(expr),
+            rhs: Box::new(Expression::PropertyReference(p.clone())),
+            op: '-',
+        };
+    }
+    Some(expr)
 }
 
 fn layout_geometry_size(

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1414,6 +1414,16 @@ mod flexbox_taffy {
         pub fn new(params: FlexboxLayoutParams) -> Self {
             let mut taffy = TaffyTree::<usize>::new();
 
+            // Cross-axis (width) upper bound for a column item: never wider than
+            // the container's content box, so height-for-width items (e.g. wrapped
+            // Text) measure against a real width.
+            let column_cross_cap = match params.flex_direction {
+                TaffyFlexDirection::Column | TaffyFlexDirection::ColumnReverse => params
+                    .container_width
+                    .map(|cw| (cw - params.padding_h.begin - params.padding_h.end).max(0 as Coord)),
+                _ => None,
+            };
+
             // Create child nodes from Slint constraints
             let mut children: Vec<NodeId> = params
                 .cells_h
@@ -1443,6 +1453,13 @@ mod flexbox_taffy {
                         }
                     };
 
+                    let max_width = h_constraint.max.min(column_cross_cap.unwrap_or(Coord::MAX));
+                    let max_width_dim = if max_width < Coord::MAX {
+                        Dimension::length(max_width as _)
+                    } else {
+                        Dimension::auto()
+                    };
+
                     taffy
                         .new_leaf_with_context(
                             Style {
@@ -1451,12 +1468,21 @@ mod flexbox_taffy {
                                     width: match params.flex_direction {
                                         TaffyFlexDirection::Column
                                         | TaffyFlexDirection::ColumnReverse => {
-                                            // Cross-axis for column
-                                            if let Some(cw) = params.container_width {
-                                                // Fit inside the container's content box (subtract padding)
-                                                let pad =
-                                                    params.padding_h.begin + params.padding_h.end;
-                                                Dimension::length((cw - pad).max(0 as Coord) as _)
+                                            // Stretching items get `auto` width so they
+                                            // size to their flex *line's* cross size (the
+                                            // per-column width when wrapped), not the whole
+                                            // container. A per-item `flex-align-self`
+                                            // overrides the container's alignment.
+                                            let stretches = match cell_h.flex_align_self {
+                                                FlexboxLayoutAlignSelf::Auto => {
+                                                    params.cross_axis_alignment
+                                                        == CrossAxisAlignment::Stretch
+                                                }
+                                                FlexboxLayoutAlignSelf::Stretch => true,
+                                                _ => false,
+                                            };
+                                            if stretches {
+                                                Dimension::auto()
                                             } else if preferred_width > 0 as Coord {
                                                 Dimension::length(preferred_width as _)
                                             } else {
@@ -1488,11 +1514,7 @@ mod flexbox_taffy {
                                     ),
                                 },
                                 max_size: Size {
-                                    width: if h_constraint.max < Coord::MAX {
-                                        Dimension::length(h_constraint.max as _)
-                                    } else {
-                                        Dimension::auto()
-                                    },
+                                    width: max_width_dim,
                                     height: if let Some(vc) = v_constraint {
                                         if vc.max < Coord::MAX {
                                             Dimension::length(vc.max as _)

--- a/tests/cases/layout/flexbox_column_definite_width_no_stretch.slint
+++ b/tests/cases/layout/flexbox_column_definite_width_no_stretch.slint
@@ -1,0 +1,93 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression tests for the column-flex stretch behavior.
+//
+// Items use `preferred-width` (definite preferred cross size, but no maximum) so
+// they are horizontally stretchable while their wrap geometry stays deterministic
+// across backends (no font metrics involved). The Text children are only there so
+// a human running the test can see which item is which.
+
+export component TestCase inherits Window {
+    width: 500px;
+    height: 400px;
+
+    // --- Test 1 -------------------------------------------------------------
+    // A flex-direction:column FlexboxLayout is given a *definite* width that is
+    // wider than its content needs, plus a height that forces the items to wrap
+    // into a second column. The wrapped columns must pack at their flex-line
+    // width and stay inside the flex; they must NOT each stretch to the full
+    // container width (which would push the second column outside the flex).
+    // The bordered Rectangle just marks the flex's bounds when viewed by a human.
+    Rectangle { x: 0; y: 0; width: 300px; height: 96px; border-width: 1px; border-color: gray; }
+    flex := FlexboxLayout {
+        flex-direction: column;
+        x: 0;
+        y: 0;
+        width: 300px;     // generous, much wider than one item column
+        height: 96px;     // forces the 3 items to wrap into 2 columns
+        spacing: 8px;
+
+        b1 := Rectangle { preferred-width: 100px; height: 40px; background: #c33; Text { text: "Portrait"; color: white; } }
+        b2 := Rectangle { preferred-width: 100px; height: 40px; background: #3c3; Text { text: "Landscape"; color: white; } }
+        b3 := Rectangle { preferred-width: 100px; height: 40px; background: #36c; Text { text: "Auto"; color: white; } }
+    }
+
+    // b3 must have wrapped into a 2nd column (x > 0) and the whole column
+    // contents must stay within the flex's 300px width.
+    out property <bool> wrapped: b3.x > 0px;
+    out property <bool> no_overflow: b3.x + b3.width <= 300px && b1.x + b1.width <= 300px;
+
+    // --- Test 2 -------------------------------------------------------------
+    // Per-item `flex-align-self: stretch` must win even when the container's
+    // `cross-axis-alignment` is NOT stretch. Here the container aligns items to
+    // the start (so plain items keep their preferred 100px width), but s3 opts
+    // into stretch and must therefore fill its flex line's cross size, which the
+    // default `align-content: stretch` grows wider than 100px.
+    Rectangle { x: 0; y: 200px; width: 300px; height: 96px; border-width: 1px; border-color: gray; }
+    flex2 := FlexboxLayout {
+        flex-direction: column;
+        cross-axis-alignment: start;
+        x: 0;
+        y: 200px;
+        width: 300px;
+        height: 96px;     // same wrap as above: s1+s2 in column 1, s3 in column 2
+        spacing: 8px;
+
+        s1 := Rectangle { preferred-width: 100px; height: 40px; background: #c33; Text { text: "start"; color: white; } }
+        s2 := Rectangle { preferred-width: 100px; height: 40px; background: #3c3; Text { text: "start"; color: white; } }
+        s3 := Rectangle { preferred-width: 100px; height: 40px; flex-align-self: stretch; background: #36c; Text { text: "stretch"; color: white; } }
+    }
+
+    // s1 keeps its preferred width (container start-aligns it); s3 stretches to
+    // its flex line, which is wider, so it must end up wider than s1.
+    out property <bool> align_self_stretches: s3.width > s1.width;
+
+    out property <bool> test: wrapped && no_overflow && align_self_stretches;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_wrapped());
+assert(handle->get_no_overflow());
+assert(handle->get_align_self_stretches());
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_wrapped(), "b3 should wrap to a 2nd column");
+assert!(instance.get_no_overflow(), "column contents overflow the 300px flex");
+assert!(instance.get_align_self_stretches(), "s3 with flex-align-self:stretch should be wider than start-aligned s1");
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.wrapped);
+assert(instance.no_overflow);
+assert(instance.align_self_stretches);
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_in_hlayout_overlap.slint
+++ b/tests/cases/layout/flexbox_in_hlayout_overlap.slint
@@ -1,0 +1,79 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for https://github.com/slint-ui/slint/issues/11936
+//
+// A column-direction FlexboxLayout nested in a HorizontalLayout. The window is
+// short enough to force the column to wrap into a *second* column. The flex must
+// report its full (two-column) width to the parent so the sibling flex is placed
+// to the right of the wrapped content. The bug: it reported only the first
+// column's width, so the parent placed the sibling over the wrapped second
+// column and the two collided.
+//
+// Fixed sizes (no font metrics) keep the wrap geometry deterministic on every
+// backend. The collision is between the *content* of the two flexes, so the
+// assertion compares content edges, not the (previously under-reported) flex
+// width.
+
+export component TestCase inherits Window {
+    width: 600px;
+    height: 120px;   // short on purpose: forces the column to wrap into 2 columns
+
+    HorizontalLayout {
+        alignment: start;
+        spacing: 24px;
+        padding: 12px;
+
+        f1 := FlexboxLayout {
+            flex-direction: column;
+            spacing: 8px;
+            r1 := Rectangle { width: 100px; height: 40px; background: #c33; Text { text: "1"; color: white; } }
+            r2 := Rectangle { width: 100px; height: 40px; background: #3c3; Text { text: "2"; color: white; } }
+            r3 := Rectangle { width: 100px; height: 40px; background: #36c; Text { text: "3"; color: white; } }
+        }
+
+        f2 := FlexboxLayout {
+            flex-direction: row;
+            spacing: 8px;
+            m := Rectangle { width: 60px; height: 40px; background: #c93; Text { text: "R"; color: white; } }
+        }
+    }
+
+    out property <length> f1_width: f1.width;
+    // rightmost edge of f1's actual content (the wrapped 2nd column)
+    out property <length> f1_content_right: f1.x + max(r1.x + r1.width, max(r2.x + r2.width, r3.x + r3.width));
+    // leftmost edge of f2's content
+    out property <length> f2_content_left: f2.x + m.x;
+
+    // r3 must have wrapped into a 2nd column for this test to exercise the bug.
+    out property <bool> wrapped: r3.x > 0px;
+    // The sibling flex must not overlap the wrapped column.
+    out property <bool> no_overlap: f2_content_left >= f1_content_right;
+
+    out property <bool> test: wrapped && no_overlap;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_wrapped());
+assert(handle->get_no_overlap());
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_wrapped(), "r3 should wrap into a 2nd column");
+assert!(instance.get_no_overlap(),
+    "sibling flex overlaps the wrapped column: f2 content left = {}, f1 content right = {}",
+    instance.get_f2_content_left(), instance.get_f1_content_right());
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.wrapped);
+assert(instance.no_overlap);
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
Two related fixes for a column-direction FlexboxLayout that wraps into
multiple columns.

* i-slint-core: a column flex with a definite width hard-set each item's
cross-axis (width) to the container width. With wrapping, every column
became full-width, so the second column was placed past the container and
overflowed. Leave the item width `auto` so cross-axis-alignment:stretch
sizes it to its flex line's cross size (the per-column width when wrapped),
and cap max_size.width to the container content width so height-for-width
items (e.g. wrapped Text) still measure against a definite width.

* Compiler (LLR): a FlexboxLayout nested in another layout under-reported its
width when wrapping -- it reported only the first column's width, so the
parent placed the sibling over the wrapped second column.
For a horizontal layout's width pass, feed each width-for-height
child the layout's real cross size (its content height) instead of the
f32::MAX "assume infinite height" fallback, so the nested flex reports its
true wrapped width.

Fixes #11936