### PR TITLE
docs: Add a Slint Viewer documentation page

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -66,11 +66,11 @@ export default defineConfig({
                                 collapsed: true,
                                 items: [
                                     "guide/tooling/vscode",
+                                    "guide/tooling/manual-setup",
                                     {
                                         label: "Other Editors",
                                         collapsed: true,
                                         items: [
-                                            "guide/tooling/manual-setup",
                                             "guide/tooling/kate",
                                             "guide/tooling/qt-creator",
                                             "guide/tooling/helix",

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
                                         ],
                                     },
                                     "guide/tooling/live-preview",
+                                    "guide/tooling/slint-viewer",
                                     "guide/tooling/figma-inspector",
                                     "guide/tooling/ai-coding-assistants",
                                 ],

--- a/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx
@@ -6,7 +6,7 @@ description: Install the Slint skill for Claude Code, Codex, Cursor, and other A
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Use the Slint skill to give your AI coding agent project-specific guidance for working with Slint.
-The skill covers the `.slint` language and layout, common gotchas, host-language interop, and the embedded MCP server.
+The skill covers the `.slint` language, layouts, common gotchas, host-language interop, and the embedded MCP server.
 
 The plugin and skills are available from the [slint-ui/ai-plugins](https://github.com/slint-ui/ai-plugins) repository.
 
@@ -57,7 +57,7 @@ The plugin and skills are available from the [slint-ui/ai-plugins](https://githu
 ## What Your Assistant Can Do
 
 With the skill installed, the assistant follows Slint's conventions when it writes, debugs, and reviews `.slint` code, and wires the UI to Rust, C++, JavaScript, or Python.
-It also renders components to an image with [`slint-viewer --screenshot`](/guide/tooling/slint-viewer/#rendering-a-screenshot) to check the look of a `.slint` file before calling the work done.
+Assistants also learn to verify rendering by taking screenshots of the scene before calling the work done.
 
 The skill also connects the assistant to the Model Context Protocol (MCP) server embedded in your running Slint application.
 Once connected, the assistant can inspect the UI through its accessibility tree, drive it with mouse, touch, and keyboard input, and capture screenshots to check the result — built on Slint's existing accessibility and testing APIs, with no debugging hooks in your application.

--- a/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx
@@ -1,11 +1,14 @@
 ---
 title: AI Coding Assistants
-description: Install the Slint skill for Claude Code and Codex.
+description: Install the Slint skill for Claude Code, Codex, Cursor, and other AI coding agents.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Use the Slint skill to give Claude Code or Codex project-specific guidance for working with Slint.
+Use the Slint skill to give your AI coding agent project-specific guidance for working with Slint.
+The skill covers the `.slint` language and layout, common gotchas, host-language interop, and the embedded MCP server.
+
+The plugin and skills are available from the [slint-ui/ai-plugins](https://github.com/slint-ui/ai-plugins) repository.
 
 <Tabs syncKey="ai-tool">
   <TabItem label="Claude Code">
@@ -50,3 +53,11 @@ Use the Slint skill to give Claude Code or Codex project-specific guidance for w
   This works for any agent supported by the `skills` CLI (Claude Code, Cursor, and others) and installs into the project's agent skills directory by default. Pass `-g` to install globally for all projects.
   </TabItem>
 </Tabs>
+
+## What Your Assistant Can Do
+
+With the skill installed, the assistant follows Slint's conventions when it writes, debugs, and reviews `.slint` code, and wires the UI to Rust, C++, JavaScript, or Python.
+It also renders components to an image with [`slint-viewer --screenshot`](/guide/tooling/slint-viewer/#rendering-a-screenshot) to check the look of a `.slint` file before calling the work done.
+
+The skill also connects the assistant to the Model Context Protocol (MCP) server embedded in your running Slint application.
+Once connected, the assistant can inspect the UI through its accessibility tree, drive it with mouse, touch, and keyboard input, and capture screenshots to check the result — built on Slint's existing accessibility and testing APIs, with no debugging hooks in your application.

--- a/docs/astro/src/content/docs/guide/tooling/manual-setup.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/manual-setup.mdx
@@ -2,7 +2,6 @@
 title: Manual Setup
 description: Manually set up Slint for your editor
 ---
-{/* cSpell: ignore libx libxcb libxkbcommon libinput libgbm */}
 
 import Link from '@slint/common-files/src/components/Link.astro';
 
@@ -88,14 +87,8 @@ If you have slint-lsp configured in your editor, you can launch the live preview
 
 ### Running `slint-viewer` from the terminal
 
-To open the live preview from a terminal, you can use the `slint-viewer` binary.
-
-To install it either:
-
-* [Download the binary](https://github.com/slint-ui/slint/releases/latest)
-* Run `cargo install slint-viewer` if you have a Rust installation
-
-Then run `slint-viewer --auto-reload <path/to/file.slint>`.
+To open the live preview from a terminal, run `slint-viewer --auto-reload <path/to/file.slint>`.
+See the <Link type="SlintViewer" label="Slint Viewer"/> page for installation, screenshots, and all command-line options.
 
 **Example on the [Printer Demo](https://github.com/slint-ui/slint/blob/master/demos/printerdemo/ui/printerdemo.slint)**
 

--- a/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
@@ -3,6 +3,8 @@ title: Slint Viewer
 description: Preview .slint files, render screenshots, and check files from the command line.
 ---
 
+import Link from '@slint/common-files/src/components/Link.astro';
+
 The `slint-viewer` command-line tool opens and previews `.slint` files.
 Use it to iterate on a UI with live reload, render screenshots, or check that a file compiles.
 
@@ -36,9 +38,7 @@ slint-viewer path/to/myfile.slint
 
 Use `-` instead of a path to read from standard input.
 
-## Live Reload
-
-`--auto-reload` watches the file on disk and reloads the preview whenever it changes, so you can iterate without restarting the viewer:
+Add `--auto-reload` to watch the file on disk and reload the preview whenever it changes, so you can iterate without restarting the viewer:
 
 ```sh
 slint-viewer --auto-reload path/to/myfile.slint
@@ -59,7 +59,7 @@ Set the `SLINT_SCALE_FACTOR` environment variable to override the default scale 
 ## Checking a File
 
 `--check` compiles the file, prints any diagnostics, and exits without opening a window.
-The exit status is `1` on errors and `0` otherwise; warnings still print.
+The exit status is `1` on error and `0` otherwise; warnings still print.
 
 ```sh
 slint-viewer --check path/to/myfile.slint
@@ -67,14 +67,37 @@ slint-viewer --check path/to/myfile.slint
 
 ## Loading and Saving Property Data
 
-`--load-data` sets the public properties of the component from a JSON file, and `--save-data` writes them back when the viewer exits:
+`--save-data` writes the component's public properties to a JSON file when the viewer exits:
 
 ```sh
-slint-viewer --load-data input.json --save-data output.json path/to/myfile.slint
+slint-viewer --save-data output.json path/to/myfile.slint
 ```
 
-Only properties whose types serialize to JSON are read or written.
-`--save-data` is incompatible with `--auto-reload`.
+`--load-data` sets them from a JSON file at startup:
+
+```sh
+slint-viewer --load-data input.json path/to/myfile.slint
+```
+
+Each works on its own; pass both to load initial values and write the result back. Only properties whose types serialize to JSON are read or written, and `--save-data` is incompatible with `--auto-reload`.
+
+For a component with these properties:
+
+```slint
+export component Form inherits Window {
+    in-out property <string> name;
+    in-out property <int> age;
+}
+```
+
+the JSON file looks like:
+
+```json
+{
+    "name": "Alice",
+    "age": 30
+}
+```
 
 ## Remote Viewer
 
@@ -93,14 +116,11 @@ Pass `--remote-address <address>` to choose a specific address and port.
 To connect, open the live preview of a `.slint` file in your editor, then pick **Remote** from the combobox in the top-right corner of the preview and enter the address the viewer shows.
 The editor compiles the `.slint` file and sends the result to the remote viewer, reloading it as you edit, while debug output from the previewed UI is sent back to the editor.
 
-`--remote` takes no file path and can't be combined with `--screenshot` or `--check`.
-
-On Android and iOS the viewer app always starts in remote mode, so you can preview on a phone or tablet straight from your editor:
-
-- **Android**: install from [Google Play](https://play.google.com/store/apps/details?id=dev.slint.viewer), or download the <a href={`${import.meta.env.BASE_URL}../demos/android/slint-viewer.apk`}>APK</a>.
-- **iOS**: join the [TestFlight beta](https://testflight.apple.com/join/pvsBXsb3).
+`--remote` doesn't take a file path, and can't be combined with `--screenshot` or `--check`.
 
 ## Command-Line Options
+
+Run `slint-viewer --help` for the authoritative, always-current list. The common options:
 
 | Option | Description |
 |---|---|
@@ -114,7 +134,7 @@ On Android and iOS the viewer app always starts in remote mode, so you can previ
 | `--remote-address <address>` | Address and port to listen on in remote mode. Defaults to an auto-assigned port on all interfaces. |
 | `--component <name>` | Load the component with this name. Defaults to the last exported component. |
 | `--style <style>` | Set the widget style. Defaults to `fluent`. |
-| `--backend <backend>` | Override the Slint rendering backend. |
+| `--backend <backend>` | Override the Slint rendering <Link type="backends_and_renderers" label="backend"/>. |
 | `-I <path>` | Add an include path for imported `.slint` files or images. |
 | `-L <library=path>` | Add a library path for `@library` imports. |
 | `--on <callback> <handler>` | Run a shell command when a callback is invoked. See [Callback Handlers](#callback-handlers). |

--- a/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
@@ -1,0 +1,170 @@
+---
+title: Slint Viewer
+description: Preview .slint files, render screenshots, and check files from the command line.
+---
+
+The `slint-viewer` command-line tool opens and previews `.slint` files.
+Use it to iterate on a UI with live reload, render screenshots, or check that a file compiles.
+
+## Installation
+
+Install the binary from crates.io with a Rust toolchain:
+
+```sh
+cargo install slint-viewer
+```
+
+Alternatively, download a pre-built binary for Linux or Windows:
+
+1. Go to [the latest Slint release](https://github.com/slint-ui/slint/releases/latest).
+2. From "Assets" download `slint-viewer-linux.tar.gz` for Linux or `slint-viewer-windows-x86_64.zip` for Windows.
+3. Uncompress the archive and run `slint-viewer`.
+
+On Debian-like systems, install the runtime dependencies with:
+
+```sh
+sudo apt install -y libx11-xcb1 libxcb1 libxkbcommon0 libinput10 libgbm1
+```
+
+## Opening a File
+
+Pass a path to preview a `.slint` file:
+
+```sh
+slint-viewer path/to/myfile.slint
+```
+
+Use `-` instead of a path to read from standard input.
+
+## Live Reload
+
+`--auto-reload` watches the file on disk and reloads the preview whenever it changes, so you can iterate without restarting the viewer:
+
+```sh
+slint-viewer --auto-reload path/to/myfile.slint
+```
+
+## Rendering a Screenshot
+
+`--screenshot` renders the component to an image and exits, with no window:
+
+```sh
+slint-viewer --screenshot screenshot.png path/to/myfile.slint
+```
+
+The image format follows the file extension (such as `.png` or `.jpg`).
+Use `-` to write a PNG to standard output.
+Set the `SLINT_SCALE_FACTOR` environment variable to override the default scale factor of `1`.
+
+## Checking a File
+
+`--check` compiles the file, prints any diagnostics, and exits without opening a window.
+The exit status is `1` on errors and `0` otherwise; warnings still print.
+
+```sh
+slint-viewer --check path/to/myfile.slint
+```
+
+## Loading and Saving Property Data
+
+`--load-data` sets the public properties of the component from a JSON file, and `--save-data` writes them back when the viewer exits:
+
+```sh
+slint-viewer --load-data input.json --save-data output.json path/to/myfile.slint
+```
+
+Only properties whose types serialize to JSON are read or written.
+`--save-data` is incompatible with `--auto-reload`.
+
+## Remote Viewer
+
+`--remote` starts the viewer in remote mode.
+Instead of loading a file, the viewer waits for the live preview in your editor to connect over the network and push the UI to it.
+Use it to preview a `.slint` file on another machine or a device while you edit on your computer.
+
+```sh
+slint-viewer --remote
+```
+
+The viewer shows an idle screen with its name and the address to connect to, and advertises itself on the local network so editors can discover it.
+By default it listens on an automatically assigned port on all network interfaces.
+Pass `--remote-address <address>` to choose a specific address and port.
+
+To connect, open the live preview of a `.slint` file in your editor, then pick **Remote** from the combobox in the top-right corner of the preview and enter the address the viewer shows.
+The editor compiles the `.slint` file and sends the result to the remote viewer, reloading it as you edit, while debug output from the previewed UI is sent back to the editor.
+
+`--remote` takes no file path and can't be combined with `--screenshot` or `--check`.
+
+On Android and iOS the viewer app always starts in remote mode, so you can preview on a phone or tablet straight from your editor:
+
+- **Android**: install from [Google Play](https://play.google.com/store/apps/details?id=dev.slint.viewer), or download the <a href={`${import.meta.env.BASE_URL}../demos/android/slint-viewer.apk`}>APK</a>.
+- **iOS**: join the [TestFlight beta](https://testflight.apple.com/join/pvsBXsb3).
+
+## Command-Line Options
+
+| Option | Description |
+|---|---|
+| `<path>` | The `.slint` file to load. Required unless `--remote` is given. |
+| `--auto-reload` | Watch the file system and reload when the file changes. |
+| `--load-data <file>` | Load the values of public properties from a JSON file. |
+| `--save-data <file>` | On exit, write the values of public properties to a JSON file. Incompatible with `--auto-reload`. |
+| `--screenshot <file>` | Render the component to an image and exit. |
+| `--check` | Compile the file, print diagnostics, and exit without opening a window. Incompatible with the options above. |
+| `--remote` | Start in remote mode and wait for the editor to connect. See [Remote Viewer](#remote-viewer). |
+| `--remote-address <address>` | Address and port to listen on in remote mode. Defaults to an auto-assigned port on all interfaces. |
+| `--component <name>` | Load the component with this name. Defaults to the last exported component. |
+| `--style <style>` | Set the widget style. Defaults to `fluent`. |
+| `--backend <backend>` | Override the Slint rendering backend. |
+| `-I <path>` | Add an include path for imported `.slint` files or images. |
+| `-L <library=path>` | Add a library path for `@library` imports. |
+| `--on <callback> <handler>` | Run a shell command when a callback is invoked. See [Callback Handlers](#callback-handlers). |
+
+Use `-` in place of a file path to read from standard input or write to standard output.
+
+A viewer built with the `gettext` feature also accepts `--translation-domain <domain>`, `--translation-dir <dir>`, and `--no-default-translation-context` to resolve `@tr(...)` strings against gettext catalogs.
+
+## Callback Handlers
+
+`--on` runs a shell command when a callback is invoked, followed by the callback name and the command.
+In the command, `$1`, `$2`, … are replaced by the callback arguments, shell-escaped.
+
+Given a `.slint` file with an `open-url` callback:
+
+```slint
+export component MyApp inherits Window {
+    callback open-url(string);
+    // ...
+}
+```
+
+Wire the callback to a command:
+
+```sh
+slint-viewer --on open-url 'xdg-open $1' myfile.slint
+```
+
+Use single quotes, or escape the `$`, so the shell does not expand `$1`.
+
+## Dialogs
+
+When the root element is a `Dialog`, the standard buttons close it if no callback is set on the button:
+
+- `ok`, `yes`, and `close` accept the dialog.
+- `cancel` and `no` reject the dialog.
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | A window was closed, or a dialog was accepted with `Ok`, `Close`, or `Yes`. |
+| `1` | A dialog was rejected with `Cancel`, `No`, or the window's close button. Also a compilation error under `--check` or `--screenshot`. |
+| `2` | Command-line argument parsing or validation failed. |
+| `-1` | Compilation failed (except under `--check` or `--screenshot`). |
+
+## Driving a UI From a Shell Script
+
+`slint-viewer` can display a GUI from a shell script.
+Read `.slint` from standard input with `-`, and write the property values back as JSON on exit with `--save-data -`, so a script can collect user input from a dialog.
+
+For a walkthrough, see the blog post [Showing GUIs from shell scripts](https://slint.dev/blog/showing-guis-from-shell-scripts).
+Ready-to-run examples live in the [examples/bash](https://github.com/slint-ui/slint/tree/master/examples/bash) folder.

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -326,6 +326,9 @@
     "SlintLSP": {
         "href": "guide/tooling/manual-setup/#slint-lsp"
     },
+    "SlintViewer": {
+        "href": "guide/tooling/slint-viewer/"
+    },
     "KateSyntaxHighlighting": {
         "href": "guide/tooling/kate/#syntax-highlighting"
     },

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -19,7 +19,7 @@ Pre-built binaries for Linux and Windows are attached to each [release](https://
 slint-viewer path/to/myfile.slint
 ```
 
-See the [Slint Viewer documentation](https://slint.dev/docs/slint/guide/tooling/slint-viewer/)
+See the [Slint Viewer documentation](https://docs.slint.dev/latest/docs/slint/guide/tooling/slint-viewer/)
 for live reload, screenshots, command-line options, callback handlers, dialogs, exit codes,
 and the remote viewer.
 

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -1,113 +1,38 @@
 
 # Viewer for Slint
 
-This program is a viewer for `.slint` files from the [Slint Project](https://slint.dev).
+This program is a viewer for `.slint` files from the [Slint project](https://slint.dev).
 
 ## Installation
 
-The viewer can be installed from crates.io:
+Install the binary from crates.io:
 
 ```bash
 cargo install slint-viewer
 ```
 
-Alternatively, you can download one of our pre-built binaries for Linux or Windows:
-
-1. Open <https://github.com/slint-ui/slint/releases>
-2. Click on the latest release
-3. From "Assets" download either `slint-viewer-linux.tar.gz` for a Linux x86-64 binary
-   or `slint-viewer-windows.zip` for a Windows x86-64 binary.
-4. Uncompress the downloaded archive and run `slint-viewer`/`slint-viewer.exe`.
+Pre-built binaries for Linux and Windows are attached to each [release](https://github.com/slint-ui/slint/releases).
 
 ## Usage
-
-You can open .slint files by just passing it as an argument:
 
 ```bash
 slint-viewer path/to/myfile.slint
 ```
 
-## Command line arguments
-
- - `--auto-reload`: Automatically watch the file system, and reload when it changes
- - `--save-data <file>`: When exiting, write the value of public properties to a json file.
-   Only property whose types can be serialized to json will be written.
-   This option is incompatible with `--auto-reload`
- - `--load-data <file>`: Load the values of public properties from a json file.
- - `-I <path>`: Add an include path to look for imported .slint files or images.
- - `-L <library=path>`: Add a library path to look for `@library` imports.
- - `--style <style>`: Set the style. Defaults to `fluent` on all platforms
- - `--backend <backend>`: Override the Slint rendering backend
- - `--on <callback> <handler>`: Set a callback handler, see [callback handler](#callback-handlers)
- - `--component <name>`: Load the component with the given name. If not specified, load the last exported component
- - `--screenshot <file>`: Render the component to an image and exit.
-   The format follows the extension (e.g. `.png`, `.jpg`); use `-` to write a PNG to standard output.
-   Set `SLINT_SCALE_FACTOR` to override the default scale factor of 1.
- - `--check`: Compile the file, print any diagnostics, and exit without opening a window.
-   Exit status is 1 on errors, 0 otherwise (warnings still print).
-
-Instead of a path to a file, one can use `-` for the standard input or the standard output.
-
-## Callback handler
-
-It is possible to tell the viewer to execute some shell commands when a callback is received.
-You can use the `--on` command line argument, followed by the callback name, followed by the command.
-Within the command arguments, `$1`, `$2`, ... will be replaced by the first, second, ... argument of the
-callback. These will be shell escaped.
-
-Example: Imagine we have a myfile.slint looking like this:
-
-```slint
-export component MyApp inherits Window {
-  callback open-url(string);
-  //...
-}
-```
-
-It is possible to make the `open-url` callback to execute a command by doing
-
-```bash
-slint-viewer --on open-url 'xdg-open $1' myfile.slint
-```
-
-Be careful to use single quote or to escape the `$` so that the shell don't expand the `$1`
-
-
-## Dialogs
-
-If the root element of the .slint file is a `Dialog`, the different StandardButton might close
-the dialog if no callback was set on the button.
-
- - `ok`, `yes`, or `close` buttons accepts the dialog
- - `cancel`, `no` buttons reject the dialog
-
-## Result code
-
-The program returns with the following error code:
- - If the command line argument parsing or argument validation fails, the exit code will be *2*
- - If the .slint compilation fails, the compilation error will be printed to stderr and the exit code
-   will be *-1*, except for `--check` and `--screenshot` which exit with *1*
- - If a Window is closed, the exit code will be *0*
- - If a Dialog is closed with the "Ok" or "Closed" or "Yes" button, the exit code will be *0*
- - If a Dialog is closed with the "Cancel" or "No" button, or using the close button in the window
-   title bar, the exit code will be *1*
-
-## Examples
-
-`slint-viewer` can be used to display an GUI from a shell script. For examples check out the
-[examples/bash](https://github.com/slint-ui/slint/tree/master/examples/bash) folder in our repository.
+See the [Slint Viewer documentation](https://slint.dev/docs/slint/guide/tooling/slint-viewer/)
+for live reload, screenshots, command-line options, callback handlers, dialogs, exit codes,
+and the remote viewer.
 
 ## Building for iOS
 
-On iOS the viewer lets you preview `.slint` files from your editor directly on an iPhone, iPad, or
-the simulator.
+On iOS the viewer previews `.slint` files from your editor on an iPhone, iPad, or the simulator.
 
 ### Prerequisites
 
- * A computer running macOS with an up-to-date installation of [Xcode](https://developer.apple.com/xcode/).
- * [Xcodegen](https://github.com/yonaskolb/XcodeGen) (e.g. `brew install xcodegen`).
- * [Rust](https://rustup.rs) with the iOS toolchains:
-   `rustup target add aarch64-apple-ios aarch64-apple-ios-sim`.
+- A computer running macOS with an up-to-date installation of [Xcode](https://developer.apple.com/xcode/).
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) (e.g. `brew install xcodegen`).
+- [Rust](https://rustup.rs) with the iOS toolchains:
+  `rustup target add aarch64-apple-ios aarch64-apple-ios-sim`.
 
 ### Build and run
 


### PR DESCRIPTION
Adds a user-facing slint-viewer page (usage, live reload, screenshots,                                                   
--check, the remote viewer, and all command-line options) and slims the
crate README to link to it. Also moves Manual Setup out of the "Other
Editors" sidebar group and expands the AI coding assistants page.