### PR TITLE
winit: Fix panic with software renderer and restore "flash of unstyled content" fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5371,6 +5371,7 @@ dependencies = [
  "webbrowser",
  "windows 0.62.2",
  "winit",
+ "x11-dl",
  "zbus",
 ]
 

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -4033,6 +4033,7 @@ dependencies = [
  "webbrowser",
  "windows",
  "winit",
+ "x11-dl",
  "zbus",
 ]
 

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -40,6 +40,7 @@ x11 = [
   "i-slint-renderer-skia?/x11",
   "softbuffer?/x11",
   "softbuffer?/x11-dlopen",
+  "dep:x11-dl",
 ]
 renderer-femtovg = ["i-slint-renderer-femtovg/opengl", "dep:glutin", "dep:glutin-winit"]
 renderer-femtovg-wgpu = ["i-slint-renderer-femtovg/wgpu", "dep:i-slint-renderer-femtovg", "unstable-wgpu-29"]
@@ -113,6 +114,9 @@ copypasta = { version = "0.10", default-features = false }
 # Use same version and executor as accesskit
 zbus = { version = "5.14.0", default-features = false, features = ["async-io"] }
 futures = { version = "0.3.31" }
+# Used to clear the X11 window background before mapping, to avoid a flash of
+# uninitialized VRAM (winit creates X11 windows with background-pixmap None).
+x11-dl = { version = "2.21", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # To disable macOS automatic shortcut translation

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -98,6 +98,58 @@ fn filter_out_zero_width_or_height(
     winit::dpi::LogicalSize { width: filter(size.width), height: filter(size.height) }
 }
 
+/// Clear the X11 window background to transparent before it is mapped.
+///
+/// winit creates X11 windows without a background pixmap (background-pixmap
+/// None), so the server never paints them. Between `XMapWindow` and our first
+/// rendered frame the window then shows uninitialized VRAM, which on
+/// multi-monitor setups is often a fragment of another monitor's contents.
+///
+/// Setting the background to pixel 0 (fully transparent, since our windows use a
+/// 32-bit ARGB visual) makes the X server clear the window itself when it is
+/// mapped, removing the flash without forcing us to render before the window is
+/// shown. Must be called while the window is still unmapped.
+#[cfg(all(unix, not(target_vendor = "apple"), feature = "x11"))]
+fn clear_x11_window_background(winit_window: &winit::window::Window) {
+    use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle};
+
+    let (Ok(display_handle), Ok(window_handle)) =
+        (winit_window.display_handle(), winit_window.window_handle())
+    else {
+        return;
+    };
+    let (RawDisplayHandle::Xlib(display), RawWindowHandle::Xlib(window)) =
+        (display_handle.as_raw(), window_handle.as_raw())
+    else {
+        // Not X11 (e.g. running on Wayland) — nothing to do.
+        return;
+    };
+    let Some(display) = display.display else {
+        return;
+    };
+
+    let Ok(xlib) = x11_dl::xlib::Xlib::open() else {
+        return;
+    };
+    // SAFETY: `display` and `window.window` are valid for as long as the winit
+    // window is alive, which outlives this call.
+    unsafe {
+        let display = display.as_ptr() as *mut x11_dl::xlib::Display;
+        let mut attributes: x11_dl::xlib::XSetWindowAttributes = std::mem::zeroed();
+        attributes.background_pixel = 0;
+        (xlib.XChangeWindowAttributes)(
+            display,
+            window.window,
+            x11_dl::xlib::CWBackPixel,
+            &mut attributes,
+        );
+        // winit drives this connection through XCB and never flushes Xlib's
+        // request buffer, so push the change out ourselves to make sure it
+        // reaches the server before the window is mapped.
+        (xlib.XFlush)(display);
+    }
+}
+
 fn apply_scale_factor_to_logical_sizes_in_attributes(
     attributes: &mut WindowAttributes,
     scale_factor: f64,
@@ -474,6 +526,12 @@ impl WinitWindowAdapter {
         }
 
         let winit_window = self.renderer.resume(active_event_loop, window_attributes)?;
+
+        // The window is created unmapped; clear its X11 background now so the
+        // server paints it transparent on the first map instead of leaking
+        // uninitialized VRAM before our first frame is presented.
+        #[cfg(all(unix, not(target_vendor = "apple"), feature = "x11"))]
+        clear_x11_window_background(&winit_window);
 
         // Push the host shell's color scheme and accent color to the SlintContext.
         // With `xdg_desktop_settings` the backend-wide portal watcher (spawned in

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1123,12 +1123,6 @@ impl WinitWindowAdapter {
                 self.resize_window(size.into())?;
             };
 
-            // Pre-render the first frame before mapping the window to avoid
-            // a flash of uninitialized VRAM on X11 (no background_pixmap).
-            if matches!(visibility, WindowVisibility::ShownFirstTime) {
-                let _ = self.renderer().render(self.window());
-            }
-
             winit_window.set_visible(true);
 
             // Refresh the SlintContext color-scheme now that the window is mapped: on some platforms


### PR DESCRIPTION
Commit ac63b922feecb365c464ac145295a32ea0c7621a fixed the issue with the default transparent windows we create on X11 to show garbage because there's no background fill done by the server, but the early rendering breaks with the software renderer and means we draw too early before we have read the xdg settings. Instead, set the x11 window background explicitly to transparent after mapping to attempt to let the x server clear the backing store.