### PR TITLE
ci: publish flashable per-board demo binaries (nightly_snapshot)

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -592,7 +592,7 @@ jobs:
 
     prepare_release:
         if: github.event.inputs.mode == 'full-nightly' || github.event.inputs.mode == 'release'
-        needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin, android]
+        needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin, android, demo_binaries]
         runs-on: ubuntu-22.04
         permissions:
             contents: write
@@ -624,6 +624,10 @@ jobs:
               with:
                   name: android-demos
                   path: android-demos
+            - uses: actions/download-artifact@v8
+              with:
+                  name: demo-binaries
+                  path: demo-binaries
             - name: Extract files
               run: |
                   # Backwards compatibility: also publish under the old artifact names.
@@ -649,6 +653,8 @@ jobs:
                   mv figma-plugin.zip artifacts/
                   # slint-viewer APK ships as a release asset (too big for the web server).
                   mv android-demos/slint-viewer.apk artifacts/
+                  # Flashable per-board demo binaries + demos.json index + ESP Web Tools manifests.
+                  mv demo-binaries/* artifacts/
             - uses: actions/checkout@v6
               with:
                 path: "slint-src"
@@ -865,3 +871,173 @@ jobs:
               with:
                   name: android-demos
                   path: android-demos/
+
+    # Build the `printerdemo_mcu` demo for every board in examples/mcu-board-support
+    # and convert each ELF into the flashable format that board expects
+    # (.uf2 / merged .bin + ESP Web Tools manifest / .elf). Publishes them as
+    # release assets via prepare_release, plus a `demos.json` index the website
+    # reads at build time to wire up download / one-click-flash / `slint.dev/flash`.
+    # The board matrix mirrors the `mcu` job in ci.yaml (the build gate); keep both in sync.
+    demo_binaries:
+        env:
+            SLINT_FONT_SIZES: 8,11,10,12,13,14,15,16,18,20,22,24,32
+            RUSTFLAGS: "--cfg slint_int_coord"
+            CARGO_PROFILE_DEV_DEBUG: 0
+            CARGO_PROFILE_RELEASE_OPT_LEVEL: s
+            # Pin the conversion tools; bump deliberately (see CI handover §6.4).
+            ELF2UF2_VERSION: "2.1.1"
+            ESPFLASH_VERSION: "3.3.0"
+            PICOTOOL_REF: "2.1.1"
+            PICO_SDK_REF: "2.1.1"
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v6
+            - uses: ./.github/actions/setup-rust
+              with:
+                  target: thumbv6m-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabihf
+                  components: llvm-tools-preview
+            - uses: esp-rs/xtensa-toolchain@v1.7
+              with:
+                  buildtargets: esp32
+                  ldproxy: false
+
+            - name: Install conversion tool dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libusb-1.0-0-dev libudev-dev pkg-config cmake build-essential
+            - name: Install elf2uf2-rs, espflash and cargo-binutils
+              run: |
+                  cargo install --locked elf2uf2-rs --version "$ELF2UF2_VERSION"
+                  cargo install --locked espflash --version "$ESPFLASH_VERSION"
+                  cargo install --locked cargo-binutils
+            - name: Build picotool (RP2350 .uf2 conversion)
+              run: |
+                  git clone --depth 1 --branch "$PICO_SDK_REF" https://github.com/raspberrypi/pico-sdk
+                  export PICO_SDK_PATH="$PWD/pico-sdk"
+                  git clone --depth 1 --branch "$PICOTOOL_REF" https://github.com/raspberrypi/picotool
+                  cmake -S picotool -B picotool/build -DPICO_SDK_PATH="$PICO_SDK_PATH"
+                  cmake --build picotool/build -j"$(nproc)"
+                  sudo cmake --install picotool/build
+
+            - name: Resolve release tag for download URLs
+              id: meta
+              run: |
+                  if [ "${{ github.event.inputs.mode }}" = "release" ]; then
+                    version=$(awk '/^\[workspace.package\]/ {f=1} f && /^version = / {gsub(/version = |"/, "", $0); print $0; exit}' Cargo.toml)
+                    if [ -z "$version" ]; then echo "Version not found"; exit 1; fi
+                    echo "tag=v$version" >> "$GITHUB_OUTPUT"
+                  else
+                    # full-nightly / website-only / test all resolve against the rolling `nightly` release.
+                    echo "tag=nightly" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Build and convert demo binaries
+              run: |
+                  set -euo pipefail
+                  OUT="$GITHUB_WORKSPACE/demo-out"
+                  rm -rf "$OUT"; mkdir -p "$OUT"
+                  : > "$OUT/index.tsv"
+
+                  # feature|target|kind|esp cargo-config (kind: rp2040 | rp2350 | stm | esp)
+                  BOARDS='
+                  pico-st7789|thumbv6m-none-eabi|rp2040|
+                  pico2-st7789|thumbv8m.main-none-eabihf|rp2350|
+                  pico2-touch-lcd-2-8|thumbv8m.main-none-eabihf|rp2350|
+                  stm32h735g|thumbv7em-none-eabihf|stm|
+                  stm32u5g9j-dk2|thumbv8m.main-none-eabihf|stm|
+                  esp32-s3-box-3|xtensa-esp32s3-none-elf|esp|examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
+                  esp32-s3-lcd-ev-board|xtensa-esp32s3-none-elf|esp|examples/mcu-board-support/esp32_s3_lcd_ev_board/cargo-config.toml
+                  esope-sld-c-w-s3|xtensa-esp32s3-none-elf|esp|examples/mcu-board-support/esope_sld_c_w_s3/cargo-config.toml
+                  waveshare-esp32-s3-touch-amoled-1-8|xtensa-esp32s3-none-elf|esp|examples/mcu-board-support/waveshare_esp32_s3_touch_amoled_1_8/cargo-config.toml
+                  m5stack-cores3|xtensa-esp32s3-none-elf|esp|examples/mcu-board-support/m5stack_cores3/cargo-config.toml
+                  '
+
+                  while IFS='|' read -r feature target kind espcfg; do
+                    [ -z "$feature" ] && continue
+                    echo "::group::Build $feature ($kind / $target)"
+                    if [ "$kind" = "esp" ]; then
+                      cargo +esp build -p printerdemo_mcu --target "$target" --no-default-features \
+                        --features="mcu-board-support/$feature" --config "$espcfg" --release
+                    else
+                      cargo build -p printerdemo_mcu --target "$target" --no-default-features \
+                        --features="mcu-board-support/$feature" --release
+                    fi
+                    elf="target/$target/release/printerdemo_mcu"
+                    echo "::endgroup::"
+
+                    echo "::group::Convert $feature -> flashable artifact"
+                    case "$kind" in
+                      rp2040)
+                        elf2uf2-rs "$elf" "$OUT/printerdemo-$feature.uf2"
+                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.uf2" "uf2" "" >> "$OUT/index.tsv"
+                        ;;
+                      rp2350)
+                        picotool uf2 convert "$elf" "$OUT/printerdemo-$feature.uf2"
+                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.uf2" "uf2" "" >> "$OUT/index.tsv"
+                        ;;
+                      stm)
+                        # .elf is the primary asset (probe-rs / STM32CubeProgrammer flash it directly);
+                        # also ship a raw .bin for tools that want it.
+                        cp "$elf" "$OUT/printerdemo-$feature.elf"
+                        rust-objcopy -O binary "$elf" "$OUT/printerdemo-$feature.bin"
+                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.elf" "elf" "" >> "$OUT/index.tsv"
+                        ;;
+                      esp)
+                        # Merged image (bootloader + partition table + app) flashable at offset 0
+                        # over WebSerial by ESP Web Tools, or by espflash/esptool.
+                        # NOTE: espflash save-image argument order is version-specific (pinned $ESPFLASH_VERSION);
+                        # validate on the first CI run and adjust if espflash is bumped.
+                        espflash save-image --merge --chip esp32s3 "$OUT/printerdemo-$feature.bin" "$elf"
+                        jq -n --arg feature "$feature" --arg path "printerdemo-$feature.bin" \
+                          '{name: ("Slint printerdemo (" + $feature + ")"), builds: [ {chipFamily: "ESP32-S3", parts: [ {path: $path, offset: 0} ]} ]}' \
+                          > "$OUT/manifest-$feature.json"
+                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.bin" "bin" "manifest-$feature.json" >> "$OUT/index.tsv"
+                        ;;
+                    esac
+                    echo "::endgroup::"
+                  done <<< "$BOARDS"
+
+                  echo "Produced artifacts:"; ls -l "$OUT"
+
+            - name: Guardrail - built boards must match mcu-board-support features
+              run: |
+                  set -euo pipefail
+                  OUT="$GITHUB_WORKSPACE/demo-out"
+                  # Single source of truth (CI handover §6.1): the buildable board features are the
+                  # [features] of examples/mcu-board-support. Fail loudly if this job's matrix drifts
+                  # from it (a new board added there but not built here, or vice versa).
+                  built=$(cut -f1 "$OUT/index.tsv" | sort -u)
+                  declared=$(awk '/^\[features\]/{f=1; next} /^\[/{f=0} f && /^[a-z0-9][a-z0-9-]* *= *\[/{sub(/ *=.*/, ""); print}' examples/mcu-board-support/Cargo.toml | sort -u)
+                  if ! diff <(printf '%s\n' "$built") <(printf '%s\n' "$declared"); then
+                    echo "::error::Demo board matrix drifted from examples/mcu-board-support [features] (< built here, > declared there)."
+                    exit 1
+                  fi
+                  echo "Board matrix in sync with mcu-board-support ($(printf '%s\n' "$declared" | grep -c .) boards)."
+
+            - name: Generate demos.json index
+              env:
+                  TAG: ${{ steps.meta.outputs.tag }}
+              run: |
+                  set -euo pipefail
+                  OUT="$GITHUB_WORKSPACE/demo-out"
+                  BASE="https://github.com/slint-ui/slint/releases/download/$TAG"
+                  # One entry per board, keyed by feature slug (matches the website's data/boards.json keys).
+                  jq -R -s --arg base "$BASE" '
+                    split("\n") | map(select(length > 0)) | map(split("\t"))
+                    | map({ key: .[0], value: (
+                        { feature: .[0], file: .[1], format: .[2], url: ($base + "/" + .[1]) }
+                        + (if ((.[3] // "") == "") then {} else { manifest: .[3], manifestUrl: ($base + "/" + .[3]) } end)
+                      ) })
+                    | from_entries
+                  ' "$OUT/index.tsv" > "$OUT/boards-index.json"
+                  jq -n --arg tag "$TAG" --slurpfile boards "$OUT/boards-index.json" \
+                    '{ demo: "printerdemo_mcu", tag: $tag, generated: (now | todateiso8601), boards: $boards[0] }' \
+                    > "$OUT/demos.json"
+                  rm -f "$OUT/boards-index.json" "$OUT/index.tsv"
+                  cat "$OUT/demos.json"
+
+            - name: Upload demo-binaries artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: demo-binaries
+                  path: demo-out/

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -1015,9 +1015,8 @@ jobs:
                       esp)
                         # Merged image (bootloader + partition table + app) flashable at offset 0
                         # over WebSerial by ESP Web Tools, or by espflash/esptool.
-                        # NOTE: espflash save-image argument order is version-specific (pinned $ESPFLASH_VERSION);
-                        # validate on the first CI run and adjust if espflash is bumped.
-                        espflash save-image --merge --chip esp32s3 "$OUT/printerdemo-$feature.bin" "$elf"
+                        # Arg order is `<ELF> <OUTPUT>` (espflash 3.x; pinned $ESPFLASH_VERSION).
+                        espflash save-image --merge --chip esp32s3 "$elf" "$OUT/printerdemo-$feature.bin"
                         jq -n --arg feature "$feature" --arg path "printerdemo-$feature.bin" \
                           '{name: ("Slint printerdemo (" + $feature + ")"), builds: [ {chipFamily: "ESP32-S3", parts: [ {path: $path, offset: 0} ]} ]}' \
                           > "$OUT/manifest-$feature.json"

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -369,7 +369,7 @@ jobs:
 
     publish_artifacts:
         if: ${{ github.event.inputs.mode != 'test' }}
-        needs: [docs, wasm_demo, wasm, check-for-secrets, android, demo_binaries]
+        needs: [docs, wasm_demo, wasm, check-for-secrets, android, demo_binaries, demo_binaries_linux]
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/download-artifact@v8
@@ -421,6 +421,11 @@ jobs:
               with:
                   name: demo-binaries
                   path: demo-binaries
+            - uses: actions/download-artifact@v8
+              with:
+                  pattern: demo-binaries-linux-*
+                  merge-multiple: true
+                  path: demo-binaries-linux
 
             - uses: actions/checkout@v6
               with:
@@ -501,11 +506,48 @@ jobs:
                   echo '</ul>'
                 } > $output_path/demos/android/index.html
 
-                # Flashable per-board MCU demo binaries + demos.json index + ESP Web Tools manifests.
-                # Served at <base>/demos/mcu/ (the URLs baked into demos.json by the demo_binaries job).
-                rm -rf $output_path/demos/mcu
-                mkdir -p $output_path/demos/mcu
+                # Flashable per-board MCU demo binaries (+ ESP Web Tools manifests) under demos/mcu/,
+                # and the runnable Linux-SBC tarballs under demos/linux/.
+                rm -rf $output_path/demos/mcu $output_path/demos/linux
+                mkdir -p $output_path/demos/mcu $output_path/demos/linux
                 cp -a ../demo-binaries/* $output_path/demos/mcu/
+                cp -a ../demo-binaries-linux/* $output_path/demos/linux/
+
+                # demos.json — the index the website reads at build time, derived from the published
+                # filenames. `boards` = MCU (flash firmware), `linux` = SBC (download + run). URLs point
+                # at this same www-releases tree (snapshots.slint.dev/<branch> or releases.slint.dev/<version>).
+                if [[ "${{ github.event.inputs.mode == 'release' }}" == "true" ]]; then
+                  demos_base="https://releases.slint.dev/${{ steps.version.outputs.VERSION }}"
+                else
+                  demos_base="https://snapshots.slint.dev/${GITHUB_REF##*/}"
+                fi
+                boards_json=$(
+                  for f in $output_path/demos/mcu/printerdemo-*; do
+                    [ -e "$f" ] || continue
+                    bn=$(basename "$f"); case "$bn" in manifest-*) continue;; esac
+                    rest=${bn#printerdemo-}; ext=${rest##*.}; feature=${rest%.*}
+                    manifest=""; [ -e "$output_path/demos/mcu/manifest-$feature.json" ] && manifest="manifest-$feature.json"
+                    jq -n --arg feature "$feature" --arg file "$bn" --arg fmt "$ext" \
+                          --arg url "$demos_base/demos/mcu/$bn" --arg manifest "$manifest" \
+                          --arg murl "$demos_base/demos/mcu/$manifest" '
+                      { key: $feature, value: (
+                          { feature: $feature, file: $file, format: $fmt, url: $url }
+                          + (if $manifest == "" then {} else { manifest: $manifest, manifestUrl: $murl } end)
+                        ) }'
+                  done | jq -s 'from_entries'
+                )
+                linux_json=$(
+                  for f in $output_path/demos/linux/printerdemo-*-linux.tar.gz; do
+                    [ -e "$f" ] || continue
+                    bn=$(basename "$f"); arch=${bn#printerdemo-}; arch=${arch%-linux.tar.gz}
+                    jq -n --arg arch "$arch" --arg file "$bn" --arg url "$demos_base/demos/linux/$bn" \
+                      '{ key: $arch, value: { arch: $arch, file: $file, format: "tar.gz", bin: "printerdemo", url: $url } }'
+                  done | jq -s 'from_entries'
+                )
+                jq -n --arg base "$demos_base" --argjson boards "$boards_json" --argjson linux "$linux_json" \
+                  '{ demo: "printerdemo", base: $base, generated: (now | todateiso8601), boards: $boards, linux: $linux }' \
+                  > $output_path/demos/demos.json
+                cat $output_path/demos/demos.json
 
                 rm -rf $output_path/wasm-interpreter
                 mkdir -p $output_path/wasm-interpreter
@@ -900,7 +942,6 @@ jobs:
             - uses: ./.github/actions/setup-rust
               with:
                   target: thumbv6m-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabihf
-                  components: llvm-tools-preview
             - uses: esp-rs/xtensa-toolchain@v1.7
               with:
                   buildtargets: esp32
@@ -910,11 +951,10 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install -y libusb-1.0-0-dev libudev-dev pkg-config cmake build-essential
-            - name: Install elf2uf2-rs, espflash and cargo-binutils
+            - name: Install elf2uf2-rs and espflash
               run: |
                   cargo install --locked elf2uf2-rs --version "$ELF2UF2_VERSION"
                   cargo install --locked espflash --version "$ESPFLASH_VERSION"
-                  cargo install --locked cargo-binutils
             - name: Build picotool (RP2350 .uf2 conversion)
               run: |
                   git clone --depth 1 --branch "$PICO_SDK_REF" https://github.com/raspberrypi/pico-sdk
@@ -924,26 +964,12 @@ jobs:
                   cmake --build picotool/build -j"$(nproc)"
                   sudo cmake --install picotool/build
 
-            - name: Resolve published base URL for demos.json
-              id: meta
-              run: |
-                  # Binaries are published into slint-ui/www-releases by publish_artifacts and served
-                  # from the snapshots/releases subdomains (same hosts as the web demos and docs).
-                  if [ "${{ github.event.inputs.mode }}" = "release" ]; then
-                    version=$(awk '/^\[workspace.package\]/ {f=1} f && /^version = / {gsub(/version = |"/, "", $0); print $0; exit}' Cargo.toml)
-                    if [ -z "$version" ]; then echo "Version not found"; exit 1; fi
-                    echo "base=https://releases.slint.dev/$version/demos/mcu" >> "$GITHUB_OUTPUT"
-                  else
-                    # full-nightly / website-only / test all serve from the rolling per-branch snapshot.
-                    echo "base=https://snapshots.slint.dev/${GITHUB_REF##*/}/demos/mcu" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Build and convert demo binaries
               run: |
                   set -euo pipefail
                   OUT="$GITHUB_WORKSPACE/demo-out"
                   rm -rf "$OUT"; mkdir -p "$OUT"
-                  : > "$OUT/index.tsv"
+                  : > "$RUNNER_TEMP/built-features.txt"
 
                   # feature|target|kind|esp cargo-config (kind: rp2040 | rp2350 | stm | esp)
                   BOARDS='
@@ -972,22 +998,19 @@ jobs:
                     elf="target/$target/release/printerdemo_mcu"
                     echo "::endgroup::"
 
+                    # One flashable file per board, named printerdemo-<feature>.<ext>; the publish job
+                    # derives demos.json straight from these filenames (ext = format, manifest = sibling).
                     echo "::group::Convert $feature -> flashable artifact"
                     case "$kind" in
                       rp2040)
                         elf2uf2-rs "$elf" "$OUT/printerdemo-$feature.uf2"
-                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.uf2" "uf2" "" >> "$OUT/index.tsv"
                         ;;
                       rp2350)
                         picotool uf2 convert "$elf" "$OUT/printerdemo-$feature.uf2"
-                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.uf2" "uf2" "" >> "$OUT/index.tsv"
                         ;;
                       stm)
-                        # .elf is the primary asset (probe-rs / STM32CubeProgrammer flash it directly);
-                        # also ship a raw .bin for tools that want it.
+                        # probe-rs / STM32CubeProgrammer flash the .elf directly.
                         cp "$elf" "$OUT/printerdemo-$feature.elf"
-                        rust-objcopy -O binary "$elf" "$OUT/printerdemo-$feature.bin"
-                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.elf" "elf" "" >> "$OUT/index.tsv"
                         ;;
                       esp)
                         # Merged image (bootloader + partition table + app) flashable at offset 0
@@ -998,9 +1021,9 @@ jobs:
                         jq -n --arg feature "$feature" --arg path "printerdemo-$feature.bin" \
                           '{name: ("Slint printerdemo (" + $feature + ")"), builds: [ {chipFamily: "ESP32-S3", parts: [ {path: $path, offset: 0} ]} ]}' \
                           > "$OUT/manifest-$feature.json"
-                        printf '%s\t%s\t%s\t%s\n' "$feature" "printerdemo-$feature.bin" "bin" "manifest-$feature.json" >> "$OUT/index.tsv"
                         ;;
                     esac
+                    echo "$feature" >> "$RUNNER_TEMP/built-features.txt"
                     echo "::endgroup::"
                   done <<< "$BOARDS"
 
@@ -1009,11 +1032,10 @@ jobs:
             - name: Guardrail - built boards must match mcu-board-support features
               run: |
                   set -euo pipefail
-                  OUT="$GITHUB_WORKSPACE/demo-out"
                   # Single source of truth (CI handover §6.1): the buildable board features are the
                   # [features] of examples/mcu-board-support. Fail loudly if this job's matrix drifts
                   # from it (a new board added there but not built here, or vice versa).
-                  built=$(cut -f1 "$OUT/index.tsv" | sort -u)
+                  built=$(sort -u "$RUNNER_TEMP/built-features.txt")
                   declared=$(awk '/^\[features\]/{f=1; next} /^\[/{f=0} f && /^[a-z0-9][a-z0-9-]* *= *\[/{sub(/ *=.*/, ""); print}' examples/mcu-board-support/Cargo.toml | sort -u)
                   if ! diff <(printf '%s\n' "$built") <(printf '%s\n' "$declared"); then
                     echo "::error::Demo board matrix drifted from examples/mcu-board-support [features] (< built here, > declared there)."
@@ -1021,29 +1043,48 @@ jobs:
                   fi
                   echo "Board matrix in sync with mcu-board-support ($(printf '%s\n' "$declared" | grep -c .) boards)."
 
-            - name: Generate demos.json index
-              env:
-                  BASE: ${{ steps.meta.outputs.base }}
-              run: |
-                  set -euo pipefail
-                  OUT="$GITHUB_WORKSPACE/demo-out"
-                  # One entry per board, keyed by feature slug (matches the website's data/boards.json keys).
-                  jq -R -s --arg base "$BASE" '
-                    split("\n") | map(select(length > 0)) | map(split("\t"))
-                    | map({ key: .[0], value: (
-                        { feature: .[0], file: .[1], format: .[2], url: ($base + "/" + .[1]) }
-                        + (if ((.[3] // "") == "") then {} else { manifest: .[3], manifestUrl: ($base + "/" + .[3]) } end)
-                      ) })
-                    | from_entries
-                  ' "$OUT/index.tsv" > "$OUT/boards-index.json"
-                  jq -n --arg base "$BASE" --slurpfile boards "$OUT/boards-index.json" \
-                    '{ demo: "printerdemo_mcu", base: $base, generated: (now | todateiso8601), boards: $boards[0] }' \
-                    > "$OUT/demos.json"
-                  rm -f "$OUT/boards-index.json" "$OUT/index.tsv"
-                  cat "$OUT/demos.json"
-
             - name: Upload demo-binaries artifact
               uses: actions/upload-artifact@v7
               with:
                   name: demo-binaries
                   path: demo-out/
+
+    # The Linux-SBC counterpart of demo_binaries: cross-build the std `printerdemo`
+    # (winit + linuxkms backends, femtovg + software renderers) for the common 64/32-bit
+    # ARM Linux targets, so a Raspberry Pi / i.MX-class board runs the demo by downloading
+    # and executing it (`SLINT_BACKEND=linuxkms` for a no-compositor kiosk) — no flashing.
+    # publish_artifacts ships these to www-releases under demos/linux/ and lists them in demos.json.
+    demo_binaries_linux:
+        needs: [cross_containers]
+        env:
+            SLINT_NO_QT: 1
+        strategy:
+            matrix:
+                include:
+                    - target: aarch64-unknown-linux-gnu
+                      arch: aarch64
+                    - target: armv7-unknown-linux-gnueabihf
+                      arch: armv7
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v6
+            - uses: ./.github/actions/setup-rust
+              with:
+                  target: ${{ matrix.target }}
+            - uses: baptiste0928/cargo-install@v3
+              with:
+                  crate: cross
+            - name: Build printerdemo
+              run: cross build --target ${{ matrix.target }} --release -p printerdemo --features "slint/backend-linuxkms-noseat,slint/backend-winit,slint/renderer-femtovg,slint/renderer-software"
+            - name: Package tarball
+              run: |
+                  set -euo pipefail
+                  mkdir -p demo-out-linux
+                  tar -C target/${{ matrix.target }}/release -czf \
+                      demo-out-linux/printerdemo-${{ matrix.arch }}-linux.tar.gz printerdemo
+                  ls -l demo-out-linux
+            - name: Upload demo-binaries-linux artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: demo-binaries-linux-${{ matrix.arch }}
+                  path: demo-out-linux/

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -369,7 +369,7 @@ jobs:
 
     publish_artifacts:
         if: ${{ github.event.inputs.mode != 'test' }}
-        needs: [docs, wasm_demo, wasm, check-for-secrets, android]
+        needs: [docs, wasm_demo, wasm, check-for-secrets, android, demo_binaries]
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/download-artifact@v8
@@ -417,6 +417,10 @@ jobs:
               with:
                   name: android-demos
                   path: android
+            - uses: actions/download-artifact@v8
+              with:
+                  name: demo-binaries
+                  path: demo-binaries
 
             - uses: actions/checkout@v6
               with:
@@ -496,6 +500,12 @@ jobs:
                   done
                   echo '</ul>'
                 } > $output_path/demos/android/index.html
+
+                # Flashable per-board MCU demo binaries + demos.json index + ESP Web Tools manifests.
+                # Served at <base>/demos/mcu/ (the URLs baked into demos.json by the demo_binaries job).
+                rm -rf $output_path/demos/mcu
+                mkdir -p $output_path/demos/mcu
+                cp -a ../demo-binaries/* $output_path/demos/mcu/
 
                 rm -rf $output_path/wasm-interpreter
                 mkdir -p $output_path/wasm-interpreter
@@ -592,7 +602,7 @@ jobs:
 
     prepare_release:
         if: github.event.inputs.mode == 'full-nightly' || github.event.inputs.mode == 'release'
-        needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin, android, demo_binaries]
+        needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin, android]
         runs-on: ubuntu-22.04
         permissions:
             contents: write
@@ -624,10 +634,6 @@ jobs:
               with:
                   name: android-demos
                   path: android-demos
-            - uses: actions/download-artifact@v8
-              with:
-                  name: demo-binaries
-                  path: demo-binaries
             - name: Extract files
               run: |
                   # Backwards compatibility: also publish under the old artifact names.
@@ -653,8 +659,6 @@ jobs:
                   mv figma-plugin.zip artifacts/
                   # slint-viewer APK ships as a release asset (too big for the web server).
                   mv android-demos/slint-viewer.apk artifacts/
-                  # Flashable per-board demo binaries + demos.json index + ESP Web Tools manifests.
-                  mv demo-binaries/* artifacts/
             - uses: actions/checkout@v6
               with:
                 path: "slint-src"
@@ -874,9 +878,10 @@ jobs:
 
     # Build the `printerdemo_mcu` demo for every board in examples/mcu-board-support
     # and convert each ELF into the flashable format that board expects
-    # (.uf2 / merged .bin + ESP Web Tools manifest / .elf). Publishes them as
-    # release assets via prepare_release, plus a `demos.json` index the website
-    # reads at build time to wire up download / one-click-flash / `slint.dev/flash`.
+    # (.uf2 / merged .bin + ESP Web Tools manifest / .elf). The publish_artifacts job
+    # copies these (+ a `demos.json` index) into slint-ui/www-releases alongside the web
+    # demos, served from snapshots.slint.dev / releases.slint.dev; the website reads
+    # demos.json at build time to wire up download / one-click-flash / `slint.dev/flash`.
     # The board matrix mirrors the `mcu` job in ci.yaml (the build gate); keep both in sync.
     demo_binaries:
         env:
@@ -919,16 +924,18 @@ jobs:
                   cmake --build picotool/build -j"$(nproc)"
                   sudo cmake --install picotool/build
 
-            - name: Resolve release tag for download URLs
+            - name: Resolve published base URL for demos.json
               id: meta
               run: |
+                  # Binaries are published into slint-ui/www-releases by publish_artifacts and served
+                  # from the snapshots/releases subdomains (same hosts as the web demos and docs).
                   if [ "${{ github.event.inputs.mode }}" = "release" ]; then
                     version=$(awk '/^\[workspace.package\]/ {f=1} f && /^version = / {gsub(/version = |"/, "", $0); print $0; exit}' Cargo.toml)
                     if [ -z "$version" ]; then echo "Version not found"; exit 1; fi
-                    echo "tag=v$version" >> "$GITHUB_OUTPUT"
+                    echo "base=https://releases.slint.dev/$version/demos/mcu" >> "$GITHUB_OUTPUT"
                   else
-                    # full-nightly / website-only / test all resolve against the rolling `nightly` release.
-                    echo "tag=nightly" >> "$GITHUB_OUTPUT"
+                    # full-nightly / website-only / test all serve from the rolling per-branch snapshot.
+                    echo "base=https://snapshots.slint.dev/${GITHUB_REF##*/}/demos/mcu" >> "$GITHUB_OUTPUT"
                   fi
 
             - name: Build and convert demo binaries
@@ -1016,11 +1023,10 @@ jobs:
 
             - name: Generate demos.json index
               env:
-                  TAG: ${{ steps.meta.outputs.tag }}
+                  BASE: ${{ steps.meta.outputs.base }}
               run: |
                   set -euo pipefail
                   OUT="$GITHUB_WORKSPACE/demo-out"
-                  BASE="https://github.com/slint-ui/slint/releases/download/$TAG"
                   # One entry per board, keyed by feature slug (matches the website's data/boards.json keys).
                   jq -R -s --arg base "$BASE" '
                     split("\n") | map(select(length > 0)) | map(split("\t"))
@@ -1030,8 +1036,8 @@ jobs:
                       ) })
                     | from_entries
                   ' "$OUT/index.tsv" > "$OUT/boards-index.json"
-                  jq -n --arg tag "$TAG" --slurpfile boards "$OUT/boards-index.json" \
-                    '{ demo: "printerdemo_mcu", tag: $tag, generated: (now | todateiso8601), boards: $boards[0] }' \
+                  jq -n --arg base "$BASE" --slurpfile boards "$OUT/boards-index.json" \
+                    '{ demo: "printerdemo_mcu", base: $base, generated: (now | todateiso8601), boards: $boards[0] }' \
                     > "$OUT/demos.json"
                   rm -f "$OUT/boards-index.json" "$OUT/index.tsv"
                   cat "$OUT/demos.json"

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -932,7 +932,9 @@ jobs:
             CARGO_PROFILE_DEV_DEBUG: 0
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             # Pin the conversion tools; bump deliberately (see CI handover §6.4).
-            ELF2UF2_VERSION: "2.1.1"
+            # elf2uf2-rs >= 2.2.0 accepts ELFOSABI_GNU (3) ELFs, which is what the
+            # mcu-board-support link step produces; 2.1.1 rejected them ("Unrecognized ABI").
+            ELF2UF2_VERSION: "2.2.0"
             ESPFLASH_VERSION: "3.3.0"
             PICOTOOL_REF: "2.1.1"
             PICO_SDK_REF: "2.1.1"
@@ -985,6 +987,7 @@ jobs:
                   m5stack-cores3|xtensa-esp32s3-none-elf|esp|examples/mcu-board-support/m5stack_cores3/cargo-config.toml
                   '
 
+                  convert_fail=0
                   while IFS='|' read -r feature target kind espcfg; do
                     [ -z "$feature" ] && continue
                     echo "::group::Build $feature ($kind / $target)"
@@ -996,37 +999,51 @@ jobs:
                         --features="mcu-board-support/$feature" --release
                     fi
                     elf="target/$target/release/printerdemo_mcu"
+                    echo "$feature" >> "$RUNNER_TEMP/built-features.txt"
                     echo "::endgroup::"
 
-                    # One flashable file per board, named printerdemo-<feature>.<ext>; the publish job
-                    # derives demos.json straight from these filenames (ext = format, manifest = sibling).
+                    # Convert to the flashable format the board expects — one file per board, named
+                    # printerdemo-<feature>.<ext> (the publish job derives demos.json from the filenames).
+                    # Resilient: a conversion failure is recorded and the loop continues, so one CI run
+                    # surfaces every conversion issue; the step still fails at the end if any board failed.
                     echo "::group::Convert $feature -> flashable artifact"
-                    case "$kind" in
-                      rp2040)
-                        elf2uf2-rs "$elf" "$OUT/printerdemo-$feature.uf2"
-                        ;;
-                      rp2350)
-                        picotool uf2 convert "$elf" "$OUT/printerdemo-$feature.uf2"
-                        ;;
-                      stm)
-                        # probe-rs / STM32CubeProgrammer flash the .elf directly.
-                        cp "$elf" "$OUT/printerdemo-$feature.elf"
-                        ;;
-                      esp)
-                        # Merged image (bootloader + partition table + app) flashable at offset 0
-                        # over WebSerial by ESP Web Tools, or by espflash/esptool.
-                        # Arg order is `<ELF> <OUTPUT>` (espflash 3.x; pinned $ESPFLASH_VERSION).
-                        espflash save-image --merge --chip esp32s3 "$elf" "$OUT/printerdemo-$feature.bin"
-                        jq -n --arg feature "$feature" --arg path "printerdemo-$feature.bin" \
-                          '{name: ("Slint printerdemo (" + $feature + ")"), builds: [ {chipFamily: "ESP32-S3", parts: [ {path: $path, offset: 0} ]} ]}' \
-                          > "$OUT/manifest-$feature.json"
-                        ;;
-                    esac
-                    echo "$feature" >> "$RUNNER_TEMP/built-features.txt"
+                    if (
+                      set -e
+                      case "$kind" in
+                        rp2040)
+                          elf2uf2-rs "$elf" "$OUT/printerdemo-$feature.uf2"
+                          ;;
+                        rp2350)
+                          picotool uf2 convert "$elf" "$OUT/printerdemo-$feature.uf2"
+                          ;;
+                        stm)
+                          # probe-rs / STM32CubeProgrammer flash the .elf directly.
+                          cp "$elf" "$OUT/printerdemo-$feature.elf"
+                          ;;
+                        esp)
+                          # Merged image (bootloader + partition table + app) flashable at offset 0
+                          # over WebSerial by ESP Web Tools, or by espflash/esptool.
+                          # Arg order is `<ELF> <OUTPUT>` (espflash 3.x; pinned $ESPFLASH_VERSION).
+                          espflash save-image --merge --chip esp32s3 "$elf" "$OUT/printerdemo-$feature.bin"
+                          jq -n --arg feature "$feature" --arg path "printerdemo-$feature.bin" \
+                            '{name: ("Slint printerdemo (" + $feature + ")"), builds: [ {chipFamily: "ESP32-S3", parts: [ {path: $path, offset: 0} ]} ]}' \
+                            > "$OUT/manifest-$feature.json"
+                          ;;
+                      esac
+                    ); then
+                      :
+                    else
+                      echo "::warning::conversion failed for $feature ($kind)"
+                      convert_fail=1
+                    fi
                     echo "::endgroup::"
                   done <<< "$BOARDS"
 
                   echo "Produced artifacts:"; ls -l "$OUT"
+                  if [ "$convert_fail" -ne 0 ]; then
+                    echo "::error::one or more board conversions failed (see warnings above)"
+                    exit 1
+                  fi
 
             - name: Guardrail - built boards must match mcu-board-support features
               run: |

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -927,8 +927,9 @@ jobs:
     # The board matrix mirrors the `mcu` job in ci.yaml (the build gate); keep both in sync.
     demo_binaries:
         env:
-            SLINT_FONT_SIZES: 8,11,10,12,13,14,15,16,18,20,22,24,32
-            RUSTFLAGS: "--cfg slint_int_coord"
+            # Match the README flash build (examples/mcu-board-support): opt-level=s only.
+            # Notably NO SLINT_FONT_SIZES (the `mcu` check-job sets 13 sizes, ~hundreds of KB of
+            # rodata that never had to *link* there) and NO `--cfg slint_int_coord`.
             CARGO_PROFILE_DEV_DEBUG: 0
             CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             # Pin the conversion tools; bump deliberately (see CI handover §6.4).
@@ -994,6 +995,12 @@ jobs:
                     if [ "$kind" = "esp" ]; then
                       cargo +esp build -p printerdemo_mcu --target "$target" --no-default-features \
                         --features="mcu-board-support/$feature" --config "$espcfg" --release
+                    elif [ "$kind" = "stm" ]; then
+                      # STM boards route Slint's textures into external OSPI flash via the
+                      # .slint_assets linker section; without this they land in internal .rodata and
+                      # overflow FLASH (the H735 only has 1MB). Only the stm32* boards define it.
+                      SLINT_ASSET_SECTION=.slint_assets cargo build -p printerdemo_mcu --target "$target" --no-default-features \
+                        --features="mcu-board-support/$feature" --release
                     else
                       cargo build -p printerdemo_mcu --target "$target" --no-default-features \
                         --features="mcu-board-support/$feature" --release
@@ -1014,7 +1021,10 @@ jobs:
                           elf2uf2-rs "$elf" "$OUT/printerdemo-$feature.uf2"
                           ;;
                         rp2350)
-                          picotool uf2 convert "$elf" "$OUT/printerdemo-$feature.uf2"
+                          # -t elf is required: picotool infers type from the extension, and the
+                          # Rust binary has none. (elf2uf2-rs can't be used here — it stamps the
+                          # RP2040 family id onto RP2350 images.)
+                          picotool uf2 convert -t elf "$elf" "$OUT/printerdemo-$feature.uf2"
                           ;;
                         stm)
                           # probe-rs / STM32CubeProgrammer flash the .elf directly.
@@ -1023,8 +1033,10 @@ jobs:
                         esp)
                           # Merged image (bootloader + partition table + app) flashable at offset 0
                           # over WebSerial by ESP Web Tools, or by espflash/esptool.
-                          # Arg order is `<ELF> <OUTPUT>` (espflash 3.x; pinned $ESPFLASH_VERSION).
-                          espflash save-image --merge --chip esp32s3 "$elf" "$OUT/printerdemo-$feature.bin"
+                          # --flash-size 16mb gives a large-enough app partition (the default 1MB is
+                          # too small for the ~1.4MB demo); --skip-padding keeps the file ~1.5MB
+                          # instead of padding to the full 16MB. Arg order is `<ELF> <OUTPUT>`.
+                          espflash save-image --merge --skip-padding --chip esp32s3 --flash-size 16mb "$elf" "$OUT/printerdemo-$feature.bin"
                           jq -n --arg feature "$feature" --arg path "printerdemo-$feature.bin" \
                             '{name: ("Slint printerdemo (" + $feature + ")"), builds: [ {chipFamily: "ESP32-S3", parts: [ {path: $path, offset: 0} ]} ]}' \
                             > "$OUT/manifest-$feature.json"


### PR DESCRIPTION
## What

Builds runnable/flashable **demo binaries per target** and publishes them into **slint-ui/www-releases** (alongside the web demos), plus a single `demos.json` index the website reads at build time. Two tracks:

- **MCU boards** (`demo_binaries`) — bare-metal `printerdemo_mcu`, **flashed** as firmware.
- **Linux SBCs** (`demo_binaries_linux`) — std `printerdemo`, **downloaded and run** (no flashing).

This is the dependency the website "Get it running" board catalog (slint-ui/website #186) is waiting on — its download links, one-click browser-flash, and `slint.dev/flash` CLI are dark until these artifacts exist (`data/boards.json` ships `"demosReady": false`).

## ✅ Validated green

`mode: test` run [28414143051](https://github.com/slint-ui/slint/actions/runs/28414143051) (commit `e90e73a`): **all three demo jobs pass**, producing all 10 MCU artifacts + 5 ESP Web Tools manifests + 2 Linux tarballs. Each artifact byte-verified: RP2350 uf2 family id `0xe48bff59`, RP2040 `0xe48bff56`, ESP merged bins start with the `e9` image magic, STM `.elf` fits flash.

Getting there required reproducing every board's build+convert **locally** (the existing `mcu` job only `cargo check`s, so it never links or converts). That surfaced four real issues:

| Path | Issue | Fix |
|---|---|---|
| RP2040 | elf2uf2-rs 2.1.1 rejects `EI_OSABI=3` (ELFOSABI_GNU) ELFs | bump to **2.2.0** |
| RP2350 | elf2uf2 stamps the **RP2040 family id**; picotool needs a type hint | **`picotool uf2 convert -t elf`** |
| STM | demo **overflows 1 MB internal FLASH (~188 KB over)** | **`SLINT_ASSET_SECTION=.slint_assets`** (STM only) → textures to external OSPI flash |
| ESP | image too big for default **1 MB app partition** | **`espflash save-image --merge --skip-padding --chip esp32s3 --flash-size 16mb`** |

Also dropped `SLINT_FONT_SIZES` (the check-job's 13 pre-rendered sizes = rodata bloat that never had to link) and `--cfg slint_int_coord`, matching the README flash build.

## Per-board artifact format

| Vendor | feature(s) | output |
|---|---|---|
| Raspberry Pi RP2040 | `pico-st7789` | `.uf2` (elf2uf2-rs) |
| Raspberry Pi RP2350 | `pico2-st7789`, `pico2-touch-lcd-2-8` | `.uf2` (picotool) |
| STMicroelectronics | `stm32h735g`, `stm32u5g9j-dk2` | `.elf` |
| Espressif ESP32-S3 | `esp32-s3-box-3`, `esp32-s3-lcd-ev-board`, `esope-sld-c-w-s3`, `waveshare-esp32-s3-touch-amoled-1-8`, `m5stack-cores3` | merged `.bin` + `manifest-<feature>.json` |
| Linux SBC | aarch64, armv7 | `printerdemo-<arch>-linux.tar.gz` |

Named `printerdemo-<feature>.<ext>`; the publish job derives `demos.json` from the filenames. A guardrail asserts the MCU matrix == `mcu-board-support` `[features]`.

## Publishing + demos.json

`publish_artifacts` (the same job that ships web demos / docs / editor to www-releases) copies MCU → `demos/mcu/`, Linux → `demos/linux/`, and generates `demos/demos.json` (`boards` = flash, `linux` = run), served from `snapshots.slint.dev/<branch>/` or `releases.slint.dev/<version>/`. The website fetches the canonical snapshot URL at build time.

## Remaining note

`mode: test` validates the **build + convert** (green above); the www-releases **copy + demos.json publish** step only runs on `full-nightly`/`release`/`website-only`, so it first executes on a real nightly (the demos.json generator was dry-run-validated separately). Follow-up website PR flips `demosReady: true` and wires the Download / `<esp-web-install-button>` / RP2040 File-System-Access / `slint.dev/flash` UI + a "download & run" card for `linux`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)