### PR TITLE
text: Use OPERATING_SYSTEM_OVERRIDE for the cross-platform cursor col…

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1433,22 +1433,15 @@ impl TextInputVisualRepresentation {
     }
 }
 
-/// Whether the running process is the screenshot test driver. The text cursor color is
-/// platform-dependent (see [`TextInput::visual_representation`]); in the screenshot tests we pick
-/// the cross-platform color so the references match regardless of the host OS.
-fn running_in_screenshot_test() -> bool {
-    #[cfg(feature = "std")]
-    {
-        // Read the environment once: this is queried while drawing the cursor every frame.
-        static IS_SCREENSHOT_TEST: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-            std::env::var_os("CARGO_PKG_NAME").is_some_and(|v| v == "test-driver-screenshots")
-        });
-        *IS_SCREENSHOT_TEST
-    }
-    #[cfg(not(feature = "std"))]
-    {
-        false
-    }
+/// Whether the text cursor is drawn in the selection color (Apple and Android platforms) rather
+/// than in the text color.
+fn cursor_uses_selection_color() -> bool {
+    matches!(
+        crate::detect_operating_system(),
+        crate::items::OperatingSystemType::Android
+            | crate::items::OperatingSystemType::Ios
+            | crate::items::OperatingSystemType::Macos
+    )
 }
 
 impl TextInput {
@@ -2005,17 +1998,14 @@ impl TextInput {
 
         let text_color = self.color();
 
-        let cursor_color = if cfg!(any(target_os = "android", target_vendor = "apple"))
-            && !running_in_screenshot_test()
-        {
+        let cursor_color = if cursor_uses_selection_color() {
             if cursor_position.is_some() {
                 self.selection_background_color().with_alpha(1.)
             } else {
                 Default::default()
             }
         } else {
-            // Other platforms (and the screenshot tests, so references match regardless of host OS)
-            // draw the cursor in the text color.
+            // Other platforms draw the cursor in the text color.
             text_color.color()
         };
 

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -145,6 +145,13 @@ pub fn detect_operating_system() -> OperatingSystemType {
         return os_override;
     }
 
+    // Querying the navigator involves a round-trip to JavaScript and some string processing, so
+    // cache the result: it cannot change for the lifetime of the page.
+    thread_local!(static DETECTED: core::cell::Cell<Option<OperatingSystemType>> = Default::default());
+    if let Some(detected) = DETECTED.with(|detected| detected.get()) {
+        return detected;
+    }
+
     let mut user_agent =
         web_sys::window().and_then(|w| w.navigator().user_agent().ok()).unwrap_or_default();
     user_agent.make_ascii_lowercase();
@@ -152,7 +159,7 @@ pub fn detect_operating_system() -> OperatingSystemType {
         web_sys::window().and_then(|w| w.navigator().platform().ok()).unwrap_or_default();
     platform.make_ascii_lowercase();
 
-    if user_agent.contains("ipad") || user_agent.contains("iphone") {
+    let detected = if user_agent.contains("ipad") || user_agent.contains("iphone") {
         OperatingSystemType::Ios
     } else if user_agent.contains("android") {
         OperatingSystemType::Android
@@ -164,7 +171,9 @@ pub fn detect_operating_system() -> OperatingSystemType {
         OperatingSystemType::Linux
     } else {
         OperatingSystemType::Other
-    }
+    };
+    DETECTED.with(|cache| cache.set(Some(detected)));
+    detected
 }
 
 /// Returns true if the current platform is an Apple platform (macOS, iOS, iPadOS)

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -147,33 +147,29 @@ pub fn detect_operating_system() -> OperatingSystemType {
 
     // Querying the navigator involves a round-trip to JavaScript and some string processing, so
     // cache the result: it cannot change for the lifetime of the page.
-    thread_local!(static DETECTED: core::cell::Cell<Option<OperatingSystemType>> = Default::default());
-    if let Some(detected) = DETECTED.with(|detected| detected.get()) {
-        return detected;
-    }
+    static DETECTED: std::sync::LazyLock<OperatingSystemType> = std::sync::LazyLock::new(|| {
+        let mut user_agent =
+            web_sys::window().and_then(|w| w.navigator().user_agent().ok()).unwrap_or_default();
+        user_agent.make_ascii_lowercase();
+        let mut platform =
+            web_sys::window().and_then(|w| w.navigator().platform().ok()).unwrap_or_default();
+        platform.make_ascii_lowercase();
 
-    let mut user_agent =
-        web_sys::window().and_then(|w| w.navigator().user_agent().ok()).unwrap_or_default();
-    user_agent.make_ascii_lowercase();
-    let mut platform =
-        web_sys::window().and_then(|w| w.navigator().platform().ok()).unwrap_or_default();
-    platform.make_ascii_lowercase();
-
-    let detected = if user_agent.contains("ipad") || user_agent.contains("iphone") {
-        OperatingSystemType::Ios
-    } else if user_agent.contains("android") {
-        OperatingSystemType::Android
-    } else if platform.starts_with("mac") {
-        OperatingSystemType::Macos
-    } else if platform.starts_with("win") {
-        OperatingSystemType::Windows
-    } else if platform.starts_with("linux") {
-        OperatingSystemType::Linux
-    } else {
-        OperatingSystemType::Other
-    };
-    DETECTED.with(|cache| cache.set(Some(detected)));
-    detected
+        if user_agent.contains("ipad") || user_agent.contains("iphone") {
+            OperatingSystemType::Ios
+        } else if user_agent.contains("android") {
+            OperatingSystemType::Android
+        } else if platform.starts_with("mac") {
+            OperatingSystemType::Macos
+        } else if platform.starts_with("win") {
+            OperatingSystemType::Windows
+        } else if platform.starts_with("linux") {
+            OperatingSystemType::Linux
+        } else {
+            OperatingSystemType::Other
+        }
+    });
+    *DETECTED
 }
 
 /// Returns true if the current platform is an Apple platform (macOS, iOS, iPadOS)

--- a/tests/screenshots/skia.rs
+++ b/tests/screenshots/skia.rs
@@ -63,6 +63,8 @@ impl WindowAdapter for SkiaScreenshotWindow {
 }
 
 pub fn init_skia() {
+    crate::testing::force_reference_os();
+
     i_slint_core::platform::set_platform(Box::new(SkiaScreenshotBackend::default()))
         .expect("platform already initialized");
 }

--- a/tests/screenshots/software.rs
+++ b/tests/screenshots/software.rs
@@ -30,6 +30,8 @@ impl i_slint_core::platform::Platform for SwrTestingBackend {
 }
 
 pub fn init_swr() -> Rc<MinimalSoftwareWindow> {
+    crate::testing::force_reference_os();
+
     let window = MinimalSoftwareWindow::new(
         slint::platform::software_renderer::RepaintBufferType::ReusedBuffer,
     );

--- a/tests/screenshots/testing.rs
+++ b/tests/screenshots/testing.rs
@@ -18,6 +18,13 @@ pub enum RenderingRotation {
     Rotate270,
 }
 
+/// Force a cross-platform OS so OS-dependent rendering (e.g. the text cursor color) matches the
+/// references regardless of the host OS.
+pub fn force_reference_os() {
+    i_slint_core::OPERATING_SYSTEM_OVERRIDE
+        .set(Some(i_slint_core::items::OperatingSystemType::Linux));
+}
+
 pub fn image_buffer(path: &str) -> Result<SharedPixelBuffer<Rgba8Pixel>, image::ImageError> {
     image::open(path).map(|image| {
         let image = image.into_rgba8();


### PR DESCRIPTION
…or in tests

The text cursor color is platform-dependent. Instead of sniffing the CARGO_PKG_NAME env var to detect the screenshot test driver, query the operating system at runtime via detect_operating_system() (which honors OPERATING_SYSTEM_OVERRIDE) and have the screenshot drivers force a cross-platform OS so the references match regardless of the host OS.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
