### PR TITLE
core: split image loading into load_from_path and load_as_html_image

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4156,11 +4156,13 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             let image = match resource_ref {
                 crate::expression_tree::ImageReference::None => r#"slint::Image()"#.to_string(),
                 resource_ref @ (crate::expression_tree::ImageReference::Path(_)
-                | crate::expression_tree::ImageReference::Url(_)
-                | crate::expression_tree::ImageReference::DataUri(_)) => format!(
+                | crate::expression_tree::ImageReference::Url(_)) => format!(
                     r#"slint::Image::load_from_path(slint::SharedString(u8"{}"))"#,
                     escape_string(resource_ref.source().unwrap())
                 ),
+                crate::expression_tree::ImageReference::DataUri(_) => {
+                    unreachable!("data: URIs are embedded before code generation")
+                }
                 crate::expression_tree::ImageReference::EmbeddedData { resource_id, extension } => {
                     let symbol = format!("slint_embedded_resource_{resource_id}");
                     format!(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3297,11 +3297,22 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 crate::expression_tree::ImageReference::None => {
                     quote!(sp::Image::default())
                 }
-                resource_ref @ (crate::expression_tree::ImageReference::Path(_)
-                | crate::expression_tree::ImageReference::Url(_)
-                | crate::expression_tree::ImageReference::DataUri(_)) => {
-                    let source = resource_ref.source().unwrap();
-                    quote!(sp::Image::load_from_path(::std::path::Path::new(#source)).unwrap_or_default())
+                crate::expression_tree::ImageReference::Path(path) => {
+                    let path = path.as_str();
+                    quote!(sp::Image::load_from_path(::std::path::Path::new(#path)).unwrap_or_default())
+                }
+                crate::expression_tree::ImageReference::Url(url) => {
+                    let url = url.as_str();
+                    // URL image references only work on the web, where the browser fetches them.
+                    quote!({
+                        #[cfg(target_arch = "wasm32")]
+                        { sp::load_as_html_image(#url).unwrap_or_default() }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        { sp::Image::default() }
+                    })
+                }
+                crate::expression_tree::ImageReference::DataUri(_) => {
+                    unreachable!("data: URIs are embedded before code generation")
                 }
                 crate::expression_tree::ImageReference::EmbeddedData { resource_id, extension } => {
                     let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id.0);

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -296,7 +296,7 @@ pub struct CachedPath {
     last_modified: u32,
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 impl CachedPath {
     fn new<P: AsRef<std::path::Path>>(path: P) -> Self {
         let path_str = path.as_ref().to_string_lossy().as_ref().into();
@@ -1101,6 +1101,18 @@ impl BorrowedOpenGLTextureBuilder {
     pub fn build(self) -> Image {
         Image(ImageInner::BorrowedOpenGLTexture(self.0))
     }
+}
+
+/// Load an image by handing a URL to an HTML `<img>` element for the browser
+/// to fetch. This is a web-only mechanism used by slintpad to display image
+/// references that are URLs rather than file-system paths; it is not general
+/// network image loading.
+/// This is called by the interpreter and the generated code.
+#[cfg(all(target_arch = "wasm32", feature = "image-decoders"))]
+pub fn load_as_html_image(url: &str) -> Result<Image, LoadImageError> {
+    self::cache::IMAGE_CACHE.with(|global_cache| {
+        global_cache.borrow_mut().load_as_html_image(url).ok_or(LoadImageError(()))
+    })
 }
 
 /// Load an image from an image embedded in the binary.

--- a/internal/core/graphics/image/cache.rs
+++ b/internal/core/graphics/image/cache.rs
@@ -5,7 +5,9 @@
 This module contains image and caching related types for the run-time library.
 */
 
-use super::{CachedPath, Image, ImageCacheKey, ImageInner, SharedImageBuffer};
+#[cfg(not(target_arch = "wasm32"))]
+use super::CachedPath;
+use super::{Image, ImageCacheKey, ImageInner, SharedImageBuffer};
 use crate::{SharedString, slice::Slice};
 
 struct ImageWeightInBytes;
@@ -72,19 +74,18 @@ impl ImageCache {
         }))
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn load_image_from_path(&mut self, _path: &SharedString) -> Option<Image> {
+        None
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn load_image_from_path(&mut self, path: &SharedString) -> Option<Image> {
         if path.is_empty() {
             return None;
         }
         let cache_key = ImageCacheKey::Path(CachedPath::new(path.as_str()));
-        #[cfg(target_arch = "wasm32")]
-        return self.lookup_image_in_cache_or_create(cache_key, |_| {
-            return Some(ImageInner::HTMLImage(vtable::VRc::new(
-                super::htmlimage::HTMLImage::new(&path),
-            )));
-        });
-        #[cfg(not(target_arch = "wasm32"))]
-        return self.lookup_image_in_cache_or_create(cache_key, |cache_key| {
+        self.lookup_image_in_cache_or_create(cache_key, |cache_key| {
             if cfg!(feature = "svg") && (path.ends_with(".svg") || path.ends_with(".svgz")) {
                 return Some(ImageInner::Svg(vtable::VRc::new(
                     super::svg::load_from_path(path, cache_key).map_or_else(
@@ -109,7 +110,20 @@ impl ImageCache {
                     })
                 },
             )
-        });
+        })
+    }
+
+    /// Load an image by handing its URL to an `<img>` element for the browser to
+    /// fetch. This is a web-only slintpad mechanism, not general network loading.
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn load_as_html_image(&mut self, url: &str) -> Option<Image> {
+        if url.is_empty() {
+            return None;
+        }
+        let cache_key = ImageCacheKey::URL(url.into());
+        self.lookup_image_in_cache_or_create(cache_key, |_| {
+            Some(ImageInner::HTMLImage(vtable::VRc::new(super::htmlimage::HTMLImage::new(url))))
+        })
     }
 
     pub(crate) fn load_image_from_embedded_data(

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -395,7 +395,16 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     corelib::graphics::Image::load_from_path(std::path::Path::new(path))
                 }
                 i_slint_compiler::expression_tree::ImageReference::Url(url) => {
-                    corelib::graphics::Image::load_from_path(std::path::Path::new(url.as_str()))
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        corelib::graphics::load_as_html_image(url.as_str())
+                    }
+                    // URL image references only work on the web, where the browser fetches them.
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        let _ = url;
+                        Err(Default::default())
+                    }
                 }
                 i_slint_compiler::expression_tree::ImageReference::EmbeddedData { .. } => {
                     todo!()


### PR DESCRIPTION
Image::load_from_path was filesystem-on-native but secretly it shoehorned the path into an <img> src on wasm.

Split that hidden web behaviour into Image::load_as_html_image, whose name makes clear it is the slintpad-specific mechanism of handing a URL to a browser <img> element rather than general network image loading. load_from_path is now path-only and fails on the web, where there is no file system.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->