### PR TITLE
docs: revive the ESP32-S3-Box-3 Rust instructions

### DIFF
--- a/docs/astro/src/content/docs/guide/platforms/embedded.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/embedded.mdx
@@ -190,11 +190,6 @@ We provide templates for a few off-the-shelf development boards from some of the
 ### Espressif (ESP32)
 
 <Tabs syncKey="dev-language">
-<TabItem label="C++" icon="seti:cpp">
-To use Slint with your C++ application, you can follow the instructions on the [Espressif Documentation site](https://components.espressif.com/components/slint/slint)
-</TabItem>
-
-{/*
 <TabItem label="Rust" icon="seti:rust">
 #### Prerequisites
 
@@ -204,15 +199,17 @@ To use Slint with your C++ application, you can follow the instructions on the [
 When flashing, with `espflash`, you will be prompted to select a USB port. If this port is always the same, then you can also pass it as a parameter on the command line to avoid the prompt. For example if
 `/dev/ttyUSB1` is the device file for your port, the command line changes to `espflash --monitor /dev/ttyUSB1 path/to/binary/to/flash_and_monitor`.
 
-#### ESP32-S3-Box
+#### ESP32-S3-Box-3
 
 To compile and run the Slint Printer demo:
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box --release --config examples/mcu-board-support/esp32_s3_box/cargo-config.toml
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box-3 --release --config examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
 ```
 </TabItem>
-*/}
+<TabItem label="C++" icon="seti:cpp">
+To use Slint with your C++ application, you can follow the instructions on the [Espressif Documentation site](https://components.espressif.com/components/slint/slint)
+</TabItem>
 </Tabs>
 
 ### ST (STM32)


### PR DESCRIPTION
Uncomment the Rust ESP tab (commented out in 2ac9e7cc47 pending S3-Box-3 support) and update the board to esp32-s3-box-3, matching the command in the mcu-board-support README and CI.
