### PR TITLE
fix(winit): pre-render first frame before mapping window to avoid X11 VRAM flash

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1123,6 +1123,12 @@ impl WinitWindowAdapter {
                 self.resize_window(size.into())?;
             };
 
+            // Pre-render the first frame before mapping the window to avoid
+            // a flash of uninitialized VRAM on X11 (no background_pixmap).
+            if matches!(visibility, WindowVisibility::ShownFirstTime) {
+                let _ = self.renderer().render(self.window());
+            }
+
             winit_window.set_visible(true);
 
             // Refresh the SlintContext color-scheme now that the window is mapped: on some platforms


### PR DESCRIPTION
## Summary

- Render the first frame into the GPU surface **before** calling `winit_window.set_visible(true)` in `set_visibility(ShownFirstTime)`
- Eliminates the flash of uninitialized VRAM on X11 multi-monitor setups

## Problem

On X11, winit creates windows with `background_pixmap = None`. Between `XMapWindow` and the first `glXSwapBuffers`/`vkQueuePresent`, the compositor shows whatever is in
VRAM — typically garbage pixels or fragments from another monitor. This is especially noticeable on multi-monitor setups with borderless (`no-frame`) windows.

This is a well-known issue across the winit ecosystem:
- winit [#1399](https://github.com/rust-windowing/winit/issues/1399) — closed as out-of-scope, maintainer recommended: *"initialize the window as hidden, and only show it
after OpenGL is able to render an initial thing"*
- Alacritty [#297](https://github.com/alacritty/alacritty/issues/297) — open since 2017, same root cause

Slint already creates windows with `visible = false` and defers `set_visible(true)`, but `renderer.render()` is not called before `set_visible(true)` — the first render
only happens when the event loop delivers `RedrawRequested`, after the window is already mapped.

## Fix

At the point where `set_visible(true)` is called in `winitwindowadapter.rs`, the renderer is fully initialized (`resume()` has created the GPU surface) and the window is
correctly sized (`resize_window()` has been called). A single `renderer.render()` call draws the UI into the surface so the window is mapped with valid content:

```rust
// Pre-render the first frame before mapping the window to avoid
// a flash of uninitialized VRAM on X11 (no background_pixmap).
let _ = self.renderer().render(self.window());

winit_window.set_visible(true);
```

## Platform impact

| Platform | Effect |
|----------|--------|
| X11 | Fixes VRAM flash on window creation |
| Wayland | No-op — compositor doesn't show surface until first buffer commit |
| macOS / Windows | Harmless — first frame renders slightly earlier |
| WASM | Unaffected — wasm already has explicit `draw()` after `show()` |

## Test plan

- [x] Tested on X11 dual-monitor setup with `no-frame: true` window (Skia renderer) — no flash
- [x] Verify no regression on Wayland
- [ ] Verify no regression on macOS / Windows

fixes #12144 

