### PR TITLE
zephyr: bump Zephyr to v4.4.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -878,7 +878,7 @@ jobs:
             with:
                 app-path: slint
                 manifest-file-name: demos/zephyr-common/west.yaml
-                sdk-version: 0.16.8
+                sdk-version: 1.0.1
           - name: Export the Zephyr CMake package
             run: west zephyr-export
           - name: Build for ${{matrix.board}}

--- a/demos/home-automation/zephyr/README.md
+++ b/demos/home-automation/zephyr/README.md
@@ -65,7 +65,7 @@ Before you can run this example, make sure you have done the following:
    pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
    ```
 
-7. [Install the Zephyr SDK](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-the-zephyr-sdk) using version [v0.16.8](https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8).
+7. [Install the Zephyr SDK](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-the-zephyr-sdk) using version [v1.0.1](https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v1.0.1).
 
 ## Build and Run the Example in the Simulator
 

--- a/demos/printerdemo/zephyr/README.md
+++ b/demos/printerdemo/zephyr/README.md
@@ -65,7 +65,7 @@ Before you can run this example, make sure you have done the following:
    pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
    ```
 
-7. [Install the Zephyr SDK](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-the-zephyr-sdk) using version [v0.16.8](https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.8).
+7. [Install the Zephyr SDK](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-the-zephyr-sdk) using version [v1.0.1](https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v1.0.1).
 
 ## Build and Run the Example in the Simulator
 

--- a/demos/zephyr-common/slint-zephyr.cpp
+++ b/demos/zephyr-common/slint-zephyr.cpp
@@ -26,7 +26,7 @@ bool is_supported_pixel_format(display_pixel_format current_pixel_format)
     case PIXEL_FORMAT_RGB_888:
         // Slint supports this format, but it uses more space.
         return false;
-    case PIXEL_FORMAT_BGR_565:
+    case PIXEL_FORMAT_RGB_565X:
 #ifdef CONFIG_SHIELD_RK055HDMIPI4MA0
         // Zephyr expects pixel data to be big endian [1].
 
@@ -191,8 +191,8 @@ std::unique_ptr<ZephyrWindowAdapter> ZephyrWindowAdapter::init_from(const device
     case PIXEL_FORMAT_ARGB_8888:
         LOG_WRN("Unsupported pixel format: ARGB_8888");
         break;
-    case PIXEL_FORMAT_BGR_565:
-        LOG_WRN("Unsupported pixel format: BGR_565");
+    case PIXEL_FORMAT_RGB_565X:
+        LOG_WRN("Unsupported pixel format: RGB_565X");
         break;
     }
 
@@ -206,8 +206,8 @@ std::unique_ptr<ZephyrWindowAdapter> ZephyrWindowAdapter::init_from(const device
             static_cast<bool>(capabilities.supported_pixel_formats & PIXEL_FORMAT_ARGB_8888));
     LOG_INF("Supports RGB_565: %d",
             static_cast<bool>(capabilities.supported_pixel_formats & PIXEL_FORMAT_RGB_565));
-    LOG_INF("Supports BGR_565: %d",
-            static_cast<bool>(capabilities.supported_pixel_formats & PIXEL_FORMAT_BGR_565));
+    LOG_INF("Supports RGB_565X: %d",
+            static_cast<bool>(capabilities.supported_pixel_formats & PIXEL_FORMAT_RGB_565X));
 
     if (!is_supported_pixel_format(capabilities.current_pixel_format)) {
         if (capabilities.supported_pixel_formats & PIXEL_FORMAT_RGB_565) {

--- a/demos/zephyr-common/west.yaml
+++ b/demos/zephyr-common/west.yaml
@@ -9,5 +9,5 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.0.0
+      revision: v4.4.1
       import: true


### PR DESCRIPTION
GT911 gained native touchscreen-common devicetree support (invert-x, swap-x-y properties) in Zephyr v4.4.0 (upstream commit 0f07faa14b3). v4.4.1 is the latest patch release on top of that.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
