### PR TITLE
DropEvent: Remove allow* fields

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -813,6 +813,7 @@ fn gen_corelib(
             .with_src(crate_dir.join("data_transfer/ffi.rs"))
             .with_src(crate_dir.join("animations.rs"))
             .with_src(crate_dir.join("input.rs"))
+            .with_src(crate_dir.join("items/drag_n_drop.rs"))
             .with_src(crate_dir.join("item_rendering.rs"))
             .with_src(crate_dir.join("window.rs"))
             .with_src(crate_dir.join("../renderers/software/lib.rs"))

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -386,15 +386,12 @@ test("language builtin structs: factory overrides", () => {
 });
 
 test("language.DropEvent: factory produces a fully-shaped object", () => {
-    const evt = language.DropEvent({ allow_copy: true });
-    expect(evt.allow_copy).toStrictEqual(true);
-    expect(evt.allow_move).toStrictEqual(false);
-    expect(evt.allow_link).toStrictEqual(false);
-    expect(evt.proposed_action).toStrictEqual("none");
+    const evt = language.DropEvent({ proposed_action: "copy" });
+    expect(evt.proposed_action).toStrictEqual("copy");
     expect(evt.position).toStrictEqual({ x: 0, y: 0 });
     // The TypeScript type alias is the strict shape.
     const typed: language.DropEvent = evt;
-    expect(typed.allow_copy).toStrictEqual(true);
+    expect(typed.proposed_action).toStrictEqual("copy");
 });
 
 test("loadSource styled-text property get/set", () => {

--- a/api/python/slint/tests/test_language_dropevent.py
+++ b/api/python/slint/tests/test_language_dropevent.py
@@ -12,26 +12,22 @@ def test_drop_event_is_a_namedtuple() -> None:
 
 def test_drop_event_default_construction() -> None:
     e = DropEvent()
-    # Boolean fields default to False; reference-typed fields default to None
+    # Reference-typed fields default to None
     # (users receive populated instances from Slint callbacks).
-    assert e.allow_copy is False
-    assert e.allow_move is False
-    assert e.allow_link is False
     assert e.data is None
     assert e.position is None
     assert e.proposed_action is None
 
 
 def test_drop_event_field_override() -> None:
-    e = DropEvent(allow_copy=True, proposed_action=DragAction.copy)
-    assert e.allow_copy is True
+    e = DropEvent(proposed_action=DragAction.copy)
     assert e.proposed_action is DragAction.copy
 
 
 def test_drop_event_namedtuple_replace() -> None:
-    e = DropEvent()._replace(allow_move=True)
-    assert e.allow_move is True
-    assert e.allow_copy is False
+    e = DropEvent()._replace(proposed_action=DragAction.move)
+    assert e.proposed_action is DragAction.move
+    assert e.data is None
 
 
 def test_drop_event_has_docstring() -> None:

--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -80,7 +80,8 @@ DragArea {
 }
 
 DropArea {
-    can-drop(event) => event.allow-move ? DragAction.move : DragAction.none;
+    // Accept the action the user is asking for; the runtime clamps it to what the source allows.
+    can-drop(event) => event.proposed-action;
     dropped(event) => {
         Api.accept-drop(event.data);
         return event.proposed-action;

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -298,7 +298,7 @@ impl Item for NativeButton {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 return InputEventResult::EventIgnored;
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
                 return InputEventResult::EventIgnored;
             }
         });

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -104,11 +104,11 @@ impl Item for NativeCheckBox {
             }
             // Ignore scroll events, so that surrounding Flickables/ScrollViews can react to them
             // Ignore Drag Events, as CheckBox doesn't accept drags/drop.
-            MouseEvent::Drop(_)
+            MouseEvent::Drop { .. }
             | MouseEvent::Wheel { .. }
             | MouseEvent::PinchGesture { .. }
             | MouseEvent::RotationGesture { .. }
-            | MouseEvent::DragMove(_) => InputEventResult::EventIgnored,
+            | MouseEvent::DragMove { .. } => InputEventResult::EventIgnored,
             // Make sure that generally mouse events are accepted, so that the hover state is
             // correctly updated
             MouseEvent::Exit | MouseEvent::Moved { .. } | MouseEvent::Pressed { .. } => {

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -258,7 +258,9 @@ impl Item for NativeScrollView {
                 MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                     InputEventResult::EventIgnored
                 }
-                MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
+                MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
+                    InputEventResult::EventIgnored
+                }
             };
             self.data.set(data);
             result

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -271,7 +271,7 @@ impl Item for NativeSlider {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventResult::EventIgnored
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => InputEventResult::EventIgnored,
             // Note: The Qt slider used to accept scroll events, however the other styles do not.
             // As the scroll event handling is problematic when a slider is placed in a Flickable,
             // ignore scroll events for now.

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -243,7 +243,7 @@ impl Item for NativeSpinBox {
                     true
                 }
                 MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => false,
-                MouseEvent::DragMove(..) | MouseEvent::Drop(..) => false,
+                MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => false,
             };
         data.active_controls = new_control;
         if changed {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -485,7 +485,7 @@ impl Item for NativeTab {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 return InputEventResult::EventIgnored;
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
                 return InputEventResult::EventIgnored;
             }
         });

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -22,8 +22,8 @@ use i_slint_core::item_tree::{
     ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeWeak, ParentItemTraversalMode,
 };
 use i_slint_core::items::{
-    self, DragAction, DropEvent, FillRule, ImageRendering, ItemRc, ItemRef, Layer, LineCap,
-    LineJoin, MouseCursor, Opacity, PointerEventButton, RenderingResult, TextWrap,
+    self, AllowedDragActions, DragAction, DropEvent, FillRule, ImageRendering, ItemRc, ItemRef,
+    Layer, LineCap, LineJoin, MouseCursor, Opacity, PointerEventButton, RenderingResult, TextWrap,
 };
 use i_slint_core::layout::Orientation;
 use i_slint_core::lengths::{
@@ -2117,12 +2117,14 @@ impl QtWindow {
         is_drop: bool,
     ) -> u32 {
         let position = i_slint_core::api::LogicalPosition::new(pos.x as f32, pos.y as f32);
-        let allow_copy = allowed & key_generated::Qt_DropAction_CopyAction != 0;
-        let allow_move = allowed
-            & (key_generated::Qt_DropAction_MoveAction
-                | key_generated::Qt_DropAction_TargetMoveAction)
-            != 0;
-        let allow_link = allowed & key_generated::Qt_DropAction_LinkAction != 0;
+        let allowed_actions = AllowedDragActions {
+            copy: allowed & key_generated::Qt_DropAction_CopyAction != 0,
+            move_: allowed
+                & (key_generated::Qt_DropAction_MoveAction
+                    | key_generated::Qt_DropAction_TargetMoveAction)
+                != 0,
+            link: allowed & key_generated::Qt_DropAction_LinkAction != 0,
+        };
         let mut data = DataTransfer::default();
         let text = text.to_shared_string();
         if !text.is_empty() {
@@ -2134,12 +2136,12 @@ impl QtWindow {
         let mut drop_event = DropEvent::default();
         drop_event.data = data;
         drop_event.position = position;
-        drop_event.allow_copy = allow_copy;
-        drop_event.allow_move = allow_move;
-        drop_event.allow_link = allow_link;
         drop_event.proposed_action = qt_drop_action_to_slint(proposed);
-        let mouse_event =
-            if is_drop { MouseEvent::Drop(drop_event) } else { MouseEvent::DragMove(drop_event) };
+        let mouse_event = if is_drop {
+            MouseEvent::Drop { event: drop_event, allowed: allowed_actions }
+        } else {
+            MouseEvent::DragMove { event: drop_event, allowed: allowed_actions }
+        };
         let chosen = WindowInner::from_pub(&self.window).process_mouse_input(mouse_event);
         timer_event();
         chosen

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -95,15 +95,6 @@ macro_rules! for_each_builtin_structs {
                 /// The cursor position in the `DropArea`'s local coordinates.
                 position: LogicalPosition,
 
-                /// Mirrors `DragArea.allow-copy`: true if the source allows the drop to copy the data.
-                allow_copy: bool,
-
-                /// Mirrors `DragArea.allow-move`: true if the source allows the drop to move the data.
-                allow_move: bool,
-
-                /// Mirrors `DragArea.allow-link`: true if the source allows the drop to link to the data.
-                allow_link: bool,
-
                 /// The action negotiated from current modifier state, clamped to the allowed set;
                 /// when no modifier is pressed, the first allowed of move, copy, link.
                 /// Updated on every `DragMove`. The target's `can-drop` callback can return this

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -8,7 +8,9 @@
 
 use crate::item_tree::ItemTreeRc;
 use crate::item_tree::{ItemRc, ItemWeak, VisitChildrenResult};
-use crate::items::{DropEvent, ItemRef, MouseCursor, OperatingSystemType, TextCursorDirection};
+use crate::items::{
+    AllowedDragActions, DropEvent, ItemRef, MouseCursor, OperatingSystemType, TextCursorDirection,
+};
 pub use crate::items::{FocusReason, KeyEvent, KeyboardModifiers, PointerEventButton};
 use crate::lengths::{ItemTransform, LogicalPoint, LogicalVector};
 use crate::timers::Timer;
@@ -72,9 +74,19 @@ pub enum MouseEvent {
     /// The mouse is being dragged over this item.
     /// [`InputEventResult::EventIgnored`] means that the item does not handle the drag operation
     /// and [`InputEventResult::EventAccepted`] means that the item can accept it.
-    DragMove(DropEvent),
+    DragMove {
+        /// The dragged payload and its current position/proposed action.
+        event: DropEvent,
+        /// The actions the drag source permits.
+        allowed: AllowedDragActions,
+    },
     /// The mouse is released while dragging over this item.
-    Drop(DropEvent),
+    Drop {
+        /// The dragged payload and its current position/proposed action.
+        event: DropEvent,
+        /// The actions the drag source permits.
+        allowed: AllowedDragActions,
+    },
     /// A platform-recognized pinch gesture (macOS/iOS trackpad, Qt).
     PinchGesture {
         /// The focal position of the gesture.
@@ -117,7 +129,7 @@ impl MouseEvent {
             MouseEvent::Wheel { position, .. } => Some(*position),
             MouseEvent::PinchGesture { position, .. } => Some(*position),
             MouseEvent::RotationGesture { position, .. } => Some(*position),
-            MouseEvent::DragMove(e) | MouseEvent::Drop(e) => {
+            MouseEvent::DragMove { event: e, .. } | MouseEvent::Drop { event: e, .. } => {
                 Some(crate::lengths::logical_point_from_api(e.position))
             }
             MouseEvent::Exit => None,
@@ -133,7 +145,7 @@ impl MouseEvent {
             MouseEvent::Wheel { position, .. } => Some(position),
             MouseEvent::PinchGesture { position, .. } => Some(position),
             MouseEvent::RotationGesture { position, .. } => Some(position),
-            MouseEvent::DragMove(e) | MouseEvent::Drop(e) => {
+            MouseEvent::DragMove { event: e, .. } | MouseEvent::Drop { event: e, .. } => {
                 e.position = crate::api::LogicalPosition::from_euclid(
                     crate::lengths::logical_point_from_api(e.position) + vec,
                 );
@@ -155,7 +167,7 @@ impl MouseEvent {
             MouseEvent::Wheel { position, .. } => Some(position),
             MouseEvent::PinchGesture { position, .. } => Some(position),
             MouseEvent::RotationGesture { position, .. } => Some(position),
-            MouseEvent::DragMove(e) | MouseEvent::Drop(e) => {
+            MouseEvent::DragMove { event: e, .. } | MouseEvent::Drop { event: e, .. } => {
                 e.position = crate::api::LogicalPosition::from_euclid(
                     transform
                         .transform_point(crate::lengths::logical_point_from_api(e.position).cast())
@@ -1214,6 +1226,16 @@ impl ClickState {
     }
 }
 
+/// The data for an in-flight drag-and-drop operation, held while a drag is active.
+#[derive(Clone)]
+pub(crate) struct DragData {
+    /// The dragged payload together with its current position and proposed action.
+    /// The `position` is updated on every move.
+    pub(crate) event: DropEvent,
+    /// The actions the drag source permits, captured at drag start.
+    pub(crate) allowed: AllowedDragActions,
+}
+
 /// The state which a window should hold for the mouse input
 #[derive(Default)]
 pub struct MouseInputState {
@@ -1231,7 +1253,7 @@ pub struct MouseInputState {
     grabbed: bool,
     /// When this is Some, it means we are in the middle of a drag-drop operation and it contains the dragged data.
     /// The `position` field has no signification
-    pub(crate) drag_data: Option<DropEvent>,
+    pub(crate) drag_data: Option<DragData>,
     /// The `DragArea` that initiated the in-flight drag.
     /// `None` for drags coming from outside (native cross-window/cross-process DnD).
     pub(crate) drag_source: Option<ItemWeak>,
@@ -1360,14 +1382,14 @@ pub(crate) fn handle_mouse_grab(
             mouse_input_state.grabbed = false;
             let drag_area_item = grabber.downcast::<crate::items::DragArea>().unwrap();
             let drag_area = drag_area_item.as_pin_ref();
-            let mut drop_event = drag_area.initial_drop_event();
+            let (mut drop_event, allowed) = drag_area.initial_drop_event();
             // Seed the drag position from the event that crossed the drag threshold so
             // the renderer can place the drag-image overlay before the first DragMove.
             drop_event.position = mouse_event
                 .position()
                 .map(crate::lengths::logical_position_to_api)
                 .unwrap_or_default();
-            mouse_input_state.drag_data = Some(drop_event);
+            mouse_input_state.drag_data = Some(DragData { event: drop_event, allowed });
             mouse_input_state.drag_source = Some(grabber.downgrade());
             drag_area.dragging.set(true);
             MouseGrabResult { event: None, accepted: true }
@@ -1482,7 +1504,7 @@ pub fn process_mouse_input(
         false,
     );
     let accepted = r.has_aborted();
-    if matches!(mouse_event, MouseEvent::DragMove(_)) {
+    if matches!(mouse_event, MouseEvent::DragMove { .. }) {
         // Remember the accepting DropArea (or forget if none did) so the subsequent
         // Release knows whether to deliver a Drop.
         result.drop_target =
@@ -1684,7 +1706,7 @@ fn send_mouse_event_to_item(
             result.grabbed = false;
             let drag_area_item = item_rc.downcast::<crate::items::DragArea>().unwrap();
             let drag_area = drag_area_item.as_pin_ref();
-            let mut drop_event = drag_area.initial_drop_event();
+            let (mut drop_event, allowed) = drag_area.initial_drop_event();
             // `mouse_event` here is in the parent item's coords (this function is called
             // recursively); translate into the DragArea's local coords, then map back to
             // window coords so the drag-image overlay places at the right spot from the start.
@@ -1694,7 +1716,7 @@ fn send_mouse_event_to_item(
                 .map(|p| item_rc.map_to_window(p))
                 .map(crate::lengths::logical_position_to_api)
                 .unwrap_or_default();
-            result.drag_data = Some(drop_event);
+            result.drag_data = Some(DragData { event: drop_event, allowed });
             result.drag_source = Some(item_rc.downgrade());
             drag_area.dragging.set(true);
             VisitChildrenResult::abort(item_rc.index(), 0)

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2018,7 +2018,7 @@ impl Item for TooltipArea {
     ) -> InputEventFilterResult {
         // Track hover in the filter stage so enter/leave transitions are reliable,
         // independent of later input handling.
-        if matches!(event, MouseEvent::DragMove(..) | MouseEvent::Drop(..)) {
+        if matches!(event, MouseEvent::DragMove { .. } | MouseEvent::Drop { .. }) {
             self.set_hover_state(false, self_rc);
             return InputEventFilterResult::ForwardAndIgnore;
         }

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -27,6 +27,22 @@ use i_slint_core_macros::*;
 
 pub type DropEventArg = (DropEvent,);
 
+/// The set of actions a drag source permits, captured when the drag starts.
+#[repr(C)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub struct AllowedDragActions {
+    pub copy: bool,
+    pub move_: bool,
+    pub link: bool,
+}
+
+impl AllowedDragActions {
+    /// True if at least one action is permitted.
+    pub fn any(self) -> bool {
+        self.copy || self.move_ || self.link
+    }
+}
+
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
@@ -69,7 +85,7 @@ impl Item for DragArea {
         _self_rc: &ItemRc,
         _: &mut MouseCursor,
     ) -> InputEventFilterResult {
-        if !self.enabled() || !self.any_action_allowed() || self.data().is_empty() {
+        if !self.enabled() || !self.allowed_actions().any() || self.data().is_empty() {
             self.cancel();
             return InputEventFilterResult::ForwardAndIgnore;
         }
@@ -112,7 +128,7 @@ impl Item for DragArea {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
         }
@@ -138,7 +154,7 @@ impl Item for DragArea {
             MouseEvent::Moved { position, .. } => {
                 if !self.pressed.get()
                     || !self.enabled()
-                    || !self.any_action_allowed()
+                    || !self.allowed_actions().any()
                     || self.data().is_empty()
                 {
                     return InputEventResult::EventIgnored;
@@ -159,7 +175,7 @@ impl Item for DragArea {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventResult::EventIgnored
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => InputEventResult::EventIgnored,
         }
     }
 
@@ -226,30 +242,25 @@ impl DragArea {
         self.pressed.set(false)
     }
 
-    pub(crate) fn any_action_allowed(self: Pin<&Self>) -> bool {
-        self.allow_copy() || self.allow_move() || self.allow_link()
+    pub(crate) fn allowed_actions(self: Pin<&Self>) -> AllowedDragActions {
+        AllowedDragActions {
+            copy: self.allow_copy(),
+            move_: self.allow_move(),
+            link: self.allow_link(),
+        }
     }
 
-    /// Build the initial DropEvent for a drag starting on this DragArea, populating
-    /// the source's allowed actions and seeding `proposed_action` from the default action
-    /// (the first allowed of move, copy, link).
-    pub(crate) fn initial_drop_event(self: Pin<&Self>) -> DropEvent {
-        let allow_copy = self.allow_copy();
-        let allow_move = self.allow_move();
-        let allow_link = self.allow_link();
-        DropEvent {
+    /// Build the initial DropEvent for a drag starting on this DragArea, together with the
+    /// source's allowed actions. `proposed_action` is seeded from the default action (the first
+    /// allowed of move, copy, link).
+    pub(crate) fn initial_drop_event(self: Pin<&Self>) -> (DropEvent, AllowedDragActions) {
+        let allowed = self.allowed_actions();
+        let event = DropEvent {
             data: self.data(),
             position: Default::default(),
-            allow_copy,
-            allow_move,
-            allow_link,
-            proposed_action: compute_proposed_action(
-                KeyboardModifiers::default(),
-                allow_copy,
-                allow_move,
-                allow_link,
-            ),
-        }
+            proposed_action: compute_proposed_action(KeyboardModifiers::default(), allowed),
+        };
+        (event, allowed)
     }
 }
 
@@ -303,9 +314,9 @@ impl Item for DropArea {
             return InputEventResult::EventIgnored;
         }
         match event {
-            MouseEvent::DragMove(event) => {
+            MouseEvent::DragMove { event, allowed } => {
                 let raw = Self::FIELD_OFFSETS.can_drop().apply_pin(self).call(&(event.clone(),));
-                let chosen = clamp_action_to_allowed(raw, event);
+                let chosen = clamp_action_to_allowed(raw, *allowed);
                 self.current_action.set(chosen);
                 if chosen != DragAction::None {
                     self.has_drag.set(true);
@@ -316,14 +327,14 @@ impl Item for DropArea {
                     InputEventResult::EventIgnored
                 }
             }
-            MouseEvent::Drop(event) => {
+            MouseEvent::Drop { event, allowed } => {
                 self.has_drag.set(false);
                 let returned =
                     Self::FIELD_OFFSETS.dropped().apply_pin(self).call(&(event.clone(),));
                 // The target's `dropped` return value is the final action reported back to
                 // the source. Clamp against the source's allowed set and stash on
                 // `current_action` so the post-dispatch step in `window.rs` can read it.
-                self.current_action.set(clamp_action_to_allowed(returned, event));
+                self.current_action.set(clamp_action_to_allowed(returned, *allowed));
                 InputEventResult::EventAccepted
             }
             MouseEvent::Exit => {
@@ -398,14 +409,12 @@ impl ItemConsts for DropArea {
 /// the first allowed of move/copy/link.
 pub(crate) fn compute_proposed_action(
     modifiers: KeyboardModifiers,
-    allow_copy: bool,
-    allow_move: bool,
-    allow_link: bool,
+    allowed_actions: AllowedDragActions,
 ) -> DragAction {
     let allowed = |a| match a {
-        DragAction::Copy => allow_copy,
-        DragAction::Move => allow_move,
-        DragAction::Link => allow_link,
+        DragAction::Copy => allowed_actions.copy,
+        DragAction::Move => allowed_actions.move_,
+        DragAction::Link => allowed_actions.link,
         DragAction::None => false,
     };
     let modifier_request = match (modifiers.control, modifiers.shift) {
@@ -427,14 +436,17 @@ pub(crate) fn compute_proposed_action(
     DragAction::None
 }
 
-/// Clamp a `can-drop` return value against the source's allowed actions on the DropEvent.
+/// Clamp a `can-drop` return value against the source's allowed actions.
 /// A concrete action the source did not allow becomes `None`.
-pub(crate) fn clamp_action_to_allowed(action: DragAction, event: &DropEvent) -> DragAction {
+pub(crate) fn clamp_action_to_allowed(
+    action: DragAction,
+    allowed: AllowedDragActions,
+) -> DragAction {
     match action {
         DragAction::None => DragAction::None,
-        DragAction::Copy if event.allow_copy => DragAction::Copy,
-        DragAction::Move if event.allow_move => DragAction::Move,
-        DragAction::Link if event.allow_link => DragAction::Link,
+        DragAction::Copy if allowed.copy => DragAction::Copy,
+        DragAction::Move if allowed.move_ => DragAction::Move,
+        DragAction::Link if allowed.link => DragAction::Link,
         _ => DragAction::None,
     }
 }
@@ -457,10 +469,20 @@ mod tests {
         KeyboardModifiers { control, shift, alt: false, meta: false }
     }
 
+    const ALL: AllowedDragActions = AllowedDragActions { copy: true, move_: true, link: true };
+    const COPY_ONLY: AllowedDragActions =
+        AllowedDragActions { copy: true, move_: false, link: false };
+    const MOVE_ONLY: AllowedDragActions =
+        AllowedDragActions { copy: false, move_: true, link: false };
+    const LINK_ONLY: AllowedDragActions =
+        AllowedDragActions { copy: false, move_: false, link: true };
+    const COPY_AND_MOVE: AllowedDragActions =
+        AllowedDragActions { copy: true, move_: true, link: false };
+
     #[test]
     fn compute_proposed_action_modifier_table() {
         // All actions allowed.
-        let a = |m| compute_proposed_action(m, true, true, true);
+        let a = |m| compute_proposed_action(m, ALL);
         assert_eq!(a(modifiers(false, false)), DragAction::Move);
         assert_eq!(a(modifiers(true, false)), DragAction::Copy);
         assert_eq!(a(modifiers(false, true)), DragAction::Move);
@@ -470,35 +492,23 @@ mod tests {
     #[test]
     fn compute_proposed_action_falls_back_when_modifier_action_not_allowed() {
         // Source only allows move; user holds Ctrl (asking for copy).
-        assert_eq!(
-            compute_proposed_action(modifiers(true, false), false, true, false),
-            DragAction::Move
-        );
+        assert_eq!(compute_proposed_action(modifiers(true, false), MOVE_ONLY), DragAction::Move);
         // User holds Ctrl+Shift asking for link, only copy allowed.
-        assert_eq!(
-            compute_proposed_action(modifiers(true, true), true, false, false),
-            DragAction::Copy
-        );
+        assert_eq!(compute_proposed_action(modifiers(true, true), COPY_ONLY), DragAction::Copy);
     }
 
     #[test]
     fn compute_proposed_action_default_is_first_allowed() {
         // No modifiers: the first allowed of move, copy, link wins.
         assert_eq!(
-            compute_proposed_action(modifiers(false, false), true, true, false),
+            compute_proposed_action(modifiers(false, false), COPY_AND_MOVE),
             DragAction::Move
         );
-        assert_eq!(
-            compute_proposed_action(modifiers(false, false), true, false, false),
-            DragAction::Copy
-        );
-        assert_eq!(
-            compute_proposed_action(modifiers(false, false), false, false, true),
-            DragAction::Link
-        );
+        assert_eq!(compute_proposed_action(modifiers(false, false), COPY_ONLY), DragAction::Copy);
+        assert_eq!(compute_proposed_action(modifiers(false, false), LINK_ONLY), DragAction::Link);
         // Nothing allowed at all.
         assert_eq!(
-            compute_proposed_action(modifiers(false, false), false, false, false),
+            compute_proposed_action(modifiers(false, false), AllowedDragActions::default()),
             DragAction::None
         );
     }

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -774,7 +774,7 @@ impl FlickableData {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventFilterResult::ForwardEvent
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
         }
@@ -916,7 +916,7 @@ impl FlickableData {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventResult::EventIgnored
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => InputEventResult::EventIgnored,
         }
     }
 }

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -91,7 +91,7 @@ impl Item for TouchArea {
             }
             return InputEventFilterResult::ForwardAndIgnore;
         }
-        if matches!(event, MouseEvent::DragMove(..) | MouseEvent::Drop(..)) {
+        if matches!(event, MouseEvent::DragMove { .. } | MouseEvent::Drop { .. }) {
             // Someone else has the grab, don't handle hover
             return InputEventFilterResult::ForwardAndIgnore;
         }
@@ -213,7 +213,7 @@ impl Item for TouchArea {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventResult::EventIgnored
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => InputEventResult::EventIgnored,
         }
     }
 
@@ -796,7 +796,7 @@ impl Item for SwipeGestureHandler {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
         }
@@ -846,7 +846,7 @@ impl Item for SwipeGestureHandler {
             MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
                 InputEventResult::EventIgnored
             }
-            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => InputEventResult::EventIgnored,
         }
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -10,9 +10,9 @@ use crate::api::{
     PlatformError, Window, WindowPosition, WindowSize,
 };
 use crate::input::{
-    ClickState, FocusEvent, FocusReason, InternalKeyEvent, KeyEventResult, KeyEventType, Keys,
-    MouseEvent, MouseInputState, PointerEventButton, TextCursorBlinker, TouchPhase, TouchState,
-    key_codes,
+    ClickState, DragData, FocusEvent, FocusReason, InternalKeyEvent, KeyEventResult, KeyEventType,
+    Keys, MouseEvent, MouseInputState, PointerEventButton, TextCursorBlinker, TouchPhase,
+    TouchState, key_codes,
 };
 use crate::item_tree::{
     ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable, ItemTreeWeak, ItemWeak,
@@ -705,7 +705,9 @@ impl WindowInner {
             Option<crate::item_tree::ItemWeak>,
         )> = None;
 
-        if let Some(mut drop_event) = mouse_input_state.drag_data.clone() {
+        if let Some(DragData { event: mut drop_event, allowed }) =
+            mouse_input_state.drag_data.clone()
+        {
             match &event {
                 MouseEvent::Released { position, button: PointerEventButton::Left, .. } => {
                     mouse_input_state.drag_data = None;
@@ -721,7 +723,7 @@ impl WindowInner {
                             .unwrap_or(crate::items::DragAction::None);
                         drop_event.proposed_action = hovered;
                         drop_event.position = crate::lengths::logical_position_to_api(*position);
-                        event = MouseEvent::Drop(drop_event);
+                        event = MouseEvent::Drop { event: drop_event, allowed };
                         if let Some(s) = source {
                             pending_drag_finished = Some((s, Some(target_weak)));
                         }
@@ -743,20 +745,18 @@ impl WindowInner {
                     // `can-drop` callback sees an up-to-date `event.proposed-action`.
                     drop_event.proposed_action = crate::items::compute_proposed_action(
                         self.context().0.modifiers.get().into(),
-                        drop_event.allow_copy,
-                        drop_event.allow_move,
-                        drop_event.allow_link,
+                        allowed,
                     );
                     // Mirror the position and proposed action into the persistent state so the
                     // renderer can place the drag-image overlay without re-deriving the cursor
                     // location, and so a subsequent synthetic Moved (e.g. fired from a modifier
                     // key press) starts from the right position.
                     if let Some(d) = mouse_input_state.drag_data.as_mut() {
-                        d.position = drop_event.position;
-                        d.proposed_action = drop_event.proposed_action;
+                        d.event.position = drop_event.position;
+                        d.event.proposed_action = drop_event.proposed_action;
                     }
                     mouse_input_state.cursor = MouseCursor::NoDrop;
-                    event = MouseEvent::DragMove(drop_event);
+                    event = MouseEvent::DragMove { event: drop_event, allowed };
                 }
                 MouseEvent::Exit => {
                     mouse_input_state.drag_data = None;
@@ -1050,7 +1050,7 @@ impl WindowInner {
             // without having to move the mouse first.
             let drag_pos = {
                 let state = self.mouse_input_state.take();
-                let pos = state.drag_data.as_ref().map(|d| d.position);
+                let pos = state.drag_data.as_ref().map(|d| d.event.position);
                 self.mouse_input_state.replace(state);
                 pos
             };
@@ -1582,7 +1582,7 @@ impl WindowInner {
         item_renderer: &mut dyn crate::item_rendering::ItemRenderer,
     ) {
         let state = self.mouse_input_state.take();
-        let cursor = state.drag_data.as_ref().map(|d| d.position);
+        let cursor = state.drag_data.as_ref().map(|d| d.event.position);
         let source = state.drag_source.as_ref().and_then(|w| w.upgrade());
         self.mouse_input_state.set(state);
 


### PR DESCRIPTION
As discussed in today's API review.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
