### PR TITLE
Avoid overwrite ListView viewport size

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -1013,20 +1013,13 @@ namespace slint {
         using types::Size;
         using types::MouseEvent;
 
-
-
-        // Define Option here (without the default argument; cbindgen will add
-        // `= void` in a later forward declaration, which is valid C++).
-        template<typename T>
-        struct Option {};
-
+        template<typename T> struct Option;
         // This specialization provides a concrete C++ type for Option types
         template<typename T>
         struct Option<T *> {
             T *ptr = nullptr;
             Option() noexcept = default;
             Option(T *p) noexcept : ptr(p) {}
-            explicit operator bool() const noexcept { return ptr != nullptr; }
         };
     }
     template<typename ModelData> class Model;

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -1012,6 +1012,22 @@ namespace slint {
         using types::IntRect;
         using types::Size;
         using types::MouseEvent;
+
+
+
+        // Define Option here (without the default argument; cbindgen will add
+        // `= void` in a later forward declaration, which is valid C++).
+        template<typename T>
+        struct Option {};
+
+        // This specialization provides a concrete C++ type for Option types
+        template<typename T>
+        struct Option<T *> {
+            T *ptr = nullptr;
+            Option() noexcept = default;
+            Option(T *p) noexcept : ptr(p) {}
+            explicit operator bool() const noexcept { return ptr != nullptr; }
+        };
     }
     template<typename ModelData> class Model;
 }",

--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -1200,8 +1200,10 @@ public:
                                 [[maybe_unused]] float listview_width,
                                 const private_api::Property<float> *listview_height) const
     {
-        viewport_width->register_as_dependency();
-        viewport_height->register_as_dependency();
+        if (viewport_width)
+            viewport_width->register_as_dependency();
+        if (viewport_height)
+            viewport_height->register_as_dependency();
         viewport_y->register_as_dependency();
         listview_height->register_as_dependency();
     }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2501,11 +2501,17 @@ fn generate_sub_component(
             let lv_h = access_member(&listview.listview_height, &ctx).unwrap();
             let vp_w = listview.viewport_width.as_ref().map_or_else(
                 || "nullptr".to_string(),
-                |w| { let w = access_member(w, &ctx).unwrap(); format!("&{w}") },
+                |w| {
+                    let w = access_member(w, &ctx).unwrap();
+                    format!("&{w}")
+                },
             );
             let vp_h = listview.viewport_height.as_ref().map_or_else(
                 || "nullptr".to_string(),
-                |h| { let h = access_member(h, &ctx).unwrap(); format!("&{h}") },
+                |h| {
+                    let h = access_member(h, &ctx).unwrap();
+                    format!("&{h}")
+                },
             );
 
             children_visitor_cases.push(format!(

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2497,19 +2497,25 @@ fn generate_sub_component(
 
         if let Some(listview) = &repeated.listview {
             let vp_y = access_member(&listview.viewport_y, &ctx).unwrap();
-            let vp_h = access_member(&listview.viewport_height, &ctx).unwrap();
-            let lv_h = access_member(&listview.listview_height, &ctx).unwrap();
-            let vp_w = access_member(&listview.viewport_width, &ctx).unwrap();
             let lv_w = access_member(&listview.listview_width, &ctx).unwrap();
+            let lv_h = access_member(&listview.listview_height, &ctx).unwrap();
+            let vp_w = listview.viewport_width.as_ref().map_or_else(
+                || "nullptr".to_string(),
+                |w| { let w = access_member(w, &ctx).unwrap(); format!("&{w}") },
+            );
+            let vp_h = listview.viewport_height.as_ref().map_or_else(
+                || "nullptr".to_string(),
+                |h| { let h = access_member(h, &ctx).unwrap(); format!("&{h}") },
+            );
 
             children_visitor_cases.push(format!(
                 "\n        case {idx}: {{
-                self->{repeater_id}.track_changes_listview(&{vp_w}, &{vp_h}, &{vp_y}, {lv_w}.get(), &{lv_h});
+                self->{repeater_id}.track_changes_listview({vp_w}, {vp_h}, &{vp_y}, {lv_w}.get(), &{lv_h});
                 return self->{repeater_id}.visit(order, visitor);
             }}",
             ));
             ensure_instantiated_stmts.push(format!(
-                "_changed |= self->{repeater_id}.ensure_updated_listview(self, &{vp_w}, &{vp_h}, &{vp_y}, {lv_w}.get(), {lv_h}.get());"
+                "_changed |= self->{repeater_id}.ensure_updated_listview(self, {vp_w}, {vp_h}, &{vp_y}, {lv_w}.get(), {lv_h}.get());"
             ));
         } else {
             children_visitor_cases.push(format!(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1385,11 +1385,17 @@ fn generate_sub_component(
                 let lv_w = access_member(&listview.listview_width, &ctx).unwrap();
                 let vp_w = listview.viewport_width.as_ref().map_or_else(
                     || quote!(None),
-                    |w| { let w = access_member(w, &ctx).unwrap(); quote!(Some(#w)) },
+                    |w| {
+                        let w = access_member(w, &ctx).unwrap();
+                        quote!(Some(#w))
+                    },
                 );
                 let vp_h = listview.viewport_height.as_ref().map_or_else(
                     || quote!(None),
-                    |h| { let h = access_member(h, &ctx).unwrap(); quote!(Some(#h)) },
+                    |h| {
+                        let h = access_member(h, &ctx).unwrap();
+                        quote!(Some(#h))
+                    },
                 );
 
                 repeated_visit_branch.push(quote!(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1381,10 +1381,16 @@ fn generate_sub_component(
             });
             if let Some(listview) = &repeated.listview {
                 let vp_y = access_member(&listview.viewport_y, &ctx).unwrap();
-                let vp_h = access_member(&listview.viewport_height, &ctx).unwrap();
                 let lv_h = access_member(&listview.listview_height, &ctx).unwrap();
-                let vp_w = access_member(&listview.viewport_width, &ctx).unwrap();
                 let lv_w = access_member(&listview.listview_width, &ctx).unwrap();
+                let vp_w = listview.viewport_width.as_ref().map_or_else(
+                    || quote!(None),
+                    |w| { let w = access_member(w, &ctx).unwrap(); quote!(Some(#w)) },
+                );
+                let vp_h = listview.viewport_height.as_ref().map_or_else(
+                    || quote!(None),
+                    |h| { let h = access_member(h, &ctx).unwrap(); quote!(Some(#h)) },
+                );
 
                 repeated_visit_branch.push(quote!(
                     #idx => {

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -387,7 +387,6 @@ pub struct ListViewInfo {
     pub prop_y: MemberReference,
     // In the repeated component context
     pub prop_height: MemberReference,
-
 }
 
 #[derive(Debug)]

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -372,7 +372,11 @@ pub struct Function {
 /// repeated's component context
 pub struct ListViewInfo {
     pub viewport_y: MemberReference,
+    /// `None` when the user explicitly sets `viewport-height` on the ListView;
+    /// `Some` when the ListView computes it from the content.
     pub viewport_height: Option<MemberReference>,
+    /// `None` when the user explicitly sets `viewport-width` on the ListView;
+    /// `Some` when the ListView computes it from the content.
     pub viewport_width: Option<MemberReference>,
     /// The ListView's inner visible height (not counting eventual scrollbar)
     pub listview_height: MemberReference,

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -372,8 +372,8 @@ pub struct Function {
 /// repeated's component context
 pub struct ListViewInfo {
     pub viewport_y: MemberReference,
-    pub viewport_height: MemberReference,
-    pub viewport_width: MemberReference,
+    pub viewport_height: Option<MemberReference>,
+    pub viewport_width: Option<MemberReference>,
     /// The ListView's inner visible height (not counting eventual scrollbar)
     pub listview_height: MemberReference,
     /// The ListView's inner visible width (not counting eventual scrollbar)
@@ -383,6 +383,7 @@ pub struct ListViewInfo {
     pub prop_y: MemberReference,
     // In the repeated component context
     pub prop_height: MemberReference,
+
 }
 
 #[derive(Debug)]

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -901,8 +901,16 @@ fn lower_repeated_component(
         let geom = component.root_element.borrow().geometry_props.clone().unwrap();
         ListViewInfo {
             viewport_y: ctx.map_property_reference(&lv.viewport_y),
-            viewport_height: ctx.map_property_reference(&lv.viewport_height),
-            viewport_width: ctx.map_property_reference(&lv.viewport_width),
+            viewport_height: if let Some(viewport_height) = &lv.viewport_height {
+                Some(ctx.map_property_reference(viewport_height))
+            } else {
+                None
+            },
+            viewport_width: if let Some(viewport_width) = &lv.viewport_width {
+                Some(ctx.map_property_reference(viewport_width))
+            } else {
+                None
+            },
             listview_height: ctx.map_property_reference(&lv.listview_height),
             listview_width: ctx.map_property_reference(&lv.listview_width),
             prop_y: sc.mapping.map_property_reference(&geom.y, ctx.state),

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -901,16 +901,8 @@ fn lower_repeated_component(
         let geom = component.root_element.borrow().geometry_props.clone().unwrap();
         ListViewInfo {
             viewport_y: ctx.map_property_reference(&lv.viewport_y),
-            viewport_height: if let Some(viewport_height) = &lv.viewport_height {
-                Some(ctx.map_property_reference(viewport_height))
-            } else {
-                None
-            },
-            viewport_width: if let Some(viewport_width) = &lv.viewport_width {
-                Some(ctx.map_property_reference(viewport_width))
-            } else {
-                None
-            },
+            viewport_height: lv.viewport_height.as_ref().map(|viewport_height| ctx.map_property_reference(viewport_height)),
+            viewport_width: lv.viewport_width.as_ref().map(|viewport_width| ctx.map_property_reference(viewport_width)),
             listview_height: ctx.map_property_reference(&lv.listview_height),
             listview_width: ctx.map_property_reference(&lv.listview_width),
             prop_y: sc.mapping.map_property_reference(&geom.y, ctx.state),

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -901,8 +901,14 @@ fn lower_repeated_component(
         let geom = component.root_element.borrow().geometry_props.clone().unwrap();
         ListViewInfo {
             viewport_y: ctx.map_property_reference(&lv.viewport_y),
-            viewport_height: lv.viewport_height.as_ref().map(|viewport_height| ctx.map_property_reference(viewport_height)),
-            viewport_width: lv.viewport_width.as_ref().map(|viewport_width| ctx.map_property_reference(viewport_width)),
+            viewport_height: lv
+                .viewport_height
+                .as_ref()
+                .map(|viewport_height| ctx.map_property_reference(viewport_height)),
+            viewport_width: lv
+                .viewport_width
+                .as_ref()
+                .map(|viewport_width| ctx.map_property_reference(viewport_width)),
             listview_height: ctx.map_property_reference(&lv.listview_height),
             listview_width: ctx.map_property_reference(&lv.listview_width),
             prop_y: sc.mapping.map_property_reference(&geom.y, ctx.state),

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -45,8 +45,12 @@ pub fn count_property_use(root: &CompilationUnit) {
             r.model.borrow().visit_property_references(ctx, &mut visit_property);
             if let Some(lv) = &r.listview {
                 visit_property(&lv.viewport_y, ctx);
-                visit_property(&lv.viewport_width, ctx);
-                visit_property(&lv.viewport_height, ctx);
+                if let Some(viewport_height) = &lv.viewport_height {
+                    visit_property(viewport_height, ctx);
+                }
+                if let Some(viewport_width) = &lv.viewport_width {
+                    visit_property(viewport_width, ctx);
+                }
                 visit_property(&lv.listview_width, ctx);
                 visit_property(&lv.listview_height, ctx);
 

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -345,8 +345,12 @@ mod visitor {
 
             if let Some(listview) = listview {
                 visit_member_reference(&mut listview.viewport_y, &scope, state, visitor);
-                visit_member_reference(&mut listview.viewport_height, &scope, state, visitor);
-                visit_member_reference(&mut listview.viewport_width, &scope, state, visitor);
+                if let Some(viewport_height) = &mut listview.viewport_height {
+                    visit_member_reference(viewport_height, &scope, state, visitor);
+                }
+                if let Some(viewport_width) = &mut listview.viewport_width {
+                    visit_member_reference(viewport_width, &scope, state, visitor);
+                }
                 visit_member_reference(&mut listview.listview_width, &scope, state, visitor);
                 visit_member_reference(&mut listview.listview_height, &scope, state, visitor);
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1106,8 +1106,11 @@ impl PropertyAnalysis {
 #[derive(Debug, Clone)]
 pub struct ListViewInfo {
     pub viewport_y: NamedReference,
-    // The viewport height and width are optional the value is only set if the user set it explicitly
+    /// `None` when the user explicitly sets `viewport-height` on the ListView;
+    /// `Some` when the ListView computes it from the content.
     pub viewport_height: Option<NamedReference>,
+    /// `None` when the user explicitly sets `viewport-width` on the ListView;
+    /// `Some` when the ListView computes it from the content.
     pub viewport_width: Option<NamedReference>,
     /// The ListView's inner visible height (not counting eventual scrollbar)
     pub listview_height: NamedReference,
@@ -2079,19 +2082,8 @@ impl Element {
 
             let lvi = ListViewInfo {
                 viewport_y: NamedReference::new(parent, SmolStr::new_static("viewport-y")),
-                viewport_height: if !viewport_height_is_explicitly_set {
-                    Some(NamedReference::new(
-                        parent,
-                        SmolStr::new_static("viewport-height"),
-                    ))
-                } else {
-                    None
-                },
-                viewport_width: if !viewport_width_is_explicitly_set {
-                    Some(NamedReference::new(parent, SmolStr::new_static("viewport-width")))
-                } else {
-                    None
-                },
+                viewport_height: (!viewport_height_is_explicitly_set).then(|| NamedReference::new(parent, SmolStr::new_static("viewport-height"))),
+                viewport_width: (!viewport_width_is_explicitly_set).then(|| NamedReference::new(parent, SmolStr::new_static("viewport-width"))),
                 listview_height: NamedReference::new(parent, SmolStr::new_static("visible-height")),
                 listview_width: NamedReference::new(parent, SmolStr::new_static("visible-width")),
             };

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1106,8 +1106,9 @@ impl PropertyAnalysis {
 #[derive(Debug, Clone)]
 pub struct ListViewInfo {
     pub viewport_y: NamedReference,
-    pub viewport_height: NamedReference,
-    pub viewport_width: NamedReference,
+    // The viewport height and width are optional the value is only set if the user set it explicitly
+    pub viewport_height: Option<NamedReference>,
+    pub viewport_width: Option<NamedReference>,
     /// The ListView's inner visible height (not counting eventual scrollbar)
     pub listview_height: NamedReference,
     /// The ListView's inner visible width (not counting eventual scrollbar)
@@ -2062,19 +2063,45 @@ impl Element {
         let is_listview = if parent_is_listview
             && let Some(geometry_props) = e.borrow().geometry_props.as_ref()
         {
+            let parent_elem = parent.borrow();
+            // Check if viewport-width and viewport-height are explicitly set by the user
+            let viewport_width_is_explicitly_set = parent_elem
+                .bindings
+                .get("viewport-width")
+                .map(|b| b.borrow().has_binding())
+                .unwrap_or(false);
+            let viewport_height_is_explicitly_set = parent_elem
+                .bindings
+                .get("viewport-height")
+                .map(|b| b.borrow().has_binding())
+                .unwrap_or(false);
+            drop(parent_elem); // Drop the borrow before creating NamedReference
+
             let lvi = ListViewInfo {
                 viewport_y: NamedReference::new(parent, SmolStr::new_static("viewport-y")),
-                viewport_height: NamedReference::new(
-                    parent,
-                    SmolStr::new_static("viewport-height"),
-                ),
-                viewport_width: NamedReference::new(parent, SmolStr::new_static("viewport-width")),
+                viewport_height: if !viewport_height_is_explicitly_set {
+                    Some(NamedReference::new(
+                        parent,
+                        SmolStr::new_static("viewport-height"),
+                    ))
+                } else {
+                    None
+                },
+                viewport_width: if !viewport_width_is_explicitly_set {
+                    Some(NamedReference::new(parent, SmolStr::new_static("viewport-width")))
+                } else {
+                    None
+                },
                 listview_height: NamedReference::new(parent, SmolStr::new_static("visible-height")),
                 listview_width: NamedReference::new(parent, SmolStr::new_static("visible-width")),
             };
             // these properties are set by the ListView layouting code
-            lvi.viewport_height.mark_as_set();
-            lvi.viewport_width.mark_as_set();
+            if let Some(viewport_height) = &lvi.viewport_height {
+                viewport_height.mark_as_set();
+            }
+            if let Some(viewport_width) = &lvi.viewport_width {
+                viewport_width.mark_as_set();
+            }
             geometry_props.y.mark_as_set();
             Some(lvi)
         } else {
@@ -3245,8 +3272,12 @@ pub fn visit_all_named_references_in_element(
         && let Some(lv) = &mut r.is_listview
     {
         vis(&mut lv.viewport_y);
-        vis(&mut lv.viewport_height);
-        vis(&mut lv.viewport_width);
+        if let Some(viewport_height) = &mut lv.viewport_height {
+            vis(viewport_height);
+        }
+        if let Some(viewport_width) = &mut lv.viewport_width {
+            vis(viewport_width);
+        }
         vis(&mut lv.listview_height);
         vis(&mut lv.listview_width);
     }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2082,8 +2082,10 @@ impl Element {
 
             let lvi = ListViewInfo {
                 viewport_y: NamedReference::new(parent, SmolStr::new_static("viewport-y")),
-                viewport_height: (!viewport_height_is_explicitly_set).then(|| NamedReference::new(parent, SmolStr::new_static("viewport-height"))),
-                viewport_width: (!viewport_width_is_explicitly_set).then(|| NamedReference::new(parent, SmolStr::new_static("viewport-width"))),
+                viewport_height: (!viewport_height_is_explicitly_set)
+                    .then(|| NamedReference::new(parent, SmolStr::new_static("viewport-height"))),
+                viewport_width: (!viewport_width_is_explicitly_set)
+                    .then(|| NamedReference::new(parent, SmolStr::new_static("viewport-width"))),
                 listview_height: NamedReference::new(parent, SmolStr::new_static("visible-height")),
                 listview_width: NamedReference::new(parent, SmolStr::new_static("visible-width")),
             };

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -257,7 +257,13 @@ fn analyze_element(
         if let Some(lv) = &repeated.is_listview {
             process_property(&lv.viewport_y.clone().into(), P, context, reverse_aliases, diag);
             if let Some(viewport_height) = &lv.viewport_height {
-                process_property(&viewport_height.clone().into(), P, context, reverse_aliases, diag);
+                process_property(
+                    &viewport_height.clone().into(),
+                    P,
+                    context,
+                    reverse_aliases,
+                    diag,
+                );
             }
             if let Some(viewport_width) = &lv.viewport_width {
                 process_property(&viewport_width.clone().into(), P, context, reverse_aliases, diag);

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -256,8 +256,12 @@ fn analyze_element(
         });
         if let Some(lv) = &repeated.is_listview {
             process_property(&lv.viewport_y.clone().into(), P, context, reverse_aliases, diag);
-            process_property(&lv.viewport_height.clone().into(), P, context, reverse_aliases, diag);
-            process_property(&lv.viewport_width.clone().into(), P, context, reverse_aliases, diag);
+            if let Some(viewport_height) = &lv.viewport_height {
+                process_property(&viewport_height.clone().into(), P, context, reverse_aliases, diag);
+            }
+            if let Some(viewport_width) = &lv.viewport_width {
+                process_property(&viewport_width.clone().into(), P, context, reverse_aliases, diag);
+            }
             process_property(&lv.listview_height.clone().into(), P, context, reverse_aliases, diag);
             process_property(&lv.listview_width.clone().into(), P, context, reverse_aliases, diag);
         }

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -517,7 +517,10 @@ impl Snapshotter {
                 is_conditional_element: r.is_conditional_element,
                 is_listview: r.is_listview.as_ref().map(|lv| object_tree::ListViewInfo {
                     viewport_y: lv.viewport_y.snapshot(self),
-                    viewport_height: lv.viewport_height.as_ref().map(|height| height.snapshot(self)),
+                    viewport_height: lv
+                        .viewport_height
+                        .as_ref()
+                        .map(|height| height.snapshot(self)),
                     viewport_width: lv.viewport_width.as_ref().map(|width| width.snapshot(self)),
                     listview_height: lv.listview_height.snapshot(self),
                     listview_width: lv.listview_width.snapshot(self),

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -517,8 +517,16 @@ impl Snapshotter {
                 is_conditional_element: r.is_conditional_element,
                 is_listview: r.is_listview.as_ref().map(|lv| object_tree::ListViewInfo {
                     viewport_y: lv.viewport_y.snapshot(self),
-                    viewport_height: lv.viewport_height.snapshot(self),
-                    viewport_width: lv.viewport_width.snapshot(self),
+                    viewport_height: if let Some(viewport_height) = &lv.viewport_height {
+                        Some(viewport_height.snapshot(self))
+                    } else {
+                        None
+                    },
+                    viewport_width: if let Some(viewport_width) = &lv.viewport_width {
+                        Some(viewport_width.snapshot(self))
+                    } else {
+                        None
+                    },
                     listview_height: lv.listview_height.snapshot(self),
                     listview_width: lv.listview_width.snapshot(self),
                 }),

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -517,16 +517,8 @@ impl Snapshotter {
                 is_conditional_element: r.is_conditional_element,
                 is_listview: r.is_listview.as_ref().map(|lv| object_tree::ListViewInfo {
                     viewport_y: lv.viewport_y.snapshot(self),
-                    viewport_height: if let Some(viewport_height) = &lv.viewport_height {
-                        Some(viewport_height.snapshot(self))
-                    } else {
-                        None
-                    },
-                    viewport_width: if let Some(viewport_width) = &lv.viewport_width {
-                        Some(viewport_width.snapshot(self))
-                    } else {
-                        None
-                    },
+                    viewport_height: lv.viewport_height.as_ref().map(|height| height.snapshot(self)),
+                    viewport_width: lv.viewport_width.as_ref().map(|width| width.snapshot(self)),
                     listview_height: lv.listview_height.snapshot(self),
                     listview_width: lv.listview_width.snapshot(self),
                 }),

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -244,7 +244,7 @@ fn update_visible_instances(
     let last_item_bottom = first_item_y + element_height * ops.len() as Coord;
 
     let (mut new_offset, mut new_offset_y) = if first_item_y > -vp_y + one_and_a_half_screen
-        || last_item_bottom + element_height < -vp_y
+        || (viewport_height.is_some() && last_item_bottom + element_height < -vp_y)
     {
         // Jumping more than 1.5 screens: random seek.
         ops.splice(0, ops.len(), 0);

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -962,16 +962,12 @@ mod ffi {
         ops: &mut RepeaterInstanceOpsVTable,
         state: &mut RepeaterLayoutState,
         row_count: usize,
-        viewport_width: *const Property<LogicalLength>,
-        viewport_height: *const Property<LogicalLength>,
+        viewport_width: Option<Pin<&Property<LogicalLength>>>,
+        viewport_height: Option<Pin<&Property<LogicalLength>>>,
         viewport_y: Pin<&Property<LogicalLength>>,
         listview_width: LogicalLength,
         listview_height: LogicalLength,
     ) -> bool {
-        let viewport_width =
-            unsafe { viewport_width.as_ref() }.map(|p| unsafe { Pin::new_unchecked(p) });
-        let viewport_height =
-            unsafe { viewport_height.as_ref() }.map(|p| unsafe { Pin::new_unchecked(p) });
         update_visible_instances(
             ops,
             state,

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -182,8 +182,8 @@ fn update_visible_instances(
     ops: &mut impl RepeaterInstanceOps,
     state: &mut RepeaterLayoutState,
     row_count: usize,
-    viewport_width: Pin<&Property<LogicalLength>>,
-    viewport_height: Pin<&Property<LogicalLength>>,
+    viewport_width: Option<Pin<&Property<LogicalLength>>>,
+    viewport_height: Option<Pin<&Property<LogicalLength>>>,
     viewport_y: Pin<&Property<LogicalLength>>,
     listview_width: LogicalLength,
     listview_height: LogicalLength,
@@ -194,9 +194,13 @@ fn update_visible_instances(
 
     if row_count == 0 {
         ops.splice(0, ops.len(), 0);
-        viewport_height.set(zero);
+        if let Some(viewport_height) = viewport_height {
+            viewport_height.set(zero);
+        }
         viewport_y.set(zero);
-        viewport_width.set(listview_width);
+        if let Some(viewport_width) = viewport_width {
+            viewport_width.set(listview_width);
+        }
         return false;
     }
 
@@ -337,8 +341,12 @@ fn update_visible_instances(
         // Recompute coordinates for the scrollbar.
         state.cached_item_height = (y - new_offset_y) / ops.len() as Coord;
         state.anchor_y = state.cached_item_height * state.offset as Coord;
-        viewport_height.set(LogicalLength::new(state.cached_item_height * row_count as Coord));
-        viewport_width.set(LogicalLength::new(vp_width));
+        if let Some(viewport_height) = viewport_height {
+            viewport_height.set(LogicalLength::new(state.cached_item_height * row_count as Coord));
+        }
+        if let Some(viewport_width) = viewport_width {
+            viewport_width.set(LogicalLength::new(vp_width));
+        }
         let new_viewport_y = -state.anchor_y + new_offset_y;
         // Important: Use get_internal here, the viewport_y may have a binding on it (especially
         // a physical animation).
@@ -627,14 +635,18 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
     /// [`Self::visit`], so this only covers the viewport geometry.
     pub fn track_changes_listview(
         self: Pin<&Self>,
-        viewport_width: Pin<&Property<LogicalLength>>,
-        viewport_height: Pin<&Property<LogicalLength>>,
+        viewport_width: Option<Pin<&Property<LogicalLength>>>,
+        viewport_height: Option<Pin<&Property<LogicalLength>>>,
         viewport_y: Pin<&Property<LogicalLength>>,
         listview_width: LogicalLength,
         listview_height: Pin<&Property<LogicalLength>>,
     ) {
-        viewport_width.register_as_dependency();
-        viewport_height.register_as_dependency();
+        if let Some(viewport_width) = viewport_width {
+            viewport_width.register_as_dependency();
+        }
+        if let Some(viewport_height) = viewport_height {
+            viewport_height.register_as_dependency();
+        }
         viewport_y.register_as_dependency();
         // listview_width is passed as a value, not a property, so it cannot
         // be registered as a dependency. Kept in the signature for symmetry
@@ -648,8 +660,8 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
     pub fn ensure_updated_listview(
         self: Pin<&Self>,
         init: impl Fn() -> ItemTreeRc<C>,
-        viewport_width: Pin<&Property<LogicalLength>>,
-        viewport_height: Pin<&Property<LogicalLength>>,
+        viewport_width: Option<Pin<&Property<LogicalLength>>>,
+        viewport_height: Option<Pin<&Property<LogicalLength>>>,
         viewport_y: Pin<&Property<LogicalLength>>,
         listview_width: LogicalLength,
         listview_height: Pin<&Property<LogicalLength>>,
@@ -950,12 +962,16 @@ mod ffi {
         ops: &mut RepeaterInstanceOpsVTable,
         state: &mut RepeaterLayoutState,
         row_count: usize,
-        viewport_width: Pin<&Property<LogicalLength>>,
-        viewport_height: Pin<&Property<LogicalLength>>,
+        viewport_width: *const Property<LogicalLength>,
+        viewport_height: *const Property<LogicalLength>,
         viewport_y: Pin<&Property<LogicalLength>>,
         listview_width: LogicalLength,
         listview_height: LogicalLength,
     ) -> bool {
+        let viewport_width =
+            unsafe { viewport_width.as_ref() }.map(|p| unsafe { Pin::new_unchecked(p) });
+        let viewport_height =
+            unsafe { viewport_height.as_ref() }.map(|p| unsafe { Pin::new_unchecked(p) });
         update_visible_instances(
             ops,
             state,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2207,16 +2207,12 @@ extern "C" fn ensure_instantiated(component: ItemTreeRefPin) -> bool {
         {
             let assume_property_logical_length =
                 |prop| unsafe { Pin::new_unchecked(&*(prop as *const Property<LogicalLength>)) };
-            let viewport_width = if let Some(viewport_width) = &lv.viewport_width {
-                Some(assume_property_logical_length(get_property_ptr(viewport_width, instance_ref)))
-            } else {
-                None
-            };
-            let viewport_height = if let Some(viewport_height) = &lv.viewport_height {
-                Some(assume_property_logical_length(get_property_ptr(viewport_height, instance_ref)))
-            } else {
-                None
-            };
+            let viewport_width = lv.viewport_width.as_ref().map(|viewport_width| {
+                assume_property_logical_length(get_property_ptr(viewport_width, instance_ref))
+            });
+            let viewport_height = lv.viewport_height.as_ref().map(|viewport_height| {
+                assume_property_logical_length(get_property_ptr(viewport_height, instance_ref))
+            });
             changed |= repeater.ensure_updated_listview(
                 init,
                 viewport_width,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2207,10 +2207,20 @@ extern "C" fn ensure_instantiated(component: ItemTreeRefPin) -> bool {
         {
             let assume_property_logical_length =
                 |prop| unsafe { Pin::new_unchecked(&*(prop as *const Property<LogicalLength>)) };
+            let viewport_width = if let Some(viewport_width) = &lv.viewport_width {
+                Some(assume_property_logical_length(get_property_ptr(viewport_width, instance_ref)))
+            } else {
+                None
+            };
+            let viewport_height = if let Some(viewport_height) = &lv.viewport_height {
+                Some(assume_property_logical_length(get_property_ptr(viewport_height, instance_ref)))
+            } else {
+                None
+            };
             changed |= repeater.ensure_updated_listview(
                 init,
-                assume_property_logical_length(get_property_ptr(&lv.viewport_width, instance_ref)),
-                assume_property_logical_length(get_property_ptr(&lv.viewport_height, instance_ref)),
+                viewport_width,
+                viewport_height,
                 assume_property_logical_length(get_property_ptr(&lv.viewport_y, instance_ref)),
                 eval::load_property(
                     instance_ref,

--- a/tests/cases/elements/listview_viewport_size.slint
+++ b/tests/cases/elements/listview_viewport_size.slint
@@ -1,0 +1,120 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { ListView  } from "std-widgets.slint";
+
+export component TestCaseFixedViewPort inherits Window  {
+    width: 400px;
+    height: 540px;
+
+    out property listview-viewport-height <=> listview.viewport-height;
+    out property listview-viewport-width <=> listview.viewport-width;
+
+    out property <bool> test: listview.viewport-width == 30000px && listview.viewport-height == 1000px;
+
+    listview := ListView {
+        viewport-width: 30000px;
+        viewport-height: 1000px;
+        for data in [
+            { text: "Blue", color: #0000ff, bg: #eeeeee},
+            { text: "Red", color: #ff0000, bg: #eeeeee},
+            { text: "Green", color: #00ff00, bg: #eeeeee},
+            { text: "Yellow", color: #ffff00, bg: #222222 },
+            { text: "Black", color: #000000, bg: #eeeeee },
+            { text: "White", color: #ffffff, bg: #222222 },
+            { text: "Magenta", color: #ff00ff, bg: #eeeeee },
+            { text: "Cyan", color: #00ffff, bg: #222222 },
+        ] : delegate := Rectangle {
+            height: 100px;
+            background: @linear-gradient(90deg, data.bg,data.bg.brighter(0.5));
+            HorizontalLayout {
+                text_Name := Text {
+                    text: data.text;
+                    color: data.color;
+                    font_size: 20px ;
+                    min-width: 1500px;
+                }
+            }
+        }
+    }
+}
+
+export component TestCaseFlexibleViewPort inherits Window  {
+    width: 400px;
+    height: 540px;
+
+    out property listview-viewport-height <=> listview.viewport-height;
+    out property listview-viewport-width <=> listview.viewport-width;
+
+    out property <bool> test: listview.viewport-width == 1500px && listview.viewport-height == 800px;
+
+    listview := ListView {
+        for data in [
+            { text: "Blue", color: #0000ff, bg: #eeeeee},
+            { text: "Red", color: #ff0000, bg: #eeeeee},
+            { text: "Green", color: #00ff00, bg: #eeeeee},
+            { text: "Yellow", color: #ffff00, bg: #222222 },
+            { text: "Black", color: #000000, bg: #eeeeee },
+            { text: "White", color: #ffffff, bg: #222222 },
+            { text: "Magenta", color: #ff00ff, bg: #eeeeee },
+            { text: "Cyan", color: #00ffff, bg: #222222 },
+        ] : delegate := Rectangle {
+            height: 100px;
+            background: @linear-gradient(90deg, data.bg,data.bg.brighter(0.5));
+            HorizontalLayout {
+                text_Name := Text {
+                    text: data.text;
+                    color: data.color;
+                    font_size: 20px ;
+                    min-width: 1500px;
+                }
+            }
+        }
+    }
+}
+
+/*
+
+// The viewport width is explicitly set to 30000 and the height to 1000px, so these values ??should be maintained
+
+```cpp
+auto handle = TestCaseFixedViewPort::create();
+const TestCaseFixedViewPort &instance = *handle;
+assert(instance.get_test());
+assert_eq(instance.get_listview_viewport_height(), 1000.);
+assert_eq(instance.get_listview_viewport_width(), 30000.);
+
+auto handle2 = TestCaseFlexibleViewPort::create();
+const TestCaseFlexibleViewPort &instance2 = *handle2;
+assert(instance2.get_test());
+assert_eq(instance2.get_listview_viewport_height(), 800.);
+assert_eq(instance2.get_listview_viewport_width(), 1500.);
+
+```
+
+```rust
+let instance = TestCaseFixedViewPort::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(instance.get_listview_viewport_height(), 1000.);
+assert_eq!(instance.get_listview_viewport_width(), 30000.);
+
+let instance = TestCaseFlexibleViewPort::new().unwrap();
+assert!(instance.get_test());
+
+assert_eq!(instance.get_listview_viewport_height(), 800.);
+assert_eq!(instance.get_listview_viewport_width(), 1500.);
+```
+
+```js
+var instance = new slint.TestCaseFixedViewPort({});
+assert(instance.test);
+assert.equal(instance.listview_viewport_height, 1000.);
+assert.equal(instance.listview_viewport_width, 30000.);
+
+var instance = new slint.TestCaseFlexibleViewPort({});
+assert(instance.test);
+assert.equal(instance.listview_viewport_height, 800.);
+assert.equal(instance.listview_viewport_width, 1500.);
+```
+
+*/

--- a/tests/cases/elements/listview_viewport_size.slint
+++ b/tests/cases/elements/listview_viewport_size.slint
@@ -9,8 +9,13 @@ export component TestCaseFixedViewPort inherits Window  {
 
     out property listview-viewport-height <=> listview.viewport-height;
     out property listview-viewport-width <=> listview.viewport-width;
+    out property<length> listview-viewport-offset_y <=> listview.viewport_y;
 
     out property <bool> test: listview.viewport-width == 30000px && listview.viewport-height == 1000px;
+
+    public function scroll-to-end() {
+        listview.viewport-y = -30000px;
+    }
 
     listview := ListView {
         viewport-width: 30000px;
@@ -45,6 +50,7 @@ export component TestCaseFlexibleViewPort inherits Window  {
 
     out property listview-viewport-height <=> listview.viewport-height;
     out property listview-viewport-width <=> listview.viewport-width;
+
 
     out property <bool> test: listview.viewport-width == 1500px && listview.viewport-height == 800px;
 
@@ -97,6 +103,10 @@ let instance = TestCaseFixedViewPort::new().unwrap();
 assert!(instance.get_test());
 assert_eq!(instance.get_listview_viewport_height(), 1000.);
 assert_eq!(instance.get_listview_viewport_width(), 30000.);
+
+// Test if scrolling to end of listview
+instance.invoke_scroll_to_end();
+assert_eq!(instance.get_listview_viewport_offset_y(), -30000.);
 
 let instance = TestCaseFlexibleViewPort::new().unwrap();
 assert!(instance.get_test());


### PR DESCRIPTION
When the viewport size is explicitly defined, the values ​​should not be overwritten when resizing the ListView.

- The viewport width and height are optional values ​​in the information structures and will only be automatically calculated when not explicitly defined by the user in the slint code;
- The ListView's scrolling behavior has been updated to allow scrolling above items when the viewport height is greater than the item height;

Fixes: #5485
