### PR TITLE
FlexboxLayout: two fixes to the preferred-size sqrt heuristic

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1906,18 +1906,31 @@ pub fn flexbox_layout_info_main_axis(
             + spacing * num_spacings
             + extra_pad
     } else {
-        // Wrapping: estimate a roughly square layout using only main-axis sizes.
-        // Approximate total area assuming each item is square (width == height),
-        // then take sqrt to get a reasonable main-axis extent.
-        let total_area: Coord = cells
-            .iter()
-            .map(|c| {
-                let w = c.constraint.preferred_bounded();
-                w * w
-            })
-            .sum();
-        let count = cells.len();
-        Float::sqrt(total_area as f32) as Coord + spacing * (count - 1) as Coord + extra_pad
+        // Wrapping: aim for a roughly square (pixel-area) arrangement, using only
+        // main-axis sizes so this stays independent of the cross axis. The square
+        // side is the sqrt of the total area (each item approximated as a main-axis
+        // square). Snap that up to a whole number of items, so a line holds a clean
+        // grid row instead of wrapping mid-item (which would over-count columns:
+        // e.g. 3 equal items want `A B / C`, not `A B C`).
+        // Accumulate the area in f64: with the integer Coord build, Coord-typed
+        // w*w (and its sum) would overflow for large items.
+        let total_area: f64 =
+            cells.iter().map(|c| c.constraint.preferred_bounded() as f64).map(|w| w * w).sum();
+        let target = Float::sqrt(total_area as f32) as Coord;
+        let mut acc = 0 as Coord;
+        let mut started = false;
+        for c in cells.iter() {
+            acc += if started {
+                spacing + c.constraint.preferred_bounded()
+            } else {
+                c.constraint.preferred_bounded()
+            };
+            started = true;
+            if acc >= target {
+                break;
+            }
+        }
+        acc + extra_pad
     };
     let stretch = cells.iter().map(|c| c.constraint.stretch).sum::<f32>();
     LayoutInfo {

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1908,14 +1908,20 @@ pub fn flexbox_layout_info_main_axis(
     } else {
         // Wrapping: aim for a roughly square (pixel-area) arrangement, using only
         // main-axis sizes so this stays independent of the cross axis. The square
-        // side is the sqrt of the total area (each item approximated as a main-axis
-        // square). Snap that up to a whole number of items, so a line holds a clean
-        // grid row instead of wrapping mid-item (which would over-count columns:
-        // e.g. 3 equal items want `A B / C`, not `A B C`).
+        // side is the sqrt of the total area; each item is approximated as a
+        // (size + spacing) square, so the gaps count toward the area and the grid
+        // stays roughly square as spacing grows (otherwise a spacing-blind target
+        // is reached with fewer items, skewing the grid taller). Snap that up to a
+        // whole number of items, so a line holds a clean grid row instead of
+        // wrapping mid-item (which would over-count columns: e.g. 3 equal items
+        // want `A B / C`, not `A B C`).
         // Accumulate the area in f64: with the integer Coord build, Coord-typed
-        // w*w (and its sum) would overflow for large items.
-        let total_area: f64 =
-            cells.iter().map(|c| c.constraint.preferred_bounded() as f64).map(|w| w * w).sum();
+        // products (and their sum) would overflow for large items.
+        let total_area: f64 = cells
+            .iter()
+            .map(|c| c.constraint.preferred_bounded() as f64 + spacing as f64)
+            .map(|w| w * w)
+            .sum();
         let target = Float::sqrt(total_area as f32) as Coord;
         let mut acc = 0 as Coord;
         let mut started = false;

--- a/tests/cases/layout/flexbox-preferred-grid-demo.slint
+++ b/tests/cases/layout/flexbox-preferred-grid-demo.slint
@@ -1,0 +1,168 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Interactive demo for the wrapping main-axis preferred-size fix: a FlexboxLayout
+// sized to its OWN preferred-width snaps to a whole number of items per row, so
+// equal items tile into a clean grid square instead of wrapping mid-item.
+//
+// Open in the viewer and use the steppers:
+//   slint-viewer tests/cases/layout/flexbox-preferred-grid-demo.slint
+// - "items": watch the block stay square (4 -> 2x2, 9 -> 3x3, 16 -> 4x4, ...);
+//   before the fix the preferred-width fell between item boundaries and an extra
+//   ragged row appeared.
+// - "spacing": the preferred-width grows only by the gaps WITHIN a row (e.g. 2
+//   gaps for a 3-column row), not one gap per item as the old code counted.
+//   Spacing is folded into the square-side target (each item modeled as a
+//   size+spacing square), so the grid stays square as spacing grows instead of
+//   skewing taller.
+// - "fill window": pin the flex to its preferred-width (off) vs stretch it to
+//   the available width (on), to compare preferred-size against re-wrapping at
+//   the actually-available width.
+//
+// No std-widgets, so no Image -> safe on the winit-only backend of this clone.
+
+// A small "- value +" stepper built from TouchAreas (no std-widgets).
+component Stepper inherits HorizontalLayout {
+    in property <string> label;
+    in property <int> step: 1;
+    in property <int> minimum: 0;
+    in property <int> maximum: 100;
+    in-out property <int> value;
+
+    spacing: 6px;
+    Text { text: root.label; vertical-alignment: center; }
+    Rectangle {
+        width: 32px;
+        border-radius: 4px;
+        background: minus-ta.pressed ? #444 : #777;
+        Text { text: "−"; color: white; horizontal-alignment: center; vertical-alignment: center; }
+        minus-ta := TouchArea {
+            clicked => { root.value = clamp(root.value - root.step, root.minimum, root.maximum); }
+        }
+    }
+    Text { text: "\{root.value}"; width: 36px; horizontal-alignment: center; vertical-alignment: center; }
+    Rectangle {
+        width: 32px;
+        border-radius: 4px;
+        background: plus-ta.pressed ? #444 : #777;
+        Text { text: "+"; color: white; horizontal-alignment: center; vertical-alignment: center; }
+        plus-ta := TouchArea {
+            clicked => { root.value = clamp(root.value + root.step, root.minimum, root.maximum); }
+        }
+    }
+}
+
+// A custom checkbox built from a TouchArea (no std-widgets).
+component Toggle inherits HorizontalLayout {
+    in property <string> label;
+    in-out property <bool> checked;
+
+    spacing: 8px;
+    Rectangle {
+        width: 22px;
+        height: 22px;
+        border-width: 2px;
+        border-color: #777;
+        border-radius: 4px;
+        background: root.checked ? #4363d8 : transparent;
+        Text { text: root.checked ? "✓" : ""; color: white; horizontal-alignment: center; vertical-alignment: center; }
+        TouchArea { clicked => { root.checked = !root.checked; } }
+    }
+    Text { text: root.label; vertical-alignment: center; }
+}
+
+export component TestCase inherits Window {
+    preferred-width: 640px;
+    preferred-height: 520px;
+    default-font-size: 16px;
+    // Live actual-vs-preferred width goes in the title: the title does not take
+    // part in layout, so reading flex.width here cannot form a binding loop.
+    title: root.fill-window
+        ? "FlexboxLayout — fill: flex.width \{round(flex.width / 1px)}px (preferred \{round(flex.preferred-width / 1px)}px)"
+        : "FlexboxLayout — fit: preferred-width \{round(flex.preferred-width / 1px)}px";
+
+    in-out property <int> item-count: 32;
+    in-out property <int> spacing-px: 0;
+    in-out property <bool> fill-window: false;
+    property <[color]> palette: [#e6194b, #3cb44b, #4363d8, #f58231, #911eb4, #008080];
+
+    VerticalLayout {
+        padding: 16px;
+        spacing: 14px;
+
+        Text {
+            text: "A wrapping FlexboxLayout sized to its own preferred-width tiles equal items "
+                + "into a clean grid square — the preferred main-axis size snaps to whole items.";
+            wrap: word-wrap;
+        }
+
+        HorizontalLayout {
+            spacing: 28px;
+            Stepper { label: "items:"; value <=> root.item-count; minimum: 1; maximum: 36; }
+            Stepper { label: "spacing:"; value <=> root.spacing-px; minimum: 0; maximum: 40; step: 5; }
+            Toggle { label: "fill window"; checked <=> root.fill-window; }
+        }
+
+        // Intrinsic (window-independent) values only, so this text never feeds the
+        // window width back into flex.width. The live actual width is in the title.
+        Text {
+            text: root.fill-window
+                ? "fill window: flex stretches to the available width and re-wraps (preferred-width \{round(flex.preferred-width / 1px)}px; live actual width in the title bar)"
+                : "fit preferred: flex.width = preferred-width = \{round(flex.preferred-width / 1px)}px";
+            wrap: word-wrap;
+            font-weight: 700;
+        }
+
+        // Fit mode: the flex takes its preferred-width (the grid square this demo is
+        // about). Fill mode: it stretches to the available width and re-wraps. Driven
+        // by layout stretch, not by binding the width to root.width — the latter forms
+        // a binding loop and ratchets the window's min-width as it grows.
+        HorizontalLayout {
+            alignment: root.fill-window ? LayoutAlignment.stretch : LayoutAlignment.start;
+            flex := FlexboxLayout {
+                align-content: start;
+                spacing: root.spacing-px * 1px;
+                vertical-stretch: 0;
+                horizontal-stretch: root.fill-window ? 1.0 : 0.0;
+
+                for idx in root.item-count: Rectangle {
+                    width: 50px;
+                    height: 50px;
+                    border-radius: 4px;
+                    background: root.palette[mod(idx, 6)];
+                    Text {
+                        text: "\{idx}";
+                        color: white;
+                        font-weight: 700;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                }
+            }
+        }
+
+        Rectangle { } // soak up remaining vertical space
+    }
+
+    // Automated check at the default state (32 items, 50px, spacing 0, no padding):
+    // sqrt(32 * 50²) ≈ 283 → snaps to 6 items per row (6×50 = 300px); 32 items
+    // wrap into 6 rows. The widest single item (50px) sets min-width.
+    out property <bool> test: flex.preferred-width == 300px && flex.min-width == 50px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox-preferred-width.slint
+++ b/tests/cases/layout/flexbox-preferred-width.slint
@@ -42,17 +42,18 @@ export component TestCase inherits Window {
         background: yellow;
     }
 
-    // flex-direction: column means items should stack vertically
-    // r1: y=0, r2: y=60 (50+10), r3: y=120 (50+10+50+10)
-    // All items should have same x position (0)
+    // A row flex sizing to its own preferred width lays the 3 items out as a
+    // grid-square: 2 columns (sqrt(sum of w²) snapped up to 2 items per row).
+    // Row 1: r1 (x=0), r2 (x=110); Row 2: r3 (x=0, y=60).
     out property <length> r1_x: r1.x;
     out property <length> r1_y: r1.y;
     out property <length> r2_x: r2.x;
     out property <length> r2_y: r2.y;
     out property <length> r3_x: r3.x;
     out property <length> r3_y: r3.y;
-    out property <bool> test: r1.x == r2.x && r2.x == r3.x &&  // same column
-                              r1.y == 0px && r2.y == 60px && r3.y == 120px;  // stacked vertically with spacing
+    out property <bool> test: r1.x == 0px && r1.y == 0px &&
+                              r2.x == 110px && r2.y == 0px &&
+                              r3.x == 0px && r3.y == 60px;
 }
 
 /*

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -38,9 +38,10 @@ export component TestCase inherits Window {
     out property <int> min_w: flex.min-width / 1px;
     out property <int> preferred_w: flex.preferred-width / 1px;
     out property <int> max_w: flex.max-width / 1px;
-    // Main-axis preferred-width uses sqrt(sum of w²) heuristic ≈ 199px.
+    // Main-axis preferred-width snaps the sqrt(sum of w²) square side up to whole
+    // items: the first row holds 3 (2 + 60+5+60+5+60 + 2) = 194px.
     // Cross-axis preferred-height uses taffy with the actual container width (200px) ≈ 129px.
-    out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width > 198px && flex.preferred-width < 200px;
+    out property <bool> flex_minmax_width_ok: flex.min-width == 94px && flex.preferred-width == 194px;
     // min-height and preferred-height are both computed at the actual container
     // width (200px), giving the same wrapping layout ≈ 129px.
     out property <bool> flex_minmax_height_ok: flex.min-height > 128px && flex.min-height < 130px && flex.preferred-height > 128px && flex.preferred-height < 130px;


### PR DESCRIPTION
* FlexboxLayout: snap the wrapping main-axis preferred size to whole items
* FlexboxLayout: fold spacing into the wrapping square-side estimate
See details in the respective commit logs.

The new interactive demo (flexbox-preferred-grid-demo.slint) shows before/after quite clearly.
For the first commit:
<img width="1467" height="707" alt="before-after-square-snap-fix" src="https://github.com/user-attachments/assets/759e1420-0258-49b4-833a-40d388378bc2" />
(notice how the fix makes it more "square")

For the second commit:
<img width="1466" height="738" alt="before-after-spacing-fix" src="https://github.com/user-attachments/assets/cf7b0390-d99b-425f-9613-7fddc079dbff" />
(notice how it was completely broken when spacing was used)