### PR TITLE
Replace the CLA with a clear MIT-0 contribution statement

### DIFF
--- a/.github/workflows/issue_triage.yaml
+++ b/.github/workflows/issue_triage.yaml
@@ -1,11 +1,13 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-name: Auto-triage on Comment
+name: Issue triage and PR welcome
 
 on:
   issue_comment:
     types: [created]
+  pull_request_target:
+    types: [opened]
 
 permissions:
   issues: write
@@ -13,6 +15,7 @@ permissions:
 
 jobs:
   update_labels:
+    if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - name: Check whether we should update the tags
@@ -34,3 +37,39 @@ jobs:
         run: |
           gh api --method DELETE -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/needs%20info
           gh api --method POST -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels -f labels[]='need triaging'
+
+  welcome_first_time_contributor:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+       github.event.pull_request.author_association == 'FIRST_TIMER')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post welcome comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Slint team members opening their first PR don't need the welcome:
+          # skip when a commit is authored from a @slint.dev address or the
+          # author is a member of the organization that owns the repository.
+          ORG="${REPO%%/*}"
+          if gh api "/repos/$REPO/pulls/$PR/commits" --jq '.[].commit.author.email' | grep -qiE '@slint\.dev$' \
+             || gh api "/orgs/$ORG/members/$AUTHOR" >/dev/null 2>&1; then
+            echo "Author is a Slint team or organization member; skipping welcome."
+            exit 0
+          fi
+          gh pr comment "$PR" --repo "$REPO" --body-file - <<'EOF'
+          👋 Welcome, and thank you for your first contribution to Slint!
+
+          If you haven't yet, take a look at our [CONTRIBUTING.md](https://github.com/slint-ui/slint/blob/master/CONTRIBUTING.md).
+
+          We're a small team, and reviews can take a while. If you don't hear back, nudge us in our [public chat](https://chat.slint.dev) so your pull request doesn't slip through the cracks.
+
+          📄 **Licensing:** by opening this pull request, you agree to license your contribution under the [MIT No Attribution license (MIT-0)](https://opensource.org/license/mit-0).
+          This keeps Slint flexible to license, while leaving you free to reuse your own code in other projects.
+          Make sure you wrote it yourself, and that no third party — such as your employer — holds rights to it; if not, tell us first.
+          If you don't agree, close this pull request and let us know.
+          EOF

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -1,0 +1,110 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+# Checks a pull request has to pass before it can be merged, one job per check,
+# so each one can be required separately in the branch ruleset.
+#
+# `pull_request_target` runs with the secrets of this repository, so this
+# workflow never checks out or runs code from the pull request.
+# It only reads the description.
+
+name: PR Checks
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  # Contributions are licensed under MIT-0, see CONTRIBUTING.md#license.
+  # A contributor accepts these terms once, for all their pull requests, by
+  # ticking a checkbox this job adds to the description of their first pull
+  # request. The pull request keeps the ticked box as the record, and later
+  # pull requests find it there through the search API. Accounts that accepted
+  # before this check existed are listed in the CONTRIBUTION_AGREEMENTS
+  # repository variable, one per line.
+  contribution_agreement:
+    # Team members are covered by their contract, bots by their operator's terms.
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(fromJson('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      AUTHOR: ${{ github.event.pull_request.user.login }}
+      BODY: ${{ github.event.pull_request.body }}
+      LEGACY_AGREED: ${{ vars.CONTRIBUTION_AGREEMENTS }}
+      AGREEMENT: >-
+        - [ ] I license this and all my future contributions to Slint under the
+        [MIT-0 license](https://opensource.org/license/mit-0).
+        They are my own work, and no third party (such as my employer) holds rights to them.
+    steps:
+      - name: Look up the agreement
+        id: lookup
+        run: |
+          # The box only counts with the complete sentence after it, unchanged.
+          sentence=$(printf '%s\n' "$AGREEMENT" | sed -n 's/^- \[ \] //p')
+          box_followed_by_sentence() {
+            tr -d '\r' \
+              | sed -n "s/^[[:space:]]*[-*][[:space:]]*\\[$1\\][[:space:]]*//p" | sed 's/[[:space:]]*$//' \
+              | grep -qxF -- "$sentence"
+          }
+          ticked() { printf '%s\n' "$BODY" | box_followed_by_sentence '[xX]'; }
+          present() { printf '%s\n' "$BODY" | box_followed_by_sentence '[ xX]'; }
+          listed_as_legacy() {
+            printf '%s\n' "$LEGACY_AGREED" | tr -s '[:space:]' '\n' | grep -qixF -- "$AUTHOR"
+          }
+          ticked_in_an_earlier_pull_request() {
+            gh api -X GET search/issues -f per_page=100 \
+              -f q="repo:$REPO is:pr author:$AUTHOR \"I license my contribution\" in:body" \
+              --jq ".items[] | select(.number != $PR) | .body" \
+              | box_followed_by_sentence '[xX]'
+          }
+          if listed_as_legacy; then
+            echo "Listed in the CONTRIBUTION_AGREEMENTS variable."
+            status=recorded
+          elif ticked_in_an_earlier_pull_request; then
+            echo "Ticked the box in an earlier pull request."
+            status=recorded
+          elif ticked; then
+            status=ticked
+          elif present; then
+            status=unticked
+          else
+            status=missing
+          fi
+          echo "status=$status" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Add the agreement checkbox to the description
+        if: steps.lookup.outputs.status == 'missing'
+        run: |
+          { [ -n "$BODY" ] && printf '%s\n\n' "$BODY"; printf '%s\n' "$AGREEMENT"; } \
+            | gh pr edit "$PR" --repo "$REPO" --body-file -
+
+      - name: Welcome the contributor and ask them to tick the box
+        if: github.event.action == 'opened' && steps.lookup.outputs.status != 'recorded' && steps.lookup.outputs.status != 'ticked'
+        run: |
+          gh pr comment "$PR" --repo "$REPO" --body-file - <<'MSG'
+          👋 Welcome, and thanks for your pull request! If you haven't yet, take a look at [CONTRIBUTING.md](https://github.com/slint-ui/slint/blob/master/CONTRIBUTING.md).
+
+          Before we can merge it, tick the box at the end of the description to confirm that you agree to the licensing described in [CONTRIBUTING.md#license](https://github.com/slint-ui/slint/blob/master/CONTRIBUTING.md#license). You only do this once. If you can't agree, tell us in a comment instead.
+
+          We're a small team and reviews can take a while. If you don't hear back, nudge us in our [public chat](https://chat.slint.dev).
+          MSG
+
+      - name: Verify the agreement
+        env:
+          STATUS: ${{ steps.lookup.outputs.status }}
+        run: |
+          case "$STATUS" in
+            recorded|ticked)
+              echo "$AUTHOR accepted the contribution terms." ;;
+            *)
+              echo "::error::Tick the box at the end of the pull request description to license your contribution under MIT-0."
+              exit 1 ;;
+          esac

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -24,7 +24,7 @@ jobs:
   # request. The pull request keeps the ticked box as the record, and later
   # pull requests find it there through the search API. Accounts that accepted
   # before this check existed are listed in the CONTRIBUTION_AGREEMENTS
-  # repository variable, one per line.
+  # repository variable, one per line; lines starting with '#' are comments.
   contribution_agreement:
     # Team members are covered by their contract, bots by their operator's terms.
     if: >-
@@ -57,7 +57,7 @@ jobs:
           ticked() { printf '%s\n' "$BODY" | box_followed_by_sentence '[xX]'; }
           present() { printf '%s\n' "$BODY" | box_followed_by_sentence '[ xX]'; }
           listed_as_legacy() {
-            printf '%s\n' "$LEGACY_AGREED" | tr -s '[:space:]' '\n' | grep -qixF -- "$AUTHOR"
+            printf '%s\n' "$LEGACY_AGREED" | grep -v '^#' | tr -s '[:space:]' '\n' | grep -qixF -- "$AUTHOR"
           }
           ticked_in_an_earlier_pull_request() {
             gh api -X GET search/issues -f per_page=100 \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,26 @@ https://github.com/slint-ui/slint/labels/good%20first%20issue.
 ## License
 
 By contributing to this project, you agree to license your contributions under
-the [MIT No Attribution License (MIT-0)](https://opensource.org/license/mit-0).
+the [MIT No Attribution license (MIT-0)](https://opensource.org/license/mit-0).
+This doesn't assign copyright or transfer ownership:
+you keep full rights to your code, and stay free to reuse it
+in other projects under any license you choose.
 
-To confirm this, you'll be asked to sign a simple [Contributor License Agreement (CLA)](https://cla-assistant.io/slint-ui/slint)
-when you open a pull request.
-The CLA does not assign copyright or transfer ownership, it simply confirms that
-you wrote the code yourself and are licensing it under MIT-0.
+Make sure you wrote the contribution yourself, and that no rights
+have been transferred to a third party, such as your employer.
+If that isn't the case, let us know before opening the pull request.
+
+### Our Open-Source Pledge
+
+We believe that open-source software development and communities are the foundation
+for a healthy ecosystem of high-quality software,
+where everyone can learn, improve and give back.
+We commit to upholding this foundation and pledge by promising to continue
+to develop Slint in the open under an open-source license compliant with the [Open Source Definition](https://opensource.org/osd).
+
+Further, we commit to provide a royalty-free license
+for those who develop desktop, mobile, or web applications
+and do not want to use open-source components under copyleft licenses.
 
 ## Coding Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,14 @@ https://github.com/slint-ui/slint/labels/good%20first%20issue.
 If you use an AI coding assistant, it reads [AGENTS.md](AGENTS.md) for build commands and
 architecture notes specific to this repository.
 
+## Pull Requests
+
+Keep pull requests small and focused.
+A bug fix or one self-contained change is easy to review; a large code drop isn't, and may wait a long time.
+If you plan a big feature, discuss it first in an issue or on our [public chat](https://chat.slint.dev) before writing the code.
+Slint is 1.x and has a stable API, so discuss any public API change with the Slint team first.
+That way we agree on the design early, and your contribution is much more likely to be accepted.
+
 ## Internal documentation
 
  - [Development guide](docs/development.md)
@@ -22,12 +30,31 @@ architecture notes specific to this repository.
 ## License
 
 By contributing to this project, you agree to license your contributions under
-the [MIT No Attribution License (MIT-0)](https://opensource.org/license/mit-0).
+the [MIT No Attribution license (MIT-0)](https://opensource.org/license/mit-0).
+This doesn't assign copyright or transfer ownership:
+you keep full rights to your code, and stay free to reuse it
+in other projects under any license you choose.
 
-To confirm this, you'll be asked to sign a simple [Contributor License Agreement (CLA)](https://cla-assistant.io/slint-ui/slint)
-when you open a pull request.
-The CLA does not assign copyright or transfer ownership, it simply confirms that
-you wrote the code yourself and are licensing it under MIT-0.
+Make sure you wrote the contribution yourself, and that no rights
+have been transferred to a third party, such as your employer.
+If that isn't the case, let us know before opening the pull request.
+
+You confirm this once, for all your contributions.
+When you open your first pull request, a bot adds a checkbox to its description.
+Tick it to accept these terms; you aren't asked again in later pull requests.
+Pull requests from accounts that haven't accepted the terms can't be merged.
+
+### Our Open-Source Pledge
+
+We believe that open-source software development and communities are the foundation
+for a healthy ecosystem of high-quality software,
+where everyone can learn, improve and give back.
+We commit to upholding this foundation and pledge by promising to continue
+to develop Slint in the open under an open-source license compliant with the [Open Source Definition](https://opensource.org/osd).
+
+Further, we commit to provide a royalty-free license
+for those who develop desktop, mobile, or web applications
+and do not want to use open-source components under copyleft licenses.
 
 ## Coding Style
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -113,7 +113,8 @@ The license does not restrict 'if' and 'how' the modifications to Slint should b
 
 #### If Slint were to be taken over by a larger company or the current owners were to have a change of heart, can they revoke existing licenses?
 
-We have a commitment to the larger Slint community to provide Slint under a Royalty-free license. This commitment is included in the [Contributors License Agreement (CLA)](http://cla-assistant.io/slint-ui/slint).
+We have a commitment to the larger Slint community to provide Slint under a Royalty-free license.
+This commitment is part of our [open-source pledge](CONTRIBUTING.md#our-open-source-pledge).
 
 ### GPLv3
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -48,8 +48,9 @@ An ***Embedded System*** is a computer system designed to perform a specific tas
 
 ## Contributions
 
-Contributions to this repository are licensed under the [MIT No Attribution License (MIT-0)](https://opensource.org/license/mit-0).
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details, including the Contributor License Agreement.
+Contributions to this repository are licensed under the [MIT No Attribution license (MIT-0)](https://opensource.org/license/mit-0).
+This does not assign copyright or transfer ownership; contributors keep full rights to their own code.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Additional Info
 

--- a/editors/tree-sitter-slint/CONTRIBUTING.md
+++ b/editors/tree-sitter-slint/CONTRIBUTING.md
@@ -72,8 +72,8 @@ Once all tests are passing this list can be removed.
   - [x] Empty expression
   - [ ] Empty expression with semi-colon
 
-## Contributor License Agreement
+## License
 
-The same license agreement exists for the tree-sitter parser as the rest of the repository
+Contributions to the tree-sitter parser are licensed under the same terms as the rest of the repository.
 
-See: [Contributor License Agreement (CLA)](https://cla-assistant.io/slint-ui/slint)
+See the [main CONTRIBUTING.md](https://github.com/slint-ui/slint/blob/master/CONTRIBUTING.md#license) for details.


### PR DESCRIPTION
The cla-assistant "CLA" was never a copyright assignment, only an MIT-0 inbound license, but the name implied otherwise and deterred contributors.

State plainly in CONTRIBUTING.md and LICENSE.md that contributions are under MIT-0, keep the open-source pledge, and welcome first-time contributors with a bot comment instead of a CLA check.
