### PR TITLE
test-driver-rust: Add a feature that verifies that running the compil…

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -778,7 +778,7 @@ pub struct NativeClass {
     pub parent: Option<Rc<NativeClass>>,
     pub class_name: SmolStr,
     pub cpp_vtable_getter: String,
-    pub properties: HashMap<SmolStr, BuiltinPropertyInfo>,
+    pub properties: BTreeMap<SmolStr, BuiltinPropertyInfo>,
     pub deprecated_aliases: HashMap<SmolStr, SmolStr>,
     /// Type override if class_name is not equal to the name to be used in the
     /// target language API.

--- a/tests/driver/rust/Cargo.toml
+++ b/tests/driver/rust/Cargo.toml
@@ -22,6 +22,7 @@ name = "test-driver-rust"
 default = ["backend-qt"]
 
 build-time = ["i-slint-compiler", "spin_on"]
+deterministic-output = ["build-time"]
 backend-qt = ["slint/backend-qt"]
 live-preview = ["slint/live-preview"]
 

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -243,9 +243,33 @@ fn generate_source(
     output: &mut impl Write,
     testcase: test_driver_lib::TestCase,
 ) -> Result<(), std::io::Error> {
-    use i_slint_compiler::{diagnostics::BuildDiagnostics, *};
-
     println!("cargo::rerun-if-env-changed=SLINT_LIVE_PREVIEW");
+
+    let generated = compile_and_generate(source, &testcase)?;
+
+    #[cfg(feature = "deterministic-output")]
+    {
+        let second = compile_and_generate(source, &testcase)?;
+        let expect_utf8 =
+            |bytes| std::str::from_utf8(bytes).expect("generated Rust is valid UTF-8");
+        assert_eq!(
+            expect_utf8(&generated),
+            expect_utf8(&second),
+            "Non-deterministic compiler output for {:?}",
+            testcase.absolute_path
+        );
+    }
+
+    output.write_all(&generated)?;
+    Ok(())
+}
+
+#[cfg(feature = "build-time")]
+fn compile_and_generate(
+    source: &str,
+    testcase: &test_driver_lib::TestCase,
+) -> Result<Vec<u8>, std::io::Error> {
+    use i_slint_compiler::{diagnostics::BuildDiagnostics, *};
 
     let include_paths = test_driver_lib::extract_include_paths(source)
         .map(std::path::PathBuf::from)
@@ -282,12 +306,13 @@ fn generate_source(
         diag.print();
     }
 
+    let mut output = Vec::new();
     generator::generate(
         generator::OutputFormat::Rust,
-        output,
+        &mut output,
         None,
         &root_component,
         &loader.compiler_config,
     )?;
-    Ok(())
+    Ok(output)
 }


### PR DESCRIPTION
…er twice produces the same output

This is implicitly activated in the CI because we use --all-features.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
