### PR TITLE
compiler: type the resource_url_mapper argument as a Url

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -2026,6 +2026,13 @@ impl ImageReference {
         }
     }
 
+    /// Classify a URL returned by the resource mapper. It is already a URL, so
+    /// the only distinction is a `data:` URI (kept as a string, see
+    /// [`Self::DataUri`]) from any other URL.
+    pub fn from_mapped_url(url: url::Url) -> Self {
+        if url.scheme() == "data" { Self::DataUri(url.as_str().into()) } else { Self::Url(url) }
+    }
+
     /// The image source loaded at run-time for a non-embedded reference: the
     /// path, the URL, or the `data:` URI, as the string handed to
     /// `Image::load_from_path`. `None` for embedded references.

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1990,14 +1990,52 @@ pub enum EasingCurve {
     // Custom(Box<dyn Fn(f32)->f32>),
 }
 
-// The compiler generates ResourceReference::AbsolutePath for all references like @image-url("foo.png")
-// and the resource lowering path may change this to EmbeddedData if configured.
+// The compiler resolves every `@image-url("foo.png")` into a `Path`, `Url`, or
+// `DataUri` reference; the resource lowering pass may then replace it with
+// `EmbeddedData`/`EmbeddedTexture` if configured.
 #[derive(Clone, Debug)]
 pub enum ImageReference {
     None,
-    AbsolutePath(SmolStr),
-    EmbeddedData { resource_id: crate::embedded_resources::EmbeddedResourcesIdx, extension: String },
-    EmbeddedTexture { resource_id: crate::embedded_resources::EmbeddedResourcesIdx },
+    /// An absolute path to a local image file on disk.
+    Path(SmolStr),
+    /// A non-`data:` URL, e.g. `builtin:/`, `http(s):`, or `user://`.
+    Url(url::Url),
+    /// An inline `data:` URI carrying the image content.
+    DataUri(SmolStr),
+    EmbeddedData {
+        resource_id: crate::embedded_resources::EmbeddedResourcesIdx,
+        extension: String,
+    },
+    EmbeddedTexture {
+        resource_id: crate::embedded_resources::EmbeddedResourcesIdx,
+    },
+}
+
+impl ImageReference {
+    /// Classify a resolved `@image-url` string (an absolute path, a URL, or a
+    /// `data:` URI) into the matching reference kind.
+    pub fn from_resolved(reference: SmolStr) -> Self {
+        if reference.starts_with("data:") {
+            return Self::DataUri(reference);
+        }
+        // A single-character scheme is a Windows drive letter (`c:\...`), i.e. a
+        // path rather than a URL.
+        match url::Url::parse(&reference) {
+            Ok(url) if url.scheme().len() > 1 => Self::Url(url),
+            _ => Self::Path(reference),
+        }
+    }
+
+    /// The image source loaded at run-time for a non-embedded reference: the
+    /// path, the URL, or the `data:` URI, as the string handed to
+    /// `Image::load_from_path`. `None` for embedded references.
+    pub fn source(&self) -> Option<&str> {
+        match self {
+            Self::Path(source) | Self::DataUri(source) => Some(source),
+            Self::Url(url) => Some(url.as_str()),
+            Self::None | Self::EmbeddedData { .. } | Self::EmbeddedTexture { .. } => None,
+        }
+    }
 }
 
 /// Print the expression as a .slint code (not necessarily valid .slint)

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4155,9 +4155,11 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         Expression::ImageReference { resource_ref, nine_slice } => {
             let image = match resource_ref {
                 crate::expression_tree::ImageReference::None => r#"slint::Image()"#.to_string(),
-                crate::expression_tree::ImageReference::AbsolutePath(path) => format!(
+                resource_ref @ (crate::expression_tree::ImageReference::Path(_)
+                | crate::expression_tree::ImageReference::Url(_)
+                | crate::expression_tree::ImageReference::DataUri(_)) => format!(
                     r#"slint::Image::load_from_path(slint::SharedString(u8"{}"))"#,
-                    escape_string(path.as_str())
+                    escape_string(resource_ref.source().unwrap())
                 ),
                 crate::expression_tree::ImageReference::EmbeddedData { resource_id, extension } => {
                     let symbol = format!("slint_embedded_resource_{resource_id}");

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3297,9 +3297,11 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 crate::expression_tree::ImageReference::None => {
                     quote!(sp::Image::default())
                 }
-                crate::expression_tree::ImageReference::AbsolutePath(path) => {
-                    let path = path.as_str();
-                    quote!(sp::Image::load_from_path(::std::path::Path::new(#path)).unwrap_or_default())
+                resource_ref @ (crate::expression_tree::ImageReference::Path(_)
+                | crate::expression_tree::ImageReference::Url(_)
+                | crate::expression_tree::ImageReference::DataUri(_)) => {
+                    let source = resource_ref.source().unwrap();
+                    quote!(sp::Image::load_from_path(::std::path::Path::new(#source)).unwrap_or_default())
                 }
                 crate::expression_tree::ImageReference::EmbeddedData { resource_id, extension } => {
                     let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id.0);

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -120,7 +120,8 @@ pub enum ComponentSelection {
 /// Unfortunately AsyncFn is not dyn-compatible yet.
 pub type OpenImportCallback =
     Rc<dyn Fn(String) -> Pin<Box<dyn Future<Output = Option<std::io::Result<String>>>>>>;
-pub type ResourceUrlMapper = Rc<dyn Fn(&url::Url) -> Pin<Box<dyn Future<Output = Option<String>>>>>;
+pub type ResourceUrlMapper =
+    Rc<dyn Fn(&url::Url) -> Pin<Box<dyn Future<Output = Option<url::Url>>>>>;
 
 /// CompilationConfiguration allows configuring different aspects of the compiler.
 #[derive(Clone)]

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -120,7 +120,7 @@ pub enum ComponentSelection {
 /// Unfortunately AsyncFn is not dyn-compatible yet.
 pub type OpenImportCallback =
     Rc<dyn Fn(String) -> Pin<Box<dyn Future<Output = Option<std::io::Result<String>>>>>>;
-pub type ResourceUrlMapper = Rc<dyn Fn(&str) -> Pin<Box<dyn Future<Output = Option<String>>>>>;
+pub type ResourceUrlMapper = Rc<dyn Fn(&url::Url) -> Pin<Box<dyn Future<Output = Option<String>>>>>;
 
 /// CompilationConfiguration allows configuring different aspects of the compiler.
 #[derive(Clone)]

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -41,7 +41,7 @@ pub async fn embed_images(
     let all_components = all_components;
 
     let mapped_urls = {
-        let mut urls = HashMap::<Url, Option<SmolStr>>::new();
+        let mut urls = HashMap::<Url, Option<Url>>::new();
 
         if let Some(mapper) = resource_url_mapper {
             // Collect URLs (sync!):
@@ -53,7 +53,7 @@ pub async fn embed_images(
 
             // Map URLs (async -- well, not really):
             for (url, mapped) in urls.iter_mut() {
-                *mapped = (*mapper)(url).await.map(SmolStr::new);
+                *mapped = (*mapper)(url).await;
             }
         }
 
@@ -102,7 +102,7 @@ fn reference_mapper_url(resource_ref: &ImageReference) -> Option<Url> {
     }
 }
 
-fn collect_image_urls_from_expression(e: &Expression, urls: &mut HashMap<Url, Option<SmolStr>>) {
+fn collect_image_urls_from_expression(e: &Expression, urls: &mut HashMap<Url, Option<Url>>) {
     if let Expression::ImageReference { resource_ref, .. } = e
         && let Some(url) = reference_mapper_url(resource_ref)
     {
@@ -114,7 +114,7 @@ fn collect_image_urls_from_expression(e: &Expression, urls: &mut HashMap<Url, Op
 
 fn embed_images_from_expression(
     e: &mut Expression,
-    urls: &HashMap<Url, Option<SmolStr>>,
+    urls: &HashMap<Url, Option<Url>>,
     global_embedded_resources: &RefCell<TiVec<EmbeddedResourcesIdx, EmbeddedResources>>,
     path_to_id: &mut HashMap<SmolStr, EmbeddedResourcesIdx>,
     embed_files: EmbedResourcesKind,
@@ -124,11 +124,11 @@ fn embed_images_from_expression(
 ) {
     if let Expression::ImageReference { resource_ref, source_location, nine_slice: _ } = e {
         // Apply the resource mapper. A Path/Url may be replaced with the mapped
-        // result (e.g. a `data:` URL), so re-classify the reference.
+        // URL (e.g. a `data:` URL), so re-classify the reference.
         if let Some(url) = reference_mapper_url(resource_ref)
             && let Some(mapped) = urls.get(&url).cloned().flatten()
         {
-            *resource_ref = ImageReference::from_resolved(mapped);
+            *resource_ref = ImageReference::from_mapped_url(mapped);
         }
 
         match resource_ref {

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -77,35 +77,34 @@ pub async fn embed_images(
     }
 }
 
-/// The URL of an image reference, as expected by the resource mapper and used
-/// to key the map of mapped resources. A local image reference is an absolute
-/// filesystem path at this stage, so turn it into a `file://` URL; references
-/// that are already URLs (`data:`, `builtin:/`, `https:`, ...) are parsed as-is.
-/// Returns `None` for a reference that is neither, which therefore cannot be
-/// mapped.
-fn image_reference_url(resource: &str) -> Option<Url> {
-    if crate::pathutils::is_url(std::path::Path::new(resource)) {
-        return Url::parse(resource).ok();
-    }
-    // `Url::from_file_path` is absent on `wasm32-unknown-unknown`, which only
-    // ever sees URL references and so never reaches this branch.
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        Url::from_file_path(resource).ok()
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        None
+/// The URL handed to the resource mapper, and the key of the mapped-resource
+/// map, for a reference the mapper may rewrite. A local [`ImageReference::Path`]
+/// becomes a `file://` URL; an [`ImageReference::Url`] is used as-is. Everything
+/// else (`data:` URIs, already-embedded references) returns `None` and is left
+/// untouched.
+fn reference_mapper_url(resource_ref: &ImageReference) -> Option<Url> {
+    match resource_ref {
+        ImageReference::Url(url) => Some(url.clone()),
+        ImageReference::Path(path) => {
+            // `Url::from_file_path` is absent on `wasm32-unknown-unknown`, which
+            // only ever sees URL references and so never reaches this branch.
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Url::from_file_path(path).ok()
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                let _ = path;
+                None
+            }
+        }
+        _ => None,
     }
 }
 
 fn collect_image_urls_from_expression(e: &Expression, urls: &mut HashMap<Url, Option<SmolStr>>) {
     if let Expression::ImageReference { resource_ref, .. } = e
-        && let ImageReference::AbsolutePath(path) = resource_ref
-        // `data:` URIs are embedded directly and never looked up in this map, so
-        // don't store their (potentially huge) content as a key.
-        && !path.starts_with("data:")
-        && let Some(url) = image_reference_url(path)
+        && let Some(url) = reference_mapper_url(resource_ref)
     {
         urls.insert(url, None);
     };
@@ -123,53 +122,63 @@ fn embed_images_from_expression(
     diag: &mut BuildDiagnostics,
     font_collection: Option<&SharedFontCollection>,
 ) {
-    if let Expression::ImageReference { resource_ref, source_location, nine_slice: _ } = e
-        && let ImageReference::AbsolutePath(path) = resource_ref
-    {
-        if path.starts_with("data:") {
-            // Data URIs have no external file to track, so skip for
-            // Nothing (interpreter) and ListAllResources (dependency tracking).
-            if !matches!(
-                embed_files,
-                EmbedResourcesKind::Nothing | EmbedResourcesKind::ListAllResources
-            ) {
-                let image_ref = embed_data_uri(
-                    global_embedded_resources,
-                    path_to_id,
-                    path,
-                    embed_files,
-                    scale_factor,
-                    diag,
-                    source_location,
-                    font_collection,
-                );
-                *resource_ref = image_ref;
-            }
-            return;
+    if let Expression::ImageReference { resource_ref, source_location, nine_slice: _ } = e {
+        // Apply the resource mapper. A Path/Url may be replaced with the mapped
+        // result (e.g. a `data:` URL), so re-classify the reference.
+        if let Some(url) = reference_mapper_url(resource_ref)
+            && let Some(mapped) = urls.get(&url).cloned().flatten()
+        {
+            *resource_ref = ImageReference::from_resolved(mapped);
         }
 
-        // use the mapped url, falling back to the original path:
-        let mapped_path = image_reference_url(path)
-            .and_then(|url| urls.get(&url).cloned().flatten())
-            .unwrap_or_else(|| path.clone());
-        *path = mapped_path;
-        if embed_files != EmbedResourcesKind::Nothing
-            && (embed_files != EmbedResourcesKind::OnlyBuiltinResources
-                || path.starts_with("builtin:/"))
-        {
-            let image_ref = embed_image(
-                global_embedded_resources,
-                path_to_id,
-                embed_files,
-                path,
-                scale_factor,
-                diag,
-                source_location,
-                font_collection,
-            );
-            if embed_files != EmbedResourcesKind::ListAllResources {
-                *resource_ref = image_ref;
+        match resource_ref {
+            ImageReference::DataUri(data) => {
+                // Data URIs have no external file to track, so skip for
+                // Nothing (interpreter) and ListAllResources (dependency tracking).
+                if !matches!(
+                    embed_files,
+                    EmbedResourcesKind::Nothing | EmbedResourcesKind::ListAllResources
+                ) {
+                    let image_ref = embed_data_uri(
+                        global_embedded_resources,
+                        path_to_id,
+                        data,
+                        embed_files,
+                        scale_factor,
+                        diag,
+                        source_location,
+                        font_collection,
+                    );
+                    *resource_ref = image_ref;
+                }
             }
+            ImageReference::Path(_) | ImageReference::Url(_) => {
+                let is_builtin = matches!(
+                    resource_ref,
+                    ImageReference::Url(url) if url.scheme() == "builtin"
+                );
+                if embed_files != EmbedResourcesKind::Nothing
+                    && (embed_files != EmbedResourcesKind::OnlyBuiltinResources || is_builtin)
+                {
+                    let path = resource_ref.source().expect("Path/Url have a source");
+                    let image_ref = embed_image(
+                        global_embedded_resources,
+                        path_to_id,
+                        embed_files,
+                        path,
+                        scale_factor,
+                        diag,
+                        source_location,
+                        font_collection,
+                    );
+                    if embed_files != EmbedResourcesKind::ListAllResources {
+                        *resource_ref = image_ref;
+                    }
+                }
+            }
+            ImageReference::None
+            | ImageReference::EmbeddedData { .. }
+            | ImageReference::EmbeddedTexture { .. } => {}
         }
     };
 

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -11,10 +11,8 @@ use image::GenericImageView;
 use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::rc::Rc;
 use typed_index_collections::TiVec;
+use url::Url;
 
 /// The fonts shared with `embed_glyphs` to rasterize SVG `<text>`. Only the
 /// software renderer embeds textures, so elsewhere this is an unused placeholder.
@@ -27,7 +25,7 @@ pub async fn embed_images(
     doc: &Document,
     embed_files: EmbedResourcesKind,
     scale_factor: f32,
-    resource_url_mapper: &Option<Rc<dyn Fn(&str) -> Pin<Box<dyn Future<Output = Option<String>>>>>>,
+    resource_url_mapper: &Option<crate::ResourceUrlMapper>,
     font_collection: Option<&SharedFontCollection>,
     diag: &mut BuildDiagnostics,
 ) {
@@ -43,7 +41,7 @@ pub async fn embed_images(
     let all_components = all_components;
 
     let mapped_urls = {
-        let mut urls = HashMap::<SmolStr, Option<SmolStr>>::new();
+        let mut urls = HashMap::<Url, Option<SmolStr>>::new();
 
         if let Some(mapper) = resource_url_mapper {
             // Collect URLs (sync!):
@@ -54,8 +52,8 @@ pub async fn embed_images(
             }
 
             // Map URLs (async -- well, not really):
-            for i in urls.iter_mut() {
-                *i.1 = (*mapper)(i.0).await.map(SmolStr::new);
+            for (url, mapped) in urls.iter_mut() {
+                *mapped = (*mapper)(url).await.map(SmolStr::new);
             }
         }
 
@@ -82,37 +80,34 @@ pub async fn embed_images(
 /// The URL of an image reference, as expected by the resource mapper and used
 /// to key the map of mapped resources. A local image reference is an absolute
 /// filesystem path at this stage, so turn it into a `file://` URL; references
-/// that are already URLs (`data:`, `builtin:/`, `https:`, ...) pass through
-/// unchanged.
-fn image_reference_url(resource: &str) -> SmolStr {
+/// that are already URLs (`data:`, `builtin:/`, `https:`, ...) are parsed as-is.
+/// Returns `None` for a reference that is neither, which therefore cannot be
+/// mapped.
+fn image_reference_url(resource: &str) -> Option<Url> {
     if crate::pathutils::is_url(std::path::Path::new(resource)) {
-        return resource.into();
+        return Url::parse(resource).ok();
     }
     // `Url::from_file_path` is absent on `wasm32-unknown-unknown`, which only
     // ever sees URL references and so never reaches this branch.
     #[cfg(not(target_arch = "wasm32"))]
     {
-        url::Url::from_file_path(resource)
-            .map(|url| SmolStr::from(url.as_str()))
-            .unwrap_or_else(|()| resource.into())
+        Url::from_file_path(resource).ok()
     }
     #[cfg(target_arch = "wasm32")]
     {
-        resource.into()
+        None
     }
 }
 
-fn collect_image_urls_from_expression(
-    e: &Expression,
-    urls: &mut HashMap<SmolStr, Option<SmolStr>>,
-) {
+fn collect_image_urls_from_expression(e: &Expression, urls: &mut HashMap<Url, Option<SmolStr>>) {
     if let Expression::ImageReference { resource_ref, .. } = e
         && let ImageReference::AbsolutePath(path) = resource_ref
         // `data:` URIs are embedded directly and never looked up in this map, so
         // don't store their (potentially huge) content as a key.
         && !path.starts_with("data:")
+        && let Some(url) = image_reference_url(path)
     {
-        urls.insert(image_reference_url(path), None);
+        urls.insert(url, None);
     };
 
     e.visit(|e| collect_image_urls_from_expression(e, urls));
@@ -120,7 +115,7 @@ fn collect_image_urls_from_expression(
 
 fn embed_images_from_expression(
     e: &mut Expression,
-    urls: &HashMap<SmolStr, Option<SmolStr>>,
+    urls: &HashMap<Url, Option<SmolStr>>,
     global_embedded_resources: &RefCell<TiVec<EmbeddedResourcesIdx, EmbeddedResources>>,
     path_to_id: &mut HashMap<SmolStr, EmbeddedResourcesIdx>,
     embed_files: EmbedResourcesKind,
@@ -154,8 +149,9 @@ fn embed_images_from_expression(
         }
 
         // use the mapped url, falling back to the original path:
-        let mapped_path =
-            urls.get(&image_reference_url(path)).cloned().flatten().unwrap_or_else(|| path.clone());
+        let mapped_path = image_reference_url(path)
+            .and_then(|url| urls.get(&url).cloned().flatten())
+            .unwrap_or_else(|| path.clone());
         *path = mapped_path;
         if embed_files != EmbedResourcesKind::Nothing
             && (embed_files != EmbedResourcesKind::OnlyBuiltinResources

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -542,7 +542,7 @@ impl Expression {
         }
 
         let resource_ref = if s.starts_with("data:") {
-            ImageReference::AbsolutePath(s)
+            ImageReference::DataUri(s)
         } else {
             let absolute_source_path = {
                 let path = std::path::Path::new(&s);
@@ -564,7 +564,7 @@ impl Expression {
                         })
                 }
             };
-            ImageReference::AbsolutePath(absolute_source_path)
+            ImageReference::from_resolved(absolute_source_path)
         };
 
         let nine_slice = node

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -368,32 +368,34 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         Expression::ImageReference { resource_ref, nine_slice, .. } => {
             let mut image = match resource_ref {
                 i_slint_compiler::expression_tree::ImageReference::None => Ok(Default::default()),
-                i_slint_compiler::expression_tree::ImageReference::AbsolutePath(path) => {
-                    if path.starts_with("data:") {
-                        i_slint_compiler::data_uri::decode_data_uri(path)
-                            .ok()
-                            .and_then(|(data, extension)| {
-                                corelib::graphics::load_image_from_dynamic_data(&data, &extension)
-                                    .ok()
-                            })
-                            .ok_or_else(Default::default)
-                    } else {
-                        let path = std::path::Path::new(path);
-                        if path.starts_with("builtin:/") {
-                            i_slint_compiler::fileaccess::load_file(path)
-                                .and_then(|virtual_file| virtual_file.builtin_contents)
-                                .map(|virtual_file| {
-                                    let extension = path.extension().unwrap().to_str().unwrap();
-                                    corelib::graphics::load_image_from_embedded_data(
-                                        corelib::slice::Slice::from_slice(virtual_file),
-                                        corelib::slice::Slice::from_slice(extension.as_bytes()),
-                                    )
-                                })
-                                .ok_or_else(Default::default)
-                        } else {
-                            corelib::graphics::Image::load_from_path(path)
-                        }
-                    }
+                i_slint_compiler::expression_tree::ImageReference::DataUri(data) => {
+                    i_slint_compiler::data_uri::decode_data_uri(data)
+                        .ok()
+                        .and_then(|(data, extension)| {
+                            corelib::graphics::load_image_from_dynamic_data(&data, &extension).ok()
+                        })
+                        .ok_or_else(Default::default)
+                }
+                i_slint_compiler::expression_tree::ImageReference::Url(url)
+                    if url.scheme() == "builtin" =>
+                {
+                    let path = std::path::Path::new(url.as_str());
+                    i_slint_compiler::fileaccess::load_file(path)
+                        .and_then(|virtual_file| virtual_file.builtin_contents)
+                        .map(|virtual_file| {
+                            let extension = path.extension().unwrap().to_str().unwrap();
+                            corelib::graphics::load_image_from_embedded_data(
+                                corelib::slice::Slice::from_slice(virtual_file),
+                                corelib::slice::Slice::from_slice(extension.as_bytes()),
+                            )
+                        })
+                        .ok_or_else(Default::default)
+                }
+                i_slint_compiler::expression_tree::ImageReference::Path(path) => {
+                    corelib::graphics::Image::load_from_path(std::path::Path::new(path))
+                }
+                i_slint_compiler::expression_tree::ImageReference::Url(url) => {
+                    corelib::graphics::Image::load_from_path(std::path::Path::new(url.as_str()))
                 }
                 i_slint_compiler::expression_tree::ImageReference::EmbeddedData { .. } => {
                     todo!()

--- a/internal/live-preview/remote/compilation.rs
+++ b/internal/live-preview/remote/compilation.rs
@@ -39,22 +39,21 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
 
     let mapper_connection = connection.clone();
     compiler.compiler_configuration(InternalToken).resource_url_mapper =
-        Some(std::rc::Rc::new(move |url: &str| {
+        Some(std::rc::Rc::new(move |url: &Url| {
             let connection = mapper_connection.clone();
-            let url_str = url.to_owned();
+            let url = url.clone();
             Box::pin(async move {
-                if url_str.starts_with("builtin:/") {
+                // Only files on the editor's machine need fetching over the
+                // connection; `builtin:/`, `data:`, `http(s):`, ... are loaded
+                // directly by the renderer.
+                if url.scheme() != "file" {
                     return None;
                 }
                 let connection = connection.upgrade()?;
-                let parsed = Url::parse(&url_str).ok()?;
-                let file_content = connection.request_file(parsed).await.ok()?;
-
-                let extension = std::path::Path::new(&url_str)
+                let extension = std::path::Path::new(url.path())
                     .extension()
                     .and_then(|e| e.to_str())
                     .unwrap_or("png");
-
                 let mime_type = match extension {
                     "svg" | "svgz" => "image/svg+xml",
                     "png" => "image/png",
@@ -64,6 +63,7 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
                     "webp" => "image/webp",
                     _ => "application/octet-stream",
                 };
+                let file_content = connection.request_file(url).await.ok()?;
 
                 use base64::Engine as _;
                 let encoded =

--- a/internal/live-preview/remote/compilation.rs
+++ b/internal/live-preview/remote/compilation.rs
@@ -68,7 +68,7 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
                 use base64::Engine as _;
                 let encoded =
                     base64::engine::general_purpose::STANDARD.encode(&*file_content.contents);
-                Some(format!("data:{mime_type};base64,{encoded}"))
+                Url::parse(&format!("data:{mime_type};base64,{encoded}")).ok()
             })
         }));
 

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -44,8 +44,7 @@ pub struct CompilerConfiguration {
     pub library_paths: HashMap<String, std::path::PathBuf>,
     pub style: Option<String>,
     pub open_import_callback: Option<OpenImportCallback>,
-    pub resource_url_mapper:
-        Option<Rc<dyn Fn(&str) -> Pin<Box<dyn Future<Output = Option<String>>>>>>,
+    pub resource_url_mapper: Option<i_slint_compiler::ResourceUrlMapper>,
     pub format: super::ByteFormat,
     /// Whether to enable experimental features.
     /// Note that the i_slint_compiler::CompilerConfiguration still reads the environment variable

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -236,7 +236,10 @@ pub fn resource_url_mapper() -> Option<i_slint_compiler::ResourceUrlMapper> {
             return Box::pin(std::future::ready(None));
         };
         let future = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(promise));
-        Box::pin(async move { future.await.ok().and_then(|v| v.as_string()) })
+        Box::pin(async move {
+            let mapped = future.await.ok().and_then(|v| v.as_string())?;
+            lsp_types::Url::parse(&mapped).ok()
+        })
     }))
 }
 

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -231,8 +231,8 @@ pub fn resource_url_mapper() -> Option<i_slint_compiler::ResourceUrlMapper> {
         callbacks.as_ref().map(|cb| js_sys::Function::from((cb.resource_url_mapper).clone()))
     })?;
 
-    Some(Rc::new(move |url: &str| {
-        let Some(promise) = callback.call1(&JsValue::UNDEFINED, &url.into()).ok() else {
+    Some(Rc::new(move |url: &lsp_types::Url| {
+        let Some(promise) = callback.call1(&JsValue::UNDEFINED, &url.as_str().into()).ok() else {
             return Box::pin(std::future::ready(None));
         };
         let future = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(promise));


### PR DESCRIPTION
The mapper is meant to receive a URL, but its argument was `&str`, so nothing stopped a caller from passing a raw filesystem path. That's what caused the bug that commit 94f17e5eec32af5f5ecd425729cf0f4fff81bea4 fixed.

The mapped value stays a String: it is written back into AbsolutePath and consumed as a string.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
