### PR TITLE
Document MCP endpoint formatting for agents

### DIFF
--- a/skills/slint/reference/debugging-and-mcp.md
+++ b/skills/slint/reference/debugging-and-mcp.md
@@ -122,8 +122,12 @@ uv add "slint[dev]"
 SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 uv run app.py
 ```
 
-Connect to `http://localhost:9315/mcp` (Streamable HTTP / JSON-RPC). From a
-shell, `curl` is the most reliable client — include the `Accept` header:
+Connect to the MCP endpoint (for example, `http://localhost:9315/mcp`) using
+Streamable HTTP / JSON-RPC. When mentioning local MCP endpoints in chat or
+status updates, always format them as inline code or inside a code block; never
+write a bare URL, because some hosts auto-render `http://127.0.0.1...` as a web
+preview even though the endpoint is not a browser UI. From a shell, `curl` is
+the most reliable client — include the `Accept` header:
 
 ```sh
 # List tools (confirms the server is up)


### PR DESCRIPTION
Coding via the desktop app of some LLM agents causes the MCP link to be auto completed into a web link which is ugly and confusing. This was the suggested text to stop it happening. Picture from codex of the random web link you otherwise get.

<img width="814" height="125" alt="Screenshot 2026-06-18 at 16 07 16" src="https://github.com/user-attachments/assets/6df4395e-c6f4-4951-875c-3c694a7a8e0d" />
