### PR TITLE
compiler: Initialize the root component's globals before running global init

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -924,12 +924,26 @@ pub fn generate(
         ));
     }
 
+    // The globals are not initialized in the constructor: a global's init may evaluate a
+    // binding (e.g. `Palette.color-scheme`) that resolves the root through `root_weak` and the
+    // root component's `globals` pointer. Those are only set after the SharedGlobals member has
+    // been constructed, so the init is deferred to `init_globals()`, called from the root
+    // component's `create()` once `globals` and `root_weak` are in place.
     globals_struct.members.push((
         Access::Public,
         Declaration::Function(Function {
             name: globals_struct.name.clone(),
             is_constructor_or_destructor: true,
             signature: "()".into(),
+            statements: Some(vec![]),
+            ..Default::default()
+        }),
+    ));
+    globals_struct.members.push((
+        Access::Public,
+        Declaration::Function(Function {
+            name: "init_globals".into(),
+            signature: "() -> void".into(),
             statements: Some(init_global),
             ..Default::default()
         }),
@@ -2039,6 +2053,9 @@ fn generate_item_tree(
 
         create_code.push("self->globals = &self->m_globals;".into());
         create_code.push("self->m_globals.root_weak = self->self_weak;".into());
+        // Now that `globals` and `root_weak` are set, the globals can be initialized: their
+        // init may resolve the root window adapter through these (see `init_globals`).
+        create_code.push("self->m_globals.init_globals();".into());
     }
 
     let global_access =

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -652,15 +652,22 @@ fn generate_shared_globals(
         impl SharedGlobals {
             #pub_token fn new(root_item_tree_weak : sp::VWeak<sp::ItemTreeVTable>) -> sp::Rc<Self> {
                 #(let #library_shared_globals_names = #library_shared_globals_types::new(root_item_tree_weak.clone());)*
-                let _self = sp::Rc::new(Self {
+                sp::Rc::new(Self {
                     #(#global_names : #global_types::new(),)*
                     #(#from_library_global_names : #library_global_vars.clone(),)*
                     window_adapter : ::core::default::Default::default(),
                     root_item_tree_weak,
                     #(#library_shared_globals_names,)*
-                });
-                #(_self.#global_names.clone().init(&_self);)*
-                _self
+                })
+            }
+
+            // Run the eager initialization of the globals. This must be called only *after* the
+            // root component's `globals` field has been set (see the root component's `new`),
+            // because a global's init may evaluate a binding (e.g. `Palette.color-scheme`) that
+            // resolves the root's window adapter through `globals`, which would otherwise panic.
+            #pub_token fn init_globals(self: &sp::Rc<Self>) {
+                #(self.#library_shared_globals_names.init_globals();)*
+                #(self.#global_names.clone().init(self);)*
             }
 
             // Clone the SharedGlobals struct but use a different window adapter. This is for example used for popup windows, because they need access to the globals, but need their own window adapter
@@ -2052,12 +2059,26 @@ fn generate_item_tree(
         })
         .collect::<Vec<_>>();
 
+    let is_root_component = !is_popup && parent_ctx.is_none();
     let globals = if is_popup {
         quote!(globals)
     } else if parent_ctx.is_some() {
         quote!(parent.upgrade().unwrap().globals.get().unwrap().clone())
     } else {
         quote!(SharedGlobals::new(sp::VRc::downgrade(&self_dyn_rc)))
+    };
+    // The root component owns the freshly created `SharedGlobals` and is responsible for running
+    // its eager initialization. The root's own `globals` field must be set *before* that init
+    // runs, because a global binding (e.g. `Palette.color-scheme`) may resolve the root's window
+    // adapter through `globals` during evaluation. Popups and sub-components receive an already
+    // initialized `SharedGlobals`, so they skip this step.
+    let set_and_init_globals = if is_root_component {
+        quote!(
+            let _ = sp::VRc::map(self_rc.clone(), |x| x).as_pin_ref().globals.set(globals.clone());
+            globals.init_globals();
+        )
+    } else {
+        quote!()
     };
     let globals_arg = is_popup.then(|| quote!(globals: sp::Rc<SharedGlobals>));
 
@@ -2203,6 +2224,7 @@ fn generate_item_tree(
                 let self_rc = sp::VRc::new(_self);
                 let self_dyn_rc = sp::VRc::into_dyn(self_rc.clone());
                 let globals = #globals;
+                #set_and_init_globals
                 sp::register_item_tree(&self_dyn_rc, #register_window_adapter_arg);
                 Self::init(sp::VRc::map(self_rc.clone(), |x| x), globals, 0, 1);
                 ::core::result::Result::Ok(self_rc)

--- a/tests/cases/globals/init_order_color_scheme.slint
+++ b/tests/cases/globals/init_order_color_scheme.slint
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for the global-initialization order bug in the Rust/C++ code generators.
+//
+// A global's eager initialization (here a `changed` handler, which installs a ChangeTracker
+// that evaluates its tracked expression immediately) reads `Palette.color-scheme`. Resolving
+// the color scheme goes through `context_for_root`, which asks the *root* component for its
+// window adapter, i.e. it reads the root component's `globals` field. The generators must
+// therefore set the root's `globals` field *before* initializing the globals, otherwise this
+// panics with `Option::unwrap()` on a `None` value during construction (the interpreter
+// already did this in the correct order).
+
+import { Palette } from "std-widgets.slint";
+
+global ColorSchemeObserver {
+    in-out property <ColorScheme> scheme: Palette.color-scheme;
+    out property <int> change-count: 0;
+    // The change tracker is initialized eagerly while the globals are set up, which evaluates
+    // `scheme` -> `Palette.color-scheme` -> the `ColorScheme` builtin -> `context_for_root`.
+    changed scheme => { self.change-count += 1; }
+}
+
+export component TestCase inherits Window {
+    // Read the global so it is part of the compilation and its init runs.
+    out property <ColorScheme> scheme: ColorSchemeObserver.scheme;
+    out property <bool> test: ColorSchemeObserver.change-count >= 0;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
A `changed` handler on a global installs a ChangeTracker that is evaluated immediately on init to capture its baseline. Since globals are initialized from `SharedGlobals::new` during the root component's construction, that evaluation runs before the root's `globals` field is set.

If the evaluated expression reads `Palette.color-scheme` (or accent-color), it resolves through `context_for_root`, which calls `window_adapter()` on the root item tree and reads exactly that not-yet-set `globals` field: Rust panics on `unwrap()` of None, C++ dereferences an empty `root_weak`.

This regressed in 8bf17e0470, which made these builtins resolve via the root's `window_adapter()` instead of `SharedGlobals::window_adapter_impl()` (the latter uses `root_item_tree_weak`, which is already set during construction).

Fix it like the interpreter already does: split the eager global init out of construction into `init_globals()` and call it only once the root's globals are wired up.

ChangeLog: Fixed a panic/crash on startup when a global reads Palette.color-scheme (or accent-color) during its initialization

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
