### PR TITLE
compiler: Fix non-finite number literals being generated as 0

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <span>
 #include <concepts>
+#include <limits>
 
 #ifndef SLINT_FEATURE_FREESTANDING
 #    include <mutex>
@@ -33,6 +34,18 @@
 namespace slint {
 
 namespace private_api {
+
+/// Saturating float-to-int cast matching Rust's `as i32` (NaN maps to 0).
+inline int saturating_float_to_int(double value)
+{
+    if (value != value) // NaN
+        return 0;
+    if (value >= std::numeric_limits<int>::max())
+        return std::numeric_limits<int>::max();
+    if (value <= std::numeric_limits<int>::min())
+        return std::numeric_limits<int>::min();
+    return static_cast<int>(value);
+}
 
 /// Convert a slint `{height: length, width: length, x: length, y: length}` to a Rect
 inline cbindgen_private::Rect convert_anonymous_rect(std::tuple<float, float, float, float> tuple)

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3811,9 +3811,14 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
     match expr {
         Expression::StringLiteral(s) => shared_string_literal(s),
         Expression::NumberLiteral(num) => {
-            if !num.is_finite() {
-                // just print something
-                "0.0".to_string()
+            if num.is_nan() {
+                "std::numeric_limits<double>::quiet_NaN()".to_string()
+            } else if num.is_infinite() {
+                if *num > 0. {
+                    "std::numeric_limits<double>::infinity()".to_string()
+                } else {
+                    "-std::numeric_limits<double>::infinity()".to_string()
+                }
             } else if num.abs() > 1_000_000_000. {
                 // If the numbers are too big, decimal notation will give too many digit
                 format!("{num:+e}")

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3912,7 +3912,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             let f = compile_expression(from, ctx);
             match (from.ty(ctx), to) {
                 (Type::Float32, Type::Int32) => {
-                    format!("static_cast<int>({f})")
+                    format!("slint::private_api::saturating_float_to_int({f})")
                 }
                 (from, Type::String) if from.as_unit_product().is_some() => {
                     format!("slint::SharedString::from_number({f})")

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2988,7 +2988,9 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                         #ignore_alt))
         },
         Expression::NumberLiteral(n) if n.is_finite() => quote!(#n),
-        Expression::NumberLiteral(_) => quote!(0.),
+        Expression::NumberLiteral(n) if n.is_nan() => quote!(f64::NAN),
+        Expression::NumberLiteral(n) if *n > 0. => quote!(f64::INFINITY),
+        Expression::NumberLiteral(_) => quote!(f64::NEG_INFINITY),
         Expression::BoolLiteral(b) => quote!(#b),
         Expression::Cast { from, to } => {
             let f = compile_expression(from, ctx);

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2987,10 +2987,19 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                         #ignore_shift,
                         #ignore_alt))
         },
-        Expression::NumberLiteral(n) if n.is_finite() => quote!(#n),
-        Expression::NumberLiteral(n) if n.is_nan() => quote!(f64::NAN),
-        Expression::NumberLiteral(n) if *n > 0. => quote!(f64::INFINITY),
-        Expression::NumberLiteral(_) => quote!(f64::NEG_INFINITY),
+        Expression::NumberLiteral(n) => {
+            if n.is_nan() {
+                quote!(f64::NAN)
+            } else if n.is_infinite() {
+                if *n > 0. {
+                    quote!(f64::INFINITY)
+                } else {
+                    quote!(f64::NEG_INFINITY)
+                }
+            } else {
+                quote!(#n)
+            }
+        }
         Expression::BoolLiteral(b) => quote!(#b),
         Expression::Cast { from, to } => {
             let f = compile_expression(from, ctx);

--- a/tests/cases/layout/max_width_infinity.slint
+++ b/tests/cases/layout/max_width_infinity.slint
@@ -1,0 +1,51 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `1px / 0` is a constant that folds to an infinite length. The generated code
+// must keep that infinity for the max-width constraint, otherwise the stretched
+// cell collapses to zero width. See issue #12213.
+
+export component TestCase inherits Rectangle {
+    width: 300phx;
+    height: 100phx;
+
+    HorizontalLayout {
+        spacing: 0phx;
+        padding: 0phx;
+        alignment: stretch;
+        r1 := Rectangle {
+            min-width: 100phx;
+            horizontal-stretch: 0;
+        }
+        r2 := Rectangle {
+            max-width: 1px / 0;
+            horizontal-stretch: 1;
+        }
+    }
+
+    out property <length> inf_length: 1px / 0;
+    out property <bool> inf_ok: inf_length > 1000000000phx;
+    out property <bool> layout_ok: r1.width == 100phx && r2.width == 200phx;
+
+    out property <bool> test: inf_ok && layout_ok;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
A constant like `max-width: 1px / 0` folds to an infinite length, but the Rust and C++ generators emitted `0` for any non-finite literal. The infinite max-width became 0, collapsing the stretched layout cell to zero width. This only showed in compiled builds; the previewer uses the interpreter, which evaluates the expression correctly.

Generate the proper infinity and NaN values instead.

Fixes: #12213
