### PR TITLE
Bump the Windows stack size in the published tools' build scripts

### DIFF
--- a/tools/lsp/build.rs
+++ b/tools/lsp/build.rs
@@ -1,7 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+/// Mirror the `/STACK` setting from `.cargo/config.toml`, which is not shipped
+/// in the published crate.
+fn bump_windows_stack_size() {
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        println!("cargo:rustc-link-arg-bins=/STACK:8000000");
+    }
+}
+
 fn main() {
+    bump_windows_stack_size();
+
     // Safety: there are no other threads at this point
     unsafe {
         // Make the compiler handle ComponentContainer:

--- a/tools/viewer/build.rs
+++ b/tools/viewer/build.rs
@@ -3,9 +3,18 @@
 
 use std::path::PathBuf;
 
+/// Mirror the `/STACK` setting from `.cargo/config.toml`, which is not shipped
+/// in the published crate.
+fn bump_windows_stack_size() {
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        println!("cargo:rustc-link-arg-bins=/STACK:8000000");
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_REMOTE");
+    bump_windows_stack_size();
     // The slint!{} macro in remote.rs needs the experimental
     // new_with_existing_window constructor.
     if std::env::var_os("CARGO_FEATURE_REMOTE").is_some() {


### PR DESCRIPTION
.cargo/config.toml raises the Windows stack to 8 MiB, but it is not shipped in the published crates, so installed builds fall back to the 1 MiB default and overflow the stack on deeply nested layouts. Set it from build.rs, which does ship, for each tool published to crates.io.

Fixes: #12250

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
