### PR TITLE
Don't error on a redundant size constraint on a popup root

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -198,11 +198,15 @@ pub struct LayoutConstraints {
 }
 
 impl LayoutConstraints {
-    /// Build the constraints for the given element
+    /// Build the constraints for the given element.
     ///
-    /// Report diagnostics when both constraints and fixed size are set
-    /// (one can set the level to warning to keep compatibility to old version of Slint)
-    pub fn new(element: &ElementRc, diag: &mut BuildDiagnostics, level: DiagnosticLevel) -> Self {
+    /// When `diag` is `Some`, a redundant size constraint (e.g. both `width` and `min-width`) is
+    /// reported at the given level; pass `None` to compute the constraints without reporting (e.g.
+    /// when another pass owns that diagnostic).
+    pub fn new(
+        element: &ElementRc,
+        mut diag: Option<(&mut BuildDiagnostics, DiagnosticLevel)>,
+    ) -> Self {
         let mut constraints = Self {
             min_width: binding_reference(element, "min-width"),
             max_width: binding_reference(element, "max-width"),
@@ -226,7 +230,8 @@ impl LayoutConstraints {
                         &other_prop.element(),
                         other_prop.name(),
                         |old, enclosing2, d2| {
-                            if Weak::ptr_eq(enclosing1, enclosing2)
+                            if let Some((diag, level)) = &mut diag
+                                && Weak::ptr_eq(enclosing1, enclosing2)
                                 && old.priority.saturating_add(d2)
                                     <= binding.priority.saturating_add(depth)
                             {
@@ -236,7 +241,7 @@ impl LayoutConstraints {
                                         other_prop.name()
                                     ),
                                     binding.to_source_location(),
-                                    level,
+                                    *level,
                                 );
                             }
                         },

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -189,7 +189,7 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
                         return None;
                     }
                     let explicit_constraints =
-                        LayoutConstraints::new(c, diag, DiagnosticLevel::Error);
+                        LayoutConstraints::new(c, Some((&mut *diag, DiagnosticLevel::Error)));
 
                     let compute = |orientation| {
                         if explicit_constraints.has_explicit_restrictions(orientation) {
@@ -229,7 +229,15 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
     let mut expr_v =
         implicit_layout_info_call(elem, Orientation::Vertical, BuiltinFilter::All, None).unwrap();
 
-    let explicit_constraints = LayoutConstraints::new(elem, diag, DiagnosticLevel::Warning);
+    // The redundant-size-constraint diagnostic of a component root is reported by the lower_layouts
+    // pass, so only report here for non-root elements.
+    let is_root = elem
+        .borrow()
+        .enclosing_component
+        .upgrade()
+        .is_some_and(|c| Rc::ptr_eq(elem, &c.root_element));
+    let explicit_constraints =
+        LayoutConstraints::new(elem, (!is_root).then_some((&mut *diag, DiagnosticLevel::Warning)));
     if !explicit_constraints.fixed_width {
         merge_explicit_constraints(&mut expr_h, &explicit_constraints, Orientation::Horizontal);
     }

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -395,21 +395,24 @@ pub fn lower_layouts(
     *component.root_constraints.borrow_mut() =
         LayoutConstraints::new(&component.root_element, Some((diag, DiagnosticLevel::Error)));
 
-    // A popup is not visited as a component on its own, so set the constraints of its root here.
-    // A redundant size constraint on a popup root is only a warning (not an error like on a window
-    // root) for compatibility with older versions of Slint that did not report it.
-    for popup in component.popup_windows.borrow().iter() {
-        *popup.component.root_constraints.borrow_mut() = LayoutConstraints::new(
-            &popup.component.root_element,
-            Some((&mut *diag, DiagnosticLevel::Warning)),
-        );
-    }
-
     recurse_elem_including_sub_components(
         component,
         &Option::default(),
         &mut |elem, parent_layout_type| {
             let component = elem.borrow().enclosing_component.upgrade().unwrap();
+
+            // A popup is not visited as a component on its own (it can be nested in a sub-component),
+            // so set the constraints of its root here, once per component when visiting its root. A
+            // redundant size constraint on a popup root is only a warning (not an error like on a
+            // window root) for compatibility with older versions of Slint that did not report it.
+            if Rc::ptr_eq(elem, &component.root_element) {
+                for popup in component.popup_windows.borrow().iter() {
+                    *popup.component.root_constraints.borrow_mut() = LayoutConstraints::new(
+                        &popup.component.root_element,
+                        Some((&mut *diag, DiagnosticLevel::Warning)),
+                    );
+                }
+            }
 
             lower_element_layout(
                 &component,

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -393,20 +393,23 @@ pub fn lower_layouts(
     });
 
     *component.root_constraints.borrow_mut() =
-        LayoutConstraints::new(&component.root_element, diag, DiagnosticLevel::Error);
+        LayoutConstraints::new(&component.root_element, Some((diag, DiagnosticLevel::Error)));
+
+    // A popup is not visited as a component on its own, so set the constraints of its root here.
+    // A redundant size constraint on a popup root is only a warning (not an error like on a window
+    // root) for compatibility with older versions of Slint that did not report it.
+    for popup in component.popup_windows.borrow().iter() {
+        *popup.component.root_constraints.borrow_mut() = LayoutConstraints::new(
+            &popup.component.root_element,
+            Some((&mut *diag, DiagnosticLevel::Warning)),
+        );
+    }
 
     recurse_elem_including_sub_components(
         component,
         &Option::default(),
         &mut |elem, parent_layout_type| {
             let component = elem.borrow().enclosing_component.upgrade().unwrap();
-
-            // Popups have their own layout constraints
-            for popup in component.popup_windows.borrow_mut().iter() {
-                let component = &popup.component;
-                *component.root_constraints.borrow_mut() =
-                    LayoutConstraints::new(&component.root_element, diag, DiagnosticLevel::Error);
-            }
 
             lower_element_layout(
                 &component,
@@ -1842,8 +1845,10 @@ fn create_layout_item(
         fix_explicit_percent("width", &rep_comp.root_element);
         fix_explicit_percent("height", &rep_comp.root_element);
 
-        *rep_comp.root_constraints.borrow_mut() =
-            LayoutConstraints::new(&rep_comp.root_element, diag, DiagnosticLevel::Error);
+        *rep_comp.root_constraints.borrow_mut() = LayoutConstraints::new(
+            &rep_comp.root_element,
+            Some((&mut *diag, DiagnosticLevel::Error)),
+        );
         rep_comp.root_element.borrow_mut().child_of_layout = true;
         (
             Some(if r.is_conditional_element {
@@ -1857,7 +1862,7 @@ fn create_layout_item(
         (None, item_element.clone())
     };
 
-    let constraints = LayoutConstraints::new(&actual_elem, diag, DiagnosticLevel::Error);
+    let constraints = LayoutConstraints::new(&actual_elem, Some((diag, DiagnosticLevel::Error)));
     CreateLayoutItemResult {
         item: LayoutItem { element: item_element.clone(), constraints },
         elem: actual_elem,

--- a/internal/compiler/tests/syntax/layout/min_max_conflict.slint
+++ b/internal/compiler/tests/syntax/layout/min_max_conflict.slint
@@ -60,5 +60,23 @@ export component Test inherits Rectangle {
         Rectangle {}
     }
 
+    // ... and for a popup nested in a conditional element
+    if true: Rectangle {
+        popup3 := PopupWindow {
+            width: 42px;
+//                 >   <warning{Cannot specify both 'width' and 'min-width'}
+            min-width: 5rem;
+        }
+    }
+
+    // ... and in a repeated element
+    for x in [1]: Rectangle {
+        popup4 := PopupWindow {
+            height: 42px;
+//                  >   <warning{Cannot specify both 'height' and 'min-height'}
+            min-height: 5rem;
+        }
+    }
+
 
 }

--- a/internal/compiler/tests/syntax/layout/min_max_conflict.slint
+++ b/internal/compiler/tests/syntax/layout/min_max_conflict.slint
@@ -41,5 +41,24 @@ export component Test inherits Rectangle {
         }
     }
 
+    // A redundant size constraint on a popup root is only a warning (not an error) for
+    // compatibility with older versions of Slint that did not report it
+    popup := PopupWindow {
+        width: 42px;
+//             >   <warning{Cannot specify both 'width' and 'min-width'}
+        min-width: 5rem;
+        HorizontalLayout {
+            Rectangle {}
+        }
+    }
+
+    // Same when the popup root does not contain a layout
+    popup2 := PopupWindow {
+        height: 42px;
+//              >   <warning{Cannot specify both 'height' and 'min-height'}
+        min-height: 5rem;
+        Rectangle {}
+    }
+
 
 }

--- a/tests/cases/elements/popupwindow_in_conditional.slint
+++ b/tests/cases/elements/popupwindow_in_conditional.slint
@@ -1,0 +1,72 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A popup nested in a conditional (or repeated) element must still get its layout constraints, so
+// that it is laid out at the right size and can be interacted with.
+
+export global Properties {
+    in-out property <int> inner-clicks: 0;
+    in-out property <length> popup-width: -1px;
+    in-out property <length> popup-height: -1px;
+}
+
+export component TestCase {
+    in property <bool> show-popup-area: true;
+
+    width: 200px;
+    height: 200px;
+
+    if show-popup-area: TouchArea {
+        clicked => {
+            popup.show();
+        }
+        popup := PopupWindow {
+            x: 0px;
+            y: 0px;
+            width: 100px;
+            height: 100px;
+            close-policy: PopupClosePolicy.no-auto-close;
+            init => {
+                Properties.popup-width = self.width;
+                Properties.popup-height = self.height;
+            }
+            TouchArea {
+                clicked => {
+                    Properties.inner-clicks += 1;
+                }
+            }
+        }
+    }
+}
+
+/*
+```rust
+use slint::platform::WindowEvent;
+use slint::platform::PointerEventButton;
+use slint::LogicalPosition;
+
+let instance = TestCase::new().unwrap();
+let window = instance.window();
+window.set_size(slint::PhysicalSize::new(200, 200));
+
+let click = |x: f32, y: f32| {
+    let position = LogicalPosition::new(x, y);
+    window.dispatch_event(WindowEvent::PointerPressed { position, button: PointerEventButton::Left });
+    window.dispatch_event(WindowEvent::PointerReleased { position, button: PointerEventButton::Left });
+    window.dispatch_event(WindowEvent::PointerMoved { position });
+    slint_testing::mock_elapsed_time(100);
+};
+
+assert_eq!(instance.global::<Properties<'_>>().get_inner_clicks(), 0);
+
+// Click outside the (not yet shown) popup area to open the popup via the conditional TouchArea.
+click(150., 150.);
+assert_eq!(instance.global::<Properties<'_>>().get_popup_width(), 100.);
+assert_eq!(instance.global::<Properties<'_>>().get_popup_height(), 100.);
+assert_eq!(instance.global::<Properties<'_>>().get_inner_clicks(), 0);
+
+// The popup covers (0,0)-(100,100). Clicking inside only reaches its TouchArea if it was laid out.
+click(50., 50.);
+assert_eq!(instance.global::<Properties<'_>>().get_inner_clicks(), 1);
+```
+*/


### PR DESCRIPTION
A PopupWindow root is not inside a layout, so setting both a fixed size and a min/max constraint is only a warning, not an error. This regressed in #11411, which set the popup constraints with DiagnosticLevel::Error. Caught by the crater build.

The diagnostic for a component root is now owned solely by lower_layouts. default_geometry no longer re-reports it for roots, which also removes a redundant warning that was emitted next to the error on a normal window, and makes the popup warning consistent whether or not the popup root contains a layout.

To compute constraints without reporting, LayoutConstraints::new now takes the diagnostics as an Option.
