### PR TITLE
SharedString deserialization: revert Cow and use visitor instead.

### DIFF
--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -166,8 +166,23 @@ impl<'de> serde::Deserialize<'de> for SharedString {
     where
         D: serde::Deserializer<'de>,
     {
-        let string: alloc::borrow::Cow<str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(SharedString::from(string.as_ref()))
+        struct SharedStringVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for SharedStringVisitor {
+            type Value = SharedString;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a borrowed or owned string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(SharedString::from(v))
+            }
+        }
+        deserializer.deserialize_str(SharedStringVisitor)
     }
 }
 


### PR DESCRIPTION
Follow-up of #12172

My assumption about serde handling Cows was wrong - actually serde always deserializes to Owned. This PR set's the matter right.

Instead of relying on Cow, we just create our own visitor for deserializing SharedString. Visitor's default "visit_string" and "visit_borrowed_str" forwards to str, so both borrowed and owned cases are handled by that visitor.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
