### PR TITLE
compiler: fix failing determinism test of the cpp/rust live-preview

### DIFF
--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -144,14 +144,14 @@ fn generate_public_component(
                 .map(|p| format!("\"{}\"", escape_string(&p.to_string_lossy())))
                 .join(", ")
         ),
-        format!(
-            "slint::SharedVector<slint::SharedString> library_paths{{ {} }};",
-            compiler_config
-                .library_paths
-                .iter()
+        format!("slint::SharedVector<slint::SharedString> library_paths{{ {} }};", {
+            let mut library_paths: Vec<_> = compiler_config.library_paths.iter().collect();
+            library_paths.sort_by(|a, b| a.0.cmp(b.0));
+            library_paths
+                .into_iter()
                 .map(|(l, p)| format!("\"{l}={}\"", p.to_string_lossy()))
                 .join(", ")
-        ),
+        }),
         format!(
             "auto live_preview = slint::private_api::live_preview::LiveReloadingComponent({main_file:?}, {:?}, include_paths, library_paths, {:?}, {:?}, {});",
             component.name,

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -167,7 +167,9 @@ fn generate_public_component(
     }
 
     let include_paths = compiler_config.include_paths.iter().map(|p| p.to_string_lossy());
-    let library_paths = compiler_config.library_paths.iter().map(|(n, p)| {
+    let mut sorted_library_paths: Vec<_> = compiler_config.library_paths.iter().collect();
+    sorted_library_paths.sort_by(|a, b| a.0.cmp(b.0));
+    let library_paths = sorted_library_paths.into_iter().map(|(n, p)| {
         let p = p.to_string_lossy();
         quote!((#n.to_string(), #p.into()))
     });


### PR DESCRIPTION
Sort the library paths

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
