### PR TITLE
Fix C++ repeater layout not invalidating when populated

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -1146,11 +1146,7 @@ public:
     /// Register the instance generation as a dependency of the current
     /// tracking scope. Layout code uses this to re-evaluate only after
     /// ensure_updated materializes instance changes.
-    void track_instance_changes() const
-    {
-        if (inner)
-            instance_generation.register_as_dependency();
-    }
+    void track_instance_changes() const { instance_generation.register_as_dependency(); }
 
     /// Register the ListView viewport properties as dependencies so that
     /// scrolling triggers a redraw.  Model dependencies are registered by

--- a/tests/cases/layout/repeater_eager_init_preferred_size.slint
+++ b/tests/cases/layout/repeater_eager_init_preferred_size.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #12128: a component created by an outer repeater whose
+// layout preferred-height depends on an inner repeater must invalidate its
+// cached layout info once the inner repeater is instantiated, even when
+// preferred-height is read eagerly during `init` (before the inner repeater
+// exists). The C++ Repeater used to skip registering the instance-generation
+// dependency while it had no instances, so the cached value stayed frozen.
+// (Worked with `if` because Conditional always registered the dependency.)
+
+component Row inherits Rectangle {
+    height: 25phx;
+}
+
+component List inherits Rectangle {
+    in property <int> count;
+    preferred-height: lay.preferred-height;
+    // Force eager evaluation of preferred-height before the inner repeater is
+    // instantiated. This is what exposes the bug.
+    init => {
+        debug("List init preferred-height:", self.preferred-height / 1phx);
+    }
+    lay := VerticalLayout {
+        for i in root.count: Row { }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200phx;
+    height: 200phx;
+
+    outer := VerticalLayout {
+        for x in 1: List {
+            count: 8;
+        }
+    }
+
+    out property <length> measured: outer.preferred-height;
+    out property <bool> test: outer.preferred-height == 200phx;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_measured(), 200.);
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_measured(), 200.);
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert.equal(instance.measured, 200.);
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
The C++ Repeater::track_instance_changes() only registered the instance-generation dependency when it already had instances. A layout whose preferred size is read eagerly during init (before the inner repeater is populated) therefore registered no dependency, so the cached layout info stayed frozen once the repeater filled in. Register the dependency unconditionally, matching Conditional and the Rust runtime.

Fixes: #12128
