### PR TITLE
zed: fix comment query nodes after the grammar split

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -59,6 +59,7 @@ docs_build:
 # Needs to be re-tested if the Tree-Sitter grammr or any Slint files in the corpus change
 tree_sitter:
  - 'editors/tree-sitter-slint/**'
+ - 'editors/zed/languages/slint/*.scm'
  - 'tests/cases/**/*.slint'
  - 'examples/**/*.slint'
  - 'demos/**/*.slint'

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -11,7 +11,7 @@ module.exports = grammar({
     [$._assignment_value_block],
     [$.assignment_block],
     // Caused by accepting arbitrary expressions in the radial-gradient/conical-gradient without a separator!
-    [$._unary_prec_operator, $.add_prec_operator]
+    [$.unary_prec_operator, $.add_prec_operator]
 ],
 
   externals: ($) => [$.block_comment],
@@ -176,8 +176,6 @@ module.exports = grammar({
         field("alias", $.expression),
         ";",
       ),
-
-    binding: ($) => seq(field("name", $.simple_identifier), ":", $._binding),
 
     global_block: ($) =>
       seq(
@@ -493,7 +491,7 @@ module.exports = grammar({
     unary_expression: ($) =>
       prec.left(
         14,
-        seq(field("op", $._unary_prec_operator), field("expr", $.expression)),
+        seq(field("op", $.unary_prec_operator), field("expr", $.expression)),
       ),
 
     binary_expression: ($) =>
@@ -748,7 +746,7 @@ module.exports = grammar({
         seq("(", optional(seq(commaSep1($.argument), optional(","))), ")"),
       ),
 
-    _unary_prec_operator: (_) => choice("!", "-", "+"),
+    unary_prec_operator: (_) => choice("!", "-", "+"),
 
     add_prec_operator: (_) => choice("+", "-"),
     mult_prec_operator: (_) => choice("*", "/"),

--- a/editors/tree-sitter-slint/run_tests.sh
+++ b/editors/tree-sitter-slint/run_tests.sh
@@ -13,6 +13,17 @@ cd "${SCRIPT_DIR}"
 $TS generate
 $TS build
 
+# Validate the editor query files against the freshly built grammar. A grammar
+# change that renames or removes a node otherwise only surfaces when an editor
+# loads the queries (e.g. Zed: Query error ... Invalid node type "comment").
+SAMPLE_SLINT="${SCRIPT_DIR}/.query-check.slint"
+trap 'rm -f "${SAMPLE_SLINT}"' EXIT
+printf 'export component Foo { /* comment */ }\n' > "${SAMPLE_SLINT}"
+for q in "${SCRIPT_DIR}"/../zed/languages/slint/*.scm; do
+    echo "Validating editor query ${q}"
+    $TS query "${q}" "${SAMPLE_SLINT}" > /dev/null
+done
+
 # Always start from a clean "generated tests" dir
 rm -rf test/corpus/gen
 mkdir -p ./test/corpus/gen/tests/

--- a/editors/tree-sitter-slint/run_tests.sh
+++ b/editors/tree-sitter-slint/run_tests.sh
@@ -16,12 +16,11 @@ $TS build
 # Validate the editor query files against the freshly built grammar. A grammar
 # change that renames or removes a node otherwise only surfaces when an editor
 # loads the queries (e.g. Zed: Query error ... Invalid node type "comment").
-SAMPLE_SLINT="${SCRIPT_DIR}/.query-check.slint"
-trap 'rm -f "${SAMPLE_SLINT}"' EXIT
-printf 'export component Foo { /* comment */ }\n' > "${SAMPLE_SLINT}"
 for q in "${SCRIPT_DIR}"/../zed/languages/slint/*.scm; do
     echo "Validating editor query ${q}"
-    $TS query "${q}" "${SAMPLE_SLINT}" > /dev/null
+    find ../../tests/cases -name "*.slint" -exec $TS query "${q}" {} \; > /dev/null
+    find ../../examples -name "*.slint" -exec $TS query "${q}" {} \; > /dev/null
+    find ../../demos -name "*.slint" -exec $TS query "${q}" {} \; > /dev/null
 done
 
 # Always start from a clean "generated tests" dir

--- a/editors/zed/languages/slint/highlights.scm
+++ b/editors/zed/languages/slint/highlights.scm
@@ -1,7 +1,7 @@
 ;; Copyright © Luke. D Jones <luke@ljones.dev>
 ;; SPDX-License-Identifier: MIT
 
-(comment) @comment @spell
+[(line_comment) (block_comment)] @comment @spell
 
 ; Different types:
 (string_value) @string @spell

--- a/editors/zed/languages/slint/highlights.scm
+++ b/editors/zed/languages/slint/highlights.scm
@@ -56,9 +56,6 @@
 (function_call
   name: (_) @function.call)
 
-(changed_function_call
-  name: (_) @function.call)
-
 ; definitions
 (callback
   name: (_) @function)
@@ -136,23 +133,20 @@
 (property
   name: (simple_identifier) @property)
 
-(binding_alias
-  name: (simple_identifier) @property)
-
-(binding
-  name: (simple_identifier) @property)
-
-(struct_block
-  (simple_identifier) @variable.member)
-
-(anon_struct_block
-  (simple_identifier) @variable.member)
-
 (property_assignment
   property: (simple_identifier) @property)
 
-(states_definition
-  name: (simple_identifier) @variable)
+(binding_alias
+  name: (simple_identifier) @property)
+
+(struct_field_definition
+  name: (simple_identifier) @variable.member)
+
+(anon_struct_assignment
+  member: (simple_identifier) @variable.member)
+
+(property_assignment
+  property: (simple_identifier) @property)
 
 (callback
   name: (simple_identifier) @variable)
@@ -172,8 +166,9 @@
     (expression
       (simple_identifier) @property))
 
-(states_definition
-  name: (simple_identifier) @constant)
+(state_definition
+  name: (simple_identifier) @constant
+  "when" @keyword)
 
 ; Attributes:
 [
@@ -192,7 +187,14 @@
 ; Keywords:
 (animate_option_identifier) @keyword
 
-(export) @keyword
+(export_statement
+  "export" @keyword)
+
+(exported_definition
+  "export" @keyword)
+
+(export_type
+  "as" @keyword)
 
 (if_statement
   "if" @keyword.conditional)
@@ -252,10 +254,7 @@
   "property" @keyword)
 
 (states_definition
-  [
-    "states"
-    "when"
-  ] @keyword)
+  "states" @keyword)
 
 (struct_definition
   "struct" @keyword)

--- a/editors/zed/languages/slint/injections.scm
+++ b/editors/zed/languages/slint/injections.scm
@@ -1,5 +1,5 @@
 ;; Copyright © Luke. D Jones <luke@ljones.dev>
 ;; SPDX-License-Identifier: MIT
 
-((comment) @injection.content
+([(line_comment) (block_comment)] @injection.content
   (#set! injection.language "comment"))

--- a/editors/zed/languages/slint/locals.scm
+++ b/editors/zed/languages/slint/locals.scm
@@ -79,9 +79,6 @@
 (function_call
   name: (_) @local.reference)
 
-(changed_function_call
-  name: (_) @local.reference)
-
 (index_op
   index: (_) @local.reference)
 
@@ -120,4 +117,4 @@
   (#set! reference.kind "type"))
 
 (unary_expression
-  left: (_) @local.reference)
+  expr: (_) @local.reference)


### PR DESCRIPTION
The grammar split the comment node into line_comment and block_comment, so the highlights and injections queries failed to load with Invalid node type "comment". Validate the editor queries against the grammar in run_tests.sh so this is caught in CI.


Prospective fix for zed extension build
https://github.com/zed-industries/extensions/actions/runs/28106620464/job/83222521178
(Failure on https://github.com/zed-industries/extensions/pull/6610 )