### PR TITLE
Fix Miri UB in slint_change_tracker_init (Tree Borrows)

### DIFF
--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -520,13 +520,13 @@ pub unsafe extern "C" fn slint_change_tracker_drop(ct: *mut ChangeTrackerOpaque)
 /// initialize the change tracker
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_change_tracker_init(
-    ct: &ChangeTrackerOpaque,
+    ct: *const ChangeTrackerOpaque,
     user_data: *mut c_void,
     drop_user_data: extern "C" fn(user_data: *mut c_void),
     eval_fn: extern "C" fn(user_data: *mut c_void) -> bool,
     notify_fn: extern "C" fn(user_data: *mut c_void),
 ) {
-    let ct = unsafe { &*(ct as *const ChangeTrackerOpaque as *const ChangeTracker) };
+    let ct = unsafe { &*ct.cast::<ChangeTracker>() };
     #[allow(non_camel_case_types)]
     struct C_ChangeTrackerInner {
         user_data: *mut c_void,
@@ -632,7 +632,7 @@ mod ffi_change_tracker_leak_test {
         let ct = ChangeTracker::default();
         unsafe {
             slint_change_tracker_init(
-                &*(&ct as *const ChangeTracker as *const ChangeTrackerOpaque),
+                &ct as *const ChangeTracker as *const ChangeTrackerOpaque,
                 &state as *const EvalState as *mut c_void,
                 drop_fn,
                 eval_fn,


### PR DESCRIPTION
Take the change tracker by raw pointer instead of `&ChangeTrackerOpaque`.

`ChangeTracker` holds a `Cell`, so a `&ChangeTracker` allows the interior write through `inner`. `ChangeTrackerOpaque` has no `UnsafeCell`, so a shared reference to it freezes the memory; on function entry that argument is retagged Frozen and the later write is undefined behavior (caught by Miri Tree Borrows). Deriving `&ChangeTracker` straight from a raw pointer avoids the frozen retag. The C++ ABI is unchanged.

Introduced in a3fe7c2e15 (TextInput: Inline the internal data instead of boxing it, #8479).
