### PR TITLE
lsp: don't panic when a watched file path has no URL representation

### DIFF
--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -608,8 +608,8 @@ async fn run_main_loop(
                 }
             }
             file_event = file_watcher_receiver.recv() => {
-                if let Some(file_event) = file_event {
-                    trigger_file_watcher(&mut ctx, common::file_to_uri(&file_event.path).unwrap(), file_event.kind).await.ok();
+                if let Some(file_event) = file_event && let Some(uri) = common::file_to_uri(&file_event.path) {
+                    trigger_file_watcher(&mut ctx, uri, file_event.kind).await.ok();
                 }
             }
             _ = tokio::time::sleep(recompile_idle_timeout) => {


### PR DESCRIPTION
file_to_uri returns None for paths that can't be converted to a URL. The file watcher fed such a path to unwrap() and panicked; skip the event instead.
