### PR TITLE
system-tray: gate the ksni backend behind a Cargo feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,7 +6334,6 @@ dependencies = [
  "futures-util",
  "pastey 0.2.3",
  "serde",
- "tokio",
  "zbus",
 ]
 
@@ -11724,7 +11723,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -14248,7 +14246,6 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
- "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,6 +6334,7 @@ dependencies = [
  "futures-util",
  "pastey 0.2.3",
  "serde",
+ "tokio",
  "zbus",
 ]
 
@@ -11723,6 +11724,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -14246,6 +14248,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -45,6 +45,11 @@ renderer-software = ["i-slint-backend-selector/renderer-software", "dep:i-slint-
 software-renderer-path = ["i-slint-renderer-software/path"]
 gettext = ["i-slint-core/gettext-rs"]
 accessibility = ["i-slint-backend-selector/accessibility"]
+# Enable the `SystemTrayIcon` element (pulls `ksni` on Linux/BSD); use
+# `system-tray-tokio` to run the tray on the tokio runtime instead of async-io.
+system-tray = ["i-slint-core/system-tray"]
+system-tray-async-io = ["i-slint-core/system-tray-async-io"]
+system-tray-tokio = ["i-slint-core/system-tray-tokio"]
 system-testing = ["i-slint-backend-selector/system-testing"]
 mcp = ["std", "i-slint-backend-selector/mcp"]
 
@@ -61,7 +66,7 @@ std = [
 freestanding = ["i-slint-core/libm", "i-slint-core/unsafe-single-threaded", "i-slint-renderer-software?/libm"]
 experimental = ["i-slint-renderer-software?/experimental"]
 
-default = ["std", "backend-winit", "renderer-femtovg"]
+default = ["std", "backend-winit", "renderer-femtovg", "system-tray"]
 
 [dependencies]
 i-slint-backend-selector = { workspace = true, optional = true }

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -45,11 +45,8 @@ renderer-software = ["i-slint-backend-selector/renderer-software", "dep:i-slint-
 software-renderer-path = ["i-slint-renderer-software/path"]
 gettext = ["i-slint-core/gettext-rs"]
 accessibility = ["i-slint-backend-selector/accessibility"]
-# Enable the `SystemTrayIcon` element (pulls `ksni` on Linux/BSD); use
-# `system-tray-tokio` to run the tray on the tokio runtime instead of async-io.
+# Enable the `SystemTrayIcon` element (pulls `ksni` on Linux/BSD).
 system-tray = ["i-slint-core/system-tray"]
-system-tray-async-io = ["i-slint-core/system-tray-async-io"]
-system-tray-tokio = ["i-slint-core/system-tray-tokio"]
 system-testing = ["i-slint-backend-selector/system-testing"]
 mcp = ["std", "i-slint-backend-selector/mcp"]
 

--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -59,7 +59,7 @@ napi-derive = "3"
 i-slint-compiler = { workspace = true, features = ["default"] }
 i-slint-core = { workspace = true, features = ["default", "gettext-rs"] }
 i-slint-backend-selector = { workspace = true }
-slint-interpreter = { workspace = true, default-features = false, features = ["display-diagnostics", "internal", "compat-1-2"] }
+slint-interpreter = { workspace = true, default-features = false, features = ["display-diagnostics", "internal", "compat-1-2", "system-tray"] }
 spin_on = { workspace = true }
 css-color-parser2 = { workspace = true }
 itertools = { workspace = true }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -86,18 +86,8 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## Enable the `SystemTrayIcon` element. On Linux/BSD this pulls in
 ## [`ksni`](https://crates.io/crates/ksni). It is on by default; to drop the
 ## tray dependency, disable default features and re-enable the ones you need
-## without `system-tray` (keep the mandatory `compat-1-2`). Enabling this
-## selects ksni's `async-io` backend.
+## without `system-tray` (keep the mandatory `compat-1-2`).
 system-tray = ["i-slint-core/system-tray"]
-
-## Like `system-tray`, but runs ksni's tray service on the `async-io` runtime.
-system-tray-async-io = ["i-slint-core/system-tray-async-io"]
-
-## Like `system-tray`, but runs ksni's tray service on the `tokio` runtime, so
-## the tray shares the runtime of a tokio-based application. Enable this instead
-## of `system-tray` (the two ksni backends are mutually exclusive, so build
-## without default features and add this).
-system-tray-tokio = ["i-slint-core/system-tray-tokio"]
 
 ## Enable integration with [raw-window-handle](raw_window_handle_06) version 0.6. This provides a
 ## [`Window::window_handle()`] function that returns a struct that implements

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -20,7 +20,15 @@ path = "lib.rs"
 
 [features]
 
-default = ["std", "backend-default", "renderer-femtovg", "renderer-software", "accessibility", "compat-1-2"]
+default = [
+  "std",
+  "backend-default",
+  "renderer-femtovg",
+  "renderer-software",
+  "accessibility",
+  "compat-1-2",
+  "system-tray",
+]
 
 ## Mandatory feature:
 ## This feature is required to keep the compatibility with Slint 1.2
@@ -74,6 +82,22 @@ unsafe-single-threaded = ["i-slint-core/unsafe-single-threaded"]
 ## Enabling this feature will try to expose the tree of UI elements to OS provided accessibility
 ## APIs to support screen readers and other assistive technologies.
 accessibility = ["i-slint-backend-selector/accessibility"]
+
+## Enable the `SystemTrayIcon` element. On Linux/BSD this pulls in
+## [`ksni`](https://crates.io/crates/ksni). It is on by default; to drop the
+## tray dependency, disable default features and re-enable the ones you need
+## without `system-tray` (keep the mandatory `compat-1-2`). Enabling this
+## selects ksni's `async-io` backend.
+system-tray = ["i-slint-core/system-tray"]
+
+## Like `system-tray`, but runs ksni's tray service on the `async-io` runtime.
+system-tray-async-io = ["i-slint-core/system-tray-async-io"]
+
+## Like `system-tray`, but runs ksni's tray service on the `tokio` runtime, so
+## the tray shares the runtime of a tokio-based application. Enable this instead
+## of `system-tray` (the two ksni backends are mutually exclusive, so build
+## without default features and add this).
+system-tray-tokio = ["i-slint-core/system-tray-tokio"]
 
 ## Enable integration with [raw-window-handle](raw_window_handle_06) version 0.6. This provides a
 ## [`Window::window_handle()`] function that returns a struct that implements

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -43,8 +43,6 @@ std = [
   "i-slint-common/color-parsing",
   "i-slint-common/markdown",
   "taffy/std",
-  "dep:ksni",
-  "dep:async-channel",
 ]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
@@ -82,6 +80,18 @@ tr = ["dep:tr"]
 
 32-bit-color = []
 default = ["std", "unicode", "shared-parley"]
+
+# System tray (`SystemTrayIcon`) support. On Linux/BSD this pulls `ksni`; on
+# other platforms it gates the native backend. When disabled, `SystemTrayIcon`
+# constructs against a no-op backend. Opt-in (not part of `std`/`default`) so an
+# application that doesn't want the tray dependency can leave it off; the
+# user-facing crates list it in their own `default` so it stays on out of the box.
+# Enabling `system-tray` selects the `async-io` ksni backend; pick
+# `system-tray-tokio` instead to run the tray on the tokio runtime (the two ksni
+# backends are mutually exclusive).
+system-tray = ["system-tray-async-io"]
+system-tray-async-io = ["dep:ksni", "dep:async-channel", "ksni/async-io", "ksni/blocking"]
+system-tray-tokio = ["dep:ksni", "dep:async-channel", "ksni/tokio", "ksni/blocking"]
 
 shared-parley = ["shared-fontique", "dep:parley", "dep:skrifa", "dep:icu_normalizer"]
 
@@ -161,7 +171,7 @@ image = { workspace = true, default-features = false, features = ["png"] }
 windows = { workspace = true, features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(all(target_family = "unix", not(target_vendor = "apple"), not(target_os = "android")))'.dependencies]
-ksni = { version = "0.3.3", optional = true, default-features = false, features = ["async-io", "blocking"] }
+ksni = { version = "0.3.3", optional = true, default-features = false }
 async-channel = { version = "2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -86,12 +86,7 @@ default = ["std", "unicode", "shared-parley"]
 # constructs against a no-op backend. Opt-in (not part of `std`/`default`) so an
 # application that doesn't want the tray dependency can leave it off; the
 # user-facing crates list it in their own `default` so it stays on out of the box.
-# Enabling `system-tray` selects the `async-io` ksni backend; pick
-# `system-tray-tokio` instead to run the tray on the tokio runtime (the two ksni
-# backends are mutually exclusive).
-system-tray = ["system-tray-async-io"]
-system-tray-async-io = ["dep:ksni", "dep:async-channel", "ksni/async-io", "ksni/blocking"]
-system-tray-tokio = ["dep:ksni", "dep:async-channel", "ksni/tokio", "ksni/blocking"]
+system-tray = ["dep:ksni", "dep:async-channel", "ksni/async-io", "ksni/blocking"]
 
 shared-parley = ["shared-fontique", "dep:parley", "dep:skrifa", "dep:icu_normalizer"]
 

--- a/internal/core/items/system_tray.rs
+++ b/internal/core/items/system_tray.rs
@@ -31,16 +31,17 @@ use core::pin::Pin;
 use i_slint_core_macros::*;
 
 // Pick the per-platform tray backend. The `dummy` arm catches anything without a
-// real native tray (Android, WASM, embedded targets, …) so a `SystemTrayIcon`-
-// rooted component constructs without surfacing an icon to any host shell.
+// real native tray (the `system-tray` feature is off, or Android, WASM, embedded
+// targets, …) so a `SystemTrayIcon`-rooted component constructs without surfacing
+// an icon to any host shell.
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "macos")] {
+    if #[cfg(all(feature = "system-tray", target_os = "macos"))] {
         mod appkit;
         use self::appkit::PlatformTray;
-    } else if #[cfg(target_os = "windows")] {
+    } else if #[cfg(all(feature = "system-tray", target_os = "windows"))] {
         mod windows;
         use self::windows::PlatformTray;
-    } else if #[cfg(all(feature = "std", target_family = "unix", not(target_vendor = "apple"), not(target_os = "android")))] {
+    } else if #[cfg(all(feature = "system-tray", target_family = "unix", not(target_vendor = "apple"), not(target_os = "android")))] {
         mod ksni;
         use self::ksni::PlatformTray;
     } else {

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -21,7 +21,7 @@ path = "lib.rs"
 
 [features]
 
-default = ["backend-default", "renderer-femtovg", "renderer-software", "accessibility", "compat-1-2"]
+default = ["backend-default", "renderer-femtovg", "renderer-software", "accessibility", "compat-1-2", "system-tray"]
 
 ## Mandatory feature:
 ## This feature is required to keep the compatibility with Slint 1.2
@@ -29,6 +29,13 @@ default = ["backend-default", "renderer-femtovg", "renderer-software", "accessib
 ## that would be enabled by default only if this feature was added
 "compat-1-2" = []
 "compat-1-0" = ["compat-1-2"]
+
+## Enable the `SystemTrayIcon` element (pulls `ksni` on Linux/BSD); on by
+## default. See the [`slint` crate](https://docs.rs/slint/latest/slint/) feature
+## of the same name.
+system-tray = ["i-slint-core/system-tray"]
+system-tray-async-io = ["i-slint-core/system-tray-async-io"]
+system-tray-tokio = ["i-slint-core/system-tray-tokio"]
 
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output
 display-diagnostics = ["i-slint-compiler/display-diagnostics"]

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -34,8 +34,6 @@ default = ["backend-default", "renderer-femtovg", "renderer-software", "accessib
 ## default. See the [`slint` crate](https://docs.rs/slint/latest/slint/) feature
 ## of the same name.
 system-tray = ["i-slint-core/system-tray"]
-system-tray-async-io = ["i-slint-core/system-tray-async-io"]
-system-tray-tokio = ["i-slint-core/system-tray-tokio"]
 
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output
 display-diagnostics = ["i-slint-compiler/display-diagnostics"]


### PR DESCRIPTION
## Problem

`i-slint-core`'s `std` feature unconditionally pulls `ksni` with a hardcoded `async-io` backend. Because Cargo unifies a dependency's features across the graph, this forces `async-io` onto every ksni consumer in the workspace. An application already using ksni with its default `tokio` backend then fails to build: ksni 0.3.5 errors when both `tokio` and `async-io` are enabled, even if it never instantiates `SystemTrayIcon`.

## Change

- Move the tray backend (and `dep:ksni` + `dep:async-channel`) behind a new `system-tray` Cargo feature, gated out of `std`.
- Enable it by default through the user-facing crates' `default` feature, so default builds are unchanged; building with `default-features = false` (re-enabling what you need, including the mandatory `compat-1-2`, but not `system-tray`) drops the tray dependency completely.
- Add `system-tray-tokio` (and `system-tray-async-io`, the prior default) so apps that *do* want the tray can run it on their own runtime.
- The same gate now covers the AppKit and Windows backends, so disabling it yields the `dummy` backend on every platform.
- Threaded through `slint`, `slint-interpreter`, `slint-cpp`, and the node bindings (python inherits it via the interpreter's default features).

## Verification

`cargo tree` confirms default builds still pull ksni (async-io); an external crate with `default-features = false` pulls no ksni. `cargo check` passes for i-slint-core under async-io / tokio / dummy, and for `slint` + `slint-interpreter` with default features.

## Context

I ran into this while migrating a workspace ahead of the 1.17 release (to try the new `Tooltip`). The workspace builds a few binaries: a main Slint GUI, and (as a separate process) a small system-tray helper that talks to the GUI over D-Bus (zbus). That tray binary predates Slint's adoption of `ksni`: it uses `ksni` directly on its default `tokio` backend, matching the rest of the app, which is tokio + `zbus`-on-tokio throughout.

The moment the GUI crate moved to Slint 1.17, the whole workspace stopped compiling, even though the GUI never instantiates `SystemTrayIcon`. Cargo unified `i-slint-core`'s `async-io`-flavored `ksni` with the tray crate's `tokio`-flavored `ksni`, and ksni 0.3.5's compile-time guard rejects having both backends enabled at once.

A minimal reproducer, two crates in one workspace:

```toml
# tray/Cargo.toml — a tokio app using ksni directly (predates Slint's tray)
[dependencies]
ksni = "0.3"     # default features → tokio backend

# gui/Cargo.toml — any Slint 1.17 GUI
[dependencies]
slint = "1.17"   # std → i-slint-core → ksni with async-io
```

```
error: Features "tokio" and "async-io" cannot be enabled at the same time.
  --> ksni-0.3.5/src/compat.rs
```

`cargo tree -i ksni` shows the two consumers pulling incompatible feature sets. With this PR the GUI builds with `default-features = false` (keeping the mandatory `compat-1-2`, omitting `system-tray`), so Slint pulls no `ksni` and the tray keeps its tokio backend, thus no conflict. Apps that *do* want Slint's tray on a tokio runtime can enable `system-tray-tokio` instead.