### PR TITLE
core-macros: Drive `remove_extern` from a single `ffi` feature

### DIFF
--- a/internal/core-macros/Cargo.toml
+++ b/internal/core-macros/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 
 [features]
 default = []
+ffi = []     # Make `remove_extern` keep the ABI; set via `i-slint-core/ffi`
 
 [lib]
 proc-macro = true

--- a/internal/core-macros/lib.rs
+++ b/internal/core-macros/lib.rs
@@ -212,8 +212,14 @@ pub fn slint_doc_str(input: TokenStream) -> TokenStream {
 /// warn about ABI incompatibilities we wouldn't care about.
 ///
 /// (can be applied to a function or a vtable struct)
+///
+/// No-op when this crate's `ffi` feature is enabled (set via `i-slint-core/ffi`).
 #[proc_macro_attribute]
 pub fn remove_extern(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    if cfg!(feature = "ffi") {
+        return item;
+    }
+
     let mut input = syn::parse_macro_input!(item as syn::Item);
 
     match &mut input {

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["gui", "development-tools", "no-std"]
 path = "lib.rs"
 
 [features]
-ffi = ["dep:static_assertions"]           # Expose C ABI
+ffi = ["dep:static_assertions", "i-slint-core-macros/ffi"] # Expose C ABI
 libm = ["num-traits/libm", "euclid/libm"]
 # Allow the viewer to query at runtime information about item types
 rtti = []


### PR DESCRIPTION
## Problem

`ItemTreeVTable` is the only vtable filled cross-crate by hand-written functions — the interpreter (`internal/interpreter/dynamic_item_tree.rs`) constructs it from a struct literal of free functions. The struct strips its function-pointer ABI to the Rust ABI (via `remove_extern`) when **`i-slint-core/ffi`** is off; the interpreter's matching filler functions strip when **`slint-interpreter/ffi`** is off.

Those two features can diverge. A build that enables `i-slint-core/ffi` *without* `slint-interpreter/ffi` leaves the vtable fields `extern "C"` but the fillers Rust-ABI, producing 19 errors:

```
error[E0308]: mismatched types
   --> internal/interpreter/dynamic_item_tree.rs:1385:9
    |
    |         visit_children_item,
    |         ^^^^^^^^^^^^^^^^^^^ expected "C" fn, found "Rust" fn
```

In practice this happens when a workspace pulls `i-slint-backend-testing` with its `ffi` feature (which turns on `i-slint-core/ffi`) alongside the interpreter, without turning on `slint-interpreter/ffi`. A single large workspace usually masks it, because feature unification enables `slint-interpreter/ffi` somewhere in the graph. It surfaced while splitting the examples/demos/tests into separate workspaces (#12097): the smaller `tests` workspace no longer unifies `slint-interpreter/ffi`.

## Fix

Drive the strip/keep decision from **one** feature instead of each crate's own. `remove_extern` now keys off its own crate's `ffi` feature — it's a no-op (keeps the ABI as written) when set, and strips otherwise. `i-slint-core/ffi` enables `i-slint-core-macros/ffi`, and because the proc-macro crate is built once with the union of all requested features, the same decision applies to every crate that uses the macro. The vtable struct and the functions that fill it can no longer disagree.

This keeps the existing behavior in both the all-ffi and no-ffi cases — in particular the **Rust ABI (and thus panic propagation) is preserved when `ffi` is off** — and only fixes the inconsistent middle case. (Per @ogoffart's review: this avoids forcing `extern "C"` onto the pure-Rust path, which would have broken panic propagation.)

## Validation

- **Divergent config** (`i-slint-core/ffi` on, `slint-interpreter/ffi` off): 38 mismatch error lines on `master` → builds clean with this change (confirmed with a stash/negative-control).
- **Pure non-ffi** (default features): builds; ABI stays Rust, so panics propagate.
- **wasm32-unknown-unknown**, ffi off, under `RUSTFLAGS=-D warnings`: clean.
- The proc-macro crate compiles both with and without its `ffi` feature.

Context: #12097