### PR TITLE
live-preview: drive the style ComboBox by current-index   (and other current-index fixes)

### DIFF
--- a/demos/usecases/ui/views/header_view.slint
+++ b/demos/usecases/ui/views/header_view.slint
@@ -27,7 +27,6 @@ export component HeaderView {
 
             ComboBox {
                 model: [@tr("English"), @tr("German")];
-                current-value: @tr("English");
                 selected() => {
                     root.select-language(self.current-index);
                 }

--- a/examples/7guis/booker.slint
+++ b/examples/7guis/booker.slint
@@ -18,7 +18,6 @@ export component Booker inherits Window {
         combo := ComboBox {
             row: 0;
             model: ["one-way flight", "return flight"];
-            current-value: "one-way flight";
             current-index: 0;
         }
         t1 := LineEdit {

--- a/examples/imagefilter/ui/main.slint
+++ b/examples/imagefilter/ui/main.slint
@@ -25,7 +25,6 @@ export component MainWindow inherits Window {
         VerticalBox {
             alignment: center;
             filter-combo := ComboBox {
-                current-value: "Blur";
                 current-index: 0;
                 vertical-stretch: 0;
             }

--- a/examples/orbit-animation/demo.slint
+++ b/examples/orbit-animation/demo.slint
@@ -38,7 +38,6 @@ export component AppWindow inherits Window {
         x: 10px;
         y: 10px;
         model: ["Demo 1", "Demo 2", "Demo 3", "Demo 4"];
-        current-value: "Demo 1";
     }
 
 

--- a/examples/sprite-sheet/demo.slint
+++ b/examples/sprite-sheet/demo.slint
@@ -16,7 +16,6 @@ export component AppWindow inherits Window {
         x: 10px;
         y: 10px;
         model: ["Boing Ball", "Static"];
-        current-value: "Boing Ball";
     }
 
     if cb.current-value == "Static": SpriteSheet {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1925,7 +1925,10 @@ fn set_show_preview_ui(show_preview_ui: bool) {
 fn set_current_style(style: String) {
     PREVIEW_STATE.with_borrow(move |preview_state| {
         if let Some(api) = preview_state.api.upgrade() {
-            api.set_current_style(style.into())
+            use slint::Model;
+            let index =
+                api.get_known_styles().iter().position(|s| s.as_str() == style).unwrap_or(0);
+            api.set_current_style_index(index as i32);
         }
     });
 }
@@ -1933,7 +1936,12 @@ fn set_current_style(style: String) {
 fn get_current_style() -> String {
     PREVIEW_STATE.with_borrow(|preview_state| -> String {
         if let Some(api) = preview_state.api.upgrade() {
-            api.get_current_style().as_str().to_string()
+            use slint::Model;
+            let index = api.get_current_style_index();
+            api.get_known_styles()
+                .row_data(usize::try_from(index).unwrap_or(0))
+                .map(|s| s.to_string())
+                .unwrap_or_default()
         } else {
             String::new()
         }

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -132,8 +132,10 @@ pub fn create_ui(
         model
     });
 
-    api.set_current_style(style.clone().into());
+    let current_style_index =
+        known_styles.iter().position(|&s| s == style.as_str()).unwrap_or(0) as i32;
     api.set_known_styles(style_model.into());
+    api.set_current_style_index(current_style_index);
 
     api.on_add_new_component(super::add_new_component);
     api.on_rename_component(super::rename_component);

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -318,8 +318,8 @@ export global Api {
     // ## Style:
     // All the known styles
     in property <[string]> known-styles;
-    // The current style
-    in-out property <string> current-style;
+    // The index of the current style within `known-styles`
+    in-out property <int> current-style-index;
     // control, but command on macOS
     in-out property <string> control-key-name: "control";
 

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -210,7 +210,7 @@ export component PreviewUi inherits Window {
                     vertical-stretch: 0;
                     height: self.preferred-height;
 
-                    current-style <=> Api.current-style;
+                    current-style-index <=> Api.current-style-index;
                     known-styles <=> Api.known-styles;
                     preview-mode <=> Api.preview-mode;
                     remote-mode: root.remote-mode;

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -10,7 +10,7 @@ import { EditorSpaceSettings, Icons, ConsoleStyles } from "../components/styling
 
 export component HeaderView {
     in-out property <bool> edit-mode <=> interaction-switch.checked;
-    in-out property <string> current-style <=> style-combobox.current-value;
+    in-out property <int> current-style-index <=> style-combobox.current-index;
     in property <[string]> known-styles <=> style-combobox.model;
     in-out property <PreviewMode> preview-mode: PreviewMode.Local;
     in property <bool> remote-mode;


### PR DESCRIPTION
Fix warning in the output tab: 
> ComboBox: `current-value` writes don't change the selection. Use `current-index` instead. See https://github.com/slint-ui/slint/issues/11970

Writing to the ComboBox `current-value` does not change the selection
and emits a debug warning. Bind the style selection to `current-index`
instead and map between the style name and its index in Rust.

Also don't use current-index in examples.