### PR TITLE
Fix live rectangle shadow effects in visual editor

### DIFF
--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -78,6 +78,7 @@ fn create_box_shadow_element(
         base_type: type_register.lookup_builtin_element("BoxShadow").unwrap(),
         enclosing_component: sibling_element.borrow().enclosing_component.clone(),
         bindings,
+        debug: sibling_element.borrow().debug.clone(),
         ..Default::default()
     };
 

--- a/internal/compiler/tests/lower_shadows.rs
+++ b/internal/compiler/tests/lower_shadows.rs
@@ -7,12 +7,23 @@ use i_slint_compiler::generator::OutputFormat;
 use i_slint_compiler::object_tree::{ElementRc, recurse_elem};
 use i_slint_compiler::parser::parse;
 use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
-use smol_str::ToSmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 
 fn compile(source: &str) -> i_slint_compiler::object_tree::Document {
     let mut diagnostics = BuildDiagnostics::default();
     let syntax_node = parse(source.into(), None, &mut diagnostics);
     let compiler_config = CompilerConfiguration::new(OutputFormat::Interpreter);
+    let (doc, diagnostics, _) =
+        spin_on::spin_on(compile_syntax_node(syntax_node, diagnostics, compiler_config));
+    assert!(!diagnostics.has_errors(), "{:?}", diagnostics.to_string_vec());
+    doc
+}
+
+fn compile_with_debug_hooks(source: &str) -> i_slint_compiler::object_tree::Document {
+    let mut diagnostics = BuildDiagnostics::default();
+    let syntax_node = parse(source.into(), None, &mut diagnostics);
+    let mut compiler_config = CompilerConfiguration::new(OutputFormat::Interpreter);
+    compiler_config.debug_hooks = Some(std::hash::RandomState::new());
     let (doc, diagnostics, _) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diagnostics, compiler_config));
     assert!(!diagnostics.has_errors(), "{:?}", diagnostics.to_string_vec());
@@ -27,6 +38,17 @@ fn find_box_shadow(root: &ElementRc) -> ElementRc {
         }
     });
     result.expect("BoxShadow element should be generated")
+}
+
+fn find_element_by_id(root: &ElementRc, id: &str) -> ElementRc {
+    let mut result = None;
+    recurse_elem(root, &(), &mut |element, _| {
+        let element_id = element.borrow().id.clone();
+        if element_id == id || element_id.starts_with(&format!("{id}-")) {
+            result = Some(element.clone());
+        }
+    });
+    result.unwrap_or_else(|| panic!("{id} element should exist"))
 }
 
 #[test]
@@ -53,6 +75,7 @@ export component TestCase inherits Window {
         drop-shadow-color: red;
     }
 }
+
 "#,
     );
 
@@ -92,6 +115,7 @@ export component TestCase inherits Window {
         drop-shadow-color: red;
     }
 }
+
 "#,
     );
 
@@ -112,4 +136,35 @@ export component TestCase inherits Window {
             "{property_name} should reference the source rectangle"
         );
     }
+}
+
+#[test]
+fn box_shadow_debug_hooks_use_source_rectangle_hash() {
+    let doc = compile_with_debug_hooks(
+        r#"
+export component TestCase inherits Window {
+    rect := Rectangle {
+        width: 100px;
+        height: 80px;
+        drop-shadow-blur: 8px;
+        drop-shadow-color: red;
+    }
+}
+"#,
+    );
+
+    let root = doc.exports.iter().next().unwrap().1.as_ref().left().unwrap().root_element.clone();
+    let rect = find_element_by_id(&root, "rect");
+    let box_shadow = find_box_shadow(&root);
+
+    let rect_hash = rect.borrow().debug.first().unwrap().element_hash;
+    let shadow_hash = box_shadow.borrow().debug.first().unwrap().element_hash;
+    assert_ne!(rect_hash, 0);
+    assert_eq!(shadow_hash, rect_hash);
+
+    let blur = box_shadow.borrow().bindings.get("blur").unwrap().borrow().expression.clone();
+    let Expression::DebugHook { id, .. } = blur else {
+        panic!("BoxShadow.blur should be wrapped in a DebugHook");
+    };
+    assert_eq!(id, i_slint_compiler::passes::property_id(rect_hash, &SmolStr::new_static("blur")));
 }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2366,6 +2366,43 @@ export component Foo2 inherits Window  {
     }
 }
 
+#[cfg(feature = "internal-highlight")]
+#[test]
+fn test_shadow_box_does_not_duplicate_source_position() {
+    use smol_str::ToSmolStr;
+
+    let code = r#"
+export component Win inherits Window {
+    rect := Rectangle {
+        width: 100px;
+        height: 80px;
+        drop-shadow-blur: 8px;
+        drop-shadow-color: red;
+    }
+}"#;
+
+    let (handle, path) = compile(code);
+    let offset = code.find("Rectangle").unwrap() as u32;
+    let elements = handle.element_node_at_source_code_position(&path, offset);
+    let element_summary = elements
+        .iter()
+        .map(|(element, debug_index)| {
+            let element = element.borrow();
+            std::format!(
+                "{}:{}:{}",
+                element.base_type.to_smolstr(),
+                element.id,
+                element.debug[*debug_index].type_name
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    assert_eq!(elements.len(), 1, "{element_summary}");
+    assert_ne!(elements[0].0.borrow().base_type.to_smolstr(), "BoxShadow");
+    assert_eq!(elements[0].0.borrow().debug[elements[0].1].type_name, "Rectangle");
+    assert_eq!(handle.component_positions(&path, offset).len(), 1);
+}
+
 // Validates the "live drag" mechanism the visual editor relies on: with `debug_hooks`
 // enabled, a `set_debug_hook_callback` that reads a per-id `Property<Option<Value>>` lets the
 // editor reactively override a property's value (and revert it) without touching the source.

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -8,7 +8,7 @@ use i_slint_compiler::object_tree::{Component, Element, ElementRc};
 use i_slint_core::graphics::euclid;
 use i_slint_core::items::ItemRc;
 use i_slint_core::lengths::{LogicalPoint, LogicalRect};
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
@@ -24,6 +24,15 @@ fn normalize_repeated_element(element: ElementRc) -> ElementRc {
     }
 
     element
+}
+
+fn is_generated_shadow_element(element: &ElementRc, debug_index: usize) -> bool {
+    let element = element.borrow();
+    element.base_type.to_smolstr() == "BoxShadow"
+        && element
+            .debug
+            .get(debug_index)
+            .is_some_and(|debug| debug.type_name != "BoxShadow")
 }
 
 /// The rectangle of an element, which may be rotated around its center
@@ -238,7 +247,9 @@ fn find_element_node_at_source_code_position(
                 })
             {
                 if node_path == path && node_range.contains(offset.into()) {
-                    result.push((elem.clone(), index));
+                    if !is_generated_shadow_element(elem, index) {
+                        result.push((elem.clone(), index));
+                    }
                 }
             }
         },

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use crate::common::{ElementRcNode, Result, file_to_uri, uri_to_file};
+use smol_str::ToSmolStr;
 use std::collections::HashSet;
 
 pub type SourceFileVersionMap = HashMap<PathBuf, SourceFileVersion>;
@@ -419,11 +420,25 @@ impl DocumentCache {
             element: &i_slint_compiler::object_tree::ElementRc,
             offset: TextSize,
         ) -> Option<usize> {
-            element
+            fn is_generated_shadow_element(
+                element: &i_slint_compiler::object_tree::ElementRc,
+                debug_index: usize,
+            ) -> bool {
+                let element = element.borrow();
+                element.base_type.to_smolstr() == "BoxShadow"
+                    && element
+                        .debug
+                        .get(debug_index)
+                        .is_some_and(|debug| debug.type_name != "BoxShadow")
+            }
+
+            let debug_index = element
                 .borrow()
                 .debug
                 .iter()
-                .position(|n| n.node.parent().is_some_and(|n| n.text_range().contains(offset)))
+                .position(|n| n.node.parent().is_some_and(|n| n.text_range().contains(offset)))?;
+
+            (!is_generated_shadow_element(element, debug_index)).then_some(debug_index)
         }
 
         for component in &document.inner_components {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1104,6 +1104,39 @@ fn override_selected_element_geometry(x: f32, y: f32, width: f32, height: f32) {
     );
 }
 
+fn override_selected_element_number_property(property_name: SharedString, value: f32) {
+    let Some(element_selection) = &selected_element() else { return };
+    let Some(element_node) = element_selection.as_element_node() else { return };
+    let Some(component_instance) = component_instance() else { return };
+
+    let element_hash = element_node
+        .element
+        .borrow()
+        .debug
+        .get(element_node.debug_index)
+        .map(|d| d.element_hash)
+        .unwrap_or(0);
+    if element_hash == 0 {
+        tracing::debug!("Element does not have a hash, cannot override property");
+        return;
+    }
+
+    let property_name = SmolStr::from(property_name.as_str());
+    let id = i_slint_compiler::passes::property_id(element_hash, &property_name);
+    PREVIEW_STATE.with_borrow(|preview_state| {
+        let overrides = (*preview_state.debug_hook_overrides).borrow();
+        let Some(property_override) = overrides.get(&id) else {
+            tracing::debug!(
+                "Property debug hook {property_name} does not exist, cannot override property",
+            );
+            return;
+        };
+        (**property_override).set(Some(slint_interpreter::Value::Number(value.into())));
+    });
+
+    component_instance.window().request_redraw();
+}
+
 fn override_selected_element_geometry_impl(
     element_node: &ElementRcNode,
     instance_index: usize,

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -1999,6 +1999,32 @@ component MyComp {
     }
 
     #[test]
+    fn test_set_shadow_binding_uses_authored_rectangle() {
+        let source = r#"
+component Foo inherits Window {
+    rect := Rectangle {
+        width: 100px;
+        height: 80px;
+        drop-shadow-blur: 8px;
+        drop-shadow-color: red;
+    }
+}
+"#;
+        let (dc, uri, _) = loaded_document_cache(source.into());
+        let element = dc
+            .element_at_offset(&uri, TextSize::new(source.find("Rectangle").unwrap() as u32))
+            .unwrap();
+        let element_information = get_element_information(&element);
+        assert_eq!(element_information.type_name.as_str(), "Rectangle");
+
+        let edit =
+            set_binding(uri.clone(), None, &element, "drop-shadow-blur", "12px".into(), dc.format)
+                .unwrap();
+        let applied = crate::common::text_edit::apply_workspace_edit(&dc, &edit).unwrap();
+        assert!(applied.first().unwrap().contents.contains("drop-shadow-blur: 12px;"));
+    }
+
+    #[test]
     fn test_remove_binding() {
         let source = r#"
 component Foo inherits Window {

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -290,6 +290,9 @@ pub fn create_ui(
     api.on_selected_element_move(super::move_selected_element);
     api.on_selected_element_delete(super::delete_selected_element);
     api.on_override_selected_element_geometry(super::override_selected_element_geometry);
+    api.on_override_selected_element_number_property(
+        super::override_selected_element_number_property,
+    );
 
     api.on_test_code_binding(super::test_code_binding);
     api.on_set_code_binding(super::set_code_binding);

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -679,6 +679,7 @@ export global Api {
 
     callback selected-element-resize(x: length, y: length, width: length, height: length);
     callback override-selected-element-geometry(x: length, y: length, width: length, height: length);
+    callback override-selected-element-number-property(property-name: string, value: float);
 
     callback selected-element-delete();
 

--- a/tools/lsp/ui/visual-editor/components/inspector-pane.slint
+++ b/tools/lsp/ui/visual-editor/components/inspector-pane.slint
@@ -327,6 +327,15 @@ export component InspectorPane inherits Rectangle {
             && root.commit-shadow-number(prefix + "offset-y", y);
     }
 
+    function override-shadow-number(property-name: string, value: float) {
+        Api.override-selected-element-number-property(property-name, value.round());
+    }
+
+    function override-shadow-offsets(angle: angle, distance: float) {
+        root.override-shadow-number("offset-x", angle.cos() * distance);
+        root.override-shadow-number("offset-y", angle.sin() * distance);
+    }
+
     function remove-shadow-family(prefix: string) -> bool {
         return root.remove-code(prefix + "color")
             && root.remove-code(prefix + "blur")
@@ -764,6 +773,10 @@ export component InspectorPane inherits Rectangle {
 
                             InspectorEffectDial {
                                 value: root.shadow-angle();
+                                changed(angle) => {
+                                    root.override-shadow-offsets(angle, root.shadow-distance());
+                                    return true;
+                                }
                                 accepted(angle) => {
                                     return root.commit-shadow-offsets(angle, root.shadow-distance());
                                 }
@@ -796,6 +809,10 @@ export component InspectorPane inherits Rectangle {
                             value: root.shadow-distance();
                             minimum: 0;
                             maximum: 96;
+                            changed(value) => {
+                                root.override-shadow-offsets(root.shadow-angle(), value);
+                                return true;
+                            }
                             accepted(value) => {
                                 return root.commit-shadow-offsets(root.shadow-angle(), value);
                             }
@@ -806,6 +823,10 @@ export component InspectorPane inherits Rectangle {
                             value: root.shadow-blur();
                             minimum: 0;
                             maximum: 128;
+                            changed(value) => {
+                                root.override-shadow-number("blur", value);
+                                return true;
+                            }
                             accepted(value) => {
                                 return root.commit-shadow-number(root.current-shadow-prefix() + "blur", value);
                             }
@@ -816,6 +837,10 @@ export component InspectorPane inherits Rectangle {
                             value: root.shadow-spread();
                             minimum: -64;
                             maximum: 64;
+                            changed(value) => {
+                                root.override-shadow-number("spread", value);
+                                return true;
+                            }
                             accepted(value) => {
                                 return root.commit-shadow-number(root.current-shadow-prefix() + "spread", value);
                             }

--- a/tools/lsp/ui/visual-editor/components/inspector/effect-dial.slint
+++ b/tools/lsp/ui/visual-editor/components/inspector/effect-dial.slint
@@ -1,21 +1,26 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import { StudioTheme } from "../common.slint";
 import { InspectorTokens } from "tokens.slint";
 
 export component InspectorEffectDial inherits Rectangle {
     in property <angle> value: 90deg;
+    callback changed(angle) -> bool;
     callback accepted(angle) -> bool;
 
     property <bool> dragging: false;
     property <angle> drag-value: 90deg;
+    property <length> dial-size: 48px;
+    property <length> dial-x: (root.width - root.dial-size) / 2;
+    property <length> dial-y: 1px;
+    property <length> dial-center-x: root.width / 2;
+    property <length> dial-center-y: root.dial-y + root.dial-size / 2;
+    property <bool> active: touch.has-hover || touch.pressed || root.dragging;
 
-    width: 44px;
-    height: 44px;
-    border-radius: 22px;
-    background: touch.has-hover || touch.pressed ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg;
-    border-width: touch.pressed ? 1px : 0px;
-    border-color: InspectorTokens.accent;
+    width: 56px;
+    height: 58px;
+    background: transparent;
     animate background { duration: 120ms; }
 
     pure function normalized-angle(angle: angle) -> angle {
@@ -24,43 +29,115 @@ export component InspectorEffectDial inherits Rectangle {
     }
 
     pure function angle-from-pointer(x: length, y: length) -> angle {
-        return root.normalized-angle(atan2((y - root.height / 2) / 1px, (x - root.width / 2) / 1px));
+        return root.normalized-angle(atan2((y - root.dial-center-y) / 1px, (x - root.dial-center-x) / 1px));
     }
 
     pure function visual-value() -> angle {
         return root.dragging ? root.drag-value : root.value;
     }
 
+    pure function angle-distance-degrees(left: angle, right: angle) -> float {
+        let distance = abs(root.normalized-angle(left - right) / 1deg);
+        return min(distance, 360 - distance);
+    }
+
     pure function knob-x() -> length {
-        return root.width / 2 + root.visual-value().cos() * 13px;
+        return root.dial-center-x + root.visual-value().cos() * 16px;
     }
 
     pure function knob-y() -> length {
-        return root.height / 2 + root.visual-value().sin() * 13px;
+        return root.dial-center-y + root.visual-value().sin() * 16px;
     }
 
     function update-drag(x: length, y: length) {
         root.drag-value = root.angle-from-pointer(x, y);
+        root.changed(root.drag-value);
+    }
+
+    for tick in 24: Rectangle {
+        property <angle> tick-angle: tick * 15deg;
+        property <bool> major: mod(tick, 6) == 0;
+
+        x: root.dial-center-x + tick-angle.cos() * 24px - self.width / 2;
+        y: root.dial-center-y + tick-angle.sin() * 24px - self.height / 2;
+        width: major ? 2px : 1px;
+        height: major ? 5px : 3px;
+        border-radius: self.width / 2;
+        background: root.active && root.angle-distance-degrees(root.visual-value(), tick-angle) < 8
+            ? InspectorTokens.accent
+            : InspectorTokens.muted.with-alpha(major ? 0.56 : 0.28);
+        transform-rotation: tick-angle + 90deg;
+        opacity: touch.pressed ? 1 : 0.82;
+        animate background, opacity { duration: 120ms; }
     }
 
     Rectangle {
-        x: 7px;
-        y: 7px;
-        width: parent.width - 14px;
-        height: parent.height - 14px;
+        x: root.dial-x - 1px;
+        y: root.dial-y;
+        width: root.dial-size + 2px;
+        height: root.dial-size + 2px;
+        border-radius: self.width / 2;
+        background: StudioTheme.dark
+            ? @conic-gradient(#f4f4f430 0deg, #161616 74deg, #050505 150deg, #ffffff22 218deg, #050505 306deg, #f4f4f430 360deg)
+            : @conic-gradient(#ffffff 0deg, #b7bec8 74deg, #747d8c 150deg, #ffffff 218deg, #929aa6 306deg, #ffffff 360deg);
+        drop-shadow-blur: touch.pressed ? 5px : 11px;
+        drop-shadow-offset-y: touch.pressed ? 1px : 4px;
+        drop-shadow-color: StudioTheme.dark ? #00000085 : #1f293744;
+        animate drop-shadow-blur, drop-shadow-offset-y { duration: 120ms; }
+    }
+
+    Rectangle {
+        x: root.dial-x + 2px;
+        y: root.dial-y + 3px;
+        width: root.dial-size - 4px;
+        height: root.dial-size - 4px;
         border-radius: self.width / 2;
         border-width: 1px;
-        border-color: InspectorTokens.divider;
-        background: InspectorTokens.panel-bg;
+        border-color: StudioTheme.dark ? #ffffff18 : #ffffffd8;
+        background: StudioTheme.dark
+            ? @radial-gradient(circle, #5a5a5a 0%, #333333 45%, #161616 100%)
+            : @radial-gradient(circle, #ffffff 0%, #d9dee6 48%, #9aa3b1 100%);
+        inner-shadow-blur: 8px;
+        inner-shadow-offset-x: StudioTheme.dark ? -2px : 1px;
+        inner-shadow-offset-y: StudioTheme.dark ? -2px : 1px;
+        inner-shadow-color: StudioTheme.dark ? #ffffff18 : #ffffff8a;
     }
 
     Rectangle {
-        x: root.width / 2 + root.visual-value().cos() * 6.5px - 6.5px;
-        y: root.height / 2 + root.visual-value().sin() * 6.5px - 0.5px;
-        width: 13px;
-        height: 1px;
-        background: InspectorTokens.accent;
+        x: root.dial-x + 7px;
+        y: root.dial-y + 7px;
+        width: 20px;
+        height: 10px;
+        border-radius: 5px;
+        background: StudioTheme.dark ? #ffffff24 : #ffffffb4;
+        opacity: StudioTheme.dark ? 0.34 : 0.58;
+        transform-rotation: -28deg;
+    }
+
+    Rectangle {
+        x: root.dial-center-x + root.visual-value().cos() * 8px - 9px;
+        y: root.dial-center-y + root.visual-value().sin() * 8px - 1.5px;
+        width: 18px;
+        height: 3px;
+        border-radius: 1.5px;
+        background: StudioTheme.dark ? #08080880 : #6b728055;
         transform-rotation: root.visual-value();
+        inner-shadow-blur: 2px;
+        inner-shadow-offset-y: 1px;
+        inner-shadow-color: #00000055;
+    }
+
+    Rectangle {
+        x: root.dial-center-x - 7px;
+        y: root.dial-center-y - 7px;
+        width: 14px;
+        height: 14px;
+        border-radius: 7px;
+        background: StudioTheme.dark
+            ? @radial-gradient(circle, #6f6f6f 0%, #303030 70%, #111111 100%)
+            : @radial-gradient(circle, #f8fafc 0%, #c6ceda 70%, #8e98a8 100%);
+        border-width: 1px;
+        border-color: StudioTheme.dark ? #ffffff12 : #ffffff99;
     }
 
     Rectangle {
@@ -70,11 +147,23 @@ export component InspectorEffectDial inherits Rectangle {
         height: 8px;
         border-radius: 4px;
         border-width: 1px;
-        border-color: InspectorTokens.panel-bg;
+        border-color: StudioTheme.dark ? #f8fbffb0 : #ffffff;
         background: InspectorTokens.accent;
-        drop-shadow-blur: 6px;
-        drop-shadow-offset-y: 2px;
-        drop-shadow-color: #00000035;
+        drop-shadow-blur: root.active ? 9px : 5px;
+        drop-shadow-offset-y: 1px;
+        drop-shadow-color: InspectorTokens.accent.with-alpha(root.active ? 0.52 : 0.28);
+        animate drop-shadow-blur, drop-shadow-color { duration: 120ms; }
+    }
+
+    Rectangle {
+        x: (parent.width - self.width) / 2;
+        y: parent.height - 11px;
+        width: 34px;
+        height: 10px;
+        border-radius: 5px;
+        background: StudioTheme.dark ? #1111118a : #eef1f5d8;
+        border-width: 1px;
+        border-color: StudioTheme.dark ? #ffffff0e : #ffffffc0;
     }
 
     Text {
@@ -83,14 +172,16 @@ export component InspectorEffectDial inherits Rectangle {
         width: parent.width;
         height: 10px;
         text: "\{(root.normalized-angle(root.visual-value()) / 1deg).round()}°";
-        color: InspectorTokens.muted;
+        color: root.active ? InspectorTokens.text : InspectorTokens.muted;
         font-size: 9px;
+        font-weight: 700;
         horizontal-alignment: center;
         vertical-alignment: center;
+        animate color { duration: 120ms; }
     }
 
     touch := TouchArea {
-        mouse-cursor: pointer;
+        mouse-cursor: root.dragging ? grabbing : grab;
 
         pointer-event(event) => {
             if event.kind == PointerEventKind.down {

--- a/tools/lsp/ui/visual-editor/components/inspector/effect-slider.slint
+++ b/tools/lsp/ui/visual-editor/components/inspector/effect-slider.slint
@@ -10,6 +10,7 @@ export component InspectorEffectSlider inherits Rectangle {
     in property <float> minimum: 0;
     in property <float> maximum: 100;
     in property <string> suffix: "px";
+    callback changed(float) -> bool;
     callback accepted(float) -> bool;
 
     property <bool> dragging: false;
@@ -37,6 +38,7 @@ export component InspectorEffectSlider inherits Rectangle {
 
     function update-at(pointer-x: length) {
         root.drag-value = root.value-at(pointer-x);
+        root.changed(root.drag-value);
     }
 
     Text {


### PR DESCRIPTION
Summary:
- route Rectangle shadow drag previews through debug-hook overrides instead of source edits
- make lowered BoxShadow elements hookable while filtering them out of selection and source lookup
- keep pointer-up commits targeting authored Rectangle shadow properties

Tests:
- cargo test -p slint-interpreter --features internal,internal-highlight test_shadow_box_does_not_duplicate_source_position
- cargo test -p i-slint-compiler --test lower_shadows
- cargo test -p slint-lsp preview::properties
- SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 cargo check -p slint-lsp --example slint-editor --no-default-features --features backend-winit,renderer-skia,renderer-software,preview