### PR TITLE
skill: promote the docs page and other fixes

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
                                     },
                                     "guide/tooling/live-preview",
                                     "guide/tooling/figma-inspector",
+                                    "guide/tooling/ai-coding-assistants",
                                 ],
                             },
                             {
@@ -217,10 +218,6 @@ export default defineConfig({
                                               {
                                                   label: "Overview",
                                                   slug: "guide/experimental/overview",
-                                              },
-                                              {
-                                                  label: "AI Coding Assistants",
-                                                  slug: "guide/experimental/ai-coding-assistants",
                                               },
                                               {
                                                   label: "FlexboxLayout",

--- a/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx
@@ -12,7 +12,7 @@ Use the Slint skill to give Claude Code or Codex project-specific guidance for w
   Add the Slint marketplace from GitHub and install the plugin:
 
   ```sh
-  /plugin marketplace add slint-ui/slint
+  /plugin marketplace add https://github.com/slint-ui/slint.git#release/1
   /plugin install slint@slint
   ```
 
@@ -22,7 +22,7 @@ Use the Slint skill to give Claude Code or Codex project-specific guidance for w
   Enter the following in the Codex prompt to install the skill from GitHub:
 
   ```sh
-  $skill-installer install https://github.com/slint-ui/slint/tree/master/skills/slint
+  $skill-installer install https://github.com/slint-ui/slint/tree/release/1/skills/slint
   ```
 
   Restart Codex after the install so it picks up the new skill.
@@ -32,10 +32,10 @@ Use the Slint skill to give Claude Code or Codex project-specific guidance for w
 
   ```sh
   # Codex
-  gh skill install slint-ui/slint slint --agent codex
+  gh skill install slint-ui/slint slint@release/1 --agent codex
 
   # Claude Code
-  gh skill install slint-ui/slint slint --agent claude-code
+  gh skill install slint-ui/slint slint@release/1 --agent claude-code
   ```
 
   See [`gh skill install`](https://cli.github.com/manual/gh_skill_install) for the full list of supported agents (Cursor, Gemini CLI, Windsurf, and others). Restart your agent afterward so it picks up the new skill.
@@ -44,7 +44,7 @@ Use the Slint skill to give Claude Code or Codex project-specific guidance for w
   Install the Slint skill into the current project with the [`skills`](https://github.com/vercel-labs/skills) CLI:
 
   ```sh
-  npx skills add slint-ui/slint --skill slint
+  npx skills add https://github.com/slint-ui/slint/tree/release/1/skills/slint
   ```
 
   This works for any agent supported by the `skills` CLI (Claude Code, Cursor, and others) and installs into the project's agent skills directory by default. Pass `-g` to install globally for all projects.

--- a/skills/.cursor-plugin/plugin.json
+++ b/skills/.cursor-plugin/plugin.json
@@ -9,5 +9,13 @@
   "homepage": "https://slint.dev",
   "repository": "https://github.com/slint-ui/slint",
   "license": "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0",
-  "skills": "./slint"
+  "skills": "./slint",
+  "lspServers": {
+    "slint": {
+      "command": "slint-lsp",
+      "extensionToLanguage": {
+        ".slint": "slint"
+      }
+    }
+  }
 }

--- a/skills/slint/SKILL.md
+++ b/skills/slint/SKILL.md
@@ -10,13 +10,17 @@ a declarative GUI toolkit for desktop, embedded, mobile, and web.
 
 ## Workflow
 
-1. Match the project's Slint version (`Cargo.toml`/`Cargo.lock`,
+1. Find the project's Slint version first (`Cargo.toml`/`Cargo.lock`,
    `package.json`, `pyproject.toml`, or the CMake `find_package`/`FetchContent`
-   line) and consult that version's docs for exact APIs rather than guessing.
+   line). This skill targets Slint **≥ 1.17** and its prose assumes the latest
+   release; anything that needs a specific version is flagged inline as
+   `(1.17+)`, `(1.18+)`, … When the project pins an *older* version, or for
+   exact element/property/widget signatures, trust that version's docs over
+   this file rather than guessing.
 2. After editing: in an IDE with the Slint extension, trust the post-edit
    diagnostics; in a terminal, `slint-viewer --check ui/main.slint` compiles
    one file and prints diagnostics, and `slint-viewer --screenshot` renders it
-   ([debugging-and-mcp.md](reference/debugging-and-mcp.md)).
+   (both `(1.17+)`; [debugging-and-mcp.md](reference/debugging-and-mcp.md)).
 3. Never declare UI work done without looking at a render — a screenshot for
    appearance, the MCP server for interactions. Review against
    [polish.md](reference/polish.md).
@@ -73,8 +77,8 @@ interop: `export global Foo { ... }`. One-time code: `init => { ... }`.
 ## Documentation
 
 Latest: https://slint.dev/docs. Pin a version with
-`https://releases.slint.dev/<version>/docs` (e.g. `…/1.15.1/docs`). From 1.17,
-every docs page also serves its markdown source — replace the URL's trailing
+`https://releases.slint.dev/<version>/docs` (e.g. `…/1.15.1/docs`). Every docs
+page also serves its markdown source `(1.17+)` — replace the URL's trailing
 slash with `.md` (`…/reference/colors-and-brushes/` →
 `…/reference/colors-and-brushes.md`). Prefer it when fetching: it is about 10×
 smaller than the HTML. It is raw MDX, so skip the `import` lines, and a few

--- a/skills/slint/reference/debugging-and-mcp.md
+++ b/skills/slint/reference/debugging-and-mcp.md
@@ -26,14 +26,14 @@
 ## Check a `.slint` file (`slint-viewer --check`)
 
 `slint-viewer --check ui/main.slint` compiles the file and prints diagnostics
-without opening a window (Slint >= 1.17): exit 1 on errors, 0 otherwise
+without opening a window `(1.17+)`: exit 1 on errors, 0 otherwise
 (warnings still print). `-I`/`-L`/`--style` apply. Use this as the fast
 per-file compile check; the host build is only needed for the interop side.
 
 ## Headless screenshots of a `.slint` file (`slint-viewer --screenshot`)
 
 Renders a component to an image with no windowing system and no app code
-(Slint >= 1.17):
+`(1.17+)`:
 
 ```sh
 slint-viewer --screenshot out.png ui/main.slint              # .png/.jpg, or - for stdout
@@ -62,7 +62,7 @@ summarize what was visually checked.
 
 ## MCP Server for AI-Assisted Debugging
 
-Slint **1.17+** ships an embedded MCP server: walk the UI tree, read
+Slint ships an embedded MCP server `(1.17+)`: walk the UI tree, read
 accessibility properties, screenshot, and simulate clicks, drags, and typing
 in the running app — the best way to verify real interactions. (If
 `--features slint/mcp` fails with "unknown feature", the Slint version is too

--- a/skills/slint/reference/gotchas.md
+++ b/skills/slint/reference/gotchas.md
@@ -34,7 +34,7 @@ bold text.
   same.
 - **Gradients**: `@linear-gradient(angle, color stop%, …)`,
   `@radial-gradient(circle [radius] [at x y], color stop%, …)` (always
-  circular; radius and center are new in 1.17), and
+  circular; radius and center are `(1.17+)`), and
   `@conic-gradient([from angle] [at x y], color deg, …)`.
 - **Animations** are declared on *properties*, inside the element whose
   property changes: `animate width { duration: 200ms; }`.


### PR DESCRIPTION
Mark features that need a particular Slint version with a `(1.17+)` floor, and state in SKILL.md that the skill targets >= 1.17 and assumes the latest release, falling back to the version-pinned docs on older projects.

Give the Cursor plugin the same slint-lsp language server as the Claude one.

Move the AI coding assistants page out of the experimental section into Tooling so it shows in the published docs, and pin the install commands to the release/1 branch.
