### PR TITLE
tests: apply SLINT_TEST_FILTER to the interpreter example tests

### DIFF
--- a/tests/driver/interpreter/build.rs
+++ b/tests/driver/interpreter/build.rs
@@ -9,6 +9,54 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tests_file = std::fs::File::create(&tests_file_path)?;
 
+    // Example .slint files that are also run through the interpreter. Unlike the
+    // test cases collected below, these live outside tests/cases, so we list them
+    // here and honor SLINT_TEST_FILTER as a substring of their repo-root-relative
+    // path (e.g. SLINT_TEST_FILTER=examples runs the examples/ entries).
+    const EXAMPLES: &[(&str, &str)] = &[
+        ("example_printerdemo", "demos/printerdemo/ui/printerdemo.slint"),
+        ("example_usecases", "demos/usecases/ui/app.slint"),
+        ("example_memory", "examples/memory/memory.slint"),
+        ("example_slide_puzzle", "examples/slide_puzzle/slide_puzzle.slint"),
+        ("example_todo", "examples/todo/ui/todo.slint"),
+        ("example_gallery", "examples/gallery/gallery.slint"),
+        ("example_fancy_demo", "examples/fancy_demo/main.slint"),
+        ("example_bash_sysinfo", "examples/bash/sysinfo.slint"),
+        ("example_carousel", "examples/carousel/ui/carousel_demo.slint"),
+        ("example_iot_dashboard", "examples/iot-dashboard/main.slint"),
+        ("example_dial", "examples/dial/dial.slint"),
+        ("example_sprite_sheet", "examples/sprite-sheet/demo.slint"),
+        ("example_fancy_switches", "examples/fancy-switches/demo.slint"),
+        ("example_home_automation", "demos/home-automation/ui/demo.slint"),
+        ("example_energy_monitor", "demos/energy-monitor/ui/desktop_window.slint"),
+        ("example_weather", "demos/weather-demo/ui/main.slint"),
+        ("example_grid_model_rows", "examples/layouts/grid-with-model-in-rows.slint"),
+        ("example_grid_with_repeated_rows", "examples/layouts/grid-with-repeated-rows.slint"),
+        ("example_vector_as_grid", "examples/layouts/vector-as-grid.slint"),
+        ("example_vlayout", "examples/layouts/vertical-layout-with-model.slint"),
+        ("example_flexbox_interactive", "examples/layouts/flexbox-interactive.slint"),
+    ];
+
+    let filter = std::env::var("SLINT_TEST_FILTER").ok();
+    for (test_function_name, path) in EXAMPLES {
+        if let Some(filter) = &filter
+            && !path.contains(filter.as_str())
+        {
+            continue;
+        }
+        write!(
+            tests_file,
+            r##"
+            #[test]
+            fn {function_name}() {{
+                run_example(r#"{path}"#);
+            }}
+        "##,
+            function_name = test_function_name,
+            path = path,
+        )?;
+    }
+
     for testcase in test_driver_lib::collect_test_cases("cases")?.into_iter() {
         let test_function_name = testcase.identifier();
         let ignored = testcase.is_ignored("interpreter");

--- a/tests/driver/interpreter/main.rs
+++ b/tests/driver/interpreter/main.rs
@@ -7,51 +7,20 @@ mod interpreter;
 
 include!(env!("TEST_FUNCTIONS"));
 
-macro_rules! test_example {
-    ($id:ident, $path:literal) => {
-        #[test]
-        fn $id() {
-            let relative_path = std::path::PathBuf::from(concat!("../../../", $path));
-            let mut absolute_path =
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(&relative_path);
-            if !absolute_path.exists() {
-                // Try with .60 instead (for the updater_test)
-                let legacy = absolute_path.to_string_lossy().replace(".slint", ".60");
-                if std::path::Path::new(&legacy).exists() {
-                    absolute_path = legacy.into();
-                }
-            }
-            interpreter::test(&test_driver_lib::TestCase {
-                absolute_path,
-                relative_path,
-                requested_style: None,
-            })
-            .unwrap();
-        }
-    };
+// Run an example .slint file (path relative to the repo root) through the interpreter.
+// The list of examples and the SLINT_TEST_FILTER handling live in build.rs.
+#[cfg(test)]
+#[allow(dead_code)] // unused when SLINT_TEST_FILTER excludes every example
+fn run_example(path: &str) {
+    let relative_path = std::path::PathBuf::from(format!("../../../{path}"));
+    let absolute_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(&relative_path);
+    interpreter::test(&test_driver_lib::TestCase {
+        absolute_path,
+        relative_path,
+        requested_style: None,
+    })
+    .unwrap();
 }
-
-test_example!(example_printerdemo, "demos/printerdemo/ui/printerdemo.slint");
-test_example!(example_usecases, "demos/usecases/ui/app.slint");
-test_example!(example_memory, "examples/memory/memory.slint");
-test_example!(example_slide_puzzle, "examples/slide_puzzle/slide_puzzle.slint");
-test_example!(example_todo, "examples/todo/ui/todo.slint");
-test_example!(example_gallery, "examples/gallery/gallery.slint");
-test_example!(example_fancy_demo, "examples/fancy_demo/main.slint");
-test_example!(example_bash_sysinfo, "examples/bash/sysinfo.slint");
-test_example!(example_carousel, "examples/carousel/ui/carousel_demo.slint");
-test_example!(example_iot_dashboard, "examples/iot-dashboard/main.slint");
-test_example!(example_dial, "examples/dial/dial.slint");
-test_example!(example_sprite_sheet, "examples/sprite-sheet/demo.slint");
-test_example!(example_fancy_switches, "examples/fancy-switches/demo.slint");
-test_example!(example_home_automation, "demos/home-automation/ui/demo.slint");
-test_example!(example_energy_monitor, "demos/energy-monitor/ui/desktop_window.slint");
-test_example!(example_weather, "demos/weather-demo/ui/main.slint");
-test_example!(example_grid_model_rows, "examples/layouts/grid-with-model-in-rows.slint");
-test_example!(example_grid_with_repeated_rows, "examples/layouts/grid-with-repeated-rows.slint");
-test_example!(example_vector_as_grid, "examples/layouts/vector-as-grid.slint");
-test_example!(example_vlayout, "examples/layouts/vertical-layout-with-model.slint");
-test_example!(example_flexbox_interactive, "examples/layouts/flexbox-interactive.slint");
 
 fn main() {
     println!("Nothing to see here, please run me through cargo test :)");


### PR DESCRIPTION
The example_* tests were hardcoded via a macro in main.rs, so they ran on
every invocation regardless of SLINT_TEST_FILTER, which only filtered the
build-time generated case tests. This made a filtered run (e.g. via
run_tests.sh) also build and run all 21 examples.

Move the example list into build.rs and generate a test only when its path
matches SLINT_TEST_FILTER, mirroring collect_test_cases. main.rs keeps a
run_example() helper the generated code calls.