### PR TITLE
core: allow Path commands bindings in no_std builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project are documented in this file.
  - Upgraded fontique and parley to 0.10: The `unstable-fontique-09` Cargo feature is renamed to
    `unstable-fontique-010`, and the `slint::fontique_09` module to `slint::fontique_010`.
  - The default font size for application is read from system settings on Windows and Linux.
+ - Software renderer: Support binding the `Path` element's `commands` property (SVG path data) in `no_std` builds.
 
 ### Slint language
 

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -130,12 +130,7 @@ pub async fn run_passes(
         );
         lower_states::lower_states(component, diag);
         lower_text_input_interface::lower_text_input_interface(component);
-        compile_paths::compile_paths(
-            component,
-            &doc.local_registry,
-            type_loader.compiler_config.embed_resources,
-            diag,
-        );
+        compile_paths::compile_paths(component, &doc.local_registry, diag);
         repeater_component::process_repeater_components(component);
         lower_popups::lower_popups(component, &doc.local_registry, diag);
         collect_init_code::collect_init_code(component);

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -9,7 +9,6 @@
 //! elements property of the Path element. That way the generators have to deal
 //! with path embedding only as part of the property assignment.
 
-use crate::EmbedResourcesKind;
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
 use crate::langtype::{BuiltinStruct, Struct, Type};
@@ -21,7 +20,6 @@ use std::rc::Rc;
 pub fn compile_paths(
     component: &Rc<Component>,
     tr: &crate::typeregister::TypeRegister,
-    _embed_resources: EmbedResourcesKind,
     diag: &mut BuildDiagnostics,
 ) {
     let path_type = tr.lookup_element("Path").unwrap();
@@ -63,20 +61,10 @@ pub fn compile_paths(
                         }
                     }
                 }
-                expr if expr.ty() == Type::String => {
-                    #[cfg(feature = "software-renderer")]
-                    if _embed_resources == EmbedResourcesKind::EmbedTextures {
-                        diag.push_warning(
-                            "Bindings to the Path element's commands are not supported with the software renderer".into(),
-                            &*elem_.borrow(),
-                        )
-                    }
-
-                    Expression::PathData(crate::expression_tree::Path::Commands(Box::new(
-                        commands_expr.expression,
-                    )))
-                    .into()
-                }
+                expr if expr.ty() == Type::String => Expression::PathData(
+                    crate::expression_tree::Path::Commands(Box::new(commands_expr.expression)),
+                )
+                .into(),
                 _ => {
                     diag.push_error(
                         "The commands property only accepts strings".into(),

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -29,7 +29,6 @@ std = [
   "euclid/std",
   "once_cell/std",
   "dep:web-time",
-  "dep:lyon_extra",
   "image-decoders",
   "svg",
   "path",
@@ -92,7 +91,7 @@ shared-parley = ["shared-fontique", "dep:parley", "dep:skrifa", "dep:icu_normali
 
 shared-swash = ["dep:swash"]
 
-path = ["dep:auto_enums", "dep:lyon_path", "dep:lyon_geom", "dep:lyon_algorithms"]
+path = ["dep:auto_enums", "dep:lyon_path", "dep:lyon_geom", "dep:lyon_algorithms", "dep:lyon_extra"]
 
 [dependencies]
 i-slint-common = { workspace = true, features = ["default"] }
@@ -109,7 +108,7 @@ euclid = { workspace = true }
 lyon_algorithms = { version = "1.0", optional = true, default-features = false }
 lyon_geom = { version = "1.0", optional = true, default-features = false }
 lyon_path = { workspace = true, optional = true, default-features = false }
-lyon_extra = { version = "1.0.1", optional = true, default-features = false }
+lyon_extra = { version = "1.1", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.5", default-features = false, features = ["critical-section"] }
 pin-project = "1"

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -5,7 +5,6 @@
 This module contains path related types and functions for the run-time library.
 */
 
-#[cfg(feature = "std")]
 use crate::debug_log;
 use crate::items::{ImageFit, PathEvent};
 #[cfg(feature = "rtti")]
@@ -287,7 +286,6 @@ pub enum PathData {
     /// associated coordinates.
     Events(crate::SharedVector<PathEvent>, crate::SharedVector<lyon_path::math::Point>),
     /// The Commands variant describes the path as a series of SVG encoded path commands.
-    #[cfg(feature = "std")]
     Commands(crate::SharedString),
 }
 
@@ -303,7 +301,6 @@ impl PathData {
                 PathData::Events(events, coordinates) => {
                     LyonPathIteratorVariant::FromEvents(events, coordinates)
                 }
-                #[cfg(feature = "std")]
                 PathData::Commands(commands) => {
                     let mut builder = lyon_path::Path::builder();
                     let mut parser = lyon_extra::parser::PathParser::new();


### PR DESCRIPTION
The lyon_extra SVG parser is no_std-capable, so there is no need to restrict dynamic bindings to a Path's commands property to std builds and deny them with the software renderer.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
