### PR TITLE
Address Sparkle appcast review comments

### DIFF
--- a/.github/workflows/visual_editor_macos_dmg.yaml
+++ b/.github/workflows/visual_editor_macos_dmg.yaml
@@ -36,6 +36,7 @@ jobs:
       NOTARY_API_KEY_ID: ${{ secrets.NOTARY_API_KEY_ID }}
       NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
       EDITOR_SPARKLE_ED_PRIVATE_KEY: ${{ secrets.EDITOR_SPARKLE_ED_PRIVATE_KEY }}
+      EDITOR_SPARKLE_PUBLIC_ED_KEY: ${{ vars.EDITOR_SPARKLE_PUBLIC_ED_KEY }}
       SPARKLE_FRAMEWORK_DIR: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v6

--- a/docs/development/macos-visual-editor-dmg.md
+++ b/docs/development/macos-visual-editor-dmg.md
@@ -40,6 +40,9 @@ organization secrets here:
 - `EDITOR_SPARKLE_ED_PRIVATE_KEY`: exported Sparkle EdDSA private key for the
   Visual Editor update feed.
   Use it only for signing update archives.
+- `EDITOR_SPARKLE_PUBLIC_ED_KEY`: optional repository variable with the public
+  Sparkle EdDSA key for the app's `SUPublicEDKey`.
+  The packaging script uses the checked-in default when this variable isn't set.
 
 ## Sparkle Keys
 
@@ -69,8 +72,8 @@ Export the private key for the `EDITOR_SPARKLE_ED_PRIVATE_KEY` GitHub secret:
 
 The export command writes the key to the file and doesn't print it.
 Use the file contents as the secret value.
-When rotating keys, update both `SUPublicEDKey` in `tools/lsp/macos-project.yml`
-and `EDITOR_SPARKLE_ED_PRIVATE_KEY` in GitHub Actions secrets.
+When rotating keys, update `EDITOR_SPARKLE_PUBLIC_ED_KEY` in GitHub Actions
+variables and `EDITOR_SPARKLE_ED_PRIVATE_KEY` in GitHub Actions secrets.
 
 ## Generated Xcode project
 

--- a/scripts/package_macos_visual_editor.bash
+++ b/scripts/package_macos_visual_editor.bash
@@ -69,6 +69,7 @@ SPARKLE_UPDATE_BASENAME="$DMG_BASENAME-$VERSION-$BUILD_NUMBER-macos-arm64.zip"
 SPARKLE_UPDATE_PATH="$CLOUDFLARE_ROOT_DIR/$SPARKLE_UPDATE_BASENAME"
 SPARKLE_APPCAST_PATH="$CLOUDFLARE_ROOT_DIR/appcast.xml"
 SPARKLE_FEED_BASE_URL="https://visual-editor.slint.dev"
+export EDITOR_SPARKLE_PUBLIC_ED_KEY="${EDITOR_SPARKLE_PUBLIC_ED_KEY:-Ncon335q8qNLM0D+L2my+HRIAXmNtNb6uGNmUR0yG2o=}"
 APP_NOTARY_ZIP_PATH="$BUILD_DIR/$DMG_BASENAME-$VERSION-$BUILD_NUMBER-macos-arm64-notary.zip"
 APP_NOTARY_LOG="$BUILD_DIR/app-notarization-log.json"
 DMG_ATTACHED=0
@@ -443,13 +444,13 @@ create_cloudflare_root() {
 
     local ed_signature
     local length
-    ed_signature="$(printf "%s\n" "$signature_output" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')"
-    length="$(printf "%s\n" "$signature_output" | sed -n 's/.*length="\([0-9][0-9]*\)".*/\1/p')"
+    ed_signature="$(echo "$signature_output" | sed 's/.*sparkle:edSignature="\([^"]*\)".*/\1/; t; d')"
+    length="$(echo "$signature_output" | sed 's/.*length="\([0-9][0-9]*\)".*/\1/; t; d')"
     [ -n "$ed_signature" ] || die "sign_update did not print sparkle:edSignature"
     [ -n "$length" ] || die "sign_update did not print length"
 
     local pub_date
-    pub_date="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+    pub_date="$(date -uR)"
 
     log "Writing Sparkle appcast at $SPARKLE_APPCAST_PATH"
     cat > "$SPARKLE_APPCAST_PATH" <<EOF

--- a/tools/lsp/macos-project.yml
+++ b/tools/lsp/macos-project.yml
@@ -45,7 +45,7 @@ targets:
         LSApplicationCategoryType: public.app-category.developer-tools
         LSMinimumSystemVersion: "12.0"
         NSHighResolutionCapable: true
-        SUPublicEDKey: Ncon335q8qNLM0D+L2my+HRIAXmNtNb6uGNmUR0yG2o=
+        SUPublicEDKey: ${EDITOR_SPARKLE_PUBLIC_ED_KEY}
         SUFeedURL: https://visual-editor.slint.dev/appcast.xml
     sources:
       - path: packaging/macos/AppIcon.icon


### PR DESCRIPTION
## Summary
- use date -uR for Sparkle appcast pubDate
- simplify sign_update output parsing while keeping empty-output checks useful
- allow the Sparkle public key to come from EDITOR_SPARKLE_PUBLIC_ED_KEY, with the current key as the packaging-script fallback

## Verification
- bash -n scripts/package_macos_visual_editor.bash
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/visual_editor_macos_dmg.yaml"); puts "workflow yaml ok"'
- git diff --check