### PR TITLE
diagnostics: Don't crash when printing diagnostics to a broken stderr

### DIFF
--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -514,9 +514,10 @@ impl BuildDiagnostics {
     #[cfg(feature = "display-diagnostics")]
     /// Print the diagnostics on the console
     pub fn print(self) {
+        use std::io::Write;
         let to_print = self.call_diagnostics(None);
         if !to_print.is_empty() {
-            std::eprintln!("{to_print}");
+            let _ = writeln!(std::io::stderr(), "{to_print}");
         }
     }
 


### PR DESCRIPTION
`eprintln!` panics if writing to stderr fails, and with `panic = "abort"` that aborts the process. GUI apps using live-reload print diagnostics on every reload, so an unavailable stderr would crash them.

Fixes: #12152
