### PR TITLE
Fix colspan ignored in conditional GridLayout cells

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2949,12 +2949,13 @@ fn generate_grid_layout_input_decl(
                 }
                 llr::RowChildTemplateInfo::Repeated { repeater_index } => {
                     let inner_rep_id = format!("repeater_{}", usize::from(*repeater_index));
+                    // Let the inner cell report its own col/row/colspan/rowspan.
                     write!(
                         fill_code,
                         "this->{inner_rep_id}.track_instance_changes();\n\
-                         {inner_rep_id}.for_each([&]([[maybe_unused]] const auto &) {{\n\
+                         {inner_rep_id}.for_each([&](const auto &sub_comp) {{\n\
                              if (write_idx < result.size()) {{\n\
-                                 result[write_idx] = slint::cbindgen_private::GridLayoutInputData {{ (write_idx == 0) && new_row, {auto_val:.1}f, {auto_val:.1}f, 1.0f, 1.0f }};\n\
+                                 sub_comp->grid_layout_input_for_repeated((write_idx == 0) && new_row, result.subspan(write_idx, 1));\n\
                              }}\n\
                              ++write_idx;\n\
                          }});\n"

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2388,10 +2388,10 @@ fn generate_repeated_component(
                             let inner_len = _self.as_ref().#inner_rep_id.len();
                             for _i in 0..inner_len {
                                 if write_idx < result.len() {
-                                    result[write_idx] = sp::GridLayoutInputData {
-                                        new_row: write_idx == 0 && new_row,
-                                        ..Default::default()
-                                    };
+                                    // Let the inner cell report its own col/row/colspan/rowspan.
+                                    if let Some(inner) = _self.as_ref().#inner_rep_id.instance_at(_i) {
+                                        inner.as_pin_ref().grid_layout_input_data(write_idx == 0 && new_row, &mut result[write_idx..=write_idx]);
+                                    }
                                 }
                                 write_idx += 1;
                             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2390,7 +2390,7 @@ fn generate_repeated_component(
                                 if write_idx < result.len() {
                                     // Let the inner cell report its own col/row/colspan/rowspan.
                                     if let Some(inner) = _self.as_ref().#inner_rep_id.instance_at(_i) {
-                                        inner.as_pin_ref().grid_layout_input_data(write_idx == 0 && new_row, &mut result[write_idx..=write_idx]);
+                                        inner.as_pin_ref().grid_layout_input_data(write_idx == 0 && new_row, core::slice::from_mut(&mut result[write_idx]));
                                     }
                                 }
                                 write_idx += 1;

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1047,7 +1047,9 @@ impl GridLayout {
                     rowspan_expr: rowspan_expr.unwrap_or(RowColExpr::Literal(1)),
                     child_items: None,
                 }));
-                child.borrow_mut().grid_layout_cell = Some(child_grid_cell);
+                // Attach to the element the solver reads: the sub-component root for an inner
+                // repeater (so it reports its own colspan/rowspan), or `child` for a static child.
+                sub_item.elem.borrow_mut().grid_layout_cell = Some(child_grid_cell);
 
                 // Compute the effective inner_rep_idx for this child:
                 // - For inner repeater items: cumulative_pos + model_index

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -798,11 +798,32 @@ fn grid_layout_input_data(
                                 repeated_element,
                                 ..
                             } => {
+                                // colspan/rowspan live on the inner sub-component's root,
+                                // evaluated per inner instance.
+                                let inner_root = repeated_element
+                                    .borrow()
+                                    .base_type
+                                    .as_component()
+                                    .root_element
+                                    .clone();
+                                let (rowspan_expr, colspan_expr) = {
+                                    let element_ref = inner_root.borrow();
+                                    let child_cell =
+                                        element_ref.grid_layout_cell.as_ref().unwrap().borrow();
+                                    (child_cell.rowspan_expr.clone(), child_cell.colspan_expr.clone())
+                                };
                                 let inner_instances =
                                     repeater_instances(sub_instance_ref, repeated_element);
-                                for i in 0..inner_instances.len() {
+                                for (i, erased_inner) in inner_instances.iter().enumerate() {
+                                    generativity::make_guard!(inner_guard);
+                                    let inner_comp = erased_inner.as_pin_ref();
+                                    let inner_instance_ref = unsafe {
+                                        InstanceRef::from_pin_ref(inner_comp.borrow(), inner_guard)
+                                    };
                                     result.push(GridLayoutInputData {
                                         new_row: i == 0 && new_row,
+                                        rowspan: eval_or_default(&rowspan_expr, inner_instance_ref),
+                                        colspan: eval_or_default(&colspan_expr, inner_instance_ref),
                                         ..Default::default()
                                     });
                                 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -810,7 +810,10 @@ fn grid_layout_input_data(
                                     let element_ref = inner_root.borrow();
                                     let child_cell =
                                         element_ref.grid_layout_cell.as_ref().unwrap().borrow();
-                                    (child_cell.rowspan_expr.clone(), child_cell.colspan_expr.clone())
+                                    (
+                                        child_cell.rowspan_expr.clone(),
+                                        child_cell.colspan_expr.clone(),
+                                    )
                                 };
                                 let inner_instances =
                                     repeater_instances(sub_instance_ref, repeated_element);

--- a/tests/cases/layout/grid_conditional_row_and_cell_colspan.slint
+++ b/tests/cases/layout/grid_conditional_row_and_cell_colspan.slint
@@ -18,6 +18,7 @@ export component TestCase inherits Window {
         // The cell and its Row are both conditional, and the cell spans two columns.
         if cond: Row {
             if cond: Rectangle {
+                background: green;
                 colspan: 2;
                 min-width: 200phx;
             }
@@ -28,8 +29,8 @@ export component TestCase inherits Window {
         // stay equal. When it is ignored, the minimum lands on column 0 alone and
         // the columns become unequal.
         Row {
-            a := Rectangle { horizontal-stretch: 1; }
-            b := Rectangle { horizontal-stretch: 1; }
+            a := Rectangle { horizontal-stretch: 1; background: red; }
+            b := Rectangle { horizontal-stretch: 1; background: blue; }
         }
     }
 

--- a/tests/cases/layout/grid_conditional_row_and_cell_colspan.slint
+++ b/tests/cases/layout/grid_conditional_row_and_cell_colspan.slint
@@ -1,0 +1,63 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for issue #12251: colspan was ignored when both the Row and
+// the cell inside it are conditional (`if cond: Row { if cond: ... colspan: 2 }`).
+// The spanned cell collapsed to a single column.
+
+export component TestCase inherits Window {
+    width: 400phx;
+    height: 200phx;
+
+    in property <bool> cond: true;
+
+    GridLayout {
+        spacing: 0phx;
+        padding: 0phx;
+
+        // The cell and its Row are both conditional, and the cell spans two columns.
+        if cond: Row {
+            if cond: Rectangle {
+                colspan: 2;
+                min-width: 200phx;
+            }
+        }
+
+        // Reference row: two stretchy columns. When the colspan above is honored,
+        // its minimum width applies to both columns combined, so the two columns
+        // stay equal. When it is ignored, the minimum lands on column 0 alone and
+        // the columns become unequal.
+        Row {
+            a := Rectangle { horizontal-stretch: 1; }
+            b := Rectangle { horizontal-stretch: 1; }
+        }
+    }
+
+    out property <length> a-width: a.width;
+    out property <length> b-width: b.width;
+    out property <bool> test: a.width == b.width && a.width == 200phx;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_a_width(), 200.);
+assert_eq(instance.get_b_width(), 200.);
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_a_width(), 200.);
+assert_eq!(instance.get_b_width(), 200.);
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
When both a Row and the cell inside it are conditional, the cell's colspan/rowspan was ignored and the cell collapsed to a single column.

Attach the grid cell to the inner sub-component root so it reports its own span, and let the repeated row delegate to it, like the outer grid already does for repeated rows.

Fixes: #12251

