### PR TITLE
winit: reconcile the size in the first-frame pre-render

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1126,7 +1126,7 @@ impl WinitWindowAdapter {
             // Pre-render the first frame before mapping the window to avoid
             // a flash of uninitialized VRAM on X11 (no background_pixmap).
             if matches!(visibility, WindowVisibility::ShownFirstTime) {
-                let _ = self.renderer().render(self.window());
+                let _ = self.draw();
             }
 
             winit_window.set_visible(true);


### PR DESCRIPTION
set_visibility pre-renders the first frame before mapping the window to avoid a flash of uninitialized window on X11. It called the renderer directly, bypassing the size reconciliation that draw() does: when the scale factor changed during window creation, the cached size was still the pre-scale value while the window item was already at the new scale, so the software renderer's buffer was too small and its assert aborted:

```
thread 'main' (1501656) panicked at internal/renderers/software/lib.rs:584:9:
buffer of size 350633 with 673 pixels per line is too small to handle a window of size 1057x781
```

Go through draw() instead, which reconciles the cached size with the actual surface before rendering.

This is a regression from #12143, which added the pre-render.
