### PR TITLE
Fix remote viewer license scrolling

### DIFF
--- a/tools/viewer/remote/licenses.slint
+++ b/tools/viewer/remote/licenses.slint
@@ -60,6 +60,7 @@ export component LicensesPage inherits Rectangle {
 
         ListView {
             vertical-stretch: 1;
+            mouse-drag-pan-enabled: true;
 
             for item in root.items: VerticalLayout {
                 padding-top: 6px;


### PR DESCRIPTION
The ListView needs to have mouse-drag-pan enabled,
otherwise we cannot scroll the view on Android.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
