### PR TITLE
Package Visual Editor Sparkle update artifact

### DIFF
--- a/.github/workflows/visual_editor_macos_dmg.yaml
+++ b/.github/workflows/visual_editor_macos_dmg.yaml
@@ -17,6 +17,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "12.0"
   CARGO_INCREMENTAL: false
   MACOS_CARGO_TIMINGS: "1"
+  VERSION: "1.17.1"
   SLINT_BUILD_NUMBER: ${{ github.run_number }}
 
 jobs:
@@ -34,6 +35,7 @@ jobs:
       NOTARY_API_KEY_BASE64: ${{ secrets.NOTARY_API_KEY_BASE64 }}
       NOTARY_API_KEY_ID: ${{ secrets.NOTARY_API_KEY_ID }}
       NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+      EDITOR_SPARKLE_ED_PRIVATE_KEY: ${{ secrets.EDITOR_SPARKLE_ED_PRIVATE_KEY }}
       SPARKLE_FRAMEWORK_DIR: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v6
@@ -99,10 +101,12 @@ jobs:
       - name: Stage and sign app
         run: ./scripts/package_macos_visual_editor.bash stage-and-sign-app
 
+      - name: Create Cloudflare root artifact
+        run: ./scripts/package_macos_visual_editor.bash create-cloudflare-root
+
       - name: Compute DMG name
         run: |
-          version="$(sed -n 's/^version = "\(.*\)"/\1/p' tools/lsp/Cargo.toml | head -n 1)"
-          echo "SLINT_DMG_NAME=SlintVisualEditor-${version:-0.0.0}-macos-arm64" >> "$GITHUB_ENV"
+          echo "SLINT_DMG_NAME=SlintVisualEditor-${VERSION:-0.0.0}-macos-arm64" >> "$GITHUB_ENV"
 
       - name: Create DMG
         id: create-dmg
@@ -139,6 +143,13 @@ jobs:
           path: |
             dist/*.dmg
             target/macos-visual-editor-dmg/notarization-log.json
+          if-no-files-found: error
+
+      - name: Upload Cloudflare root artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: slint-visual-editor-cloudflare-root
+          path: dist/cloudflare-root/*
           if-no-files-found: error
 
       - name: Upload Rust build report

--- a/docs/development/macos-visual-editor-dmg.md
+++ b/docs/development/macos-visual-editor-dmg.md
@@ -37,6 +37,40 @@ organization secrets here:
   upload.
 - `NOTARY_API_KEY_ID`: App Store Connect API key ID for `notarytool`.
 - `NOTARY_ISSUER_ID`: issuer UUID for a Team API key.
+- `EDITOR_SPARKLE_ED_PRIVATE_KEY`: exported Sparkle EdDSA private key for the
+  Visual Editor update feed.
+  Use it only for signing update archives.
+
+## Sparkle Keys
+
+Install Sparkle's framework and tools:
+
+```sh
+./scripts/download-sparkle.sh
+```
+
+Generate or look up the Visual Editor signing key:
+
+```sh
+./sparkle-bin/generate_keys --account slint-visual-editor
+```
+
+Print the public key for `SUPublicEDKey`:
+
+```sh
+./sparkle-bin/generate_keys --account slint-visual-editor -p
+```
+
+Export the private key for the `EDITOR_SPARKLE_ED_PRIVATE_KEY` GitHub secret:
+
+```sh
+./sparkle-bin/generate_keys --account slint-visual-editor -x /tmp/slint-visual-editor-sparkle-private-key
+```
+
+The export command writes the key to the file and doesn't print it.
+Use the file contents as the secret value.
+When rotating keys, update both `SUPublicEDKey` in `tools/lsp/macos-project.yml`
+and `EDITOR_SPARKLE_ED_PRIVATE_KEY` in GitHub Actions secrets.
 
 ## Generated Xcode project
 
@@ -92,20 +126,31 @@ The package driver is `scripts/package_macos_visual_editor.bash`.
     `target/macos-visual-editor-dmg/cargo-timings/`.
 12. Deletes Xcode and Cargo build intermediates after the signed app is staged.
     This is done to free up space on the runner image.
-13. Computes the versioned DMG name from `tools/lsp/Cargo.toml`.
-14. Creates the DMG with `L-Super/create-dmg-actions`, passing
+13. Creates `dist/cloudflare-root/` with `appcast.xml` and a Sparkle-signed
+    update ZIP.
+14. Computes the versioned DMG name from the workflow's `VERSION`.
+15. Creates the DMG with `L-Super/create-dmg-actions`, passing
     `tools/lsp/packaging/macos/dmg-background.svg`, the Finder window size, the
     app icon position, and the Applications drop-link position as action inputs.
-15. Moves the action output to `dist/`, signs the DMG with `codesign`, then
+16. Moves the action output to `dist/`, signs the DMG with `codesign`, then
     verifies the DMG and mounted app payload.
-16. Submits the DMG with `xcrun notarytool submit --wait`.
-17. Staples and validates the accepted ticket with `xcrun stapler`, then
+17. Submits the DMG with `xcrun notarytool submit --wait`.
+18. Staples and validates the accepted ticket with `xcrun stapler`, then
     repeats the DMG and mounted app signature checks on the final artifact.
-18. Mounts the DMG, verifies the mounted app with `codesign`, and checks it
+19. Mounts the DMG, verifies the mounted app with `codesign`, and checks it
     with `spctl`.
-19. Uploads `dist/*.dmg` as the `slint-visual-editor-macos-dmg` artifact and
-    the Cargo timing report as the `slint-visual-editor-rust-build-report`
-    artifact.
+20. Uploads `dist/*.dmg` as the `slint-visual-editor-macos-dmg` artifact,
+    `dist/cloudflare-root/*` as the `slint-visual-editor-cloudflare-root`
+    artifact, and the Cargo timing report as the
+    `slint-visual-editor-rust-build-report` artifact.
+
+The daily update channel sets the workflow `VERSION` to `1.17.1`.
+The app's `CFBundleShortVersionString` and Sparkle
+`sparkle:shortVersionString` stay at that value.
+The app's `CFBundleVersion` and Sparkle `sparkle:version` use
+`SLINT_BUILD_NUMBER`, which comes from `github.run_number`.
+Sparkle therefore offers newer daily builds even when the marketing version
+doesn't change.
 
 For local debugging, the same phases can be run individually:
 
@@ -114,6 +159,7 @@ For local debugging, the same phases can be run individually:
 ./scripts/package_macos_visual_editor.bash install-signing-material
 ./scripts/package_macos_visual_editor.bash archive-app
 ./scripts/package_macos_visual_editor.bash stage-and-sign-app
+./scripts/package_macos_visual_editor.bash create-cloudflare-root
 ./scripts/package_macos_visual_editor.bash create-dmg
 ./scripts/package_macos_visual_editor.bash sign-dmg
 ./scripts/package_macos_visual_editor.bash notarize-and-staple-dmg
@@ -154,8 +200,17 @@ The expected artifact name is:
 dist/SlintVisualEditor-<version>-macos-arm64.dmg
 ```
 
-The Rust build report artifact is `slint-visual-editor-rust-build-report`. Cargo
-documents that `--timings` writes `cargo-timing.html` and timestamped reports to
+The Cloudflare deploy artifact is `slint-visual-editor-cloudflare-root`.
+Extract its contents to the root of `https://visual-editor.slint.dev/`.
+It contains:
+
+```text
+appcast.xml
+SlintVisualEditor-<version>-<build>-macos-arm64.zip
+```
+
+The Rust build report artifact is `slint-visual-editor-rust-build-report`.
+Cargo documents that `--timings` writes `cargo-timing.html` and timestamped reports to
 the target directory's `cargo-timings` directory:
 <https://doc.rust-lang.org/cargo/commands/cargo-build.html#compilation-options>.
 

--- a/scripts/download-sparkle.sh
+++ b/scripts/download-sparkle.sh
@@ -6,8 +6,8 @@ EXPECTED_SHA256="74a07da821f92b79310009954c0e15f350173374a3abe39095b4fc5096916be
 
 cd "$(git rev-parse --show-toplevel)"
 
-if [ -d "Sparkle.framework" ]; then
-    echo "Sparkle.framework already exists"
+if [ -d "Sparkle.framework" ] && [ -x "sparkle-bin/sign_update" ] && [ -x "sparkle-bin/generate_keys" ]; then
+    echo "Sparkle.framework and Sparkle tools already exist"
     exit 0
 fi
 
@@ -23,16 +23,19 @@ echo "${EXPECTED_SHA256}  $TEMP_DIR/sparkle.tar.xz" | shasum -a 256 -c -
 echo "Extracting Sparkle.framework..."
 tar -xf "$TEMP_DIR/sparkle.tar.xz" -C "$TEMP_DIR"
 
+rm -rf Sparkle.framework sparkle-bin
 cp -R "$TEMP_DIR/Sparkle.framework" .
 
 # Also copy the bin tools (generate_keys, sign_update)
 if [ -d "$TEMP_DIR/bin" ]; then
-    echo "Linking Sparkle bin tools..."
-    ln -s "$TEMP_DIR/bin" ./sparkle-bin
+    echo "Copying Sparkle bin tools..."
+    cp -R "$TEMP_DIR/bin" ./sparkle-bin
     chmod +x ./sparkle-bin/*
 fi
 
 echo "Done!"
 echo ""
 echo "To generate EdDSA keys for signing updates:"
-echo "  ./sparkle-bin/generate_keys"
+echo "  ./sparkle-bin/generate_keys --account slint-visual-editor"
+echo "  ./sparkle-bin/generate_keys --account slint-visual-editor -p"
+echo "  ./sparkle-bin/generate_keys --account slint-visual-editor -x /tmp/slint-visual-editor-sparkle-private-key"

--- a/scripts/package_macos_visual_editor.bash
+++ b/scripts/package_macos_visual_editor.bash
@@ -46,7 +46,7 @@ if [ -z "$VERSION" ]; then
 fi
 VERSION="${VERSION:-0.0.0}"
 
-BUILD_NUMBER="${BUILD_NUMBER:-${GITHUB_RUN_NUMBER:-$(git -C "$ROOT_DIR" rev-list --count HEAD 2>/dev/null || echo 1)}}"
+BUILD_NUMBER="${BUILD_NUMBER:-${SLINT_BUILD_NUMBER:-${GITHUB_RUN_NUMBER:-$(git -C "$ROOT_DIR" rev-list --count HEAD 2>/dev/null || echo 1)}}}"
 DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
 BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/target/macos-visual-editor-dmg}"
 RUNNER_TEMP_DIR="${RUNNER_TEMP:-$BUILD_DIR/secrets}"
@@ -64,6 +64,11 @@ CERTIFICATE_PATH="$RUNNER_TEMP_DIR/developer-id-application.p12"
 NOTARY_KEY_PATH="$RUNNER_TEMP_DIR/AuthKey_${NOTARY_API_KEY_ID:-unset}.p8"
 CARGO_XCODE_TARGET_DIR="$ROOT_DIR/target/xcode-cargo/slint-visual-editor"
 CARGO_TIMINGS_REPORT_DIR="$BUILD_DIR/cargo-timings"
+CLOUDFLARE_ROOT_DIR="$DIST_DIR/cloudflare-root"
+SPARKLE_UPDATE_BASENAME="$DMG_BASENAME-$VERSION-$BUILD_NUMBER-macos-arm64.zip"
+SPARKLE_UPDATE_PATH="$CLOUDFLARE_ROOT_DIR/$SPARKLE_UPDATE_BASENAME"
+SPARKLE_APPCAST_PATH="$CLOUDFLARE_ROOT_DIR/appcast.xml"
+SPARKLE_FEED_BASE_URL="https://visual-editor.slint.dev"
 DMG_ATTACHED=0
 
 cleanup() {
@@ -369,12 +374,67 @@ smoke_test_app_launch() {
     die "app exited during launch smoke test with status $launch_status"
 }
 
+create_cloudflare_root() {
+    require_env EDITOR_SPARKLE_ED_PRIVATE_KEY
+    [ -d "$STAGED_APP_PATH" ] || die "staged app missing: $STAGED_APP_PATH"
+    [ -x "$ROOT_DIR/sparkle-bin/sign_update" ] || die "sparkle-bin/sign_update is required; run scripts/download-sparkle.sh"
+
+    log "Creating Cloudflare root at $CLOUDFLARE_ROOT_DIR"
+    rm -rf "$CLOUDFLARE_ROOT_DIR"
+    mkdir -p "$CLOUDFLARE_ROOT_DIR"
+
+    log "Creating Sparkle update ZIP at $SPARKLE_UPDATE_PATH"
+    ditto -c -k --sequesterRsrc --keepParent "$STAGED_APP_PATH" "$SPARKLE_UPDATE_PATH"
+
+    log "Signing Sparkle update ZIP"
+    local signature_output
+    signature_output="$(printf "%s" "$EDITOR_SPARKLE_ED_PRIVATE_KEY" \
+        | "$ROOT_DIR/sparkle-bin/sign_update" --ed-key-file - "$SPARKLE_UPDATE_PATH")"
+
+    local ed_signature
+    local length
+    ed_signature="$(printf "%s\n" "$signature_output" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')"
+    length="$(printf "%s\n" "$signature_output" | sed -n 's/.*length="\([0-9][0-9]*\)".*/\1/p')"
+    [ -n "$ed_signature" ] || die "sign_update did not print sparkle:edSignature"
+    [ -n "$length" ] || die "sign_update did not print length"
+
+    local pub_date
+    pub_date="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+
+    log "Writing Sparkle appcast at $SPARKLE_APPCAST_PATH"
+    cat > "$SPARKLE_APPCAST_PATH" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Slint Visual Editor Updates</title>
+    <link>$SPARKLE_FEED_BASE_URL/appcast.xml</link>
+    <description>Slint Visual Editor daily updates</description>
+    <item>
+      <title>Slint Visual Editor $VERSION ($BUILD_NUMBER)</title>
+      <pubDate>$pub_date</pubDate>
+      <sparkle:version>$BUILD_NUMBER</sparkle:version>
+      <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
+      <enclosure
+        url="$SPARKLE_FEED_BASE_URL/$SPARKLE_UPDATE_BASENAME"
+        sparkle:edSignature="$ed_signature"
+        length="$length"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+EOF
+
+    log "Cloudflare root contains:"
+    find "$CLOUDFLARE_ROOT_DIR" -maxdepth 1 -type f -print
+}
+
 full_package() {
     trap cleanup EXIT
     validate_environment
     install_signing_material
     archive_app
     stage_and_sign_app
+    create_cloudflare_root
     create_dmg
     sign_dmg
     notarize_and_staple_dmg
@@ -401,6 +461,9 @@ case "$COMMAND" in
     stage-and-sign-app)
         validate_environment
         stage_and_sign_app
+        ;;
+    create-cloudflare-root)
+        create_cloudflare_root
         ;;
     create-dmg)
         create_dmg
@@ -439,5 +502,8 @@ esac
 case "$COMMAND" in
     full | create-dmg | sign-dmg | create-and-sign-dmg | notarize-and-staple-dmg | assess-stapled-app | smoke-test-app-launch)
         log "DMG path: $DMG_PATH"
+        ;;
+    create-cloudflare-root)
+        log "Cloudflare root path: $CLOUDFLARE_ROOT_DIR"
         ;;
 esac

--- a/tools/lsp/macos-project.yml
+++ b/tools/lsp/macos-project.yml
@@ -45,7 +45,7 @@ targets:
         LSApplicationCategoryType: public.app-category.developer-tools
         LSMinimumSystemVersion: "12.0"
         NSHighResolutionCapable: true
-        SUPublicEDKey: IfbmMbVN3sKz+bUDIEExtwKlrNLlUgP2PDR3ygoIGec=
+        SUPublicEDKey: Ncon335q8qNLM0D+L2my+HRIAXmNtNb6uGNmUR0yG2o=
         SUFeedURL: https://visual-editor.slint.dev/appcast.xml
     sources:
       - path: packaging/macos/AppIcon.icon


### PR DESCRIPTION
## Summary
- build the Visual Editor macOS workflow as marketing version 1.17.1 while keeping the GitHub run number as the Sparkle build version
- add a Cloudflare-root artifact containing appcast.xml and the Sparkle-signed update ZIP
- document Sparkle key generation/export and make the Sparkle downloader provide sign_update reliably

## Verification
- bash -n scripts/package_macos_visual_editor.bash
- bash -n scripts/download-sparkle.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/visual_editor_macos_dmg.yaml"); puts "workflow yaml ok"'
- git diff --check