### PR TITLE
Fixup a few small issues in Backends & Renderers docs

### DIFF
--- a/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
+++ b/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
@@ -102,12 +102,12 @@ The Qt renderer comes with the <Link type="QtBackend" label="Qt backend" /> and 
  - Available in the <Link type="WinitBackend" label="Winit backend" /> and <Link type="LinuxkmsBackend" label="LinuxKMS backend" />.
  - Public <LangRefLink lang="cpp" relpath="api/slint/platform/skiarenderer/">C++</LangRefLink> API.
 
-#### Troubleshooting
+#### Troubleshooting Skia
 
 You may run into compile issues when enabling the Skia renderer. The following sections track
 issues we're aware of and how to resolve them.
 
-* Compilation error on Windows with messages about multiple source files and unused linker input
+##### Compilation error on Windows with messages about multiple source files and unused linker input
 
   You may see compile errors that contain this error and warning from clang-cl:
   ```
@@ -120,7 +120,7 @@ issues we're aware of and how to resolve them.
   which contains spaces if the login name contains spaces. To resolve this issue, set the `CARGO_HOME`
   environment variable to a path without spaces, such as `c:\cargo_home`.
 
-* Compilation error when compiling for ARMv7 with hardware floating-point support
+##### Compilation error when compiling for ARMv7 with hardware floating-point support
 
   You may see compiler errors that contain this message:
 
@@ -128,7 +128,7 @@ issues we're aware of and how to resolve them.
    Unable to generate bindings: ClangDiagnostic("/home/runner/work/slint/yocto-sdk/sysroots/cortexa15t2hf-neon-poky-linux-gnueabi/usr/include/gnu/stubs-32.h:7:11: fatal error: 'gnu/stubs-soft.h' file not found\n")
   ```
 
-  The Skia build invokes clang in multiple occasions and is sensitive to compiler flags
+  The Skia build invokes Clang in multiple occasions and is sensitive to compiler flags
   that affect the floating point abi (such as `-mfloat-abi=hard`), as they affect header file lookups.
 
   The solve this, set the `BINDGEN_EXTRA_CLANG_ARGS` environment variable to contain the same
@@ -137,7 +137,7 @@ issues we're aware of and how to resolve them.
   For example, if you're building against a Yocto SDK, then you can find these flags in the
   `OECORE_TUNE_CCARGS` environment variable.
 
-* Compilation error when linking on Windows
+##### Compilation error when linking on Windows
 
   You may see compiler errors that contain this message:
 
@@ -153,7 +153,7 @@ issues we're aware of and how to resolve them.
   The Skia build requires the use of Microsoft Visual Studio 2022 as compiler. Make sure to have the latest patches
   to the compiler installed.
 
- * Compilation error on macOS:
+##### Compilation error on macOS:
 
   The build fails and somewhere in the log output you see this message:
 
@@ -169,9 +169,9 @@ issues we're aware of and how to resolve them.
   sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
   ```
 
- * Compilation error when cross-compiling with Yocto:
+##### Compilation error when cross-compiling with Yocto:
 
-  The build fails and towards the end of the log message you see this message:
+  The build fails and you see this message in the logs:
 
   ```
       error occurred: unknown target `arm-org-linux-gnueabi`
@@ -185,9 +185,9 @@ issues we're aware of and how to resolve them.
   cargo update -p cc --precise 1.1.31
   ```
 
- * The application doesn't start on Windows but exist immediately
+##### The application doesn't start on Windows but exits immediately
 
- The build succeeds, but running the `.exe` on Windows terminates immediately without error messages.
+ The build succeeds, but running the `.exe` on Windows terminates immediately without an error message.
 
- This might be caused by missing MSVC runtime libraries. To solve this install, install the
+ This might be caused by missing MSVC runtime libraries. To solve this install the
  [Microsoft Visual C++ Redistributable package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)


### PR DESCRIPTION
Theres a few typos here, and due to some quirk in the documentation the troubleshooting heading is not only super small but it doesn't show up in the table of contents. This section is only relevant for Skia, but it's hard to know when scrolling through, so I made it clearer.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
