### PR TITLE
android: include the display cutout in the safe-area insets

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -486,7 +486,23 @@ public class SlintAndroidJavaHelper {
     }
 
     private WindowInsets dispatchInsets(WindowInsets insets) {
-        Insets safeAreaInsets = insets.getInsets(WindowInsets.Type.systemBars());
+        // The listener-supplied `insets` reflects what reaches the decor view
+        // AFTER any ancestor has consumed insets, so in edge-to-edge mode the
+        // system bars and the display cutout often arrive as zero. Read those
+        // straight from the WindowManager, which always returns the unconsumed
+        // values — matching what get_safe_area() does. The IME inset still
+        // comes from the listener stream so keyboard show/hide animates.
+        Insets sysBars;
+        Insets cutout;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsets src = mActivity.getWindowManager().getCurrentWindowMetrics().getWindowInsets();
+            sysBars = src.getInsets(WindowInsets.Type.systemBars());
+            cutout = src.getInsets(WindowInsets.Type.displayCutout());
+        } else {
+            sysBars = insets.getInsets(WindowInsets.Type.systemBars());
+            cutout = insets.getInsets(WindowInsets.Type.displayCutout());
+        }
+        Insets safeAreaInsets = Insets.max(sysBars, cutout);
         Insets keyboardAreaInsets = insets.getInsets(WindowInsets.Type.ime());
         Rect windowRect = get_view_rect();
         SlintAndroidJavaHelper.setInsets(
@@ -605,8 +621,10 @@ public class SlintAndroidJavaHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             WindowMetrics metrics = mActivity.getWindowManager().getCurrentWindowMetrics();
             WindowInsets insets = metrics.getWindowInsets();
-            Insets systemBars = insets.getInsets(WindowInsets.Type.systemBars());
-            return new Rect(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            Insets safeArea = Insets.max(
+                    insets.getInsets(WindowInsets.Type.systemBars()),
+                    insets.getInsets(WindowInsets.Type.displayCutout()));
+            return new Rect(safeArea.left, safeArea.top, safeArea.right, safeArea.bottom);
         } else {
             View decorView = mActivity.getWindow().getDecorView();
             // Note: `View.getRootWindowInsets` requires API level 23 or above


### PR DESCRIPTION
My Android app had the top-middle area partially covered by the tablet camera (in landscape mode).

`get_safe_area` only consulted `WindowInsets.Type.systemBars()`, so a notch or punch-hole camera that sat outside the status bar could overlap app content (e.g. obscure a tab label in landscape on tablets). OR it with `WindowInsets.Type.displayCutout()` via `Insets.max` so both contribute.

The listener-driven `dispatchInsets` had the same issue, plus a second quirk: the insets it receives are post-consumption, so in edge-to-edge mode `systemBars` and `displayCutout` typically arrive as zero. Read both straight from `WindowManager.getCurrentWindowMetrics()` (same source `get_safe_area` uses), and keep the IME inset from the listener stream so keyboard show/hide still animates.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
