### PR TITLE
feat: add no-frame option for custom tooltips

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2634,6 +2634,9 @@ export component Tooltip inherits Empty {
     /// The text to display in the tooltip.
     /// Don't set this property when using custom content.
     in property <styled-text> text;
+
+    /// If true, disables the style-provided tooltip frame, background, border, and padding.
+    in property <bool> no-frame;
     //-can_be_declared_without_children_slot
     //-is_non_item_type
 }

--- a/internal/compiler/passes/lower_tooltips.rs
+++ b/internal/compiler/passes/lower_tooltips.rs
@@ -51,6 +51,7 @@ const WIDTH: &str = "width";
 const HEIGHT: &str = "height";
 const OFFSET: &str = "offset";
 const TEXT: &str = "text";
+const NO_FRAME: &str = "no-frame";
 
 /// Report an error and replace any named reference that points to the tooltip element itself.
 /// References to the tooltip's *children* are caught later by `lower_popups::check_no_reference_to_popup`
@@ -92,6 +93,7 @@ fn build_tooltip_content(
     enclosing_component: &std::rc::Weak<Component>,
     tooltip_impl_type: &ElementType,
     tooltip_text: Option<NamedReference>,
+    tooltip_no_frame: Option<BindingExpression>,
     children: Vec<ElementRc>,
 ) -> ElementRc {
     let mut bindings = std::collections::BTreeMap::new();
@@ -100,6 +102,9 @@ fn build_tooltip_content(
             SmolStr::new_static("text"),
             RefCell::new(Expression::PropertyReference(tooltip_text).into()),
         );
+    }
+    if let Some(tooltip_no_frame) = tooltip_no_frame {
+        bindings.insert(SmolStr::new_static(NO_FRAME), RefCell::new(tooltip_no_frame));
     }
     Element {
         id: format_smolstr!("{}-content", popup_id),
@@ -418,11 +423,14 @@ fn lower_tooltips_in_component(
         let pointer_y = NamedReference::new(&tooltip_area, SmolStr::new_static(MOUSE_Y));
         let tooltip_text = (!has_custom_content)
             .then(|| NamedReference::new(&tooltip_area, SmolStr::new_static(TEXT)));
+        let tooltip_no_frame =
+            tooltip_config.borrow().bindings.get(NO_FRAME).map(|binding| binding.borrow().clone());
         let tooltip_content = build_tooltip_content(
             &popup_id,
             &enclosing_component,
             tooltip_impl_type,
             tooltip_text,
+            tooltip_no_frame,
             custom_children,
         );
         let popup_children = vec![tooltip_content.clone()];

--- a/internal/compiler/widgets/common/tooltip-base.slint
+++ b/internal/compiler/widgets/common/tooltip-base.slint
@@ -5,17 +5,18 @@ import { Palette } from "style-base.slint";
 
 export component ToolTipImpl inherits Rectangle {
     in property <styled-text> text;
+    in property <bool> no-frame;
 
-    background: Palette.alternate-background;
-    border-radius: 4px;
-    border-width: 1px;
-    border-color: Palette.border;
+    background: root.no-frame ? transparent : Palette.alternate-background;
+    border-radius: root.no-frame ? 0px : 4px;
+    border-width: root.no-frame ? 0px : 1px;
+    border-color: root.no-frame ? transparent : Palette.border;
 
     VerticalLayout {
-        padding-left: 9px;
-        padding-right: 9px;
-        padding-top: 6px;
-        padding-bottom: 6px;
+        padding-left: root.no-frame ? 0px : 9px;
+        padding-right: root.no-frame ? 0px : 9px;
+        padding-top: root.no-frame ? 0px : 6px;
+        padding-bottom: root.no-frame ? 0px : 6px;
 
         StyledText {
             text: root.text;

--- a/tests/cases/elements/tooltip_no_frame.slint
+++ b/tests/cases/elements/tooltip_no_frame.slint
@@ -1,0 +1,49 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase {
+    width: 220px;
+    height: 140px;
+
+    in-out property <bool> tooltip-created;
+
+    Rectangle {
+        x: 10px;
+        y: 10px;
+        width: 120px;
+        height: 40px;
+
+        Tooltip {
+            no-frame: true;
+
+            Rectangle {
+                width: 100px;
+                height: 50px;
+                background: #060138;
+                border-radius: 20px;
+
+                init => {
+                    root.tooltip-created = true;
+                }
+            }
+        }
+    }
+}
+
+/*
+
+```rust
+use slint::{platform::WindowEvent, LogicalPosition};
+
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_tooltip_created());
+
+instance.window().dispatch_event(WindowEvent::PointerMoved {
+    position: LogicalPosition::new(20.0, 20.0),
+});
+slint_testing::mock_elapsed_time(600);
+
+assert!(instance.get_tooltip_created());
+```
+
+*/


### PR DESCRIPTION
Adds Tooltip no-frame to let custom tooltip content opt out of the style provided frame while keeping the default Tool Tip behavior unchanged
fixes #12131.