### PR TITLE
Tree-sitter: Fix @rust-attr with multiline or string arguments

### DIFF
--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -52,7 +52,7 @@ module.exports = grammar({
       optional(seq("from", field("from", $.string_value), ";"))
     ),
 
-    _rust_attr_args: ($) => seq("(", seq(/[^()]*/, repeat(seq($._rust_attr_args, /[^()]*/))), ")"),
+    _rust_attr_args: ($) => seq("(", repeat(choice(/[^()"]+/, $.string_value, $._rust_attr_args)), ")"),
 
     rust_attr: ($) => seq(repeat1(seq("@rust-attr", $._rust_attr_args)), choice($.exported_definition, $._local_type)),
 

--- a/editors/tree-sitter-slint/test/corpus/rust_attr.txt
+++ b/editors/tree-sitter-slint/test/corpus/rust_attr.txt
@@ -1,0 +1,49 @@
+================================================================================
+rust-attr with nested and multiline arguments
+================================================================================
+
+@rust-attr(derive(
+    serde::Deserialize,
+    serde::Serialize
+))
+export struct MyData {
+    x: int,
+    y: int,
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (rust_attr
+    (exported_definition
+      (struct_definition
+        (user_type_identifier)
+        (struct_block
+          (struct_field_definition
+            (simple_identifier)
+            (type
+              (builtin_type_identifier)))
+          (struct_field_definition
+            (simple_identifier)
+            (type
+              (builtin_type_identifier))))))))
+
+================================================================================
+rust-attr with a string argument containing parentheses
+================================================================================
+
+@rust-attr(doc = "see foo(bar)")
+struct Other {
+    x: int,
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (rust_attr
+    (string_value)
+    (struct_definition
+      (user_type_identifier)
+      (struct_block
+        (struct_field_definition
+          (simple_identifier)
+          (type
+            (builtin_type_identifier)))))))


### PR DESCRIPTION
The _rust_attr_args rule used a matches-empty token that overlapped with the whitespace extras, so arguments spanning multiple lines produced ERROR nodes and broke syntax highlighting for the rest of the file. A string argument containing a parenthesis was also mis-parsed.

Match non-empty runs and handle string literals so the delimiters inside strings are ignored.

Fixes: #12223
