### PR TITLE
Fix unbounded window height with an unsized Image

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1390,7 +1390,9 @@ fn is_height_for_width_cell(elem: &ElementRc) -> bool {
 /// `layout_info_v_with_constraint` also has `layout_info_prop` set (the
 /// constrained function is synthesized from the existing `layoutinfo-v`
 /// binding), so the `layout_info_prop` branch covers it.
-fn default_cross_axis_constraint(elem: &ElementRc) -> Option<crate::expression_tree::Expression> {
+pub(crate) fn default_cross_axis_constraint(
+    elem: &ElementRc,
+) -> Option<crate::expression_tree::Expression> {
     let elem_b = elem.borrow();
 
     // Route through `layoutinfo-h-with-constraint` when available so we

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -627,12 +627,23 @@ fn lower_sub_component(
         None,
     )
     .into();
+    // Measure the root's height for its preferred width, not an unbounded one, so a
+    // height-for-width Image doesn't report infinite height (mirrors the interpreter).
+    let v_cross_constraint = component
+        .root_element
+        .borrow()
+        .layout_info_v_with_constraint
+        .is_some()
+        .then(|| {
+            super::lower_layout_expression::default_cross_axis_constraint(&component.root_element)
+        })
+        .flatten();
     sub_component.layout_info_v = super::lower_layout_expression::get_layout_info(
         &component.root_element,
         &mut ctx,
         &component.root_constraints.borrow(),
         crate::layout::Orientation::Vertical,
-        None,
+        v_cross_constraint,
     )
     .into();
     // For repeated elements in a FlexboxLayout, generate code to read flex properties

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2229,19 +2229,24 @@ extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     let orientation = crate::eval_layout::from_runtime(orientation);
 
-    // The vtable layout_info path is taken e.g. for repeater cells. When
-    // the component root has a parameterized layout-info function, route
-    // through it: reading the bare `layoutinfo-{h,v}` would cycle on
-    // `self.{w,h}` for the cross-axis case, and we have no explicit
-    // constraint at this entry point. `f32::MAX` (i.e. "unconstrained")
-    // tells the runtime's flex algorithm to behave as if items don't
-    // need to wrap, which gives the natural max-cell-cross-axis result
-    // — much closer to correct than the `sqrt(item-areas)` heuristic
-    // that a `-1` sentinel would trigger.
+    // Vtable entry (repeater cells, window auto-size). Pass the cross-axis size
+    // to the root's parameterized layout-info function explicitly, avoiding a
+    // cycle on `self.{w,h}`: for the vertical query the preferred width, so a
+    // height-for-width Image sizes its height to that and not to infinity; for
+    // the horizontal query `f32::MAX`, i.e. "don't wrap".
     let root = &instance_ref.description.original.root_element;
+    let window_adapter = instance_ref.window_adapter();
     let cross_axis_constraint = match orientation {
         i_slint_compiler::layout::Orientation::Vertical => {
-            root.borrow().layout_info_v_with_constraint.is_some().then_some(f32::MAX)
+            root.borrow().layout_info_v_with_constraint.is_some().then(|| {
+                crate::eval_layout::get_layout_info(
+                    root,
+                    instance_ref,
+                    &window_adapter,
+                    i_slint_compiler::layout::Orientation::Horizontal,
+                )
+                .preferred_bounded()
+            })
         }
         i_slint_compiler::layout::Orientation::Horizontal => {
             root.borrow().layout_info_h_with_constraint.is_some().then_some(f32::MAX)
@@ -2250,7 +2255,7 @@ extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -
     let mut result = crate::eval_layout::get_layout_info_with_constraint(
         root,
         instance_ref,
-        &instance_ref.window_adapter(),
+        &window_adapter,
         orientation,
         cross_axis_constraint,
     );

--- a/tests/cases/layout/issue_12139_image_window_autosize.slint
+++ b/tests/cases/layout/issue_12139_image_window_autosize.slint
@@ -30,8 +30,8 @@ assert_eq!(size, slint::PhysicalSize::new(128, 128));
 
 ```js
 let instance = new slint.TestCase({});
-instance.window().show();
-let size = instance.window().physicalSize;
+instance.window.show();
+let size = instance.window.physicalSize;
 assert.equal(size.width, 128);
 assert.equal(size.height, 128);
 ```

--- a/tests/cases/layout/issue_12139_image_window_autosize.slint
+++ b/tests/cases/layout/issue_12139_image_window_autosize.slint
@@ -1,0 +1,39 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #12139: an unsized Image used to give an auto-sizing window an unbounded
+// height (its aspect ratio scaled the unconstrained measuring width to infinity).
+// It should auto-size to the 128x128 image.
+export component TestCase inherits Window {
+    VerticalLayout {
+        Image { source: @image-url("../../../logo/slint-logo-square-light-128x128.png"); }
+    }
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+handle->show();
+auto size = handle->window().size();
+assert(size == slint::PhysicalSize({128, 128}));
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+instance.show().unwrap();
+let size = instance.window().size();
+assert_eq!(size, slint::PhysicalSize::new(128, 128));
+```
+
+
+```js
+let instance = new slint.TestCase({});
+instance.window().show();
+let size = instance.window().physicalSize;
+assert.equal(size.width, 128);
+assert.equal(size.height, 128);
+```
+
+*/


### PR DESCRIPTION
An unsized Image in an auto-sizing window reported an infinite height: the height was measured with an unbounded width, which the aspect-ratio image scaled into infinity. Measure the preferred width first and pass it as the cross-axis constraint, in both the interpreter and the generated code.

Fixes: #12139
