### PR TITLE
Clarify licensing in LICENSE.md, README.md and FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -59,20 +59,18 @@ You can use Slint under ***any*** of the following licenses, at your choice:
 
 ### Can I keep my own code under a permissive license such as MIT?
 
-Yes.
-Your own source files can carry MIT, Apache-2.0, or any other permissive license, whichever Slint license you use.
+Yes — whichever Slint license you use, your own source files can stay under a permissive license such as MIT or Apache-2.0.
 
-The product you ship also includes Slint, which stays under its three licenses (GPLv3, Royalty-free, or paid).
-Pick how you distribute the result:
+Slint itself stays under its three licenses (GPLv3, Royalty-free, or the Slint Software License), so the combined product you distribute is licensed one of two ways:
 
 - **Open-source the whole product? Use the GPLv3.**
   The product as a whole is then GPL: free, on any platform including embedded.
   Your own files keep their permissive headers (MIT is GPL-compatible).
-- **Prefer to set your own terms? Use the Royalty-free or paid license.**
-  The Royalty-free license is free for desktop, mobile, and web — just show the Slint attribution.
-  The paid license adds embedded and more.
+- **Want your own terms instead? Use the Royalty-free or Slint Software License.**
+  The Royalty-free license is free for desktop, mobile, and web, as long as you show the Slint attribution.
+  The Slint Software License (our commercial license) covers embedded and lets you set your own terms.
 
-For worked examples, see the [GPLv3 scenarios below](#gplv3).
+For detailed scenarios, see the [GPLv3 questions below](#gplv3).
 
 ### Royalty-free license
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -10,6 +10,7 @@
     - [Who can use the Royalty-free license?](#who-can-use-the-royalty-free-license)
     - [What obligations do I need to fulfil to use the Royalty-free license?](#what-obligations-do-i-need-to-fulfil-to-use-the-royalty-free-license)
     - [Are there any limitations with the Royalty-free license?](#are-there-any-limitations-with-the-royalty-free-license)
+    - [What counts as an embedded system?](#what-counts-as-an-embedded-system)
     - [Scenario: What happens if my application is open-source (e.g. under MIT), forked by a different person and then redistributed?](#scenario-what-happens-if-my-application-is-open-source-eg-under-mit-forked-by-a-different-person-and-then-redistributed)
     - [How are modifications to Slint itself covered under this license?](#how-are-modifications-to-slint-itself-covered-under-this-license)
     - [If Slint were to be taken over by a larger company or the current owners were to have a change of heart, can they revoke existing licenses?](#if-slint-were-to-be-taken-over-by-a-larger-company-or-the-current-owners-were-to-have-a-change-of-heart-can-they-revoke-existing-licenses)
@@ -95,6 +96,12 @@ You need to do one of the following:
 3. You are not permitted to distribute an Application that exposes the APIs, in part or in total, of Slint.
 
 4. You are not permitted to remove or alter any license notices (including copyright notices, disclaimers of warranty, or limitations of liability) contained within the source code form of Slint.
+
+#### What counts as an embedded system?
+
+It's **embedded** when Slint ships as part of a hardware product or device — driving the screen of an appliance, a point-of-sale terminal, or a car dashboard, for example — even if that device uses general-purpose hardware like a built-in tablet. Embedded use needs the Commercial license.
+
+It's **not** embedded when your app runs on the user's own computer or phone as one app among many, which is the free desktop, mobile, and web case.
 
 #### Scenario: What happens if my application is open-source (e.g. under MIT), forked by a different person and then redistributed?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -18,8 +18,8 @@
     - [My MIT-licensed program links to Slint GPLv3. Can someone fork my program to build and distribute a proprietary program?](#my-mit-licensed-program-links-to-slint-gplv3-can-someone-fork-my-program-to-build-and-distribute-a-proprietary-program)
     - [My MIT-licensed program links to Slint GPLv3. How can I convey to someone that they can distribute my program as part of a proprietary licensed program?](#my-mit-licensed-program-links-to-slint-gplv3-how-can-i-convey-to-someone-that-they-can-distribute-my-program-as-part-of-a-proprietary-licensed-program)
     - [My MIT-licensed program links to Slint GPLv3. Under what license can I release the entire work i.e my Program combined with Slint?](#my-mit-licensed-program-links-to-slint-gplv3-under-what-license-can-i-release-the-entire-work-ie-my-program-combined-with-slint)
-  - [Paid License](#paid-license)
-    - [What are the paid license options?](#what-are-the-paid-license-options)
+  - [Commercial License](#commercial-license)
+    - [What are the Commercial license options?](#what-are-the-commercial-license-options)
 - [Miscellaneous](#miscellaneous)
   - [Do you provide Support?](#do-you-provide-support)
 
@@ -55,20 +55,20 @@ You can use Slint under ***any*** of the following licenses, at your choice:
 
 1. [Royalty-free license](LICENSES/LicenseRef-Slint-Royalty-free-2.0.md),
 2. [GNU GPLv3](LICENSES/GPL-3.0-only.txt),
-3. [Paid license](LICENSES/LicenseRef-Slint-Software-3.0.md).
+3. [Commercial license](LICENSES/LicenseRef-Slint-Software-3.0.md).
 
 ### Can I keep my own code under a permissive license such as MIT?
 
 Yes — whichever Slint license you use, your own source files can stay under a permissive license such as MIT or Apache-2.0.
 
-Slint itself stays under its three licenses (GPLv3, Royalty-free, or the Slint Software License), so the combined product you distribute is licensed one of two ways:
+Slint itself stays under its three licenses (GPLv3, Royalty-free, or Commercial), so the combined product you distribute is licensed one of two ways:
 
 - **Open-source the whole product? Use the GPLv3.**
   The product as a whole is then GPL: free, on any platform including embedded.
   Your own files keep their permissive headers (MIT is GPL-compatible).
-- **Want your own terms instead? Use the Royalty-free or Slint Software License.**
+- **Want your own terms instead? Use the Royalty-free or Commercial license.**
   The Royalty-free license is free for desktop, mobile, and web, as long as you show the Slint attribution.
-  The Slint Software License (our commercial license) covers embedded and lets you set your own terms.
+  The Commercial license covers embedded and lets you set your own terms.
 
 For detailed scenarios, see the [GPLv3 questions below](#gplv3).
 
@@ -98,7 +98,7 @@ You need to do one of the following:
 
 #### Scenario: What happens if my application is open-source (e.g. under MIT), forked by a different person and then redistributed?
 
-The license does not restrict users on how they license their application. In the above scenario, the user may choose to use MIT-license for their application, which can be forked by a different person and then redistributed. If the forked application also uses Slint, then the person forking the application can choose to use Slint under any one of the licenses - Royalty-free, GPLv3, or paid license.
+The license does not restrict users on how they license their application. In the above scenario, the user may choose to use MIT-license for their application, which can be forked by a different person and then redistributed. If the forked application also uses Slint, then the person forking the application can choose to use Slint under any one of the licenses - Royalty-free, GPLv3, or Commercial license.
 
 #### How are modifications to Slint itself covered under this license?
 
@@ -118,7 +118,7 @@ Refer to GPL FAQ [https://www.gnu.org/licenses/gpl-faq.en.html#LinkingWithGPL](h
 
 #### My MIT-licensed program links to Slint GPLv3. Can someone fork my program to build and distribute a proprietary program?
 
-Yes, provided the person distributing the proprietary program acquired a Slint proprietary license, such as the Slint Royalty-free license or a paid license, instead of using Slint under GPLv3. The other option would be to remove the dependency to Slint altogether.
+Yes, provided the person distributing the proprietary program acquired a Slint proprietary license, such as the Slint Royalty-free license or a Commercial license, instead of using Slint under GPLv3. The other option would be to remove the dependency to Slint altogether.
 
 #### My MIT-licensed program links to Slint GPLv3. How can I convey to someone that they can distribute my program as part of a proprietary licensed program?
 
@@ -128,9 +128,9 @@ You can add a note as part of your license that to distribute a proprietary lice
 
 While your software modules can remain under the MIT-license, the work as a whole must be licensed under the GPL.
 
-### Paid License
+### Commercial License
 
-#### What are the paid license options?
+#### What are the Commercial license options?
 
 Check out the pricing plans on our website <https://slint.dev/pricing>.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -5,6 +5,7 @@
   - [Why does Slint use a domain specific language?](#why-does-slint-use-a-domain-specific-language)
   - [Will there be API bindings to integrate with my favorite programming language?](#will-there-be-api-bindings-to-integrate-with-my-favorite-programming-language)
 - [Licensing](#licensing)
+  - [Can I keep my own code under a permissive license such as MIT?](#can-i-keep-my-own-code-under-a-permissive-license-such-as-mit)
   - [Royalty-free license](#royalty-free-license)
     - [Who can use the Royalty-free license?](#who-can-use-the-royalty-free-license)
     - [What obligations do I need to fulfil to use the Royalty-free license?](#what-obligations-do-i-need-to-fulfil-to-use-the-royalty-free-license)
@@ -16,11 +17,9 @@
     - [If I link my program with Slint GPLv3, does it mean that I have to license my program under the GPLv3, too?](#if-i-link-my-program-with-slint-gplv3-does-it-mean-that-i-have-to-license-my-program-under-the-gplv3-too)
     - [My MIT-licensed program links to Slint GPLv3. Can someone fork my program to build and distribute a proprietary program?](#my-mit-licensed-program-links-to-slint-gplv3-can-someone-fork-my-program-to-build-and-distribute-a-proprietary-program)
     - [My MIT-licensed program links to Slint GPLv3. How can I convey to someone that they can distribute my program as part of a proprietary licensed program?](#my-mit-licensed-program-links-to-slint-gplv3-how-can-i-convey-to-someone-that-they-can-distribute-my-program-as-part-of-a-proprietary-licensed-program)
-    - [My MIT-licensed program links to Slint GPLv3. Under what license can I release the binary of my program?](#my-mit-licensed-program-links-to-slint-gplv3-under-what-license-can-i-release-the-binary-of-my-program)
-    - [Scenario: Alice is a software developer, she wants her code to be licensed under MIT. She is developing an application "AliceApp" that links to Slint GPLv3. Alice also wants to allow that Bob, a user of AliceApp, can fork AliceApp into a proprietary application called BobApp](#scenario-alice-is-a-software-developer-she-wants-her-code-to-be-licensed-under-mit-she-is-developing-an-application-aliceapp-that-links-to-slint-gplv3-alice-also-wants-to-allow-that-bob-a-user-of-aliceapp-can-fork-aliceapp-into-a-proprietary-application-called-bobapp)
-      - [Can Alice use the MIT license header to the source code of AliceApp application?](#can-alice-use-the-mit-license-header-to-the-source-code-of-aliceapp-application)
-      - [Under what license should she distribute the AliceApp binary?](#under-what-license-should-she-distribute-the-aliceapp-binary)
-      - [How can Alice make it clear to Bob that he can distribute BobApp under a proprietary license?](#how-can-alice-make-it-clear-to-bob-that-he-can-distribute-bobapp-under-a-proprietary-license)
+    - [My MIT-licensed program links to Slint GPLv3. Under what license can I release the entire work i.e my Program combined with Slint?](#my-mit-licensed-program-links-to-slint-gplv3-under-what-license-can-i-release-the-entire-work-ie-my-program-combined-with-slint)
+  - [Paid License](#paid-license)
+    - [What are the paid license options?](#what-are-the-paid-license-options)
 - [Miscellaneous](#miscellaneous)
   - [Do you provide Support?](#do-you-provide-support)
 
@@ -35,15 +34,17 @@ and optimize to provide high graphics performance. Strictly typed binding
 expressions offer a powerful and robust way for humans to declare relationships
 between properties, even in complex user interfaces.
 
+Read more in our blog post on [declarative versus imperative UI](https://slint.dev/blog/domain-specific-language-vs-imperative-for-ui).
+
 ### Will there be API bindings to integrate with my favorite programming language?
 
-We want to make it possible to use Slint with any programming language. We do
-not favor one programming language over another. We have chosen to start with
-three languages:
+We want to make it possible to use Slint with any programming language, and we
+don't favor one over another. Slint currently supports four:
 
 - Rust, our implementation language.
 - C++, another systems programming language we have a lot of experience with.
 - JavaScript, a popular dynamically typed language.
+- Python, widely used for tooling, scripting, and data science.
 
 This choice builds the foundation that allows us to create bindings for most
 types of programming languages.
@@ -56,6 +57,23 @@ You can use Slint under ***any*** of the following licenses, at your choice:
 2. [GNU GPLv3](LICENSES/GPL-3.0-only.txt),
 3. [Paid license](LICENSES/LicenseRef-Slint-Software-3.0.md).
 
+### Can I keep my own code under a permissive license such as MIT?
+
+Yes.
+Your own source files can carry MIT, Apache-2.0, or any other permissive license, whichever Slint license you use.
+
+The product you ship also includes Slint, which stays under its three licenses (GPLv3, Royalty-free, or paid).
+Pick how you distribute the result:
+
+- **Open-source the whole product? Use the GPLv3.**
+  The product as a whole is then GPL: free, on any platform including embedded.
+  Your own files keep their permissive headers (MIT is GPL-compatible).
+- **Prefer to set your own terms? Use the Royalty-free or paid license.**
+  The Royalty-free license is free for desktop, mobile, and web — just show the Slint attribution.
+  The paid license adds embedded and more.
+
+For worked examples, see the [GPLv3 scenarios below](#gplv3).
+
 ### Royalty-free license
 
 #### Who can use the Royalty-free license?
@@ -66,7 +84,7 @@ This license is suitable for those who develop desktop, mobile, or web applicati
 
 You need to do one of the following:
 
-1. Display the [`AboutSlint`](https://slint.dev/snapshots/master/docs/slint/src/language/widgets/aboutslint.html) widget in an "About" screen or dialog that is accessible from the top level menu of the Application. In the absence of such a screen or dialog, display the widget in the "Splash Screen" of the Application.
+1. Display the [`AboutSlint`](https://docs.slint.dev/latest/docs/slint/reference/std-widgets/misc/aboutslint/) widget in an "About" screen or dialog that is accessible from the top level menu of the Application. In the absence of such a screen or dialog, display the widget in the "Splash Screen" of the Application.
 
 2. Display the [Slint attribution badge](https://github.com/slint-ui/slint/tree/master/logo/MadeWithSlint-logo-whitebg.png) on a public webpage, preferably where the binaries of your Application can be downloaded from, in such a way that it can be easily found by any visitor to that page.
 
@@ -111,20 +129,6 @@ You can add a note as part of your license that to distribute a proprietary lice
 #### My MIT-licensed program links to Slint GPLv3. Under what license can I release the entire work i.e my Program combined with Slint?
 
 While your software modules can remain under the MIT-license, the work as a whole must be licensed under the GPL.
-
-#### Scenario: Alice is a software developer, she wants her code to be licensed under MIT. She is developing an application "AliceApp" that links to Slint GPLv3. Alice also wants to allow that Bob, a user of AliceApp, can fork AliceApp into a proprietary application called BobApp
-
-- Can Alice use the MIT license header to the source code of AliceApp application?
-
-Yes. Alice can license her copyrighted source code under any license compatible with GPLv3. Refer FAQ [If I link my program with Slint GPLv3, does it mean that I have to license my program under the GPLv3, too?](#if-i-link-my-program-with-slint-gplv3-does-it-mean-that-i-have-to-license-my-program-under-the-gplv3-too)
-
-- Under what license should she distribute the AliceApp binary?
-
-Under GPLv3. While the different software modules can remain under any license compatible with GPLv3, the work as a whole must be licensed under the GPL. Refer FAQ [My MIT-licensed program links to Slint GPLv3. Under what license can I release the binary of my program?](#my-mit-licensed-program-links-to-slint-gplv3-under-what-license-can-i-release-the-binary-of-my-program)
-
-- How can Alice make it clear to Bob that he can distribute BobApp under a proprietary license?
-
-Alice can add a note that Bob can distribute BobApp under a proprietary license if he either acquires a Slint proprietary license or removes the dependency to Slint.
 
 ### Paid License
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,13 +1,37 @@
 
 # Slint License
 
-You can use Slint under ***any*** of the following licenses, at your choice:
+This repository contains several parts under different licenses:
+
+- The **Slint framework** (the runtime libraries and the language tooling) is triple-licensed.
+  See below.
+- The **documentation and examples** are under the [MIT License](LICENSES/MIT.txt),
+  so you can reuse them in any project, including proprietary ones.
+- Some **third-party assets and code** keep their own licenses.
+
+The exact license of each file is documented in its header or, where that's not possible, via [REUSE](https://reuse.software/) metadata in `REUSE.toml`.
+The full text of every license used is in the `LICENSES` folder.
+
+## Slint Framework License
+
+You can use the Slint framework under ***any*** of the following licenses, at your choice:
 
 1. [Royalty-free License](LICENSES/LicenseRef-Slint-Royalty-free-2.0.md) - Permits use in **proprietary** desktop, mobile, and web applications **at no cost**. Use in embedded systems is excluded.
 2. [GNU GPLv3](LICENSES/GPL-3.0-only.txt) - Permits use in **open source software** under GPL-compatible terms, **at no cost**, for desktop, mobile, and web applications, as well as for embedded systems.
 3. [Commercial license](LICENSES/LicenseRef-Slint-Software-3.0.md) - Permits use in **proprietary** applications, including desktop, mobile, web, and embedded systems.
+   See the [pricing page](https://slint.dev/pricing.html) for the available plans.
 
-Third party licenses listed in the `LICENSES` folder also apply to parts of the product.
+### What This Means in Practice
+
+- **Do you want to build an open-source application?**
+  Use Slint for free under the GPLv3 on any platform, embedded included; your own files can stay MIT or Apache-2.0.
+  You're not tied to the GPL, though — the Royalty-free or Commercial license works too.
+- **Do you want to keep your application proprietary?**
+  Use the Royalty-free License for free for desktop, mobile, and web applications.
+  It requires you to disclose that you use Slint, for example with the `AboutSlint` widget or the Slint badge.
+  Embedded systems, and anything the Royalty-free License doesn't cover, need the Commercial license.
+
+See the [Licensing FAQ](FAQ.md#licensing) for the details and common scenarios.
 
 ## Definitions
 
@@ -18,6 +42,11 @@ A ***Mobile Application*** is a computer program that is designed to run on a ge
 A ***Web Application*** is a computer program that is designed to run in the sandbox environment provided by a web browser.
 
 An ***Embedded System*** is a computer system designed to perform a specific task within a larger mechanical or electrical system.
+
+## Contributions
+
+Contributions to this repository are licensed under the [MIT No Attribution License (MIT-0)](https://opensource.org/license/mit-0).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details, including the Contributor License Agreement.
 
 ## Additional Info
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -12,7 +12,7 @@ This repository contains several parts under different licenses:
 The exact license of each file is documented in its header or, where that's not possible, via [REUSE](https://reuse.software/) metadata in `REUSE.toml`.
 The full text of every license used is in the `LICENSES` folder.
 
-## Slint Framework License
+## Licenses of the Slint Framework
 
 You can use the Slint framework under ***any*** of the following licenses, at your choice:
 
@@ -24,12 +24,11 @@ You can use the Slint framework under ***any*** of the following licenses, at yo
 ### What This Means in Practice
 
 - **Do you want to build an open-source application?**
-  Use Slint for free under the GPLv3 on any platform, embedded included; your own files can stay MIT or Apache-2.0.
+  Use Slint for free under the GPLv3 on any platform; your own files can stay MIT or Apache-2.0.
   You're not tied to the GPL, though — the Royalty-free or Commercial license works too.
 - **Do you want to keep your application proprietary?**
-  Use the Royalty-free License for free for desktop, mobile, and web applications.
-  It requires you to disclose that you use Slint, for example with the `AboutSlint` widget or the Slint badge.
-  Embedded systems, and anything the Royalty-free License doesn't cover, need the Commercial license.
+  Use the Royalty-free License for free, for desktop, mobile, and web applications, as long as you disclose that you use Slint (for example with the `AboutSlint` widget or the Slint badge).
+  For embedded systems, or to avoid these conditions, use the Commercial license.
 
 See the [Licensing FAQ](FAQ.md#licensing) for the details and common scenarios.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -27,8 +27,9 @@ You can use the Slint framework under ***any*** of the following licenses, at yo
   Use Slint for free under the GPLv3 on any platform; your own files can stay MIT or Apache-2.0.
   You're not tied to the GPL, though — the Royalty-free or Commercial license works too.
 - **Do you want to keep your application proprietary?**
-  Use the Royalty-free License for free, for desktop, mobile, and web applications, as long as you disclose that you use Slint (for example with the `AboutSlint` widget or the Slint badge).
-  For embedded systems, or to avoid these conditions, use the Commercial license.
+  Both the Royalty-free and Commercial licenses cover proprietary desktop, mobile, and web applications.
+  The Royalty-free License is free, as long as you disclose that you use Slint (for example with the `AboutSlint` widget or the Slint badge); without that disclosure, use the Commercial license.
+  A Commercial license is required for embedded systems, regardless of disclosure.
 
 See the [Licensing FAQ](FAQ.md#licensing) for the details and common scenarios.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,6 +31,9 @@ You can use the Slint framework under ***any*** of the following licenses, at yo
   The Royalty-free License is free, as long as you disclose that you use Slint (for example with the `AboutSlint` widget or the Slint badge); without that disclosure, use the Commercial license.
   A Commercial license is required for embedded systems, regardless of disclosure.
 
+The Royalty-free License is meant for software that runs on a user's own general-purpose computer or phone, as one application among the many they install.
+It does not cover software that ships as part of a hardware product or device — an embedded system — which needs the Commercial license.
+
 See the [Licensing FAQ](FAQ.md#licensing) for the details and common scenarios.
 
 ## Definitions

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ configure your favorite editor to work well with Slint.
 
 ## License
 
+See [LICENSE.md](LICENSE.md) for the licensing of the whole repository, including documentation and examples.
+
 You can use Slint under ***any*** of the following licenses, at your choice:
 
 1. Build proprietary desktop, mobile, or web applications for free with the [Royalty-free License](LICENSES/LicenseRef-Slint-Royalty-free-2.0.md),

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ configure your favorite editor to work well with Slint.
 
 ## License
 
-See [LICENSE.md](LICENSE.md) for the licensing of the whole repository, including documentation and examples.
+See [LICENSE.md](LICENSE.md) for the licensing terms of the whole repository, including documentation and examples.
 
 You can use Slint under ***any*** of the following licenses, at your choice:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You can use Slint under ***any*** of the following licenses, at your choice:
 
 1. Build proprietary desktop, mobile, or web applications for free with the [Royalty-free License](LICENSES/LicenseRef-Slint-Royalty-free-2.0.md),
 2. Build open source embedded, desktop, mobile, or web applications for free with the [GNU GPLv3](LICENSES/GPL-3.0-only.txt),
-3. Build proprietary embedded, desktop, mobile, or web applications with the [Paid license](LICENSES/LicenseRef-Slint-Software-3.0.md).
+3. Build proprietary embedded, desktop, mobile, or web applications with the [Commercial license](LICENSES/LicenseRef-Slint-Software-3.0.md).
 
 See the [Slint licensing options on the website](https://slint.dev/pricing.html) and the [Licensing FAQ](FAQ.md#licensing).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ We commit to publishing security updates for the last release of Slint:
 | `slint-viewer` | Convenience tool to view `.slint` files from the command line | https://crates.io/crates/slint-viewer \| https://github.com/slint-ui/slint/releases/latest |
 | `slint-lsp` | Language Server Protocol implementation for `.slint` files | https://crates.io/crates/slint-lsp \| https://github.com/slint-ui/slint/releases/latest |
 
-Paid license holders may be eligible for support on additional versions, depending on their specific terms of
+Commercial license holders may be eligible for support on additional versions, depending on their specific terms of
 agreement.
 
 ## Reporting a Vulnerability

--- a/api/cpp/esp-idf/slint/README.md
+++ b/api/cpp/esp-idf/slint/README.md
@@ -30,7 +30,7 @@ You can use Slint under ***any*** of the following licenses, at your choice:
 
 1. [Royalty-free license](https://github.com/slint-ui/slint/blob/master/LICENSES/LicenseRef-Slint-Royalty-free-2.0.md),
 2. [GNU GPLv3](https://github.com/slint-ui/slint/blob/master/LICENSES/GPL-3.0-only.txt),
-3. [Paid license](https://github.com/slint-ui/slint/blob/master/LICENSES/LicenseRef-Slint-Software-3.0.md).
+3. [Commercial license](https://github.com/slint-ui/slint/blob/master/LICENSES/LicenseRef-Slint-Software-3.0.md).
 
 See also the [Licensing FAQ](https://github.com/slint-ui/slint/blob/master/FAQ.md#licensing).
 


### PR DESCRIPTION
Explain that different parts of the repository have different licenses, that documentation and examples are MIT, and that contributions are MIT-0. Describe what the framework's triple license means in practice for open source and proprietary applications, and clarify that your own code can stay permissive while the product ships under the GPL or your own terms.

Also tidy up the FAQ: add a question about permissive licenses, link the DSL blog post, add Python to the supported languages, drop the redundant Alice/Bob scenario, fix the AboutSlint link, and add the Paid License to the table of contents.
