### PR TITLE
DropArea: Rename contains-drag to has-drag

### DIFF
--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -39,7 +39,7 @@ export component Example inherits Window {
         }
 
         Rectangle {
-            background: drop.contains-drag ? #80e080 : #a0a0a0;
+            background: drop.has-drag ? #80e080 : #a0a0a0;
             drop := DropArea {
                 can-drop(event) => {
                     Api.can-drop(event.data) ? DragAction.copy : DragAction.none

--- a/examples/dnd-kanban/kanban.slint
+++ b/examples/dnd-kanban/kanban.slint
@@ -93,10 +93,10 @@ component KanbanColumn inherits Rectangle {
         floor((hover-y - Layout.card-height / 2) / Layout.card-stride) + 1,
         0, root.tasks.length);
 
-    background: drop-area.contains-drag ? Theme.column-drop-bg : Theme.column-bg;
+    background: drop-area.has-drag ? Theme.column-drop-bg : Theme.column-bg;
     border-radius: 10px;
     border-width: 1px;
-    border-color: drop-area.contains-drag ? root.accent : Theme.column-border;
+    border-color: drop-area.has-drag ? root.accent : Theme.column-border;
     animate background, border-color { duration: 120ms; }
 
     VerticalLayout {
@@ -152,7 +152,7 @@ component KanbanColumn inherits Rectangle {
 
             // Drop indicator: a 3px line centred in the gap above card `drop-index`
             // (or at the top / below the last card for the boundary positions).
-            if drop-area.contains-drag: Rectangle {
+            if drop-area.has-drag: Rectangle {
                 x: 0;
                 width: parent.width;
                 y: max(0px, root.drop-index * Layout.card-stride

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1286,7 +1286,7 @@ export component DropArea {
     callback dropped(event: DropEvent) -> DragAction;
     /// `true` while an accepted drag hovers over the area, `false` otherwise.
     /// Bind it to a visual property to give the user feedback, for example a background color.
-    out property <bool> contains-drag;
+    out property <bool> has-drag;
     /// The action the runtime is currently negotiating with the source: `none` when no drag is hovering,
     /// or `copy`/`move`/`link` once a concrete action is settled.
     out property <DragAction> current-action;

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -259,7 +259,7 @@ impl DragArea {
 /// The implementation of the `DropArea` element
 pub struct DropArea {
     pub enabled: Property<bool>,
-    pub contains_drag: Property<bool>,
+    pub has_drag: Property<bool>,
     pub current_action: Property<DragAction>,
     pub can_drop: Callback<DropEventArg, DragAction>,
     pub dropped: Callback<DropEventArg, DragAction>,
@@ -308,16 +308,16 @@ impl Item for DropArea {
                 let chosen = clamp_action_to_allowed(raw, event);
                 self.current_action.set(chosen);
                 if chosen != DragAction::None {
-                    self.contains_drag.set(true);
+                    self.has_drag.set(true);
                     *cursor = cursor_for_action(chosen);
                     InputEventResult::EventAccepted
                 } else {
-                    self.contains_drag.set(false);
+                    self.has_drag.set(false);
                     InputEventResult::EventIgnored
                 }
             }
             MouseEvent::Drop(event) => {
-                self.contains_drag.set(false);
+                self.has_drag.set(false);
                 let returned =
                     Self::FIELD_OFFSETS.dropped().apply_pin(self).call(&(event.clone(),));
                 // The target's `dropped` return value is the final action reported back to
@@ -327,7 +327,7 @@ impl Item for DropArea {
                 InputEventResult::EventAccepted
             }
             MouseEvent::Exit => {
-                self.contains_drag.set(false);
+                self.has_drag.set(false);
                 self.current_action.set(DragAction::None);
                 InputEventResult::EventIgnored
             }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -958,7 +958,7 @@ impl WindowInner {
                 .apply_pin(drag_area)
                 .call(&(action,));
             // The drag is over: reset the target's `current_action` so it matches
-            // `contains_drag` and the docstring ("none when no drag is hovering").
+            // `has_drag` and the docstring ("none when no drag is hovering").
             if let Some(target) = target {
                 target.as_pin_ref().current_action.set(crate::items::DragAction::None);
             }

--- a/tests/cases/elements/dragarea_droparea.slint
+++ b/tests/cases/elements/dragarea_droparea.slint
@@ -24,7 +24,7 @@ export component TestCase inherits Window {
     out property <image> result-image;
     in property <bool> use-image: false;
     in property <bool> empty-data: false;
-    out property <bool> contains-drag <=> da.contains-drag;
+    out property <bool> has-drag <=> da.has-drag;
     out property <DragAction> current-action <=> da.current-action;
     out property <bool> dragging <=> dragger.dragging;
     // TODO: Expose the image version
@@ -50,7 +50,7 @@ export component TestCase inherits Window {
             }
         }
         Rectangle {
-            background: da.contains-drag ? green : blue;
+            background: da.has-drag ? green : blue;
             da := DropArea {
                 can-drop(event) => {
                     debug("can-drop", event);
@@ -95,11 +95,11 @@ instance.on_can_drop(|data, use_image| {
     }
 });
 
-// `contains-drag`, `current-action`, and `dragging` should always move in lockstep:
+// `has-drag`, `current-action`, and `dragging` should always move in lockstep:
 // drop-area has-drag <-> action is concrete, and dragging is true between StartDrag
 // and the drop / cancel.
-let assert_drag_state = |contains: bool, action: DragAction, dragging: bool| {
-    assert_eq!(instance.get_contains_drag(), contains, "contains-drag");
+let assert_drag_state = |has_drag: bool, action: DragAction, dragging: bool| {
+    assert_eq!(instance.get_has_drag(), has_drag, "has-drag");
     assert_eq!(instance.get_current_action(), action, "current-action");
     assert_eq!(instance.get_dragging(), dragging, "dragging");
 };

--- a/tests/cases/elements/dragarea_image.slint
+++ b/tests/cases/elements/dragarea_image.slint
@@ -19,7 +19,7 @@ export component TestCase inherits Window {
     width: 100px;
     height: 200px;
     in-out property <string> result;
-    out property <bool> contains-drag <=> da.contains-drag;
+    out property <bool> has-drag <=> da.has-drag;
 
     VerticalLayout {
         Rectangle {
@@ -54,7 +54,7 @@ let instance = TestCase::new().unwrap();
 instance.on_string_to_transfer(Into::into);
 instance.on_can_drop(|data| data.has_plain_text());
 
-assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_has_drag(), false);
 
 // Press, cross drag threshold, hover over the drop area, release.
 instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(20.0, 25.0), button: PointerEventButton::Left });
@@ -63,12 +63,12 @@ instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPo
 slint_testing::mock_elapsed_time(20);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(22.0, 120.0) });
 slint_testing::mock_elapsed_time(20);
-assert_eq!(instance.get_contains_drag(), true);
+assert_eq!(instance.get_has_drag(), true);
 
 instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(22.0, 120.0), button: PointerEventButton::Left });
 slint_testing::mock_elapsed_time(20);
 assert_eq!(instance.get_result(), "drop;");
-assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_has_drag(), false);
 ```
 
 */

--- a/tools/lsp/ui/views/outline-view.slint
+++ b/tools/lsp/ui/views/outline-view.slint
@@ -96,7 +96,7 @@ export component OutlineView inherits VerticalLayout {
                 Rectangle {
                     height: 1px;
                     background: Palette.foreground;
-                    visible: parent.contains-drag;
+                    visible: parent.has-drag;
                 }
             }
 
@@ -118,7 +118,7 @@ export component OutlineView inherits VerticalLayout {
                 Rectangle {
                     height: 1px;
                     background: Palette.foreground;
-                    visible: parent.contains-drag;
+                    visible: parent.has-drag;
                 }
             }
 
@@ -141,7 +141,7 @@ export component OutlineView inherits VerticalLayout {
                 Rectangle {
                     background: {
                         let bg-color = selected ? Palette.selection-background : Palette.background;
-                        return ta-open.has-hover || ta.has-hover || drop-as-child.contains-drag ? bg-color.mix(Palette.selection-background, 50%) : bg-color;
+                        return ta-open.has-hover || ta.has-hover || drop-as-child.has-drag ? bg-color.mix(Palette.selection-background, 50%) : bg-color;
                     }
                     animate background {
                         duration: 200ms;


### PR DESCRIPTION
For consistency with the other has-* properties in our APIs.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
