### PR TITLE
winit: Don't pre-render the first frame on Wayland

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1123,9 +1123,12 @@ impl WinitWindowAdapter {
                 self.resize_window(size.into())?;
             };
 
-            // Pre-render the first frame before mapping the window to avoid
-            // a flash of uninitialized VRAM on X11 (no background_pixmap).
-            if matches!(visibility, WindowVisibility::ShownFirstTime) {
+            // Pre-render the first frame before mapping the window to avoid a flash of
+            // uninitialized VRAM on X11 (no background_pixmap). Skipped on Wayland, where
+            // rendering before the initial configure makes the compositor mis-size the window.
+            if matches!(visibility, WindowVisibility::ShownFirstTime)
+                && !self.shared_backend_data.is_wayland
+            {
                 let _ = self.draw();
             }
 


### PR DESCRIPTION
The pre-render before mapping (added to avoid a flash of uninitialized VRAM on X11) also ran on Wayland, where it caused a wrong initial size on Mutter: the title bar got counted in the window height.

On X11 set_visible maps the window independently of drawing, so painting first just fills the buffer before it is shown. On Wayland set_visible is a no-op and a surface becomes visible by committing a buffer, which must happen after the initial xdg configure. The pre-render commits before that handshake, so Mutter mis-sizes the window. Wayland also never shows an unmapped surface, so there is no flash to prevent there.

Fixes: #12262
