### PR TITLE
perf: cache parsed builtin documents across slint! expansions

### DIFF
--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -27,7 +27,7 @@ pub(crate) fn load_builtins(
     symbol_counters: &Rc<crate::symbol_counters::SymbolCounters>,
 ) {
     let mut diag = crate::diagnostics::BuildDiagnostics::default();
-    let node = crate::parser::parse(include_str!("builtins.slint").into(), None, &mut diag);
+    let node = crate::parser::parse_builtin_cached(include_str!("builtins.slint"), None, &mut diag);
     if !diag.is_empty() {
         let vec = diag.to_string_vec();
         #[cfg(feature = "display-diagnostics")]

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -1076,6 +1076,41 @@ pub fn parse(
     }
 }
 
+/// Process-global cache of parsed builtin documents (`std-widgets.slint`, the per-style
+/// files, `builtins.slint`), keyed by the identity (address + length) of their embedded
+/// `&'static` source bytes.
+///
+/// Builtin sources are immutable, so their parsed green tree can be reused across compiler
+/// invocations instead of re-parsing on every `slint!` expansion. rowan's `GreenNode` is
+/// `Send + Sync`, so a process-global cache works even though each `slint!` expansion runs on
+/// a fresh thread in rust-analyzer (where a `thread_local!` cache would not survive between
+/// expansions).
+static BUILTIN_PARSE_CACHE: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<(usize, usize), rowan::GreenNode>>,
+> = std::sync::OnceLock::new();
+
+/// Like [`parse`], but memoizes the parsed green tree, keyed by the identity of the immutable
+/// `source` bytes (which must be the embedded `&'static` contents of a builtin file). On a cache
+/// hit the green tree is re-wrapped in a fresh `SourceFile` (cheap).
+pub(crate) fn parse_builtin_cached(
+    source: &'static str,
+    path: Option<&std::path::Path>,
+    build_diagnostics: &mut BuildDiagnostics,
+) -> SyntaxNode {
+    let key = (source.as_ptr() as usize, source.len());
+    let cache = BUILTIN_PARSE_CACHE.get_or_init(Default::default);
+    if let Some(green) = cache.lock().unwrap().get(&key).cloned() {
+        let source_file = std::rc::Rc::new(crate::diagnostics::SourceFileInner::new(
+            path.map(crate::pathutils::clean_path).unwrap_or_default(),
+            source.into(),
+        ));
+        return SyntaxNode { node: rowan::SyntaxNode::new_root(green), source_file };
+    }
+    let sn = parse(source.into(), path, build_diagnostics);
+    cache.lock().unwrap().insert(key, sn.node.green().into_owned());
+    sn
+}
+
 pub fn parse_file<P: AsRef<std::path::Path>>(
     path: P,
     build_diagnostics: &mut BuildDiagnostics,

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1399,13 +1399,11 @@ impl TypeLoader {
             }
             Some(doc_node)
         } else if let Some(builtin) = builtin {
-            // Builtin sources (std-widgets, styles, …) are immutable and embedded, so reading
-            // them cannot fail; handle them separately from the fallible filesystem path.
-            let source = String::from(
-                core::str::from_utf8(builtin)
-                    .expect("internal error: embedded file is not UTF-8 source code"),
-            );
-            syntax_nodes::Document::new(crate::parser::parse(
+            // Builtin sources (std-widgets, styles, …) are immutable; cache the parsed
+            // green tree across invocations instead of re-parsing every expansion.
+            let source = core::str::from_utf8(builtin)
+                .expect("internal error: embedded file is not UTF-8 source code");
+            syntax_nodes::Document::new(crate::parser::parse_builtin_cached(
                 source,
                 Some(&path_canon),
                 state.borrow_mut().diag,

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1398,13 +1398,20 @@ impl TypeLoader {
                 state.borrow_mut().diag.push_internal_error(e);
             }
             Some(doc_node)
+        } else if let Some(builtin) = builtin {
+            // Builtin sources (std-widgets, styles, …) are immutable and embedded, so reading
+            // them cannot fail; handle them separately from the fallible filesystem path.
+            let source = String::from(
+                core::str::from_utf8(builtin)
+                    .expect("internal error: embedded file is not UTF-8 source code"),
+            );
+            syntax_nodes::Document::new(crate::parser::parse(
+                source,
+                Some(&path_canon),
+                state.borrow_mut().diag,
+            ))
         } else {
-            let source_code_result = if let Some(builtin) = builtin {
-                Ok(String::from(
-                    core::str::from_utf8(builtin)
-                        .expect("internal error: embedded file is not UTF-8 source code"),
-                ))
-            } else {
+            let source_code_result = {
                 let callback = state.borrow().tl.compiler_config.open_import_callback.clone();
                 if let Some(callback) = callback {
                     let result = callback(path_canon.to_string_lossy().into()).await;


### PR DESCRIPTION
## What

Builtin Slint documents (`std-widgets.slint`, the per-style files, `builtins.slint`) are immutable, but they were re-parsed from scratch on every `slint!` macro expansion. Parsing `std-widgets` dominates the per-expansion compiler cost (~10 ms in a release build).

This PR memoizes the parsed rowan green tree of builtin documents in a process-global cache, keyed by the identity (address + length) of the embedded `&'static` source bytes. On a cache hit the green tree is re-wrapped in a fresh `SourceFile` (a cheap `Arc` clone) instead of being re-parsed.

Because rowan's `GreenNode` is `Send + Sync`, the cache works as a `OnceLock<Mutex<HashMap>>` even though rust-analyzer runs each `slint!` expansion on a fresh thread (where a `thread_local!` would not survive between expansions).

## Why / numbers

Measured in a release build (`std-widgets`, fluent style), averaged over 40–60 iterations:

| | time |
|---|---|
| new loader + parse std-widgets (what the cache replaces) | ~11.3 ms |
| cached re-wrap | ~1.7 ms |
| **saving per distinct expansion** | **~9.5 ms** |

This is **additive** to the recently merged `slint!` token-stream cache (#12145): that cache short-circuits re-expansion of an *identical* macro invocation, whereas this avoids re-parsing the builtins on the cache-miss path that every *distinct* expansion still takes. The std-widgets parse cost is unchanged by #12145, so the two savings stack.

## Commits

1. **`refactor: separate the infallible builtin source path in the type loader`** — no behavior change. Embedded builtins are infallible to read, yet were funneled through the same `Result`-based path as filesystem imports (with `builtin.is_some()` re-tested inside the `Ok` arm). This gives them their own infallible branch in `ensure_document_loaded`.
2. **`perf: cache parsed builtin documents across slint! expansions`** — introduces `parse_builtin_cached` and wires up the two builtin call sites.

## Notes

- The cache is never evicted, but the key set is the fixed list of embedded builtin files, so it is bounded by construction.
- Keying on `(ptr, len)` is sound: distinct `&'static` sources cannot share an address, and identical content (the only way keys could collide) yields an identical tree; `path`/`SourceFile` are rebuilt fresh per call.
- Builtins are CI-validated and known-good, so the hit path does not need to re-emit parse diagnostics.
