### PR TITLE
skia: Share wgpu's Metal command queue to synchronize imported textures

### DIFF
--- a/internal/core/graphics/wgpu_29.rs
+++ b/internal/core/graphics/wgpu_29.rs
@@ -214,12 +214,30 @@ impl From<Box<dyn wgpu::DisplayAndWindowHandle + 'static>> for SurfaceTarget {
     }
 }
 
+/// Optional override for creating the wgpu device and queue once an adapter has been selected.
+///
+/// Returning `None` lets [`init_instance_adapter_device_queue_surface`] fall back to the default
+/// `adapter.request_device()`. A renderer can use this to build the device from resources it also
+/// uses elsewhere — for example a command queue it shares with another graphics library, so a
+/// single-queue driver keeps the two ordered. It is only consulted when Slint creates the device
+/// itself; a developer-provided (`Manual`) device/queue is used as-is.
+pub type DeviceQueueFactory<'a> = dyn FnMut(
+        &wgpu_29::Adapter,
+        &wgpu_29::DeviceDescriptor<'_>,
+    ) -> Option<
+        Result<
+            (wgpu_29::Device, wgpu_29::Queue),
+            Box<dyn std::error::Error + Send + Sync + 'static>,
+        >,
+    > + 'a;
+
 /// Internal helper function to initialize the wgpu instance/adapter/device/queue from either scratch or
 /// developer-provided config. This is called by any renderer intending to support WGPU.
 pub fn init_instance_adapter_device_queue_surface(
     surface_target: impl Into<SurfaceTarget>,
     requested_graphics_api: Option<RequestedGraphicsAPI>,
     backends_to_avoid: wgpu::Backends,
+    mut device_queue_factory: Option<&mut DeviceQueueFactory<'_>>,
 ) -> Result<
     (
         wgpu_29::Instance,
@@ -249,6 +267,26 @@ pub fn init_instance_adapter_device_queue_surface(
                 "Error creating wgpu window surface: {e}"
             ))
         })
+    };
+
+    // Create the device and queue, giving a renderer-provided factory the first chance (so it can,
+    // for example, share its Metal command queue with wgpu). Falls back to `request_device`.
+    let mut make_device_queue = |adapter: &wgpu::Adapter,
+                                 descriptor: wgpu::DeviceDescriptor<'_>|
+     -> Result<
+        (wgpu::Device, wgpu::Queue),
+        Box<dyn std::error::Error + Send + Sync + 'static>,
+    > {
+        if let Some(factory) = device_queue_factory.as_deref_mut()
+            && let Some(result) = factory(adapter, &descriptor)
+        {
+            return result;
+        }
+        // wgpu uses async here, but the returned future is ready on first poll on all platforms
+        // except WASM, which we don't support right now.
+        Ok(poll_once(async { adapter.request_device(&descriptor).await })
+            .expect("internal error: wgpu device creation is not expected to be async")
+            .expect("Failed to create device"))
     };
 
     let (instance, adapter, device, queue, surface) = match requested_graphics_api {
@@ -299,23 +337,20 @@ pub fn init_instance_adapter_device_queue_surface(
             })
             .expect("internal error: wgpu adapter creation is not expected to be async");
 
-            let (device, queue) = poll_once(async {
-                adapter
-                    .request_device(&wgpu::DeviceDescriptor {
-                        label: wgpu29_settings.device_label.as_deref(),
-                        required_features: wgpu29_settings.device_required_features,
-                        // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
-                        required_limits: wgpu29_settings
-                            .device_required_limits
-                            .using_resolution(adapter.limits()),
-                        experimental_features: wgpu29_settings.device_experimental_features,
-                        memory_hints: wgpu29_settings.device_memory_hints,
-                        trace: wgpu::Trace::default(),
-                    })
-                    .await
-                    .expect("Failed to create device")
-            })
-            .expect("internal error: wgpu device creation is not expected to be async");
+            let (device, queue) = make_device_queue(
+                &adapter,
+                wgpu::DeviceDescriptor {
+                    label: wgpu29_settings.device_label.as_deref(),
+                    required_features: wgpu29_settings.device_required_features,
+                    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+                    required_limits: wgpu29_settings
+                        .device_required_limits
+                        .using_resolution(adapter.limits()),
+                    experimental_features: wgpu29_settings.device_experimental_features,
+                    memory_hints: wgpu29_settings.device_memory_hints,
+                    trace: wgpu::Trace::default(),
+                },
+            )?;
 
             (instance, adapter, device, queue, surface)
         }
@@ -347,23 +382,19 @@ pub fn init_instance_adapter_device_queue_surface(
             })
             .expect("internal error: wgpu adapter creation is not expected to be async");
 
-            let (device, queue) = poll_once(async {
-                adapter
-                    .request_device(&wgpu::DeviceDescriptor {
-                        label: None,
-                        // Request all non-experimental features the adapter supports,
-                        // so that embedders like Bevy can use full GPU capabilities.
-                        required_features: adapter.features()
-                            - wgpu::Features::all_experimental_mask(),
-                        required_limits: adapter.limits(),
-                        experimental_features: wgpu::ExperimentalFeatures::disabled(),
-                        memory_hints: wgpu::MemoryHints::MemoryUsage,
-                        trace: wgpu::Trace::default(),
-                    })
-                    .await
-                    .expect("Failed to create device")
-            })
-            .expect("internal error: wgpu device creation is not expected to be async");
+            let (device, queue) = make_device_queue(
+                &adapter,
+                wgpu::DeviceDescriptor {
+                    label: None,
+                    // Request all non-experimental features the adapter supports,
+                    // so that embedders like Bevy can use full GPU capabilities.
+                    required_features: adapter.features() - wgpu::Features::all_experimental_mask(),
+                    required_limits: adapter.limits(),
+                    experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                    memory_hints: wgpu::MemoryHints::MemoryUsage,
+                    trace: wgpu::Trace::default(),
+                },
+            )?;
             (instance, adapter, device, queue, surface)
         }
         Some(_) => {

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -318,6 +318,8 @@ impl FemtoVGRenderer<WGPUBackend> {
                 requested_graphics_api,
                 /* rendering artifacts :( */
                 wgpu::Backends::GL,
+                // FemtoVG renders through wgpu directly, so it has no separate command queue to share.
+                None,
             )?;
 
         let mut surface_config =

--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -42,16 +42,48 @@ impl WGPUSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, PlatformError> {
+        let backends_to_avoid = wgpu::Backends::GL /* we're not mapping that to skia because we can't save/restore state */
+            .union(if cfg!(target_os = "windows") {
+                wgpu::Backends::VULKAN
+            } else {
+                wgpu::Backends::empty()
+            });
+
+        // On Metal, build wgpu's device from a command queue we allocate ourselves, so we can hand
+        // the same `MTLCommandQueue` to Skia. Metal's automatic hazard tracking only synchronizes
+        // accesses within a single queue, so sharing the queue lets it order wgpu's work (e.g. a
+        // texture render) before Skia samples it; otherwise Skia can read not-yet-produced content
+        // (magenta under Metal validation). wgpu 29 doesn't expose the queue it would create itself.
+        #[cfg(target_vendor = "apple")]
+        let mut shared_metal_queue: Option<
+            objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLCommandQueue>>,
+        > = None;
+        #[cfg(target_vendor = "apple")]
+        let mut metal_factory =
+            |adapter: &wgpu::Adapter, descriptor: &wgpu::DeviceDescriptor<'_>| {
+                (adapter.get_info().backend == wgpu::Backend::Metal).then(|| {
+                    metal::create_shared_metal_device_queue(
+                        adapter,
+                        descriptor,
+                        &mut shared_metal_queue,
+                    )
+                })
+            };
+        #[cfg(target_vendor = "apple")]
+        let device_queue_factory: Option<
+            &mut i_slint_core::graphics::wgpu_29::DeviceQueueFactory,
+        > = Some(&mut metal_factory);
+        #[cfg(not(target_vendor = "apple"))]
+        let device_queue_factory: Option<
+            &mut i_slint_core::graphics::wgpu_29::DeviceQueueFactory,
+        > = None;
+
         let (instance, adapter, device, queue, surface) =
             i_slint_core::graphics::wgpu_29::init_instance_adapter_device_queue_surface(
                 surface_target,
                 requested_graphics_api,
-                wgpu::Backends::GL /* we're not mapping that to skia because we can't save/restore state */
-                    .union(if cfg!(target_os = "windows") {
-                        wgpu::Backends::VULKAN
-                    } else {
-                        wgpu::Backends::empty()
-                    }),
+                backends_to_avoid,
+                device_queue_factory,
             )?;
 
         let mut surface_config =
@@ -71,7 +103,18 @@ impl WGPUSurface {
 
         let backend: Backend = adapter.get_info().backend.try_into()?;
 
-        let gr_context = backend.make_context(&adapter, &device, &queue);
+        // The command queue we shared with wgpu (if any). `shared_metal_queue` is kept alive until
+        // after `make_context`, which retains it into Skia's backend context; wgpu's device retains
+        // it too via the queue.
+        #[cfg(target_vendor = "apple")]
+        let shared_command_queue_handle: Option<*const core::ffi::c_void> = shared_metal_queue
+            .as_ref()
+            .map(|q| objc2::rc::Retained::as_ptr(q) as *const core::ffi::c_void);
+        #[cfg(not(target_vendor = "apple"))]
+        let shared_command_queue_handle: Option<*const core::ffi::c_void> = None;
+
+        let gr_context =
+            backend.make_context(&adapter, &device, &queue, shared_command_queue_handle);
 
         Ok(Self {
             gr_context: RefCell::new(
@@ -279,6 +322,14 @@ impl crate::Surface for WGPUSurface {
             i_slint_core::graphics::WGPUTexture::WGPU29Texture(texture) => texture.clone(),
         };
 
+        // NOTE: correct synchronization here relies on Skia sharing wgpu's command queue, so that
+        // Metal's per-queue hazard tracking orders the producing work before Skia's sample. That
+        // sharing only happens when Slint creates the device itself (`Automatic`). With a
+        // developer-provided device/queue (`Manual` config or `SkiaWGPURenderer`), Skia runs on its
+        // own queue and this sample can race the producer, since wgpu 29 exposes neither the queue
+        // to share (`Queue::as_raw`) nor an event to synchronize across queues. Both are restored on
+        // wgpu trunk; revisit once a release ships them.
+
         // Skia won't submit commands right away, so remember the texture and transition before
         // submitting.
         self.textures_to_transition_for_sampling.borrow_mut().push(texture.clone());
@@ -345,10 +396,13 @@ impl Backend {
         _adapter: &wgpu::Adapter,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        // On Metal, the `MTLCommandQueue` we shared with wgpu (see `make_metal_context`). `None` on
+        // other backends and when we didn't create the device ourselves.
+        _shared_metal_command_queue: Option<*const core::ffi::c_void>,
     ) -> Option<skia_safe::gpu::DirectContext> {
         match self {
             #[cfg(target_vendor = "apple")]
-            Self::Metal => metal::make_metal_context(device, queue),
+            Self::Metal => metal::make_metal_context(device, queue, _shared_metal_command_queue),
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_context(&_adapter, &device, &queue) },
             #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]

--- a/internal/renderers/skia/wgpu_29_surface/metal.rs
+++ b/internal/renderers/skia/wgpu_29_surface/metal.rs
@@ -3,10 +3,22 @@
 
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLDevice, MTLTexture};
+use objc2_metal::{MTLCommandQueue, MTLDevice, MTLTexture};
 use skia_safe::gpu::mtl;
 
 use wgpu_29 as wgpu;
+
+/// Matches the limit wgpu's own Metal backend uses when creating its command queue
+/// (`wgpu_hal::metal::adapter::MAX_COMMAND_BUFFERS`).
+const MAX_COMMAND_BUFFERS: usize = 4096;
+
+/// Creates an `MTLCommandQueue` on `device`, sized like wgpu's own queue so the two agree on the
+/// in-flight command-buffer limit.
+fn make_command_queue(
+    device: &ProtocolObject<dyn MTLDevice>,
+) -> Option<Retained<ProtocolObject<dyn MTLCommandQueue>>> {
+    device.newCommandQueueWithMaxCommandBufferCount(MAX_COMMAND_BUFFERS)
+}
 
 /// # Safety
 /// `metal_handle` must be a valid Metal texture handle for the lifetime of the returned Surface.
@@ -92,21 +104,96 @@ pub unsafe fn import_metal_texture(
     }
 }
 
+/// Builds the Skia Metal context.
+///
+/// When `shared_command_queue` is `Some`, it is the `MTLCommandQueue` that wgpu's device was also
+/// built from (see [`create_shared_metal_device_queue`]). Sharing one queue lets Metal's automatic
+/// per-queue hazard tracking order wgpu's work (e.g. rendering into a texture) before Skia samples
+/// it, avoiding reads of not-yet-produced (magenta under Metal validation) content.
+///
+/// When it is `None` (a developer-provided `Manual` device/queue, whose `MTLCommandQueue` wgpu 29
+/// doesn't expose), Skia falls back to its own queue. Cross-queue accesses are then not
+/// synchronized; see the note in `WGPUSurface::import_wgpu_texture`.
 pub fn make_metal_context(
     device: &wgpu::Device,
     _queue: &wgpu::Queue,
+    shared_command_queue: Option<*const core::ffi::c_void>,
 ) -> Option<skia_safe::gpu::DirectContext> {
+    let metal_device = unsafe { device.as_hal::<wgpu::wgc::api::Metal>() }?;
+    let metal_device_raw: &Retained<ProtocolObject<dyn MTLDevice>> = metal_device.raw_device();
+
+    // When wgpu's queue isn't shared with us, create our own; keep it owned so it outlives the
+    // `BackendContext` creation below, which retains it.
+    let owned_command_queue = match shared_command_queue {
+        Some(_) => None,
+        None => Some(make_command_queue(metal_device_raw)?),
+    };
+    let command_queue_handle: mtl::Handle = match &owned_command_queue {
+        Some(queue) => Retained::as_ptr(queue) as mtl::Handle,
+        None => shared_command_queue.expect("present when we didn't create our own queue") as _,
+    };
+
     let backend = unsafe {
-        let metal_device = device.as_hal::<wgpu::wgc::api::Metal>()?;
-        let metal_device_raw: &Retained<ProtocolObject<dyn MTLDevice>> = metal_device.raw_device();
-        // wgpu-29's Metal `Queue` no longer exposes its underlying `MTLCommandQueue`,
-        // so create a dedicated queue from the same device for Skia to submit on.
-        let skia_command_queue = metal_device_raw.newCommandQueue()?;
         mtl::BackendContext::new(
             Retained::as_ptr(metal_device_raw) as mtl::Handle,
-            Retained::as_ptr(&skia_command_queue) as mtl::Handle,
+            command_queue_handle,
         )
     };
 
     skia_safe::gpu::direct_contexts::make_metal(&backend, None)
+}
+
+/// Creates the wgpu device and queue from an `MTLCommandQueue` we allocate ourselves, and returns
+/// that queue through `shared_command_queue_out` so the Skia context can submit on it too.
+///
+/// This is the device/queue factory passed to `init_instance_adapter_device_queue_surface` for the
+/// Metal backend when Slint owns device creation. wgpu 29 doesn't let us read back the queue it would
+/// create itself, so we substitute our own before building the device.
+///
+/// TODO(wgpu>29): once a wgpu release restores `Queue::as_raw` (gfx-rs/wgpu#9560), drop this whole
+/// hal-interop dance and just read the queue back from the device wgpu creates normally.
+pub fn create_shared_metal_device_queue(
+    adapter: &wgpu::Adapter,
+    descriptor: &wgpu::DeviceDescriptor<'_>,
+    shared_command_queue_out: &mut Option<Retained<ProtocolObject<dyn MTLCommandQueue>>>,
+) -> Result<(wgpu::Device, wgpu::Queue), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    // The hal `Adapter::open` trait method; aliased so it doesn't clash with `wgpu::Adapter`.
+    use wgpu::hal::Adapter as _;
+
+    unsafe {
+        let hal_adapter = adapter
+            .as_hal::<wgpu::wgc::api::Metal>()
+            .ok_or("Skia: expected a Metal hal adapter to share the command queue")?;
+
+        // `open` also builds a queue we can't read back, so we replace it with our own below.
+        let mut open_device = hal_adapter
+            .open(
+                descriptor.required_features,
+                &descriptor.required_limits,
+                &descriptor.memory_hints,
+            )
+            .map_err(|e| format!("Skia: failed to open Metal device for queue sharing: {e}"))?;
+
+        let metal_device: Retained<ProtocolObject<dyn MTLDevice>> =
+            open_device.device.raw_device().clone();
+
+        let shared_command_queue = make_command_queue(&metal_device)
+            .ok_or("Skia: failed to create a shared Metal command queue")?;
+
+        // Mirror wgpu's own timestamp-period heuristic (wgpu_hal::metal::adapter::open). Slint never
+        // reads GPU timestamps, so the exact value only matters for API parity.
+        let timestamp_period =
+            if metal_device.name().to_string().starts_with("Intel") { 83.333 } else { 1.0 };
+
+        open_device.queue =
+            wgpu::hal::metal::Queue::queue_from_raw(shared_command_queue.clone(), timestamp_period);
+
+        let (device, queue) = adapter
+            .create_device_from_hal::<wgpu::wgc::api::Metal>(open_device, descriptor)
+            .map_err(|e| format!("Skia: failed to create wgpu device from shared queue: {e}"))?;
+
+        *shared_command_queue_out = Some(shared_command_queue);
+
+        Ok((device, queue))
+    }
 }

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -46,9 +46,13 @@ impl SkiaWGPURenderer {
     ) -> Result<Self, PlatformError> {
         let backend: Backend = adapter.get_info().backend.try_into()?;
 
-        let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
-            PlatformError::from("Failed to create Skia graphics context from WGPU")
-        })?;
+        // The device and queue are provided by the caller, so we can't share wgpu's command queue
+        // with Skia (wgpu 29 doesn't expose it). Skia therefore runs on its own queue; see the note
+        // in `WGPUSurface::import_wgpu_texture` about the cross-queue synchronization limitation.
+        let gr_context =
+            backend.make_context(&adapter, &device, &queue, None).ok_or_else(|| {
+                PlatformError::from("Failed to create Skia graphics context from WGPU")
+            })?;
 
         let surface = WGPUSurface::new_offscreen(instance, device, queue, backend, gr_context);
 


### PR DESCRIPTION
When Slint owns wgpu device creation, build the device from a command queue we allocate and hand the same MTLCommandQueue to Skia. Metal's per-queue hazard tracking then orders wgpu's texture writes before Skia samples them, instead of Skia reading not-yet-produced content from its own separate command queue.

wgpu 29 dropped Queue::as_raw, so we recreate the device via hal interop (open + queue_from_raw + create_device_from_hal) to substitute our queue.

Unfortunately we can't fix this when using manual config or for SkiaWGPURenderer until a wgpu release restores queue/event access.

Closes #12271

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
