### PR TITLE
core + Qt: Add native drag-and-drop

### DIFF
--- a/api/rs/slint/tests/native_drag.rs
+++ b/api/rs/slint/tests/native_drag.rs
@@ -1,80 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Native drag-and-drop handoff, driven by a custom backend whose `start_drag` takes over the
-//! drag (like Qt). The testing backend declines `start_drag`, so the `dragarea_*` cases only
-//! cover the in-window fallback.
+//! Native drag-and-drop handoff, exercised through the testing backend's native-drag
+//! simulation: `set_simulate_native_drag` makes `start_drag` take the drag over like a real
+//! backend, and the `simulate_native_drag_*` helpers drive the OS receive path.
 
-use slint::platform::software_renderer::SoftwareRenderer;
-use slint::platform::{PlatformError, PointerEventButton, WindowAdapter, WindowEvent};
-use slint::{LogicalPosition, PhysicalSize};
-use std::cell::RefCell;
-use std::rc::{Rc, Weak};
-
-use i_slint_core::InternalToken;
-use i_slint_core::window::{DragRequest, WindowAdapterInternal, WindowInner};
-use slint::private_unstable_api::re_exports::{
-    AllowedDragActions, DragAction, DropEvent, MouseEvent,
-};
-
-thread_local! {
-    static NEXT_WINDOW: RefCell<Option<Rc<TestWindow>>> = const { RefCell::new(None) };
-}
-
-struct TestPlatform;
-impl slint::platform::Platform for TestPlatform {
-    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
-        Ok(NEXT_WINDOW
-            .with(|c| c.borrow_mut().take())
-            .expect("queue a TestWindow before creating a component"))
-    }
-}
-
-/// A window adapter that takes over native drags by recording them. It never renders; the
-/// renderer only exists to satisfy the trait.
-struct TestWindow {
-    window: slint::Window,
-    renderer: SoftwareRenderer,
-    /// The data captured by `start_drag`; the cross-window test uses it to build the drop, and
-    /// its presence confirms the backend took the drag over.
-    dragged_data: RefCell<Option<slint::DataTransfer>>,
-}
-
-impl TestWindow {
-    fn new() -> Rc<Self> {
-        Rc::new_cyclic(|w: &Weak<Self>| Self {
-            window: slint::Window::new(w.clone()),
-            renderer: SoftwareRenderer::new(),
-            dragged_data: Default::default(),
-        })
-    }
-}
-
-impl WindowAdapter for TestWindow {
-    fn window(&self) -> &slint::Window {
-        &self.window
-    }
-
-    fn size(&self) -> PhysicalSize {
-        Default::default()
-    }
-
-    fn renderer(&self) -> &dyn slint::platform::Renderer {
-        &self.renderer
-    }
-
-    fn internal(&self, _: InternalToken) -> Option<&dyn WindowAdapterInternal> {
-        Some(self)
-    }
-}
-
-impl WindowAdapterInternal for TestWindow {
-    // Take over the drag and record its data; the test routes the drop itself.
-    fn start_drag(&self, request: &DragRequest) -> bool {
-        *self.dragged_data.borrow_mut() = Some(request.data().clone());
-        true
-    }
-}
+use i_slint_backend_testing::access_testing_window;
+use i_slint_core::window::WindowInner;
+use slint::LogicalPosition;
+use slint::platform::{PointerEventButton, WindowEvent};
+use slint::private_unstable_api::re_exports::DragAction;
 
 slint::slint! {
     export component Source inherits Window {
@@ -87,7 +22,6 @@ slint::slint! {
             width: 100%;
             height: 100%;
             allow-copy: true;
-            allow-move: true;
             data: to-transfer("payload-text");
             drag-finished(action) => {
                 root.finished = true;
@@ -130,8 +64,9 @@ slint::slint! {
         out property <bool> got-drop;
         out property <string> dropped-text;
         out property <bool> has-drag <=> dropper.has-drag;
+        out property <bool> dragging <=> dragger.dragging;
         VerticalLayout {
-            DragArea {
+            dragger := DragArea {
                 allow-copy: true;
                 data: to-transfer("payload-text");
                 drag-finished(action) => {
@@ -153,31 +88,20 @@ slint::slint! {
     }
 }
 
-/// Make a window adapter for the next component creation to pick up.
-fn queue_window() -> Rc<TestWindow> {
-    let window = TestWindow::new();
-    NEXT_WINDOW.with(|c| *c.borrow_mut() = Some(window.clone()));
-    window
-}
-
-/// The OS negotiates the allowed actions, so for an incoming drop let any DropArea choice through.
-const ALL_ACTIONS: AllowedDragActions = AllowedDragActions { copy: true, move_: true, link: true };
-
 #[test]
 fn native_drag_across_windows() {
-    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    i_slint_backend_testing::init_no_event_loop();
 
-    let source_window = queue_window();
     let source = Source::new().unwrap();
     source.on_to_transfer(slint::DataTransfer::from);
+    access_testing_window(source.window(), |w| w.set_simulate_native_drag(true));
 
-    queue_window();
     let target = Target::new().unwrap();
     target.on_accept(|data| data.has_plain_text());
     target.on_text_of(|data| data.plain_text().unwrap_or_default());
 
-    // Press, then move past the 8px drag threshold: this calls our `start_drag`, which takes
-    // over (so no in-window drag is armed) and records the dragged data.
+    // Press, then move past the 8px drag threshold: this calls the backend's `start_drag`,
+    // which (in simulate mode) takes the drag over and records the dragged data.
     source.window().dispatch_event(WindowEvent::PointerPressed {
         position: LogicalPosition::new(50.0, 50.0),
         button: PointerEventButton::Left,
@@ -185,33 +109,16 @@ fn native_drag_across_windows() {
     source
         .window()
         .dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 90.0) });
-
-    let data = source_window
-        .dragged_data
-        .borrow_mut()
-        .take()
-        .expect("start_drag should have been invoked and taken over the drag");
     assert!(!source.get_finished(), "drag isn't finished until reported");
 
-    // Deliver the drag to the *target* window as a backend's receive path does: DragMove to
-    // hover, then Drop.
-    let mut event = DropEvent::default();
-    event.data = data;
-    event.position = LogicalPosition::new(50.0, 50.0);
-    event.proposed_action = DragAction::Copy;
-
-    let target_inner = WindowInner::from_pub(target.window());
-    target_inner
-        .process_mouse_input(MouseEvent::DragMove { event: event.clone(), allowed: ALL_ACTIONS });
-    assert!(target.get_has_drag(), "the DropArea should report the hovering drag");
-
-    let action = target_inner
-        .process_mouse_input(MouseEvent::Drop { event, allowed: ALL_ACTIONS })
-        .and_then(|r| r.drag_action)
-        .unwrap_or(DragAction::None);
-
-    // Report completion to the source, as the backend does when the OS drag ends.
-    WindowInner::from_pub(source.window()).report_drag_finished(action);
+    // Deliver the drag to the *target* window, as a backend does on the OS receive path:
+    // DragMove to hover, then Drop with completion reported back to the source.
+    let hover = LogicalPosition::new(50.0, 50.0);
+    let action = access_testing_window(source.window(), |w| {
+        w.simulate_native_drag_move(target.window(), hover);
+        assert!(target.get_has_drag(), "the DropArea should report the hovering drag");
+        w.simulate_native_drop(target.window(), hover)
+    });
 
     assert!(target.get_got_drop(), "the drop should have reached the target DropArea");
     assert_eq!(target.get_dropped_text(), "payload-text");
@@ -225,13 +132,13 @@ fn native_drag_across_windows() {
 // The in-window machinery then drives the drag to its drop.
 #[test]
 fn native_drag_falls_back_to_in_window() {
-    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    i_slint_backend_testing::init_no_event_loop();
 
-    let window = queue_window();
     let ui = SameWindow::new().unwrap();
     ui.on_to_transfer(slint::DataTransfer::from);
     ui.on_accept(|data| data.has_plain_text());
     ui.on_text_of(|data| data.plain_text().unwrap_or_default());
+    access_testing_window(ui.window(), |w| w.set_simulate_native_drag(true));
 
     // Start the drag on the DragArea (top half): the backend takes over and records it.
     ui.window().dispatch_event(WindowEvent::PointerPressed {
@@ -240,10 +147,7 @@ fn native_drag_falls_back_to_in_window() {
     });
     ui.window()
         .dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 60.0) });
-    assert!(
-        window.dragged_data.borrow().is_some(),
-        "start_drag should have been invoked and taken over the drag"
-    );
+    assert!(ui.get_dragging(), "start_drag should have taken the drag over");
 
     // The native start "fails": fall back to the in-window drag, as a backend does.
     WindowInner::from_pub(ui.window()).start_in_window_drag();

--- a/api/rs/slint/tests/native_drag.rs
+++ b/api/rs/slint/tests/native_drag.rs
@@ -1,0 +1,266 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Native drag-and-drop handoff, driven by a custom backend whose `start_drag` takes over the
+//! drag (like Qt). The testing backend declines `start_drag`, so the `dragarea_*` cases only
+//! cover the in-window fallback.
+
+use slint::platform::software_renderer::SoftwareRenderer;
+use slint::platform::{PlatformError, PointerEventButton, WindowAdapter, WindowEvent};
+use slint::{LogicalPosition, PhysicalSize};
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
+
+use i_slint_core::InternalToken;
+use i_slint_core::window::{DragRequest, WindowAdapterInternal, WindowInner};
+use slint::private_unstable_api::re_exports::{
+    AllowedDragActions, DragAction, DropEvent, MouseEvent,
+};
+
+thread_local! {
+    static NEXT_WINDOW: RefCell<Option<Rc<TestWindow>>> = const { RefCell::new(None) };
+}
+
+struct TestPlatform;
+impl slint::platform::Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        Ok(NEXT_WINDOW
+            .with(|c| c.borrow_mut().take())
+            .expect("queue a TestWindow before creating a component"))
+    }
+}
+
+/// A window adapter that takes over native drags by recording them. It never renders; the
+/// renderer only exists to satisfy the trait.
+struct TestWindow {
+    window: slint::Window,
+    renderer: SoftwareRenderer,
+    /// The data captured by `start_drag`; the cross-window test uses it to build the drop, and
+    /// its presence confirms the backend took the drag over.
+    dragged_data: RefCell<Option<slint::DataTransfer>>,
+}
+
+impl TestWindow {
+    fn new() -> Rc<Self> {
+        Rc::new_cyclic(|w: &Weak<Self>| Self {
+            window: slint::Window::new(w.clone()),
+            renderer: SoftwareRenderer::new(),
+            dragged_data: Default::default(),
+        })
+    }
+}
+
+impl WindowAdapter for TestWindow {
+    fn window(&self) -> &slint::Window {
+        &self.window
+    }
+
+    fn size(&self) -> PhysicalSize {
+        Default::default()
+    }
+
+    fn renderer(&self) -> &dyn slint::platform::Renderer {
+        &self.renderer
+    }
+
+    fn internal(&self, _: InternalToken) -> Option<&dyn WindowAdapterInternal> {
+        Some(self)
+    }
+}
+
+impl WindowAdapterInternal for TestWindow {
+    // Take over the drag and record its data; the test routes the drop itself.
+    fn start_drag(&self, request: &DragRequest) -> bool {
+        *self.dragged_data.borrow_mut() = Some(request.data().clone());
+        true
+    }
+}
+
+slint::slint! {
+    export component Source inherits Window {
+        pure callback to-transfer(string) -> data-transfer;
+        width: 100px;
+        height: 100px;
+        out property <bool> finished;
+        out property <DragAction> finished-action;
+        DragArea {
+            width: 100%;
+            height: 100%;
+            allow-copy: true;
+            allow-move: true;
+            data: to-transfer("payload-text");
+            drag-finished(action) => {
+                root.finished = true;
+                root.finished-action = action;
+            }
+        }
+    }
+
+    export component Target inherits Window {
+        pure callback accept(data-transfer) -> bool;
+        pure callback text-of(data-transfer) -> string;
+        width: 100px;
+        height: 100px;
+        out property <bool> got-drop;
+        out property <string> dropped-text;
+        out property <bool> has-drag <=> dropper.has-drag;
+        dropper := DropArea {
+            width: 100%;
+            height: 100%;
+            can-drop(event) => {
+                accept(event.data) ? DragAction.copy : DragAction.none
+            }
+            dropped(event) => {
+                root.got-drop = true;
+                root.dropped-text = text-of(event.data);
+                return event.proposed-action;
+            }
+        }
+    }
+
+    // A DragArea (top) and a DropArea (bottom) in one window, to drop within itself.
+    export component SameWindow inherits Window {
+        pure callback to-transfer(string) -> data-transfer;
+        pure callback accept(data-transfer) -> bool;
+        pure callback text-of(data-transfer) -> string;
+        width: 100px;
+        height: 200px;
+        out property <bool> finished;
+        out property <DragAction> finished-action;
+        out property <bool> got-drop;
+        out property <string> dropped-text;
+        out property <bool> has-drag <=> dropper.has-drag;
+        VerticalLayout {
+            DragArea {
+                allow-copy: true;
+                data: to-transfer("payload-text");
+                drag-finished(action) => {
+                    root.finished = true;
+                    root.finished-action = action;
+                }
+            }
+            dropper := DropArea {
+                can-drop(event) => {
+                    accept(event.data) ? DragAction.copy : DragAction.none
+                }
+                dropped(event) => {
+                    root.got-drop = true;
+                    root.dropped-text = text-of(event.data);
+                    return event.proposed-action;
+                }
+            }
+        }
+    }
+}
+
+/// Make a window adapter for the next component creation to pick up.
+fn queue_window() -> Rc<TestWindow> {
+    let window = TestWindow::new();
+    NEXT_WINDOW.with(|c| *c.borrow_mut() = Some(window.clone()));
+    window
+}
+
+/// The OS negotiates the allowed actions, so for an incoming drop let any DropArea choice through.
+const ALL_ACTIONS: AllowedDragActions = AllowedDragActions { copy: true, move_: true, link: true };
+
+#[test]
+fn native_drag_across_windows() {
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+
+    let source_window = queue_window();
+    let source = Source::new().unwrap();
+    source.on_to_transfer(slint::DataTransfer::from);
+
+    queue_window();
+    let target = Target::new().unwrap();
+    target.on_accept(|data| data.has_plain_text());
+    target.on_text_of(|data| data.plain_text().unwrap_or_default());
+
+    // Press, then move past the 8px drag threshold: this calls our `start_drag`, which takes
+    // over (so no in-window drag is armed) and records the dragged data.
+    source.window().dispatch_event(WindowEvent::PointerPressed {
+        position: LogicalPosition::new(50.0, 50.0),
+        button: PointerEventButton::Left,
+    });
+    source
+        .window()
+        .dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 90.0) });
+
+    let data = source_window
+        .dragged_data
+        .borrow_mut()
+        .take()
+        .expect("start_drag should have been invoked and taken over the drag");
+    assert!(!source.get_finished(), "drag isn't finished until reported");
+
+    // Deliver the drag to the *target* window as a backend's receive path does: DragMove to
+    // hover, then Drop.
+    let mut event = DropEvent::default();
+    event.data = data;
+    event.position = LogicalPosition::new(50.0, 50.0);
+    event.proposed_action = DragAction::Copy;
+
+    let target_inner = WindowInner::from_pub(target.window());
+    target_inner
+        .process_mouse_input(MouseEvent::DragMove { event: event.clone(), allowed: ALL_ACTIONS });
+    assert!(target.get_has_drag(), "the DropArea should report the hovering drag");
+
+    let action = target_inner
+        .process_mouse_input(MouseEvent::Drop { event, allowed: ALL_ACTIONS })
+        .and_then(|r| r.drag_action)
+        .unwrap_or(DragAction::None);
+
+    // Report completion to the source, as the backend does when the OS drag ends.
+    WindowInner::from_pub(source.window()).report_drag_finished(action);
+
+    assert!(target.get_got_drop(), "the drop should have reached the target DropArea");
+    assert_eq!(target.get_dropped_text(), "payload-text");
+    assert_eq!(action, DragAction::Copy);
+    assert!(source.get_finished(), "drag-finished should have fired on the source");
+    assert_eq!(source.get_finished_action(), DragAction::Copy);
+}
+
+// The backend takes over the drag, but the native start then fails, so it falls back to the
+// in-window drag via `start_in_window_drag` — as a backend does when the native start errors.
+// The in-window machinery then drives the drag to its drop.
+#[test]
+fn native_drag_falls_back_to_in_window() {
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+
+    let window = queue_window();
+    let ui = SameWindow::new().unwrap();
+    ui.on_to_transfer(slint::DataTransfer::from);
+    ui.on_accept(|data| data.has_plain_text());
+    ui.on_text_of(|data| data.plain_text().unwrap_or_default());
+
+    // Start the drag on the DragArea (top half): the backend takes over and records it.
+    ui.window().dispatch_event(WindowEvent::PointerPressed {
+        position: LogicalPosition::new(50.0, 25.0),
+        button: PointerEventButton::Left,
+    });
+    ui.window()
+        .dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 60.0) });
+    assert!(
+        window.dragged_data.borrow().is_some(),
+        "start_drag should have been invoked and taken over the drag"
+    );
+
+    // The native start "fails": fall back to the in-window drag, as a backend does.
+    WindowInner::from_pub(ui.window()).start_in_window_drag();
+
+    // The in-window machinery now drives it: move over the DropArea (bottom half), then release.
+    ui.window()
+        .dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 150.0) });
+    assert!(ui.get_has_drag(), "the in-window drag should hover the DropArea");
+    assert!(!ui.get_got_drop());
+
+    ui.window().dispatch_event(WindowEvent::PointerReleased {
+        position: LogicalPosition::new(50.0, 150.0),
+        button: PointerEventButton::Left,
+    });
+
+    assert!(ui.get_got_drop(), "the in-window drop should reach the DropArea");
+    assert_eq!(ui.get_dropped_text(), "payload-text");
+    assert!(ui.get_finished(), "drag-finished should fire when the in-window drag ends");
+    assert_eq!(ui.get_finished_action(), DragAction::Copy);
+}

--- a/examples/dnd-kanban/main.rs
+++ b/examples/dnd-kanban/main.rs
@@ -50,6 +50,10 @@ fn main() -> Result<(), slint::PlatformError> {
 
     api.on_make_data(|task, source_column, source_index| {
         let mut transfer = DataTransfer::default();
+        // Plain text lets the card drop onto other apps via a native drag.
+        transfer.set_plain_text(task.title.clone());
+        // The in-app payload carries the full move info. It can't cross a native drag boundary,
+        // but Slint restores it for drops back onto this window.
         transfer.set_user_data(Rc::new(DragPayload {
             task,
             source_column: source_column as usize,

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2478,10 +2478,11 @@ impl WindowAdapterInternal for QtWindow {
 
         let drag_pixmap =
             image_to_pixmap(<&ImageInner>::from(request.drag_image()), None).unwrap_or_default();
-        let offset_x = request.drag_image_offset().x as i32;
-        let offset_y = request.drag_image_offset().y as i32;
+        let offset = request.drag_image_offset();
+        let offset_x = offset.x;
+        let offset_y = offset.y;
 
-        let allowed = request.allowed();
+        let allowed = request.allowed_actions();
         let allow_copy = allowed.copy;
         let allow_move = allowed.move_;
         let allow_link = allowed.link;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore frameless qbrush qimage qpointf qreal qvariant qwidgetsize svgz Nesw qsize qstring
+// cSpell: ignore frameless qbrush qdrag qimage qpointf qreal qvariant qwidgetsize svgz Nesw qsize qstring
 
 use cpp::*;
 use i_slint_common::sharedfontique::HashedBlob;
@@ -33,7 +33,9 @@ use i_slint_core::lengths::{
 use i_slint_core::platform::{PlatformError, WindowEvent};
 use i_slint_core::string::ToSharedString;
 use i_slint_core::textlayout::sharedparley::{self, GlyphRenderer, fontique, parley};
-use i_slint_core::window::{WindowAdapter, WindowAdapterInternal, WindowInner, WindowKind};
+use i_slint_core::window::{
+    DragRequest, WindowAdapter, WindowAdapterInternal, WindowInner, WindowKind,
+};
 use i_slint_core::{ImageInner, SharedString};
 
 use std::cell::RefCell;
@@ -59,6 +61,7 @@ cpp! {{
     #include <QtGui/QAccessible>
     #include <QtGui/QCursor>
     #include <QtGui/QDesktopServices>
+    #include <QtGui/QDrag>
     #include <QtGui/QDragEnterEvent>
     #include <QtGui/QDragLeaveEvent>
     #include <QtGui/QDragMoveEvent>
@@ -2456,6 +2459,87 @@ fn into_qsize(logical_size: i_slint_core::api::LogicalSize) -> qttypes::QSize {
 impl WindowAdapterInternal for QtWindow {
     fn get_parent(&self) -> Option<Rc<dyn WindowAdapter>> {
         self.parent.clone().upgrade().map(|rc| rc as _)
+    }
+
+    fn start_drag(&self, request: &DragRequest) -> bool {
+        let widget_ptr = self.widget_ptr();
+
+        let has_text = request.data().has_plain_text();
+        let text: qttypes::QString =
+            request.data().plain_text().map(|s| s.as_str().into()).unwrap_or_default();
+
+        let has_image = request.data().has_image();
+        let payload_pixmap = request
+            .data()
+            .image()
+            .ok()
+            .and_then(|img| image_to_pixmap(<&ImageInner>::from(&img), None))
+            .unwrap_or_default();
+
+        let drag_pixmap =
+            image_to_pixmap(<&ImageInner>::from(request.drag_image()), None).unwrap_or_default();
+        let offset_x = request.drag_image_offset().x as i32;
+        let offset_y = request.drag_image_offset().y as i32;
+
+        let allowed = request.allowed();
+        let allow_copy = allowed.copy;
+        let allow_move = allowed.move_;
+        let allow_link = allowed.link;
+        // With no modifier held, the proposed action is the first allowed of move, copy, link.
+        let default_action = slint_drag_action_to_qt(i_slint_core::items::compute_proposed_action(
+            Default::default(),
+            allowed,
+        ));
+
+        let rust_window: &QtWindow = self;
+
+        // QDrag::exec runs a nested event loop, so defer it to a queued event (as win32 does)
+        // rather than running it inside this input-handling call; report the action when it ends.
+        cpp! {unsafe [
+            widget_ptr as "QWidget*",
+            has_text as "bool",
+            text as "QString",
+            has_image as "bool",
+            payload_pixmap as "QPixmap",
+            drag_pixmap as "QPixmap",
+            offset_x as "int",
+            offset_y as "int",
+            allow_copy as "bool",
+            allow_move as "bool",
+            allow_link as "bool",
+            default_action as "uint32_t",
+            rust_window as "void*"
+        ] {
+            QMetaObject::invokeMethod(widget_ptr, [=]() {
+                QMimeData *mime = new QMimeData();
+                if (has_text) {
+                    mime->setText(text);
+                }
+                if (has_image) {
+                    mime->setImageData(payload_pixmap.toImage());
+                }
+                QDrag *qdrag = new QDrag(widget_ptr);
+                qdrag->setMimeData(mime);
+                if (!drag_pixmap.isNull()) {
+                    qdrag->setPixmap(drag_pixmap);
+                    qdrag->setHotSpot(QPoint(offset_x, offset_y));
+                }
+                Qt::DropActions actions = Qt::IgnoreAction;
+                if (allow_copy) actions |= Qt::CopyAction;
+                if (allow_move) actions |= Qt::MoveAction;
+                if (allow_link) actions |= Qt::LinkAction;
+                uint32_t performed = static_cast<uint32_t>(
+                    qdrag->exec(actions, static_cast<Qt::DropAction>(default_action)));
+                rust!(Slint_reportDragFinished [
+                    rust_window: &QtWindow as "void*",
+                    performed: u32 as "uint32_t"
+                ] {
+                    WindowInner::from_pub(&rust_window.window)
+                        .report_drag_finished(qt_drop_action_to_slint(performed));
+                });
+            }, Qt::QueuedConnection);
+        }};
+        true
     }
 
     fn register_item_tree(&self, _: ItemTreeRefPin) {

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -13,7 +13,9 @@ use i_slint_core::window::{
 };
 
 use i_slint_core::SharedString;
-use i_slint_core::items::TextWrap;
+use i_slint_core::api::LogicalPosition;
+use i_slint_core::input::MouseEvent;
+use i_slint_core::items::{AllowedDragActions, DragAction, DropEvent, TextWrap};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -191,6 +193,8 @@ impl i_slint_core::platform::Platform for TestingBackend {
             open_url: self.open_url.clone(),
             debug_logs: self.debug_logs.clone(),
             native_popup: Cell::new(false),
+            simulate_native_drag: Cell::new(false),
+            native_drag: Default::default(),
             #[cfg(supports_headless)]
             renderer_name: self.renderer_name.clone(),
             #[cfg(supports_headless)]
@@ -289,6 +293,10 @@ pub struct TestingWindow {
     pub open_url: Rc<RefCell<Option<SharedString>>>,
     pub debug_logs: Rc<RefCell<Vec<String>>>,
     native_popup: Cell<bool>,
+    simulate_native_drag: Cell<bool>,
+    /// Payload and allowed actions recorded by `start_drag` while simulating a native drag,
+    /// so the receive-side helpers can build the drop they deliver to a target window.
+    native_drag: RefCell<Option<(i_slint_core::data_transfer::DataTransfer, AllowedDragActions)>>,
     /// Remembered for child popups, so they pick the same rasterizer.
     #[cfg(supports_headless)]
     renderer_name: Option<SharedString>,
@@ -318,11 +326,74 @@ impl TestingWindow {
     pub fn take_debug_log(&self) -> Vec<String> {
         self.debug_logs.borrow_mut().drain(..).collect()
     }
+
+    /// Enable simulating native (OS-level) drag-and-drop. Once enabled, `start_drag` takes the
+    /// drag over as a real backend does (instead of declining it and using the in-window
+    /// fallback), recording the payload so [`Self::simulate_native_drag_move`] and
+    /// [`Self::simulate_native_drop`] can drive the receive side.
+    pub fn set_simulate_native_drag(&self, enabled: bool) {
+        self.simulate_native_drag.set(enabled);
+    }
+
+    /// Move the in-flight simulated native drag over `target` at `position`, as a backend does
+    /// when the OS drags across a window. Returns the action the target's `DropArea` proposes.
+    pub fn simulate_native_drag_move(
+        &self,
+        target: &i_slint_core::api::Window,
+        position: LogicalPosition,
+    ) -> DragAction {
+        self.deliver_native_drag(target, position, false)
+    }
+
+    /// Drop the in-flight simulated native drag onto `target` at `position`, then report
+    /// completion back to this source window, as a backend does when the OS drag ends. Returns
+    /// the final negotiated action.
+    pub fn simulate_native_drop(
+        &self,
+        target: &i_slint_core::api::Window,
+        position: LogicalPosition,
+    ) -> DragAction {
+        let action = self.deliver_native_drag(target, position, true);
+        WindowInner::from_pub(&self.window).report_drag_finished(action);
+        action
+    }
+
+    fn deliver_native_drag(
+        &self,
+        target: &i_slint_core::api::Window,
+        position: LogicalPosition,
+        drop: bool,
+    ) -> DragAction {
+        let (data, allowed) =
+            self.native_drag.borrow().clone().expect("no simulated native drag in flight");
+        let mut event = DropEvent::default();
+        event.data = data;
+        event.position = position;
+        event.proposed_action =
+            i_slint_core::items::compute_proposed_action(Default::default(), allowed);
+        let event = if drop {
+            MouseEvent::Drop { event, allowed }
+        } else {
+            MouseEvent::DragMove { event, allowed }
+        };
+        WindowInner::from_pub(target)
+            .process_mouse_input(event)
+            .and_then(|r| r.drag_action)
+            .unwrap_or(DragAction::None)
+    }
 }
 
 impl WindowAdapterInternal for TestingWindow {
     fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
         self.ime_requests.borrow_mut().push(request)
+    }
+
+    fn start_drag(&self, request: &i_slint_core::window::DragRequest) -> bool {
+        if !self.simulate_native_drag.get() {
+            return false;
+        }
+        *self.native_drag.borrow_mut() = Some((request.data().clone(), request.allowed_actions()));
+        true
     }
 
     fn set_mouse_cursor(&self, cursor: i_slint_core::items::MouseCursor) {
@@ -365,6 +436,8 @@ impl WindowAdapterInternal for TestingWindow {
                 open_url: self.open_url.clone(),
                 debug_logs: self.debug_logs.clone(),
                 native_popup: self.native_popup.clone(),
+                simulate_native_drag: self.simulate_native_drag.clone(),
+                native_drag: Default::default(),
                 #[cfg(supports_headless)]
                 renderer_name: self.renderer_name.clone(),
                 #[cfg(supports_headless)]

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1272,6 +1272,21 @@ impl MouseInputState {
         self.item_stack.last().and_then(|x| x.0.upgrade())
     }
 
+    /// Arm the in-window drag: seed `drag_data`/`drag_source` from `drag_area` at `seed_position`
+    /// and mark it dragging.
+    pub(crate) fn arm_in_window_drag(
+        &mut self,
+        drag_area: core::pin::Pin<&crate::items::DragArea>,
+        source: ItemWeak,
+        seed_position: crate::api::LogicalPosition,
+    ) {
+        let (mut drop_event, allowed) = drag_area.initial_drop_event();
+        drop_event.position = seed_position;
+        self.drag_data = Some(DragData { event: drop_event, allowed });
+        self.drag_source = Some(source);
+        drag_area.dragging.set(true);
+    }
+
     /// Returns the item in the top of the stack, if there is a delayed event, this would be the top of the delayed stack
     pub fn top_item_including_delayed(&self) -> Option<ItemRc> {
         self.delayed_exit_items.last().and_then(|x| x.upgrade()).or_else(|| self.top_item())
@@ -1302,6 +1317,41 @@ pub(crate) struct MouseGrabResult {
     /// Whether the grabber consumed the original event before any follow-up event was
     /// synthesized for hover/grab refresh.
     pub accepted: bool,
+}
+
+/// Start a drag from `drag_area`, preferring a native (OS-level) drag and falling back to the
+/// in-window drag (armed on `state`) when no backend takes over.
+fn offer_native_drag(
+    window_adapter: &Rc<dyn WindowAdapter>,
+    drag_area: core::pin::Pin<&crate::items::DragArea>,
+    source: ItemWeak,
+    seed_position: crate::api::LogicalPosition,
+    state: &mut MouseInputState,
+) {
+    let data = drag_area.data();
+    // A native drag only carries serializable data, so offer it only when there's some.
+    if data.has_plain_text() || data.has_image() {
+        let request = crate::window::DragRequest {
+            data: data.clone(),
+            allowed: drag_area.allowed_actions(),
+            drag_image: drag_area.drag_image(),
+            drag_image_offset: crate::api::LogicalPosition::new(
+                drag_area.drag_image_offset_x() as f32,
+                drag_area.drag_image_offset_y() as f32,
+            ),
+        };
+        if window_adapter.internal(crate::InternalToken).is_some_and(|i| i.start_drag(&request)) {
+            // The backend took over (and defers the actual drag). Stash it so it can report
+            // completion or fall back, and so a drop back onto this window restores the data.
+            let drag = crate::window::PendingDrag { request, source, seed_position };
+            crate::window::WindowInner::from_pub(window_adapter.window())
+                .set_native_drag(Some(drag));
+            drag_area.dragging.set(true);
+            return;
+        }
+    }
+    // No backend took over: fall back to the in-window drag.
+    state.arm_in_window_drag(drag_area, source, seed_position);
 }
 
 /// Try to handle the mouse grabber.
@@ -1382,16 +1432,19 @@ pub(crate) fn handle_mouse_grab(
             mouse_input_state.grabbed = false;
             let drag_area_item = grabber.downcast::<crate::items::DragArea>().unwrap();
             let drag_area = drag_area_item.as_pin_ref();
-            let (mut drop_event, allowed) = drag_area.initial_drop_event();
             // Seed the drag position from the event that crossed the drag threshold so
             // the renderer can place the drag-image overlay before the first DragMove.
-            drop_event.position = mouse_event
+            let seed_position = mouse_event
                 .position()
                 .map(crate::lengths::logical_position_to_api)
                 .unwrap_or_default();
-            mouse_input_state.drag_data = Some(DragData { event: drop_event, allowed });
-            mouse_input_state.drag_source = Some(grabber.downgrade());
-            drag_area.dragging.set(true);
+            offer_native_drag(
+                window_adapter,
+                drag_area,
+                grabber.downgrade(),
+                seed_position,
+                mouse_input_state,
+            );
             MouseGrabResult { event: None, accepted: true }
         }
         InputEventResult::EventAccepted | InputEventResult::EventIgnored => {
@@ -1706,19 +1759,22 @@ fn send_mouse_event_to_item(
             result.grabbed = false;
             let drag_area_item = item_rc.downcast::<crate::items::DragArea>().unwrap();
             let drag_area = drag_area_item.as_pin_ref();
-            let (mut drop_event, allowed) = drag_area.initial_drop_event();
             // `mouse_event` here is in the parent item's coords (this function is called
             // recursively); translate into the DragArea's local coords, then map back to
             // window coords so the drag-image overlay places at the right spot from the start.
-            drop_event.position = mouse_event
+            let seed_position = mouse_event
                 .position()
                 .map(|p| p - geom.origin.to_vector())
                 .map(|p| item_rc.map_to_window(p))
                 .map(crate::lengths::logical_position_to_api)
                 .unwrap_or_default();
-            result.drag_data = Some(DragData { event: drop_event, allowed });
-            result.drag_source = Some(item_rc.downgrade());
-            drag_area.dragging.set(true);
+            offer_native_drag(
+                window_adapter,
+                drag_area,
+                item_rc.downgrade(),
+                seed_position,
+                result,
+            );
             VisitChildrenResult::abort(item_rc.index(), 0)
         }
     }

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1335,15 +1335,15 @@ fn offer_native_drag(
             data: data.clone(),
             allowed: drag_area.allowed_actions(),
             drag_image: drag_area.drag_image(),
-            drag_image_offset: crate::api::LogicalPosition::new(
-                drag_area.drag_image_offset_x() as f32,
-                drag_area.drag_image_offset_y() as f32,
+            drag_image_offset: euclid::vec2(
+                drag_area.drag_image_offset_x(),
+                drag_area.drag_image_offset_y(),
             ),
         };
         if window_adapter.internal(crate::InternalToken).is_some_and(|i| i.start_drag(&request)) {
             // The backend took over (and defers the actual drag). Stash it so it can report
             // completion or fall back, and so a drop back onto this window restores the data.
-            let drag = crate::window::PendingDrag { request, source, seed_position };
+            let drag = crate::window::NativePendingDrag { request, source, seed_position };
             crate::window::WindowInner::from_pub(window_adapter.window())
                 .set_native_drag(Some(drag));
             drag_area.dragging.set(true);

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -262,6 +262,13 @@ impl DragArea {
         };
         (event, allowed)
     }
+
+    /// Clear the `dragging` flag and fire the `drag-finished` callback with the final negotiated
+    /// action. Shared by the in-window drag path and the native backends.
+    pub(crate) fn finish_drag(self: Pin<&Self>, action: DragAction) {
+        self.dragging.set(false);
+        Self::FIELD_OFFSETS.drag_finished().apply_pin(self).call(&(action,));
+    }
 }
 
 #[repr(C)]
@@ -407,7 +414,7 @@ impl ItemConsts for DropArea {
 /// Compute the action proposed by the user's current modifier state, clamped to the source's
 /// allowed actions. Ctrl alone → copy, Shift alone → move, Ctrl+Shift → link, no modifier →
 /// the first allowed of move/copy/link.
-pub(crate) fn compute_proposed_action(
+pub fn compute_proposed_action(
     modifiers: KeyboardModifiers,
     allowed_actions: AllowedDragActions,
 ) -> DragAction {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -180,7 +180,7 @@ pub struct DragRequest {
     pub(crate) data: crate::data_transfer::DataTransfer,
     pub(crate) allowed: crate::items::AllowedDragActions,
     pub(crate) drag_image: crate::graphics::Image,
-    pub(crate) drag_image_offset: LogicalPosition,
+    pub(crate) drag_image_offset: euclid::default::Vector2D<i32>,
 }
 
 impl DragRequest {
@@ -189,15 +189,15 @@ impl DragRequest {
         &self.data
     }
     /// The set of actions the drag source permits.
-    pub fn allowed(&self) -> crate::items::AllowedDragActions {
+    pub fn allowed_actions(&self) -> crate::items::AllowedDragActions {
         self.allowed
     }
     /// The image to show under the cursor while dragging.
     pub fn drag_image(&self) -> &crate::graphics::Image {
         &self.drag_image
     }
-    /// The offset of the drag image relative to the cursor.
-    pub fn drag_image_offset(&self) -> LogicalPosition {
+    /// The offset of the drag image relative to the cursor, in pixels.
+    pub fn drag_image_offset(&self) -> euclid::default::Vector2D<i32> {
         self.drag_image_offset
     }
 }
@@ -206,7 +206,7 @@ impl DragRequest {
 /// The backend sees only the [`DragRequest`]; the source and seed position stay here to report
 /// completion and to arm the in-window fallback.
 #[derive(Clone)]
-pub(crate) struct PendingDrag {
+pub(crate) struct NativePendingDrag {
     pub(crate) request: DragRequest,
     /// The `DragArea` that initiated the drag.
     pub(crate) source: ItemWeak,
@@ -599,7 +599,7 @@ pub struct WindowInner {
     /// It holds the source and seed position to report completion and to arm the in-window
     /// fallback, and lets a drop back onto this same window restore the source's `DataTransfer`:
     /// the OS round-trip can't carry in-app `user_data`.
-    native_drag: RefCell<Option<PendingDrag>>,
+    native_drag: RefCell<Option<NativePendingDrag>>,
 }
 
 impl Drop for WindowInner {
@@ -1048,7 +1048,7 @@ impl WindowInner {
 
     /// Remember (or clear) the in-flight native drag, so a backend can report completion or fall
     /// back, and a drop back onto this window can restore the data. Set by `offer_native_drag`.
-    pub(crate) fn set_native_drag(&self, drag: Option<PendingDrag>) {
+    pub(crate) fn set_native_drag(&self, drag: Option<NativePendingDrag>) {
         *self.native_drag.borrow_mut() = drag;
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -169,6 +169,51 @@ pub trait WindowAdapter {
     }
 }
 
+/// What a `DragArea` offers to start a native (OS-level) drag, passed to
+/// [`WindowAdapterInternal::start_drag`].
+///
+/// A read-only view: the backend reads the payload, allowed actions, and drag image; the source
+/// item and other routing data stay in the core.
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct DragRequest {
+    pub(crate) data: crate::data_transfer::DataTransfer,
+    pub(crate) allowed: crate::items::AllowedDragActions,
+    pub(crate) drag_image: crate::graphics::Image,
+    pub(crate) drag_image_offset: LogicalPosition,
+}
+
+impl DragRequest {
+    /// The data being transferred.
+    pub fn data(&self) -> &crate::data_transfer::DataTransfer {
+        &self.data
+    }
+    /// The set of actions the drag source permits.
+    pub fn allowed(&self) -> crate::items::AllowedDragActions {
+        self.allowed
+    }
+    /// The image to show under the cursor while dragging.
+    pub fn drag_image(&self) -> &crate::graphics::Image {
+        &self.drag_image
+    }
+    /// The offset of the drag image relative to the cursor.
+    pub fn drag_image_offset(&self) -> LogicalPosition {
+        self.drag_image_offset
+    }
+}
+
+/// A drag a `DragArea` started, tracked by the core while in flight.
+/// The backend sees only the [`DragRequest`]; the source and seed position stay here to report
+/// completion and to arm the in-window fallback.
+#[derive(Clone)]
+pub(crate) struct PendingDrag {
+    pub(crate) request: DragRequest,
+    /// The `DragArea` that initiated the drag.
+    pub(crate) source: ItemWeak,
+    /// The pointer position that crossed the drag threshold, used to seed the in-window drag.
+    pub(crate) seed_position: LogicalPosition,
+}
+
 /// Implementation details behind [`WindowAdapter`], but since this
 /// trait is not exported in the public API, it is not possible for the
 /// users to call or re-implement these functions.
@@ -262,6 +307,19 @@ pub trait WindowAdapterInternal: core::any::Any {
     /// This is necessary to avoid overlapping system UI such as notches or system bars.
     fn safe_area_inset(&self) -> crate::lengths::PhysicalEdges {
         Default::default()
+    }
+
+    /// Start a native (OS-level) drag-and-drop operation.
+    ///
+    /// Returns `true` if the backend took the drag over (it may defer the actual start).
+    /// Returns `false` (the default) when native drag is unsupported; the caller then arms the
+    /// in-window drag.
+    ///
+    /// On completion the backend calls [`WindowInner::report_drag_finished`]
+    /// (`DragAction::None` if cancelled), or [`WindowInner::start_in_window_drag`] if a native
+    /// start fails after returning `true`.
+    fn start_drag(&self, _request: &DragRequest) -> bool {
+        false
     }
 }
 
@@ -537,6 +595,11 @@ pub struct WindowInner {
     close_requested: Callback<(), CloseRequestResponse>,
     click_state: ClickState,
     ctx: core::cell::OnceCell<crate::SlintContext>,
+    /// The native drag we started, if one is in flight.
+    /// It holds the source and seed position to report completion and to arm the in-window
+    /// fallback, and lets a drop back onto this same window restore the source's `DataTransfer`:
+    /// the OS round-trip can't carry in-app `user_data`.
+    native_drag: RefCell<Option<PendingDrag>>,
 }
 
 impl Drop for WindowInner {
@@ -599,6 +662,7 @@ impl WindowInner {
             prevent_focus_change: Default::default(),
             ctx: Default::default(),
             menubar: Default::default(),
+            native_drag: Default::default(),
         }
     }
 
@@ -766,6 +830,15 @@ impl WindowInner {
                     }
                 }
                 _ => {}
+            }
+        } else if let MouseEvent::DragMove { event, .. } | MouseEvent::Drop { event, .. } =
+            &mut event
+        {
+            // An incoming native drag while our own is in flight: the same operation looping
+            // back onto the source window. Restore the full source data so a same-window drop
+            // sees the `user_data` the OS round-trip dropped.
+            if let Some(pending) = self.native_drag.borrow().as_ref() {
+                event.data = pending.request.data.clone();
             }
         }
 
@@ -938,6 +1011,11 @@ impl WindowInner {
             window_adapter.request_redraw();
         }
 
+        if pending_drag_finished.is_some() {
+            // A drag ended in-window (including after a native start fell back), so drop the
+            // stash.
+            self.native_drag.borrow_mut().take();
+        }
         if let Some((source_weak, target_weak)) = pending_drag_finished
             && let Some(source) = source_weak.upgrade()
             && let Some(drag_area) = source.downcast::<crate::items::DragArea>()
@@ -951,12 +1029,7 @@ impl WindowInner {
                 .as_ref()
                 .map(|d| d.as_pin_ref().current_action())
                 .unwrap_or(crate::items::DragAction::None);
-            let drag_area = drag_area.as_pin_ref();
-            drag_area.dragging.set(false);
-            crate::items::DragArea::FIELD_OFFSETS
-                .drag_finished()
-                .apply_pin(drag_area)
-                .call(&(action,));
+            drag_area.as_pin_ref().finish_drag(action);
             // The drag is over: reset the target's `current_action` so it matches
             // `has_drag` and the docstring ("none when no drag is hovering").
             if let Some(target) = target {
@@ -971,6 +1044,49 @@ impl WindowInner {
         self.ensure_tree_instantiated();
 
         Some(MouseDispatchResult { drag_action, accepted })
+    }
+
+    /// Remember (or clear) the in-flight native drag, so a backend can report completion or fall
+    /// back, and a drop back onto this window can restore the data. Set by `offer_native_drag`.
+    pub(crate) fn set_native_drag(&self, drag: Option<PendingDrag>) {
+        *self.native_drag.borrow_mut() = drag;
+    }
+
+    /// Report that the in-flight native drag finished with `action`.
+    ///
+    /// Backends call this when the OS drag completes (`DragAction::None` if cancelled); the
+    /// source `DragArea` clears `dragging` and fires `drag-finished`.
+    pub fn report_drag_finished(&self, action: crate::items::DragAction) {
+        let Some(pending) = self.native_drag.borrow_mut().take() else {
+            return;
+        };
+        if let Some(drag_area) =
+            pending.source.upgrade().and_then(|i| i.downcast::<crate::items::DragArea>())
+        {
+            drag_area.as_pin_ref().finish_drag(action);
+        }
+    }
+
+    /// Fall back to the in-window drag for the in-flight native drag.
+    ///
+    /// Backends call this when a native start fails after taking the drag over; subsequent mouse
+    /// moves then drive `DragMove`/`Drop` and the drag-image overlay, in-process.
+    pub fn start_in_window_drag(&self) {
+        let (source, seed_position) = {
+            let native_drag = self.native_drag.borrow();
+            let Some(drag) = native_drag.as_ref() else {
+                return;
+            };
+            (drag.source.clone(), drag.seed_position)
+        };
+        let Some(drag_area) = source.upgrade().and_then(|i| i.downcast::<crate::items::DragArea>())
+        else {
+            return;
+        };
+        let mut state = self.mouse_input_state.take();
+        state.arm_in_window_drag(drag_area.as_pin_ref(), source, seed_position);
+        self.mouse_input_state.set(state);
+        self.window_adapter().request_redraw();
     }
 
     /// Receive a raw touch event from a backend and either forward it as a mouse


### PR DESCRIPTION
Let a DragArea start an OS-level drag so data can be dropped onto other applications.

Add WindowAdapterInternal::start_drag, which a backend implements to take over a drag natively, receiving a read-only DragRequest (data, allowed actions, drag image). When no backend supports it, or a native start fails, the existing in-window drag-and-drop is used as a fallback. The core tracks the in-flight drag, so a backend reports completion or falls back with no arguments.

Implement it in the Qt backend via QDrag, run from a queued event so its nested event loop doesn't re-enter the input handler. The winit backend is done separately.
