### PR TITLE
Python: pin maturin <1.14.1 to fix iOS abi3 cross-link

### DIFF
--- a/api/python/slint/pyproject.toml
+++ b/api/python/slint/pyproject.toml
@@ -3,7 +3,9 @@
 
 # cSpell: ignore cibuildwheel
 [build-system]
-requires = ["maturin>=1,<2"]
+# maturin 1.14.1 (PR #3226) encodes the abi3 floor (python3.11) as the link
+# lib name, which breaks the iOS cross-link (only libpython3.13 is shipped).
+requires = ["maturin>=1,<1.14.1"]
 build-backend = "maturin"
 
 [project]

--- a/cspell.json
+++ b/cspell.json
@@ -143,6 +143,7 @@
     "inout",
     "knip",
     "layouting",
+    "libpython",
     "linebreak",
     "lineedit",
     "LINUXFB",


### PR DESCRIPTION
maturin 1.14.1 (PR #3226) encodes the abi3 floor version (python3.11) as the libpython link name, but the iOS framework only ships libpython3.13, so the cross-link fails with 'library python3.11 not found'.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
