### PR TITLE
compiler: Make alias removal deterministic

### DIFF
--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -165,7 +165,12 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
         })
     });
 
-    // Remove the properties
+    // Process the removal in a deterministic order to ensure that changed callbacks
+    // are always merged in the same order.
+    let mut aliases_to_remove = aliases_to_remove.into_iter().collect::<Vec<_>>();
+    aliases_to_remove.sort_by_cached_key(|(remove, _)| {
+        (remove.element().borrow().id.clone(), remove.name().clone())
+    });
     for (remove, to) in aliases_to_remove {
         let elem = remove.element();
         let to_elem = to.element();


### PR DESCRIPTION
When several two-way-bound (aliased) properties are merged into a single canonical property, the `changed` callbacks of the removed properties are appended to the canonical property's callback list. This merge was done while iterating the `aliases_to_remove` HashMap, so the order of the merged callbacks -- and therefore the generated code (which change tracker gets which handler) -- depended on hashmap iteration order. That made the output non-deterministic between compilations and defeated the incremental compilation cache.

Process the removed aliases in a stable order (sorted by the removed property's element id and name; element ids are unique because they are assigned before this pass), so the merge order and the generated code are deterministic.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
