### PR TITLE
Popup: Use dedicated Properties instead of access function

### DIFF
--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -164,25 +164,13 @@ public:
 
         auto popup = Component::create(parent_component, _own_globals);
         auto popup_dyn = popup.into_dyn();
+        auto position = pos(popup);
 
-        struct PopupPositionData
-        {
-            PosGetter pos;
-            decltype(popup) popup_component;
-        };
-
-        auto position_data = new PopupPositionData { std::move(pos), popup };
         // Keeps the parent component's `PopupWindow::is-open` property in sync: invoked with `true`
         // when the popup is shown and with `false` from every close path.
         auto is_open_data = new IsOpenSetter(std::move(is_open_setter));
         auto id = cbindgen_private::slint_windowrc_show_popup(
-                &inner, &popup_dyn,
-                [](void *user_data, LogicalPosition *pos) {
-                    auto data = reinterpret_cast<PopupPositionData *>(user_data);
-                    *pos = data->pos(data->popup_component);
-                },
-                [](void *user_data) { delete reinterpret_cast<PopupPositionData *>(user_data); },
-                position_data, close_policy, &parent_item, window_kind,
+                &inner, &popup_dyn, position, close_policy, &parent_item, window_kind,
                 [](void *user_data, bool is_open) {
                     (*reinterpret_cast<IsOpenSetter *>(user_data))(is_open);
                 },
@@ -231,17 +219,12 @@ public:
         auto popup = Component::create(globals);
         init(&*popup);
         auto popup_dyn = popup.into_dyn();
-        auto position_data = new LogicalPosition(pos);
         auto id = cbindgen_private::slint_windowrc_show_popup(
-                &inner, &popup_dyn,
-                [](void *user_data, LogicalPosition *pos) {
-                    *pos = *reinterpret_cast<LogicalPosition *>(user_data);
-                },
-                [](void *user_data) { delete reinterpret_cast<LogicalPosition *>(user_data); },
-                position_data, cbindgen_private::PopupClosePolicy::CloseOnClickOutside,
+                // Menus are positioned by the caller, not by `x`/`y` bindings.
+                &inner, &popup_dyn, pos, cbindgen_private::PopupClosePolicy::CloseOnClickOutside,
                 &context_menu_rc, cbindgen_private::WindowKind::Menu,
                 // Menus do not expose `is-open`, so the setter is a no-op.
-                [](void *, bool) {}, [](void *) {}, nullptr);
+                [](void *, bool) { }, [](void *) { }, nullptr);
         popup->user_init();
         return id;
     }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1508,6 +1508,8 @@ export component ContextMenuArea inherits Empty {
 }
 
 component WindowItem {
+    in-out property <length> x;
+    in-out property <length> y;
     in-out property <length> width;
     in-out property <length> height;
     /// Whether the window should be placed above all other windows on window managers supporting it.
@@ -2491,10 +2493,7 @@ export component RadioGroup {
 /// :::
 /// \group:window
 export component PopupWindow {
-    //property <length> x;
-    //property <length> y;
-    in property <length> width;
-    in property <length> height;
+
     /*property <length> anchor_x;
     in property <length> anchor_y;
     in property <length> anchor_height;
@@ -2865,7 +2864,8 @@ export global Platform {
     /// to the top of the window stack. On other platforms this function is a no-op.
     ///
     /// This corresponds to the standard macOS **Window › Bring All to Front** menu item.
-    function macos-bring-all-windows-to-front() { }
+    function macos-bring-all-windows-to-front() {
+    }
 }
 
 export component NativeButton {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4949,7 +4949,8 @@ fn compile_builtin_function_call(
                     CppGeneratorContext { global_access: "self->globals".into(), conditional_includes: ctx.generator_state.conditional_includes },
                     Some(&parent_ctx),
                 );
-                let position = compile_expression(&popup.position.borrow(), &popup_ctx);
+                let popup_x = compile_expression(&crate::llr::Expression::PropertyReference(popup.x.clone()), &popup_ctx);
+                let popup_y = compile_expression(&crate::llr::Expression::PropertyReference(popup.y.clone()), &popup_ctx);
                 let close_policy = compile_expression(close_policy, ctx);
                 let window_kind = if popup.is_tooltip { "slint::cbindgen_private::WindowKind::ToolTip" } else { "slint::cbindgen_private::WindowKind::Popup" };
                 // Keep the parent's `is-open` property in sync. The setter is passed directly into
@@ -4981,7 +4982,11 @@ fn compile_builtin_function_call(
                     "{window}.close_popup({component_access}->popup_id_{popup_index}); \
                     {component_access}->popup_id_{popup_index} =  \
                         {window}.template show_popup<{popup_window_id}>(&*({component_access}),  \
-                                                                        [=](auto self) {{ return {position}; }},  \
+                                                                        [=](auto self) {{ \
+                                                                            return slint::LogicalPosition( slint::Point<float> {{ \
+                                                                                {popup_x}, {popup_y}    \
+                                                                            }}); \
+                                                                        }},  \
                                                                         {close_policy},  \
                                                                         {{ {parent_component} }},  \
                                                                         {window_kind},  \

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3692,14 +3692,6 @@ fn compile_builtin_function_call(
                     inner_component_id(&ctx.compilation_unit.sub_components[popup.item_tree.root]);
                 let parent_item = access_item_rc(parent_ref, ctx);
 
-                let parent_ctx = ParentScope::new(ctx, None);
-                let popup_ctx = EvaluationContext::new_sub_component(
-                    ctx.compilation_unit,
-                    popup.item_tree.root,
-                    RustGeneratorContext { global_access: quote!(_self.globals.get().unwrap()) },
-                    Some(&parent_ctx),
-                );
-                let position = compile_expression(&popup.position.borrow(), &popup_ctx);
                 let close_policy = compile_expression(close_policy, ctx);
                 let popup_id_name = internal_popup_id(*popup_index as usize);
                 let window_kind = if popup.is_tooltip {
@@ -3758,15 +3750,9 @@ fn compile_builtin_function_call(
                             window.close_popup(current_id);
                         }
 
-                        let popup_instance_vrc_for_position = popup_instance_vrc.clone();
-                        let access_position = sp::Box::new(move || {
-                            let _self = popup_instance_vrc_for_position.as_pin_ref(); #position
-                        });
-
                         #is_open_self_weak_decl
                         let popup_id = window.show_popup(
                             &sp::VRc::into_dyn(popup_instance.into()),
-                            access_position,
                             #close_policy,
                             parent_item,
                             #window_kind,
@@ -3861,10 +3847,14 @@ fn compile_builtin_function_call(
                 .then(|context_menu| quote!(#context_menu.popup_id.set(Some(id))));
             let slint_show = quote! {
                 #close_popup
-                let access_position = sp::Box::new(move || position);
+
+                // Menus are positioned at show time and have no `x`/`y` binding, so store the
+                // computed `position` on the popup's `WindowItem` before showing it. `show_popup`
+                // then derives the placement from those fields.
+                let popup_rc = sp::VRc::into_dyn(popup_instance.into());
+                sp::WindowInner::set_popup_position(&popup_rc, position);
                 let id = sp::WindowInner::from_pub(window_adapter.window()).show_popup(
-                    &sp::VRc::into_dyn(popup_instance.into()),
-                    access_position,
+                    &popup_rc,
                     sp::PopupClosePolicy::CloseOnClickOutside,
                     #context_menu_rc,
                     sp::WindowKind::Menu,

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -508,8 +508,9 @@ pub struct SubComponent {
 #[derive(Debug)]
 pub struct PopupWindow {
     pub item_tree: ItemTree,
-    pub position: MutExpression,
     pub is_tooltip: bool,
+    pub x: MemberReference,
+    pub y: MemberReference,
 }
 
 #[derive(Debug)]

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -880,20 +880,15 @@ fn lower_popup_component(
     compiler_config: &CompilerConfiguration,
 ) -> PopupWindow {
     let sc = lower_sub_component(&popup.component, ctx.state, Some(&ctx.inner), compiler_config);
-    use super::Expression::PropertyReference as PR;
-    let position = super::lower_expression::make_struct(
-        BuiltinStruct::LogicalPosition,
-        [
-            ("x", Type::LogicalLength, PR(sc.mapping.map_property_reference(&popup.x, ctx.state))),
-            ("y", Type::LogicalLength, PR(sc.mapping.map_property_reference(&popup.y, ctx.state))),
-        ],
-    );
+
+    let x = sc.mapping.map_property_reference(&popup.x, ctx.state);
+    let y = sc.mapping.map_property_reference(&popup.y, ctx.state);
 
     let item_tree = ItemTree {
         tree: make_tree(ctx.state, &popup.component.root_element, &sc, &[]),
         root: ctx.state.push_sub_component(sc),
     };
-    PopupWindow { item_tree, position: position.into(), is_tooltip: popup.is_tooltip }
+    PopupWindow { item_tree, is_tooltip: popup.is_tooltip, x, y }
 }
 
 fn lower_timer(timer: &object_tree::Timer, ctx: &ExpressionLoweringCtx) -> Timer {

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -122,8 +122,10 @@ pub fn count_property_use(root: &CompilationUnit) {
                 (),
                 Some(&parent_ctx),
             );
-            popup.position.borrow().visit_property_references(&popup_ctx, &mut visit_property)
+            visit_property(&popup.x, &popup_ctx);
+            visit_property(&popup.y, &popup_ctx);
         }
+
         // 11. timer
         for timer in &sc.timers {
             timer.interval.borrow().visit_property_references(ctx, &mut visit_property);

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -289,7 +289,7 @@ mod visitor {
             items: _,
             repeated,
             component_containers: _,
-            popup_windows,
+            popup_windows: _,
             menu_item_trees: _,
             timers,
             sub_components: _,
@@ -351,10 +351,6 @@ mod visitor {
             }
         }
 
-        for p in popup_windows {
-            let popup_scope = EvaluationScope::SubComponent(p.item_tree.root, None);
-            visit_expression(p.position.get_mut(), &popup_scope, state, visitor);
-        }
         for t in timers {
             visit_expression(t.interval.get_mut(), &scope, state, visitor);
             visit_expression(t.triggered.get_mut(), &scope, state, visitor);

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -247,9 +247,10 @@ impl PrettyPrinter<'_> {
                 EvaluationContext::new_sub_component(root, w.item_tree.root, (), Some(&parent));
             write!(
                 self.writer,
-                "{} at {} : /*@popup({i})*/ ",
+                "{} at ({}, {}) : /*@popup({i})*/ ",
                 if w.is_tooltip { "tooltip" } else { "popup" },
-                DisplayExpression(&w.position.borrow(), &popup_ctx)
+                DisplayPropertyRef(&w.x, &popup_ctx),
+                DisplayPropertyRef(&w.y, &popup_ctx)
             )?;
             self.print_component(root, w.item_tree.root, Some(&parent))?
         }

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -484,7 +484,9 @@ fn duplicate_sub_component(
         exported_global_names: component_to_duplicate.exported_global_names.clone(),
         used: component_to_duplicate.used.clone(),
         private_properties: Default::default(),
-        inherits_popup_window: core::cell::Cell::new(false),
+        inherits_popup_window: core::cell::Cell::new(
+            component_to_duplicate.inherits_popup_window.get(),
+        ),
         from_library: core::cell::Cell::new(false),
     };
 

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -244,6 +244,12 @@ pub async fn lower_menus(
                 process_context_menu(elem, &useful_menu_component, diag);
             }
         });
+
+        // `PopupMenuImpl` is a `Window`; its native `x`/`y` fields hold the popup position (set via
+        // `set_popup_position`), so its item geometry must be decoupled from them the same way
+        // `lower_popups` does for lowered `PopupWindow`s.
+        super::lower_popups::detach_window_geometry_from_position(&popup_menu_impl.root_element);
+
         doc.popup_menu_impl = popup_menu_impl.into();
     }
 }

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -185,6 +185,10 @@ fn lower_popup_window(
         parent_element: RefCell::new(Rc::downgrade(parent_element)),
         ..Component::default()
     });
+    // The root was a `PopupWindow` (now lowered to a `Window`); record that so later passes
+    // can treat it specially. `materialize_fake_properties` uses this to keep `x`/`y` bound to
+    // the native `WindowItem` item fields instead of synthesizing local properties.
+    popup_comp.inherits_popup_window.set(true);
 
     let weak = Rc::downgrade(&popup_comp);
     recurse_elem(&popup_comp.root_element, &(), &mut |e, _| {
@@ -233,17 +237,7 @@ fn lower_popup_window(
 
     // Meanwhile, set the geometry x/y to zero, because we'll be shown as a top-level and
     // children should be rendered starting with a (0, 0) offset.
-    {
-        let mut popup_mut = popup_comp.root_element.borrow_mut();
-        let name = format_smolstr!("popup-{}-dummy", popup_mut.id);
-        popup_mut.property_declarations.insert(name.clone(), Type::LogicalLength.into());
-        drop(popup_mut);
-        let dummy1 = NamedReference::new(&popup_comp.root_element, name.clone());
-        let dummy2 = NamedReference::new(&popup_comp.root_element, name.clone());
-        let mut popup_mut = popup_comp.root_element.borrow_mut();
-        popup_mut.geometry_props.as_mut().unwrap().x = dummy1;
-        popup_mut.geometry_props.as_mut().unwrap().y = dummy2;
-    }
+    detach_window_geometry_from_position(&popup_comp.root_element);
 
     check_no_reference_to_popup(popup_window_element, &parent_component, &weak, &coord_x, diag);
 
@@ -266,6 +260,30 @@ fn lower_popup_window(
 
 fn report_const_error(prop: &str, span: &Option<SourceLocation>, diag: &mut BuildDiagnostics) {
     diag.push_error(format!("The {prop} property only supports constants at the moment"), span);
+}
+
+/// Point the geometry `x`/`y` of a window/popup root element to a fresh dummy property (default 0)
+/// instead of the element's own `x`/`y`.
+///
+/// A `WindowItem`'s native `x`/`y` fields hold the *popup position* (where the window is placed on
+/// screen), which `show_popup`/`set_popup_position` read. Now that `x`/`y` are real `WindowItem`
+/// properties, the element's item geometry would otherwise resolve to those same fields and get
+/// offset by the popup position. Since the root is shown as a top-level, its children must be
+/// rendered starting at a (0, 0) offset, so decouple the geometry from the position here.
+pub fn detach_window_geometry_from_position(root_element: &ElementRc) {
+    let mut root_mut = root_element.borrow_mut();
+    if root_mut.geometry_props.is_none() {
+        return;
+    }
+    let name = format_smolstr!("popup-{}-dummy", root_mut.id);
+    root_mut.property_declarations.insert(name.clone(), Type::LogicalLength.into());
+    drop(root_mut);
+    let dummy1 = NamedReference::new(root_element, name.clone());
+    let dummy2 = NamedReference::new(root_element, name);
+    let mut root_mut = root_element.borrow_mut();
+    let geom = root_mut.geometry_props.as_mut().unwrap();
+    geom.x = dummy1;
+    geom.y = dummy2;
 }
 
 /// Throw error when accessing the popup from outside

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -11,21 +11,19 @@ use crate::langtype::{ElementType, Type};
 use crate::layout::Orientation;
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
-use smol_str::SmolStr;
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::cell::RefCell;
 use std::rc::Rc;
 
 pub fn materialize_fake_properties(component: &Rc<Component>) {
     let mut to_materialize = std::collections::HashMap::new();
 
     visit_all_named_references(component, &mut |nr| {
-        let elem = nr.element();
-        let elem = elem.borrow();
+        let elem_rc = nr.element();
         if !to_materialize.contains_key(nr)
-            && let Some(ty) =
-                should_materialize(&elem.property_declarations, &elem.base_type, nr.name())
+            && let Some(ty) = should_materialize(&elem_rc, nr.name())
         {
+            let elem = elem_rc.borrow();
             // This only brings more trouble down the line
             if elem.repeated.is_some() {
                 panic!(
@@ -41,13 +39,10 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
     recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
         for prop in elem.borrow().bindings.keys() {
             let nr = NamedReference::new(elem, prop.clone());
-            if let std::collections::hash_map::Entry::Vacant(e) = to_materialize.entry(nr) {
-                let elem = elem.borrow();
-                if let Some(ty) =
-                    should_materialize(&elem.property_declarations, &elem.base_type, prop)
-                {
-                    e.insert(ty);
-                }
+            if let std::collections::hash_map::Entry::Vacant(e) = to_materialize.entry(nr)
+                && let Some(ty) = should_materialize(elem, prop)
+            {
+                e.insert(ty);
             }
         }
     });
@@ -92,39 +87,31 @@ fn must_initialize(elem: &Element, prop: &str) -> bool {
 }
 
 /// Returns a type if the property needs to be materialized.
-fn should_materialize(
-    property_declarations: &BTreeMap<SmolStr, PropertyDeclaration>,
-    base_type: &ElementType,
-    prop: &str,
-) -> Option<Type> {
-    if property_declarations.contains_key(prop) {
+/// It should be materialized for example if
+/// - it is not a reserved property
+/// - it is not a property of the base type
+fn should_materialize(element_rc: &Rc<RefCell<Element>>, prop: &str) -> Option<Type> {
+    let element = element_rc.borrow();
+
+    if has_declared_property(&element, prop) {
         return None;
     }
-    let has_declared_property = match base_type {
-        ElementType::Component(c) => has_declared_property(&c.root_element.borrow(), prop),
-        ElementType::Builtin(b) => b.native_class.lookup_property(prop).is_some(),
-        ElementType::Native(n) => n.lookup_property(prop).is_some(),
-        ElementType::Global | ElementType::Interface | ElementType::Error => false,
-    };
 
-    if !has_declared_property {
-        let ty = crate::typeregister::reserved_property(Cow::Borrowed(prop)).property_type.clone();
-        if ty != Type::Invalid {
-            return Some(ty);
-        } else if prop == "close-on-click" {
-            // PopupWindow::close-on-click
-            return Some(Type::Bool);
-        } else if prop == "close-policy" {
-            // PopupWindow::close-policy
-            return Some(Type::Enumeration(
-                crate::typeregister::BUILTIN.with(|e| e.enums.PopupClosePolicy.clone()),
-            ));
-        } else {
-            let ty = base_type.lookup_property(prop).property_type.clone();
-            return (ty != Type::Invalid).then_some(ty);
-        }
+    let ty = crate::typeregister::reserved_property(Cow::Borrowed(prop)).property_type.clone();
+    if ty != Type::Invalid {
+        Some(ty)
+    } else if prop == "close-on-click" {
+        // PopupWindow::close-on-click
+        Some(Type::Bool)
+    } else if prop == "close-policy" {
+        // PopupWindow::close-policy
+        Some(Type::Enumeration(
+            crate::typeregister::BUILTIN.with(|e| e.enums.PopupClosePolicy.clone()),
+        ))
+    } else {
+        let ty = element.base_type.lookup_property(prop).property_type.clone();
+        (ty != Type::Invalid).then_some(ty)
     }
-    None
 }
 
 /// Returns true if the property is declared in this element or parent

--- a/internal/compiler/passes/remove_unused_properties.rs
+++ b/internal/compiler/passes/remove_unused_properties.rs
@@ -12,8 +12,8 @@ pub fn remove_unused_properties(doc: &Document) {
         crate::object_tree::recurse_elem_including_sub_components_no_borrow(
             component,
             &(),
-            &mut |elem, _| {
-                let mut elem = elem.borrow_mut();
+            &mut |elem_rc, _| {
+                let mut elem = elem_rc.borrow_mut();
                 let mut to_remove = HashSet::new();
                 for (prop, decl) in &elem.property_declarations {
                     if !decl.expose_in_public_api

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -355,6 +355,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
 }
 
 /// lookup reserved property injected in every item
+/// Returns a valid PropertyLookupResult if the property with name `name` is reserved
 pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResult<'_> {
     thread_local! {
         static RESERVED_PROPERTIES: HashMap<&'static str, (Type, PropertyVisibility, Option<BuiltinFunction>)>

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -2785,9 +2785,9 @@ mod tests {
         // A popup has it's own ItemTreeVTable
         let (window_adapter, parent) = create_one_node_component(Some(window_item));
         let popup_component = create_subsubtree_items(Some(window_adapter.clone())).1;
+        crate::window::WindowInner::set_popup_position(&popup_component, POPUP_LOCATION);
         window_adapter.window.0.show_popup(
             &popup_component,
-            alloc::boxed::Box::new(move || POPUP_LOCATION),
             crate::items::PopupClosePolicy::NoAutoClose,
             &ItemRc::new_root(parent.clone()),
             crate::window::WindowKind::Popup,
@@ -2823,9 +2823,9 @@ mod tests {
     fn test_map_to_window_popup() {
         const POPUP_LOCATION: LogicalPosition = LogicalPosition::new(20., 33.);
         let (window_adapter, item_tree) = create_subsubtree_items(None);
+        crate::window::WindowInner::set_popup_position(&item_tree, POPUP_LOCATION);
         window_adapter.window.0.show_popup(
             &item_tree,
-            alloc::boxed::Box::new(move || POPUP_LOCATION),
             crate::items::PopupClosePolicy::NoAutoClose,
             &ItemRc::new_root(item_tree.clone()),
             crate::window::WindowKind::Popup,
@@ -2924,9 +2924,9 @@ mod tests {
         // A popup has it's own ItemTreeVTable
         let (window_adapter, parent) = create_one_node_component(Some(window_item));
         let popup_component = create_subsubtree_items_dynamic_elements(window_adapter.clone());
+        crate::window::WindowInner::set_popup_position(&popup_component, POPUP_LOCATION);
         window_adapter.window.0.show_popup(
             &popup_component,
-            alloc::boxed::Box::new(move || POPUP_LOCATION),
             crate::items::PopupClosePolicy::NoAutoClose,
             &ItemRc::new_root(parent.clone()),
             crate::window::WindowKind::Popup,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1270,6 +1270,11 @@ pub struct WindowItem {
     pub default_font_size: Property<LogicalLength>,
     pub default_font_weight: Property<i32>,
     pub cached_rendering_data: CachedRenderingData,
+
+    // Popup related properties
+    /// position of the popup. Important: Not relevant for normal windows
+    pub x: Property<LogicalLength>,
+    pub y: Property<LogicalLength>,
 }
 
 impl Item for WindowItem {

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1542,5 +1542,40 @@ fn test_nested_property_tracker_evaluate_if_dirty() {
     assert_eq!(r, 12);
 }
 
+#[test]
+#[allow(clippy::redundant_closure)]
+fn test_tracker_chained_properties() {
+    use pin_weak::rc::PinWeak;
+    use std::rc::Rc;
+
+    let scope = Box::<PropertyTracker<true>>::pin(PropertyTracker::default());
+    let prop1 = Box::pin(Property::new(42));
+    let prop2 = Rc::pin(Property::new(25));
+
+    prop1.set_binding({
+        let w = PinWeak::downgrade(prop2.clone());
+        move || w.upgrade().unwrap().as_ref().get()
+    });
+    assert!(scope.is_dirty()); // It is dirty at the beginning
+
+    let r = scope.as_ref().evaluate(|| prop1.as_ref().get());
+    assert_eq!(r, 25);
+    assert!(!scope.is_dirty()); // It is no longer dirty
+
+    // Changing property 2 should lead to a dirty tracker
+    prop2.as_ref().set(26);
+    assert!(scope.is_dirty()); // now dirty for prop2 changed.
+    let r = scope.as_ref().evaluate(|| prop1.as_ref().get() + 1);
+    assert_eq!(r, 27);
+    assert!(!scope.is_dirty());
+
+    // Evaluate tracker again but with non dirty prop1
+    let r = scope.as_ref().evaluate(|| prop1.as_ref().get() + 1);
+    assert_eq!(r, 27);
+    assert!(!scope.is_dirty());
+    prop2.as_ref().set(39);
+    assert!(scope.is_dirty());
+}
+
 #[cfg(feature = "ffi")]
 pub(crate) mod ffi;

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -512,10 +512,6 @@ pub struct PopupWindow {
     /// Overlay tooltip: no focus steal, unclamped placement, skipped in main mouse routing.
     /// Context / popup menu: participates in menu-chain hit testing and cascading close.
     pub window_kind: WindowKind,
-    /// Callback that returns the current desired logical position of the popup.
-    /// Called during re-evaluation of the position tracker to re-subscribe to dependencies.
-    /// IMPORTANT: This position is relative to the parent
-    position_access: Box<dyn Fn() -> LogicalPosition>,
     /// Keeps the parent component's `PopupWindow::is-open` property in sync. Provided to
     /// [`WindowInner::show_popup`], invoked with `true` when the popup is shown and with `false` when
     /// this `PopupWindow` is dropped (see the `Drop` impl below). It is a no-op for popups whose
@@ -1556,9 +1552,15 @@ impl WindowInner {
         let offset = {
             let active_popups = self.active_popups.borrow();
             let Some(popup) = active_popups.iter().find(|p| p.popup_id == popup_id) else { return };
+            let component = ItemTreeRc::borrow_pin(&popup.component);
+            let root_item = component.as_ref().get_item_ref(0);
+            let window_item = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
+                .expect("Popup component is a Window item");
             if let Some(parent) = popup.parent_item.clone().upgrade() {
                 parent.map_to_native_window(
-                    parent.geometry().origin + (popup.position_access)().to_euclid().to_vector(),
+                    parent.geometry().origin
+                        + LogicalPoint::new(window_item.x().get(), window_item.y().get())
+                            .to_vector(),
                 )
             } else {
                 LogicalPoint::zero()
@@ -1575,6 +1577,10 @@ impl WindowInner {
                         let window_item =
                             ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
                                 .expect("Popup component is a Window item");
+
+                        window_item.x().get(); // Dummy access to track position changes
+                        window_item.y().get(); // Dummy access to track position changes
+
                         // Access the properties to set them as dependencies
                         let old_popup_region = LogicalRect::new(
                             *old_location,
@@ -1641,7 +1647,12 @@ impl WindowInner {
                 // The size is already tracked in the windowadapter
                 let mut new_position: Option<LogicalPosition> = None;
                 popup.properties_tracker.as_ref().evaluate_as_dependency_root(|| {
-                    (popup.position_access)(); // Dummy access to track position changes
+                    let component = ItemTreeRc::borrow_pin(&popup.component);
+                    let root_item = component.as_ref().get_item_ref(0);
+                    let window_item = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
+                        .expect("Popup component is a Window item");
+                    window_item.x().get(); // Dummy access to track position changes
+                    window_item.y().get(); // Dummy access to track position changes
                     new_position = Some(LogicalPosition::from_euclid(offset));
                 });
                 if let Some(pos) = new_position {
@@ -1832,8 +1843,34 @@ impl WindowInner {
             .and_then(|s| s.create_child_window_adapter(kind))
     }
 
-    /// Show a popup at the given position relative to the `parent_item` and returns its ID.
+    /// Store `position` on the popup component's root `WindowItem` `x`/`y` fields.
+    ///
+    /// [`show_popup`](Self::show_popup) derives a popup's placement from those fields. Regular popups
+    /// and tooltips carry reactive `x`/`y` bindings that already produce the right value, so they must
+    /// *not* call this (it would overwrite the binding). It is only for popups whose position is
+    /// computed at show time and is not backed by a binding — namely menus — which must call this
+    /// before `show_popup`. It is a no-op for popup roots that are not a `WindowItem`.
+    pub fn set_popup_position(popup_componentrc: &ItemTreeRc, position: LogicalPosition) {
+        let popup_component = ItemTreeRc::borrow_pin(popup_componentrc);
+        let popup_root = popup_component.as_ref().get_item_ref(0);
+        if let Some(window_item) = ItemRef::downcast_pin::<crate::items::WindowItem>(popup_root) {
+            crate::items::WindowItem::FIELD_OFFSETS
+                .x()
+                .apply_pin(window_item)
+                .set(LogicalLength::new(position.x as Coord));
+            crate::items::WindowItem::FIELD_OFFSETS
+                .y()
+                .apply_pin(window_item)
+                .set(LogicalLength::new(position.y as Coord));
+        }
+    }
+
+    /// Show a popup relative to the `parent_item` and returns its ID.
     /// The returned ID will always be non-zero.
+    ///
+    /// The popup's position is taken from its root `WindowItem`'s `x`/`y` fields (evaluated from the
+    /// popup's `x`/`y` bindings). Callers showing a popup whose position is not backed by a binding
+    /// (menus) must set it first via [`set_popup_position`](Self::set_popup_position).
     ///
     /// `is_open_setter` keeps the parent component's `PopupWindow::is-open` property in sync with this
     /// popup: it is invoked immediately with `true`, and again with `false` when the popup is closed
@@ -1842,7 +1879,6 @@ impl WindowInner {
     pub fn show_popup(
         &self,
         popup_componentrc: &ItemTreeRc,
-        popup_access_position: Box<dyn Fn() -> LogicalPosition>,
         close_policy: PopupClosePolicy,
         parent_item: &ItemRc,
         window_kind: WindowKind,
@@ -1851,9 +1887,6 @@ impl WindowInner {
         // Popups live in their own ItemTree, which was invisible to any
         // earlier instantiation pass; materialize it before the layout queries below.
         crate::item_tree::ensure_item_tree_instantiated(popup_componentrc);
-        let position = parent_item.map_to_native_window(
-            parent_item.geometry().origin + popup_access_position().to_euclid().to_vector(),
-        );
         let popup_component = ItemTreeRc::borrow_pin(popup_componentrc);
         let popup_root = popup_component.as_ref().get_item_ref(0);
 
@@ -1881,13 +1914,22 @@ impl WindowInner {
 
         let size = crate::lengths::LogicalSize::from_lengths(w, h);
 
-        if let Some(window_item) = ItemRef::downcast_pin(popup_root) {
+        let native_position = if let Some(window_item) =
+            ItemRef::downcast_pin::<crate::items::WindowItem>(popup_root)
+        {
             let width_property =
                 crate::items::WindowItem::FIELD_OFFSETS.width().apply_pin(window_item);
             let height_property =
                 crate::items::WindowItem::FIELD_OFFSETS.height().apply_pin(window_item);
             width_property.set(size.width_length());
             height_property.set(size.height_length());
+
+            parent_item.map_to_native_window(
+                parent_item.geometry().origin
+                    + LogicalPoint::new(window_item.x().get(), window_item.y().get()).to_vector(),
+            )
+        } else {
+            LogicalPoint::default()
         };
 
         let popup_id = self.next_popup_id.get();
@@ -1954,7 +1996,7 @@ impl WindowInner {
                     self.window_adapter().size().to_logical(self.scale_factor()).to_euclid(),
                 ));
                 let rect = popup::place_popup(
-                    popup::Placement::Fixed(LogicalRect::new(position, size)),
+                    popup::Placement::Fixed(LogicalRect::new(native_position, size)),
                     &clip_region,
                 );
                 self.window_adapter().request_redraw();
@@ -1970,7 +2012,7 @@ impl WindowInner {
             } else {
                 let popup_window = popup_window_adapter.window();
                 WindowInner::from_pub(popup_window).set_component(popup_componentrc);
-                popup_window.set_position(LogicalPosition::from_euclid(position));
+                popup_window.set_position(LogicalPosition::from_euclid(native_position));
                 popup_window.set_size(WindowSize::Logical(LogicalSize::from_euclid(size)));
 
                 popup_window_adapter.set_visible(true).expect("unable to show popup window");
@@ -2007,7 +2049,6 @@ impl WindowInner {
             focus_item_in_parent: focus_item,
             parent_item: parent_item.downgrade(),
             window_kind,
-            position_access: popup_access_position,
             is_open_setter,
             properties_tracker,
         });
@@ -2388,14 +2429,6 @@ pub mod ffi {
         }
     }
 
-    impl WithUserData<extern "C" fn(user_data: *mut c_void, pos: &mut LogicalPosition)> {
-        fn call(&self) -> LogicalPosition {
-            let mut logical_position = LogicalPosition::default();
-            (self.callback)(self.user_data, &mut logical_position);
-            logical_position
-        }
-    }
-
     impl WithUserData<extern "C" fn(user_data: *mut c_void) -> CloseRequestResponse> {
         fn call(&self) -> CloseRequestResponse {
             (self.callback)(self.user_data)
@@ -2572,9 +2605,7 @@ pub mod ffi {
     pub unsafe extern "C" fn slint_windowrc_show_popup(
         handle: *const WindowAdapterRcOpaque,
         popup: &ItemTreeRc,
-        position: extern "C" fn(user_data: *mut c_void, pos: &mut LogicalPosition),
-        drop_user_data: extern "C" fn(user_data: *mut c_void),
-        user_data: *mut c_void,
+        position: LogicalPosition,
         close_policy: PopupClosePolicy,
         parent_item: &ItemRc,
         window_kind: WindowKind,
@@ -2583,16 +2614,20 @@ pub mod ffi {
         is_open_setter_user_data: *mut c_void,
     ) -> NonZeroU32 {
         unsafe {
-            let with_user_data = WithUserData { callback: position, drop_user_data, user_data };
             let is_open_with_user_data = WithUserData {
                 callback: is_open_setter,
                 drop_user_data: is_open_setter_drop_user_data,
                 user_data: is_open_setter_user_data,
             };
             let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
+            // Menus are positioned at show time and have no `x`/`y` binding to carry the position,
+            // so store it on the popup's `WindowItem` before showing. Regular popups and tooltips
+            // keep their bindings and derive the position from them inside `show_popup`.
+            if matches!(window_kind, WindowKind::Menu) {
+                WindowInner::set_popup_position(popup, position);
+            }
             WindowInner::from_pub(window_adapter.window()).show_popup(
                 popup,
-                Box::new(move || with_user_data.call()),
                 close_policy,
                 parent_item,
                 window_kind,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -15,7 +15,6 @@ use i_slint_compiler::{diagnostics::BuildDiagnostics, object_tree::PropertyDecla
 use i_slint_core::accessibility::{
     AccessibilityAction, AccessibleStringProperty, SupportedAccessibilityAction,
 };
-use i_slint_core::api::LogicalPosition;
 use i_slint_core::component_factory::ComponentFactory;
 use i_slint_core::input::Keys;
 use i_slint_core::item_tree::{
@@ -2788,7 +2787,6 @@ pub fn show_popup(
     element: ElementRc,
     instance: InstanceRef,
     popup: &object_tree::PopupWindow,
-    pos_getter: impl Fn(InstanceRef<'_, '_>) -> LogicalPosition + 'static,
     close_policy: PopupClosePolicy,
     parent_comp: ErasedItemTreeBoxWeak,
     parent_window_adapter: WindowAdapterRc,
@@ -2834,13 +2832,6 @@ pub fn show_popup(
         Some(&WindowOptions::UseExistingWindow(popup_window_adapter)),
         globals,
     );
-    let inst_for_position = inst.clone();
-    let access_position = Box::new(move || {
-        generativity::make_guard!(guard);
-        let compo_box = inst_for_position.unerase(guard);
-        let instance_ref = compo_box.borrow_instance();
-        pos_getter(instance_ref)
-    });
     close_popup(element.clone(), instance, parent_window_adapter.clone());
     let window_kind = if popup.is_tooltip { WindowKind::ToolTip } else { WindowKind::Popup };
     // Keep the parent's `is-open` property in sync: `show_popup` invokes this with `true` now and with
@@ -2868,7 +2859,6 @@ pub fn show_popup(
         };
     let popup_id = WindowInner::from_pub(parent_window_adapter.window()).show_popup(
         &vtable::VRc::into_dyn(inst.clone()),
-        access_position,
         close_policy,
         parent_item,
         window_kind,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -976,24 +976,11 @@ fn call_builtin_function(
                 )
                 .try_into()
                 .expect("Invalid internal enumeration representation for close policy");
-                let popup_x = popup.x.clone();
-                let popup_y = popup.y.clone();
 
                 crate::dynamic_item_tree::show_popup(
                     popup_window,
                     enclosing_component,
                     popup,
-                    move |instance_ref| {
-                        let comp = ComponentInstance::InstanceRef(instance_ref);
-                        let x = load_property_helper(&comp, &popup_x.element(), popup_x.name())
-                            .unwrap();
-                        let y = load_property_helper(&comp, &popup_y.element(), popup_y.name())
-                            .unwrap();
-                        corelib::api::LogicalPosition::new(
-                            x.try_into().unwrap(),
-                            y.try_into().unwrap(),
-                        )
-                    },
                     close_policy,
                     (*enclosing_component.self_weak().get().unwrap()).clone(),
                     component.window_adapter(),
@@ -1155,9 +1142,12 @@ fn call_builtin_function(
                 if let Some(old_id) = context_menu_elem.popup_id.take() {
                     window.close_popup(old_id)
                 }
+                // Menus are positioned at show time and have no `x`/`y` binding, so store the
+                // computed position on the popup's `WindowItem` before showing it.
+                let popup_rc = vtable::VRc::into_dyn(inst.clone());
+                WindowInner::set_popup_position(&popup_rc, position);
                 let id = window.show_popup(
-                    &vtable::VRc::into_dyn(inst.clone()),
-                    Box::new(move || position),
+                    &popup_rc,
                     corelib::items::PopupClosePolicy::CloseOnClickOutside,
                     &item_rc,
                     WindowKind::Menu,


### PR DESCRIPTION
- [ ] ~~If the change modifies a visible behavior, it changes the documentation accordingly~~
- [ ] ~~If possible, the change is auto-tested~~ Already tests available
- [ ] ~~If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`~~
- [ ] ~~If the change is noteworthy, the commit message should contain `ChangeLog: ...`~~

When adding new properties in the future to the popup, we always have to route them into using access function which is not suitable. Therefore we store those new properties in the WindowItem directly. So they are more verbose and can be used more concise with other properties

<img width="1853" height="688" alt="grafik" src="https://github.com/user-attachments/assets/381961b6-4feb-434f-ae1b-061674d51823" />


Decided to make the x/y properties part of the WindowItem builtins.slint so we don't need this workaround. Neverthless this workaround is required in the future for the anchoring system because we don't wanna expose those properties to general Window Items
