### PR TITLE
Cache the slint! macro output token stream (rust-analyzer fast path)

### DIFF
--- a/api/rs/macros/expansion_cache.rs
+++ b/api/rs/macros/expansion_cache.rs
@@ -1,0 +1,236 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! A process-global cache of the `slint!` macro's generated output.
+//!
+//! rust-analyzer re-expands `slint!` very frequently in a long-lived process,
+//! usually with an unchanged body, and a full expansion costs tens of milliseconds
+//! (it compiles the builtins, the style and any imported widgets). Caching the
+//! output turns an unchanged re-expansion into a lookup plus a re-parse.
+//!
+//! The cached value is a `String`, not a `TokenStream`: it is shared across the
+//! thread rust-analyzer spawns per expansion, and a `TokenStream` is not `Send`.
+//!
+//! On by default under rust-analyzer (where the live-preview output is small and
+//! re-parsing is cheap); opt in elsewhere with `SLINT_MACRO_CACHE=1`.
+
+use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use i_slint_compiler::CompilerConfiguration;
+use i_slint_compiler::parser::Token;
+
+/// Maximum number of entries; editing a body creates a new key each time, so the
+/// cache must be bounded.
+const CAPACITY: usize = 64;
+
+/// Whether the macro is running under rust-analyzer, detected via its unstable
+/// internal environment variable. `lib.rs` uses it to select the live-preview
+/// generator.
+pub fn is_rust_analyzer() -> bool {
+    std::env::var_os("RUST_ANALYZER_INTERNALS_DO_NOT_USE").is_some()
+}
+
+/// Whether the output cache should be used: on under rust-analyzer, opt-in
+/// elsewhere with `SLINT_MACRO_CACHE=1` (off by default).
+pub fn enabled() -> bool {
+    is_rust_analyzer()
+        || matches!(std::env::var("SLINT_MACRO_CACHE").as_deref(), Ok("1") | Ok("true"))
+}
+
+struct Entry {
+    /// The full key, compared verbatim on lookup so a hash near-collision can't
+    /// serve a wrong entry.
+    key: String,
+    /// The serialized generated token stream.
+    output: String,
+    /// Loaded external files with a content hash of each; the entry is invalidated
+    /// once any of them no longer matches.
+    deps: Vec<(PathBuf, u64)>,
+}
+
+/// Bounded, insertion-ordered set of entries (FIFO eviction). Lookup is a linear
+/// scan, which is fine at this capacity.
+#[derive(Default)]
+struct Cache {
+    entries: VecDeque<Entry>,
+}
+
+impl Cache {
+    /// The cached output and deps for `key`; deps are validated by the caller after
+    /// the lock is released (see `lookup`).
+    fn candidate(&self, key: &str) -> Option<(String, Vec<(PathBuf, u64)>)> {
+        self.entries.iter().find(|e| e.key == key).map(|e| (e.output.clone(), e.deps.clone()))
+    }
+
+    fn put(&mut self, key: String, output: String, deps: Vec<(PathBuf, u64)>) {
+        if let Some(existing) = self.entries.iter_mut().find(|e| e.key == key) {
+            existing.output = output;
+            existing.deps = deps;
+            return;
+        }
+        if self.entries.len() >= CAPACITY {
+            self.entries.pop_front();
+        }
+        self.entries.push_back(Entry { key, output, deps });
+    }
+}
+
+/// Whether every dependency still hashes to its recorded value. An unreadable
+/// file counts as changed, which invalidates the entry.
+fn deps_match(deps: &[(PathBuf, u64)]) -> bool {
+    deps.iter().all(|(path, expected)| content_hash(path) == Some(*expected))
+}
+
+fn cache() -> &'static Mutex<Cache> {
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(Cache::default()))
+}
+
+fn hash64<H: Hash>(value: &H) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Content hash of `path`, or `None` if it can't be read (treated as changed).
+fn content_hash(path: &Path) -> Option<u64> {
+    std::fs::read(path).ok().map(|bytes| hash64(&bytes))
+}
+
+/// Build the cache key from everything that varies between expansions and affects
+/// the output: the source path, the relevant compiler configuration, and the macro
+/// body (token kind + text; spans are excluded so the same body at a different call
+/// site still hits). Environment variables are constant for the life of the
+/// process, so they don't belong in the key.
+pub fn key_material(
+    tokens: &[Token],
+    config: &CompilerConfiguration,
+    source_path: &Path,
+) -> String {
+    use std::fmt::Write;
+    let mut key = String::new();
+    let _ = write!(key, "src={source_path:?};");
+    let _ = write!(key, "style={:?};", config.style);
+    let _ = write!(key, "inc={:?};", config.include_paths);
+    let mut libs: Vec<_> = config.library_paths.iter().collect();
+    libs.sort_by(|a, b| a.0.cmp(b.0));
+    let _ = write!(key, "lib={libs:?};");
+    let _ = write!(key, "td={:?};", config.translation_domain);
+    let _ = write!(key, "dtc={:?};", config.default_translation_context);
+    let _ = write!(key, "exp={};", config.enable_experimental);
+    let _ = write!(key, "inl={};", config.inline_all_elements);
+    key.push_str("tokens=");
+    for t in tokens {
+        let _ = write!(key, "{:?}:{};", t.kind, t.text);
+    }
+    key
+}
+
+/// Test-only hit counter: a hit is otherwise indistinguishable from a fresh
+/// expansion, so a test needs this to assert one actually happened.
+#[cfg(test)]
+static HIT_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[inline]
+fn note_hit() {
+    #[cfg(test)]
+    HIT_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Cached output for `key` if present and all its dependencies are unchanged.
+/// Deps are hashed after the lock is released so concurrent expansions don't
+/// serialize on disk reads.
+pub fn lookup(key: &str) -> Option<String> {
+    let (output, deps) = cache().lock().ok()?.candidate(key)?;
+    if deps_match(&deps) {
+        note_hit();
+        Some(output)
+    } else {
+        None
+    }
+}
+
+/// Cache `output` for `key`. `loaded_files` are the files the output depends on
+/// (the set that also drives the `include_bytes!` reload markers); if any can't be
+/// hashed the entry is dropped rather than stored without validation.
+pub fn store(key: String, output: String, loaded_files: &[PathBuf]) {
+    let mut deps = Vec::with_capacity(loaded_files.len());
+    for path in loaded_files {
+        match content_hash(path) {
+            Some(h) => deps.push((path.clone(), h)),
+            None => return,
+        }
+    }
+    if let Ok(mut guard) = cache().lock() {
+        guard.put(key, output, deps);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit_count() -> u64 {
+        HIT_COUNT.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// A real round-trip through the public `store`/`lookup` API: a stored key is
+    /// served back (a hit), an absent key is not, and the hit is actually recorded.
+    /// Keys are unique so the test is independent of the shared process-global cache.
+    #[test]
+    fn store_then_lookup_is_a_recorded_hit() {
+        let key = "expansion_cache::store_then_lookup_is_a_recorded_hit";
+        assert_eq!(lookup(key), None, "absent key misses");
+
+        store(key.into(), "OUTPUT".into(), &[]);
+        let before = hit_count();
+        assert_eq!(lookup(key).as_deref(), Some("OUTPUT"), "stored key hits");
+        assert!(hit_count() > before, "the hit is recorded");
+    }
+
+    /// A changed (or deleted) dependency must turn a would-be hit into a miss, which
+    /// is what makes the cache safe when an imported `.slint` file is edited.
+    #[test]
+    fn changed_dependency_turns_a_hit_into_a_miss() {
+        let key = "expansion_cache::changed_dependency_turns_a_hit_into_a_miss";
+        let dir = std::env::temp_dir().join("slint_macro_cache_test_dep");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("dep.slint");
+        std::fs::write(&file, b"export component A {}").unwrap();
+
+        store(key.into(), "OUTPUT".into(), std::slice::from_ref(&file));
+        assert_eq!(lookup(key).as_deref(), Some("OUTPUT"), "unchanged dep hits");
+
+        std::fs::write(&file, b"export component A { width: 1px; }").unwrap();
+        assert_eq!(lookup(key), None, "changed dep invalidates");
+
+        std::fs::remove_file(&file).unwrap();
+        assert_eq!(lookup(key), None, "missing dep invalidates");
+    }
+
+    #[test]
+    fn put_replaces_an_existing_key() {
+        let mut cache = Cache::default();
+        cache.put("k".into(), "v1".into(), vec![]);
+        cache.put("k".into(), "v2".into(), vec![]);
+        assert_eq!(cache.candidate("k").map(|(o, _)| o).as_deref(), Some("v2"));
+        assert_eq!(cache.entries.len(), 1);
+    }
+
+    #[test]
+    fn put_evicts_the_oldest_when_full() {
+        let mut cache = Cache::default();
+        for i in 0..CAPACITY + 10 {
+            cache.put(format!("k{i}"), format!("v{i}"), vec![]);
+        }
+        assert_eq!(cache.entries.len(), CAPACITY, "size is bounded");
+        // The 10 oldest keys were evicted (FIFO); the most recent CAPACITY remain.
+        assert!(cache.candidate("k0").is_none());
+        assert!(cache.candidate("k9").is_none());
+        assert_eq!(cache.candidate("k10").map(|(o, _)| o).as_deref(), Some("v10"));
+    }
+}

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -15,6 +15,8 @@ use proc_macro::{Spacing, TokenStream, TokenTree};
 use quote::quote;
 use std::path::PathBuf;
 
+mod expansion_cache;
+
 /// Returns true if the two token are touching. For example the two token `foo`and `-` are touching if
 /// it was written like so in the source code: `foo-` but not when written like so `foo -`
 ///
@@ -324,6 +326,17 @@ fn extract_compiler_config(
     remaining_stream
 }
 
+/// The external files whose changes should invalidate this expansion: the loaded
+/// files that are absolute and not the `Cargo.toml`. This is the set that both the
+/// `include_bytes!` recompile markers and the output cache key off of.
+fn loaded_files(diag: &BuildDiagnostics) -> Vec<PathBuf> {
+    diag.all_loaded_files
+        .iter()
+        .filter(|path| path.is_absolute() && !path.ends_with("Cargo.toml"))
+        .cloned()
+        .collect()
+}
+
 /// This macro allows you to use the Slint design markup language inline in Rust code. Within the braces of the macro
 /// you can use place Slint code and the named exported components will be available for instantiation.
 ///
@@ -369,15 +382,32 @@ pub fn slint(stream: TokenStream) -> TokenStream {
         tokens.first()?.span?.local_file()
     }
 
-    let source_file = if let Some(path) = local_file(&tokens) {
-        diagnostics::SourceFileInner::from_path_only(path)
+    let source_path: PathBuf = if let Some(path) = local_file(&tokens) {
+        path
     } else if let Some(cargo_manifest) = std::env::var_os("CARGO_MANIFEST_DIR") {
         let mut path: std::path::PathBuf = cargo_manifest.into();
         path.push("Cargo.toml");
-        diagnostics::SourceFileInner::from_path_only(path)
+        path
     } else {
-        diagnostics::SourceFileInner::from_path_only(Default::default())
+        Default::default()
     };
+
+    compiler_config.translation_domain = std::env::var("CARGO_PKG_NAME").ok();
+
+    // Consult the output cache before doing any (expensive) compilation. The key
+    // is computed from the macro body plus everything else that influences the
+    // generated output; a hit just re-parses the cached output string. Only
+    // active under rust-analyzer (see expansion_cache docs).
+    let cache_key = expansion_cache::enabled()
+        .then(|| expansion_cache::key_material(&tokens, &compiler_config, &source_path));
+    if let Some(key) = &cache_key
+        && let Some(output) = expansion_cache::lookup(key)
+        && let Ok(stream) = output.parse::<TokenStream>()
+    {
+        return stream;
+    }
+
+    let source_file = diagnostics::SourceFileInner::from_path_only(source_path);
     let mut diag = BuildDiagnostics::default();
     let syntax_node = parser::parse_tokens(tokens.clone(), source_file, &mut diag);
     if diag.has_errors() {
@@ -385,7 +415,6 @@ pub fn slint(stream: TokenStream) -> TokenStream {
     }
 
     //println!("{syntax_node:#?}");
-    compiler_config.translation_domain = std::env::var("CARGO_PKG_NAME").ok();
     let (root_component, diag, loader) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
     //println!("{tree:#?}");
@@ -393,15 +422,25 @@ pub fn slint(stream: TokenStream) -> TokenStream {
         return diag.report_macro_diagnostic(&tokens);
     }
 
-    if std::env::var("RUST_ANALYZER_INTERNALS_DO_NOT_USE").is_ok() {
+    if expansion_cache::is_rust_analyzer() {
         // When running on rust-analyzer, only generate the API (using the live preview) to make rust-analyzer faster and use less memory
         // (This uses an unstable env variable, but it is just an optimization)
-        return generator::rust_live_preview::generate(&root_component, &loader.compiler_config)
-            .unwrap_or_else(|e| {
-                let e_str = e.to_string();
-                quote!(compile_error!(#e_str))
-            })
-            .into();
+        let generated = generator::rust_live_preview::generate(
+            &root_component,
+            &loader.compiler_config,
+        )
+        .unwrap_or_else(|e| {
+            let e_str = e.to_string();
+            quote!(compile_error!(#e_str))
+        });
+        // Populate the cache so the next identical expansion is a cheap re-parse.
+        // The live-preview output is a pure function of the compiled component and
+        // config (no diagnostic/span tokens), so it is safe to cache regardless of
+        // warnings — which this path discards anyway.
+        if let Some(key) = cache_key {
+            expansion_cache::store(key, generated.to_string(), &loaded_files(&diag));
+        }
+        return generated.into();
     }
 
     let mut result = generator::rust::generate(&root_component, &loader.compiler_config)
@@ -411,10 +450,9 @@ pub fn slint(stream: TokenStream) -> TokenStream {
         });
 
     // Make sure to recompile if any of the external files changes
-    let reload = diag
-        .all_loaded_files
+    let loaded = loaded_files(&diag);
+    let reload = loaded
         .iter()
-        .filter(|path| path.is_absolute() && !path.ends_with("Cargo.toml"))
         .filter_map(|p| p.to_str())
         .map(|p| quote! {const _ : &'static [u8] = ::core::include_bytes!(#p);});
 
@@ -423,7 +461,13 @@ pub fn slint(stream: TokenStream) -> TokenStream {
 
     let mut result = TokenStream::from(result);
     if !diag.is_empty() {
+        // Output carries span-bearing diagnostic tokens tied to this call site, so
+        // it must not be cached.
         result.extend(diag.report_macro_diagnostic(&tokens));
+    } else if let Some(key) = cache_key {
+        // Clean expansion: cache the full output (including the reload markers) so
+        // the next identical expansion is a cheap re-parse.
+        expansion_cache::store(key, result.to_string(), &loaded);
     }
     result
 }

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -425,14 +425,12 @@ pub fn slint(stream: TokenStream) -> TokenStream {
     if expansion_cache::is_rust_analyzer() {
         // When running on rust-analyzer, only generate the API (using the live preview) to make rust-analyzer faster and use less memory
         // (This uses an unstable env variable, but it is just an optimization)
-        let generated = generator::rust_live_preview::generate(
-            &root_component,
-            &loader.compiler_config,
-        )
-        .unwrap_or_else(|e| {
-            let e_str = e.to_string();
-            quote!(compile_error!(#e_str))
-        });
+        let generated =
+            generator::rust_live_preview::generate(&root_component, &loader.compiler_config)
+                .unwrap_or_else(|e| {
+                    let e_str = e.to_string();
+                    quote!(compile_error!(#e_str))
+                });
         // Populate the cache so the next identical expansion is a cheap re-parse.
         // The live-preview output is a pure function of the compiled component and
         // config (no diagnostic/span tokens), so it is safe to cache regardless of


### PR DESCRIPTION
## Motivation

Expanding the `slint!` macro recompiles the builtins, the selected style and any imported widgets on *every* invocation — tens of milliseconds even for a tiny snippet. rust-analyzer runs proc macros in a long-lived process and re-expands them very frequently (typically while the user edits *elsewhere*, so the macro body is unchanged), which makes this a hot path and a noticeable source of editor latency.

## Approach

Add a process-global cache of the macro's generated output, keyed by a hash of the macro body plus everything else that influences code generation (config fields, relevant env vars, source path) and validated against the **contents** of every loaded external file (the same set that drives the `include_bytes!` recompile markers). On a hit the whole expansion — parse, dependency loading, ~60 passes, codegen — is skipped and the cached output is re-parsed into a token stream.

The cached value is a `String`, not a `TokenStream`, because the cache is shared across the fresh thread rust-analyzer spawns per expansion, so entries must be `Send + Sync`. A `proc_macro::TokenStream` is neither (it is a handle into the compiler bridge, valid only within one expansion on one thread), so the portable cached form is the serialized source text, re-parsed on a hit.

It lives in `i-slint-compiler` next to the `CompilerConfiguration`/`Token` types its key is built from (gated behind the existing `rust` feature, `#[doc(hidden)]`) and is driven by the `slint-macros` proc macro.

- **On by default under rust-analyzer**, where the macro emits the compact live-preview output so re-parsing is cheap and re-expansions are frequent.
- **Off by default for ordinary `cargo build`** (the macro runs at most once per crate build, so populating a cache there is wasted work); opt in with `SLINT_MACRO_CACHE=1`.
- Bounded with FIFO eviction; dependency hashes are validated *after* releasing the lock so concurrent expansions don't serialize on disk reads.

## Impact (live-preview / rust-analyzer path, release, in-process medians)

| Path | Per expansion | vs base |
|---|---|---|
| No cache (base) | ~32 ms | — |
| Cache **miss** (compile + populate) | ~32.5 ms | ~noise |
| Cache **hit** (key + lookup + re-parse) | ~57 µs | **~560×** |

Amortized over re-expansions of an unchanged body (the rust-analyzer pattern): ~10× at 10 re-expansions, ~86× at 100. The miss path adds no meaningful overhead, so enabling it is effectively free.

## Tests & benchmarks

- Unit tests for the cache mechanics: hit/miss, dependency-change + file-deletion invalidation, FIFO eviction bound.
- An end-to-end replay test (two identical-body modules) that compiles a cached, re-parsed expansion.
- A `cache_simulation` benchmark module (`internal/compiler/benches/semantic_analysis.rs`) measuring miss vs hit for both codegen paths, the two cache-key strategies, and a head-to-head using the real `key_material`.

## Notes / limitations

- The cache key enumerates the config fields and env vars that reach the **live-preview** generator (the default-on path); it is complete there. The `SLINT_MACRO_CACHE` full-codegen opt-in is documented as requiring other codegen-affecting env (e.g. `SLINT_EMBED_RESOURCES`, `SLINT_SCALE_FACTOR`) to be held constant. A type-derived fingerprint to make this robust against future config fields is a sensible follow-up.

History is structured into two independently-buildable commits: the feature (all behavior change) and the benchmarks.