### PR TITLE
winit: don't show windows before the desktop appearance is known

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -412,8 +412,9 @@ pub(crate) struct SharedBackendData {
     /// event loop or is from a stale event.
     event_loop_generation: Arc<AtomicUsize>,
     is_wayland: bool,
+    /// Desktop settings read from the XDG portal (cursor blink, appearance query).
     #[cfg(xdg_desktop_settings)]
-    cursor_blink_interval: std::cell::Cell<core::time::Duration>,
+    desktop_settings: xdg_desktop_settings::DesktopSettings,
     #[cfg(target_os = "ios")]
     #[allow(unused)]
     keyboard_notifications: ios::KeyboardNotifications,
@@ -502,7 +503,7 @@ impl SharedBackendData {
             event_loop_generation: Default::default(),
             is_wayland,
             #[cfg(xdg_desktop_settings)]
-            cursor_blink_interval: std::cell::Cell::new(DEFAULT_CURSOR_FLASH_CYCLE),
+            desktop_settings: xdg_desktop_settings::DesktopSettings::new(),
             #[cfg(target_os = "ios")]
             keyboard_notifications,
         })
@@ -573,6 +574,12 @@ impl SharedBackendData {
         &self,
         event_loop: &winit::event_loop::ActiveEventLoop,
     ) -> Result<(), PlatformError> {
+        // Wait for the appearance query so windows aren't shown with default colors;
+        // the next `about_to_wait` retries once it clears.
+        #[cfg(xdg_desktop_settings)]
+        if self.desktop_settings.is_appearance_pending() {
+            return Ok(());
+        }
         let mut inactive_windows = self.inactive_windows.take();
         let mut result = Ok(());
         while let Some(window_weak) = inactive_windows.pop() {
@@ -689,18 +696,8 @@ impl i_slint_core::platform::Platform for Backend {
     fn bind_context(&self, _ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
         #[cfg(xdg_desktop_settings)]
         {
-            let strong_ctx = _ctx
-                .upgrade()
-                .expect("bind_context is called while the SlintContext is still alive");
-            let shared_weak = Rc::downgrade(&self.shared_data);
-            let ctx_weak = _ctx.clone();
-            if let Ok(handle) = strong_ctx.spawn_local(async move {
-                if let Err(err) = crate::xdg_desktop_settings::watch(shared_weak, ctx_weak).await {
-                    i_slint_core::debug_log!("Error watching for xdg desktop settings: {}", err);
-                }
-            }) {
-                *self.xdg_watcher.borrow_mut() = Some(handle);
-            }
+            *self.xdg_watcher.borrow_mut() =
+                crate::xdg_desktop_settings::spawn(&self.shared_data, &_ctx);
         }
         #[cfg(target_os = "windows")]
         if let Some(ctx) = _ctx.upgrade() {
@@ -903,7 +900,7 @@ impl i_slint_core::platform::Platform for Backend {
 
     #[cfg(xdg_desktop_settings)]
     fn cursor_flash_cycle(&self) -> core::time::Duration {
-        self.shared_data.cursor_blink_interval.get()
+        self.shared_data.desktop_settings.cursor_flash_cycle()
     }
 
     fn open_url(&self, url: &str) -> Result<(), i_slint_core::platform::PlatformError> {

--- a/internal/backends/winit/xdg_desktop_settings.rs
+++ b/internal/backends/winit/xdg_desktop_settings.rs
@@ -120,6 +120,7 @@ fn apply_color_scheme_value(value: zbus::zvariant::OwnedValue, cx: &SettingsCont
     let theme = match scheme {
         ColorScheme::Dark => Some(winit::window::Theme::Dark),
         ColorScheme::Light => Some(winit::window::Theme::Light),
+        ColorScheme::Unknown => None,
         _ => None,
     };
     for adapter_weak in shared.active_windows.borrow().values() {
@@ -247,7 +248,8 @@ pub(crate) fn spawn(
         })
         .ok();
 
-    // Safety net: create the windows anyway if the portal never answers.
+    // Safety net: create the windows anyway if the portal never answers. Clearing
+    // the flag lets the next `about_to_wait` create the pending inactive windows.
     i_slint_core::timers::Timer::single_shot(APPEARANCE_QUERY_TIMEOUT, move || {
         finish_appearance_query(&shared_weak);
     });

--- a/internal/backends/winit/xdg_desktop_settings.rs
+++ b/internal/backends/winit/xdg_desktop_settings.rs
@@ -1,7 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::rc::Weak;
+use std::cell::Cell;
+use std::rc::{Rc, Weak};
+use std::time::Duration;
 
 use i_slint_core::SlintContextWeak;
 use i_slint_core::graphics::Color;
@@ -10,19 +12,87 @@ use i_slint_core::lengths::LogicalLength;
 
 use crate::SharedBackendData;
 
+/// How long the first windows wait for the appearance query before mapping with
+/// defaults. Keep it above portal activation time; a missing portal fails fast.
+const APPEARANCE_QUERY_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Desktop settings read from the XDG portal: cursor blink and the one-time
+/// appearance query the first windows wait for. Updated by [`watch`].
+pub(crate) struct DesktopSettings {
+    /// Whether the cursor blinks at all.
+    cursor_blink_enabled: Cell<bool>,
+    /// The cursor blink period, used when blinking is enabled.
+    cursor_blink_time: Cell<Duration>,
+    /// True while the appearance query is in flight; the backend holds the first
+    /// windows in `inactive_windows` until it clears, to avoid a default flash.
+    appearance_pending: Cell<bool>,
+}
+
+impl DesktopSettings {
+    pub(crate) fn new() -> Self {
+        Self {
+            cursor_blink_enabled: Cell::new(true),
+            cursor_blink_time: Cell::new(crate::DEFAULT_CURSOR_FLASH_CYCLE),
+            appearance_pending: Cell::new(false),
+        }
+    }
+
+    /// The cursor blink period, or zero when blinking is disabled.
+    pub(crate) fn cursor_flash_cycle(&self) -> Duration {
+        if self.cursor_blink_enabled.get() { self.cursor_blink_time.get() } else { Duration::ZERO }
+    }
+
+    /// Whether the first windows must still wait for the appearance query.
+    pub(crate) fn is_appearance_pending(&self) -> bool {
+        self.appearance_pending.get()
+    }
+}
+
+const APPEARANCE: &str = "org.freedesktop.appearance";
+const GNOME_INTERFACE: &str = "org.gnome.desktop.interface";
+
+/// Handles passed to a setting's `apply` function so it can push the parsed value
+/// into the runtime context or the backend.
+struct SettingsContext<'a> {
+    ctx: &'a SlintContextWeak,
+    shared: &'a Weak<SharedBackendData>,
+}
+
+/// One desktop setting read from the portal. The initial read and the
+/// `SettingChanged` handler both call `apply`, so a new setting is one row.
+struct SettingDescriptor {
+    namespace: &'static str,
+    key: &'static str,
+    apply: fn(zbus::zvariant::OwnedValue, &SettingsContext),
+}
+
+/// Every desktop setting Slint reacts to. Add a row here (and a small `apply_*`
+/// function) to support a new one.
+static SETTINGS: &[SettingDescriptor] = &[
+    SettingDescriptor {
+        namespace: APPEARANCE,
+        key: "color-scheme",
+        apply: apply_color_scheme_value,
+    },
+    SettingDescriptor { namespace: APPEARANCE, key: "accent-color", apply: apply_accent_value },
+    SettingDescriptor { namespace: GNOME_INTERFACE, key: "font-name", apply: apply_font_value },
+    SettingDescriptor {
+        namespace: GNOME_INTERFACE,
+        key: "cursor-blink",
+        apply: apply_cursor_blink_value,
+    },
+    SettingDescriptor {
+        namespace: GNOME_INTERFACE,
+        key: "cursor-blink-time",
+        apply: apply_cursor_blink_time_value,
+    },
+];
+
 /// Parses the trailing point size from a GNOME font description such as
 /// `"Helvetica 11"` or `"Sans Bold 10.5"`.
 fn parse_font_points(font_name: &str) -> Option<f32> {
     let last = font_name.split_whitespace().next_back()?;
     last.parse::<f32>().ok().filter(|p| p.is_finite() && *p > 0.0)
-}
-
-fn apply_font_name(ctx_weak: &SlintContextWeak, font_name: &str) {
-    let Some(points) = parse_font_points(font_name) else { return };
-    let size = LogicalLength::new(points * 96.0 / 72.0);
-    if let Some(ctx) = ctx_weak.upgrade() {
-        ctx.set_platform_default_font_size(Some(size));
-    }
 }
 
 fn xdg_color_scheme_to_slint(value: zbus::zvariant::OwnedValue) -> ColorScheme {
@@ -39,22 +109,17 @@ fn xdg_accent_color_to_slint(value: zbus::zvariant::OwnedValue) -> Option<Color>
     Some(Color::from_argb_f32(1.0, r as f32, g as f32, b as f32))
 }
 
-/// Writes the new color scheme to the SlintContext and pushes the matching
-/// winit theme to every currently-mapped window so that client-side decorations
-/// stay in sync.
-fn apply_color_scheme(
-    ctx_weak: &SlintContextWeak,
-    shared_data_weak: &Weak<SharedBackendData>,
-    scheme: ColorScheme,
-) {
-    if let Some(ctx) = ctx_weak.upgrade() {
+/// Sets the color scheme on the context and pushes the matching winit theme to
+/// every mapped window so client-side decorations stay in sync.
+fn apply_color_scheme_value(value: zbus::zvariant::OwnedValue, cx: &SettingsContext) {
+    let scheme = xdg_color_scheme_to_slint(value);
+    if let Some(ctx) = cx.ctx.upgrade() {
         ctx.set_color_scheme(scheme);
     }
-    let Some(shared) = shared_data_weak.upgrade() else { return };
+    let Some(shared) = cx.shared.upgrade() else { return };
     let theme = match scheme {
         ColorScheme::Dark => Some(winit::window::Theme::Dark),
         ColorScheme::Light => Some(winit::window::Theme::Light),
-        ColorScheme::Unknown => None,
         _ => None,
     };
     for adapter_weak in shared.active_windows.borrow().values() {
@@ -66,31 +131,62 @@ fn apply_color_scheme(
     }
 }
 
-async fn read_cursor_blink_settings(
-    settings_proxy: &zbus::Proxy<'_>,
-) -> Option<core::time::Duration> {
-    let blink_enabled: zbus::Result<zbus::zvariant::OwnedValue> =
-        settings_proxy.call("ReadOne", &("org.gnome.desktop.interface", "cursor-blink")).await;
-    if let Ok(value) = blink_enabled
-        && value.downcast_ref::<bool>() == Ok(false)
+fn apply_accent_value(value: zbus::zvariant::OwnedValue, cx: &SettingsContext) {
+    if let Some(color) = xdg_accent_color_to_slint(value)
+        && let Some(ctx) = cx.ctx.upgrade()
     {
-        return Some(core::time::Duration::ZERO);
+        ctx.set_accent_color(color);
     }
-
-    let blink_time: zbus::Result<zbus::zvariant::OwnedValue> =
-        settings_proxy.call("ReadOne", &("org.gnome.desktop.interface", "cursor-blink-time")).await;
-    if let Ok(value) = blink_time
-        && let Ok(ms) = value.downcast_ref::<i32>()
-        && ms > 0
-    {
-        return Some(core::time::Duration::from_millis(ms as u64));
-    }
-
-    None
 }
 
-pub async fn watch(
-    shared_data_weak: Weak<SharedBackendData>,
+fn apply_font_value(value: zbus::zvariant::OwnedValue, cx: &SettingsContext) {
+    if let Ok(name) = value.downcast_ref::<&str>()
+        && let Some(points) = parse_font_points(name)
+        && let Some(ctx) = cx.ctx.upgrade()
+    {
+        ctx.set_platform_default_font_size(Some(LogicalLength::new(points * 96.0 / 72.0)));
+    }
+}
+
+fn apply_cursor_blink_value(value: zbus::zvariant::OwnedValue, cx: &SettingsContext) {
+    if let Ok(enabled) = value.downcast_ref::<bool>()
+        && let Some(shared) = cx.shared.upgrade()
+    {
+        shared.desktop_settings.cursor_blink_enabled.set(enabled);
+    }
+}
+
+fn apply_cursor_blink_time_value(value: zbus::zvariant::OwnedValue, cx: &SettingsContext) {
+    if let Ok(ms) = value.downcast_ref::<i32>()
+        && ms > 0
+        && let Some(shared) = cx.shared.upgrade()
+    {
+        shared.desktop_settings.cursor_blink_time.set(Duration::from_millis(ms as u64));
+    }
+}
+
+/// Reads every entry in [`SETTINGS`] concurrently and applies each result, so the
+/// whole batch costs roughly one round-trip instead of one per setting.
+async fn read_all_settings(settings_proxy: &zbus::Proxy<'_>, cx: &SettingsContext<'_>) {
+    futures::future::join_all(SETTINGS.iter().map(|setting| async move {
+        let value: zbus::Result<zbus::zvariant::OwnedValue> =
+            settings_proxy.call("ReadOne", &(setting.namespace, setting.key)).await;
+        if let Ok(value) = value {
+            (setting.apply)(value, cx);
+        }
+    }))
+    .await;
+}
+
+/// Clears the pending flag so the backend creates and shows the first windows.
+fn finish_appearance_query(shared: &Weak<SharedBackendData>) {
+    if let Some(shared) = shared.upgrade() {
+        shared.desktop_settings.appearance_pending.set(false);
+    }
+}
+
+async fn watch(
+    shared_data_weak: &Weak<SharedBackendData>,
     ctx_weak: SlintContextWeak,
 ) -> zbus::Result<()> {
     let connection = zbus::Connection::session().await?;
@@ -101,35 +197,16 @@ pub async fn watch(
         .build()
         .await?;
 
-    let initial_value: zbus::zvariant::OwnedValue =
-        settings_proxy.call("ReadOne", &("org.freedesktop.appearance", "color-scheme")).await?;
-    apply_color_scheme(&ctx_weak, &shared_data_weak, xdg_color_scheme_to_slint(initial_value));
+    let cx = SettingsContext { ctx: &ctx_weak, shared: shared_data_weak };
 
-    let accent_result: zbus::Result<zbus::zvariant::OwnedValue> =
-        settings_proxy.call("ReadOne", &("org.freedesktop.appearance", "accent-color")).await;
-    if let Some(color) = accent_result.ok().and_then(xdg_accent_color_to_slint)
-        && let Some(ctx) = ctx_weak.upgrade()
-    {
-        ctx.set_accent_color(color);
-    }
-
-    if let Some(interval) = read_cursor_blink_settings(&settings_proxy).await
-        && let Some(shared) = shared_data_weak.upgrade()
-    {
-        shared.cursor_blink_interval.set(interval);
-    }
-
-    let font_name_result: zbus::Result<zbus::zvariant::OwnedValue> =
-        settings_proxy.call("ReadOne", &("org.gnome.desktop.interface", "font-name")).await;
-    if let Ok(value) = font_name_result
-        && let Ok(name) = value.downcast_ref::<&str>()
-    {
-        apply_font_name(&ctx_weak, name);
-    }
-
+    // Subscribe before the initial read so no change is missed in the gap between them.
     use futures::stream::StreamExt;
-
     let mut settings_stream = settings_proxy.receive_signal("SettingChanged").await?;
+
+    read_all_settings(&settings_proxy, &cx).await;
+
+    // The appearance is known now, so the first windows can be created and shown.
+    finish_appearance_query(shared_data_weak);
 
     while let Some(message) = settings_stream.next().await {
         let Ok((namespace, key, value)) =
@@ -137,47 +214,43 @@ pub async fn watch(
         else {
             continue;
         };
-        match (namespace.as_str(), key.as_str()) {
-            ("org.freedesktop.appearance", "color-scheme") => {
-                apply_color_scheme(&ctx_weak, &shared_data_weak, xdg_color_scheme_to_slint(value));
-            }
-            ("org.freedesktop.appearance", "accent-color") => {
-                if let Some(color) = xdg_accent_color_to_slint(value)
-                    && let Some(ctx) = ctx_weak.upgrade()
-                {
-                    ctx.set_accent_color(color);
-                }
-            }
-            ("org.gnome.desktop.interface", "cursor-blink") => {
-                if let Ok(enabled) = value.downcast_ref::<bool>() {
-                    let interval = if enabled {
-                        read_cursor_blink_settings(&settings_proxy)
-                            .await
-                            .unwrap_or(crate::DEFAULT_CURSOR_FLASH_CYCLE)
-                    } else {
-                        core::time::Duration::ZERO
-                    };
-                    if let Some(shared) = shared_data_weak.upgrade() {
-                        shared.cursor_blink_interval.set(interval);
-                    }
-                }
-            }
-            ("org.gnome.desktop.interface", "cursor-blink-time") => {
-                if let Ok(ms) = value.downcast_ref::<i32>()
-                    && ms > 0
-                    && let Some(shared) = shared_data_weak.upgrade()
-                {
-                    shared.cursor_blink_interval.set(core::time::Duration::from_millis(ms as u64));
-                }
-            }
-            ("org.gnome.desktop.interface", "font-name") => {
-                if let Ok(name) = value.downcast_ref::<&str>() {
-                    apply_font_name(&ctx_weak, name);
-                }
-            }
-            _ => {}
+        if let Some(setting) = SETTINGS.iter().find(|s| s.namespace == namespace && s.key == key) {
+            (setting.apply)(value, &cx);
         }
     }
 
     Ok(())
+}
+
+/// Starts the portal watcher and the timeout that releases the first windows if
+/// the portal is slow or missing. Returns the task so the backend can abort it.
+pub(crate) fn spawn(
+    shared_data: &Rc<SharedBackendData>,
+    ctx: &SlintContextWeak,
+) -> Option<i_slint_core::future::JoinHandle<()>> {
+    let strong_ctx = ctx.upgrade().expect("spawn is called while the SlintContext is still alive");
+    // Hold back the first windows until the query applies the real appearance.
+    shared_data.desktop_settings.appearance_pending.set(true);
+
+    let shared_weak = Rc::downgrade(shared_data);
+    let ctx_weak = ctx.clone();
+    let handle = strong_ctx
+        .spawn_local({
+            let shared_weak = shared_weak.clone();
+            async move {
+                if let Err(err) = watch(&shared_weak, ctx_weak).await {
+                    i_slint_core::debug_log!("Error watching for xdg desktop settings: {err}");
+                    // The portal is unavailable; create the waiting windows anyway.
+                    finish_appearance_query(&shared_weak);
+                }
+            }
+        })
+        .ok();
+
+    // Safety net: create the windows anyway if the portal never answers.
+    i_slint_core::timers::Timer::single_shot(APPEARANCE_QUERY_TIMEOUT, move || {
+        finish_appearance_query(&shared_weak);
+    });
+
+    handle
 }

--- a/internal/backends/winit/xdg_desktop_settings.rs
+++ b/internal/backends/winit/xdg_desktop_settings.rs
@@ -248,8 +248,9 @@ pub(crate) fn spawn(
         })
         .ok();
 
-    // Safety net: create the windows anyway if the portal never answers. Clearing
-    // the flag lets the next `about_to_wait` create the pending inactive windows.
+    // Safety net: create the windows anyway if the portal never answers.
+    // After the timer fires, the event loop returns to `about_to_wait`,
+    // which then creates any pending inactive windows.
     i_slint_core::timers::Timer::single_shot(APPEARANCE_QUERY_TIMEOUT, move || {
         finish_appearance_query(&shared_weak);
     });


### PR DESCRIPTION
On Linux the color scheme, accent color and font size come from the XDG portal asynchronously. The first windows were shown with the defaults and re-rendered once the values arrived, flashing the wrong accent color and font size at startup.

Now they wait for the query: while it is pending, create_inactive_windows leaves them uncreated, and the next about_to_wait creates them once it clears. A short timeout creates them anyway if the portal is slow or missing.

The settings are read in parallel from one descriptor table shared by the initial read and the SettingChanged handler, kept in a DesktopSettings type in the xdg_desktop_settings module.
