### PR TITLE
CI embedded build: build energy-monitor without the network feature

### DIFF
--- a/.github/workflows/embedded_build.yaml
+++ b/.github/workflows/embedded_build.yaml
@@ -71,7 +71,13 @@ jobs:
               with:
                   crate: cross
             - name: Build
-              run: cross build --release --target=${{ matrix.target }} ${{ env.EXTRA_ARGS }} --features slint/backend-linuxkms-noseat,slint/renderer-skia -p energy-monitor -p printerdemo -p todo -p slint-viewer -p gallery -p home-automation
+              run: cross build --release --target=${{ matrix.target }} ${{ env.EXTRA_ARGS }} --features slint/backend-linuxkms-noseat,slint/renderer-skia -p printerdemo -p todo -p slint-viewer -p gallery -p home-automation
+            - name: Build energy-monitor
+              # Built separately with its `network` feature disabled: that feature pulls in
+              # reqwest -> rustls/aws-lc-rs -> aws-lc-sys, whose cc-builder aborts on the x86_64
+              # cross image's GCC (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189). Without
+              # `network` the demo builds fine; only the live weather panel is inactive.
+              run: cross build --release --target=${{ matrix.target }} ${{ env.EXTRA_ARGS }} --features slint/backend-linuxkms-noseat,slint/renderer-skia -p energy-monitor --no-default-features --features chrono
             - name: "Upload demo artifacts"
               uses: actions/upload-artifact@v7
               with:


### PR DESCRIPTION
energy-monitor's default 'network' feature pulls in reqwest, which since #12073 (reqwest 0.13, feature 'rustls') brings in aws-lc-rs/aws-lc-sys. aws-lc-sys's cc-builder compiles and runs a memcmp probe that the x86_64 cross image's GCC miscompiles (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189), aborting the Embedded Build.

Build energy-monitor in its own step with --no-default-features (re-adding only chrono), so it no longer drags in aws-lc-sys. A separate invocation is needed because 'network' is a default feature and --no-default-features would otherwise also affect the other packages built together. The demo still builds and ships; only its live weather panel is inactive.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
