### PR TITLE
ci: Ensure the nightly snapshot builds against fresh cross containers

### DIFF
--- a/.github/workflows/cross_containers.yaml
+++ b/.github/workflows/cross_containers.yaml
@@ -1,0 +1,51 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+# Build and push the `cross` container images used to cross-compile for embedded
+# (MPU) targets. Other workflows (the nightly snapshot, cross_containers_and_demos)
+# call this so their `cross` builds run against freshly built images.
+name: Cross Containers
+
+on:
+    workflow_dispatch:
+    workflow_call:
+
+jobs:
+    build_containers:
+        runs-on: ubuntu-22.04
+        strategy:
+            matrix:
+                target:
+                    - armv7-unknown-linux-gnueabihf
+                    - aarch64-unknown-linux-gnu
+                    - riscv64gc-unknown-linux-gnu
+                    - x86_64-unknown-linux-gnu
+        env:
+            SLINT_NO_QT: 1
+            SLINT_STYLE: fluent
+        steps:
+            - uses: actions/checkout@v6
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v4
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.CR_PAT }}
+            - name: Build and push
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: ./docker/Dockerfile.${{ matrix.target }}
+                  push: true
+                  tags: ghcr.io/slint-ui/slint/${{matrix.target}}:latest
+            - name: Build and push C++ image
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: ./docker/Dockerfile.cpp-image
+                  push: true
+                  tags: ghcr.io/slint-ui/slint/${{matrix.target}}-cpp:latest
+                  build-args: |
+                      arch=${{matrix.target}}

--- a/.github/workflows/cross_containers_and_demos.yaml
+++ b/.github/workflows/cross_containers_and_demos.yaml
@@ -1,53 +1,17 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-name: Embedded Build
+name: Cross Containers and Demos
 
+# No schedule: this is triggered manually (workflow_dispatch). Fresh containers for
+# the nightly snapshot come from the nightly workflow calling cross_containers.yaml.
 on:
     workflow_dispatch:
 
-    schedule:
-        - cron: "0 1 * * *"
-
 jobs:
     build_containers:
-        runs-on: ubuntu-22.04
-        strategy:
-            matrix:
-                target:
-                    - armv7-unknown-linux-gnueabihf
-                    - aarch64-unknown-linux-gnu
-                    - riscv64gc-unknown-linux-gnu
-                    - x86_64-unknown-linux-gnu
-        env:
-            SLINT_NO_QT: 1
-            SLINT_STYLE: fluent
-        steps:
-            - uses: actions/checkout@v6
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v4
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.CR_PAT }}
-            - name: Build and push
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  file: ./docker/Dockerfile.${{ matrix.target }}
-                  push: true
-                  tags: ghcr.io/slint-ui/slint/${{matrix.target}}:latest
-            - name: Build and push C++ image
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  file: ./docker/Dockerfile.cpp-image
-                  push: true
-                  tags: ghcr.io/slint-ui/slint/${{matrix.target}}-cpp:latest
-                  build-args: |
-                      arch=${{matrix.target}}
+        uses: ./.github/workflows/cross_containers.yaml
+        secrets: inherit
 
     build_demos:
         needs: [build_containers]

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -29,7 +29,15 @@ env:
     CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
 
 jobs:
+    # Rebuild and push the `cross` container images first, so every `cross` build
+    # below (the ARM tool binaries and the cross LSP) runs against images built
+    # from this commit rather than stale ones.
+    cross_containers:
+        uses: ./.github/workflows/cross_containers.yaml
+        secrets: inherit
+
     slint-viewer-binary:
+        needs: [cross_containers]
         uses: ./.github/workflows/slint_tool_binary.yaml
         with:
             program: "viewer"
@@ -39,6 +47,7 @@ jobs:
             keychain_password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
             developer_id: ${{ secrets.APPLE_DEV_ID }}
     slint-lsp-binary:
+        needs: [cross_containers]
         uses: ./.github/workflows/slint_tool_binary.yaml
         with:
             program: "lsp"
@@ -196,6 +205,7 @@ jobs:
                   path: .
 
     build_vscode_cross_linux_lsp:
+        needs: [cross_containers]
         env:
             SLINT_NO_QT: 1
         strategy:


### PR DESCRIPTION
The nightly tool binaries cross-compile inside container images that were only rebuilt on a separate daily schedule. When that schedule lagged behind, the nightly silently used stale containers, producing binaries that did not match the current sources.

Make the container build a dependency the nightly drives itself, so fresh images are guaranteed before any cross build runs and the two can no longer drift apart.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
