### PR TITLE
core: fix grid layout panic on out-of-range row or column

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -381,8 +381,8 @@ mod grid_internal {
                     &repeater_steps,
                 );
                 if span > 1 {
-                    let span_data =
-                        &mut layout_data[(col_or_row as usize)..(col_or_row as usize + span as usize)];
+                    let span_data = &mut layout_data
+                        [(col_or_row as usize)..(col_or_row as usize + span as usize)];
 
                     // Adjust minimum sizes
                     let mut min = constraint.min;

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -328,7 +328,7 @@ mod grid_internal {
             orientation,
             &repeater_indices,
             &repeater_steps,
-        ) as usize;
+        );
         if num < 1 {
             return Default::default();
         }
@@ -382,7 +382,7 @@ mod grid_internal {
                 );
                 if span > 1 {
                     let span_data =
-                        &mut layout_data[(col_or_row as usize)..(col_or_row + span) as usize];
+                        &mut layout_data[(col_or_row as usize)..(col_or_row as usize + span as usize)];
 
                     // Adjust minimum sizes
                     let mut min = constraint.min;
@@ -561,14 +561,16 @@ impl GridLayoutOrganizedData {
         orientation: Orientation,
         repeater_indices: &Slice<u32>,
         repeater_steps: &Slice<u32>,
-    ) -> u16 {
+    ) -> usize {
         let mut max = 0;
         // This could be rewritten more efficiently to avoid a loop calling a loop, by keeping track of the repeaters we saw until now
         // Not sure it's worth the complexity though
         for idx in 0..num_cells {
             let (col_or_row, span) =
                 self.col_or_row_and_span(idx, orientation, repeater_indices, repeater_steps);
-            max = max.max(col_or_row + span.max(1));
+            // Widen to usize: a cell with an out-of-range row/col is clamped to u16::MAX, so adding
+            // the span here in u16 would overflow and under-size the layout vector.
+            max = max.max(col_or_row as usize + span.max(1) as usize);
         }
         max
     }
@@ -2747,7 +2749,7 @@ mod tests {
                 &repeater_indices,
                 &repeater_steps
             ),
-            num_rows as u16 // max row (4) + rowspan (1) = 5
+            num_rows as usize // max row (4) + rowspan (1) = 5
         );
 
         // Now test GridLayoutCacheGenerator

--- a/tests/cases/layout/grid_out_of_range_row.slint
+++ b/tests/cases/layout/grid_out_of_range_row.slint
@@ -1,0 +1,62 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test that an out-of-range row index doesn't make grid layout panic.
+// A row near u16::MAX (65535) used to overflow the row-count computation and
+// index past the end of the layout vector, both for plain cells and for spans.
+// (Columns can't reach this because col + colspan is already clamped to u16::MAX.)
+export component TestCase inherits Rectangle {
+    width: 200phx;
+    height: 200phx;
+
+    GridLayout {
+        spacing: 0px;
+        padding: 0px;
+        // Anchor at the origin.
+        Rectangle {
+            row: 0;
+            col: 0;
+            min-width: 30phx;
+            min-height: 30phx;
+        }
+        // Far row with a span: occupies rows 65534 and 65535. This exercises both the
+        // row-count overflow and the span-slice indexing at the top of the row range.
+        Rectangle {
+            row: 65534;
+            col: 0;
+            rowspan: 2;
+            min-height: 20phx;
+        }
+        // Far column, to exercise the (clamped) horizontal path with a large index.
+        Rectangle {
+            row: 0;
+            col: 65535;
+            min-width: 25phx;
+        }
+    }
+
+    // Reading the constraints forces the grid to be solved. The empty rows/columns in
+    // between contribute nothing, so the size is just the non-empty cells: row 0 (30) plus
+    // the spanned rows (20 split evenly), and column 0 (30) plus the far column (25).
+    out property <bool> test: root.min-height == 50phx && root.min-width == 55phx;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
A cell with a huge row/col is clamped to u16::MAX (65535). max_value summed the index and span in u16, overflowing to a small number that under-sized the layout vector, so accessing the clamped cell panicked with an out-of-bounds index. Compute the size in usize.
