### PR TITLE
Introduce `TextInput.input-method-hints`

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -460,6 +460,7 @@ fn gen_corelib(
         "FillRule",
         "MouseCursorInner",
         "InputType",
+        "CapitalizationMode",
         "StandardButtonKind",
         "DialogButtonRole",
         "FocusReason",

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -124,13 +124,14 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
     writeln!(structs_priv, "#include \"private/slint_keys.h\"")?;
     writeln!(structs_priv, "namespace slint::cbindgen_private {{")?;
     writeln!(structs_priv, "enum class KeyEventType : uint8_t;")?;
+
     macro_rules! print_structs {
         ($(
             $(#[doc = $struct_doc:literal])*
             $(#[non_exhaustive])?
             $(#[derive(Copy, Eq)])?
             $vis:vis struct $Name:ident {
-                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty, )*
+                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty $(= $field_default:expr)?, )*
             }
         )*) => {
             $(
@@ -149,7 +150,7 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
                         "f32" | "Coord" => "float",
                         other => other,
                     };
-                    writeln!(file, "    {} {};", field_type, stringify!($field))?;
+                    writeln!(file, "    {} {}{{ {} }};", field_type, stringify!($field), stringify!($($field_default)*))?;
                 )*
                 writeln!(file, "    /// \\private")?;
                 writeln!(file, "    {}", format!("friend bool operator==(const {name}&, const {name}&) = default;", name = stringify!($Name)))?;
@@ -259,7 +260,7 @@ fn live_preview_enums(path: &Path) -> anyhow::Result<()> {
     let mut structs: Vec<(String, Vec<String>)> = Vec::new();
     macro_rules! collect_structs {
         ($( $(#[$attr:meta])* $vis:vis struct $Name:ident {
-            $( $(#[$field_attr:meta])* $field:ident : $ty:ty,)*
+            $( $(#[$field_attr:meta])* $field:ident : $ty:ty $(= $field_default:expr)?,)*
         })*) => {
             $(
                 if stringify!($vis) == "pub"

--- a/api/node/build.rs
+++ b/api/node/build.rs
@@ -54,7 +54,7 @@ fn generate_language_module() {
             $(#[non_exhaustive])?
             $(#[derive(Copy, Eq)])?
             $vis:vis struct $Name:ident {
-                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty, )*
+                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ty $(= $field_default:expr)?, )*
             }
         )*) => {
             $(
@@ -63,7 +63,8 @@ fn generate_language_module() {
                         name: stringify!($Name),
                         docs: vec![$($struct_doc),*],
                         fields: vec![$(
-                            (stringify!($field), stringify!($field_type), vec![$($field_doc),*])
+                            (stringify!($field), stringify!($field_type), vec![$($field_doc),*],
+                                i_slint_common::builtin_struct_field_default_tokens!($($field_default)?))
                         ),*],
                     });
                 }
@@ -180,7 +181,7 @@ fn generate_language_module() {
     for s in &structs {
         write_jsdoc(&mut ts, "    ", &s.docs);
         ts.push_str(&format!("    export type {name} = {{\n", name = s.name));
-        for (field, rust_ty, field_docs) in &s.fields {
+        for (field, rust_ty, field_docs, _) in &s.fields {
             write_jsdoc(&mut ts, "        ", field_docs);
             ts.push_str(&format!(
                 "        {field}: {ts_ty};\n",
@@ -222,14 +223,28 @@ fn map_field_type(rust_ty: &str, in_language: &HashSet<&'static str>) -> String 
     }
 }
 
-/// Compute the JS default expression for a struct field of the given Rust type. Primitives
-/// fall back to zero/empty/false; enum fields use the first-variant kebab string (matching
-/// the Rust `Default` impl); nested struct fields recurse via `_data.<Name>()`.
+/// Compute the JS default expression for a struct field of the given Rust type.
+/// A default value declared in builtin_structs.rs wins; otherwise primitives
+/// fall back to zero/empty/false, enum fields use the first-variant kebab string (matching
+/// the Rust `Default` impl), and nested struct fields recurse via `_data.<Name>()`.
 fn field_default(
     rust_ty: &str,
+    declared: Option<&str>,
     enum_defaults: &HashMap<&'static str, String>,
     structs: &HashSet<&'static str>,
 ) -> String {
+    if let Some(declared) = declared {
+        let text: String =
+            declared.chars().filter(|c| !c.is_whitespace() && *c != ')' && *c != '(').collect();
+        return match text.split_once("::") {
+            // Enum values are kebab-case strings in the JS API
+            Some((_, variant)) => {
+                format!("\"{}\"", to_kebab_case(variant.trim_start_matches("r#")))
+            }
+            // bool and number literals are the same in JS
+            None => text,
+        };
+    }
     let t = rust_ty.trim();
     match t {
         "bool" => "false".to_string(),
@@ -275,10 +290,10 @@ fn emit_struct_factory(
         "    {name}: (props?: Partial<language.{name}>): language.{name} => Object.freeze({{",
         name = s.name
     ));
-    for (field, rust_ty, _) in &s.fields {
+    for (field, rust_ty, _, declared_default) in &s.fields {
         out.push_str(&format!(
             " {field}: {default},",
-            default = field_default(rust_ty, enum_defaults, struct_names)
+            default = field_default(rust_ty, *declared_default, enum_defaults, struct_names)
         ));
     }
     out.push_str(" ...props }),\n");
@@ -289,7 +304,8 @@ fn emit_struct_factory(
 struct StructEntry {
     name: &'static str,
     docs: Vec<&'static str>,
-    fields: Vec<(&'static str, &'static str, Vec<&'static str>)>,
+    /// (name, rust type, docs, declared default value tokens)
+    fields: Vec<(&'static str, &'static str, Vec<&'static str>, Option<&'static str>)>,
 }
 
 /// Emit the rustdoc lines as a JSDoc block at the given indent. No-op if `docs` is empty.

--- a/api/python/slint/build.rs
+++ b/api/python/slint/build.rs
@@ -30,13 +30,31 @@ fn map_default(ty: &str) -> &str {
     }
 }
 
+/// The Python form of a field default value declared in builtin_structs.rs
+fn declared_default(tokens: &str) -> String {
+    let text: String = tokens.chars().filter(|c| !c.is_whitespace()).collect();
+    match text.split_once("::") {
+        // Enum members are named after the kebab-case value, with underscores
+        Some((enum_name, variant)) => {
+            let member = to_kebab_case(variant.trim_start_matches("r#")).replace('-', "_");
+            format!("{enum_name}.{member}")
+        }
+        None => match text.as_str() {
+            "true" => "True".into(),
+            "false" => "False".into(),
+            // Number literals are the same in Python
+            _ => text,
+        },
+    }
+}
+
 macro_rules! generate_builtin_structs_pyi {
     ($(
         $(#[doc = $struct_doc:literal])*
         $(#[non_exhaustive])?
         $(#[derive(Copy, Eq)])?
         $vis:vis struct $Name:ident {
-            $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
+            $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident $(= $field_default:expr)?, )*
         }
     )*) => {
         fn generate_pyi(writer: &mut impl Write) {
@@ -66,7 +84,10 @@ macro_rules! generate_builtin_structs_pyi {
                     }
                     writeln!(writer, "").unwrap();
                     $(
-                        writeln!(writer, "    {}: {} = {}", stringify!($field), map_type(stringify!($field_type)), map_default(stringify!($field_type))).unwrap();
+                        let default = i_slint_common::builtin_struct_field_default_tokens!($($field_default)?)
+                            .map(declared_default)
+                            .unwrap_or_else(|| map_default(stringify!($field_type)).to_string());
+                        writeln!(writer, "    {}: {} = {}", stringify!($field), map_type(stringify!($field_type)), default).unwrap();
                         let field_doc_str = vec![$($field_doc),*].join("\n").trim().to_string();
                         if !field_doc_str.is_empty() {
                             writeln!(writer, "    \"\"\"").unwrap();

--- a/api/python/slint/build.rs
+++ b/api/python/slint/build.rs
@@ -4,7 +4,33 @@
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
-fn map_type(ty: &str) -> &str {
+/// The names of the enums declared in the `slint.language` submodule
+/// (only `pub` enums are registered; see `register_enums` in language.rs).
+macro_rules! collect_public_enums {
+    ($( $(#[$enum_attr:meta])* $vis:vis enum $Name:ident { $($_body:tt)* })*) => {
+        fn public_enum_names() -> std::collections::HashSet<&'static str> {
+            let mut names = std::collections::HashSet::new();
+            $(if stringify!($vis) == "pub" {
+                names.insert(stringify!($Name));
+            })*
+            names
+        }
+    };
+}
+
+i_slint_common::for_each_enums!(collect_public_enums);
+
+fn map_type(
+    ty: &str,
+    public_enums: &std::collections::HashSet<&'static str>,
+    has_declared_default: bool,
+) -> String {
+    // Enums in the same submodule; resolved as forward references via
+    // `from __future__ import annotations`. Fields without a declared default
+    // value default to None at runtime.
+    if public_enums.contains(ty) {
+        return if has_declared_default { ty.into() } else { format!("{ty} | None") };
+    }
     match ty {
         "bool" => "bool",
         "SharedString" => "str",
@@ -13,11 +39,9 @@ fn map_type(ty: &str) -> &str {
         // Types exposed by the binding outside the `language` submodule.
         "DataTransfer" => "DataTransfer | None",
         "LogicalPosition" => "LogicalPosition | None",
-        // Enums in the same submodule; resolved as forward references via
-        // `from __future__ import annotations`.
-        "DragAction" => "DragAction | None",
         _ => "typing.Any",
     }
+    .into()
 }
 
 fn map_default(ty: &str) -> &str {
@@ -67,6 +91,7 @@ macro_rules! generate_builtin_structs_pyi {
             writeln!(writer, "import typing").unwrap();
             writeln!(writer, "from slint import DataTransfer, LogicalPosition").unwrap();
 
+            let public_enums = public_enum_names();
             $(
                 if stringify!($vis) == "pub" {
                     writeln!(writer, "\nclass {}(typing.NamedTuple):", stringify!($Name)).unwrap();
@@ -84,10 +109,12 @@ macro_rules! generate_builtin_structs_pyi {
                     }
                     writeln!(writer, "").unwrap();
                     $(
-                        let default = i_slint_common::builtin_struct_field_default_tokens!($($field_default)?)
+                        let declared = i_slint_common::builtin_struct_field_default_tokens!($($field_default)?);
+                        let field_type = map_type(stringify!($field_type), &public_enums, declared.is_some());
+                        let default = declared
                             .map(declared_default)
                             .unwrap_or_else(|| map_default(stringify!($field_type)).to_string());
-                        writeln!(writer, "    {}: {} = {}", stringify!($field), map_type(stringify!($field_type)), default).unwrap();
+                        writeln!(writer, "    {}: {} = {}", stringify!($field), field_type, default).unwrap();
                         let field_doc_str = vec![$($field_doc),*].join("\n").trim().to_string();
                         if !field_doc_str.is_empty() {
                             writeln!(writer, "    \"\"\"").unwrap();

--- a/api/python/slint/language.rs
+++ b/api/python/slint/language.rs
@@ -27,6 +27,34 @@ fn get_default_value<'py>(py: Python<'py>, ty: &str) -> PyResult<Bound<'py, PyAn
     }
 }
 
+/// The Python value of a field default declared in builtin_structs.rs.
+/// Enum defaults resolve to the already registered enum member,
+/// so `register_structs` must run after `register_enums`.
+fn declared_default_value<'py>(
+    py: Python<'py>,
+    m: &Bound<'py, PyModule>,
+    tokens: &str,
+    rust_ty: &str,
+) -> PyResult<Bound<'py, PyAny>> {
+    let text: String =
+        tokens.chars().filter(|c| !c.is_whitespace() && *c != '(' && *c != ')').collect();
+    if let Some((enum_name, variant)) = text.split_once("::") {
+        let member = to_kebab_case(variant.trim_start_matches("r#")).replace('-', "_");
+        return language_submodule(py, m)?.getattr(enum_name)?.getattr(member.as_str());
+    }
+    if let Ok(b) = text.parse::<bool>() {
+        return b.into_bound_py_any(py);
+    }
+    let value = text
+        .parse::<f64>()
+        .unwrap_or_else(|_| panic!("unsupported builtin struct field default `{tokens}`"));
+    if rust_ty == "i32" {
+        (value as i32).into_bound_py_any(py)
+    } else {
+        value.into_bound_py_any(py)
+    }
+}
+
 /// Returns the `slint.language` submodule, creating and registering it on the parent
 /// module + `sys.modules` on first call so `from slint.language import …` works.
 fn language_submodule<'py>(
@@ -53,7 +81,7 @@ fn register_named_tuple(
     m: &Bound<'_, PyModule>,
     class_name: &str,
     class_doc: &str,
-    fields: &[(&str, &str, String)], // name, rust_type, doc
+    fields: &[(&str, &str, String, Option<&str>)], // name, rust_type, doc, declared default
 ) -> PyResult<()> {
     let collections = py.import("collections")?;
     let namedtuple = collections.getattr("namedtuple")?;
@@ -62,9 +90,12 @@ fn register_named_tuple(
     let mut defaults = Vec::new();
     let mut full_doc = class_doc.to_string();
 
-    for (name, rust_ty, doc) in fields {
+    for (name, rust_ty, doc, declared) in fields {
         field_names.push(*name);
-        defaults.push(get_default_value(py, rust_ty)?);
+        defaults.push(match declared {
+            Some(tokens) => declared_default_value(py, m, tokens, rust_ty)?,
+            None => get_default_value(py, rust_ty)?,
+        });
         if !doc.is_empty() {
             use std::fmt::Write;
             let _ = write!(full_doc, "\n\n:param {name}: {doc}");
@@ -127,7 +158,7 @@ macro_rules! declare_python_public_structs {
         $(#[non_exhaustive])?
         $(#[derive(Copy, Eq)])?
         $vis:vis struct $Name:ident {
-            $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
+            $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident $(= $field_default:expr)?, )*
         }
     )*) => {
         fn register_structs(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -136,7 +167,8 @@ macro_rules! declare_python_public_structs {
                     let class_doc = [ $($struct_doc),* ].join("\n");
                     let fields = vec![
                         $(
-                            (stringify!($field), stringify!($field_type), [ $($field_doc),* ].join("\n")),
+                            (stringify!($field), stringify!($field_type), [ $($field_doc),* ].join("\n"),
+                                i_slint_common::builtin_struct_field_default_tokens!($($field_default)?)),
                         )*
                     ];
                     register_named_tuple(py, m, stringify!($Name), &class_doc, &fields)?;
@@ -199,7 +231,8 @@ i_slint_common::for_each_enums!(declare_python_public_enums);
 
 /// Entry point called once from `lib.rs` during module initialization.
 pub fn register_all(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    register_structs(py, m)?;
+    // Enums first: struct field defaults may reference their members
     register_enums(py, m)?;
+    register_structs(py, m)?;
     Ok(())
 }

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -494,7 +494,7 @@ pub mod language {
         ($(
             $(#[$attr:meta])*
             $vis:vis struct $Name:ident {
-                $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
+                $( $(#[$field_attr:meta])* $field:ident : $field_type:ty $(= $field_default:expr)?, )*
             }
         )*) => {
             $( #[allow(unused_imports)] $vis use i_slint_core::items::$Name; )*

--- a/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
@@ -58,6 +58,17 @@ Set to true when the line edit currently has the focus
 The horizontal alignment of the text.
 </SlintProperty>
 
+### input-method-hints
+<SlintProperty propName="input-method-hints" typeName="struct" structName="InputMethodHints">
+Hints for the platform's input method (such as a soft keyboard), for example to configure auto-capitalization.
+The input method may take these hints into account, but might also ignore them.
+```slint "input-method-hints: { capitalization: CapitalizationMode.words };"
+LineEdit {
+    input-method-hints: { capitalization: CapitalizationMode.words };
+}
+```
+</SlintProperty>
+
 ### input-type
 <SlintProperty propName="input-type" typeName="enum" enumName="InputType" defaultValue="text">
 The way to allow special input viewing properties such as password fields.

--- a/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
@@ -65,6 +65,17 @@ Set to true when the widget currently has the focus.
 When false, nothing can be entered.
 </SlintProperty>
 
+### input-method-hints
+<SlintProperty propName="input-method-hints" typeName="struct" structName="InputMethodHints">
+Hints for the platform's input method (such as a soft keyboard), for example to configure auto-capitalization.
+The input method may take these hints into account, but might also ignore them.
+```slint "input-method-hints: { capitalization: CapitalizationMode.words };"
+TextEdit {
+    input-method-hints: { capitalization: CapitalizationMode.words };
+}
+```
+</SlintProperty>
+
 ### read-only
 <SlintProperty propName="read-only" typeName="bool" defaultValue="false" >
 When set to true, text editing via keyboard and mouse is disabled but selecting text is still enabled as well as editing text programmatically.

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -306,7 +306,7 @@ pub fn extract_builtin_structs(
             $(#[non_exhaustive])?
             $(#[derive(Copy, Eq)])?
             $vis:vis struct $Name:ident {
-                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident, )*
+                $( $(#[doc = $field_doc:literal])* $field:ident : $field_type:ident $(= $field_default:expr)?, )*
             }
         )*) => {
             $(

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -11,7 +11,7 @@ use i_slint_core::api::{PhysicalPosition, PhysicalSize};
 use i_slint_core::graphics::{Color, euclid};
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType};
 use i_slint_core::item_rendering::HasFont;
-use i_slint_core::items::{ColorScheme, InputType};
+use i_slint_core::items::{CapitalizationMode, ColorScheme, InputType};
 use i_slint_core::lengths::{LogicalLength, PhysicalEdges};
 use i_slint_core::platform::WindowAdapter;
 use jni::objects::{JClass, JClassLoader, JString, LoaderContext};
@@ -216,6 +216,31 @@ bind_java_type! {
             sig = jint,
             get = TYPE_NUMBER_FLAG_DECIMAL,
         },
+        #[allow(non_snake_case)]
+        static TYPE_TEXT_FLAG_CAP_SENTENCES {
+            sig = jint,
+            get = TYPE_TEXT_FLAG_CAP_SENTENCES,
+        },
+        #[allow(non_snake_case)]
+        static TYPE_TEXT_FLAG_CAP_WORDS {
+            sig = jint,
+            get = TYPE_TEXT_FLAG_CAP_WORDS,
+        },
+        #[allow(non_snake_case)]
+        static TYPE_TEXT_FLAG_CAP_CHARACTERS {
+            sig = jint,
+            get = TYPE_TEXT_FLAG_CAP_CHARACTERS,
+        },
+        #[allow(non_snake_case)]
+        static TYPE_TEXT_FLAG_AUTO_CORRECT {
+            sig = jint,
+            get = TYPE_TEXT_FLAG_AUTO_CORRECT,
+        },
+        #[allow(non_snake_case)]
+        static TYPE_TEXT_FLAG_AUTO_COMPLETE {
+            sig = jint,
+            get = TYPE_TEXT_FLAG_AUTO_COMPLETE,
+        },
     }
 }
 
@@ -388,7 +413,36 @@ impl JavaHelper {
             let text = JString::new(env, text.as_str())?;
 
             let input_type = match data.input_type {
-                InputType::Text | InputType::Search => AndroidInputType::TYPE_CLASS_TEXT(env)?,
+                InputType::Text | InputType::Search => {
+                    let hints = &data.input_method_hints;
+                    let capitalization_flag = match hints.capitalization {
+                        CapitalizationMode::None => 0 as jint,
+                        CapitalizationMode::Sentences => {
+                            AndroidInputType::TYPE_TEXT_FLAG_CAP_SENTENCES(env)?
+                        }
+                        CapitalizationMode::Words => {
+                            AndroidInputType::TYPE_TEXT_FLAG_CAP_WORDS(env)?
+                        }
+                        CapitalizationMode::Characters => {
+                            AndroidInputType::TYPE_TEXT_FLAG_CAP_CHARACTERS(env)?
+                        }
+                        _ => 0 as jint,
+                    };
+                    let auto_correct_flag = if hints.auto_correct {
+                        AndroidInputType::TYPE_TEXT_FLAG_AUTO_CORRECT(env)?
+                    } else {
+                        0 as jint
+                    };
+                    let auto_complete_flag = if hints.auto_complete {
+                        AndroidInputType::TYPE_TEXT_FLAG_AUTO_COMPLETE(env)?
+                    } else {
+                        0 as jint
+                    };
+                    AndroidInputType::TYPE_CLASS_TEXT(env)?
+                        | capitalization_flag
+                        | auto_correct_flag
+                        | auto_complete_flag
+                }
                 InputType::Password => {
                     AndroidInputType::TYPE_TEXT_VARIATION_PASSWORD(env)?
                         | AndroidInputType::TYPE_CLASS_TEXT(env)?

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -3,11 +3,34 @@
 
 //! This module contains all builtin structures exposed in the .slint language.
 
+/// Maps the optional `$(= $field_default:expr)?` capture of a
+/// [`for_each_builtin_structs!`](crate::for_each_builtin_structs) consumer to an `Option`
+/// of the default's `stringify!`-ed tokens:
+/// `builtin_struct_field_default_tokens!($($field_default)?)`.
+/// Note that raw tokens stringify with spaces, such as `- 1.0` or `SortOrder :: Unsorted`.
+#[macro_export]
+macro_rules! builtin_struct_field_default_tokens {
+    () => {
+        None
+    };
+    ($field_default:expr) => {
+        Some(stringify!($field_default))
+    };
+}
+
 /// Call a macro with every builtin structures exposed in the .slint language
 ///
 /// Each struct is declared with `pub struct` if it should be re-exported in a public
 /// language-binding module (e.g. `slint::language` in the Rust crate), or plain `struct`
 /// to stay private. Consumers can dispatch on `$vis:vis`.
+///
+/// A field can declare a default value with `= expression` after its type.
+/// The expression is limited to number literals, bool literals, and enum values,
+/// because the consumers translate it to every target language: Rust and C++ use
+/// the expression verbatim, the other consumers apply their own minimal translation
+/// (see [`builtin_struct_field_default_tokens!`](crate::builtin_struct_field_default_tokens))
+/// and fail their build on anything outside the supported subset.
+/// Fields without a default value default to the zero value of their type.
 ///
 /// ## Example
 /// ```rust
@@ -15,7 +38,7 @@
 ///     ($(
 ///         $(#[$struct_attr:meta])*
 ///         $vis:vis struct $Name:ident {
-///             $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
+///             $( $(#[$field_attr:meta])* $field:ident : $field_type:ty $(= $field_default:tt)?, )*
 ///         }
 ///     )*) => {
 ///         $(println!("{} ({}) => [{}]", stringify!($Name), stringify!($vis), stringify!($($field),*));)*

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -162,6 +162,22 @@ macro_rules! for_each_builtin_structs {
                 cap_height: Coord,
             }
 
+            /// This structure holds the hints that a `TextInput` gives to the platform's input method
+            /// (e.g. a soft keyboard) about the expected input.
+            /// The input method may take these hints into account, but might also ignore them.
+            #[non_exhaustive]
+            pub struct InputMethodHints {
+                /// The auto-capitalization behavior that the input method should apply.
+                /// Defaults to sentences.
+                capitalization: CapitalizationMode = (CapitalizationMode::Sentences),
+                /// Hint that the input method may automatically correct spelling mistakes as the user types.
+                /// Defaults to true.
+                auto_correct: bool = true,
+                /// Hint that the input method may offer auto-completion suggestions for the entered text.
+                /// Defaults to true.
+                auto_complete: bool = true,
+            }
+
             /// An item in the menu of a menu bar or context menu
             struct MenuEntry {
                 /// The text of the menu entry

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -81,6 +81,20 @@ macro_rules! for_each_enums {
                 Center,
             }
 
+            /// This enum describes the auto-capitalization behavior that the input method
+            /// (e.g. a soft keyboard) should apply while text is entered in a `TextInput`.
+            #[non_exhaustive]
+            pub enum CapitalizationMode {
+                /// No auto-capitalization.
+                None,
+                /// Capitalize the first character of each sentence.
+                Sentences,
+                /// Capitalize the first character of each word.
+                Words,
+                /// Capitalize all characters.
+                Characters,
+            }
+
             /// This enum describes whether an event was rejected or accepted by an event handler.
             #[non_exhaustive]
             enum EventResult {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1738,6 +1738,9 @@ export component TextInput {
     ///  Use this to configure `TextInput` for editing special input, such as password fields.
     /// \default text
     in property <InputType> input-type;
+    /// Hints for the platform's input method (such as a soft keyboard), for example to configure auto-capitalization.
+    /// The input method may take these hints into account, but might also ignore them.
+    in property <InputMethodHints> input-method-hints;
     // Internal, undocumented property, only exposed for tests.
     out property <int> cursor-position_byte-offset;
     // Internal, undocumented property, only exposed for tests.

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5242,7 +5242,9 @@ fn compile_builtin_function_call(
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let window = access_window_field(ctx);
-                format!("slint_cpp_text_item_fontmetrics(&{window}.handle(), &{item_rc})")
+                format!(
+                    "[&]{{ slint::cbindgen_private::FontMetrics fm; slint_cpp_text_item_fontmetrics(&{window}.handle(), &{item_rc}, &fm); return fm; }}()"
+                )
             } else {
                 panic!("internal error: invalid args to ItemFontMetrics {arguments:?}")
             }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -690,7 +690,7 @@ macro_rules! define_builtin_struct_enum {
     ($(
         $(#[$attr:meta])*
         $vis:vis struct $Name:ident {
-            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
+            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty $(= $field_default:expr)?, )*
         }
     )*) => {
         #[derive(Debug, Clone, PartialEq, strum::EnumString, strum::IntoStaticStr)]
@@ -998,7 +998,7 @@ impl From<BuiltinStruct> for StructName {
 #[derive(Debug, Clone)]
 pub struct Struct {
     pub fields: BTreeMap<SmolStr, Type>,
-    /// User-declared default values for fields (`struct Foo { bar: int = 42 }`).
+    /// Default values for the fields.
     /// The expressions are resolved, converted to the field type, and constant-folded.
     /// Like the syntax node in `name`, this is ignored by `Type`'s equality comparison.
     pub field_defaults: BTreeMap<SmolStr, ConstantExpression>,
@@ -1006,8 +1006,7 @@ pub struct Struct {
 }
 
 impl Struct {
-    /// Create a struct without user-declared field default values
-    /// (only named struct declarations in .slint can have those).
+    /// Create a struct without declared field default values.
     pub fn new(fields: BTreeMap<SmolStr, Type>, name: impl Into<StructName>) -> Self {
         Self { fields, field_defaults: Default::default(), name: name.into() }
     }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -502,7 +502,7 @@ impl TypeRegister {
             ($(
                 $(#[$attr:meta])*
                 $vis:vis struct $Name:ident {
-                    $( $(#[$field_attr:meta])* $field:ident : $field_type:ident, )*
+                    $( $(#[$field_attr:meta])* $field:ident : $field_type:ident $(= $field_default:expr)?, )*
                 }
             )*) => { $(
                 register.insert_type_with_name(Type::Struct(builtin_structs::$Name()), SmolStr::new(stringify!($Name)));
@@ -817,6 +817,7 @@ impl TypeRegister {
 /// Type definitions for each builtin struct
 pub mod builtin_structs {
     use super::*;
+    use crate::langtype::ConstantExpression;
 
     thread_local! {
         pub static BUILTIN_STRUCTS: BuiltinStructs = BuiltinStructs::new();
@@ -845,11 +846,25 @@ pub mod builtin_structs {
         };
     }
 
+    macro_rules! parse_default_field {
+        (true) => { ConstantExpression::BoolLiteral(true) };
+        (false) => { ConstantExpression::BoolLiteral(false) };
+        ($lit:literal) => { ConstantExpression::NumberLiteral($lit as _, Unit::None) };
+        ($enum:ident :: $value:ident) => {
+            ConstantExpression::EnumerationValue(BUILTIN.with(|e| {
+                let variant = crate::generator::to_kebab_case(stringify!($value));
+                e.enums.$enum.clone().try_value_from_string(&variant)
+                    .expect(concat!("unknown enum variant in field default ", stringify!($enum), "::", stringify!($value)))
+            }))
+        };
+        (($($tt:tt)*)) => { parse_default_field!($($tt)*) };
+    }
+
     macro_rules! declare_builtin_structs {
         ($(
             $(#[$attr:meta])*
             $vis:vis struct $Name:ident {
-                $( $(#[$field_attr:meta])* $field:ident : $field_type:ident, )*
+                $( $(#[$field_attr:meta])* $field:ident : $field_type:ident $(= $field_default:tt)?, )*
             }
         )*) => {
             pub struct BuiltinStructs {
@@ -861,13 +876,26 @@ pub mod builtin_structs {
             impl BuiltinStructs {
                 pub fn new() -> Self {
                     $(
-                    #[allow(non_snake_case)]
-                    let $Name = Rc::new(Struct::new(
-                        BTreeMap::from([
-                            $((stringify!($field).replace_smolstr("_", "-"), map_type!($field_type, $field_type))),*
-                        ]),
-                        BuiltinStruct::$Name,
-                    ));
+                        #[allow(non_snake_case)]
+                        let $Name = {
+                            let mut fields = BTreeMap::new();
+                            #[allow(unused_mut)]
+                            let mut field_defaults = BTreeMap::new();
+                            $(
+                                let field_name = stringify!($field).replace_smolstr("_", "-");
+                                let field_type = map_type!($field_type, $field_type);
+                                $(field_defaults.insert(
+                                    field_name.clone(),
+                                    parse_default_field!($field_default),
+                                );)?
+                                fields.insert(field_name, field_type);
+                            )*
+                            Rc::new(Struct {
+                                fields,
+                                field_defaults,
+                                name: BuiltinStruct::$Name.into(),
+                            })
+                        };
                     )*
 
                     Self {

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -15,6 +15,7 @@ export component LineEditBase implements LineEditInterface inherits Rectangle {
     in-out property <bool> password-revealed: false;
     horizontal-alignment <=> text-input.horizontal-alignment;
     read-only <=> text-input.read-only;
+    input-method-hints <=> text-input.input-method-hints;
 
     changed has-focus => {
         if !self.has-focus {

--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -8,6 +8,7 @@ export component TextEditBase inherits Rectangle {
 
     in property <TextWrap> wrap <=> text-input.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> text-input.horizontal-alignment;
+    in property <InputMethodHints> input-method-hints <=> text-input.input-method-hints;
     in property <bool> read-only <=> text-input.read-only;
     in property <length> font-size <=> text-input.font-size;
     in property <string> font-family <=> text-input.font-family;

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -8,6 +8,7 @@ import { TextEditBase } from "../common/textedit-base.slint";
 export component TextEdit {
     in property <TextWrap> wrap <=> base.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> base.horizontal-alignment;
+    in property <InputMethodHints> input-method-hints <=> base.input-method-hints;
     in property <bool> read-only <=> base.read-only;
     in property <length> font-size <=> base.font-size;
     in property <string> font-family <=> base.font-family;

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -62,6 +62,7 @@ component ScrollView {
 export component TextEdit {
     in property <TextWrap> wrap <=> text-input.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> text-input.horizontal-alignment;
+    in property <InputMethodHints> input-method-hints <=> text-input.input-method-hints;
     in property <bool> read-only <=> text-input.read-only;
     in property <length> font-size <=> text-input.font-size;
     in property <string> font-family <=> text-input.font-family;

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -8,6 +8,7 @@ import { TextEditBase } from "../common/textedit-base.slint";
 export component TextEdit {
     in property <TextWrap> wrap <=> base.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> base.horizontal-alignment;
+    in property <InputMethodHints> input-method-hints <=> base.input-method-hints;
     in property <bool> read-only <=> base.read-only;
     in property <length> font-size <=> base.font-size;
     in property <string> font-family <=> base.font-family;

--- a/internal/compiler/widgets/interfaces/lineedit.slint
+++ b/internal/compiler/widgets/interfaces/lineedit.slint
@@ -7,6 +7,7 @@ export interface LineEdit {
     in property <bool> font-italic;
     in property <length> font-size;
     in property <TextHorizontalAlignment> horizontal-alignment;
+    in property <InputMethodHints> input-method-hints;
     in property <InputType> input-type;
     in property <string> placeholder-text;
     in property <bool> read-only;

--- a/internal/compiler/widgets/material/textedit.slint
+++ b/internal/compiler/widgets/material/textedit.slint
@@ -8,6 +8,7 @@ import { TextEditBase } from "../common/textedit-base.slint";
 export component TextEdit {
     in property <TextWrap> wrap <=> base.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> base.horizontal-alignment;
+    in property <InputMethodHints> input-method-hints <=> base.input-method-hints;
     in property <bool> read-only <=> base.read-only;
     in property <length> font-size <=> base.font-size;
     in property <string> font-family <=> base.font-family;

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -7,6 +7,7 @@ import { StyleMetrics  } from "std-widgets-impl.slint";
 export component TextEdit {
     in property <TextWrap> wrap <=> base.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> base.horizontal-alignment;
+    in property <InputMethodHints> input-method-hints <=> base.input-method-hints;
     in property <bool> read-only <=> base.read-only;
     in property <length> font-size <=> base.font-size;
     in property <string> font-family <=> base.font-family;

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2168,15 +2168,31 @@ declare_item_vtable! {
     fn slint_get_TooltipAreaVTable() -> TooltipAreaVTable for TooltipArea
 }
 
+/// Expands to a builtin struct field's declared default value,
+/// or to the zero value of the field's type when no default is declared.
+/// Number literals for `Coord` fields are cast, because `Coord` is `f32` or `i32`
+/// depending on `cfg(slint_int_coord)`.
+macro_rules! builtin_struct_field_default {
+    (Coord, $default:expr) => {
+        ($default) as Coord
+    };
+    ($field_type:ident, $default:expr) => {
+        $default
+    };
+    ($field_type:ident) => {
+        ::core::default::Default::default()
+    };
+}
+
 macro_rules! declare_builtin_structs {
     ($(
         $(#[$struct_attr:meta])*
         $vis:vis struct $Name:ident {
-            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
+            $( $(#[$field_attr:meta])* $field:ident : $field_type:ident $(= $field_default:expr)?, )*
         }
     )*) => {
         $(
-            #[derive(Clone, Debug, Default, PartialEq)]
+            #[derive(Clone, Debug, PartialEq)]
             #[repr(C)]
             $(#[$struct_attr])*
             pub struct $Name {
@@ -2185,11 +2201,33 @@ macro_rules! declare_builtin_structs {
                     pub $field : $field_type,
                 )*
             }
+
+            // Not derived, so that the fields take their declared default values
+            impl ::core::default::Default for $Name {
+                fn default() -> Self {
+                    Self {
+                        $($field: builtin_struct_field_default!($field_type $(, $field_default)?),)*
+                    }
+                }
+            }
         )*
     };
 }
 
 i_slint_common::for_each_builtin_structs!(declare_builtin_structs);
+
+#[test]
+fn builtin_struct_field_defaults() {
+    // No builtin struct field declares a default value yet, so the macro-generated
+    // Default impls must match what derive(Default) used to produce
+    let table_column = TableColumn::default();
+    assert_eq!(table_column.sort_order, SortOrder::Unsorted);
+    assert_eq!(table_column.min_width, 0 as Coord);
+    assert_eq!(table_column.horizontal_stretch, 0.0);
+    assert_eq!(table_column.title, SharedString::default());
+    assert!(!KeyEvent::default().repeat);
+    assert_eq!(PointerEvent::default().touch_finger_id, 0);
+}
 
 #[cfg(feature = "ffi")]
 #[unsafe(no_mangle)]

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2218,8 +2218,8 @@ i_slint_common::for_each_builtin_structs!(declare_builtin_structs);
 
 #[test]
 fn builtin_struct_field_defaults() {
-    // No builtin struct field declares a default value yet, so the macro-generated
-    // Default impls must match what derive(Default) used to produce
+    // Fields without a declared default value take the zero value of their type,
+    // like with derive(Default)
     let table_column = TableColumn::default();
     assert_eq!(table_column.sort_order, SortOrder::Unsorted);
     assert_eq!(table_column.min_width, 0 as Coord);
@@ -2227,6 +2227,12 @@ fn builtin_struct_field_defaults() {
     assert_eq!(table_column.title, SharedString::default());
     assert!(!KeyEvent::default().repeat);
     assert_eq!(PointerEvent::default().touch_finger_id, 0);
+
+    // Fields with a declared default value take it
+    let hints = InputMethodHints::default();
+    assert_eq!(hints.capitalization, CapitalizationMode::Sentences);
+    assert!(hints.auto_correct);
+    assert!(hints.auto_complete);
 }
 
 #[cfg(feature = "ffi")]

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -9,10 +9,10 @@ When adding an item or a property, it needs to be kept in sync with different pl
 Lookup the [`crate::items`] module documentation.
 */
 use super::{
-    EventResult, FontMetrics, InputType, Item, ItemConsts, ItemRc, ItemRef, KeyEventArg,
-    KeyEventResult, KeyEventType, PointArg, PointerEventButton, RenderingResult, StringArg,
-    TextHorizontalAlignment, TextOverflow, TextStrokeStyle, TextVerticalAlignment, TextWrap,
-    VoidArg,
+    EventResult, FontMetrics, InputMethodHints, InputType, Item, ItemConsts, ItemRc, ItemRef,
+    KeyEventArg, KeyEventResult, KeyEventType, PointArg, PointerEventButton, RenderingResult,
+    StringArg, TextHorizontalAlignment, TextOverflow, TextStrokeStyle, TextVerticalAlignment,
+    TextWrap, VoidArg,
 };
 use crate::graphics::{Brush, Color, FontRequest};
 use crate::input::{
@@ -760,6 +760,7 @@ pub struct TextInput {
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub wrap: Property<TextWrap>,
     pub input_type: Property<InputType>,
+    pub input_method_hints: Property<InputMethodHints>,
     pub letter_spacing: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
@@ -1854,6 +1855,7 @@ impl TextInput {
             cursor_rect_size,
             anchor_point,
             input_type: self.input_type(),
+            input_method_hints: self.input_method_hints(),
             clip_rect,
         }
     }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -2516,11 +2516,12 @@ pub unsafe extern "C" fn slint_cpp_text_item_fontmetrics(
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
     self_index: u32,
-) -> FontMetrics {
+    out: *mut FontMetrics,
+) {
     unsafe {
         let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
         let self_rc = ItemRc::new(self_component.clone(), self_index);
         let self_ref = self_rc.borrow();
-        slint_text_item_fontmetrics(window_adapter, self_ref, &self_rc)
+        core::ptr::write(out, slint_text_item_fontmetrics(window_adapter, self_ref, &self_rc));
     }
 }

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -55,6 +55,7 @@ macro_rules! declare_ValueType_2 {
             crate::component_factory::ComponentFactory,
             crate::api::LogicalPosition,
             crate::items::FontMetrics,
+            crate::items::InputMethodHints,
             crate::items::MenuEntry,
             crate::items::DropEvent,
             crate::model::ModelRc<crate::items::MenuEntry>,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -19,7 +19,9 @@ use crate::item_tree::{
     ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable, ItemTreeWeak, ItemWeak,
     ParentItemTraversalMode,
 };
-use crate::items::{BuiltInMouseCursor, InputType, ItemRef, MenuEntry, PopupClosePolicy};
+use crate::items::{
+    BuiltInMouseCursor, InputMethodHints, InputType, ItemRef, MenuEntry, PopupClosePolicy,
+};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalVector, SizeLengths};
 use crate::menus::MenuVTable;
 use crate::properties::{Property, PropertyTracker};
@@ -371,6 +373,8 @@ pub struct InputMethodProperties {
     pub anchor_point: LogicalPosition,
     /// The type of input for the text edit.
     pub input_type: InputType,
+    /// The hints for the input method for the text edit.
+    pub input_method_hints: InputMethodHints,
     /// The clip rect in window coordinates
     pub clip_rect: Option<LogicalRect>,
 }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -309,7 +309,7 @@ macro_rules! declare_value_struct_conversion {
     ($(
         $(#[$struct_attr:meta])*
         $vis:vis struct $Name:ident {
-            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty, )*
+            $( $(#[$field_attr:meta])* $field:ident : $field_type:ty $(= $field_default:expr)?, )*
         }
     )*) => {
         $(
@@ -329,6 +329,8 @@ macro_rules! declare_value_struct_conversion {
                             type Ty = $Name;
                             #[allow(unused)]
                             let mut res: Ty = Ty::default();
+                            // Every field is required and overwritten, so declared field
+                            // defaults do not apply to this conversion
                             $(res.$field = x.get_field(stringify!($field)).ok_or(())?.clone().try_into().map_err(|_|())?;)*
                             Ok(res)
                         }

--- a/tests/cases/types/builtin_struct_field_defaults.slint
+++ b/tests/cases/types/builtin_struct_field_defaults.slint
@@ -1,0 +1,80 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Builtin structs can declare field default values in builtin_structs.rs;
+// InputMethodHints declares auto-correct and auto-complete as true,
+// and capitalization as sentences.
+
+export component TestCase {
+    ti := TextInput {}
+
+    // A property that is never set is initialized with the declared defaults
+    in-out property <InputMethodHints> never-set;
+    // Missing fields in a struct literal take the declared defaults
+    in-out property <InputMethodHints> partial: { capitalization: CapitalizationMode.words };
+    in-out property <InputMethodHints> opt-out: { auto-correct: false, auto-complete: false };
+
+    out property <bool> test:
+        never-set.auto-correct && never-set.auto-complete
+        && never-set.capitalization == CapitalizationMode.sentences
+        && partial.auto-correct && partial.auto-complete
+        && partial.capitalization == CapitalizationMode.words
+        && !opt-out.auto-correct && !opt-out.auto-complete
+        && opt-out.capitalization == CapitalizationMode.sentences
+        && ti.input-method-hints.auto-correct && ti.input-method-hints.auto-complete
+        && ti.input-method-hints.capitalization == CapitalizationMode.sentences;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+let hints = slint::language::InputMethodHints::default();
+assert!(hints.auto_correct);
+assert!(hints.auto_complete);
+assert_eq!(hints.capitalization, slint::language::CapitalizationMode::Sentences);
+
+// The struct is non-exhaustive, so custom values start from the defaults
+let mut custom = slint::language::InputMethodHints::default();
+custom.capitalization = slint::language::CapitalizationMode::Words;
+assert!(custom.auto_correct);
+assert!(custom.auto_complete);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+slint::language::InputMethodHints hints{};
+assert(hints.auto_correct);
+assert(hints.auto_complete);
+assert(hints.capitalization == slint::language::CapitalizationMode::Sentences);
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+
+let hints = slintlib.language.InputMethodHints();
+assert.equal(hints.auto_correct, true);
+assert.equal(hints.auto_complete, true);
+assert.equal(hints.capitalization, "sentences");
+
+let custom = slintlib.language.InputMethodHints({ capitalization: "words" });
+assert.equal(custom.auto_correct, true);
+assert.equal(custom.auto_complete, true);
+```
+
+```python
+instance = TestCase()
+assert instance.test
+
+import slint
+hints = slint.language.InputMethodHints()
+assert hints.auto_correct
+assert hints.auto_complete
+assert hints.capitalization == slint.language.CapitalizationMode.sentences
+```
+*/


### PR DESCRIPTION
Supersedes #9016, following the discussion there: instead of a single `caps-mode` enum property, this adds an `InputMethodHints` struct with a `capitalization` mode as well as `auto-correct` and `auto-complete` flags, and an `input-method-hints` property on `TextInput` and the style `LineEdit`s:

```slint
LineEdit {
    input-method-hints: { capitalization: CapitalizationMode.sentences };
}
```

The hints are passed to the backend through `InputMethodProperties`, so custom platform implementations can access them via the input method request. The Android backend maps them to the corresponding `android.text.InputType` flags. The hints may be ignored by input methods that don't support them.

The struct is marked `#[non_exhaustive]` so that more hints (e.g. configuring the accept button of the soft keyboard, as mentioned in #9016) can be added later without breaking the API.

Based on the original patch by @badicsalex.
