### PR TITLE
Winit: native drag-and-drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpi"
 version = "0.1.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 
 [[package]]
 name = "drm"
@@ -10174,12 +10174,12 @@ dependencies = [
 [[package]]
 name = "winit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cfg_aliases",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "raw-window-handle",
  "rustix 1.1.4",
@@ -10200,11 +10200,11 @@ dependencies = [
 [[package]]
 name = "winit-android"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "android-activity 0.6.1",
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "ndk 0.9.0",
  "raw-window-handle",
  "smol_str 0.3.2",
@@ -10215,12 +10215,12 @@ dependencies = [
 [[package]]
 name = "winit-appkit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "winit-common"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "block2 0.6.2",
  "memmap2",
@@ -10254,24 +10254,25 @@ dependencies = [
 [[package]]
 name = "winit-core"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "keyboard-types 0.8.3",
  "raw-window-handle",
  "smol_str 0.3.2",
+ "url",
  "web-time",
 ]
 
 [[package]]
 name = "winit-orbital"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libredox",
  "orbclient",
  "raw-window-handle",
@@ -10284,12 +10285,12 @@ dependencies = [
 [[package]]
 name = "winit-uikit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -10304,15 +10305,16 @@ dependencies = [
 [[package]]
 name = "winit-wayland"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "foldhash 0.2.0",
  "libc",
  "memmap2",
+ "percent-encoding",
  "raw-window-handle",
  "rustix 1.1.4",
  "sctk-adwaita",
@@ -10330,13 +10332,13 @@ dependencies = [
 [[package]]
 name = "winit-web"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "atomic-waker",
  "bitflags 2.13.0",
  "concurrent-queue",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "js-sys",
  "pin-project",
  "raw-window-handle",
@@ -10352,15 +10354,16 @@ dependencies = [
 [[package]]
 name = "winit-win32"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "raw-window-handle",
  "smol_str 0.3.2",
  "tracing",
  "unicode-segmentation",
+ "url",
  "windows-sys 0.61.2",
  "winit-core",
 ]
@@ -10368,13 +10371,13 @@ dependencies = [
 [[package]]
 name = "winit-x11"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "percent-encoding",
  "raw-window-handle",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -1443,7 +1443,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpi"
 version = "0.1.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 
 [[package]]
 name = "drm"
@@ -7119,12 +7119,12 @@ dependencies = [
 [[package]]
 name = "winit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cfg_aliases",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "raw-window-handle",
  "rustix 1.1.4",
@@ -7145,11 +7145,11 @@ dependencies = [
 [[package]]
 name = "winit-android"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "android-activity 0.6.1",
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "ndk 0.9.0",
  "raw-window-handle",
  "smol_str 0.3.6",
@@ -7160,12 +7160,12 @@ dependencies = [
 [[package]]
 name = "winit-appkit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -7182,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "winit-common"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "block2 0.6.2",
  "memmap2",
@@ -7199,24 +7199,25 @@ dependencies = [
 [[package]]
 name = "winit-core"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "keyboard-types 0.8.3",
  "raw-window-handle",
  "smol_str 0.3.6",
+ "url",
  "web-time",
 ]
 
 [[package]]
 name = "winit-orbital"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libredox",
  "orbclient",
  "raw-window-handle",
@@ -7229,12 +7230,12 @@ dependencies = [
 [[package]]
 name = "winit-uikit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -7249,15 +7250,16 @@ dependencies = [
 [[package]]
 name = "winit-wayland"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "foldhash 0.2.0",
  "libc",
  "memmap2",
+ "percent-encoding",
  "raw-window-handle",
  "rustix 1.1.4",
  "sctk-adwaita",
@@ -7275,13 +7277,13 @@ dependencies = [
 [[package]]
 name = "winit-web"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "atomic-waker",
  "bitflags 2.13.0",
  "concurrent-queue",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "js-sys",
  "pin-project",
  "raw-window-handle",
@@ -7297,15 +7299,16 @@ dependencies = [
 [[package]]
 name = "winit-win32"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "raw-window-handle",
  "smol_str 0.3.6",
  "tracing",
  "unicode-segmentation",
+ "url",
  "windows-sys 0.61.2",
  "winit-core",
 ]
@@ -7313,13 +7316,13 @@ dependencies = [
 [[package]]
 name = "winit-x11"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "percent-encoding",
  "raw-window-handle",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4134,7 +4134,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpi"
 version = "0.1.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 
 [[package]]
 name = "drm"
@@ -17157,12 +17157,12 @@ dependencies = [
 [[package]]
 name = "winit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cfg_aliases",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "raw-window-handle",
  "rustix 1.1.4",
@@ -17183,11 +17183,11 @@ dependencies = [
 [[package]]
 name = "winit-android"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "android-activity 0.6.1",
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "ndk 0.9.0",
  "raw-window-handle",
  "smol_str 0.3.6",
@@ -17198,12 +17198,12 @@ dependencies = [
 [[package]]
 name = "winit-appkit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -17220,7 +17220,7 @@ dependencies = [
 [[package]]
 name = "winit-common"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "block2 0.6.2",
  "memmap2",
@@ -17237,24 +17237,25 @@ dependencies = [
 [[package]]
 name = "winit-core"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "keyboard-types 0.8.3",
  "raw-window-handle",
  "smol_str 0.3.6",
+ "url",
  "web-time",
 ]
 
 [[package]]
 name = "winit-orbital"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libredox",
  "orbclient",
  "raw-window-handle",
@@ -17267,12 +17268,12 @@ dependencies = [
 [[package]]
 name = "winit-uikit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -17287,15 +17288,16 @@ dependencies = [
 [[package]]
 name = "winit-wayland"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "foldhash 0.2.0",
  "libc",
  "memmap2",
+ "percent-encoding",
  "raw-window-handle",
  "rustix 1.1.4",
  "sctk-adwaita 0.11.0",
@@ -17313,13 +17315,13 @@ dependencies = [
 [[package]]
 name = "winit-web"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "atomic-waker",
  "bitflags 2.13.0",
  "concurrent-queue",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "js-sys",
  "pin-project",
  "raw-window-handle",
@@ -17335,15 +17337,16 @@ dependencies = [
 [[package]]
 name = "winit-win32"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "raw-window-handle",
  "smol_str 0.3.6",
  "tracing",
  "unicode-segmentation",
+ "url",
  "windows-sys 0.61.2",
  "winit-core",
 ]
@@ -17351,13 +17354,13 @@ dependencies = [
 [[package]]
 name = "winit-x11"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "percent-encoding",
  "raw-window-handle",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -78,7 +78,7 @@ lyon_path = { workspace = true }
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
 strum = { workspace = true }
-winit = { git = "https://github.com/rust-windowing/winit.git", rev = "c4afadbf", default-features = false }
+winit = { git = "https://github.com/rust-windowing/winit.git", rev = "156433eb912a62a1a07da0f9bbaa2d775270c788", default-features = false }
 raw-window-handle = { version = "0.6", features = ["alloc"] }
 scopeguard = { version = "1.1.0", default-features = false }
 
@@ -114,8 +114,8 @@ accesskit_winit = { version = "0.33", optional = true, default-features = false,
 i-slint-core = { workspace = true, features = ["image-decoders", "svg"] }
 
 [target.'cfg(not(any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32", target_os = "android")))'.dependencies]
-winit-wayland = { git = "https://github.com/rust-windowing/winit.git", rev = "c4afadbf", optional = true }
-winit-x11 = { git = "https://github.com/rust-windowing/winit.git", rev = "c4afadbf", optional = true }
+winit-wayland = { git = "https://github.com/rust-windowing/winit.git", rev = "156433eb912a62a1a07da0f9bbaa2d775270c788", optional = true }
+winit-x11 = { git = "https://github.com/rust-windowing/winit.git", rev = "156433eb912a62a1a07da0f9bbaa2d775270c788", optional = true }
 # Use same version and executor as accesskit
 zbus = { version = "5.14.0", default-features = false, features = ["async-io"] }
 futures = { version = "0.3.31" }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -159,6 +159,118 @@ impl EventLoopState {
             runtime_window.process_mouse_input(MouseEvent::Moved { position, touch_finger_id: 0 });
         }
     }
+
+    /// Hand a native drag built by `WinitWindowAdapter::start_drag` to winit, now that the
+    /// `ActiveEventLoop` is in hand.
+    ///
+    /// Falls back to the in-window drag if the native start fails, so the gesture isn't lost.
+    fn start_drag_if_pending(&mut self, event_loop: &dyn ActiveEventLoop) {
+        let Some(drag) = self.shared_backend_data.pending_drag.borrow_mut().take() else {
+            return;
+        };
+
+        if event_loop.start_drag(drag.window_id, drag.data, &drag.actions, drag.icon).is_err()
+            && let Some(window) = self.shared_backend_data.window_by_id(drag.window_id)
+        {
+            WindowInner::from_pub(window.window()).start_in_window_drag();
+        }
+    }
+
+    /// Dispatch an incoming native drag as a `DragMove` (or `Drop`) to the item tree, using
+    /// the data accumulated for `id`, and return the action a `DropArea` negotiated.
+    fn dispatch_incoming_drag(
+        &self,
+        runtime_window: &WindowInner,
+        id: winit::data_transfer::DataTransferId,
+        proposed: corelib::items::DragAction,
+        is_drop: bool,
+    ) -> corelib::items::DragAction {
+        let data = self
+            .shared_backend_data
+            .incoming_transfers
+            .borrow()
+            .get(&id)
+            .cloned()
+            .unwrap_or_default();
+        let mut drop_event = corelib::items::DropEvent::default();
+        drop_event.data = data;
+        drop_event.position =
+            corelib::api::LogicalPosition::new(self.cursor_pos.x, self.cursor_pos.y);
+        drop_event.proposed_action = proposed;
+        // The OS already negotiated the source's allowed actions, so let any DropArea choice
+        // through.
+        let allowed = corelib::items::AllowedDragActions { copy: true, move_: true, link: true };
+        let event = if is_drop {
+            MouseEvent::Drop { event: drop_event, allowed }
+        } else {
+            MouseEvent::DragMove { event: drop_event, allowed }
+        };
+        runtime_window
+            .process_mouse_input(event)
+            .and_then(|r| r.drag_action)
+            .unwrap_or(corelib::items::DragAction::None)
+    }
+
+    /// Dispatch a `DragMove` for an incoming drag and report the resulting valid actions to the
+    /// OS. Called once the payload has arrived, so `can-drop` sees the real data.
+    fn dispatch_and_report_incoming(
+        &self,
+        event_loop: &dyn ActiveEventLoop,
+        runtime_window: &WindowInner,
+        id: winit::data_transfer::DataTransferId,
+        proposed: corelib::items::DragAction,
+    ) {
+        let action = self.dispatch_incoming_drag(runtime_window, id, proposed, false);
+        let _ = event_loop.set_valid_dnd_actions(id, slint_action_to_dnd(action).as_slice());
+    }
+
+    /// Whether the payload of the incoming drag `id` has arrived (via `DataTransferReceived`).
+    fn has_incoming_data(&self, id: winit::data_transfer::DataTransferId) -> bool {
+        self.shared_backend_data.incoming_transfers.borrow().contains_key(&id)
+    }
+}
+
+/// Map a winit drag action to Slint's `DragAction`. A `None` (e.g. unknown) action becomes
+/// `DragAction::None`.
+fn dnd_action_to_slint(action: Option<winit::event_loop::DndAction>) -> corelib::items::DragAction {
+    use corelib::items::DragAction;
+    use winit::event_loop::DndAction;
+    match action {
+        Some(DndAction::Move) => DragAction::Move,
+        Some(DndAction::Copy) => DragAction::Copy,
+        Some(DndAction::Link) => DragAction::Link,
+        Some(DndAction::Ask) | Some(DndAction::Private) | None => DragAction::None,
+    }
+}
+
+/// The action proposed by the OS for an incoming drag, defaulting to `Copy` when the platform
+/// did not supply one (some platforms, such as X11, only report the action when the drop
+/// completes).
+fn proposed_action_or_copy(
+    action: Option<winit::event_loop::DndAction>,
+) -> corelib::items::DragAction {
+    let action = dnd_action_to_slint(action);
+    if action == corelib::items::DragAction::None {
+        corelib::items::DragAction::Copy
+    } else {
+        action
+    }
+}
+
+/// Map a `DropArea`'s chosen action to the single valid winit drag action to report to the OS,
+/// or `None` to reject the drag. Returned as an `Option` so the per-event report on the drag
+/// hot path needs no allocation.
+fn slint_action_to_dnd(action: corelib::items::DragAction) -> Option<winit::event_loop::DndAction> {
+    use corelib::items::DragAction;
+    match action {
+        DragAction::Move => Some(winit::event_loop::DndAction::Move),
+        DragAction::Copy => Some(winit::event_loop::DndAction::Copy),
+        DragAction::Link => Some(winit::event_loop::DndAction::Link),
+        DragAction::None => None,
+        // `DragAction` is `#[non_exhaustive]`, so a catch-all is still required.
+        #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
+        _ => None,
+    }
 }
 
 impl winit::application::ApplicationHandler for EventLoopState {
@@ -419,6 +531,15 @@ impl winit::application::ApplicationHandler for EventLoopState {
                     if let Some(finger_id) = self.map_touch_finger_id(finger_id, phase) {
                         runtime_window.process_touch_input(finger_id, pos, phase);
                     }
+                } else if self.pressed {
+                    // A held-button move may cross a DragArea's threshold and start a native
+                    // drag. That must happen while the platform's pointer grab is still active,
+                    // so dispatch it now instead of buffering (a deferred start gets cancelled).
+                    self.pending_mouse_move = None;
+                    runtime_window.process_mouse_input(MouseEvent::Moved {
+                        position: pos,
+                        touch_finger_id: 0,
+                    });
                 } else {
                     // winit sends this event at a very high frequency. So, bunch up consecutive
                     // cursor moved events and dispatch them as soon as any other kind of event
@@ -561,8 +682,69 @@ impl winit::application::ApplicationHandler for EventLoopState {
                     phase: winit_touch_phase(phase),
                 });
             }
+            // A native drag we started has finished. The core knows which drag is in flight, so
+            // we only report the negotiated action (`None` for a cancel).
+            WindowEvent::OutgoingDragDropped { action, .. } => {
+                runtime_window.report_drag_finished(dnd_action_to_slint(action));
+            }
+            WindowEvent::OutgoingDragCanceled { .. } => {
+                runtime_window.report_drag_finished(corelib::items::DragAction::None);
+            }
+            // An incoming native drag (maybe from another app) entered or moved over the window.
+            // Fetch the data lazily, dispatch it to the DropAreas, and report which actions are
+            // valid so the OS shows the right cursor.
+            WindowEvent::DragEntered { id, position } => {
+                // Fetch the payload. We can only tell whether a DropArea accepts it, and report
+                // the valid actions to the OS, once it arrives (in `DataTransferReceived` below).
+                let _ =
+                    event_loop.fetch_data_transfer(id, &winit::data_transfer::TypeHint::Plaintext);
+                if let Some(position) = position {
+                    let pos = position.to_logical(runtime_window.scale_factor() as f64);
+                    self.cursor_pos = euclid::point2(pos.x, pos.y);
+                }
+            }
+            WindowEvent::DragPosition { id, position, proposed_action } => {
+                let pos = position.to_logical(runtime_window.scale_factor() as f64);
+                self.cursor_pos = euclid::point2(pos.x, pos.y);
+                // Only evaluate once the payload has arrived, so `can-drop` sees the data.
+                if self.has_incoming_data(id) {
+                    let proposed = proposed_action_or_copy(proposed_action);
+                    self.dispatch_and_report_incoming(event_loop, runtime_window, id, proposed);
+                }
+            }
+            WindowEvent::DragDropped { id, proposed_action } => {
+                let proposed = proposed_action_or_copy(proposed_action);
+                self.dispatch_incoming_drag(runtime_window, id, proposed, true);
+                self.shared_backend_data.incoming_transfers.borrow_mut().remove(&id);
+            }
+            WindowEvent::DragLeft { id } => {
+                runtime_window.process_mouse_input(MouseEvent::Exit);
+                self.shared_backend_data.incoming_transfers.borrow_mut().remove(&id);
+            }
+            WindowEvent::DataTransferReceived { id, value, .. } => {
+                if let Ok(text) = value.try_as_string() {
+                    self.shared_backend_data
+                        .incoming_transfers
+                        .borrow_mut()
+                        .entry(id)
+                        .or_default()
+                        .set_plain_text(text.into());
+                    // The payload is now available: evaluate the DropAreas at the current
+                    // position and report the valid actions to the OS.
+                    self.dispatch_and_report_incoming(
+                        event_loop,
+                        runtime_window,
+                        id,
+                        corelib::items::DragAction::Copy,
+                    );
+                }
+            }
             _ => {}
         }
+
+        // A `DragArea` may have requested a native drag above; start it now while the
+        // `ActiveEventLoop` is in hand.
+        self.start_drag_if_pending(event_loop);
 
         if self.loop_error.is_some() {
             event_loop.exit();

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -392,6 +392,17 @@ impl BackendBuilder {
     }
 }
 
+/// A native drag built by [`WinitWindowAdapter::start_drag`], ready for the event loop to hand
+/// to `ActiveEventLoop::start_drag` (which is only reachable from inside the event handler).
+pub(crate) struct PendingNativeDrag {
+    pub(crate) window_id: winit::window::WindowId,
+    pub(crate) data: Box<dyn winit::data_transfer::DataTransferSend>,
+    /// Allowed actions, ordered by preference, as Wayland and macOS expect.
+    pub(crate) actions: Vec<winit::event_loop::DndAction>,
+    /// The image shown under the cursor while dragging, if any.
+    pub(crate) icon: Option<winit::event_loop::DragIcon>,
+}
+
 pub(crate) struct SharedBackendData {
     /// Allow fallback if the desired renderer is not found
     allow_fallback: bool,
@@ -412,6 +423,15 @@ pub(crate) struct SharedBackendData {
     /// event loop or is from a stale event.
     event_loop_generation: Arc<AtomicUsize>,
     is_wayland: bool,
+    /// A native drag a `DragArea` requested, built and waiting to be handed to the active event
+    /// loop. See [`WinitWindowAdapter::start_drag`] and `EventLoopState::start_drag_if_pending`.
+    pub(crate) pending_drag: RefCell<Option<PendingNativeDrag>>,
+    /// Data of incoming native drags, keyed by winit's data-transfer id. winit delivers it
+    /// asynchronously via `DataTransferReceived`, so we accumulate it here and read it when
+    /// dispatching `DragMove`/`Drop` to `DropArea`s.
+    pub(crate) incoming_transfers: RefCell<
+        HashMap<winit::data_transfer::DataTransferId, i_slint_core::data_transfer::DataTransfer>,
+    >,
     /// Desktop settings read from the XDG portal (cursor blink, appearance query).
     #[cfg(xdg_desktop_settings)]
     desktop_settings: xdg_desktop_settings::DesktopSettings,
@@ -503,6 +523,8 @@ impl SharedBackendData {
             event_queue: Default::default(),
             event_loop_generation: Default::default(),
             is_wayland,
+            pending_drag: None.into(),
+            incoming_transfers: Default::default(),
             #[cfg(xdg_desktop_settings)]
             desktop_settings: xdg_desktop_settings::DesktopSettings::new(),
             #[cfg(target_os = "ios")]

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -41,7 +41,7 @@ use corelib::api::PhysicalSize;
 use corelib::layout::Orientation;
 use corelib::lengths::LogicalLength;
 use corelib::platform::{PlatformError, WindowEvent};
-use corelib::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
+use corelib::window::{DragRequest, WindowAdapter, WindowAdapterInternal, WindowInner};
 use corelib::{Coord, graphics::*};
 use i_slint_core::{self as corelib};
 use winit::cursor::CustomCursorSource;
@@ -1433,6 +1433,50 @@ impl WindowAdapterInternal for WinitWindowAdapter {
         if let Some(winit_window) = self.winit_window_or_none.borrow().as_window() {
             let _ = winit_window.drag_window();
         }
+    }
+
+    fn start_drag(&self, request: &DragRequest) -> bool {
+        // winit's drag API lives on the `ActiveEventLoop`, only reachable inside the event
+        // handler. Build the transfer now and stash it; the handler hands it to winit.
+        let Some(winit_window) = self.winit_window() else {
+            return false;
+        };
+        // Only plain text is sent natively for now; without it, fall back to the in-window drag.
+        let Some(text) = request.data().plain_text().ok().filter(|t| !t.is_empty()) else {
+            return false;
+        };
+        let data = winit::data_transfer::DataTransferSendBuilder::new(text.to_string())
+            .with_type(winit::data_transfer::TypeHint::Plaintext, |text: &String, _| {
+                Some(text.clone())
+            })
+            .build();
+        let allowed = request.allowed_actions();
+        let mut actions = Vec::new();
+        if allowed.move_ {
+            actions.push(winit::event_loop::DndAction::Move);
+        }
+        if allowed.copy {
+            actions.push(winit::event_loop::DndAction::Copy);
+        }
+        if allowed.link {
+            actions.push(winit::event_loop::DndAction::Link);
+        }
+        let drag_image = request.drag_image();
+        let image_size = drag_image.size();
+        let icon = icon_to_winit(
+            drag_image.clone(),
+            euclid::Size2D::new(image_size.width as Coord, image_size.height as Coord),
+        )
+        .map(|icon| winit::event_loop::DragIcon {
+            icon,
+            // Slint's `drag-image-offset` is the point of the image under the cursor; winit's
+            // offset is the image's top-left relative to the cursor.
+            offset_x: -request.drag_image_offset().x,
+            offset_y: -request.drag_image_offset().y,
+        });
+        *self.shared_backend_data.pending_drag.borrow_mut() =
+            Some(crate::PendingNativeDrag { window_id: winit_window.id(), data, actions, icon });
+        true
     }
 
     fn set_mouse_cursor(&self, cursor: MouseCursorInner) {

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -1428,7 +1428,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpi"
 version = "0.1.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 
 [[package]]
 name = "drm"
@@ -6802,12 +6802,12 @@ dependencies = [
 [[package]]
 name = "winit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cfg_aliases",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "raw-window-handle",
  "rustix 1.1.4",
@@ -6828,11 +6828,11 @@ dependencies = [
 [[package]]
 name = "winit-android"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "android-activity 0.6.1",
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "ndk 0.9.0",
  "raw-window-handle",
  "smol_str 0.3.6",
@@ -6843,12 +6843,12 @@ dependencies = [
 [[package]]
 name = "winit-appkit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -6865,7 +6865,7 @@ dependencies = [
 [[package]]
 name = "winit-common"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "block2 0.6.2",
  "memmap2",
@@ -6882,24 +6882,25 @@ dependencies = [
 [[package]]
 name = "winit-core"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "keyboard-types 0.8.3",
  "raw-window-handle",
  "smol_str 0.3.6",
+ "url",
  "web-time",
 ]
 
 [[package]]
 name = "winit-orbital"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libredox",
  "orbclient",
  "raw-window-handle",
@@ -6912,12 +6913,12 @@ dependencies = [
 [[package]]
 name = "winit-uikit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -6932,15 +6933,16 @@ dependencies = [
 [[package]]
 name = "winit-wayland"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "foldhash 0.2.0",
  "libc",
  "memmap2",
+ "percent-encoding",
  "raw-window-handle",
  "rustix 1.1.4",
  "sctk-adwaita",
@@ -6958,13 +6960,13 @@ dependencies = [
 [[package]]
 name = "winit-web"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "atomic-waker",
  "bitflags 2.13.0",
  "concurrent-queue",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "js-sys",
  "pin-project",
  "raw-window-handle",
@@ -6980,15 +6982,16 @@ dependencies = [
 [[package]]
 name = "winit-win32"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "raw-window-handle",
  "smol_str 0.3.6",
  "tracing",
  "unicode-segmentation",
+ "url",
  "windows-sys 0.61.2",
  "winit-core",
 ]
@@ -6996,13 +6999,13 @@ dependencies = [
 [[package]]
 name = "winit-x11"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/rust-windowing/winit.git?rev=c4afadbf#c4afadbfabf7b1e7989b40b493db1a4c7bd8ff4e"
+source = "git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788#156433eb912a62a1a07da0f9bbaa2d775270c788"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "calloop 0.14.4",
  "cursor-icon",
- "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=c4afadbf)",
+ "dpi 0.1.2 (git+https://github.com/rust-windowing/winit.git?rev=156433eb912a62a1a07da0f9bbaa2d775270c788)",
  "libc",
  "percent-encoding",
  "raw-window-handle",


### PR DESCRIPTION
Start an OS-level drag from a DragArea so data can be dropped onto other applications, and receive drags from other applications onto DropAreas.

Add WindowAdapterInternal::start_drag, which a backend implements to take over a drag natively, receiving a read-only DragRequest (data, allowed actions, drag image). When no backend supports it, or a native start fails, the existing in-window drag-and-drop is used as a fallback. The core tracks the in-flight drag, so a backend reports completion or falls back with no arguments.

Implement it in the Qt backend via QDrag, and in the winit backend (send and receive) using the new winit drag-and-drop API, switching the winit dependency to the slint-ui/winit drag-n-drop branch.

Receiving native drops doesn't work on Wayland yet: copypasta's clipboard creates a second wl_data_device that the compositor delivers incoming drags to instead of winit's. It needs clipboard and drag-and-drop to share one data device.
