### PR TITLE
Publish the Android viewer to Google Play on release

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -791,6 +791,19 @@ jobs:
                   mkdir -p target/release/apk
                   unzip -p slint-viewer.apks universal.apk > target/release/apk/slint-viewer.apk
 
+            # Push the release AAB to the Play Store. Only on `release`: other
+            # modes carry a nightly versionName that Play would reject or that
+            # would burn a versionCode.
+            - name: Publish slint-viewer to Google Play
+              if: github.event.inputs.mode == 'release'
+              uses: r0adkll/upload-google-play@v1
+              with:
+                  serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+                  packageName: dev.slint.viewer
+                  releaseFiles: tools/viewer/android-aab/app/build/outputs/bundle/release/slint-viewer.aab
+                  track: production
+                  status: completed
+
             # Flatten into one directory so the artifact holds bare files.
             - name: Collect Android artifacts
               if: always()

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -791,10 +791,12 @@ jobs:
                   mkdir -p target/release/apk
                   unzip -p slint-viewer.apks universal.apk > target/release/apk/slint-viewer.apk
 
-            # Push the release AAB to the Play Store. Only on `release`: other
-            # modes carry a nightly versionName that Play would reject or that
-            # would burn a versionCode.
-            - name: Publish slint-viewer to Google Play
+            # Upload the release AAB to the Play Store as a draft. A human
+            # publishes it from the console, so an accidental `release` run
+            # never reaches users. Only on `release`: other modes carry a
+            # nightly versionName that Play would reject or that would burn a
+            # versionCode.
+            - name: Upload slint-viewer to Google Play
               if: github.event.inputs.mode == 'release'
               uses: r0adkll/upload-google-play@v1
               with:
@@ -802,7 +804,7 @@ jobs:
                   packageName: dev.slint.viewer
                   releaseFiles: tools/viewer/android-aab/app/build/outputs/bundle/release/slint-viewer.aab
                   track: production
-                  status: completed
+                  status: draft
 
             # Flatten into one directory so the artifact holds bare files.
             - name: Collect Android artifacts

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -71,7 +71,7 @@ In the mean time, the version in the master branch can be updated
 
  - **Trigger a build of binary artifacts** (docs, demos, etc.) on https://github.com/slint-ui/slint/actions/workflows/nightly_snapshot.yaml
     Select the right `pre-release/x.y` branch, and choose `release` for the mode.
-    As a result artifacts will be built and made available for download and a new VS code extension be built and uploaded to the market places (open-vsx.org and microsoft).
+    As a result artifacts will be built and made available for download, a new VS code extension be built and uploaded to the market places (open-vsx.org and microsoft), and the Android viewer published to Google Play.
 
  - **Publish to crates.io** using the `./scripts/publish.sh`.
     (This can be done in parallel to the nightly_snapshot build)

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -71,7 +71,7 @@ In the mean time, the version in the master branch can be updated
 
  - **Trigger a build of binary artifacts** (docs, demos, etc.) on https://github.com/slint-ui/slint/actions/workflows/nightly_snapshot.yaml
     Select the right `pre-release/x.y` branch, and choose `release` for the mode.
-    As a result artifacts will be built and made available for download, a new VS code extension be built and uploaded to the market places (open-vsx.org and microsoft), and the Android viewer published to Google Play.
+    As a result artifacts will be built and made available for download, a new VS code extension be built and uploaded to the market places (open-vsx.org and microsoft), and the Android viewer uploaded to Google Play as a draft.
 
  - **Publish to crates.io** using the `./scripts/publish.sh`.
     (This can be done in parallel to the nightly_snapshot build)
@@ -86,6 +86,10 @@ In the mean time, the version in the master branch can be updated
   - https://github.com/slint-ui/slint/actions/workflows/upload_pypi.yaml
   - https://github.com/slint-ui/slint/actions/workflows/upload_pypi_briefcase.yaml
   - https://github.com/slint-ui/slint/actions/workflows/upload_pypi_slint_compiler.yaml
+
+ - **Publish the Android viewer on Google Play:** the `nightly_snapshot` build uploads it to the
+   production track as a draft. Open the [Play Console](https://play.google.com/console) for
+   `dev.slint.viewer` and publish the release.
 
  - **Publish the blog post** (if any). Remove the `DRAFT: ` from the title, check the date, and push to `prod` on the `slint/website` repo.
 


### PR DESCRIPTION
This PR has two commit: Just a smoke test, and the actual change.
The idea is just to submit the smoke test, run it to see if it works, then revert it.

