### PR TITLE
interpreter: fix layout recursion for width-for-height flex beside height-for-width child

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -257,6 +257,7 @@ hidpi
 highp
 HINSTANCE
 Hira
+hlayout
 hmenu
 horizontalbox
 horizontallayout
@@ -658,6 +659,7 @@ verticalbox
 verticallayout
 VGWGPU
 viewports
+vlayout
 vref
 vscodeversion
 vtables

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -161,13 +161,31 @@ pub(crate) fn solve_box_layout(
     };
 
     let mut repeated_indices = Vec::new();
+    // For a horizontal layout's main (width) pass, supply the layout's real cross
+    // size (content height) so width-for-height children (e.g. a column
+    // FlexboxLayout) compute their width from it via layoutinfo-h-with-constraint,
+    // instead of reading self.height and cycling through our own vertical pass.
+    let cross_axis_size = (orientation == box_layout.orientation
+        && orientation == Orientation::Horizontal
+        && box_layout
+            .elems
+            .iter()
+            .any(|c| c.element.borrow().inherited_layout_info_h_with_constraint().is_some()))
+    .then(|| {
+        let cross = orientation.orthogonal();
+        box_layout.geometry.rect.size_reference(cross).map(&expr_eval).map(|s| {
+            let (pad, _) = padding_and_spacing(&box_layout.geometry, cross, &expr_eval);
+            s - pad.begin - pad.end
+        })
+    })
+    .flatten();
     let (cells, alignment) = box_layout_data(
         box_layout,
         orientation,
         component,
         &expr_eval,
         Some(&mut repeated_indices),
-        None,
+        cross_axis_size,
     );
     let (padding, spacing) = padding_and_spacing(&box_layout.geometry, orientation, &expr_eval);
     let size = box_layout.geometry.rect.size_reference(orientation).map(&expr_eval).unwrap_or(0.);
@@ -1217,30 +1235,35 @@ pub(crate) fn get_layout_info_with_constraint(
     }
 }
 
-/// Decide the cross-axis (width) constraint to forward to a cell's
-/// vertical layout-info call: returns `Some` only when this cell is
-/// height-for-width (a builtin Text with wrap, Image, or a component
-/// with a synthesized `layoutinfo-v-with-constraint`) AND the parent
-/// has supplied the cross-axis dimension.
+/// Decide the cross-axis constraint to forward to a cell's perpendicular
+/// layout-info call. Returns `Some` only when the parent supplied the cross
+/// dimension and the cell consumes it: a height-for-width cell on the vertical
+/// pass (wrapped Text/Image, or a `layoutinfo-v-with-constraint` component), or a
+/// width-for-height cell on the horizontal pass (a `layoutinfo-h-with-constraint`
+/// component, e.g. a column FlexboxLayout).
 fn cross_axis_size_for_cell(
     elem: &ElementRc,
     orientation: Orientation,
     parent_cross_axis_size: Option<f32>,
 ) -> Option<f32> {
-    if orientation != Orientation::Vertical {
-        return None;
-    }
-    let width = parent_cross_axis_size?;
+    let cross = parent_cross_axis_size?;
     let elem_b = elem.borrow();
+    if orientation == Orientation::Horizontal {
+        // Width-for-height cells (e.g. a column FlexboxLayout) carry a synthesized
+        // layoutinfo-h-with-constraint; forward the cross size so they compute their
+        // width from it instead of reading self.height (which would cycle through
+        // the parent's vertical pass).
+        return elem_b.inherited_layout_info_h_with_constraint().is_some().then_some(cross);
+    }
     if elem_b.layout_info_v_with_constraint.is_some() {
-        return Some(width);
+        return Some(cross);
     }
     // For builtin height-for-width items, the existing VTable cross_axis_constraint
     // parameter mechanism is what consumes the value; conservatively
     // forward it for any element without its own layoutinfo-v property
     // (i.e. anything that ends up calling the builtin VTable).
     if elem_b.layout_info_prop(Orientation::Vertical).is_none() {
-        return Some(width);
+        return Some(cross);
     }
     None
 }

--- a/tests/cases/layout/flexbox_mixed_in_hlayout.slint
+++ b/tests/cases/layout/flexbox_mixed_in_hlayout.slint
@@ -1,0 +1,56 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test: a width-for-height child (column FlexboxLayout) next to a
+// height-for-width child (wrapped Text) in the same HorizontalLayout used to
+// panic with "Recursion detected ... layoutinfo-h" in the interpreter. The
+// column flex's width-info read self.height, which depends back on the vertical
+// pass (the text's height-for-width). The layout must resolve instead.
+
+import { Button } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 400px;
+    height: 300px;   // tall enough that the column flex does not wrap
+    HorizontalLayout {
+        alignment: start;
+        cross-axis-alignment: start;   // don't stretch children vertically
+        spacing: 10px;
+        padding: 10px;
+
+        flex := FlexboxLayout {       // width-for-height (column)
+            flex-direction: column;
+            spacing: 4px;
+            Button { text: "A"; }
+            Button { text: "B"; }
+            Button { text: "C"; }
+        }
+
+        txt := Text {                 // height-for-width
+            text: "This is a long text that wraps across several lines when given a narrow width";
+            wrap: word-wrap;
+            horizontal-stretch: 1;     // let the layout decide its width
+        }
+    }
+
+    // Reading these forces the layout solve (before the fix it recursed). The
+    // text sits to the right of the flex, not overlapping it.
+    out property <bool> test: flex.width > 0px && txt.width > 0px
+        && txt.x >= flex.x + flex.width;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_subcomponent_in_hlayout.slint
+++ b/tests/cases/layout/flexbox_subcomponent_in_hlayout.slint
@@ -1,0 +1,61 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test, same recursion as flexbox_mixed_in_hlayout.slint, but the
+// width-for-height column FlexboxLayout is the root of a sub-component instead
+// of being inlined into the HorizontalLayout. The layoutinfo-h constraint then
+// lives on the sub-component's base root, so it is only visible through the
+// inherited lookup; the cell element's own field is empty. The layout must
+// still resolve (no "Recursion detected ... layoutinfo-h") and the text must
+// sit to the right of the flex without overlap.
+
+import { Button } from "std-widgets.slint";
+
+component FlexCol inherits FlexboxLayout {   // width-for-height (column)
+    flex-direction: column;
+    spacing: 4px;
+    Button { text: "A"; }
+    Button { text: "B"; }
+    Button { text: "C"; }
+}
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 300px;   // tall enough that the column flex does not wrap
+    HorizontalLayout {
+        alignment: start;
+        cross-axis-alignment: start;   // don't stretch children vertically
+        spacing: 10px;
+        padding: 10px;
+
+        flex := FlexCol { }
+
+        txt := Text {                 // height-for-width
+            text: "This is a long text that wraps across several lines when given a narrow width";
+            wrap: word-wrap;
+            horizontal-stretch: 1;     // let the layout decide its width
+        }
+    }
+
+    // Reading these forces the layout solve (before the fix it recursed). The
+    // text sits to the right of the flex, not overlapping it.
+    out property <bool> test: flex.width > 0px && txt.width > 0px
+        && txt.x >= flex.x + flex.width;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
A column FlexboxLayout (width-for-height) next to a wrapped Text (height-for-width) in the same HorizontalLayout recursed in the interpreter ("Recursion detected ... layoutinfo-h"): the flex's width-info read self.height, which depends back on the vertical pass (the text's height-for-width).

Mirror the compiler: on a horizontal layout's width pass, feed the flex the layout's real cross size (content height) so it computes its width via layoutinfo-h-with-constraint instead of reading self.height. Only do this when the layout actually has a width-for-height cell, to avoid an eager self.height read cycling plain layouts whose own height depends on the width pass.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
