### PR TITLE
Warn about a DragArea with no data set

### DIFF
--- a/internal/compiler/passes/check_drag_area.rs
+++ b/internal/compiler/passes/check_drag_area.rs
@@ -29,7 +29,7 @@ pub fn check_drag_area(component: &Component, diag: &mut BuildDiagnostics) {
             if !elem.borrow().is_property_set("data") {
                 diag.push_warning(
                     "This 'DragArea' has no 'data' set and will never start a drag; \
-                     bind 'data' to the value to drag"
+                     add a binding for the 'data' property"
                         .into(),
                     &*elem.borrow(),
                 );

--- a/internal/compiler/passes/check_drag_area.rs
+++ b/internal/compiler/passes/check_drag_area.rs
@@ -1,8 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! This pass warns about a `DragArea` that permits no drag action, i.e. none of
-//! `allow-copy`, `allow-move`, or `allow-link` is set. Such a `DragArea` never starts a drag.
+//! This pass warns about a `DragArea` that never starts a drag, either because
+//! it permits no drag action (none of `allow-copy`, `allow-move`, or
+//! `allow-link` is set) or because its `data` payload is left unset.
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::object_tree::{Component, ElementRc};
@@ -17,15 +18,22 @@ pub fn check_drag_area(component: &Component, diag: &mut BuildDiagnostics) {
             if !is_drag_area(elem) {
                 return;
             }
-            if ALLOW_PROPERTIES.iter().any(|prop| elem.borrow().is_property_set(prop)) {
-                return;
+            if !ALLOW_PROPERTIES.iter().any(|prop| elem.borrow().is_property_set(prop)) {
+                diag.push_warning(
+                    "This 'DragArea' permits no drag action and will never start a drag; \
+                     set 'allow-copy', 'allow-move', or 'allow-link' to true"
+                        .into(),
+                    &*elem.borrow(),
+                );
             }
-            diag.push_warning(
-                "This 'DragArea' permits no drag action and will never start a drag; \
-                 set 'allow-copy', 'allow-move', or 'allow-link' to true"
-                    .into(),
-                &*elem.borrow(),
-            );
+            if !elem.borrow().is_property_set("data") {
+                diag.push_warning(
+                    "This 'DragArea' has no 'data' set and will never start a drag; \
+                     bind 'data' to the value to drag"
+                        .into(),
+                    &*elem.borrow(),
+                );
+            }
         },
     );
 }

--- a/internal/compiler/tests/syntax/elements/dragarea.slint
+++ b/internal/compiler/tests/syntax/elements/dragarea.slint
@@ -5,11 +5,11 @@ export component Test {
     // No allowed action and no data: warns about both.
     DragArea { }
 //  >       <warning{This 'DragArea' permits no drag action and will never start a drag; set 'allow-copy', 'allow-move', or 'allow-link' to true}
-//  >       <^warning{This 'DragArea' has no 'data' set and will never start a drag; bind 'data' to the value to drag}
+//  >       <^warning{This 'DragArea' has no 'data' set and will never start a drag; add a binding for the 'data' property}
 
     // Allowed action but no data: warns about the data only.
     DragArea {
-//  >       <warning{This 'DragArea' has no 'data' set and will never start a drag; bind 'data' to the value to drag}
+//  >       <warning{This 'DragArea' has no 'data' set and will never start a drag; add a binding for the 'data' property}
         allow-move: true;
     }
 

--- a/internal/compiler/tests/syntax/elements/dragarea.slint
+++ b/internal/compiler/tests/syntax/elements/dragarea.slint
@@ -2,18 +2,22 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component Test {
-    // No allowed action: warns.
+    // No allowed action and no data: warns about both.
     DragArea { }
 //  >       <warning{This 'DragArea' permits no drag action and will never start a drag; set 'allow-copy', 'allow-move', or 'allow-link' to true}
+//  >       <^warning{This 'DragArea' has no 'data' set and will never start a drag; bind 'data' to the value to drag}
 
-    // At least one allowed action: fine.
+    // Allowed action but no data: warns about the data only.
     DragArea {
+//  >       <warning{This 'DragArea' has no 'data' set and will never start a drag; bind 'data' to the value to drag}
         allow-move: true;
     }
 
-    // Inherited allowed action: fine.
+    // Allowed action and data set: fine.
     DragArea {
         allow-copy: my-flag;
         property <bool> my-flag: true;
+        data <=> my-data;
     }
+    in property <data-transfer> my-data;
 }


### PR DESCRIPTION
A DragArea whose data property is left unset never starts a drag, so warn about it like we already do for one that permits no drag action.

Asked in https://github.com/slint-ui/slint/issues/1967#issuecomment-4799679050