### PR TITLE
Fix TextEdit scroll behavior on cursor movement

### DIFF
--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -127,16 +127,26 @@ export component TextEditBase inherits Rectangle {
                 }
 
                 cursor-position-changed(cpos) => {
-                    if (cpos.x + root.viewport-x < 12px) {
-                        root.viewport-x = min(0px, max(parent.visible-width - self.width,  - cpos.x + 12px));
-                    } else if (cpos.x + root.viewport-x > parent.visible-width - 12px) {
-                        root.viewport-x = min(0px, max(parent.visible-width - self.width,  parent.visible-width - cpos.x - 12px));
+                    if (cpos.x + root.viewport-x < 0px) {
+                        root.viewport-x = min(0px, max(parent.visible-width - self.width, -cpos.x));
+                    } else if (cpos.x + root.viewport-x > parent.visible-width) {
+                        root.viewport-x = min(0px, max(parent.visible-width - self.width, parent.visible-width - cpos.x));
                     }
-                    if (cpos.y + root.viewport-y < 12px) {
-                        root.viewport-y = min(0px, max(parent.visible-height - self.height,  - cpos.y + 12px));
-                    } else if (cpos.y + root.viewport-y > parent.visible-height - 12px - 20px) {
+
+                    if (cpos.y + root.viewport-y < 0px) {
+                        root.viewport-y = min(
+                            0px,
+
+                            // This prevents jumping back and forth between this case and the
+                            // else if on each cursor movement. This means that if the visible
+                            // height is less than the line height we align on the cursor bottom.
+                            parent.visible-height - cpos.y - 20px,
+
+                            max(parent.visible-height - self.height, -cpos.y),
+                        );
+                    } else if (cpos.y + root.viewport-y > parent.visible-height - 20px) {
                         // FIXME: font-height hardcoded to 20px
-                            root.viewport-y = min(0px, max(parent.visible-height - self.height,  parent.visible-height - cpos.y - 12px - 20px));
+                        root.viewport-y = min(0px, max(parent.visible-height - self.height, parent.visible-height - cpos.y - 20px));
                     }
                 }
             }

--- a/tests/cases/issues/issue_10496_text_cursor_movement.slint
+++ b/tests/cases/issues/issue_10496_text_cursor_movement.slint
@@ -1,0 +1,38 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { TextEdit } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 80px;
+    height: 32px;
+    forward-focus: edit;
+    out property viewport-y <=> edit.viewport-y;
+
+    public function set-selection-offsets(start: int, end: int) {
+        edit.set-selection-offsets(start, end);
+    }
+
+    edit := TextEdit {
+        text: "Abc\nabc\nabc";
+        font-family: "FixedTestFont";
+    }
+}
+
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+instance.show().unwrap();
+
+instance.invoke_set_selection_offsets(11, 11);
+
+slint_testing::send_keyboard_string_sequence(&instance, "a");
+
+let y = instance.get_viewport_y();
+
+slint_testing::send_keyboard_string_sequence(&instance, "b");
+
+assert_eq!(instance.get_viewport_y(), y);
+```
+*/


### PR DESCRIPTION
This fixes #10496.

Previously if the height of the text field didn't have the right height it would bounce back and forth between the the `if` and the `else if` conditions with every cursor movement. Because of the hardcoded 20px that isn't necessarily only if the height of the TextEdit is less than the line height, but also happens with a bit more.

An alternative fix would be to just change the `else if` to a separate `if` such that the lower condition always wins, but it seemed a bit unclean to me to assign `viewport-y` twice and it could also cause confusion when reading the code.

As far as I can tell the 12px were intended to subtract the padding. It seems to have been introduced in https://github.com/slint-ui/slint/commit/e3486542d825ef5197bb40e0813dab7434cd97ce when `scroll-view-padding` didn't exist yet. But since the padding is outside the `ScrollView` the coordinates are already relative to that. So my interpretation is that that must already have been a bug back then, but I'm not fully sure.

I wasn't quite sure where to best add a test. `tests/cases/widgets/textedit.slint` didn't seem like the right place because there's only a single `TextEdit` there with a fixed height and the issue only reproduces with a low enough height. I decided to put a test in `tests/cases/issues`. I hope that makes sense.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
