### PR TITLE
Open Visual Editor wizard before choosing files

### DIFF
--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -32,9 +32,7 @@ pub fn editor_main() -> std::result::Result<(), slint::PlatformError> {
     use clap::Parser;
 
     let cli = Cli::parse();
-    let Some(mut cli) = cli.with_initial_file() else {
-        return Ok(());
-    };
+    let mut cli = cli;
 
     let (to_lsp, from_preview) = crossbeam_channel::unbounded();
     let (to_preview, from_lsp) = crossbeam_channel::unbounded();
@@ -142,43 +140,6 @@ struct Cli {
     component: Option<String>,
     #[arg(long, short)]
     update_url: Option<String>,
-}
-
-impl Cli {
-    fn with_initial_file(mut self) -> Option<Self> {
-        if self.file.is_none() {
-            self.file = choose_initial_file();
-        }
-        self.file.as_ref()?;
-        Some(self)
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn choose_initial_file() -> Option<String> {
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSModalResponseOK, NSOpenPanel};
-    use objc2_foundation::NSString;
-
-    let mtm = MainThreadMarker::new()?;
-    let panel = NSOpenPanel::openPanel(mtm);
-    panel.setCanChooseFiles(true);
-    panel.setCanChooseDirectories(false);
-    panel.setAllowsMultipleSelection(false);
-    panel.setTitle(Some(&NSString::from_str("Open Slint File")));
-    panel.setMessage(Some(&NSString::from_str("Choose a .slint file to edit.")));
-
-    if panel.runModal() != NSModalResponseOK {
-        return None;
-    }
-
-    panel.URLs().firstObject()?.to_file_path().map(|path| path.to_string_lossy().into_owned())
-}
-
-#[cfg(not(target_os = "macos"))]
-fn choose_initial_file() -> Option<String> {
-    eprintln!("No input file provided.");
-    None
 }
 
 fn start_processing_lsp_messages_thread(
@@ -343,26 +304,34 @@ async fn lsp_main(
         preview_to_lsp_sender: from_preview_tx,
     };
 
-    // Load the initial document through the compiler. This triggers the import
-    // callback for all transitive dependencies, sending their contents to the preview.
-    let file = cli.file.as_ref().expect("initial file should be resolved before startup");
-    let full_path = std::fs::canonicalize(file)
-        .map_err(|err| format!("Failed to determine full path for {file}: {err}"))?;
-    let root_path = full_path.clone();
-    let url =
-        Url::from_file_path(full_path).map_err(|_| format!("Failed to convert {file} to URL!"))?;
-    language::show_preview(
-        PreviewComponent { url: url.clone(), component: cli.component },
-        &mut ctx,
-    );
-
-    // Make sure the document is loaded before we start processing messages from the preview, so we
-    // have the correct state already loaded.
-    language::reload_document(&mut ctx, url)
-        .await
-        .map_err(|err| format!("Failed to load file: {file}: {err}"))?;
     let mut watch_paths_revision = None;
-    sync_file_watcher_if_needed(&mut file_watcher, &ctx, &root_path, &mut watch_paths_revision)?;
+    let mut root_path = None;
+
+    // Load the initial document through the compiler if the editor was launched
+    // with a file. Finder launches without a file stay on the startup wizard.
+    if let Some(file) = cli.file.as_ref() {
+        let full_path = std::fs::canonicalize(file)
+            .map_err(|err| format!("Failed to determine full path for {file}: {err}"))?;
+        let url = Url::from_file_path(full_path.clone())
+            .map_err(|_| format!("Failed to convert {file} to URL!"))?;
+        language::show_preview(
+            PreviewComponent { url: url.clone(), component: cli.component },
+            &mut ctx,
+        );
+
+        // Make sure the document is loaded before we start processing messages from the preview, so
+        // we have the correct state already loaded.
+        language::reload_document(&mut ctx, url)
+            .await
+            .map_err(|err| format!("Failed to load file: {file}: {err}"))?;
+        root_path = Some(full_path);
+        sync_file_watcher_if_needed(
+            &mut file_watcher,
+            &ctx,
+            root_path.as_deref().unwrap(),
+            &mut watch_paths_revision,
+        )?;
+    }
 
     const RECOMPILE_IDLE_TIMEOUT: Duration = Duration::from_millis(50);
     loop {
@@ -377,7 +346,12 @@ async fn lsp_main(
             }
             msg = from_preview_rx.recv() => {
                 match msg {
-                    Some(msg) => handle_preview_message(msg, &mut ctx).await,
+                    Some(msg) => {
+                        if let Some(path) = handle_preview_message(msg, &mut ctx).await {
+                            root_path = Some(path);
+                            watch_paths_revision = None;
+                        }
+                    }
                     None => {
                         tracing::debug!("Preview->LSP channel closed, exiting");
                         break Ok(());
@@ -396,12 +370,14 @@ async fn lsp_main(
             }
         }
 
-        sync_file_watcher_if_needed(
-            &mut file_watcher,
-            &ctx,
-            &root_path,
-            &mut watch_paths_revision,
-        )?;
+        if let Some(root_path) = root_path.as_deref() {
+            sync_file_watcher_if_needed(
+                &mut file_watcher,
+                &ctx,
+                root_path,
+                &mut watch_paths_revision,
+            )?;
+        }
     }
 }
 
@@ -442,12 +418,17 @@ fn sync_file_watcher_if_needed(
     Ok(())
 }
 
-async fn handle_preview_message(msg: PreviewToLspMessage, ctx: &mut language::Context) {
+async fn handle_preview_message(
+    msg: PreviewToLspMessage,
+    ctx: &mut language::Context,
+) -> Option<std::path::PathBuf> {
     use PreviewToLspMessage::*;
     match &msg {
         RequestState { files, settings } => {
             tracing::debug!("Preview requested state");
             let requested_preview = requested_file_tree_preview(files, settings);
+            let requested_path =
+                requested_preview.as_ref().and_then(|url| common::uri_to_file(url));
             let slint_files: Vec<_> =
                 files.iter().filter(|url| is_slint_url(url)).cloned().collect();
             for url in slint_files {
@@ -459,9 +440,11 @@ async fn handle_preview_message(msg: PreviewToLspMessage, ctx: &mut language::Co
                 ctx.to_show = Some(PreviewComponent { url, component: None });
             }
             language::send_requested_state_to_preview(ctx, files, settings);
+            requested_path
         }
         UpdateUserSettings { name, contents } => {
             language::store_user_settings(name, contents);
+            None
         }
         SendShowMessage { message } => {
             match message.typ {
@@ -470,9 +453,11 @@ async fn handle_preview_message(msg: PreviewToLspMessage, ctx: &mut language::Co
                 MessageType::LOG => tracing::debug!("Preview: {}", message.message),
                 _ => tracing::info!("Preview: {}", message.message),
             };
+            None
         }
         DebugMessage { location, message } => {
             eprintln!("{}", common::preview_log_message_to_string(location, message));
+            None
         }
 
         Diagnostics { .. }
@@ -482,9 +467,11 @@ async fn handle_preview_message(msg: PreviewToLspMessage, ctx: &mut language::Co
         | ConnectRemote { .. }
         | DisconnectRemote => {
             tracing::debug!("Ignoring message from preview: {msg:?}");
+            None
         }
         SendWorkspaceEdit { label, edit } => {
             handle_workspace_edit(&ctx.document_cache, label.as_deref(), edit);
+            None
         }
     }
 }

--- a/tools/lsp/preview/ui/file_tree.rs
+++ b/tools/lsp/preview/ui/file_tree.rs
@@ -12,26 +12,60 @@ use slint::{Image, ModelRc, SharedString, ToSharedString as _, VecModel};
 use super::{Api, EditorSurfaceMode, FileTreeNode, FileTreeNodeKind, ImageAssetPreview};
 
 pub fn setup(api: &Api<'_>, api_weak: slint::Weak<Api<'static>>, use_editor_ui: bool) {
-    let Some((root, selected_path)) = initial_file_tree_paths(use_editor_ui) else {
+    if !use_editor_ui {
         api.set_file_tree(Default::default());
         api.set_selected_project_file(Default::default());
         return;
     };
 
-    let controller = Rc::new(RefCell::new(FileTreeController::new(root, selected_path)));
-    controller.borrow().publish(api);
+    let controller = Rc::new(RefCell::new(
+        initial_file_tree_paths()
+            .map(|(root, selected_path)| FileTreeController::new(root, selected_path)),
+    ));
+    if let Some(controller) = controller.borrow().as_ref() {
+        controller.publish(api);
+    } else {
+        api.set_file_tree(Default::default());
+        api.set_selected_project_file(Default::default());
+    }
 
     let controller_for_select = controller.clone();
     let api_weak_for_select = api_weak.clone();
     api.on_file_tree_select(move |path| {
         if let Some(api) = api_weak_for_select.upgrade() {
-            controller_for_select.borrow_mut().select(Path::new(path.as_str()), &api);
+            if let Some(controller) = controller_for_select.borrow_mut().as_mut() {
+                controller.select(Path::new(path.as_str()), &api);
+            }
+        }
+    });
+
+    let controller_for_open = controller.clone();
+    let api_weak_for_open = api_weak.clone();
+    api.on_open_existing_project(move || {
+        let Some(path) = choose_project_file() else {
+            return false;
+        };
+        let Some(root) = path.parent().map(Path::to_path_buf) else {
+            return false;
+        };
+        if let Some(api) = api_weak_for_open.upgrade() {
+            let mut controller = controller_for_open.borrow_mut();
+            *controller = Some(FileTreeController::new(root, Some(path.clone())));
+            if let Some(controller) = controller.as_mut() {
+                controller.publish(&api);
+            }
+            super::super::request_file_tree_preview(&path);
+            true
+        } else {
+            false
         }
     });
 
     api.on_file_tree_toggle(move |path| {
         if let Some(api) = api_weak.upgrade() {
-            controller.borrow_mut().toggle(Path::new(path.as_str()), &api);
+            if let Some(controller) = controller.borrow_mut().as_mut() {
+                controller.toggle(Path::new(path.as_str()), &api);
+            }
         }
     });
 
@@ -48,11 +82,7 @@ pub fn setup(api: &Api<'_>, api_weak: slint::Weak<Api<'static>>, use_editor_ui: 
     });
 }
 
-fn initial_file_tree_paths(use_editor_ui: bool) -> Option<(PathBuf, Option<PathBuf>)> {
-    if !use_editor_ui {
-        return None;
-    }
-
+fn initial_file_tree_paths() -> Option<(PathBuf, Option<PathBuf>)> {
     #[cfg(target_arch = "wasm32")]
     {
         None
@@ -64,6 +94,37 @@ fn initial_file_tree_paths(use_editor_ui: bool) -> Option<(PathBuf, Option<PathB
         let root = selected_path.parent()?.to_path_buf();
         Some((root, Some(selected_path)))
     }
+}
+
+#[cfg(target_os = "macos")]
+fn choose_project_file() -> Option<PathBuf> {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSModalResponseOK, NSOpenPanel};
+    use objc2_foundation::NSString;
+
+    let mtm = MainThreadMarker::new()?;
+    let panel = NSOpenPanel::openPanel(mtm);
+    panel.setCanChooseFiles(true);
+    panel.setCanChooseDirectories(false);
+    panel.setAllowsMultipleSelection(false);
+    panel.setTitle(Some(&NSString::from_str("Open Slint File")));
+    panel.setMessage(Some(&NSString::from_str("Choose a .slint file to edit.")));
+
+    if panel.runModal() != NSModalResponseOK {
+        return None;
+    }
+
+    panel.URLs().firstObject()?.to_file_path()
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_arch = "wasm32")))]
+fn choose_project_file() -> Option<PathBuf> {
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn choose_project_file() -> Option<PathBuf> {
+    None
 }
 
 struct FileTreeController {
@@ -138,7 +199,9 @@ impl FileTreeController {
             &self.active_folder_path,
         );
         api.set_file_tree(ModelRc::new(VecModel::from(rows)));
-        api.set_selected_project_file(selected_project_file(&self.root, self.selected_path.as_deref()).into());
+        api.set_selected_project_file(
+            selected_project_file(&self.root, self.selected_path.as_deref()).into(),
+        );
     }
 
     fn path_in_root(&self, path: &Path) -> Option<PathBuf> {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -813,6 +813,7 @@ export global Api {
         { url: "examples/sprite-sheet/demo.slint", title: "Sprite sheet Demo" },
     ];
     callback new-file();
+    callback open-existing-project() -> bool;
     callback share-permalink-to-clipboard();
     callback load-demo(url: string);
     callback show-about-slint();

--- a/tools/lsp/ui/visual-editor/editor.slint
+++ b/tools/lsp/ui/visual-editor/editor.slint
@@ -627,6 +627,11 @@ export component EditorUi inherits Window {
         opened => {
             root.open-project();
         }
+        open-existing-project => {
+            if Api.open-existing-project() {
+                root.open-project();
+            }
+        }
     }
 
     if root.show-update-status(): Rectangle {

--- a/tools/lsp/ui/visual-editor/startup-wizard.slint
+++ b/tools/lsp/ui/visual-editor/startup-wizard.slint
@@ -329,6 +329,7 @@ component TemplateCard inherits Rectangle {
 export component StartupWizard inherits Rectangle {
     in-out property <ProjectKind> selected-project: ProjectKind.mobile;
     callback opened;
+    callback open-existing-project;
 
     property <WizardPage> page: WizardPage.welcome;
     property <bool> showing-templates: page == WizardPage.templates;
@@ -472,7 +473,7 @@ export component StartupWizard inherits Rectangle {
                 enabled: !root.showing-templates;
                 progress: root.page-progress;
                 clicked => {
-                    root.opened();
+                    root.open-existing-project();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- stop opening the native file chooser before the Visual Editor UI appears
- allow the embedded editor LSP to start without an initial file
- show the startup wizard on Finder/no-argument launch
- open the native file chooser only when the wizard's Open Existing Project action is clicked

## Verification
- SPARKLE_FRAMEWORK_DIR=/Users/nigelb/gb-slint cargo check -p slint-lsp --no-default-features --features backend-winit,renderer-skia
- cargo fmt --package slint-lsp
- git diff --check