### PR TITLE
Additional cherry-picks for 1.17.1

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <span>
 #include <concepts>
+#include <limits>
 
 #ifndef SLINT_FEATURE_FREESTANDING
 #    include <mutex>
@@ -33,6 +34,18 @@
 namespace slint {
 
 namespace private_api {
+
+/// Saturating float-to-int cast matching Rust's `as i32` (NaN maps to 0).
+inline int saturating_float_to_int(double value)
+{
+    if (value != value) // NaN
+        return 0;
+    if (value >= std::numeric_limits<int>::max())
+        return std::numeric_limits<int>::max();
+    if (value <= std::numeric_limits<int>::min())
+        return std::numeric_limits<int>::min();
+    return static_cast<int>(value);
+}
 
 /// Convert a slint `{height: length, width: length, x: length, y: length}` to a Rect
 inline cbindgen_private::Rect convert_anonymous_rect(std::tuple<float, float, float, float> tuple)

--- a/api/rs/slint/tests/spawn_local.rs
+++ b/api/rs/slint/tests/spawn_local.rs
@@ -103,3 +103,92 @@ fn with_context() {
     });
     ctx.run_event_loop().unwrap()
 }
+
+/// A minimal backend whose event loop proxy fails once the loop has terminated, like
+/// winit does. Used to check that waking a still-pending future during teardown doesn't panic.
+mod terminating_backend {
+    use std::collections::VecDeque;
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use slint::platform::{EventLoopProxy, Platform, PlatformError, WindowAdapter};
+
+    enum Event {
+        Quit,
+        Invoke(Box<dyn FnOnce() + Send>),
+    }
+
+    #[derive(Clone, Default)]
+    pub struct Backend {
+        queue: Arc<Mutex<VecDeque<Event>>>,
+        terminated: Arc<AtomicBool>,
+    }
+
+    impl EventLoopProxy for Backend {
+        fn quit_event_loop(&self) -> Result<(), slint::EventLoopError> {
+            self.queue.lock().unwrap().push_back(Event::Quit);
+            Ok(())
+        }
+
+        fn invoke_from_event_loop(
+            &self,
+            event: Box<dyn FnOnce() + Send>,
+        ) -> Result<(), slint::EventLoopError> {
+            if self.terminated.load(Ordering::Relaxed) {
+                return Err(slint::EventLoopError::EventLoopTerminated);
+            }
+            self.queue.lock().unwrap().push_back(Event::Invoke(event));
+            Ok(())
+        }
+    }
+
+    impl Platform for Backend {
+        fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+            Err(PlatformError::Unsupported)
+        }
+
+        fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
+            Some(Box::new(self.clone()))
+        }
+
+        fn run_event_loop(&self) -> Result<(), PlatformError> {
+            // The test enqueues everything before running, so an empty queue means we're done.
+            while let Some(event) = self.queue.lock().unwrap().pop_front() {
+                match event {
+                    Event::Quit => break,
+                    Event::Invoke(event) => event(),
+                }
+            }
+            self.terminated.store(true, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn wake_after_event_loop_terminated() {
+    use i_slint_core::SlintContext;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Poll, Waker};
+
+    let ctx = SlintContext::new(Box::new(terminating_backend::Backend::default()));
+
+    // The future stays pending and hands its waker out so we can fire it after the loop quits.
+    let waker: Arc<Mutex<Option<Waker>>> = Arc::default();
+    let waker_clone = waker.clone();
+    let _handle = ctx
+        .spawn_local(std::future::poll_fn(move |cx| -> Poll<()> {
+            *waker_clone.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }))
+        .unwrap();
+
+    // Run the loop once so the future is polled (storing its waker), then quit.
+    ctx.event_loop_proxy().unwrap().quit_event_loop().unwrap();
+    ctx.run_event_loop().unwrap();
+
+    // The event loop is gone. Waking the still-pending future used to panic with
+    // "No event loop despite we checked"; now the late wake is simply dropped.
+    waker.lock().unwrap().take().unwrap().wake();
+}

--- a/docs/slint-doc-generator/main.rs
+++ b/docs/slint-doc-generator/main.rs
@@ -120,8 +120,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             mdx::generate(&cfg)?;
             if !cfg.skip_screenshots {
                 let docs_folder = cfg.astro_dir.join("src/content");
+                let reference_elements = cfg.astro_dir.join("src/content/docs/reference/elements");
                 screenshots::run(screenshots::ScreenshotsArgs {
-                    include_paths: vec![],
+                    include_paths: vec![reference_elements],
                     library_paths: vec![],
                     docs_folder,
                     style: None,

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1123,9 +1123,12 @@ impl WinitWindowAdapter {
                 self.resize_window(size.into())?;
             };
 
-            // Pre-render the first frame before mapping the window to avoid
-            // a flash of uninitialized VRAM on X11 (no background_pixmap).
-            if matches!(visibility, WindowVisibility::ShownFirstTime) {
+            // Pre-render the first frame before mapping the window to avoid a flash of
+            // uninitialized VRAM on X11 (no background_pixmap). Skipped on Wayland, where
+            // rendering before the initial configure makes the compositor mis-size the window.
+            if matches!(visibility, WindowVisibility::ShownFirstTime)
+                && !self.shared_backend_data.is_wayland
+            {
                 let _ = self.draw();
             }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3828,9 +3828,14 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
     match expr {
         Expression::StringLiteral(s) => shared_string_literal(s),
         Expression::NumberLiteral(num) => {
-            if !num.is_finite() {
-                // just print something
-                "0.0".to_string()
+            if num.is_nan() {
+                "std::numeric_limits<double>::quiet_NaN()".to_string()
+            } else if num.is_infinite() {
+                if *num > 0. {
+                    "std::numeric_limits<double>::infinity()".to_string()
+                } else {
+                    "-std::numeric_limits<double>::infinity()".to_string()
+                }
             } else if num.abs() > 1_000_000_000. {
                 // If the numbers are too big, decimal notation will give too many digit
                 format!("{num:+e}")
@@ -3924,7 +3929,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             let f = compile_expression(from, ctx);
             match (from.ty(ctx), to) {
                 (Type::Float32, Type::Int32) => {
-                    format!("static_cast<int>({f})")
+                    format!("slint::private_api::saturating_float_to_int({f})")
                 }
                 (from, Type::String) if from.as_unit_product().is_some() => {
                     format!("slint::SharedString::from_number({f})")

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2966,12 +2966,13 @@ fn generate_grid_layout_input_decl(
                 }
                 llr::RowChildTemplateInfo::Repeated { repeater_index } => {
                     let inner_rep_id = format!("repeater_{}", usize::from(*repeater_index));
+                    // Let the inner cell report its own col/row/colspan/rowspan.
                     write!(
                         fill_code,
                         "this->{inner_rep_id}.track_instance_changes();\n\
-                         {inner_rep_id}.for_each([&]([[maybe_unused]] const auto &) {{\n\
+                         {inner_rep_id}.for_each([&](const auto &sub_comp) {{\n\
                              if (write_idx < result.size()) {{\n\
-                                 result[write_idx] = slint::cbindgen_private::GridLayoutInputData {{ (write_idx == 0) && new_row, {auto_val:.1}f, {auto_val:.1}f, 1.0f, 1.0f }};\n\
+                                 sub_comp->grid_layout_input_for_repeated((write_idx == 0) && new_row, result.subspan(write_idx, 1));\n\
                              }}\n\
                              ++write_idx;\n\
                          }});\n"

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2410,10 +2410,10 @@ fn generate_repeated_component(
                             let inner_len = _self.as_ref().#inner_rep_id.len();
                             for _i in 0..inner_len {
                                 if write_idx < result.len() {
-                                    result[write_idx] = sp::GridLayoutInputData {
-                                        new_row: write_idx == 0 && new_row,
-                                        ..Default::default()
-                                    };
+                                    // Let the inner cell report its own col/row/colspan/rowspan.
+                                    if let Some(inner) = _self.as_ref().#inner_rep_id.instance_at(_i) {
+                                        inner.as_pin_ref().grid_layout_input_data(write_idx == 0 && new_row, core::slice::from_mut(&mut result[write_idx]));
+                                    }
                                 }
                                 write_idx += 1;
                             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3009,8 +3009,19 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                         #ignore_shift,
                         #ignore_alt))
         },
-        Expression::NumberLiteral(n) if n.is_finite() => quote!(#n),
-        Expression::NumberLiteral(_) => quote!(0.),
+        Expression::NumberLiteral(n) => {
+            if n.is_nan() {
+                quote!(f64::NAN)
+            } else if n.is_infinite() {
+                if *n > 0. {
+                    quote!(f64::INFINITY)
+                } else {
+                    quote!(f64::NEG_INFINITY)
+                }
+            } else {
+                quote!(#n)
+            }
+        }
         Expression::BoolLiteral(b) => quote!(#b),
         Expression::Cast { from, to } => {
             let f = compile_expression(from, ctx);

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1390,7 +1390,9 @@ fn is_height_for_width_cell(elem: &ElementRc) -> bool {
 /// `layout_info_v_with_constraint` also has `layout_info_prop` set (the
 /// constrained function is synthesized from the existing `layoutinfo-v`
 /// binding), so the `layout_info_prop` branch covers it.
-fn default_cross_axis_constraint(elem: &ElementRc) -> Option<crate::expression_tree::Expression> {
+pub(crate) fn default_cross_axis_constraint(
+    elem: &ElementRc,
+) -> Option<crate::expression_tree::Expression> {
     let elem_b = elem.borrow();
 
     // Route through `layoutinfo-h-with-constraint` when available so we

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -615,12 +615,23 @@ fn lower_sub_component(
         None,
     )
     .into();
+    // Measure the root's height for its preferred width, not an unbounded one, so a
+    // height-for-width Image doesn't report infinite height (mirrors the interpreter).
+    let v_cross_constraint = component
+        .root_element
+        .borrow()
+        .layout_info_v_with_constraint
+        .is_some()
+        .then(|| {
+            super::lower_layout_expression::default_cross_axis_constraint(&component.root_element)
+        })
+        .flatten();
     sub_component.layout_info_v = super::lower_layout_expression::get_layout_info(
         &component.root_element,
         &mut ctx,
         &component.root_constraints.borrow(),
         crate::layout::Orientation::Vertical,
-        None,
+        v_cross_constraint,
     )
     .into();
     // For repeated elements in a FlexboxLayout, generate code to read flex properties

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1047,7 +1047,9 @@ impl GridLayout {
                     rowspan_expr: rowspan_expr.unwrap_or(RowColExpr::Literal(1)),
                     child_items: None,
                 }));
-                child.borrow_mut().grid_layout_cell = Some(child_grid_cell);
+                // Attach to the element the solver reads: the sub-component root for an inner
+                // repeater (so it reports its own colspan/rowspan), or `child` for a static child.
+                sub_item.elem.borrow_mut().grid_layout_cell = Some(child_grid_cell);
 
                 // Compute the effective inner_rep_idx for this child:
                 // - For inner repeater items: cumulative_pos + model_index

--- a/internal/compiler/widgets/cosmic/button.slint
+++ b/internal/compiler/widgets/cosmic/button.slint
@@ -62,8 +62,6 @@ export component Button {
             }
 
             if (root.text != ""): Text {
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 horizontal-alignment: center;
                 vertical-alignment: center;
                 text: root.text;

--- a/internal/compiler/widgets/cosmic/checkbox.slint
+++ b/internal/compiler/widgets/cosmic/checkbox.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { CosmicFontSettings, CosmicPalette, Icons } from "styling.slint";
+import { CosmicPalette, Icons } from "styling.slint";
 import { StateLayer } from "components.slint";
 
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> state-layer.enabled;
-    in property <length> font-size: CosmicFontSettings.body.font-size;
-    in property <int> font-weight: CosmicFontSettings.body.font-weight;
+    in property <length> font-size;
+    in property <int> font-weight;
     out property <bool> has-focus: state-layer.has-focus;
     in-out property <bool> checked;
 

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -64,8 +64,6 @@ export component ComboBox {
                 horizontal-stretch: 1;
                 horizontal-alignment: left;
                 vertical-alignment: center;
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 color: CosmicPalette.control-foreground;
                 text: root.current-value;
                 overflow: elide;

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -134,8 +134,6 @@ export component ListItem {
                 text := Text {
                     text: root.item.text;
                     color: CosmicPalette.control-foreground;
-                    font-size: CosmicFontSettings.body.font-size;
-                    font-weight: CosmicFontSettings.body.font-weight;
                     vertical-alignment: center;
                     horizontal-alignment: left;
                     overflow: elide;

--- a/internal/compiler/widgets/cosmic/datepicker.slint
+++ b/internal/compiler/widgets/cosmic/datepicker.slint
@@ -62,8 +62,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: CosmicPalette.foreground,
                   },
                   title-style: {
-                      font-size: CosmicFontSettings.body.font-size,
-                      font-weight: CosmicFontSettings.body.font-weight,
                       foreground: CosmicPalette.foreground,
                   },
                   previous-icon: Icons.arrow-back,
@@ -75,8 +73,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: CosmicPalette.foreground,
                       state-brush: CosmicPalette.state,
                       icon-size: 8px,
-                      font-size: CosmicFontSettings.body.font-size,
-                      font-weight: CosmicFontSettings.body.font-weight
                   }
             };
         }

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -38,8 +38,6 @@ export component LineEdit uses { LineEditInterface from base } {
             padding-right: 16px;
 
             base := LineEditBase {
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 selection-background-color: CosmicPalette.selection-background;
                 selection-foreground-color: CosmicPalette.accent-foreground;
                 text-color: CosmicPalette.foreground;

--- a/internal/compiler/widgets/cosmic/menu.slint
+++ b/internal/compiler/widgets/cosmic/menu.slint
@@ -22,8 +22,6 @@ export component MenuBarItem {
         pressed-foreground: CosmicPalette.accent-background;
         hover-background: CosmicPalette.state-hover;
         pressed-background: CosmicPalette.state-pressed;
-        font-size: CosmicFontSettings.body.font-size;
-        font-weight: CosmicFontSettings.body.font-weight;
         border-radius: 12px;
     }
 }
@@ -62,8 +60,6 @@ export component MenuItem {
             current-foreground: CosmicPalette.foreground;
             current-background: CosmicPalette.state-hover;
             separator-color: CosmicPalette.border;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             horizontal-padding: 16px;
             spacing: 8px;
             sub-menu-icon: @image-url("_arrow_forward.svg");

--- a/internal/compiler/widgets/cosmic/radiogroup.slint
+++ b/internal/compiler/widgets/cosmic/radiogroup.slint
@@ -51,8 +51,6 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: root.text-color;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cosmic/spinbox.slint
+++ b/internal/compiler/widgets/cosmic/spinbox.slint
@@ -22,8 +22,6 @@ export component SpinBoxButton {
         animate background, border-color { duration: 150ms; }
 
         text := Text {
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             horizontal-alignment: center;
             vertical-alignment: center;
             text: root.text;
@@ -92,8 +90,6 @@ export component SpinBox {
             base := SpinBoxBase {
                 width: 100%;
                 color: CosmicPalette.control-foreground;
-                font-size: CosmicFontSettings.body.font-size;
-                font-weight: CosmicFontSettings.body.font-weight;
                 selection-background-color: CosmicPalette.selection-background;
                 selection-foreground-color: CosmicPalette.accent-foreground;
                 horizontal-alignment: center;

--- a/internal/compiler/widgets/cosmic/styling.slint
+++ b/internal/compiler/widgets/cosmic/styling.slint
@@ -9,9 +9,8 @@ export struct TextStyle {
 }
 
 export global CosmicFontSettings {
-    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: FontWeight.normal };
-    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
-    out property <TextStyle> title: { font-size: 24 * 0.0769rem, font-weight: FontWeight.light };
+    out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> title: { font-size: 24pt * 1rem / 14pt, font-weight: FontWeight.light };
 }
 
 export global CosmicPalette {

--- a/internal/compiler/widgets/cosmic/switch.slint
+++ b/internal/compiler/widgets/cosmic/switch.slint
@@ -100,8 +100,6 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: CosmicFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cosmic/tableview.slint
+++ b/internal/compiler/widgets/cosmic/tableview.slint
@@ -220,8 +220,6 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: CosmicFontSettings.body.font-weight;
-                        font-size: CosmicFontSettings.body.font-size;
                         color: CosmicPalette.foreground;
                         overflow: elide;
                     }
@@ -261,8 +259,6 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: CosmicFontSettings.body.font-weight;
-                            font-size: CosmicFontSettings.body.font-size;
                             color: mod(idx, 2) == 0 ? CosmicPalette.control-foreground : CosmicPalette.foreground;
 
                             states [

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -130,8 +130,7 @@ export component TabImpl inherits Rectangle {
         text := Text {
             vertical-alignment: center;
             horizontal-alignment: center;
-            font-size: CosmicFontSettings.body.font-size;
-            font-weight: root.is-current ? CosmicFontSettings.body-strong.font-weight : CosmicFontSettings.body.font-weight;
+            font-weight: root.is-current ? CosmicFontSettings.body-strong.font-weight : FontWeight.normal;
             color: root.is-current ? CosmicPalette.accent-background : CosmicPalette.control-foreground;
             accessible-role: none;
         }

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -76,8 +76,6 @@ export component TextEdit {
         border-color: CosmicPalette.control-divider;
         scroll-view-padding: 12px;
         foreground: CosmicPalette.foreground;
-        font-size: CosmicFontSettings.body.font-size;
-        font-weight: CosmicFontSettings.body.font-weight;
         selection-background-color: CosmicPalette.selection-background;
         selection-foreground-color: CosmicPalette.selection-foreground;
         placeholder-color: CosmicPalette.placeholder-foreground;

--- a/internal/compiler/widgets/cosmic/time-picker.slint
+++ b/internal/compiler/widgets/cosmic/time-picker.slint
@@ -54,7 +54,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: CosmicPalette.foreground,
                     foreground-selected: CosmicPalette.accent-foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {
@@ -70,8 +70,6 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: CosmicFontSettings.body.font-size,
-                    font-weight: CosmicFontSettings.body.font-weight,
                     foreground: CosmicPalette.foreground,
                 },
             };

--- a/internal/compiler/widgets/cupertino/button.slint
+++ b/internal/compiler/widgets/cupertino/button.slint
@@ -127,8 +127,6 @@ export component Button {
 
         if (root.text != "") : Text {
             opacity: root.enabled ? 1 : 0.5;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             horizontal-alignment: center;
             vertical-alignment: center;
             text: root.text;

--- a/internal/compiler/widgets/cupertino/checkbox.slint
+++ b/internal/compiler/widgets/cupertino/checkbox.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { CupertinoFontSettings, CupertinoPalette, Icons } from "styling.slint";
+import { CupertinoPalette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> i-touch-area.enabled;
-    in property <length> font-size: CupertinoFontSettings.body.font-size;
-    in property <int> font-weight: CupertinoFontSettings.body.font-weight;
+    in property <length> font-size;
+    in property <int> font-weight;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -99,8 +99,6 @@ export component ComboBox {
             horizontal-stretch: 1;
             horizontal-alignment: left;
             vertical-alignment: center;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             color: CupertinoPalette.foreground;
             text: root.current-value;
             overflow: elide;

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -100,8 +100,6 @@ export component ListItem {
                 i-text := Text {
                     text: root.item.text;
                     color: CupertinoPalette.foreground;
-                    font-size: CupertinoFontSettings.body.font-size;
-                    font-weight: CupertinoFontSettings.body.font-weight;
                     vertical-alignment: center;
                     horizontal-alignment: left;
                     overflow: elide;

--- a/internal/compiler/widgets/cupertino/datepicker.slint
+++ b/internal/compiler/widgets/cupertino/datepicker.slint
@@ -62,8 +62,6 @@ export component DatePickerPopup inherits PopupWindow {
                       font-weight: CupertinoFontSettings.title.font-weight,
                   },
                   title-style: {
-                      font-size: CupertinoFontSettings.body.font-size,
-                      font-weight: CupertinoFontSettings.body.font-weight,
                       foreground: CupertinoPalette.foreground,
                   },
                   previous-icon: Icons.arrow-back,
@@ -75,8 +73,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: CupertinoPalette.foreground,
                       state-brush: CupertinoPalette.state,
                       icon-size: 8px,
-                      font-size: CupertinoFontSettings.body.font-size,
-                      font-weight: CupertinoFontSettings.body.font-weight
                   }
             };
         }

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -55,8 +55,6 @@ export component LineEdit uses { LineEditInterface from base } {
             spacing: 3px;
 
             base := LineEditBase {
-                font-size: CupertinoFontSettings.body.font-size;
-                font-weight: CupertinoFontSettings.body.font-weight;
                 selection-background-color: CupertinoPalette.selection-background;
                 selection-foreground-color: CupertinoPalette.selection-foreground;
                 text-color: CupertinoPalette.foreground;

--- a/internal/compiler/widgets/cupertino/menu.slint
+++ b/internal/compiler/widgets/cupertino/menu.slint
@@ -61,8 +61,6 @@ export component MenuItem {
             current-foreground: CupertinoPalette.accent-foreground;
             current-background: CupertinoPalette.accent-background;
             separator-color: CupertinoPalette.border;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             border-radius: 5px;
             horizontal-padding: 8px;
             spacing: 4px;

--- a/internal/compiler/widgets/cupertino/radiogroup.slint
+++ b/internal/compiler/widgets/cupertino/radiogroup.slint
@@ -46,8 +46,6 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: CupertinoPalette.foreground;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cupertino/spinbox.slint
+++ b/internal/compiler/widgets/cupertino/spinbox.slint
@@ -141,8 +141,6 @@ export component SpinBox {
                 opacity: root.enabled ? 1 : 0.5;
                 width: 100%;
                 color: CupertinoPalette.foreground;
-                font-size: CupertinoFontSettings.body.font-size;
-                font-weight: CupertinoFontSettings.body.font-weight;
                 selection-background-color: CupertinoPalette.selection-background;
                 selection-foreground-color: self.color;
             }

--- a/internal/compiler/widgets/cupertino/styling.slint
+++ b/internal/compiler/widgets/cupertino/styling.slint
@@ -9,12 +9,10 @@ export struct TextStyle {
 }
 
 export global CupertinoFontSettings {
-    out property <TextStyle> body: { font-size: 13 * 0.0769rem, font-weight: FontWeight.normal };
-
-    out property <TextStyle> title: { font-size: 28 * 0.0769rem, font-weight: FontWeight.light };
+    out property <TextStyle> title: { font-size: 28pt * 1rem / 13pt, font-weight: FontWeight.light };
 
     // needed?
-    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 13pt, font-weight: FontWeight.semi-bold };
 }
 
 export global CupertinoColors {

--- a/internal/compiler/widgets/cupertino/switch.slint
+++ b/internal/compiler/widgets/cupertino/switch.slint
@@ -104,8 +104,6 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: CupertinoFontSettings.body.font-size;
-            font-weight: CupertinoFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cupertino/tableview.slint
+++ b/internal/compiler/widgets/cupertino/tableview.slint
@@ -217,9 +217,8 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: column.sort-order == SortOrder.unsorted ? CupertinoFontSettings.body.font-weight :
+                        font-weight: column.sort-order == SortOrder.unsorted ? FontWeight.normal :
                             CupertinoFontSettings.body-strong.font-weight;
-                        font-size: CupertinoFontSettings.body.font-size;
                         color: CupertinoPalette.foreground;
                         overflow: elide;
                     }
@@ -259,8 +258,6 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: CupertinoFontSettings.body.font-weight;
-                            font-size: CupertinoFontSettings.body.font-size;
                             color: root.current-row == idx ? CupertinoPalette.accent-foreground : CupertinoPalette.foreground ;
                         }
                     }

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -170,8 +170,6 @@ export component TextEdit {
             text-input := TextInput {
                 enabled: true;
                 color: CupertinoPalette.foreground;
-                font-size: CupertinoFontSettings.body.font-size;
-                font-weight: CupertinoFontSettings.body.font-weight;
                 selection-background-color: CupertinoPalette.selection-background;
                 selection-foreground-color: self.color;
                 single-line: false;

--- a/internal/compiler/widgets/cupertino/time-picker.slint
+++ b/internal/compiler/widgets/cupertino/time-picker.slint
@@ -53,7 +53,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: CupertinoPalette.foreground,
                     foreground-selected: CupertinoPalette.foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {
@@ -69,8 +69,6 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: CupertinoFontSettings.body.font-size,
-                    font-weight: CupertinoFontSettings.body.font-weight,
                     foreground: CupertinoPalette.foreground,
                 },
             };

--- a/internal/compiler/widgets/fluent/button.slint
+++ b/internal/compiler/widgets/fluent/button.slint
@@ -83,8 +83,6 @@ export component Button {
             }
 
             if (root.text != ""): Text {
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 horizontal-alignment: center;
                 vertical-alignment: center;
                 text: root.text;

--- a/internal/compiler/widgets/fluent/checkbox.slint
+++ b/internal/compiler/widgets/fluent/checkbox.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { FluentFontSettings, FluentPalette, Icons } from "styling.slint";
+import { FluentPalette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
     in property <string> text;
     in property <bool> enabled <=> touch-area.enabled;
-    in property <length> font-size: FluentFontSettings.body.font-size;
-    in property <int> font-weight: FluentFontSettings.body.font-weight;
+    in property <length> font-size;
+    in property <int> font-weight;
     out property <bool> has-focus: focus-scope.has-focus;
     in-out property <bool> checked;
 

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -79,8 +79,6 @@ export component ComboBox {
                 horizontal-stretch: 1;
                 horizontal-alignment: left;
                 vertical-alignment: center;
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 color: FluentPalette.control-foreground;
                 text: root.current-value;
                 overflow: elide;

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -85,8 +85,6 @@ export component ListItem {
             i-text := Text {
                 text: root.item.text;
                 color: FluentPalette.control-foreground;
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 vertical-alignment: center;
                 horizontal-alignment: left;
                 overflow: elide;

--- a/internal/compiler/widgets/fluent/datepicker.slint
+++ b/internal/compiler/widgets/fluent/datepicker.slint
@@ -62,8 +62,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: FluentPalette.foreground,
                   },
                   title-style: {
-                      font-size: FluentFontSettings.body.font-size,
-                      font-weight: FluentFontSettings.body.font-weight,
                       foreground: FluentPalette.foreground,
                   },
                   previous-icon: Icons.arrow-back,
@@ -75,8 +73,6 @@ export component DatePickerPopup inherits PopupWindow {
                       foreground: FluentPalette.foreground,
                       state-brush: FluentPalette.state,
                       icon-size: 8px,
-                      font-size: FluentFontSettings.body.font-size,
-                      font-weight: FluentFontSettings.body.font-weight
                   }
             };
         }

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -45,8 +45,6 @@ export component LineEdit uses { LineEditInterface from base } {
             padding-right: 12px;
 
             base := LineEditBase {
-                font-size: FluentFontSettings.body.font-size;
-                font-weight: FluentFontSettings.body.font-weight;
                 selection-background-color: FluentPalette.selection-background;
                 selection-foreground-color: FluentPalette.accent-foreground;
                 text-color: FluentPalette.foreground;

--- a/internal/compiler/widgets/fluent/menu.slint
+++ b/internal/compiler/widgets/fluent/menu.slint
@@ -22,8 +22,6 @@ export component MenuBarItem {
         pressed-foreground: FluentPalette.text-secondary;
         hover-background: FluentPalette.subtle-secondary;
         pressed-background: FluentPalette.control-alt-tertiary;
-        font-size: FluentFontSettings.body.font-size;
-        font-weight: FluentFontSettings.body.font-weight;
         border-radius: 3px;
     }
 }
@@ -67,8 +65,6 @@ export component MenuItem {
             current-foreground: FluentPalette.foreground;
             current-background: FluentPalette.subtle-secondary;
             separator-color: FluentPalette.border;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
             border-radius: 4px;
             horizontal-padding: 11px;
             spacing: 8px;

--- a/internal/compiler/widgets/fluent/radiogroup.slint
+++ b/internal/compiler/widgets/fluent/radiogroup.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { FluentFontSettings, FluentPalette } from "styling.slint";
+import { FluentPalette } from "styling.slint";
 import { RadioButtonImplBase, RadioGroupImplBase } from "../common/radiogroup-base.slint";
 import { FocusBorder } from "components.slint";
 
@@ -61,8 +61,6 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: root.text-color;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }
@@ -75,8 +73,8 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
 
 export component RadioGroupImpl inherits RadioGroupImplBase {
     title-color: !root.enabled ? FluentPalette.text-disabled : FluentPalette.control-foreground;
-    title-font-size: FluentFontSettings.body.font-size;
-    title-font-weight: FluentFontSettings.body.font-weight;
+    title-font-size: 1rem;
+    title-font-weight: FontWeight.normal;
 }
 
 export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/fluent/spinbox.slint
+++ b/internal/compiler/widgets/fluent/spinbox.slint
@@ -97,8 +97,6 @@ export component SpinBox {
                 base := SpinBoxBase {
                     width: 100%;
                     color: FluentPalette.control-foreground;
-                    font-size: FluentFontSettings.body.font-size;
-                    font-weight: FluentFontSettings.body.font-weight;
                     selection-background-color: FluentPalette.selection-background;
                     selection-foreground-color: FluentPalette.accent-foreground;
                 }

--- a/internal/compiler/widgets/fluent/styling.slint
+++ b/internal/compiler/widgets/fluent/styling.slint
@@ -9,9 +9,8 @@ export struct TextStyle {
 }
 
 export global FluentFontSettings {
-    out property <TextStyle> body: { font-size: 14 * 0.0769rem, font-weight: FontWeight.normal };
-    out property <TextStyle> body-strong: { font-size: 14 * 0.0769rem, font-weight: FontWeight.semi-bold };
-    out property <TextStyle> title: { font-size: 28 * 0.0769rem, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> body-strong: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
+    out property <TextStyle> title: { font-size: 28pt * 1rem / 14pt, font-weight: FontWeight.semi-bold };
 }
 
 export global FluentPalette {

--- a/internal/compiler/widgets/fluent/switch.slint
+++ b/internal/compiler/widgets/fluent/switch.slint
@@ -108,8 +108,6 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: FluentFontSettings.body.font-size;
-            font-weight: FluentFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/fluent/tableview.slint
+++ b/internal/compiler/widgets/fluent/tableview.slint
@@ -239,8 +239,6 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: FluentFontSettings.body.font-weight;
-                        font-size: FluentFontSettings.body.font-size;
                         color: FluentPalette.text-secondary;
                         overflow: elide;
                     }
@@ -280,8 +278,6 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: FluentFontSettings.body.font-weight;
-                            font-size: FluentFontSettings.body.font-size;
                             color: mod(idx, 2) == 0 ? FluentPalette.control-foreground : FluentPalette.text-secondary;
                         }
                     }

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -82,8 +82,8 @@ export component TabImpl inherits Rectangle {
         i-text := Text {
             vertical-alignment: center;
             horizontal-alignment: left;
-            font-size: root.is-current ? FluentFontSettings.body-strong.font-size : FluentFontSettings.body.font-size;
-            font-weight: root.is-current ? FluentFontSettings.body-strong.font-weight : FluentFontSettings.body.font-weight;
+            font-size: root.is-current ? FluentFontSettings.body-strong.font-size : 1rem;
+            font-weight: root.is-current ? FluentFontSettings.body-strong.font-weight : FontWeight.normal;
             color: root.is-current ? FluentPalette.control-foreground : FluentPalette.text-secondary;
             accessible-role: none;
         }

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -83,8 +83,6 @@ export component TextEdit {
         border-color: FluentPalette.text-control-border;
         scroll-view-padding: 12px;
         foreground: FluentPalette.foreground;
-        font-size: FluentFontSettings.body.font-size;
-        font-weight: FluentFontSettings.body.font-weight;
         placeholder-color: FluentPalette.text-secondary;
         selection-background-color: FluentPalette.selection-background;
         selection-foreground-color: FluentPalette.selection-foreground;

--- a/internal/compiler/widgets/fluent/time-picker.slint
+++ b/internal/compiler/widgets/fluent/time-picker.slint
@@ -52,7 +52,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: FluentPalette.foreground,
                     foreground-selected: FluentPalette.accent-foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {
@@ -68,8 +68,6 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: FluentFontSettings.body.font-size,
-                    font-weight: FluentFontSettings.body.font-weight,
                     foreground: FluentPalette.foreground,
                 },
             };

--- a/internal/compiler/widgets/material/radiogroup.slint
+++ b/internal/compiler/widgets/material/radiogroup.slint
@@ -58,8 +58,8 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
         if root.text != "": Text {
             text: root.text;
             color: root.text-color;
-            font-size: MaterialFontSettings.body-large.font-size;
-            font-weight: MaterialFontSettings.body-large.font-weight;
+            font-size: MaterialFontSettings.title-small.font-size;
+            font-weight: MaterialFontSettings.title-small.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }
@@ -68,8 +68,8 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
 
 export component RadioGroupImpl inherits RadioGroupImplBase {
     title-color: !root.enabled ? MaterialPalette.control-foreground-variant : MaterialPalette.foreground;
-    title-font-size: MaterialFontSettings.body-large.font-size;
-    title-font-weight: MaterialFontSettings.body-large.font-weight;
+    title-font-size: MaterialFontSettings.title-small.font-size;
+    title-font-weight: MaterialFontSettings.title-small.font-weight;
 }
 
 export component RadioGroup inherits RadioGroup { }

--- a/internal/compiler/widgets/material/styling.slint
+++ b/internal/compiler/widgets/material/styling.slint
@@ -8,12 +8,12 @@ import { ColorSchemeSelector } from "color-scheme.slint";
 struct TextStyle { font-size: relative-font-size, font-weight: int}
 
 export global MaterialFontSettings {
-    out property <TextStyle> label-large: { font-size: 14 * 0.0625rem, font-weight: FontWeight.medium };
-    out property <TextStyle> label-medium: { font-size: 12 * 0.0625rem, font-weight: FontWeight.medium };
-    out property <TextStyle> body-large: { font-size: 16 * 0.0625rem, font-weight: FontWeight.normal };
-    out property <TextStyle> body-small: { font-size: 12 * 0.0625rem, font-weight: FontWeight.normal };
-    out property <TextStyle> title-small: { font-size: 14 * 0.0625rem, font-weight: FontWeight.medium };
-    out property <TextStyle> headline-large: { font-size: 32 * 0.0625rem, font-weight: FontWeight.medium };
+    out property <TextStyle> label-large: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.medium };
+    out property <TextStyle> label-medium: { font-size: 12pt * 1rem / 14pt, font-weight: FontWeight.medium };
+    out property <TextStyle> body-large: { font-size: 16pt * 1rem / 14pt, font-weight: FontWeight.normal };
+    out property <TextStyle> body-small: { font-size: 12pt * 1rem / 14pt, font-weight: FontWeight.normal };
+    out property <TextStyle> title-small: { font-size: 14pt * 1rem / 14pt, font-weight: FontWeight.medium };
+    out property <TextStyle> headline-large: { font-size: 32pt * 1rem / 14pt, font-weight: FontWeight.medium };
 }
 
 export global Elevation {

--- a/internal/compiler/widgets/material/time-picker.slint
+++ b/internal/compiler/widgets/material/time-picker.slint
@@ -54,7 +54,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: MaterialPalette.foreground,
                     foreground-selected: MaterialPalette.foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {

--- a/internal/compiler/widgets/qt/time-picker.slint
+++ b/internal/compiler/widgets/qt/time-picker.slint
@@ -45,7 +45,7 @@ export component TimePickerPopup inherits PopupWindow {
                     time-selector-style: {
                         foreground: Palette.foreground,
                         foreground-selected: Palette.accent-foreground,
-                        font-size: 12 * 0.0625rem,
+                        font-size: 12pt * 1rem / 16pt,
                         font-weight: FontWeight.normal
                     }
                 },
@@ -55,7 +55,7 @@ export component TimePickerPopup inherits PopupWindow {
                     foreground: Palette.foreground,
                     foreground-selected: Palette.foreground,
                     border-radius: 8px,
-                    font-size: 57 * 0.0625rem,
+                    font-size: 57pt * 1rem / 16pt,
                     font-weight: FontWeight.normal
                 },
                 period-selector-style: {
@@ -63,7 +63,7 @@ export component TimePickerPopup inherits PopupWindow {
                     border-width: 1px,
                     border-brush: Palette.border,
                     item-style: {
-                        font-size: 14 * 0.0625rem,
+                        font-size: 14pt * 1rem / 16pt,
                         font-weight: FontWeight.normal,
                         foreground: Palette.foreground,
                         background-selected: Palette.accent-background,
@@ -71,7 +71,7 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                    font-size: 12 * 0.0625rem,
+                    font-size: 12pt * 1rem / 16pt,
                     font-weight: FontWeight.light,
                     foreground: Palette.foreground,
                 },

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -81,7 +81,8 @@ impl<T: 'static> Wake for FutureRunner<T> {
                 }
             }
         }))
-        .expect("No event loop despite we checked");
+        // The event loop may be gone during teardown; the future can't progress, so drop the wake.
+        .ok();
     }
 }
 

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -328,7 +328,7 @@ mod grid_internal {
             orientation,
             &repeater_indices,
             &repeater_steps,
-        ) as usize;
+        );
         if num < 1 {
             return Default::default();
         }
@@ -381,8 +381,8 @@ mod grid_internal {
                     &repeater_steps,
                 );
                 if span > 1 {
-                    let span_data =
-                        &mut layout_data[(col_or_row as usize)..(col_or_row + span) as usize];
+                    let span_data = &mut layout_data
+                        [(col_or_row as usize)..(col_or_row as usize + span as usize)];
 
                     // Adjust minimum sizes
                     let mut min = constraint.min;
@@ -561,14 +561,16 @@ impl GridLayoutOrganizedData {
         orientation: Orientation,
         repeater_indices: &Slice<u32>,
         repeater_steps: &Slice<u32>,
-    ) -> u16 {
+    ) -> usize {
         let mut max = 0;
         // This could be rewritten more efficiently to avoid a loop calling a loop, by keeping track of the repeaters we saw until now
         // Not sure it's worth the complexity though
         for idx in 0..num_cells {
             let (col_or_row, span) =
                 self.col_or_row_and_span(idx, orientation, repeater_indices, repeater_steps);
-            max = max.max(col_or_row + span.max(1));
+            // Widen to usize: a cell with an out-of-range row/col is clamped to u16::MAX, so adding
+            // the span here in u16 would overflow and under-size the layout vector.
+            max = max.max(col_or_row as usize + span.max(1) as usize);
         }
         max
     }
@@ -2728,7 +2730,7 @@ mod tests {
                 &repeater_indices,
                 &repeater_steps
             ),
-            num_rows as u16 // max row (4) + rowspan (1) = 5
+            num_rows as usize // max row (4) + rowspan (1) = 5
         );
 
         // Now test GridLayoutCacheGenerator

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -230,15 +230,15 @@ where
             if let Some(cp) = Property::check_common_property(p) {
                 return cp;
             }
-            // link_two_way sets a TwoWayBinding on p, which
-            // check_common_property can find on subsequent calls.
-            // Only safe when p has no binding yet (a pre-existing
-            // binding's intercept_set_binding may not accept this).
-            if !p.has_binding() {
-                let anchor = Rc::pin(Property::<Value>::default());
-                Property::link_two_way(anchor.as_ref(), p);
-                return Property::check_common_property(p).unwrap();
-            }
+            // link_two_way installs a TwoWayBinding on p (moving any
+            // existing binding into the shared common property), which
+            // check_common_property finds on subsequent calls. This keeps
+            // prepare_for_two_way_binding idempotent: when several fields of
+            // the same struct property are two-way bound, they must all share
+            // one common property instead of each creating its own.
+            let anchor = Rc::pin(Property::<Value>::default());
+            Property::link_two_way(anchor.as_ref(), p);
+            return Property::check_common_property(p).unwrap();
         }
 
         let p1 = self.apply_pin(item);

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1628,11 +1628,6 @@ pub fn instantiate(
         {
             continue;
         }
-        if let Some(b) = description.original.root_element.borrow().bindings.get(prop_name)
-            && b.borrow().two_way_bindings.is_empty()
-        {
-            continue;
-        }
         let p = description.custom_properties.get(prop_name).unwrap();
         unsafe {
             let item = Pin::new_unchecked(&*instance_ref.as_ptr().add(p.offset));

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2229,19 +2229,24 @@ extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     let orientation = crate::eval_layout::from_runtime(orientation);
 
-    // The vtable layout_info path is taken e.g. for repeater cells. When
-    // the component root has a parameterized layout-info function, route
-    // through it: reading the bare `layoutinfo-{h,v}` would cycle on
-    // `self.{w,h}` for the cross-axis case, and we have no explicit
-    // constraint at this entry point. `f32::MAX` (i.e. "unconstrained")
-    // tells the runtime's flex algorithm to behave as if items don't
-    // need to wrap, which gives the natural max-cell-cross-axis result
-    // — much closer to correct than the `sqrt(item-areas)` heuristic
-    // that a `-1` sentinel would trigger.
+    // Vtable entry (repeater cells, window auto-size). Pass the cross-axis size
+    // to the root's parameterized layout-info function explicitly, avoiding a
+    // cycle on `self.{w,h}`: for the vertical query the preferred width, so a
+    // height-for-width Image sizes its height to that and not to infinity; for
+    // the horizontal query `f32::MAX`, i.e. "don't wrap".
     let root = &instance_ref.description.original.root_element;
+    let window_adapter = instance_ref.window_adapter();
     let cross_axis_constraint = match orientation {
         i_slint_compiler::layout::Orientation::Vertical => {
-            root.borrow().layout_info_v_with_constraint.is_some().then_some(f32::MAX)
+            root.borrow().layout_info_v_with_constraint.is_some().then(|| {
+                crate::eval_layout::get_layout_info(
+                    root,
+                    instance_ref,
+                    &window_adapter,
+                    i_slint_compiler::layout::Orientation::Horizontal,
+                )
+                .preferred_bounded()
+            })
         }
         i_slint_compiler::layout::Orientation::Horizontal => {
             root.borrow().layout_info_h_with_constraint.is_some().then_some(f32::MAX)
@@ -2250,7 +2255,7 @@ extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -
     let mut result = crate::eval_layout::get_layout_info_with_constraint(
         root,
         instance_ref,
-        &instance_ref.window_adapter(),
+        &window_adapter,
         orientation,
         cross_axis_constraint,
     );

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -798,11 +798,35 @@ fn grid_layout_input_data(
                                 repeated_element,
                                 ..
                             } => {
+                                // colspan/rowspan live on the inner sub-component's root,
+                                // evaluated per inner instance.
+                                let inner_root = repeated_element
+                                    .borrow()
+                                    .base_type
+                                    .as_component()
+                                    .root_element
+                                    .clone();
+                                let (rowspan_expr, colspan_expr) = {
+                                    let element_ref = inner_root.borrow();
+                                    let child_cell =
+                                        element_ref.grid_layout_cell.as_ref().unwrap().borrow();
+                                    (
+                                        child_cell.rowspan_expr.clone(),
+                                        child_cell.colspan_expr.clone(),
+                                    )
+                                };
                                 let inner_instances =
                                     repeater_instances(sub_instance_ref, repeated_element);
-                                for i in 0..inner_instances.len() {
+                                for (i, erased_inner) in inner_instances.iter().enumerate() {
+                                    generativity::make_guard!(inner_guard);
+                                    let inner_comp = erased_inner.as_pin_ref();
+                                    let inner_instance_ref = unsafe {
+                                        InstanceRef::from_pin_ref(inner_comp.borrow(), inner_guard)
+                                    };
                                     result.push(GridLayoutInputData {
                                         new_row: i == 0 && new_row,
+                                        rowspan: eval_or_default(&rowspan_expr, inner_instance_ref),
+                                        colspan: eval_or_default(&colspan_expr, inner_instance_ref),
                                         ..Default::default()
                                     });
                                 }

--- a/tests/cases/issues/issue_12265_two_way_field_focus.slint
+++ b/tests/cases/issues/issue_12265_two_way_field_focus.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #12265: instantiating this in the interpreter (LSP live preview /
+// slint-viewer) panicked with "binding was of the wrong type: ()".
+//
+// `data` is a struct property the parent sets, and `checked <=> data.<field>` two-way binds into
+// it while `enabled: data.enabled` reads it. `data` is stored as a `Value`, whose default is `Void`
+// rather than a `Data`; when its value was read before its binding had run, `data.enabled` came back
+// `Void` and aborted when converted to `bool`. The fix initializes struct/array/enum properties to
+// their type's default instead of `Void`.
+//
+// In #12265 the early read came from a std CheckBox's `if has-focus && enabled` focus border being
+// evaluated during the TabWidget's layout. Here `changed enabled` reproduces the same early read
+// without any widget: a ChangeTracker reads its property once at instantiation to record a baseline,
+// so `enabled` (hence `data.enabled`) is read before `data`'s binding has run.
+
+struct Data { a: bool, b: bool, enabled: bool }
+
+component Field {
+    in-out property <bool> checked;
+    in property <bool> enabled <=> touch-area.enabled;
+    changed enabled => { }
+    touch-area := TouchArea { }
+}
+
+component Page {
+    in-out property <Data> data;
+    Field { checked <=> data.a; enabled: data.enabled; }
+    Field { checked <=> data.b; enabled: data.enabled; }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    in-out property <Data> model: { a: true, b: false, enabled: true };
+    Page { data: model; }
+    out property <bool> test: model.a && !model.b && model.enabled;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+let instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/issues/issue_12268_two_way_struct_fields.slint
+++ b/tests/cases/issues/issue_12268_two_way_struct_fields.slint
@@ -1,0 +1,63 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// C++ live preview cannot search elements (the wrapper has no item tree).
+//ignore: cpp-live-preview
+
+// Two-way binding the `first` and `second` fields of a struct to separate
+// sub-components must keep both fields working. Preparing the second field's
+// two-way binding used to detach the first from the struct, so the array
+// `first` rendered as empty. The corruption only shows in the interpreter
+// while rendering, so the test blocks visit the elements to render the tree
+// and then check that the array still has its three items.
+// Regression test for #12268.
+
+struct Data {
+    first: [bool],
+    second: bool,
+}
+
+component BindFirst {
+    in-out property <[bool]> first;
+    VerticalLayout {
+        Text { text: "first.length = " + first.length; }
+        for value in first: Text { text: value ? "on" : "off"; }
+    }
+}
+
+component BindSecond {
+    in-out property <bool> second;
+    Text { text: second ? "on" : "off"; }
+}
+
+component BindMultiple {
+    in-out property <Data> data;
+    VerticalLayout {
+        BindFirst { first <=> data.first; }
+        BindSecond { second <=> data.second; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <[Data]> data: [{ first: [false, false, false], second: false }];
+    for row in data: BindMultiple { data <=> row; }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+// Visiting the elements renders the tree, which evaluates `first.length`.
+// With the bug the array is empty, so the label reads "first.length = 0".
+let found = slint_testing::ElementHandle::find_by_accessible_label(&instance, "first.length = 3").count();
+assert_eq!(found, 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+auto found =
+    slint::testing::ElementHandle::find_by_accessible_label(handle, "first.length = 3");
+assert_eq(found.size(), 1);
+```
+*/

--- a/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
+++ b/tests/cases/issues/issue_12269_two_way_struct_fields_panic.slint
@@ -1,0 +1,73 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// C++ live preview cannot search elements (the wrapper has no item tree).
+//ignore: cpp-live-preview
+
+// Same root cause as #12268, but here the struct comes from a struct literal
+// rather than a model row, so the dropped `first` field is not even an array
+// and the interpreter panics ("First argument not an array") while evaluating
+// `first.length` during rendering. The test blocks render the tree, which
+// panics with the bug. Regression test for #12269.
+
+struct Data {
+    first: [bool],
+    second: bool,
+}
+
+component Check {
+    in-out property <bool> checked;
+    Text { text: checked ? "[x]" : "[ ]"; }
+}
+
+component BindFirst {
+    in-out property <[bool]> first;
+    VerticalLayout {
+        Text { text: "first.length = " + first.length; }
+        for value[index] in first: Check { checked <=> value; }
+    }
+}
+
+component BindSecond {
+    in-out property <bool> second;
+    Check { checked <=> second; }
+}
+
+component BindMultiple {
+    in-out property <Data> data;
+    VerticalLayout {
+        BindFirst { first <=> data.first; }
+        BindSecond { second <=> data.second; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Data> data: { first: [false, false, false], second: false };
+    BindMultiple { data <=> data; }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+// Visiting every element renders the tree; with the bug this panics on
+// `first.length`. With the fix the three items render, giving 5 Text elements
+// (the length label, three items and `second`).
+let texts = slint_testing::ElementHandle::find_by_element_type_name(&instance, "Text").count();
+assert_eq!(texts, 5);
+```
+
+```cpp
+auto handle = TestCase::create();
+auto texts =
+    slint::testing::ElementHandle::find_by_element_type_name(handle, "Text");
+assert_eq(texts.size(), 5);
+```
+
+```js
+var instance = new slint.TestCase();
+// Rendering the tree evaluates `first.length`, which panics with the bug.
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+```
+*/

--- a/tests/cases/layout/grid_conditional_row_and_cell_colspan.slint
+++ b/tests/cases/layout/grid_conditional_row_and_cell_colspan.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for issue #12251: colspan was ignored when both the Row and
+// the cell inside it are conditional (`if cond: Row { if cond: ... colspan: 2 }`).
+// The spanned cell collapsed to a single column.
+
+export component TestCase inherits Window {
+    width: 400phx;
+    height: 200phx;
+
+    in property <bool> cond: true;
+
+    GridLayout {
+        spacing: 0phx;
+        padding: 0phx;
+
+        // The cell and its Row are both conditional, and the cell spans two columns.
+        if cond: Row {
+            if cond: Rectangle {
+                background: green;
+                colspan: 2;
+                min-width: 200phx;
+            }
+        }
+
+        // Reference row: two stretchy columns. When the colspan above is honored,
+        // its minimum width applies to both columns combined, so the two columns
+        // stay equal. When it is ignored, the minimum lands on column 0 alone and
+        // the columns become unequal.
+        Row {
+            a := Rectangle { horizontal-stretch: 1; background: red; }
+            b := Rectangle { horizontal-stretch: 1; background: blue; }
+        }
+    }
+
+    out property <length> a-width: a.width;
+    out property <length> b-width: b.width;
+    out property <bool> test: a.width == b.width && a.width == 200phx;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_a_width(), 200.);
+assert_eq(instance.get_b_width(), 200.);
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_a_width(), 200.);
+assert_eq!(instance.get_b_width(), 200.);
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+
+*/

--- a/tests/cases/layout/grid_out_of_range_row.slint
+++ b/tests/cases/layout/grid_out_of_range_row.slint
@@ -1,0 +1,62 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test that an out-of-range row index doesn't make grid layout panic.
+// A row near u16::MAX (65535) used to overflow the row-count computation and
+// index past the end of the layout vector, both for plain cells and for spans.
+// (Columns can't reach this because col + colspan is already clamped to u16::MAX.)
+export component TestCase inherits Rectangle {
+    width: 200phx;
+    height: 200phx;
+
+    GridLayout {
+        spacing: 0px;
+        padding: 0px;
+        // Anchor at the origin.
+        Rectangle {
+            row: 0;
+            col: 0;
+            min-width: 30phx;
+            min-height: 30phx;
+        }
+        // Far row with a span: occupies rows 65534 and 65535. This exercises both the
+        // row-count overflow and the span-slice indexing at the top of the row range.
+        Rectangle {
+            row: 65534;
+            col: 0;
+            rowspan: 2;
+            min-height: 20phx;
+        }
+        // Far column, to exercise the (clamped) horizontal path with a large index.
+        Rectangle {
+            row: 0;
+            col: 65535;
+            min-width: 25phx;
+        }
+    }
+
+    // Reading the constraints forces the grid to be solved. The empty rows/columns in
+    // between contribute nothing, so the size is just the non-empty cells: row 0 (30) plus
+    // the spanned rows (20 split evenly), and column 0 (30) plus the far column (25).
+    out property <bool> test: root.min-height == 50phx && root.min-width == 55phx;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/

--- a/tests/cases/layout/issue_12139_image_window_autosize.slint
+++ b/tests/cases/layout/issue_12139_image_window_autosize.slint
@@ -1,0 +1,39 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #12139: an unsized Image used to give an auto-sizing window an unbounded
+// height (its aspect ratio scaled the unconstrained measuring width to infinity).
+// It should auto-size to the 128x128 image.
+export component TestCase inherits Window {
+    VerticalLayout {
+        Image { source: @image-url("../../../logo/slint-logo-square-light-128x128.png"); }
+    }
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+handle->show();
+auto size = handle->window().size();
+assert(size == slint::PhysicalSize({128, 128}));
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+instance.show().unwrap();
+let size = instance.window().size();
+assert_eq!(size, slint::PhysicalSize::new(128, 128));
+```
+
+
+```js
+let instance = new slint.TestCase({});
+instance.window.show();
+let size = instance.window.physicalSize;
+assert.equal(size.width, 128);
+assert.equal(size.height, 128);
+```
+
+*/

--- a/tests/cases/layout/max_width_infinity.slint
+++ b/tests/cases/layout/max_width_infinity.slint
@@ -1,0 +1,51 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `1px / 0` is a constant that folds to an infinite length. The generated code
+// must keep that infinity for the max-width constraint, otherwise the stretched
+// cell collapses to zero width. See issue #12213.
+
+export component TestCase inherits Rectangle {
+    width: 300phx;
+    height: 100phx;
+
+    HorizontalLayout {
+        spacing: 0phx;
+        padding: 0phx;
+        alignment: stretch;
+        r1 := Rectangle {
+            min-width: 100phx;
+            horizontal-stretch: 0;
+        }
+        r2 := Rectangle {
+            max-width: 1px / 0;
+            horizontal-stretch: 1;
+        }
+    }
+
+    out property <length> inf_length: 1px / 0;
+    out property <bool> inf_ok: inf_length > 1000000000phx;
+    out property <bool> layout_ok: r1.width == 100phx && r2.width == 200phx;
+
+    out property <bool> test: inf_ok && layout_ok;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/

--- a/tests/cases/widgets/textedit.slint
+++ b/tests/cases/widgets/textedit.slint
@@ -11,6 +11,8 @@ export component TestCase inherits Window {
     edit := TextEdit {
         width: 100%;
         height: 100%;
+        // Pin the font size so the page navigation lands at the same spot in every style.
+        font-size: 1rem;
     }
 
     forward-focus: edit;

--- a/tools/lsp/build.rs
+++ b/tools/lsp/build.rs
@@ -1,7 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+/// Mirror the `/STACK` setting from `.cargo/config.toml`, which is not shipped
+/// in the published crate.
+fn bump_windows_stack_size() {
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        println!("cargo:rustc-link-arg-bins=/STACK:8000000");
+    }
+}
+
 fn main() {
+    bump_windows_stack_size();
+
     // Safety: there are no other threads at this point
     unsafe {
         // Make the compiler handle ComponentContainer:

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -608,8 +608,8 @@ async fn run_main_loop(
                 }
             }
             file_event = file_watcher_receiver.recv() => {
-                if let Some(file_event) = file_event {
-                    trigger_file_watcher(&mut ctx, common::file_to_uri(&file_event.path).unwrap(), file_event.kind).await.ok();
+                if let Some(file_event) = file_event && let Some(uri) = common::file_to_uri(&file_event.path) {
+                    trigger_file_watcher(&mut ctx, uri, file_event.kind).await.ok();
                 }
             }
             _ = tokio::time::sleep(recompile_idle_timeout) => {

--- a/tools/viewer/build.rs
+++ b/tools/viewer/build.rs
@@ -3,9 +3,18 @@
 
 use std::path::PathBuf;
 
+/// Mirror the `/STACK` setting from `.cargo/config.toml`, which is not shipped
+/// in the published crate.
+fn bump_windows_stack_size() {
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        println!("cargo:rustc-link-arg-bins=/STACK:8000000");
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_REMOTE");
+    bump_windows_stack_size();
     // The slint!{} macro in remote.rs needs the experimental
     // new_with_existing_window constructor.
     if std::env::var_os("CARGO_FEATURE_REMOTE").is_some() {


### PR DESCRIPTION
| Subject | Commit | PR |
|---------|--------|----|
| Interpreter: fix crash with two-way binding to a struct field | `7ea6d217b0` | #12278 |
| Bump the Windows stack size in the published tools' build scripts | `aee9a91ab0` | #12267 |
| interpreter: fix two-way binding of several struct fields | `5c92ec20e0` | #12279 |
| Make widget default font size consistent with plain Text | `cad72ee04b` | #12237 |
| core: don't panic when a future's waker fires after the event loop stopped | `1c03104a44` | #12289 |
| lsp: don't panic when a watched file path has no URL representation | `7f715de369` | #12291 |
| core: fix grid layout panic on out-of-range row or column | `430de1ba40` | #12292 |
| Fix unbounded window height with an unsized Image | `594c94eedf` | #12286 |
| Fix generated element doc screenshot asset lookup | `7a5e20f710` | #12293 |
| compiler: Fix non-finite number literals being generated as 0 | `a7029a4524` | #12230 |
| Fix colspan ignored in conditional GridLayout cells | `f3b7f819f9` | #12257 |
| winit: Don't pre-render the first frame on Wayland | `985bbb7965` | #12316 |