### PR TITLE
fix(femtovg-wgpu): honour window transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
  - winit: Honor the system cursor blink rate.
  - `TextInput`: Show caret and allow selection in read-only text inputs
  - FemtoVG: Fixed rounded clip rendering when children don't fill the clip. (#11608)
+ - FemtoVG WGPU: Honor window transparency by selecting a non-opaque swapchain composite alpha mode.
  - Instantiate `for` and `if` eagerly via an update pass.
  - PopupWindow now react on change in their geometry properties after being shown (#6000)
  - iOS: Added detection of system dark/light theme

--- a/internal/backends/linuxkms/renderer/femtovg_wgpu.rs
+++ b/internal/backends/linuxkms/renderer/femtovg_wgpu.rs
@@ -28,7 +28,7 @@ impl FemtoVGWgpuRendererAdapter {
 
         let renderer = i_slint_renderer_femtovg::FemtoVGRenderer::new_suspended();
         renderer
-            .set_surface(surface_target, size, requested_graphics_api.cloned())
+            .set_surface(surface_target, size, requested_graphics_api.cloned(), false)
             .map_err(|e| format!("Error initializing FemtoVG wgpu surface: {e}"))?;
 
         let renderer = Box::new(Self { renderer, size, _drm_output: drm_output });

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -212,6 +212,7 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
         active_event_loop: &ActiveEventLoop,
         window_attributes: winit::window::WindowAttributes,
     ) -> Result<Arc<winit::window::Window>, PlatformError> {
+        let transparent = window_attributes.transparent;
         let winit_window = Arc::new(active_event_loop.create_window(window_attributes).map_err(
             |winit_os_error| {
                 PlatformError::from(format!(
@@ -229,6 +230,7 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
                 as Box<dyn i_slint_core::graphics::wgpu_29::wgpu::DisplayAndWindowHandle>,
             crate::winitwindowadapter::physical_size_to_slint(&size),
             self.requested_graphics_api.clone(),
+            transparent,
         )?;
 
         Ok(winit_window)

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -310,6 +310,7 @@ impl FemtoVGRenderer<WGPUBackend> {
         surface_target: impl Into<i_slint_core::graphics::wgpu_29::SurfaceTarget>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
+        transparent: bool,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let (instance, adapter, device, queue, surface) =
             i_slint_core::graphics::wgpu_29::init_instance_adapter_device_queue_surface(
@@ -332,6 +333,19 @@ impl FemtoVGRenderer<WGPUBackend> {
             .copied()
             .unwrap_or_else(|| swapchain_capabilities.formats[0]);
         surface_config.format = swapchain_format;
+
+        // The default `Opaque` discards the scene's alpha; pick a translucent mode if offered.
+        // Metal (CAMetalLayer) only offers `PostMultiplied`, so it must be a fallback.
+        if transparent {
+            use wgpu::CompositeAlphaMode::{PostMultiplied, PreMultiplied};
+            let advertised = &swapchain_capabilities.alpha_modes;
+            if let Some(mode) =
+                [PreMultiplied, PostMultiplied].into_iter().find(|m| advertised.contains(m))
+            {
+                surface_config.alpha_mode = mode;
+            }
+        }
+
         surface.configure(&device, &surface_config);
 
         *self.graphics_backend.instance.borrow_mut() = Some(instance.clone());


### PR DESCRIPTION
- set non-opaque alpha_mode (PreMultiplied) when window transparent
- thread transparent flag through set_surface (winit, linuxkms callers)

Re #9507 (femtovg path; skia path unaddressed), #11642 ChangeLog: FemtoVG WGPU: Honor window transparency by selecting a non-opaque swapchain composite alpha mode.