### PR TITLE
Use Cow instead of borrow when deserializing SharedString

### DIFF
--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -166,8 +166,8 @@ impl<'de> serde::Deserialize<'de> for SharedString {
     where
         D: serde::Deserializer<'de>,
     {
-        let string: &str = serde::Deserialize::deserialize(deserializer)?;
-        Ok(SharedString::from(string))
+        let string: std::borrow::Cow<str> = serde::Deserialize::deserialize(deserializer)?;
+        Ok(SharedString::from(string.as_ref()))
     }
 }
 
@@ -770,6 +770,15 @@ fn test_serialize_deserialize_sharedstring() {
     let v = SharedString::from("data");
     let serialized = serde_json::to_string(&v).unwrap();
     let deserialized: SharedString = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(v, deserialized);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serialize_deserialize_sharedstring_from_reader() {
+    let v = SharedString::from("data");
+    let serialized = serde_json::to_string(&v).unwrap();
+    let deserialized: SharedString = serde_json::from_reader(serialized.as_bytes()).unwrap();
     assert_eq!(v, deserialized);
 }
 

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -166,7 +166,7 @@ impl<'de> serde::Deserialize<'de> for SharedString {
     where
         D: serde::Deserializer<'de>,
     {
-        let string: std::borrow::Cow<str> = serde::Deserialize::deserialize(deserializer)?;
+        let string: alloc::borrow::Cow<str> = serde::Deserialize::deserialize(deserializer)?;
         Ok(SharedString::from(string.as_ref()))
     }
 }


### PR DESCRIPTION
SharedString Deserialize implementation always tried to deserialize into `&str`. But not every deseralizer allow borrowed deserializing, those reading a reader in particular. In that case any struct containing SharedString fails with message like `invalid type: string \"data\", expected a borrowed string`. 

This changes &str to Cow<str> which will deserialize to borrowed str if possible, and to owned String if not.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
