### PR TITLE
core: don't panic dispatching window events before a platform is set

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -660,8 +660,10 @@ impl Window {
         event: crate::platform::WindowEvent,
     ) -> Result<(), PlatformError> {
         // Only clone the event when a hook is installed to avoid allocation on the hot path.
-        let event_for_hook =
-            self.0.context().0.window_event_hook.borrow().is_some().then(|| event.clone());
+        let event_for_hook = self
+            .0
+            .try_context()
+            .and_then(|ctx| ctx.0.window_event_hook.borrow().is_some().then(|| event.clone()));
         let dispatch_result = match event {
             crate::platform::WindowEvent::PointerPressed { position, button } => self
                 .0
@@ -755,7 +757,8 @@ impl Window {
             }
         };
         if let Some(event_for_hook) = event_for_hook
-            && let Some(hook) = self.0.context().0.window_event_hook.borrow().as_ref()
+            && let Some(ctx) = self.0.try_context()
+            && let Some(hook) = ctx.0.window_event_hook.borrow().as_ref()
         {
             hook(&self.0.window_adapter(), &event_for_hook, dispatch_result);
         }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -2179,6 +2179,17 @@ impl WindowInner {
             .get_or_init(|| crate::context::GLOBAL_CONTEXT.with(|ctx| ctx.get().unwrap().clone()))
     }
 
+    /// Like [`Self::context`], but returns `None` instead of panicking when no context is
+    /// available yet.
+    pub fn try_context(&self) -> Option<&crate::SlintContext> {
+        if self.ctx.get().is_none()
+            && let Some(ctx) = crate::context::GLOBAL_CONTEXT.with(|ctx| ctx.get().cloned())
+        {
+            let _ = self.ctx.set(ctx);
+        }
+        self.ctx.get()
+    }
+
     /// Set the SlintContext.
     /// This needs to be called once before any other functions that would use the context.
     pub fn set_context(&self, ctx: crate::SlintContext) {

--- a/internal/renderers/software/minimal_software_window.rs
+++ b/internal/renderers/software/minimal_software_window.rs
@@ -131,3 +131,15 @@ fn test_empty_window() {
     assert_eq!(region.bounding_box_size(), i_slint_core::api::PhysicalSize::default());
     assert_eq!(region.bounding_box_origin(), i_slint_core::api::PhysicalPosition::default());
 }
+
+#[test]
+fn test_set_size_without_platform() {
+    // Regression test for #12179: driving a MinimalSoftwareWindow directly (e.g. on a
+    // microcontroller) by calling set_size before a platform is installed used to panic,
+    // because dispatching the resulting Resized event tried to resolve the (absent) context
+    // to look up the window event hook. set_size must not panic in this case.
+    // Each test runs on its own thread, so the thread-local global context is unset here.
+    let msw = MinimalSoftwareWindow::new(RepaintBufferType::NewBuffer);
+    msw.set_size(i_slint_core::api::PhysicalSize::new(320, 240));
+    assert_eq!(msw.size(), i_slint_core::api::PhysicalSize::new(320, 240));
+}


### PR DESCRIPTION
try_dispatch_event unconditionally resolved the SlintContext to look up the window-event hook added in d37ca00. WindowInner::context() unwraps the global context, which panics when a window is driven directly and set_size dispatches a Resized event before set_platform has been called.

Add a non-panicking WindowInner::try_context() and use it for the hook lookup: with no context there is no hook, so dispatching proceeds as it did before the hook was introduced.

Fixes #12179

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
