### PR TITLE
Tweaks to the C++ documentation 

### DIFF
--- a/docs/common/src/utils/markdown-endpoint.ts
+++ b/docs/common/src/utils/markdown-endpoint.ts
@@ -42,6 +42,12 @@ export interface MarkdownEndpointOptions {
      * blocks. Sites whose pages don't import code from files omit this.
      */
     projectRoot?: string;
+    /**
+     * Fold the C++ API reference's `api-signature` `<pre>` HTML into ```cpp
+     * fences and drop the empty heading anchors. Only the doxygen-generated
+     * pages carry that HTML (and the fence is C++), so other sites omit this.
+     */
+    apiSignatures?: boolean;
 }
 
 /**
@@ -62,6 +68,9 @@ export function renderMarkdownResponse(
 ): Response {
     const data = entry.data;
     let body = entry.body ?? "";
+    if (options.apiSignatures) {
+        body = simplifyApiReferenceHtml(body);
+    }
     if (options.projectRoot) {
         body = inlineRawCodeImports(body, options.projectRoot, entry.filePath);
     }
@@ -95,6 +104,64 @@ export function renderMarkdownResponse(
 // YAML-safe double-quoting for single-line scalar values.
 function quote(s: string): string {
     return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+// The C++ pages render signatures as `<pre class="api-signature">` HTML and
+// give member headings an `<a id>` anchor — both noise in the plain markdown an
+// agent reads. Fold signatures into ```cpp fences, drop the anchors and the
+// `<small>` markers (keeping their text). A no-op for pages without that HTML.
+const API_SIGNATURE_RE =
+    /<pre\b[^>]*class="[^"]*\bapi-signature\b[^"]*"[^>]*>([\s\S]*?)<\/pre>/g;
+// cSpell:ignore apos
+const NAMED_ENTITY: Record<string, string> = {
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    amp: "&",
+};
+
+// Decode the entities in the signature markup. Shiki escapes `<` as the hex
+// `&#x3C;`, so numeric refs are handled too, not just named ones. `&amp;` is
+// decoded last so an escaped `&amp;lt;` survives as the literal `&lt;`.
+function decodeHtmlEntities(s: string): string {
+    return s
+        .replace(
+            /&#x([0-9a-fA-F]+);|&#(\d+);|&(lt|gt|quot|apos);/g,
+            (_, hex: string, dec: string, name: string) => {
+                if (hex !== undefined) {
+                    return String.fromCodePoint(Number.parseInt(hex, 16));
+                }
+                if (dec !== undefined) {
+                    return String.fromCodePoint(Number.parseInt(dec, 10));
+                }
+                return NAMED_ENTITY[name];
+            },
+        )
+        .replace(/&amp;/g, "&");
+}
+
+function simplifyApiReferenceHtml(body: string): string {
+    return (
+        body
+            .replace(API_SIGNATURE_RE, (_whole, inner: string) => {
+                const code = inner
+                    // Keep only the `<code>…</code>` payload.
+                    .replace(/^[\s\S]*?<code[^>]*>/, "")
+                    .replace(/<\/code>[\s\S]*$/, "")
+                    // Shiki wraps each source line in its own span.
+                    .replace(/<span class="line">/g, "\n")
+                    .replace(/<[^>]+>/g, "");
+                const text = decodeHtmlEntities(code)
+                    .replace(/^\n+/, "")
+                    .replace(/\n+$/, "");
+                return `\`\`\`cpp\n${text}\n\`\`\``;
+            })
+            // Empty heading anchors (`### <a id="name"></a> \`name\``) and the
+            // `<small>(virtual)</small>` markers around member headings.
+            .replace(/<a id="[^"]*"><\/a>\s?/g, "")
+            .replace(/<\/?small>/g, "")
+    );
 }
 
 // Replace `<Link type="X" label="Y" />` (the in-prose linking component used

--- a/docs/common/tests/markdown-endpoint.test.ts
+++ b/docs/common/tests/markdown-endpoint.test.ts
@@ -203,3 +203,40 @@ test("without projectRoot, code imports are left as-is", async () => {
     const text = await res.text();
     assert.match(text, /import script from/);
 });
+
+test("API-reference signature HTML collapses to a ```cpp fence", async () => {
+    const body = [
+        '### <a id="title"></a> `title` <small>(virtual)</small>',
+        "",
+        '<pre class="shiki api-signature" style="--x:1"><code><span class="line">' +
+            '<a href="../sharedstring/" class="api-link">SharedString</a>' +
+            "<span> slint</span><span>::</span><span>title</span>" +
+            "<span>() </span><span>const</span></span></code></pre>",
+    ].join("\n");
+    const text = await renderMarkdownResponse(entry({ body }), {
+        apiSignatures: true,
+    }).text();
+    // The signature becomes a plain fence with the entities/tags stripped.
+    assert.match(text, /```cpp\nSharedString slint::title\(\) const\n```/);
+    // The empty deep-link anchor and the <small> marker are gone, the heading
+    // text (kept as inline code) and the marker text remain.
+    assert.doesNotMatch(text, /<a id=|<small>|<pre/);
+    assert.match(text, /### `title` \(virtual\)/);
+});
+
+test("angle-bracket types in a signature are decoded, not left as entities", async () => {
+    // Shiki escapes `<` as the hex reference `&#x3C;` (not `&lt;`); `>` is left
+    // bare. Both the hex and named forms must decode.
+    const body =
+        '<pre class="api-signature"><code>' +
+        "std::optional&#x3C; SharedPixelBuffer&lt;Rgba8Pixel> > take_snapshot()" +
+        "</code></pre>";
+    const text = await renderMarkdownResponse(entry({ body }), {
+        apiSignatures: true,
+    }).text();
+    assert.match(
+        text,
+        /```cpp\nstd::optional< SharedPixelBuffer<Rgba8Pixel> > take_snapshot\(\)\n```/,
+    );
+    assert.doesNotMatch(text, /&#x|&lt;|&gt;/);
+});

--- a/docs/cpp/astro.config.mjs
+++ b/docs/cpp/astro.config.mjs
@@ -42,6 +42,23 @@ export default defineConfig({
     ...(_cppBase ? { base: _cppBase } : {}),
     trailingSlash: SLINT_STARLIGHT_TRAILING_SLASH,
     markdown: slintStarlightMarkdownRehypeExternalLinksOnly(),
+    vite: {
+        resolve: {
+            // Swap our PagefindUI wrapper (which adds `processTerm`) in for
+            // `@pagefind/default-ui`, so qualified C++ identifier searches
+            // resolve. Exact-match `find` so subpath imports (the CSS, the
+            // wrapper's own import) are left alone.
+            alias: [
+                {
+                    find: /^@pagefind\/default-ui$/,
+                    replacement: new URL(
+                        "./src/pagefind-ui-override.mjs",
+                        import.meta.url,
+                    ).pathname,
+                },
+            ],
+        },
+    },
     integrations: [
         sitemap(),
         starlight({

--- a/docs/cpp/package.json
+++ b/docs/cpp/package.json
@@ -25,6 +25,7 @@
         "@astrojs/check": "catalog:",
         "@astrojs/sitemap": "catalog:",
         "@astrojs/starlight": "catalog:",
+        "@pagefind/default-ui": "catalog:",
         "@slint/common-files": "workspace:*",
         "@types/node": "catalog:",
         "astro": "catalog:",

--- a/docs/cpp/scripts/lib/doxygen.ts
+++ b/docs/cpp/scripts/lib/doxygen.ts
@@ -320,7 +320,11 @@ export class DoxygenConverter {
      */
     private renderMemberPage(nsName: string, page: MemberPage): string {
         const out: string[] = ["---"];
-        out.push(`title: ${frontmatterString(`${nsName}::${page.name}`)}`);
+        // A kind suffix mirrors the compound pages' `Color Class` titles.
+        const kindLabel = page.kind === "enum" ? "Enum" : "Function";
+        out.push(
+            `title: ${frontmatterString(`${nsName}::${page.name} ${kindLabel}`)}`,
+        );
         const description = firstLine(
             this.renderBlocks(child(page.members[0], "briefdescription")),
         );

--- a/docs/cpp/scripts/lib/doxygen.ts
+++ b/docs/cpp/scripts/lib/doxygen.ts
@@ -617,7 +617,9 @@ export class DoxygenConverter {
             return undefined;
         }
         const params = children(list, "param").map((p) => {
-            const type = textContent(child(p, "type") ?? emptyElement()).trim();
+            const type = tightenAngles(
+                textContent(child(p, "type") ?? emptyElement()).trim(),
+            );
             const declname = textContent(
                 child(p, "declname") ?? emptyElement(),
             ).trim();
@@ -644,7 +646,7 @@ export class DoxygenConverter {
     }
 
     private linkForCompoundRef(ref: XmlElement): string {
-        const text = textContent(ref).trim();
+        const text = tightenAngles(textContent(ref).trim());
         const refid = ref.attrs.refid;
         const target = refid ? this.compoundTargets.get(refid) : undefined;
         return target
@@ -944,7 +946,7 @@ export class DoxygenConverter {
             text += args;
         }
 
-        return { text, links };
+        return tightenTemplateSpacing(text, links);
     }
 
     /**
@@ -1272,6 +1274,56 @@ function collectRefs(node: XmlElement): XmlElement[] {
  * the cross-referenced type ranges in `<a>` links. Used when no Shiki
  * highlighter is supplied (e.g. the unit tests).
  */
+/**
+ * Drop Doxygen's angle-bracket padding (`Foo< Bar >` → `Foo<Bar>`) to match our
+ * code style; only spaces directly inside `<`/`>` go. For plain strings like
+ * type labels; signatures with link offsets use {@link tightenTemplateSpacing}.
+ */
+export function tightenAngles(text: string): string {
+    return text.replace(/<[ \t]+/g, "<").replace(/[ \t]+>/g, ">");
+}
+
+/**
+ * Like {@link tightenAngles}, but for a built signature: also shifts each
+ * cross-reference link's offsets as it drops spaces, since the links index
+ * into `text`.
+ */
+export function tightenTemplateSpacing(
+    text: string,
+    links: SignatureLink[],
+): { text: string; links: SignatureLink[] } {
+    // Mark padding spaces (right after `<` or before `>`) for removal.
+    const drop = new Array<boolean>(text.length).fill(false);
+    for (const m of text.matchAll(/<[ \t]+|[ \t]+>/g)) {
+        for (let i = 0; i < m[0].length; i++) {
+            if (m[0][i] === " " || m[0][i] === "\t") {
+                drop[m.index + i] = true;
+            }
+        }
+    }
+    if (!drop.includes(true)) {
+        return { text, links };
+    }
+    // old index → new index (positions of kept characters shift left).
+    const newIndex = new Array<number>(text.length + 1);
+    let out = "";
+    for (let i = 0; i < text.length; i++) {
+        newIndex[i] = out.length;
+        if (!drop[i]) {
+            out += text[i];
+        }
+    }
+    newIndex[text.length] = out.length;
+    return {
+        text: out,
+        links: links.map((l) => ({
+            ...l,
+            start: newIndex[l.start],
+            end: newIndex[l.end],
+        })),
+    };
+}
+
 function signatureFallback(text: string, links: SignatureLink[]): string {
     const sorted = [...links].sort((a, b) => a.start - b.start);
     let html = "";

--- a/docs/cpp/scripts/lib/slug.ts
+++ b/docs/cpp/scripts/lib/slug.ts
@@ -6,11 +6,15 @@
 /** Starlight collects pages under `src/content/docs`; the generated API lives under `api/`. */
 export const API_ROOT = "api";
 
-/** A filesystem/url-safe fragment, lowercased, with `::` and other separators collapsed to `-`. */
+/**
+ * A filesystem/url-safe fragment: lowercased, punctuation collapsed to `-`.
+ * Underscores are kept (like {@link memberAnchorBase}) so the slug mirrors the
+ * C++ identifier, e.g. `update_all_translations` not `update-all-translations`.
+ */
 function slugify(text: string): string {
     return text
         .replace(/::/g, "-")
-        .replace(/[^a-zA-Z0-9]+/g, "-")
+        .replace(/[^a-zA-Z0-9_]+/g, "-")
         .replace(/-+/g, "-")
         .replace(/^-|-$/g, "")
         .toLowerCase();

--- a/docs/cpp/src/pagefind-ui-override.mjs
+++ b/docs/cpp/src/pagefind-ui-override.mjs
@@ -1,0 +1,17 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+// cSpell:ignore Pagefind
+
+// Wrap Pagefind's `PagefindUI` to inject a `processTerm` that normalizes C++
+// scope/identifier separators (`::`, `_`) to spaces, so a search for a qualified
+// name matches (Pagefind splits those apart when indexing but keeps them joined
+// in a query). Aliased in for `@pagefind/default-ui` (see astro.config.mjs), so
+// Starlight's `new PagefindUI(...)` picks it up. Imports the dependency by its
+// concrete path to avoid the alias recursing into this file.
+import { PagefindUI as Base } from "@pagefind/default-ui/npm_dist/mjs/ui-core.mjs";
+
+export class PagefindUI extends Base {
+    constructor(opts = {}) {
+        super({ processTerm: (t) => t.replace(/[:_]+/g, " "), ...opts });
+    }
+}

--- a/docs/cpp/src/pages/[...slug].md.ts
+++ b/docs/cpp/src/pages/[...slug].md.ts
@@ -20,4 +20,5 @@ export const getStaticPaths: GetStaticPaths = async () => {
 type Props = { entry: CollectionEntry<"docs"> };
 
 export const GET: APIRoute<Props> = ({ props }) =>
-    renderMarkdownResponse(props.entry);
+    // The generated C++ pages embed `api-signature` HTML to fold into fences.
+    renderMarkdownResponse(props.entry, { apiSignatures: true });

--- a/docs/cpp/tests/convert.test.ts
+++ b/docs/cpp/tests/convert.test.ts
@@ -10,7 +10,11 @@ import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
-import { DoxygenConverter } from "../scripts/lib/doxygen.ts";
+import {
+    DoxygenConverter,
+    tightenAngles,
+    tightenTemplateSpacing,
+} from "../scripts/lib/doxygen.ts";
 import type {
     ConvertResult,
     GeneratedPage,
@@ -219,4 +223,40 @@ test("sidebar hoists the implicit root namespace directly under API Reference", 
     const en = items.find((i) => i.label === "EventLoopMode");
     assert.equal(fn?.slug, "api/slint/run_event_loop");
     assert.equal(en?.slug, "api/slint/eventloopmode");
+});
+
+test("tightenAngles collapses bracket padding but keeps comma/keyword spacing", () => {
+    assert.equal(
+        tightenAngles("std::optional< SharedPixelBuffer< Rgba8Pixel > >"),
+        "std::optional<SharedPixelBuffer<Rgba8Pixel>>",
+    );
+    assert.equal(
+        tightenAngles("slint::Model< ModelData >"),
+        "slint::Model<ModelData>",
+    );
+    // Spaces after a comma between arguments stay.
+    assert.equal(tightenAngles("map< K, V >"), "map<K, V>");
+    // The `template <…>` keyword spacing (space before `<`) is left alone.
+    assert.equal(
+        tightenAngles("template <typename T>"),
+        "template <typename T>",
+    );
+});
+
+test("tightenTemplateSpacing keeps cross-reference links aligned", () => {
+    const text = "optional< Foo< Bar > > f()";
+    const foo = text.indexOf("Foo");
+    const bar = text.indexOf("Bar");
+    const { text: out, links } = tightenTemplateSpacing(text, [
+        { start: foo, end: foo + 3, url: "/foo/" },
+        { start: bar, end: bar + 3, url: "/bar/" },
+    ]);
+    assert.equal(out, "optional<Foo<Bar>> f()");
+    // The remapped offsets still bound exactly the linked type names.
+    assert.equal(out.slice(links[0].start, links[0].end), "Foo");
+    assert.equal(out.slice(links[1].start, links[1].end), "Bar");
+    assert.deepEqual(
+        links.map((l) => l.url),
+        ["/foo/", "/bar/"],
+    );
 });

--- a/docs/cpp/tests/convert.test.ts
+++ b/docs/cpp/tests/convert.test.ts
@@ -45,11 +45,11 @@ test("emits one page per page-kind compound with the expected slugs", () => {
 
 test("namespace free functions and enums get their own page", () => {
     const fn = convert().get("api/slint/run_event_loop")?.markdown ?? "";
-    assert.match(fn, /title: "slint::run_event_loop"/);
+    assert.match(fn, /title: "slint::run_event_loop Function"/);
     assert.match(fn, /Enters the main event loop\./);
 
     const en = convert().get("api/slint/eventloopmode")?.markdown ?? "";
-    assert.match(en, /title: "slint::EventLoopMode"/);
+    assert.match(en, /title: "slint::EventLoopMode Enum"/);
     assert.match(
         en,
         /\| `QuitOnLastWindowClosed` \| Quit when the last window/,

--- a/docs/cpp/tests/convert.test.ts
+++ b/docs/cpp/tests/convert.test.ts
@@ -37,14 +37,14 @@ test("emits one page per page-kind compound with the expected slugs", () => {
             "api/slint/color",
             "api/slint/sharedstring",
             // Free functions and enums each become their own page too.
-            "api/slint/run-event-loop",
+            "api/slint/run_event_loop",
             "api/slint/eventloopmode",
         ].sort(),
     );
 });
 
 test("namespace free functions and enums get their own page", () => {
-    const fn = convert().get("api/slint/run-event-loop")?.markdown ?? "";
+    const fn = convert().get("api/slint/run_event_loop")?.markdown ?? "";
     assert.match(fn, /title: "slint::run_event_loop"/);
     assert.match(fn, /Enters the main event loop\./);
 
@@ -137,7 +137,7 @@ test("namespace pages list their types (classes and structs together) with links
 test("namespace pages link to function/enum pages instead of inlining them", () => {
     const ns = convert().get("api/slint")?.markdown ?? "";
     // Free functions and enums are listed as links to their own pages…
-    assert.match(ns, /## Functions\n- \[run_event_loop\]\(run-event-loop\/\)/);
+    assert.match(ns, /## Functions\n- \[run_event_loop\]\(run_event_loop\/\)/);
     assert.match(ns, /## Enumerations\n- \[EventLoopMode\]\(eventloopmode\/\)/);
     // …not rendered inline as member sections on the namespace page.
     assert.doesNotMatch(ns, /### <a id="run_event_loop">/);
@@ -217,6 +217,6 @@ test("sidebar hoists the implicit root namespace directly under API Reference", 
     // Free functions and enums link to their own page (not an anchor).
     const fn = items.find((i) => i.label === "run_event_loop");
     const en = items.find((i) => i.label === "EventLoopMode");
-    assert.equal(fn?.slug, "api/slint/run-event-loop");
+    assert.equal(fn?.slug, "api/slint/run_event_loop");
     assert.equal(en?.slug, "api/slint/eventloopmode");
 });

--- a/docs/cpp/tests/md-endpoint.test.ts
+++ b/docs/cpp/tests/md-endpoint.test.ts
@@ -1,0 +1,58 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// cSpell:ignore eventloopmode
+
+// Integration test: a generated page through the shared .md endpoint. Uses the
+// real Shiki highlighter (so the HTML matches production) but asserts the fenced
+// C++ text, not the HTML, so it survives Shiki output changes.
+//
+// Runnable with: node --experimental-strip-types tests/md-endpoint.test.ts
+
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { createHighlighter } from "shiki";
+import { renderMarkdownResponse } from "@slint/common-files/src/utils/markdown-endpoint.ts";
+import { DoxygenConverter } from "../scripts/lib/doxygen.ts";
+
+const xmlDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "xml");
+
+/** Render a generated page as the `.md` endpoint serves it, via real Shiki. */
+async function renderMd(slug: string): Promise<string> {
+    const highlighter = await createHighlighter({
+        themes: ["light-plus", "dark-plus"],
+        langs: ["cpp"],
+    });
+    const page = new DoxygenConverter(xmlDir, { highlighter })
+        .convert()
+        .pages.find((p) => p.slug === slug);
+    assert.ok(page, `expected a generated page for ${slug}`);
+    return renderMarkdownResponse(
+        { id: slug, data: {}, body: page.markdown },
+        { apiSignatures: true },
+    ).text();
+}
+
+test("a class's member signatures are served as fenced C++, not HTML", async () => {
+    const md = await renderMd("api/slint/color");
+    // The signature reads as the real C++ declaration inside a ```cpp fence …
+    assert.match(
+        md,
+        /```cpp\nstatic Color slint::Color::from_argb_encoded\(uint32_t argb_encoded\)\n```/,
+    );
+    // … and a member with a linked parameter type keeps the type as plain text.
+    assert.match(
+        md,
+        /```cpp\nvoid slint::Color::blend\(const Color &other\)\n```/,
+    );
+    // No raw signature HTML, Shiki wrappers or heading anchors leak through.
+    assert.doesNotMatch(md, /<pre|class="[^"]*api-signature|<span|<a id=/);
+});
+
+test("member headings keep the member name without the anchor markup", async () => {
+    const md = await renderMd("api/slint/color");
+    assert.match(md, /### `from_argb_encoded`/);
+    assert.doesNotMatch(md, /<a id="from_argb_encoded">/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@expressive-code/plugin-line-numbers':
       specifier: 0.43.1
       version: 0.43.1
+    '@pagefind/default-ui':
+      specifier: 1.5.2
+      version: 1.5.2
     '@playwright/test':
       specifier: 1.60.0
       version: 1.60.0
@@ -241,6 +244,9 @@ importers:
       '@astrojs/starlight':
         specifier: 'catalog:'
         version: 0.40.0(astro@6.4.6(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(terser@5.46.1)(yaml@2.9.0))(typescript@6.0.3)
+      '@pagefind/default-ui':
+        specifier: 'catalog:'
+        version: 1.5.2
       '@slint/common-files':
         specifier: workspace:*
         version: link:../common

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ catalog:
   '@astrojs/starlight': 0.40.0
   '@biomejs/biome': 2.5.0
   '@expressive-code/plugin-line-numbers': 0.43.1
+  '@pagefind/default-ui': 1.5.2
   '@playwright/test': 1.60.0
   '@types/node': 24.12.0
   astro: 6.4.6


### PR DESCRIPTION
- keep underscores in URL for function names
- Fix search with namespace and underscores
- make the .md files prettier
