### PR TITLE
LSP: Code Action & Auto Complete for imported Property types

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -584,18 +584,53 @@ pub struct ComponentInformation {
 
 impl ComponentInformation {
     pub fn import_file_name(&self, current_uri: &Option<lsp_types::Url>) -> Option<String> {
-        if self.is_std_widget {
-            Some("std-widgets.slint".to_string())
+        import_file_name_for_url(
+            self.defined_at.as_ref().map(|p| &p.url),
+            self.is_std_widget,
+            current_uri,
+        )
+    }
+}
+
+fn import_file_name_for_url(
+    url: Option<&lsp_types::Url>,
+    is_std_widget: bool,
+    current_uri: &Option<lsp_types::Url>,
+) -> Option<String> {
+    if is_std_widget {
+        Some("std-widgets.slint".to_string())
+    } else {
+        let url = url?;
+        if let Some(path) = url.path().strip_prefix("/@") {
+            Some(format!("@{path}"))
+        } else if let Some(current_uri) = current_uri {
+            lsp_types::Url::make_relative(current_uri, url)
         } else {
-            let url = self.defined_at.as_ref().map(|p| &p.url)?;
-            if let Some(path) = url.path().strip_prefix("/@") {
-                Some(format!("@{path}"))
-            } else if let Some(current_uri) = current_uri {
-                lsp_types::Url::make_relative(current_uri, url)
-            } else {
-                url.to_file_path().ok().map(|p| p.to_string_lossy().to_string())
-            }
+            url.to_file_path().ok().map(|path| path.to_string_lossy().to_string())
         }
+    }
+}
+
+/// Information on an exported value type (struct or enum) that can be named as a
+/// property type, callback argument type, or function return type.
+///
+/// Distinct from [`ComponentInformation`], which represents things instantiable as
+/// elements.  The two categories are disjoint: a struct/enum can never be an element
+/// base type, and a component can never be a property type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeInformation {
+    /// The exported name of the type
+    pub name: String,
+    /// The URL to the file where this type is defined.
+    /// `None` for std-widget types (use `is_std_widget` to compute the import path).
+    pub defined_at: Option<lsp_types::Url>,
+    /// This type is exported from the standard widgets library
+    pub is_std_widget: bool,
+}
+
+impl TypeInformation {
+    pub fn import_file_name(&self, current_uri: &Option<lsp_types::Url>) -> Option<String> {
+        import_file_name_for_url(self.defined_at.as_ref(), self.is_std_widget, current_uri)
     }
 }
 

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -626,6 +626,10 @@ pub struct TypeInformation {
     pub defined_at: Option<lsp_types::Url>,
     /// This type is exported from the standard widgets library
     pub is_std_widget: bool,
+    /// The "kind" of type (e.g. struct/array, etc.).
+    /// This is a simplified representation of the real Type used by the compiler
+    /// that should be sufficient for the LSPs completions, etc.
+    pub kind: lsp_types::CompletionItemKind,
 }
 
 impl TypeInformation {

--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -6,7 +6,9 @@
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
 
-use crate::common::{ComponentInformation, DocumentCache, Position, PropertyChange};
+use crate::common::{
+    ComponentInformation, DocumentCache, Position, PropertyChange, TypeInformation,
+};
 #[cfg(feature = "preview-engine")]
 use i_slint_compiler::langtype::ElementType;
 
@@ -160,7 +162,10 @@ fn libraryize_url(document_cache: &DocumentCache, url: lsp_types::Url) -> lsp_ty
     }
 }
 
-/// Fill the result with all exported components that matches the given filter
+/// Fill the result with all exported components that matches the given filter.
+///
+/// Note that these are the components that can be instantiated as elements, and are distinct from
+/// exported value types (structs and enums) which are used in property types, callback argument types, etc.
 pub fn all_exported_components(
     document_cache: &DocumentCache,
     filter: &mut dyn FnMut(&ComponentInformation) -> bool,
@@ -198,6 +203,50 @@ pub fn all_exported_components(
 
             let Some(to_push) = to_push else {
                 continue;
+            };
+
+            if !filter(&to_push) {
+                continue;
+            }
+
+            result.push(to_push);
+        }
+    }
+}
+
+/// Fill the result with all exported value types (structs and enums) that match the
+/// given filter.
+///
+/// These are the types that can be named in `property <T>`, callback argument types,
+/// and function signatures. They are distinct from components/globals, which are
+/// instantiable as elements.
+pub fn all_exported_types(
+    document_cache: &DocumentCache,
+    filter: &mut dyn FnMut(&TypeInformation) -> bool,
+    result: &mut Vec<TypeInformation>,
+) {
+    for url in document_cache.all_urls() {
+        let Some(doc) = document_cache.get_document(&url) else { continue };
+        let is_builtin = url.scheme() == "builtin";
+        let is_std_widget = is_builtin && url.path().ends_with("/std-widgets.slint");
+
+        // Skip internal builtins — they have no importable struct/enum exports
+        if is_builtin && !is_std_widget {
+            continue;
+        }
+
+        let url = libraryize_url(document_cache, url);
+
+        for (exported_name, ty) in &*doc.exports {
+            // Only process struct/enum exports (Either::Right); components are Either::Left
+            let Some(_) = ty.as_ref().right() else {
+                continue;
+            };
+
+            let to_push = TypeInformation {
+                name: exported_name.to_string(),
+                defined_at: if is_std_widget { None } else { Some(url.clone()) },
+                is_std_widget,
             };
 
             if !filter(&to_push) {

--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -11,6 +11,7 @@ use crate::common::{
 };
 #[cfg(feature = "preview-engine")]
 use i_slint_compiler::langtype::ElementType;
+use lsp_types::CompletionItemKind;
 
 #[cfg(feature = "preview-engine")]
 fn builtin_component_info(name: &str) -> ComponentInformation {
@@ -214,6 +215,16 @@ pub fn all_exported_components(
     }
 }
 
+/// Get the types completion kind
+pub fn type_completion_kind(ty: &i_slint_compiler::langtype::Type) -> CompletionItemKind {
+    use i_slint_compiler::langtype::Type;
+    match *ty {
+        Type::Struct(_) => CompletionItemKind::STRUCT,
+        Type::Enumeration(_) => CompletionItemKind::ENUM,
+        _ => CompletionItemKind::TYPE_PARAMETER,
+    }
+}
+
 /// Fill the result with all exported value types (structs and enums) that match the
 /// given filter.
 ///
@@ -239,14 +250,16 @@ pub fn all_exported_types(
 
         for (exported_name, ty) in &*doc.exports {
             // Only process struct/enum exports (Either::Right); components are Either::Left
-            let Some(_) = ty.as_ref().right() else {
+            let Some(ty) = ty.as_ref().right() else {
                 continue;
             };
+            let kind = type_completion_kind(ty);
 
             let to_push = TypeInformation {
                 name: exported_name.to_string(),
                 defined_at: if is_std_widget { None } else { Some(url.clone()) },
                 is_std_widget,
+                kind,
             };
 
             if !filter(&to_push) {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1195,9 +1195,9 @@ fn get_code_actions(
                 &token,
                 document_cache,
                 &mut |ci| !ci.is_global && ci.is_exported && ci.name == text,
-                &mut |_name, file, edit| {
+                &mut |name, file, edit| {
                     result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
-                        title: format!("Add import from \"{file}\""),
+                        title: format!("import {{ {name} }} from \"{file}\""),
                         kind: Some(lsp_types::CodeActionKind::QUICKFIX),
                         edit: common::create_workspace_edit_from_path(
                             document_cache,
@@ -1378,9 +1378,9 @@ fn get_code_actions(
                 &token,
                 document_cache,
                 &mut |type_info| type_info.name == text,
-                &mut |_name, file, edit| {
+                &mut |name, file, edit| {
                     result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
-                        title: format!("Add import from \"{file}\""),
+                        title: format!("import {{ {name} }} from \"{file}\""),
                         kind: Some(lsp_types::CodeActionKind::QUICKFIX),
                         edit: common::create_workspace_edit_from_path(
                             document_cache,
@@ -2352,7 +2352,7 @@ export global NoPreviewForGlobal {}
                 &capabilities
             )),
             Some(vec![CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
-                title: "Add import from \"std-widgets.slint\"".into(),
+                title: "import { LineEdit } from \"std-widgets.slint\"".into(),
                 kind: Some(lsp_types::CodeActionKind::QUICKFIX),
                 edit: Some(WorkspaceEdit {
                     document_changes: Some(lsp_types::DocumentChanges::Edits(vec![
@@ -2461,7 +2461,7 @@ export component TestWindow inherits Window {
         assert_eq!(
             action,
             Some(vec![CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
-                title: "Add import from \"types.slint\"".into(),
+                title: "import { MyPoint } from \"types.slint\"".into(),
                 kind: Some(lsp_types::CodeActionKind::QUICKFIX),
                 edit: Some(WorkspaceEdit {
                     document_changes: Some(lsp_types::DocumentChanges::Edits(vec![

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -2427,8 +2427,8 @@ export component TestWindow inherits Window {
 }
 "#;
 
-        let types_url = Url::from_file_path("/foo/types.slint").unwrap();
-        let main_url = Url::from_file_path("/foo/main.slint").unwrap();
+        let types_url = Url::from_file_path(common::test::test_file_name("types.slint")).unwrap();
+        let main_url = Url::from_file_path(common::test::test_file_name("main.slint")).unwrap();
 
         // Load the types file first so the cache knows about it
         let mut dc = test::empty_document_cache();

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1378,7 +1378,7 @@ fn get_code_actions(
                 &token,
                 document_cache,
                 &mut |type_info| type_info.name == text,
-                &mut |name, file, edit| {
+                &mut |_type_info, name, file, edit| {
                     result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
                         title: format!("import {{ {name} }} from \"{file}\""),
                         kind: Some(lsp_types::CodeActionKind::QUICKFIX),

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -18,7 +18,7 @@ use crate::{common, util};
 
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
-use i_slint_compiler::object_tree::ElementRc;
+use i_slint_compiler::object_tree::{ElementRc, QualifiedTypeName};
 use i_slint_compiler::parser::{
     NodeOrToken, SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TextSize, syntax_nodes,
 };
@@ -1191,7 +1191,7 @@ fn get_code_actions(
         if is_lookup_error {
             // Couldn't lookup the element, there is probably an error. Suggest an edit
             let text = token.text();
-            completion::build_import_statements_edits(
+            completion::build_component_import_statements_edits(
                 &token,
                 document_cache,
                 &mut |ci| !ci.is_global && ci.is_exported && ci.name == text,
@@ -1355,6 +1355,42 @@ fn get_code_actions(
                     ..Default::default()
                 }));
             }
+        }
+    } else if token.kind() == SyntaxKind::Identifier
+        && node.kind() == SyntaxKind::QualifiedName
+        && node.parent().map(|n| n.kind()) == Some(SyntaxKind::Type)
+    {
+        // Offer "Add import from ..." for unresolved type references in property/callback/
+        // function type annotations (e.g. `property <MyStruct> foo`).
+        let is_lookup_error =
+            syntax_nodes::QualifiedName::new(node.clone()).is_some_and(|qualified_name| {
+                let qual = QualifiedTypeName::from_node(qualified_name);
+                let global_tr = document_cache.global_type_registry();
+                let tr = document_cache
+                    .get_document_for_source_file(&token.source_file)
+                    .map(|doc| &doc.local_registry)
+                    .unwrap_or(&global_tr);
+                matches!(tr.lookup_qualified(&qual.members), Type::Invalid)
+            });
+        if is_lookup_error {
+            let text = token.text();
+            completion::build_type_import_statements_edits(
+                &token,
+                document_cache,
+                &mut |type_info| type_info.name == text,
+                &mut |_name, file, edit| {
+                    result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                        title: format!("Add import from \"{file}\""),
+                        kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                        edit: common::create_workspace_edit_from_path(
+                            document_cache,
+                            token.source_file.path(),
+                            vec![edit],
+                        ),
+                        ..Default::default()
+                    }))
+                },
+            );
         }
     }
 
@@ -2367,6 +2403,109 @@ export global NoPreviewForGlobal {}
             assert!(token.text().starts_with("NoPreviewFor"));
             assert_eq!(get_code_actions(&mut dc, token, &capabilities), None);
         }
+    }
+
+    #[test]
+    fn test_add_import_for_type_annotation() {
+        // Document that uses a user-defined exported struct from a separate file as a
+        // property type, but doesn't import it yet.  The code action should be offered
+        // on the unresolved type identifier, and should NOT be offered once imported.
+        //
+        // We load the "types" file first so the DocumentCache knows about it, then
+        // load the main file that references the struct without importing it.
+        let types_content = r#"export struct MyPoint { x: int, y: int }
+export enum MyDirection { Up, Down, Left, Right }
+"#;
+        let main_content_without_import = r#"export component TestWindow inherits Window {
+    property <MyPoint> position;
+}
+"#;
+        let main_content_with_import = r#"import { MyPoint } from "types.slint";
+
+export component TestWindow inherits Window {
+    property <MyPoint> position;
+}
+"#;
+
+        let types_url = Url::from_file_path("/foo/types.slint").unwrap();
+        let main_url = Url::from_file_path("/foo/main.slint").unwrap();
+
+        // Load the types file first so the cache knows about it
+        let mut dc = test::empty_document_cache();
+        spin_on::spin_on(dc.preload_builtins());
+        let mut diagnostics = BuildDiagnostics::default();
+        let _ = spin_on::spin_on(dc.load_url(
+            &types_url,
+            Some(1),
+            types_content.to_string(),
+            &mut diagnostics,
+        ));
+
+        // Load the main file (no import for MyPoint yet) with version 42 for test assertions
+        let _ = spin_on::spin_on(dc.load_url(
+            &main_url,
+            Some(42),
+            main_content_without_import.to_string(),
+            &mut diagnostics,
+        ));
+
+        let capabilities = ClientCapabilities::default();
+
+        // Cursor on "MyPoint" in `property <MyPoint> position;` (line 1, col 14)
+        // Line 1: `    property <MyPoint> position;`
+        // Col 13: `<`, col 14: `M`
+        let type_pos = Position::new(1, 14);
+        let action = token_descr(&dc, &main_url, &type_pos)
+            .and_then(|(token, _)| get_code_actions(&mut dc, token, &capabilities));
+
+        assert_eq!(
+            action,
+            Some(vec![CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                title: "Add import from \"types.slint\"".into(),
+                kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                edit: Some(WorkspaceEdit {
+                    document_changes: Some(lsp_types::DocumentChanges::Edits(vec![
+                        lsp_types::TextDocumentEdit {
+                            text_document: lsp_types::OptionalVersionedTextDocumentIdentifier {
+                                version: Some(42),
+                                uri: main_url.clone(),
+                            },
+                            // New import line at the top (no existing imports to merge into)
+                            edits: vec![lsp_types::OneOf::Left(TextEdit::new(
+                                lsp_types::Range::new(Position::new(0, 0), Position::new(0, 0)),
+                                "import { MyPoint } from \"types.slint\";\n".into()
+                            ))]
+                        }
+                    ])),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })])
+        );
+
+        // Now load the version WITH the import — action should no longer appear
+        let mut document_cache_with_import = test::empty_document_cache();
+        spin_on::spin_on(document_cache_with_import.preload_builtins());
+        let mut diagnostics = BuildDiagnostics::default();
+        let _ = spin_on::spin_on(document_cache_with_import.load_url(
+            &types_url,
+            Some(1),
+            types_content.to_string(),
+            &mut diagnostics,
+        ));
+        let _ = spin_on::spin_on(document_cache_with_import.load_url(
+            &main_url,
+            Some(42),
+            main_content_with_import.to_string(),
+            &mut diagnostics,
+        ));
+
+        // Cursor on "MyPoint" — now on line 3 col 14 (because the import line is added)
+        let action2 = token_descr(&document_cache_with_import, &main_url, &Position::new(3, 14))
+            .and_then(|(token, _)| {
+                get_code_actions(&mut document_cache_with_import, token, &capabilities)
+            });
+        assert_eq!(action2, None, "import action should not appear when type is already imported");
     }
 
     #[test]

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -3,7 +3,7 @@
 
 // cSpell: ignore rfind barbar funi
 
-use crate::common::component_catalog::{all_exported_components, all_exported_types};
+use crate::common::component_catalog::{self, all_exported_components, all_exported_types};
 use crate::common::{self, DocumentCache};
 use crate::util::{lookup_current_element_type, text_size_to_lsp_position, with_lookup_ctx};
 
@@ -947,23 +947,24 @@ fn resolve_type_scope(
     document_cache: &DocumentCache,
 ) -> Option<Vec<CompletionItem>> {
     let global_tr = document_cache.global_type_registry();
-    let tr = token
+    let type_register = token
         .source_file()
         .and_then(|sf| document_cache.get_document_for_source_file(sf))
         .map(|doc| &doc.local_registry)
         .unwrap_or(&global_tr);
-    Some(
-        tr.all_types()
-            .into_iter()
-            .filter_map(|(k, t)| {
-                t.is_property_type().then(|| {
-                    let mut c = CompletionItem::new_simple(k.to_string(), String::new());
-                    c.kind = Some(CompletionItemKind::TYPE_PARAMETER);
-                    c
-                })
+    let mut result: Vec<CompletionItem> = type_register
+        .all_types()
+        .into_iter()
+        .filter_map(|(name, ty)| {
+            ty.is_property_type().then(|| {
+                let mut c = CompletionItem::new_simple(name.to_string(), String::new());
+                c.kind = Some(component_catalog::type_completion_kind(&ty));
+                c
             })
-            .collect(),
-    )
+        })
+        .collect();
+    add_types_to_import(&token, document_cache, &mut result);
+    Some(result)
 }
 
 fn complete_path_in_string(
@@ -1010,17 +1011,14 @@ fn add_components_to_import(
     document_cache: &common::DocumentCache,
     result: &mut Vec<CompletionItem>,
 ) {
-    let mut available_types: HashSet<_> = result.iter().map(|c| c.label.clone()).collect();
+    let available_types: HashSet<_> = result.iter().map(|c| c.label.clone()).collect();
     build_component_import_statements_edits(
         token,
         document_cache,
-        &mut |ci: &common::ComponentInformation| {
-            if ci.is_global || !ci.is_exported || available_types.contains(&ci.name) {
-                false
-            } else {
-                available_types.insert(ci.name.clone());
-                true
-            }
+        &mut |component: &common::ComponentInformation| {
+            !component.is_global
+                && component.is_exported
+                && !available_types.contains(&component.name)
         },
         &mut |exported_name, file, the_import| {
             result.push(CompletionItem {
@@ -1033,6 +1031,34 @@ fn add_components_to_import(
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 filter_text: Some(exported_name.to_string()),
                 kind: Some(CompletionItemKind::CLASS),
+                detail: Some(format!("(import from \"{file}\")")),
+                additional_text_edits: Some(vec![the_import]),
+                ..Default::default()
+            });
+        },
+    );
+}
+
+/// Add the exported value types (structs/enums) that require an import to `result`.
+///
+/// Already-available types (those already in `result`) are excluded via a `HashSet` dedup,
+/// mirroring the same pattern used by [`add_components_to_import`] for elements.
+fn add_types_to_import(
+    token: &SyntaxToken,
+    document_cache: &common::DocumentCache,
+    result: &mut Vec<CompletionItem>,
+) {
+    let available_types: HashSet<_> = result.iter().map(|c| c.label.clone()).collect();
+    build_type_import_statements_edits(
+        token,
+        document_cache,
+        &mut |type_info: &common::TypeInformation| !available_types.contains(&type_info.name),
+        &mut |type_info, exported_name, file, the_import| {
+            result.push(CompletionItem {
+                label: format!("{exported_name} (import from \"{file}\")"),
+                insert_text: Some(exported_name.to_string()),
+                filter_text: Some(exported_name.to_string()),
+                kind: Some(type_info.kind),
                 detail: Some(format!("(import from \"{file}\")")),
                 additional_text_edits: Some(vec![the_import]),
                 ..Default::default()
@@ -1179,31 +1205,33 @@ pub fn build_component_import_statements_edits(
         token,
         document_cache,
         exported_types.iter().filter_map(|type_info| {
-            type_info.import_file_name(&current_uri).map(|path| (type_info.name.clone(), path))
+            type_info
+                .import_file_name(&current_uri)
+                .map(|path| (type_info, type_info.name.clone(), path))
         }),
-        add_edit,
+        &mut |_component_info, name, file, the_import| add_edit(name, file, the_import),
     )
 }
 
-fn build_import_statements_edits(
+fn build_import_statements_edits<T>(
     token: &SyntaxToken,
     document_cache: &DocumentCache,
-    imports: impl Iterator<Item = (String, String)>,
-    add_edit: &mut dyn FnMut(&str, &str, TextEdit),
+    imports: impl Iterator<Item = (T, String, String)>,
+    add_edit: &mut dyn FnMut(T, &str, &str, TextEdit),
 ) -> Option<()> {
     let current_doc =
         document_cache.get_document_for_source_file(&token.source_file)?.node.as_ref()?;
     let (missing_import_location, known_import_locations) =
         find_import_locations(current_doc, document_cache.format);
 
-    for (type_name, file) in imports {
+    for (type_info, type_name, file) in imports {
         let the_import = create_import_edit_impl(
             &type_name,
             &file,
             &missing_import_location,
             &known_import_locations,
         );
-        add_edit(&type_name, &file, the_import);
+        add_edit(type_info, &type_name, &file, the_import);
     }
 
     Some(())
@@ -1220,7 +1248,7 @@ pub fn build_type_import_statements_edits(
     token: &SyntaxToken,
     document_cache: &common::DocumentCache,
     filter: &mut dyn FnMut(&common::TypeInformation) -> bool,
-    add_edit: &mut dyn FnMut(&str, &str, TextEdit),
+    add_edit: &mut dyn FnMut(&common::TypeInformation, &str, &str, TextEdit),
 ) -> Option<()> {
     let current_file = token.source_file.path().to_owned();
     let current_uri = lsp_types::Url::from_file_path(&current_file).ok();
@@ -1231,7 +1259,9 @@ pub fn build_type_import_statements_edits(
         token,
         document_cache,
         exported_types.iter().filter_map(|type_info| {
-            type_info.import_file_name(&current_uri).map(|path| (type_info.name.clone(), path))
+            type_info
+                .import_file_name(&current_uri)
+                .map(|path| (type_info, type_info.name.clone(), path))
         }),
         add_edit,
     )
@@ -1350,13 +1380,35 @@ mod tests {
             );
         }
 
-        if let Some(insert_text_format) = expected.insert_text_format {
+        if let Some(insert_text_format) = &expected.insert_text_format {
             assert_eq!(
-                found.insert_text_format,
+                found.insert_text_format.as_ref(),
                 Some(insert_text_format),
                 "Unexpected insert_text_format for '{}'",
                 expected.label,
             );
+        }
+
+        if let Some(filter_text) = &expected.filter_text {
+            assert_eq!(
+                found.filter_text.as_ref(),
+                Some(filter_text),
+                "Unexpected filter_text for '{}'",
+                expected.label,
+            );
+        }
+
+        if let Some(text_edits) = &expected.additional_text_edits {
+            let Some(actual_edits) = found.additional_text_edits.as_ref() else {
+                panic!("Expected additional_text_edits for completion {}", expected.label)
+            };
+            for (expected_edit, actual_edit) in text_edits.iter().zip_eq(actual_edits) {
+                assert_eq!(
+                    expected_edit.new_text, actual_edit.new_text,
+                    "Unexpected text_edit for completion {}",
+                    expected.label
+                );
+            }
         }
     }
 
@@ -2312,5 +2364,116 @@ mod tests {
         assert!(!res.iter().any(|ci| ci.label == "opacity"));
         assert!(!res.iter().any(|ci| ci.label == "absolute-position"));
         assert!(!res.iter().any(|ci| ci.label == "accessible-action-default"));
+    }
+
+    /// Helper for multi-file completion tests: load `types_file` first so the DocumentCache
+    /// knows about it, then request completions at the `🔺` cursor in `main_file`.
+    fn get_completions_multi_file(
+        types_file_name: &str,
+        types_content: &str,
+        main_file_name: &str,
+        main_file_with_cursor: &str,
+    ) -> Option<Vec<CompletionItem>> {
+        use i_slint_compiler::diagnostics::BuildDiagnostics;
+        use lsp_types::Url;
+
+        const CURSOR_EMOJI: char = '🔺';
+        let main_content = main_file_with_cursor.replace(CURSOR_EMOJI, "");
+        let cursor_offset = (main_file_with_cursor.find(CURSOR_EMOJI).unwrap() as u32).into();
+
+        let mut dc = crate::language::test::empty_document_cache();
+        spin_on::spin_on(dc.preload_builtins());
+        let mut diagnostics = BuildDiagnostics::default();
+
+        let types_url = Url::from_file_path(format!("/foo/{types_file_name}")).unwrap();
+        let _ = spin_on::spin_on(dc.load_url(
+            &types_url,
+            Some(1),
+            types_content.to_string(),
+            &mut diagnostics,
+        ));
+
+        let main_url = Url::from_file_path(format!("/foo/{main_file_name}")).unwrap();
+        let _ = spin_on::spin_on(dc.load_url(
+            &main_url,
+            Some(2),
+            main_content.clone(),
+            &mut diagnostics,
+        ));
+
+        let doc = dc.get_document(&main_url)?;
+        let token = crate::language::token_at_offset(doc.node.as_ref()?, cursor_offset)?;
+        let caps = CompletionClientCapabilities {
+            completion_item: Some(lsp_types::CompletionItemCapability {
+                snippet_support: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        completion_at(&mut dc, token, cursor_offset, Some(&caps))
+    }
+
+    #[test]
+    fn type_completion_suggests_import_for_unimported_struct() {
+        // types.slint exports MyPoint (struct) and MyDirection (enum).
+        // main.slint does not import them.  Completing `<My` should surface
+        // `MyPoint (import from "types.slint")` and
+        // `MyDirection (import from "types.slint")` with bare insert_text and
+        // an additional_text_edit that adds the import line.
+        let types_content = r#"export struct MyPoint { x: int, y: int }
+export enum MyDirection { Up, Down, Left, Right }
+"#;
+        let main_content = r#"export component TestWindow inherits Window {
+    property <My🔺> position;
+}
+"#;
+        let results =
+            get_completions_multi_file("types.slint", types_content, "main.slint", main_content)
+                .unwrap();
+
+        // Both the struct and enum should appear with an import note
+        for type_name in &["MyPoint", "MyDirection"] {
+            let expected_label = format!("{type_name} (import from \"types.slint\")");
+
+            assert_completion_found(
+                &CompletionItem {
+                    label: expected_label.clone(),
+                    insert_text: Some(type_name.to_string()),
+                    filter_text: Some(type_name.to_string()),
+                    additional_text_edits: Some(vec![TextEdit {
+                        range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                        new_text: format!("import {{ {type_name} }} from \"types.slint\";\n"),
+                    }]),
+                    ..Default::default()
+                },
+                &results,
+            );
+        }
+    }
+
+    #[test]
+    fn type_completion_no_import_suggestion_when_already_imported() {
+        // When main.slint already imports MyPoint, the "(import from ...)" completion
+        // variant must NOT appear — only the plain "MyPoint" entry should be present.
+        let types_content = r#"export struct MyPoint { x: int, y: int }
+"#;
+        let main_content = r#"import { MyPoint } from "types.slint";
+export component TestWindow inherits Window {
+    property <MyP🔺> position;
+}
+"#;
+        let results =
+            get_completions_multi_file("types.slint", types_content, "main.slint", main_content)
+                .unwrap();
+
+        assert_completion_found(
+            &CompletionItem { label: "MyPoint".into(), ..Default::default() },
+            &results,
+        );
+        // The "(import from ...)" variant must not appear
+        assert!(
+            !results.iter().any(|ci| ci.label == "MyPoint (import from \"types.slint\")"),
+            "unexpected import-suggestion for already-imported type"
+        );
     }
 }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -2385,7 +2385,8 @@ mod tests {
         spin_on::spin_on(dc.preload_builtins());
         let mut diagnostics = BuildDiagnostics::default();
 
-        let types_url = Url::from_file_path(format!("/foo/{types_file_name}")).unwrap();
+        let types_url =
+            Url::from_file_path(crate::common::test::test_file_name(types_file_name)).unwrap();
         let _ = spin_on::spin_on(dc.load_url(
             &types_url,
             Some(1),
@@ -2393,7 +2394,8 @@ mod tests {
             &mut diagnostics,
         ));
 
-        let main_url = Url::from_file_path(format!("/foo/{main_file_name}")).unwrap();
+        let main_url =
+            Url::from_file_path(crate::common::test::test_file_name(main_file_name)).unwrap();
         let _ = spin_on::spin_on(dc.load_url(
             &main_url,
             Some(2),

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -3,7 +3,7 @@
 
 // cSpell: ignore rfind barbar funi
 
-use crate::common::component_catalog::all_exported_components;
+use crate::common::component_catalog::{all_exported_components, all_exported_types};
 use crate::common::{self, DocumentCache};
 use crate::util::{lookup_current_element_type, text_size_to_lsp_position, with_lookup_ctx};
 
@@ -757,7 +757,7 @@ fn resolve_expression_scope(
         })
     {
         let mut available_types: HashSet<String> = r.iter().map(|c| c.label.clone()).collect();
-        build_import_statements_edits(
+        build_component_import_statements_edits(
             &token,
             document_cache,
             &mut |ci: &common::ComponentInformation| {
@@ -1011,7 +1011,7 @@ fn add_components_to_import(
     result: &mut Vec<CompletionItem>,
 ) {
     let mut available_types: HashSet<_> = result.iter().map(|c| c.label.clone()).collect();
-    build_import_statements_edits(
+    build_component_import_statements_edits(
         token,
         document_cache,
         &mut |ci: &common::ComponentInformation| {
@@ -1159,7 +1159,7 @@ pub fn create_import_edit(
 /// This is used for auto-completion and also for fixup diagnostics
 ///
 /// Call `add_edit` with the component name and file name and TextEdit for every component for which the `filter` callback returns true
-pub fn build_import_statements_edits(
+pub fn build_component_import_statements_edits(
     token: &SyntaxToken,
     document_cache: &common::DocumentCache,
     filter: &mut dyn FnMut(&common::ComponentInformation) -> bool,
@@ -1168,32 +1168,73 @@ pub fn build_import_statements_edits(
     // Find out types that can be imported
     let current_file = token.source_file.path().to_owned();
     let current_uri = lsp_types::Url::from_file_path(&current_file).ok();
-    let current_doc =
-        document_cache.get_document_for_source_file(&token.source_file)?.node.as_ref()?;
-    let (missing_import_location, known_import_locations) =
-        find_import_locations(current_doc, document_cache.format);
 
-    let exports = {
+    let exported_types = {
         let mut tmp = Vec::new();
         all_exported_components(document_cache, filter, &mut tmp);
         tmp
     };
 
-    for ci in &exports {
-        let Some(file) = ci.import_file_name(&current_uri) else {
-            continue;
-        };
+    build_import_statements_edits(
+        token,
+        document_cache,
+        exported_types.iter().filter_map(|type_info| {
+            type_info.import_file_name(&current_uri).map(|path| (type_info.name.clone(), path))
+        }),
+        add_edit,
+    )
+}
 
+fn build_import_statements_edits(
+    token: &SyntaxToken,
+    document_cache: &DocumentCache,
+    imports: impl Iterator<Item = (String, String)>,
+    add_edit: &mut dyn FnMut(&str, &str, TextEdit),
+) -> Option<()> {
+    let current_doc =
+        document_cache.get_document_for_source_file(&token.source_file)?.node.as_ref()?;
+    let (missing_import_location, known_import_locations) =
+        find_import_locations(current_doc, document_cache.format);
+
+    for (type_name, file) in imports {
         let the_import = create_import_edit_impl(
-            &ci.name,
+            &type_name,
             &file,
             &missing_import_location,
             &known_import_locations,
         );
-        add_edit(&ci.name, &file, the_import);
+        add_edit(&type_name, &file, the_import);
     }
 
     Some(())
+}
+
+/// Try to generate `import { XXX } from "foo.slint";` for every exported value type
+/// (struct or enum) for which the `filter` callback returns true.
+///
+/// This is the counterpart of [`build_component_import_statements_edits`] for type references
+/// (property types, callback/function argument types) rather than element types.
+///
+/// Call `add_edit` with the type name, file name, and `TextEdit` for every matching type.
+pub fn build_type_import_statements_edits(
+    token: &SyntaxToken,
+    document_cache: &common::DocumentCache,
+    filter: &mut dyn FnMut(&common::TypeInformation) -> bool,
+    add_edit: &mut dyn FnMut(&str, &str, TextEdit),
+) -> Option<()> {
+    let current_file = token.source_file.path().to_owned();
+    let current_uri = lsp_types::Url::from_file_path(&current_file).ok();
+
+    let mut exported_types = Vec::new();
+    all_exported_types(document_cache, filter, &mut exported_types);
+    build_import_statements_edits(
+        token,
+        document_cache,
+        exported_types.iter().filter_map(|type_info| {
+            type_info.import_file_name(&current_uri).map(|path| (type_info.name.clone(), path))
+        }),
+        add_edit,
+    )
 }
 
 fn is_followed_by_brace(token: &SyntaxToken) -> bool {


### PR DESCRIPTION
- **Add code action for importing unresolved type**
- **Reword import code action**
- **Auto-complete type names that require import**

Currently, only components can be auto-imported by code action or autocompletion.

This PR adds support for the same behavior for property types.

It also now suggests all possible import locations for a given type name (both component and property types),
instead of only the first one.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
