### PR TITLE
compiler: Store Expression::Struct fields in a BTreeMap

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -14,7 +14,7 @@ use crate::typeregister;
 use core::cell::RefCell;
 use smol_str::{SmolStr, format_smolstr};
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::rc::{Rc, Weak};
 
 // FIXME remove the pub
@@ -789,7 +789,7 @@ pub enum Expression {
     },
     Struct {
         ty: Rc<Struct>,
-        values: HashMap<SmolStr, Expression>,
+        values: BTreeMap<SmolStr, Expression>,
     },
 
     PathData(Path),
@@ -1472,7 +1472,7 @@ impl Expression {
                     if left.fields != right.fields =>
                 {
                     if let Expression::Struct { mut values, .. } = self {
-                        let mut new_values = HashMap::new();
+                        let mut new_values = BTreeMap::new();
                         for (key, ty) in &right.fields {
                             let (key, expression) = values.remove_entry(key).map_or_else(
                                 || (key.clone(), Expression::default_value_for_type(ty)),
@@ -1485,7 +1485,7 @@ impl Expression {
                         return Expression::Struct { values: new_values, ty: right.clone() };
                     }
                     let var_name = symbol_counters.generate_name("tmpobj_conv_");
-                    let mut new_values = HashMap::new();
+                    let mut new_values = BTreeMap::new();
                     for (key, ty) in &right.fields {
                         let expression = if left.fields.contains_key(key) {
                             Expression::StructFieldAccess {
@@ -1582,7 +1582,7 @@ impl Expression {
         {
             // Also special case struct literal in case they contain array literal
             let mut fields = struct_type.fields.clone();
-            let mut new_values = HashMap::new();
+            let mut new_values = BTreeMap::new();
             for (f, v) in values {
                 if let Some(t) = fields.remove(f) {
                     new_values.insert(

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::rc::{Rc, Weak};
 
 use smol_str::SmolStr;
@@ -364,7 +364,7 @@ fn lower_assignment(
             };
             let lower_base =
                 tree_Expression::ReadLocalVariable { name: unique_name, ty: ty.clone() };
-            let mut values = HashMap::new();
+            let mut values = BTreeMap::new();
             let Type::Struct(ty) = ty else { unreachable!() };
 
             for field in ty.fields.keys() {

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -21,7 +21,7 @@ use crate::layout::{BuiltinFilter, LayoutConstraints, Orientation, implicit_layo
 use crate::object_tree::{Component, ElementRc};
 use crate::symbol_counters::SymbolCounters;
 use smol_str::{SmolStr, format_smolstr};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub fn default_geometry(
     root_component: &Rc<Component>,
@@ -317,7 +317,7 @@ fn merge_explicit_constraints(
                     },
                 )
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         for (nr, s) in constraints.for_each_restrictions(orientation) {
             let e = nr
@@ -337,7 +337,7 @@ fn merge_explicit_constraints(
 }
 
 fn explicit_layout_info(e: &ElementRc, orientation: Orientation) -> Expression {
-    let mut values = HashMap::new();
+    let mut values = BTreeMap::new();
     let (size, orient) = match orientation {
         Orientation::Horizontal => ("width", "horizontal"),
         Orientation::Vertical => ("height", "vertical"),

--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use smol_str::SmolStr;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use crate::expression_tree::Expression;
@@ -568,7 +568,7 @@ fn codeblock_with_expr(mut pre_statements: Vec<Expression>, expr: Expression) ->
 
 fn make_struct(it: impl Iterator<Item = (&'static str, Type, Expression)>) -> Expression {
     let mut fields = BTreeMap::<SmolStr, Type>::new();
-    let mut values = HashMap::<SmolStr, Expression>::new();
+    let mut values = BTreeMap::<SmolStr, Expression>::new();
     let mut voids = Vec::new();
     for (name, ty, expr) in it {
         if !has_value(&ty) {
@@ -594,7 +594,7 @@ fn convert_struct(from: Expression, to: Type, symbol_counters: &SymbolCounters) 
         return Expression::Invalid;
     };
     if let Expression::Struct { mut values, .. } = from {
-        let mut new_values = HashMap::new();
+        let mut new_values = BTreeMap::new();
         for (key, ty) in &to.fields {
             let (key, expression) = values
                 .remove_entry(key)
@@ -605,7 +605,7 @@ fn convert_struct(from: Expression, to: Type, symbol_counters: &SymbolCounters) 
     }
     let var_name = symbol_counters.generate_name("tmpobj_ret_conv_");
     let from_ty = from.ty();
-    let mut new_values = HashMap::new();
+    let mut new_values = BTreeMap::new();
     let Type::Struct(from_s) = &from_ty else {
         assert_eq!(from_ty, Type::Invalid);
         return Expression::Invalid;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -20,7 +20,7 @@ use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
 use core::num::IntErrorKind;
 use smol_str::{SmolStr, ToSmolStr};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -1864,7 +1864,7 @@ impl Expression {
         node: syntax_nodes::ObjectLiteral,
         ctx: &mut LookupCtx,
     ) -> Expression {
-        let values: HashMap<SmolStr, Expression> = node
+        let values: BTreeMap<SmolStr, Expression> = node
             .ObjectMember()
             .map(|n| {
                 (


### PR DESCRIPTION
The fields of `Expression::Struct` were kept in a `HashMap`, so a struct literal bundling several image references was walked in randomized order when embedding resources. The resource ids, and hence the generated code, then differed between otherwise identical compilations, defeating rustc's incremental cache.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
