### PR TITLE
api: add update_all_translations as public Rust API

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -412,6 +412,14 @@ macro_rules! init_translations {
     };
 }
 
+/// Forces all the strings that are translated with `@tr(...)` to be re-evaluated.
+/// Call this function after changing the language at run-time and when translating
+/// with either gettext or a custom translator. For bundled translations, there is no need
+/// to call this function.
+pub fn update_all_translations() {
+    i_slint_core::translations::mark_all_translations_dirty();
+}
+
 /// This module contains items that you need to use or implement if you want use Slint in an environment without
 /// one of the supplied platform backends such as qt or winit.
 ///


### PR DESCRIPTION
This is already public in the C++ API so copied to the Rust API.

Closes #12161 
