### PR TITLE
nightly: auto-trigger PyPI and npm publish on release

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -731,10 +731,18 @@ jobs:
         needs: [prepare_release]
         runs-on: ubuntu-latest
         steps:
-            - name: Trigger PyPI publish
+            - name: Trigger PyPI publish (slint)
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: gh workflow run upload_pypi.yaml --ref ${{ github.ref_name }} --repo ${{ github.repository }} -f release=true
+            - name: Trigger PyPI publish (slint-compiler)
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh workflow run upload_pypi_slint_compiler.yaml --ref ${{ github.ref_name }} --repo ${{ github.repository }} -f release=true
+            - name: Trigger PyPI publish (briefcasex-slint)
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh workflow run upload_pypi_briefcase.yaml --ref ${{ github.ref_name }} --repo ${{ github.repository }} -f release=true
             - name: Trigger npm publish
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -726,6 +726,20 @@ jobs:
                 https://api.github.com/repos/slint-ui/slint-cpp-templates-stm32/actions/workflows/ci.yaml/dispatches \
                 -d '{"ref":"main"}'
 
+    trigger_package_publishing:
+        if: github.event.inputs.mode == 'release'
+        needs: [prepare_release]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Trigger PyPI publish
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh workflow run upload_pypi.yaml --ref ${{ github.ref_name }} --repo ${{ github.repository }} -f release=true
+            - name: Trigger npm publish
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh workflow run publish_npm_package.yaml --ref ${{ github.ref_name }} --repo ${{ github.repository }} -f private=false -f release=true
+
     android:
         env:
             CARGO_APK_RELEASE_KEYSTORE: /home/runner/.android/release.keystore

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -78,11 +78,8 @@ In the mean time, the version in the master branch can be updated
     Before running the script, make sure that your working directory is clean and that you are checked out on the same commit as the one for which the nightly_snapshot.
     - If new crates were uploaded to crates.io, go to the crates.io settings and send permission invitations
 
- - **Publish to npm:** Trigger a build on https://github.com/slint-ui/slint/actions/workflows/publish_npm_package.yaml
-    Select the right `pre-release/x.y` branch, and choose false for private and true for release.
-
- - **Publish to PyPi:** Trigger a build on the following workflows on the right branch and choose `true` for release.
-   The deployments will also need to be approved
+ - **Approve to Python Package Index Uploads:** The nightly snapshot workflow also kicks off the different uploads for the Python Package Index. When completed,
+   the deployments from the following jobs will need to be approved (GitHub notifies about pending approvals):
   - https://github.com/slint-ui/slint/actions/workflows/upload_pypi.yaml
   - https://github.com/slint-ui/slint/actions/workflows/upload_pypi_briefcase.yaml
   - https://github.com/slint-ui/slint/actions/workflows/upload_pypi_slint_compiler.yaml


### PR DESCRIPTION
When the nightly snapshot runs with mode=release, dispatch the upload_pypi.yaml and publish_npm_package.yaml workflows automatically after prepare_release succeeds, instead of triggering them by hand.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
