### PR TITLE
Improve local Sparkle update test

### DIFF
--- a/docs/development/macos-visual-editor-dmg.md
+++ b/docs/development/macos-visual-editor-dmg.md
@@ -202,8 +202,16 @@ SlintVisualEditor-<version>-<build>-macos-arm64.zip
 
 ## Local Sparkle update test
 
-To test the update path without production keys or Cloudflare, use two local
-`.app` bundles:
+To test the update path without production keys or Cloudflare, let the helper
+build a local Visual Editor app:
+
+```sh
+./scripts/local_sparkle_update_test.sh --build-editor
+```
+
+This uses Cargo for the app binary and Xcode's `actool` for the app icon.
+
+To test existing artifacts instead, pass two local `.app` bundles:
 
 ```sh
 ./scripts/local_sparkle_update_test.sh \
@@ -211,10 +219,9 @@ To test the update path without production keys or Cloudflare, use two local
     --new-app "/path/to/new/Slint Visual Editor.app"
 ```
 
-The script copies both apps to `/private/tmp`, generates or reuses a local
-Sparkle keychain account, patches only the temp copies, serves a local
-`appcast.xml`, launches the old app with `open`, and checks whether Sparkle
-replaced it with the newer build.
+The script generates or reuses a local Sparkle keychain account, patches only
+the temp copies, serves a local `appcast.xml`, launches the old app with
+`open -n`, and checks whether Sparkle replaced it with the newer build.
 
 The Rust build report artifact is `slint-visual-editor-rust-build-report`.
 Cargo documents that `--timings` writes `cargo-timing.html` and timestamped reports to

--- a/scripts/local_sparkle_update_test.sh
+++ b/scripts/local_sparkle_update_test.sh
@@ -10,6 +10,10 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 APP_NAME="Slint Visual Editor"
 ACCOUNT="slint-visual-editor-local-test"
+BUNDLE_IDENTIFIER="dev.slint.visual-editor.sparkle-test"
+ICON_SOURCE="$ROOT_DIR/tools/lsp/packaging/macos/AppIcon.icon"
+RUST_TARGET="aarch64-apple-darwin"
+CARGO_FEATURES="backend-winit,renderer-skia"
 HOST="127.0.0.1"
 PORT="8765"
 WORK_DIR="/private/tmp/slint-sparkle-local-test"
@@ -18,30 +22,37 @@ NEW_BUILD="101"
 VERSION=""
 OLD_APP=""
 NEW_APP=""
+BUILD_EDITOR=0
 SERVER_PID=""
 
 usage() {
     cat <<EOF
 Usage:
+  $0 --build-editor
   $0 --old-app "/path/to/old/Slint Visual Editor.app" --new-app "/path/to/new/Slint Visual Editor.app"
 
 Options:
-  --version VERSION       Marketing version for both temp apps. Defaults to tools/lsp/Cargo.toml.
+  --build-editor         Build a local Visual Editor app first.
+  --version VERSION       App version. Defaults to tools/lsp/Cargo.toml.
   --old-build BUILD      CFBundleVersion for the installed old app. Default: $OLD_BUILD
   --new-build BUILD      CFBundleVersion for the update app. Default: $NEW_BUILD
   --account ACCOUNT      Sparkle keychain account. Default: $ACCOUNT
+  --bundle-id ID         Bundle id for temp app copies. Default: $BUNDLE_IDENTIFIER
   --port PORT            Local HTTP port. Default: $PORT
   --work-dir DIR         Temp working directory. Default: $WORK_DIR
   -h, --help             Show this help.
 
-The script patches only temporary app copies, signs them ad-hoc, serves a local
-appcast, launches the old app via LaunchServices, and waits while you click
-through Sparkle's UI.
+Creates a local appcast, launches the old app copy, and waits while you trigger
+the update in the Visual Editor.
 EOF
 }
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        --build-editor)
+            BUILD_EDITOR=1
+            shift
+            ;;
         --old-app)
             OLD_APP="${2:-}"
             shift 2
@@ -66,6 +77,10 @@ while [ "$#" -gt 0 ]; do
             ACCOUNT="${2:-}"
             shift 2
             ;;
+        --bundle-id)
+            BUNDLE_IDENTIFIER="${2:-}"
+            shift 2
+            ;;
         --port)
             PORT="${2:-}"
             shift 2
@@ -85,22 +100,26 @@ while [ "$#" -gt 0 ]; do
 done
 
 [ "$(uname -s)" = "Darwin" ] || die "this script requires macOS"
-[ -n "$OLD_APP" ] || die "--old-app is required"
-[ -n "$NEW_APP" ] || die "--new-app is required"
-[ -d "$OLD_APP" ] || die "old app not found: $OLD_APP"
-[ -d "$NEW_APP" ] || die "new app not found: $NEW_APP"
 [ -n "$WORK_DIR" ] || die "--work-dir must not be empty"
+[ -n "$BUNDLE_IDENTIFIER" ] || die "--bundle-id must not be empty"
 case "$WORK_DIR" in
     /tmp/* | /private/tmp/*) ;;
     *) die "--work-dir must be under /tmp or /private/tmp" ;;
 esac
 
-for tool in codesign ditto plutil python3; do
+if [ "$BUILD_EDITOR" -eq 1 ]; then
+    [ -z "$OLD_APP" ] || die "--build-editor cannot be combined with --old-app"
+    [ -z "$NEW_APP" ] || die "--build-editor cannot be combined with --new-app"
+else
+    [ -n "$OLD_APP" ] || die "--old-app is required unless --build-editor is used"
+    [ -n "$NEW_APP" ] || die "--new-app is required unless --build-editor is used"
+    [ -d "$OLD_APP" ] || die "old app not found: $OLD_APP"
+    [ -d "$NEW_APP" ] || die "new app not found: $NEW_APP"
+fi
+
+for tool in codesign ditto open plutil python3; do
     command -v "$tool" >/dev/null || die "$tool is required"
 done
-
-OLD_APP="$(abs_path "$OLD_APP")"
-NEW_APP="$(abs_path "$NEW_APP")"
 
 if [ -z "$VERSION" ]; then
     command -v cargo >/dev/null || die "cargo is required to determine the Visual Editor version"
@@ -126,6 +145,110 @@ ensure_sparkle_tools() {
     fi
 }
 
+build_editor_app() {
+    [ "$(uname -m)" = "arm64" ] || die "--build-editor currently builds and runs the arm64 macOS app"
+
+    command -v cargo >/dev/null || die "cargo is required for --build-editor"
+    command -v xcrun >/dev/null || die "xcrun is required for --build-editor"
+    if command -v rustup >/dev/null &&
+        ! rustup target list --installed | grep -qx "$RUST_TARGET"; then
+        die "Rust target $RUST_TARGET is required; run: rustup target add $RUST_TARGET"
+    fi
+
+    local build_dir="$WORK_DIR/build"
+    local app="$build_dir/$APP_NAME.app"
+    local executable="$ROOT_DIR/target/$RUST_TARGET/release/slint-visual-editor"
+    local plist="$app/Contents/Info.plist"
+
+    log "Building local Visual Editor binary for $RUST_TARGET"
+    env \
+        SPARKLE_FRAMEWORK_DIR="$ROOT_DIR" \
+        RUSTFLAGS="-Clink-args=-Wl,-rpath,@loader_path/../Frameworks" \
+        cargo build \
+            --release \
+            --target "$RUST_TARGET" \
+            --bin slint-visual-editor \
+            --no-default-features \
+            --features "$CARGO_FEATURES"
+
+    [ -x "$executable" ] || die "built executable missing: $executable"
+
+    log "Assembling temporary app bundle at $app"
+    rm -rf "$app"
+    mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+    cp "$executable" "$app/Contents/MacOS/$APP_NAME"
+    chmod +x "$app/Contents/MacOS/$APP_NAME"
+    compile_app_icon "$app"
+
+    cat > "$plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleExecutable</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
+  <key>CFBundleIconName</key>
+  <string>AppIcon</string>
+  <key>CFBundleIdentifier</key>
+  <string>$BUNDLE_IDENTIFIER</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$VERSION</string>
+  <key>CFBundleVersion</key>
+  <string>$OLD_BUILD</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>SUFeedURL</key>
+  <string>https://visual-editor.slint.dev/appcast.xml</string>
+  <key>SUPublicEDKey</key>
+  <string>$PUBLIC_KEY</string>
+</dict>
+</plist>
+EOF
+
+    BUILT_EDITOR_APP="$app"
+}
+
+compile_app_icon() {
+    local app="$1"
+    local icon_dir="$WORK_DIR/icon"
+    local out_dir="$icon_dir/out"
+    local partial_dir="$icon_dir/partial"
+
+    [ -d "$ICON_SOURCE" ] || die "app icon source missing: $ICON_SOURCE"
+
+    log "Compiling app icon"
+    rm -rf "$icon_dir"
+    mkdir -p "$out_dir" "$partial_dir"
+    xcrun actool \
+        --compile "$out_dir" \
+        --platform macosx \
+        --minimum-deployment-target 12.0 \
+        --app-icon AppIcon \
+        --output-partial-info-plist "$partial_dir/Info.plist" \
+        "$ICON_SOURCE" >/dev/null
+
+    [ -f "$out_dir/AppIcon.icns" ] || die "actool did not produce AppIcon.icns"
+    [ -f "$out_dir/Assets.car" ] || die "actool did not produce Assets.car"
+    ditto "$out_dir/AppIcon.icns" "$app/Contents/Resources/AppIcon.icns"
+    ditto "$out_dir/Assets.car" "$app/Contents/Resources/Assets.car"
+}
+
 sparkle_public_key() {
     "$ROOT_DIR/sparkle-bin/generate_keys" --account "$ACCOUNT" >/dev/null
 
@@ -148,11 +271,13 @@ patch_app() {
     mkdir -p "$app/Contents/Frameworks"
     ditto "$ROOT_DIR/Sparkle.framework" "$app/Contents/Frameworks/Sparkle.framework"
 
+    plutil -replace CFBundleIdentifier -string "$BUNDLE_IDENTIFIER" "$plist"
     plutil -replace CFBundleShortVersionString -string "$version" "$plist"
     plutil -replace CFBundleVersion -string "$build" "$plist"
     plutil -replace SUFeedURL -string "$feed_url" "$plist"
     plutil -replace SUPublicEDKey -string "$public_key" "$plist"
 
+    xattr -dr com.apple.quarantine "$app" >/dev/null 2>&1 || true
     codesign --force --deep --sign - "$app"
 }
 
@@ -199,6 +324,15 @@ ensure_sparkle_tools
 
 PUBLIC_KEY="$(sparkle_public_key)"
 [ -n "$PUBLIC_KEY" ] || die "could not read Sparkle public key for account $ACCOUNT"
+
+if [ "$BUILD_EDITOR" -eq 1 ]; then
+    build_editor_app
+    OLD_APP="$BUILT_EDITOR_APP"
+    NEW_APP="$BUILT_EDITOR_APP"
+fi
+
+OLD_APP="$(abs_path "$OLD_APP")"
+NEW_APP="$(abs_path "$NEW_APP")"
 
 OLD_STAGE="$WORK_DIR/old/$APP_NAME.app"
 NEW_STAGE="$WORK_DIR/new/$APP_NAME.app"
@@ -251,17 +385,15 @@ Local Sparkle feed is ready:
 Installed old app copy:
   $INSTALL_APP
 
-Launching with LaunchServices now. This is the path closest to double-clicking
-the app in Finder:
+Launching:
 
-  open "$INSTALL_APP"
+  open -n "$INSTALL_APP"
 
-When Sparkle appears, click Install and Relaunch.
-Press Return here after the app relaunches, or after you decide the update UI
-did not appear.
+In the Visual Editor, click Update once to download and again to install.
+Press Return here after the app relaunches.
 EOF
 
-open "$INSTALL_APP"
+open -n "$INSTALL_APP"
 read -r _
 
 INSTALLED_VERSION="$(plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist")"


### PR DESCRIPTION
Tidy up the test script to ensure it builds a copy of the app and uses the app icon