### PR TITLE
Drop input focus when the focused item becomes invisible on pointer input

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1748,20 +1748,25 @@ fn generate_item_tree(
     let parent_item_from_parent_component = parent_ctx.as_ref()
         .map(|parent| {
             parent.repeater_index.map_or_else(|| {
-                // No repeater index, this could be a PopupWindow
+                // No repeater index, this could be a PopupWindow. The parent may
+                // already be gone (e.g. walked while a subtree is being torn
+                // down), so leave `*result` empty rather than unwrapping a dead
+                // weak (matches the Rust backend).
                 vec![
                     format!("auto self = reinterpret_cast<const {item_tree_class_name}*>(component.instance);"),
-                    format!("auto parent = self->parent.lock().value();"),
+                    format!("if (auto parent = self->parent.lock()) {{"),
                     // TODO: store popup index in ctx and set it here instead of 0?
-                    format!("*result = {{ parent->self_weak, 0 }};"),
+                    format!("    *result = {{ (*parent)->self_weak, 0 }};"),
+                    format!("}}"),
                     ]
                 }, |idx| {
                 let current_sub_component = &root.sub_components[parent.sub_component];
                 let parent_index = current_sub_component.repeated[idx].index_in_tree;
                 vec![
                     format!("auto self = reinterpret_cast<const {item_tree_class_name}*>(component.instance);"),
-                    format!("auto parent = self->parent.lock().value();"),
-                    format!("*result = {{ parent->self_weak, parent->tree_index_of_first_child + {} }};", parent_index - 1),
+                    format!("if (auto parent = self->parent.lock()) {{"),
+                    format!("    *result = {{ (*parent)->self_weak, (*parent)->tree_index_of_first_child + {} }};", parent_index - 1),
+                    format!("}}"),
                 ]
             })
         })

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -760,6 +760,14 @@ impl WindowInner {
         let item_tree = self.try_component()?;
         self.ensure_tree_instantiated();
 
+        // If the focused item became invisible (e.g. a TabWidget switched away from
+        // the tab holding it), drop the focus so that input methods get torn down.
+        // The key-event handler does the same, but a tab is switched with a pointer
+        // tap, not a key press, so it must also happen here.
+        if self.focus_item.borrow().upgrade().is_some_and(|i| !i.is_visible()) {
+            self.take_focus_item(&FocusEvent::FocusOut(FocusReason::TabNavigation));
+        }
+
         // handle multiple press release
         event = self.click_state.check_repeat(event, self.context().platform().click_interval());
 

--- a/tests/cases/focus/text-input-focused-tabwidget.slint
+++ b/tests/cases/focus/text-input-focused-tabwidget.slint
@@ -1,0 +1,82 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Switching a TabWidget away from a tab that holds the focused LineEdit must
+// drop the input focus, so that `TextInputInterface.text-input-focused` becomes
+// false and the platform tears the input method down (hides the virtual
+// keyboard and, on Android, the native text-selection/caret handle popups).
+//
+//   The Android selection/caret handles are native PopupWindows tied to the
+//   focused TextInput. They are dismissed via:
+//       FocusOut -> set_text_input_focused(false)
+//                -> InputMethodRequest::Disable
+//                -> show_or_hide_soft_input(false)
+//                -> Java hide_keyboard() -> setCursorPos(..., 0)   (hides handles)
+//   So they only go away when the TextInput loses focus.
+//
+//   A TabWidget switch does NOT cause a FocusOut. lower_tabwidget.rs gives
+//   each Tab's content a `visible: <current-index == n>` binding (it explicitly
+//   forbids the user setting `visible` on a Tab), so the non-current tab's
+//   LineEdit is merely hidden — the element stays alive and keeps the focus.
+//
+//   Slint resets focus held by an invisible item lazily, when the next input
+//   event arrives. The key-event handler did this already; a tab is switched
+//   with a pointer tap, not a key press, so WindowInner::process_mouse_input()
+//   now performs the same check (see window.rs).
+//
+//   Contrast text-input-focused-condition-disable.slint: there the LineEdit
+//   lives under an `if`, so disabling the condition *destroys* the element, and
+//   destruction releases its focus. A TabWidget keeps the element.
+
+import { LineEdit, TabWidget } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    in-out property <int> current-tab: 0;
+
+    callback focus-the-line-edit();
+    focus-the-line-edit => {
+        le.focus();
+    }
+
+    TabWidget {
+        current-index <=> root.current-tab;
+        Tab {
+            title: "One";
+            le := LineEdit { }
+        }
+        Tab {
+            title: "Two";
+            Rectangle { }
+        }
+    }
+
+    out property <bool> le-has-focus <=> le.has-focus;
+    out property <bool> focused: TextInputInterface.text-input-focused;
+}
+
+/*
+```rust
+use slint::{platform::WindowEvent, LogicalPosition};
+
+let instance = TestCase::new().unwrap();
+// A pointer event makes the runtime traverse the item tree (as in the other
+// text-input-focused tests).
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(0., 0.) });
+assert!(!instance.get_focused());
+
+instance.invoke_focus_the_line_edit();
+assert!(instance.get_le_has_focus());
+assert!(instance.get_focused());
+
+// Switch to the second tab: the first tab (and its LineEdit) becomes invisible,
+// but the element is not destroyed.
+instance.set_current_tab(1);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(0., 0.) });
+
+// The LineEdit is no longer visible, so it must no longer hold the input focus.
+assert!(!instance.get_focused());
+```
+*/


### PR DESCRIPTION
Switching a TabWidget away from the tab holding a focused LineEdit left the
LineEdit holding focus: a Tab's content is hidden (visible: false), not
destroyed, so the element stays alive and keeps the focus. As a result
TextInputInterface.text-input-focused stayed true and the platform never tore
the input method down (virtual keyboard, and on Android the native
text-selection/caret handle popups), which then lingered over the new tab.

process_key_event() already drops focus held by an invisible item, but a tab is
switched with a pointer tap, not a key press. Do the same check in
process_mouse_input().

Adds tests/cases/focus/text-input-focused-tabwidget.slint covering the switch.