### PR TITLE
skia: Update to version 0.99 and cap the Vulkan API version at BackendContext construction time

### DIFF
--- a/.github/actions/install-skia-dependencies/action.yaml
+++ b/.github/actions/install-skia-dependencies/action.yaml
@@ -25,6 +25,18 @@ runs:
           if: runner.os == 'Windows'
           run: rm /usr/bin/link
           shell: bash
+        # The macos-14 image defaults to Xcode 15.4, whose libc++ lacks the
+        # P0960 parenthesized-aggregate-init support that skia-bindings' PDF
+        # code (SkPDFTag.cpp) relies on. Select a newer Xcode that the image
+        # also ships. xcode-select propagates to /usr/bin/clang and the
+        # LIBCLANG_PATH derived below. Newer images default to a working Xcode.
+        - name: Select a newer Xcode on macos-14
+          if: runner.os == 'macOS'
+          shell: bash
+          run: |
+              if [ "$ImageOS" = "macos14" ]; then
+                  sudo xcode-select -s /Applications/Xcode_16.2.app
+              fi
         - name: Unselect homebrew clang to work around https://github.com/actions/runner-images/issues/13827
           if: runner.os == 'macOS'
           shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -820,12 +820,26 @@ jobs:
               with:
                   toolchain: stable
                   target: ${{ matrix.target }}
+            - name: Install a libclang new enough for bindgen
+              # The runner's system libclang (15) cannot parse the SDK's GCC 15.2
+              # libstdc++ headers (<format>, <ranges>) that skia-bindings' bindgen
+              # pulls in, so install a newer libclang from apt.llvm.org. The SDK
+              # itself ships clang-22 but no libclang.so, so it can't be reused here.
+              run: |
+                  wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+                  chmod +x /tmp/llvm.sh
+                  sudo /tmp/llvm.sh 20
+                  sudo apt-get install --assume-yes libclang-20-dev
+                  rm -f /tmp/llvm.sh
             - name: C++ Build
               run: |
                   . ${{ runner.workspace }}/yocto-sdk/${{ matrix.env_setup }}
                   # Only needed for 32-bit arm builds where soft-fp/hard-fp affects header file lookup, hence the need to drag in these flags. See also commit
                   # f5c3908b7ec5131b7b19ff642b5975660c7484f8
                   export BINDGEN_EXTRA_CLANG_ARGS=$OECORE_TUNE_CCARGS
+                  # bindgen must parse the SDK's GCC 15.2 libstdc++ headers, which the
+                  # runner's system libclang is too old for; use the one installed above.
+                  export LIBCLANG_PATH=/usr/lib/llvm-20/lib
                   mkdir ${{ runner.workspace }}/cppbuild
                   cmake -GNinja -B ${{ runner.workspace }}/cppbuild -S . -DRust_CARGO_TARGET=${{ matrix.target }} -DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_RENDERER_SKIA=ON -DSLINT_FEATURE_BACKEND_QT=OFF -DSLINT_FEATURE_BACKEND_LINUXKMS=ON -DSLINT_FEATURE_INTERPRETER=ON
                   cmake --build ${{ runner.workspace }}/cppbuild

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -796,10 +796,10 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - sdk_url: https://nextcloud.slint.dev/s/SCXYDmEmr45pkak/download/poky-glibc-x86_64-core-image-weston-cortexa57-qemuarm64-toolchain-4.0.9.sh
+                    - sdk_url: https://nextcloud.slint.dev/s/DRCzxmr8nRrnkcT/download/poky-glibc-x86_64-core-image-weston-sdk-cortexa57-qemuarm64-toolchain-6.0.1.sh
                       env_setup: environment-setup-cortexa57-poky-linux
                       target: aarch64-unknown-linux-gnu
-                    - sdk_url: https://nextcloud.slint.dev/s/BTL5NtLACjgS7Pf/download/poky-glibc-x86_64-core-image-weston-cortexa15t2hf-neon-qemuarm-toolchain-4.0.9.sh
+                    - sdk_url: https://nextcloud.slint.dev/s/SN5REo4B8zyYYoL/download/poky-glibc-x86_64-core-image-weston-sdk-cortexa15t2hf-neon-qemuarm-toolchain-6.0.1.sh
                       env_setup: environment-setup-cortexa15t2hf-neon-poky-linux-gnueabi
                       target: armv7-unknown-linux-gnueabihf
         runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10368,9 +10368,9 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a38f4d460276ea40588c958396a9de0eec808c679009a5b52afdf6ebf34132"
+checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -10385,9 +10385,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
+checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
 dependencies = [
  "bitflags 2.13.0",
  "skia-bindings",

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -1,6 +1,8 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+# cSpell: ignore CLANGCC CLANGCXX
+
 # Use cross-image once https://github.com/rust-embedded/cross/pull/591 is merged & released
 #FROM rustembedded/cross:armv7-unknown-linux-gnueabihf-0.2.1
 FROM ghcr.io/slint-ui/cross-armv7-base:1.0
@@ -9,7 +11,7 @@ RUN dpkg --add-architecture armhf && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes libfontconfig1-dev:armhf libxcb1-dev:armhf libxcb-render0-dev:armhf libxcb-shape0-dev:armhf libxcb-xfixes0-dev:armhf libxkbcommon-dev:armhf libinput-dev:armhf libgbm-dev:armhf libssl-dev:armhf python3 python3-pip \
     libfontconfig1-dev \
-    clang g++-10-arm-linux-gnueabihf libstdc++-10-dev:armhf ninja-build
+    clang clang-18 g++-10-arm-linux-gnueabihf libstdc++-10-dev:armhf ninja-build
 
 # Work around the Skia source build requiring a newer git version (that supports --path-format=relative with rev-parse, as needed by git-sync-deps.py),
 # as well as a disabling of the directory safety checks (https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765) as
@@ -32,3 +34,10 @@ ENV BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf=-I/usr/include
 # requires -std=c++20, which GCC 9 does not recognize (it only has -std=c++2a).
 ENV CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc-10 \
     CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++-10
+
+# Build Skia's own C++ sources with Clang 18: skia-bindings 0.99's PDF code needs
+# C++20 parenthesized aggregate initialization (P0960) and std::ranges support,
+# which the focal default Clang 10 lacks. skia-bindings honors CLANGCC/CLANGCXX
+# to pick the compiler for the Skia build (it adds the appropriate --target).
+ENV CLANGCC=clang-18 \
+    CLANGCXX=clang++-18

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -6866,9 +6866,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a38f4d460276ea40588c958396a9de0eec808c679009a5b52afdf6ebf34132"
+checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
 dependencies = [
  "bindgen",
  "cc",
@@ -6883,9 +6883,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
+checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
 dependencies = [
  "bitflags 2.13.0",
  "skia-bindings",

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -49,7 +49,7 @@ scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.6", features = ["std"] }
 clru = { workspace = true }
 
-skia-safe = { version = "0.97.2", features = ["gl"] }
+skia-safe = { version = "0.99.0", features = ["gl"] }
 glow = { workspace = true }
 unicode-segmentation = { workspace = true }
 
@@ -71,7 +71,7 @@ bytemuck = { workspace = true }
 [target.'cfg(target_family = "windows")'.dependencies]
 windows = { workspace = true, features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
 windows-core = { workspace = true, optional = true }
-skia-safe = { version = "0.97.2", features = ["d3d"] }
+skia-safe = { version = "0.99.0", features = ["d3d"] }
 wgpu-28 = { workspace = true, optional = true, features = ["dx12"] }
 wgpu-29 = { workspace = true, optional = true, features = ["dx12"] }
 
@@ -82,7 +82,7 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = ["s
 objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["std", "objc2-metal", "CALayer", "CAMetalLayer", "objc2-core-foundation"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSResponder", "NSView"] }
 objc2-core-foundation = { version = "0.3.2", default-features = false, features = ["CFCGTypes"] }
-skia-safe = { version = "0.97.2", features = ["metal"] }
+skia-safe = { version = "0.99.0", features = ["metal"] }
 raw-window-metal = "1.0"
 
 foreign-types = { version = "0.5.0", optional = true }
@@ -94,12 +94,12 @@ read-fonts = { workspace = true }
 write-fonts = { version = "0.48" }
 
 [target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.97.2", features = ["gl", "vulkan"] }
+skia-safe = { version = "0.99.0", features = ["gl", "vulkan"] }
 wgpu-28 = { workspace = true, optional = true, features = ["vulkan"] }
 wgpu-29 = { workspace = true, optional = true, features = ["vulkan"] }
 
 [target.'cfg(all(any(target_os = "ios", target_os="macos", target_os="windows", target_os="android", target_os="linux"), not(target_arch = "arm")))'.dependencies]
-skia-safe = { version = "0.97.2", features = ["textlayout"] }
+skia-safe = { version = "0.99.0", features = ["textlayout"] }
 
 [target.aarch64-apple-ios-sim.dependencies]
 # Disabling encoding assertions until https://github.com/madsmtm/objc2/issues/795 is fixed.

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -179,18 +179,36 @@ impl VulkanSurface {
             }
         };
 
+        // Cap the Vulkan API version Skia uses. Skia otherwise assumes the highest version reported
+        // by the physical device and tries to load functions and request features for it. That fails
+        // on drivers where the logical device we created only negotiated a lower version, so limit it
+        // to the version vulkano negotiated for this physical device under our instance.
+        let api_version = physical_device.api_version();
+        let max_api_version = skia_safe::gpu::vk::Version::new(
+            api_version.major as _,
+            api_version.minor as _,
+            api_version.patch as _,
+        );
+
         let backend_context = unsafe {
-            skia_safe::gpu::vk::BackendContext::new(
+            skia_safe::gpu::vk::BackendContext::new_builder(
                 instance.handle().as_raw() as _,
                 physical_device.handle().as_raw() as _,
                 device.handle().as_raw() as _,
                 (queue.handle().as_raw() as _, queue.queue_index() as _),
                 &get_proc,
+                Some(max_api_version),
             )
+            .build()
         };
 
         let gr_context = skia_safe::gpu::direct_contexts::make_vulkan(&backend_context, None)
-            .ok_or_else(|| "Error creating Skia Vulkan context".to_string())?;
+            .ok_or_else(|| {
+                format!(
+                    "Error creating Skia Vulkan context (max api version {}.{}.{})",
+                    api_version.major, api_version.minor, api_version.patch
+                )
+            })?;
 
         let previous_frame_end = RefCell::new(Some(sync::now(device.clone()).boxed()));
 

--- a/internal/renderers/skia/wgpu_28_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_28_surface/vulkan.rs
@@ -171,17 +171,17 @@ pub unsafe fn make_vulkan_context(
             }
         };
 
-        let mut backend = vk::BackendContext::new(
+        // WGPU 28 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the
+        // physical device is chosen, causing it to ask for unsupported features/functions.
+        let backend = vk::BackendContext::new_builder(
             vulkan_device.shared_instance().raw_instance().handle().as_raw() as _,
             vulkan_device.raw_physical_device().as_raw() as _,
             vulkan_device.raw_device().handle().as_raw() as _,
             (vulkan_queue_raw.as_raw() as _, vulkan_device.queue_family_index() as _),
             &get_proc,
-        );
-
-        // WGPU 28 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the physical device is chosen,
-        // causing it to ask for unsupported features/functions
-        backend.set_max_api_version(vk::Version::new(1, 3, 0));
+            Some(vk::Version::new(1, 3, 0)),
+        )
+        .build();
 
         skia_safe::gpu::direct_contexts::make_vulkan(&backend, None)
     }

--- a/internal/renderers/skia/wgpu_29_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_29_surface/vulkan.rs
@@ -171,17 +171,17 @@ pub unsafe fn make_vulkan_context(
             }
         };
 
-        let mut backend = vk::BackendContext::new(
+        // WGPU 29 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the
+        // physical device is chosen, causing it to ask for unsupported features/functions.
+        let backend = vk::BackendContext::new_builder(
             vulkan_device.shared_instance().raw_instance().handle().as_raw() as _,
             vulkan_device.raw_physical_device().as_raw() as _,
             vulkan_device.raw_device().handle().as_raw() as _,
             (vulkan_queue_raw.as_raw() as _, vulkan_device.queue_family_index() as _),
             &get_proc,
-        );
-
-        // WGPU 28 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the physical device is chosen,
-        // causing it to ask for unsupported features/functions
-        backend.set_max_api_version(vk::Version::new(1, 3, 0));
+            Some(vk::Version::new(1, 3, 0)),
+        )
+        .build();
 
         skia_safe::gpu::direct_contexts::make_vulkan(&backend, None)
     }


### PR DESCRIPTION
This should help with #11876