### PR TITLE
  Make widget default font size consistent with plain Text

### DIFF
--- a/internal/compiler/widgets/cosmic/button.slint
+++ b/internal/compiler/widgets/cosmic/button.slint
@@ -62,8 +62,6 @@ export component Button {
             }
 
             if (root.text != ""): Text {
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 horizontal-alignment: center;
                 vertical-alignment: center;
                 text: root.text;

--- a/internal/compiler/widgets/cosmic/checkbox.slint
+++ b/internal/compiler/widgets/cosmic/checkbox.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { CosmicFontSettings, CosmicPalette, Icons } from "styling.slint";
+import { CosmicPalette, Icons } from "styling.slint";
 import { StateLayer } from "components.slint";
 
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> state-layer.enabled;
-    in property <length> font-size: CosmicFontSettings.body.font-size;
-    in property <int> font-weight: CosmicFontSettings.body.font-weight;
+    in property <length> font-size;
+    in property <int> font-weight;
     out property <bool> has-focus: state-layer.has-focus;
     in-out property <bool> checked;
 

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -64,8 +64,6 @@ export component ComboBox {
                 horizontal-stretch: 1;
                 horizontal-alignment: left;
                 vertical-alignment: center;
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 color: CosmicPalette.control-foreground;
                 text: root.current-value;
                 overflow: elide;

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -134,8 +134,6 @@ export component ListItem {
                 text := Text {
                     text: root.item.text;
                     color: CosmicPalette.control-foreground;
-                    font-size: CosmicFontSettings.body.font-size;
-                    font-weight: CosmicFontSettings.body.font-weight;
                     vertical-alignment: center;
                     horizontal-alignment: left;
                     overflow: elide;

--- a/internal/compiler/widgets/cosmic/datepicker.slint
+++ b/internal/compiler/widgets/cosmic/datepicker.slint
@@ -62,8 +62,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: CosmicPalette.foreground,
                   },
                   title-style: {
-                      font-size: CosmicFontSettings.body.font-size,
-                      font-weight: CosmicFontSettings.body.font-weight,
                       foreground: CosmicPalette.foreground,
                   },
                   previous-icon: Icons.arrow-back,
@@ -75,8 +73,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: CosmicPalette.foreground,
                       state-brush: CosmicPalette.state,
                       icon-size: 8px,
-                      font-size: CosmicFontSettings.body.font-size,
-                      font-weight: CosmicFontSettings.body.font-weight
                   }
             };
         }

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -38,8 +38,6 @@ export component LineEdit uses { LineEditInterface from base } {
             padding-right: 16px;
 
             base := LineEditBase {
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 selection-background-color: CosmicPalette.selection-background;
                 selection-foreground-color: CosmicPalette.accent-foreground;
                 text-color: CosmicPalette.foreground;

--- a/internal/compiler/widgets/cosmic/menu.slint
+++ b/internal/compiler/widgets/cosmic/menu.slint
@@ -22,8 +22,6 @@ export component MenuBarItem {
         pressed-foreground: CosmicPalette.accent-background;
         hover-background: CosmicPalette.state-hover;
         pressed-background: CosmicPalette.state-pressed;
-        font-size: CosmicFontSettings.body.font-size;
-        font-weight: CosmicFontSettings.body.font-weight;
         border-radius: 12px;
     }
 }
@@ -62,8 +60,6 @@ export component MenuItem {
             current-foreground: CosmicPalette.foreground;
             current-background: CosmicPalette.state-hover;
             separator-color: CosmicPalette.border;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             horizontal-padding: 16px;
             spacing: 8px;
             sub-menu-icon: @image-url("_arrow_forward.svg");

--- a/internal/compiler/widgets/cosmic/radiogroup.slint
+++ b/internal/compiler/widgets/cosmic/radiogroup.slint
@@ -51,8 +51,6 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: root.text-color;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cosmic/spinbox.slint
+++ b/internal/compiler/widgets/cosmic/spinbox.slint
@@ -22,8 +22,6 @@ export component SpinBoxButton {
         animate background, border-color { duration: 150ms; }
 
         text := Text {
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             horizontal-alignment: center;
             vertical-alignment: center;
             text: root.text;
@@ -92,8 +90,6 @@ export component SpinBox {
             base := SpinBoxBase {
                 width: 100%;
                 color: CosmicPalette.control-foreground;
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 selection-background-color: CosmicPalette.selection-background;
                 selection-foreground-color: CosmicPalette.accent-foreground;
                 horizontal-alignment: center;

--- a/internal/compiler/widgets/cosmic/styling.slint
+++ b/internal/compiler/widgets/cosmic/styling.slint
@@ -9,9 +9,9 @@ export struct TextStyle {
 }
 
 export global CosmicFontSettings {
-    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: FontWeight.normal };
-    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
-    out property <TextStyle> title: { font-size: 24 * 0.0769rem, font-weight: FontWeight.light };
+    out property <TextStyle> body: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.normal };
+    out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> title: { font-size: 24pt * 1rem / 14pt, font-weight: FontWeight.light };
 }
 
 export global CosmicPalette {

--- a/internal/compiler/widgets/cosmic/styling.slint
+++ b/internal/compiler/widgets/cosmic/styling.slint
@@ -9,7 +9,6 @@ export struct TextStyle {
 }
 
 export global CosmicFontSettings {
-    out property <TextStyle> body: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.normal };
     out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
     out property <TextStyle> title: { font-size: 24pt * 1rem / 14pt, font-weight: FontWeight.light };
 }

--- a/internal/compiler/widgets/cosmic/switch.slint
+++ b/internal/compiler/widgets/cosmic/switch.slint
@@ -100,8 +100,6 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cosmic/tableview.slint
+++ b/internal/compiler/widgets/cosmic/tableview.slint
@@ -220,8 +220,6 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: CosmicFontSettings.body.font-weight;
-                        font-size: CosmicFontSettings.body.font-size;
                         color: CosmicPalette.foreground;
                         overflow: elide;
                     }
@@ -261,8 +259,6 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: CosmicFontSettings.body.font-weight;
-                            font-size: CosmicFontSettings.body.font-size;
                             color: mod(idx, 2) == 0 ? CosmicPalette.control-foreground : CosmicPalette.foreground;
 
                             states [

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -130,7 +130,6 @@ export component TabImpl inherits Rectangle {
         text := Text {
             vertical-alignment: center;
             horizontal-alignment: center;
-            font-size: CosmicFontSettings.body.font-size;
             font-weight: root.is-current ? CosmicFontSettings.body-strong.font-weight : CosmicFontSettings.body.font-weight;
             color: root.is-current ? CosmicPalette.accent-background : CosmicPalette.control-foreground;
             accessible-role: none;

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -130,7 +130,7 @@ export component TabImpl inherits Rectangle {
         text := Text {
             vertical-alignment: center;
             horizontal-alignment: center;
-            font-weight: root.is-current ? CosmicFontSettings.body-strong.font-weight : CosmicFontSettings.body.font-weight;
+            font-weight: root.is-current ? CosmicFontSettings.body-strong.font-weight : FontWeight.normal;
             color: root.is-current ? CosmicPalette.accent-background : CosmicPalette.control-foreground;
             accessible-role: none;
         }

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -76,8 +76,6 @@ export component TextEdit {
         border-color: CosmicPalette.control-divider;
         scroll-view-padding: 12px;
         foreground: CosmicPalette.foreground;
-        font-size: CosmicFontSettings.body.font-size;
-        font-weight: CosmicFontSettings.body.font-weight;
         selection-background-color: CosmicPalette.selection-background;
         selection-foreground-color: CosmicPalette.selection-foreground;
         placeholder-color: CosmicPalette.placeholder-foreground;

--- a/internal/compiler/widgets/cosmic/time-picker.slint
+++ b/internal/compiler/widgets/cosmic/time-picker.slint
@@ -54,7 +54,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: CosmicPalette.foreground,
                     foreground-selected: CosmicPalette.accent-foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {

--- a/internal/compiler/widgets/cosmic/time-picker.slint
+++ b/internal/compiler/widgets/cosmic/time-picker.slint
@@ -70,8 +70,6 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: CosmicFontSettings.body.font-size,
-                    font-weight: CosmicFontSettings.body.font-weight,
                     foreground: CosmicPalette.foreground,
                 },
             };

--- a/internal/compiler/widgets/cupertino/button.slint
+++ b/internal/compiler/widgets/cupertino/button.slint
@@ -127,8 +127,6 @@ export component Button {
 
         if (root.text != "") : Text {
             opacity: root.enabled ? 1 : 0.5;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             horizontal-alignment: center;
             vertical-alignment: center;
             text: root.text;

--- a/internal/compiler/widgets/cupertino/checkbox.slint
+++ b/internal/compiler/widgets/cupertino/checkbox.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { CupertinoFontSettings, CupertinoPalette, Icons } from "styling.slint";
+import { CupertinoPalette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> i-touch-area.enabled;
-    in property <length> font-size: CupertinoFontSettings.body.font-size;
-    in property <int> font-weight: CupertinoFontSettings.body.font-weight;
+    in property <length> font-size;
+    in property <int> font-weight;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -99,8 +99,6 @@ export component ComboBox {
             horizontal-stretch: 1;
             horizontal-alignment: left;
             vertical-alignment: center;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             color: CupertinoPalette.foreground;
             text: root.current-value;
             overflow: elide;

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -100,8 +100,6 @@ export component ListItem {
                 i-text := Text {
                     text: root.item.text;
                     color: CupertinoPalette.foreground;
-                    font-size: CupertinoFontSettings.body.font-size;
-                    font-weight: CupertinoFontSettings.body.font-weight;
                     vertical-alignment: center;
                     horizontal-alignment: left;
                     overflow: elide;

--- a/internal/compiler/widgets/cupertino/datepicker.slint
+++ b/internal/compiler/widgets/cupertino/datepicker.slint
@@ -62,8 +62,6 @@ export component DatePickerPopup inherits PopupWindow {
                       font-weight: CupertinoFontSettings.title.font-weight,
                   },
                   title-style: {
-                      font-size: CupertinoFontSettings.body.font-size,
-                      font-weight: CupertinoFontSettings.body.font-weight,
                       foreground: CupertinoPalette.foreground,
                   },
                   previous-icon: Icons.arrow-back,
@@ -75,8 +73,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: CupertinoPalette.foreground,
                       state-brush: CupertinoPalette.state,
                       icon-size: 8px,
-                      font-size: CupertinoFontSettings.body.font-size,
-                      font-weight: CupertinoFontSettings.body.font-weight
                   }
             };
         }

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -55,8 +55,6 @@ export component LineEdit uses { LineEditInterface from base } {
             spacing: 3px;
 
             base := LineEditBase {
-                font-size: CupertinoFontSettings.body.font-size;
-                font-weight: CupertinoFontSettings.body.font-weight;
                 selection-background-color: CupertinoPalette.selection-background;
                 selection-foreground-color: CupertinoPalette.selection-foreground;
                 text-color: CupertinoPalette.foreground;

--- a/internal/compiler/widgets/cupertino/menu.slint
+++ b/internal/compiler/widgets/cupertino/menu.slint
@@ -61,8 +61,6 @@ export component MenuItem {
             current-foreground: CupertinoPalette.accent-foreground;
             current-background: CupertinoPalette.accent-background;
             separator-color: CupertinoPalette.border;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             border-radius: 5px;
             horizontal-padding: 8px;
             spacing: 4px;

--- a/internal/compiler/widgets/cupertino/radiogroup.slint
+++ b/internal/compiler/widgets/cupertino/radiogroup.slint
@@ -46,8 +46,6 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: CupertinoPalette.foreground;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cupertino/spinbox.slint
+++ b/internal/compiler/widgets/cupertino/spinbox.slint
@@ -141,8 +141,6 @@ export component SpinBox {
                 opacity: root.enabled ? 1 : 0.5;
                 width: 100%;
                 color: CupertinoPalette.foreground;
-                font-size: CupertinoFontSettings.body.font-size;
-                font-weight: CupertinoFontSettings.body.font-weight;
                 selection-background-color: CupertinoPalette.selection-background;
                 selection-foreground-color: self.color;
             }

--- a/internal/compiler/widgets/cupertino/styling.slint
+++ b/internal/compiler/widgets/cupertino/styling.slint
@@ -9,12 +9,12 @@ export struct TextStyle {
 }
 
 export global CupertinoFontSettings {
-    out property <TextStyle> body: { font-size: 13 * 0.0769rem, font-weight: FontWeight.normal };
+    out property <TextStyle> body: { font-size: 13pt * 1rem / 13pt, font-weight: FontWeight.normal };
 
-    out property <TextStyle> title: { font-size: 28 * 0.0769rem, font-weight: FontWeight.light };
+    out property <TextStyle> title: { font-size: 28pt * 1rem / 13pt, font-weight: FontWeight.light };
 
     // needed?
-    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 13pt, font-weight: FontWeight.semi-bold };
 }
 
 export global CupertinoColors {

--- a/internal/compiler/widgets/cupertino/styling.slint
+++ b/internal/compiler/widgets/cupertino/styling.slint
@@ -9,8 +9,6 @@ export struct TextStyle {
 }
 
 export global CupertinoFontSettings {
-    out property <TextStyle> body: { font-size: 13pt * 1rem / 13pt, font-weight: FontWeight.normal };
-
     out property <TextStyle> title: { font-size: 28pt * 1rem / 13pt, font-weight: FontWeight.light };
 
     // needed?

--- a/internal/compiler/widgets/cupertino/switch.slint
+++ b/internal/compiler/widgets/cupertino/switch.slint
@@ -104,8 +104,6 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cupertino/tableview.slint
+++ b/internal/compiler/widgets/cupertino/tableview.slint
@@ -217,7 +217,7 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: column.sort-order == SortOrder.unsorted ? CupertinoFontSettings.body.font-weight :
+                        font-weight: column.sort-order == SortOrder.unsorted ? FontWeight.normal :
                             CupertinoFontSettings.body-strong.font-weight;
                         color: CupertinoPalette.foreground;
                         overflow: elide;

--- a/internal/compiler/widgets/cupertino/tableview.slint
+++ b/internal/compiler/widgets/cupertino/tableview.slint
@@ -219,7 +219,6 @@ export component StandardTableView {
                         text: column.title;
                         font-weight: column.sort-order == SortOrder.unsorted ? CupertinoFontSettings.body.font-weight :
                             CupertinoFontSettings.body-strong.font-weight;
-                        font-size: CupertinoFontSettings.body.font-size;
                         color: CupertinoPalette.foreground;
                         overflow: elide;
                     }
@@ -259,8 +258,6 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: CupertinoFontSettings.body.font-weight;
-                            font-size: CupertinoFontSettings.body.font-size;
                             color: root.current-row == idx ? CupertinoPalette.accent-foreground : CupertinoPalette.foreground ;
                         }
                     }

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -170,8 +170,6 @@ export component TextEdit {
             text-input := TextInput {
                 enabled: true;
                 color: CupertinoPalette.foreground;
-                font-size: CupertinoFontSettings.body.font-size;
-                font-weight: CupertinoFontSettings.body.font-weight;
                 selection-background-color: CupertinoPalette.selection-background;
                 selection-foreground-color: self.color;
                 single-line: false;

--- a/internal/compiler/widgets/cupertino/time-picker.slint
+++ b/internal/compiler/widgets/cupertino/time-picker.slint
@@ -53,7 +53,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: CupertinoPalette.foreground,
                     foreground-selected: CupertinoPalette.foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {

--- a/internal/compiler/widgets/cupertino/time-picker.slint
+++ b/internal/compiler/widgets/cupertino/time-picker.slint
@@ -69,8 +69,6 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: CupertinoFontSettings.body.font-size,
-                    font-weight: CupertinoFontSettings.body.font-weight,
                     foreground: CupertinoPalette.foreground,
                 },
             };

--- a/internal/compiler/widgets/fluent/button.slint
+++ b/internal/compiler/widgets/fluent/button.slint
@@ -83,8 +83,6 @@ export component Button {
             }
 
             if (root.text != ""): Text {
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 horizontal-alignment: center;
                 vertical-alignment: center;
                 text: root.text;

--- a/internal/compiler/widgets/fluent/checkbox.slint
+++ b/internal/compiler/widgets/fluent/checkbox.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { FluentFontSettings, FluentPalette, Icons } from "styling.slint";
+import { FluentPalette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> touch-area.enabled;
-    in property <length> font-size: FluentFontSettings.body.font-size;
-    in property <int> font-weight: FluentFontSettings.body.font-weight;
+    in property <length> font-size;
+    in property <int> font-weight;
     out property <bool> has-focus: focus-scope.has-focus;
     in-out property <bool> checked;
 

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -79,8 +79,6 @@ export component ComboBox {
                 horizontal-stretch: 1;
                 horizontal-alignment: left;
                 vertical-alignment: center;
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 color: FluentPalette.control-foreground;
                 text: root.current-value;
                 overflow: elide;

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -85,8 +85,6 @@ export component ListItem {
             i-text := Text {
                 text: root.item.text;
                 color: FluentPalette.control-foreground;
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 vertical-alignment: center;
                 horizontal-alignment: left;
                 overflow: elide;

--- a/internal/compiler/widgets/fluent/datepicker.slint
+++ b/internal/compiler/widgets/fluent/datepicker.slint
@@ -62,8 +62,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: FluentPalette.foreground,
                   },
                   title-style: {
-                      font-size: FluentFontSettings.body.font-size,
-                      font-weight: FluentFontSettings.body.font-weight,
                       foreground: FluentPalette.foreground,
                   },
                   previous-icon: Icons.arrow-back,
@@ -75,8 +73,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: FluentPalette.foreground,
                       state-brush: FluentPalette.state,
                       icon-size: 8px,
-                      font-size: FluentFontSettings.body.font-size,
-                      font-weight: FluentFontSettings.body.font-weight
                   }
             };
         }

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -45,8 +45,6 @@ export component LineEdit uses { LineEditInterface from base } {
             padding-right: 12px;
 
             base := LineEditBase {
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 selection-background-color: FluentPalette.selection-background;
                 selection-foreground-color: FluentPalette.accent-foreground;
                 text-color: FluentPalette.foreground;

--- a/internal/compiler/widgets/fluent/menu.slint
+++ b/internal/compiler/widgets/fluent/menu.slint
@@ -22,8 +22,6 @@ export component MenuBarItem {
         pressed-foreground: FluentPalette.text-secondary;
         hover-background: FluentPalette.subtle-secondary;
         pressed-background: FluentPalette.control-alt-tertiary;
-        font-size: FluentFontSettings.body.font-size;
-        font-weight: FluentFontSettings.body.font-weight;
         border-radius: 3px;
     }
 }
@@ -67,8 +65,6 @@ export component MenuItem {
             current-foreground: FluentPalette.foreground;
             current-background: FluentPalette.subtle-secondary;
             separator-color: FluentPalette.border;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
             border-radius: 4px;
             horizontal-padding: 11px;
             spacing: 8px;

--- a/internal/compiler/widgets/fluent/radiogroup.slint
+++ b/internal/compiler/widgets/fluent/radiogroup.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { FluentFontSettings, FluentPalette } from "styling.slint";
+import { FluentPalette } from "styling.slint";
 import { RadioButtonImplBase, RadioGroupImplBase } from "../common/radiogroup-base.slint";
 import { FocusBorder } from "components.slint";
 
@@ -73,8 +73,8 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
 
 export component RadioGroupImpl inherits RadioGroupImplBase {
     title-color: !root.enabled ? FluentPalette.text-disabled : FluentPalette.control-foreground;
-    title-font-size: FluentFontSettings.body.font-size;
-    title-font-weight: FluentFontSettings.body.font-weight;
+    title-font-size: 1rem;
+    title-font-weight: FontWeight.normal;
 }
 
 export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/fluent/radiogroup.slint
+++ b/internal/compiler/widgets/fluent/radiogroup.slint
@@ -61,8 +61,6 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: root.text-color;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/fluent/spinbox.slint
+++ b/internal/compiler/widgets/fluent/spinbox.slint
@@ -97,8 +97,6 @@ export component SpinBox {
                 base := SpinBoxBase {
                     width: 100%;
                     color: FluentPalette.control-foreground;
-                    font-size: FluentFontSettings.body.font-size;
-                    font-weight: FluentFontSettings.body.font-weight;
                     selection-background-color: FluentPalette.selection-background;
                     selection-foreground-color: FluentPalette.accent-foreground;
                 }

--- a/internal/compiler/widgets/fluent/styling.slint
+++ b/internal/compiler/widgets/fluent/styling.slint
@@ -9,9 +9,9 @@ export struct TextStyle {
 }
 
 export global FluentFontSettings {
-    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: FontWeight.normal };
-    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
-    out property <TextStyle> title: { font-size: 28 * 0.0769rem, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> body: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.normal };
+    out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> title: { font-size: 28pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
 }
 
 export global FluentPalette {

--- a/internal/compiler/widgets/fluent/styling.slint
+++ b/internal/compiler/widgets/fluent/styling.slint
@@ -9,7 +9,6 @@ export struct TextStyle {
 }
 
 export global FluentFontSettings {
-    out property <TextStyle> body: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.normal };
     out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
     out property <TextStyle> title: { font-size: 28pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
 }

--- a/internal/compiler/widgets/fluent/switch.slint
+++ b/internal/compiler/widgets/fluent/switch.slint
@@ -108,8 +108,6 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/fluent/tableview.slint
+++ b/internal/compiler/widgets/fluent/tableview.slint
@@ -239,8 +239,6 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: FluentFontSettings.body.font-weight;
-                        font-size: FluentFontSettings.body.font-size;
                         color: FluentPalette.text-secondary;
                         overflow: elide;
                     }
@@ -280,8 +278,6 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: FluentFontSettings.body.font-weight;
-                            font-size: FluentFontSettings.body.font-size;
                             color: mod(idx, 2) == 0 ? FluentPalette.control-foreground : FluentPalette.text-secondary;
                         }
                     }

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -82,8 +82,8 @@ export component TabImpl inherits Rectangle {
         i-text := Text {
             vertical-alignment: center;
             horizontal-alignment: left;
-            font-size: root.is-current ? FluentFontSettings.body-strong.font-size : FluentFontSettings.body.font-size;
-            font-weight: root.is-current ? FluentFontSettings.body-strong.font-weight : FluentFontSettings.body.font-weight;
+            font-size: root.is-current ? FluentFontSettings.body-strong.font-size : 1rem;
+            font-weight: root.is-current ? FluentFontSettings.body-strong.font-weight : FontWeight.normal;
             color: root.is-current ? FluentPalette.control-foreground : FluentPalette.text-secondary;
             accessible-role: none;
         }

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -83,8 +83,6 @@ export component TextEdit {
         border-color: FluentPalette.text-control-border;
         scroll-view-padding: 12px;
         foreground: FluentPalette.foreground;
-        font-size: FluentFontSettings.body.font-size;
-        font-weight: FluentFontSettings.body.font-weight;
         placeholder-color: FluentPalette.text-secondary;
         selection-background-color: FluentPalette.selection-background;
         selection-foreground-color: FluentPalette.selection-foreground;

--- a/internal/compiler/widgets/fluent/time-picker.slint
+++ b/internal/compiler/widgets/fluent/time-picker.slint
@@ -68,8 +68,6 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: FluentFontSettings.body.font-size,
-                    font-weight: FluentFontSettings.body.font-weight,
                     foreground: FluentPalette.foreground,
                 },
             };

--- a/internal/compiler/widgets/fluent/time-picker.slint
+++ b/internal/compiler/widgets/fluent/time-picker.slint
@@ -52,7 +52,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: FluentPalette.foreground,
                     foreground-selected: FluentPalette.accent-foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {

--- a/internal/compiler/widgets/material/radiogroup.slint
+++ b/internal/compiler/widgets/material/radiogroup.slint
@@ -58,8 +58,8 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: root.text-color;
-            font-size: MaterialFontSettings.body-large.font-size;
-            font-weight: MaterialFontSettings.body-large.font-weight;
+            font-size: MaterialFontSettings.title-small.font-size;
+            font-weight: MaterialFontSettings.title-small.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }
@@ -68,8 +68,8 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
 
 export component RadioGroupImpl inherits RadioGroupImplBase {
     title-color: !root.enabled ? MaterialPalette.control-foreground-variant : MaterialPalette.foreground;
-    title-font-size: MaterialFontSettings.body-large.font-size;
-    title-font-weight: MaterialFontSettings.body-large.font-weight;
+    title-font-size: MaterialFontSettings.title-small.font-size;
+    title-font-weight: MaterialFontSettings.title-small.font-weight;
 }
 
 export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/material/styling.slint
+++ b/internal/compiler/widgets/material/styling.slint
@@ -8,12 +8,12 @@ import { ColorSchemeSelector } from "color-scheme.slint";
 struct TextStyle { font-size: relative-font-size, font-weight: int}
 
 export global MaterialFontSettings {
-    out property <TextStyle> label-large: { font-size: 14pt * 1rem / 16pt, font-weight: FontWeight.medium };
-    out property <TextStyle> label-medium: { font-size: 12pt * 1rem / 16pt, font-weight: FontWeight.medium };
-    out property <TextStyle> body-large: { font-size: 16pt * 1rem / 16pt, font-weight: FontWeight.normal };
-    out property <TextStyle> body-small: { font-size: 12pt * 1rem / 16pt, font-weight: FontWeight.normal };
-    out property <TextStyle> title-small: { font-size: 14pt * 1rem / 16pt, font-weight: FontWeight.medium };
-    out property <TextStyle> headline-large: { font-size: 32pt * 1rem / 16pt, font-weight: FontWeight.medium };
+    out property <TextStyle> label-large: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.medium };
+    out property <TextStyle> label-medium: { font-size: 12pt * 1rem / 14pt, font-weight: FontWeight.medium };
+    out property <TextStyle> body-large: { font-size: 16pt * 1rem / 14pt, font-weight: FontWeight.normal };
+    out property <TextStyle> body-small: { font-size: 12pt * 1rem / 14pt, font-weight: FontWeight.normal };
+    out property <TextStyle> title-small: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.medium };
+    out property <TextStyle> headline-large: { font-size: 32pt * 1rem / 14pt, font-weight: FontWeight.medium };
 }
 
 export global Elevation {

--- a/internal/compiler/widgets/material/styling.slint
+++ b/internal/compiler/widgets/material/styling.slint
@@ -8,12 +8,12 @@ import { ColorSchemeSelector } from "color-scheme.slint";
 struct TextStyle { font-size: relative-font-size, font-weight: int}
 
 export global MaterialFontSettings {
-    out property <TextStyle> label-large: { font-size: 14 * 0.0625rem, font-weight: FontWeight.medium };
-    out property <TextStyle> label-medium: { font-size: 12 * 0.0625rem, font-weight: FontWeight.medium };
-    out property <TextStyle> body-large: { font-size: 16 * 0.0625rem, font-weight: FontWeight.normal };
-    out property <TextStyle> body-small: { font-size: 12 * 0.0625rem, font-weight: FontWeight.normal };
-    out property <TextStyle> title-small: { font-size: 14 * 0.0625rem, font-weight: FontWeight.medium };
-    out property <TextStyle> headline-large: { font-size: 32 * 0.0625rem, font-weight: FontWeight.medium };
+    out property <TextStyle> label-large: { font-size: 14pt * 1rem / 16pt, font-weight: FontWeight.medium };
+    out property <TextStyle> label-medium: { font-size: 12pt * 1rem / 16pt, font-weight: FontWeight.medium };
+    out property <TextStyle> body-large: { font-size: 16pt * 1rem / 16pt, font-weight: FontWeight.normal };
+    out property <TextStyle> body-small: { font-size: 12pt * 1rem / 16pt, font-weight: FontWeight.normal };
+    out property <TextStyle> title-small: { font-size: 14pt * 1rem / 16pt, font-weight: FontWeight.medium };
+    out property <TextStyle> headline-large: { font-size: 32pt * 1rem / 16pt, font-weight: FontWeight.medium };
 }
 
 export global Elevation {

--- a/internal/compiler/widgets/material/time-picker.slint
+++ b/internal/compiler/widgets/material/time-picker.slint
@@ -54,7 +54,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: MaterialPalette.foreground,
                     foreground-selected: MaterialPalette.foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {

--- a/internal/compiler/widgets/qt/time-picker.slint
+++ b/internal/compiler/widgets/qt/time-picker.slint
@@ -45,7 +45,7 @@ export component TimePickerPopup inherits PopupWindow {
                     time-selector-style: {
                         foreground: Palette.foreground,
                         foreground-selected: Palette.accent-foreground,
-                        font-size: 12 * 0.0625rem,
+                        font-size: 12pt * 1rem / 16pt,
                         font-weight: FontWeight.normal
                     }
                 },
@@ -55,7 +55,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: Palette.foreground,
                     foreground-selected: Palette.foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {
@@ -63,7 +63,7 @@ export component TimePickerPopup inherits PopupWindow {
                     border-width: 1px,
                     border-brush: Palette.border,
                     item-style: {
-                        font-size: 14 * 0.0625rem,
+                        font-size: 14pt * 1rem / 16pt,
                         font-weight: FontWeight.normal,
                         foreground: Palette.foreground,
                         background-selected: Palette.accent-background,
@@ -71,7 +71,7 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: 12 * 0.0625rem,
+                    font-size: 12pt * 1rem / 16pt,
                     font-weight: FontWeight.light,
                     foreground: Palette.foreground,
                 },

--- a/tests/cases/widgets/textedit.slint
+++ b/tests/cases/widgets/textedit.slint
@@ -11,6 +11,8 @@ export component TestCase inherits Window {
     edit := TextEdit {
         width: 100%;
         height: 100%;
+        // Pin the font size so the page navigation lands at the same spot in every style.
+        font-size: 1rem;
     }
 
     forward-focus: edit;


### PR DESCRIPTION
Widgets rendered their default text at a different size than a plain `Text {}`, so e.g. a `Switch` label didn't match adjacent text.
  
  - Fluent & Cosmic: body text used `14/13 rem`; anchor it to `1rem` so it matches a plain `Text`.
  - Express all theme font sizes as their design-spec point sizes over the base that maps to `1rem` (e.g. `28pt * 1rem / 14pt`) instead of magic factors.
  - Material: anchor `1rem` to the 14sp default text size (Body Medium / the
    platform default font) instead of Body Large (16sp), so normal labels match a plain `Text` while `LineEdit` (Body Large) stays larger, per the M3 spec.
  - Drop now-redundant `font-size`/`font-weight: …body…` bindings on plain `Text`  elements (they just re-set the default).

Fixes https://github.com/slint-ui/slint/issues/12226