### PR TITLE
interpreter: fix two-way binding of several struct fields

### DIFF
--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -230,15 +230,15 @@ where
             if let Some(cp) = Property::check_common_property(p) {
                 return cp;
             }
-            // link_two_way sets a TwoWayBinding on p, which
-            // check_common_property can find on subsequent calls.
-            // Only safe when p has no binding yet (a pre-existing
-            // binding's intercept_set_binding may not accept this).
-            if !p.has_binding() {
-                let anchor = Rc::pin(Property::<Value>::default());
-                Property::link_two_way(anchor.as_ref(), p);
-                return Property::check_common_property(p).unwrap();
-            }
+            // link_two_way installs a TwoWayBinding on p (moving any
+            // existing binding into the shared common property), which
+            // check_common_property finds on subsequent calls. This keeps
+            // prepare_for_two_way_binding idempotent: when several fields of
+            // the same struct property are two-way bound, they must all share
+            // one common property instead of each creating its own.
+            let anchor = Rc::pin(Property::<Value>::default());
+            Property::link_two_way(anchor.as_ref(), p);
+            return Property::check_common_property(p).unwrap();
         }
 
         let p1 = self.apply_pin(item);

--- a/tests/cases/issues/issue_12268_two_way_struct_fields.slint
+++ b/tests/cases/issues/issue_12268_two_way_struct_fields.slint
@@ -54,7 +54,7 @@ assert_eq!(found, 1);
 ```cpp
 auto handle = TestCase::create();
 auto found =
-    slint_testing::ElementHandle::find_by_accessible_label(handle, "first.length = 3");
+    slint::testing::ElementHandle::find_by_accessible_label(handle, "first.length = 3");
 assert_eq(found.size(), 1);
 ```
 */

--- a/tests/cases/issues/issue_12268_two_way_struct_fields.slint
+++ b/tests/cases/issues/issue_12268_two_way_struct_fields.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview cannot search elements (the wrapper has no item tree).
+//ignore: cpp-live-preview
+
 // Two-way binding the `first` and `second` fields of a struct to separate
 // sub-components must keep both fields working. Preparing the second field's
 // two-way binding used to detach the first from the struct, so the array

--- a/tests/cases/issues/issue_12268_two_way_struct_fields.slint
+++ b/tests/cases/issues/issue_12268_two_way_struct_fields.slint
@@ -1,0 +1,60 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Two-way binding the `first` and `second` fields of a struct to separate
+// sub-components must keep both fields working. Preparing the second field's
+// two-way binding used to detach the first from the struct, so the array
+// `first` rendered as empty. The corruption only shows in the interpreter
+// while rendering, so the test blocks visit the elements to render the tree
+// and then check that the array still has its three items.
+// Regression test for #12268.
+
+struct Data {
+    first: [bool],
+    second: bool,
+}
+
+component BindFirst {
+    in-out property <[bool]> first;
+    VerticalLayout {
+        Text { text: "first.length = " + first.length; }
+        for value in first: Text { text: value ? "on" : "off"; }
+    }
+}
+
+component BindSecond {
+    in-out property <bool> second;
+    Text { text: second ? "on" : "off"; }
+}
+
+component BindMultiple {
+    in-out property <Data> data;
+    VerticalLayout {
+        BindFirst { first <=> data.first; }
+        BindSecond { second <=> data.second; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <[Data]> data: [{ first: [false, false, false], second: false }];
+    for row in data: BindMultiple { data <=> row; }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+// Visiting the elements renders the tree, which evaluates `first.length`.
+// With the bug the array is empty, so the label reads "first.length = 0".
+let found = slint_testing::ElementHandle::find_by_accessible_label(&instance, "first.length = 3").count();
+assert_eq!(found, 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+auto found =
+    slint_testing::ElementHandle::find_by_accessible_label(handle, "first.length = 3");
+assert_eq(found.size(), 1);
+```
+*/

--- a/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
+++ b/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview cannot search elements (the wrapper has no item tree).
+//ignore: cpp-live-preview
+
 // Same root cause as #12268, but here the struct comes from a struct literal
 // rather than a model row, so the dropped `first` field is not even an array
 // and the interpreter panics ("First argument not an array") while evaluating

--- a/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
+++ b/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
@@ -58,7 +58,7 @@ assert_eq!(texts, 5);
 ```cpp
 auto handle = TestCase::create();
 auto texts =
-    slint_testing::ElementHandle::find_by_element_type_name(handle, "Text");
+    slint::testing::ElementHandle::find_by_element_type_name(handle, "Text");
 assert_eq(texts.size(), 5);
 ```
 

--- a/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
+++ b/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
@@ -1,0 +1,70 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Same root cause as #12268, but here the struct comes from a struct literal
+// rather than a model row, so the dropped `first` field is not even an array
+// and the interpreter panics ("First argument not an array") while evaluating
+// `first.length` during rendering. The test blocks render the tree, which
+// panics with the bug. Regression test for #12269.
+
+struct Data {
+    first: [bool],
+    second: bool,
+}
+
+component Check {
+    in-out property <bool> checked;
+    Text { text: checked ? "[x]" : "[ ]"; }
+}
+
+component BindFirst {
+    in-out property <[bool]> first;
+    VerticalLayout {
+        Text { text: "first.length = " + first.length; }
+        for value[index] in first: Check { checked <=> value; }
+    }
+}
+
+component BindSecond {
+    in-out property <bool> second;
+    Check { checked <=> second; }
+}
+
+component BindMultiple {
+    in-out property <Data> data;
+    VerticalLayout {
+        BindFirst { first <=> data.first; }
+        BindSecond { second <=> data.second; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Data> data: { first: [false, false, false], second: false };
+    BindMultiple { data <=> data; }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+// Visiting every element renders the tree; with the bug this panics on
+// `first.length`. With the fix the three items render, giving 5 Text elements
+// (the length label, three items and `second`).
+let texts = slint_testing::ElementHandle::find_by_element_type_name(&instance, "Text").count();
+assert_eq!(texts, 5);
+```
+
+```cpp
+auto handle = TestCase::create();
+auto texts =
+    slint_testing::ElementHandle::find_by_element_type_name(handle, "Text");
+assert_eq(texts.size(), 5);
+```
+
+```js
+var instance = new slint.TestCase();
+// Rendering the tree evaluates `first.length`, which panics with the bug.
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+```
+*/


### PR DESCRIPTION
Two-way binding two fields of a struct property to different sub-components made the second binding create its own common property and detach the first field from the struct. The array field then read back empty, or made the interpreter panic while rendering.

Fixes: #12268
Fixes: #12269
