### PR TITLE
Interfaces do not permit default property bindings, bindings or two-way bindings

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -25,7 +25,7 @@ interface TextInterface {
 An interface body may contain:
 
 - Properties with visibility `in`, `out`, or `in-out`.
-  Default values are allowed and are applied to implementing components that do not override them.
+  Default values are not permitted.
 - Callbacks, with any signature except `init`.
 - Function declarations without a body.
   They must be `public` and can be `pure`.
@@ -81,7 +81,7 @@ If two `uses` entries expose properties with the same name, the first one wins a
 
 ```slint no-test
 interface Counter {
-    in-out property <int> value: 0;
+    in-out property <int> value;
     callback increment();
 }
 

--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -30,7 +30,7 @@ An interface body may contain:
 - Function declarations without a body.
   They must be `public` and can be `pure`.
 
-An interface body may **not** contain child elements, layouts, `states`, `animate` blocks, or private properties.
+An interface body may **not** contain bindings, child elements, layouts, `states`, two-way bindings, `animate` blocks, or private properties.
 An interface can be exported with `export interface`.
 
 ## Implementing an interface

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1216,6 +1216,7 @@ impl Element {
         } else {
             tr.empty_type()
         };
+        let is_interface = base_type == ElementType::Interface;
         // This isn't truly qualified yet, the enclosing component is added at the end of Component::from_node
         let qualified_id = (!id.is_empty()).then(|| id.clone());
         if let ElementType::Component(c) = &base_type {
@@ -1331,11 +1332,25 @@ impl Element {
                 }
             });
 
-            if base_type == ElementType::Interface && visibility == PropertyVisibility::Private {
-                diag.push_error(
-                    "'private' properties are inaccessible in an interface".into(),
-                    &prop_decl,
-                );
+            if is_interface {
+                if let Some(binding_expression) = &prop_decl.BindingExpression() {
+                    diag.push_error(
+                        "Interface properties cannot have default values".into(),
+                        binding_expression,
+                    )
+                }
+                if let Some(two_way) = &prop_decl.TwoWayBinding() {
+                    diag.push_error(
+                        "Interface properties cannot have default bindings".into(),
+                        two_way,
+                    )
+                }
+                if visibility == PropertyVisibility::Private {
+                    diag.push_error(
+                        "'private' properties are inaccessible in an interface".into(),
+                        &prop_decl,
+                    );
+                }
             }
 
             // Use the name as declared, not the resolved name: when the declaration
@@ -1570,7 +1585,7 @@ impl Element {
                 }
             }
 
-            if base_type == ElementType::Interface && visibility != PropertyVisibility::Public {
+            if is_interface && visibility != PropertyVisibility::Public {
                 diag.push_error(
                     "Function declarations in an interface must be public".into(),
                     &func,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1208,6 +1208,11 @@ impl Element {
                 }
             });
 
+            if parent_type == ElementType::Interface {
+                node.Binding().for_each(|n| error_on(&n, "bindings"));
+                node.TwoWayBinding().for_each(|n| error_on(&n, "two-way bindings"));
+            }
+
             parent_type
         } else if parent_type != ElementType::Error {
             // This should normally never happen because the parser does not allow for this

--- a/internal/compiler/tests/syntax/interfaces/interface_export.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_export.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export interface TestInterface {
-    out property <bool> test: false;
+    out property <bool> test;
 }
 
 // We intentionally do not use TestInterface here to verify that resolve_native_classes does not get invoked

--- a/internal/compiler/tests/syntax/interfaces/interface_implements.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_implements.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export interface TestInterface {
-    in-out property <bool> test: false;
+    in-out property <bool> test;
 }
 
 export interface ImplementingInterface implements

--- a/internal/compiler/tests/syntax/interfaces/interface_properties.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_properties.slint
@@ -27,3 +27,19 @@ export interface Background {
 export component MyComponent implements Background inherits Rectangle { }
 //                                      >         <error{Cannot implement interface 'Background' because 'background' conflicts with an existing property in 'Rectangle'}
 //                                      >         <^error{Cannot implement interface 'Background' because 'clip' conflicts with an existing property in 'Rectangle'}
+
+export interface InterfaceWithDefaultPropertyValues {
+    in property <int> in-property: 42;
+//                                 > <error{Interface properties cannot have default values}
+    out property <string> out-property: "Hello World";
+//                                      >            <error{Interface properties cannot have default values}
+
+    in-out property <angle> in-out-property: 90deg;
+//                                           >    <error{Interface properties cannot have default values}
+}
+
+export interface InterfaceWithDefaultPropertyBindings {
+    in property <int> in-property;
+    out property <int> out-property <=> self.in-property;
+//                                  >                   <error{Interface properties cannot have default bindings}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_properties.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_properties.slint
@@ -43,3 +43,17 @@ export interface InterfaceWithDefaultPropertyBindings {
     out property <int> out-property <=> self.in-property;
 //                                  >                   <error{Interface properties cannot have default bindings}
 }
+
+export interface InterfaceWithDefaultBindings {
+    in property <int> in-property;
+    out property <int> out-property;
+    out-property: self.in-property;
+//  >                             <error{An interface cannot have bindings}
+}
+
+export interface InterfaceWithDefaultTwoWayBindings {
+    in property <int> in-property;
+    out property <int> out-property;
+    out-property <=> self.in-property;
+//  >                                <error{An interface cannot have two-way bindings}
+}

--- a/internal/compiler/tests/syntax/interfaces/uses_errors.slint
+++ b/internal/compiler/tests/syntax/interfaces/uses_errors.slint
@@ -167,7 +167,7 @@ export component ConflictingNames uses { ValidInterface from base } {
 }
 
 component BaseWithConflicts {
-    in-out property <int> value: 10;
+    in-out property <int> value;
     callback speak();
     public pure function reset() {
     }
@@ -193,7 +193,7 @@ component AImpl implements InterfaceA {
 }
 
 interface InterfaceB {
-    out property <bool> test: true;
+    out property <bool> test;
     callback test-callback(string);
     pure public function test-function(i: int) -> int;
 }

--- a/internal/compiler/widgets/interfaces/lineedit.slint
+++ b/internal/compiler/widgets/interfaces/lineedit.slint
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export interface LineEdit {
-    in property <bool> enabled: true;
-    in property <string> font-family: "";
-    in property <bool> font-italic: false;
-    in property <length> font-size: 0px;
-    in property <TextHorizontalAlignment> horizontal-alignment: TextHorizontalAlignment.left;
-    in property <InputType> input-type: InputType.text;
-    in property <string> placeholder-text: "";
-    in property <bool> read-only: false;
+    in property <bool> enabled;
+    in property <string> font-family;
+    in property <bool> font-italic;
+    in property <length> font-size;
+    in property <TextHorizontalAlignment> horizontal-alignment;
+    in property <InputType> input-type;
+    in property <string> placeholder-text;
+    in property <bool> read-only;
 
     out property <bool> has-focus;
 
-    in-out property <string> text: "";
+    in-out property <string> text;
 
     callback accepted(text: string);
     callback edited(text: string);

--- a/tests/cases/imports/property_bindings.slint
+++ b/tests/cases/imports/property_bindings.slint
@@ -14,6 +14,7 @@ import { ComboBoxInterface } from "export_interfaces.slint";
 // in this file.
 
 component ComboBoxBase implements ComboBoxInterface {
+    current-value: root.model[root.current-index];
     model: ["Kiwi", "Mango"];
 }
 

--- a/tests/cases/interfaces/component_overrides_defaults.slint
+++ b/tests/cases/interfaces/component_overrides_defaults.slint
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 interface InterfaceWithDefaults {
-    in-out property <string> text: "Hello";
-    out property <bool> enabled: true;
-    in property <int> precision: 2;
-    in property <float> confidence: 1.0;
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    in property <float> confidence;
 
     public pure function length(text: string) -> int;
     callback checked();
@@ -13,7 +13,7 @@ interface InterfaceWithDefaults {
 
 export component TestCase implements InterfaceWithDefaults {
 
-    out property <bool> test: self.text == "Hello" && self.enabled && self.precision == 2 && self.confidence == 0.5;
+    out property <bool> test: self.text == "" && !self.enabled && self.precision == 0 && self.confidence == 0.5;
 
     public pure function length(text: string) -> int {
         text.character-count
@@ -25,9 +25,9 @@ export component TestCase implements InterfaceWithDefaults {
 /*
 ```rust
 let instance = TestCase::new().unwrap();
-assert_eq!(instance.get_text(), "Hello");
-assert_eq!(instance.get_enabled(), true);
-assert_eq!(instance.get_precision(), 2);
+assert_eq!(instance.get_text(), "");
+assert_eq!(instance.get_enabled(), false);
+assert_eq!(instance.get_precision(), 0);
 assert_eq!(instance.get_confidence(), 0.5);
 assert!(instance.get_test());
 ```
@@ -35,18 +35,18 @@ assert!(instance.get_test());
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-assert_eq(instance.get_text(), "Hello");
-assert_eq(instance.get_enabled(), true);
-assert_eq(instance.get_precision(), 2);
+assert_eq(instance.get_text(), "");
+assert_eq(instance.get_enabled(), false);
+assert_eq(instance.get_precision(), 0);
 assert_eq(instance.get_confidence(), 0.5);
 assert(instance.get_test());
 ```
 
 ```js
 var instance = new slint.TestCase({});
-assert.equal(instance.text, "Hello");
-assert.equal(instance.enabled, true);
-assert.equal(instance.precision, 2);
+assert.equal(instance.text, "");
+assert.equal(instance.enabled, false);
+assert.equal(instance.precision, 0);
 assert.equal(instance.confidence, 0.5);
 assert(instance.test);
 ```

--- a/tests/cases/interfaces/derived_implements_defaults.slint
+++ b/tests/cases/interfaces/derived_implements_defaults.slint
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 interface InterfaceWithDefaults {
-    in-out property <string> text: "Hello";
-    out property <bool> enabled: true;
-    in property <int> precision: 2;
-    in property <float> confidence: 1.0;
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    in property <float> confidence;
 
     public pure function length(text: string) -> int;
     callback checked();
@@ -23,16 +23,16 @@ component Base implements InterfaceWithDefaults {
 
 export component TestCase inherits Base {
     // We expect to be using the Base value for confidence
-    out property <bool> test: self.text == "Hello" && self.enabled && self.precision == 2 && self.confidence == 0.5;
+    out property <bool> test: self.text == "" && !self.enabled && self.precision == 0 && self.confidence == 0.5;
 }
 
 /*
 ```rust
 let instance = TestCase::new().unwrap();
 // TODO: Interface properties aren't part of the public API
-// assert_eq!(instance.get_text(), "Hello");
-// assert_eq!(instance.get_enabled(), true);
-// assert_eq!(instance.get_precision(), 2);
+// assert_eq!(instance.get_text(), "");
+// assert_eq!(instance.get_enabled(), false);
+// assert_eq!(instance.get_precision(), 0);
 // assert_eq!(instance.get_confidence(), 0.5);
 assert!(instance.get_test());
 ```
@@ -41,9 +41,9 @@ assert!(instance.get_test());
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 // TODO: Interface properties aren't part of the public API
-// assert_eq(instance.get_text(), "Hello");
-// assert_eq(instance.get_enabled(), true);
-// assert_eq(instance.get_precision(), 2);
+// assert_eq(instance.get_text(), "");
+// assert_eq(instance.get_enabled(), false);
+// assert_eq(instance.get_precision(), 0);
 // assert_eq(instance.get_confidence(), 0.5);
 assert(instance.get_test());
 ```
@@ -51,9 +51,9 @@ assert(instance.get_test());
 ```js
 var instance = new slint.TestCase({});
 // TODO: Interface properties aren't part of the public API
-// assert.equal(instance.text, "Hello");
-// assert.equal(instance.enabled, true);
-// assert.equal(instance.precision, 2);
+// assert.equal(instance.text, "");
+// assert.equal(instance.enabled, false);
+// assert.equal(instance.precision, 0);
 // assert.equal(instance.confidence, 0.5);
 assert(instance.test);
 ```

--- a/tests/cases/interfaces/derived_implicitly_implements.slint
+++ b/tests/cases/interfaces/derived_implicitly_implements.slint
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 interface InterfaceWithDefaults {
-    in-out property <string> text: "Hello";
-    out property <bool> enabled: true;
-    in property <int> precision: 2;
-    in property <float> confidence: 1.0;
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    in property <float> confidence;
 
     public pure function length(text: string) -> int;
     callback checked();
@@ -42,9 +42,9 @@ export component TestCase implements InterfaceWithDefaults inherits Base {
 ```rust
 let instance = TestCase::new().unwrap();
 // TODO: Interface properties aren't part of the public API
-// assert_eq!(instance.get_text(), "Hello");
-// assert_eq!(instance.get_enabled(), true);
-// assert_eq!(instance.get_precision(), 2);
+// assert_eq!(instance.get_text(), "");
+// assert_eq!(instance.get_enabled(), false);
+// assert_eq!(instance.get_precision(), 0);
 // assert_eq!(instance.get_confidence(), 0.5);
 assert!(instance.get_test());
 ```
@@ -53,9 +53,9 @@ assert!(instance.get_test());
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 // TODO: Interface properties aren't part of the public API
-// assert_eq(instance.get_text(), "Hello");
-// assert_eq(instance.get_enabled(), true);
-// assert_eq(instance.get_precision(), 2);
+// assert_eq(instance.get_text(), "");
+// assert_eq(instance.get_enabled(), false);
+// assert_eq(instance.get_precision(), 0);
 // assert_eq(instance.get_confidence(), 0.5);
 assert(instance.get_test());
 ```
@@ -63,9 +63,9 @@ assert(instance.get_test());
 ```js
 var instance = new slint.TestCase({});
 // TODO: Interface properties aren't part of the public API
-// assert.equal(instance.text, "Hello");
-// assert.equal(instance.enabled, true);
-// assert.equal(instance.precision, 2);
+// assert.equal(instance.text, "");
+// assert.equal(instance.enabled, false);
+// assert.equal(instance.precision, 0);
 // assert.equal(instance.confidence, 0.5);
 assert(instance.test);
 ```

--- a/tests/cases/interfaces/implements_defaults.slint
+++ b/tests/cases/interfaces/implements_defaults.slint
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 interface InterfaceWithDefaults {
-    in-out property <string> text: "Hello";
-    out property <bool> enabled: true;
-    in property <int> precision: 2;
-    in property <float> confidence: 1.0;
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    in property <float> confidence;
 
     public pure function length(text: string) -> int;
     callback checked();
@@ -15,7 +15,7 @@ export component TestCase implements InterfaceWithDefaults {
 
     confidence: 0.5;
 
-    out property <bool> test: self.text == "Hello" && self.enabled && self.precision == 2 && self.confidence == 0.5;
+    out property <bool> test: self.text == "" && !self.enabled && self.precision == 0 && self.confidence == 0.5;
 
     public pure function length(text: string) -> int {
         text.character-count
@@ -25,9 +25,9 @@ export component TestCase implements InterfaceWithDefaults {
 /*
 ```rust
 let instance = TestCase::new().unwrap();
-assert_eq!(instance.get_text(), "Hello");
-assert_eq!(instance.get_enabled(), true);
-assert_eq!(instance.get_precision(), 2);
+assert_eq!(instance.get_text(), "");
+assert_eq!(instance.get_enabled(), false);
+assert_eq!(instance.get_precision(), 0);
 assert_eq!(instance.get_confidence(), 0.5);
 assert!(instance.get_test());
 ```
@@ -35,18 +35,18 @@ assert!(instance.get_test());
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-assert_eq(instance.get_text(), "Hello");
-assert_eq(instance.get_enabled(), true);
-assert_eq(instance.get_precision(), 2);
+assert_eq(instance.get_text(), "");
+assert_eq(instance.get_enabled(), false);
+assert_eq(instance.get_precision(), 0);
 assert_eq(instance.get_confidence(), 0.5);
 assert(instance.get_test());
 ```
 
 ```js
 var instance = new slint.TestCase({});
-assert.equal(instance.text, "Hello");
-assert.equal(instance.enabled, true);
-assert.equal(instance.precision, 2);
+assert.equal(instance.text, "");
+assert.equal(instance.enabled, false);
+assert.equal(instance.precision, 0);
 assert.equal(instance.confidence, 0.5);
 assert(instance.test);
 ```

--- a/tests/cases/interfaces/implements_inherits.slint
+++ b/tests/cases/interfaces/implements_inherits.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 interface TestInterface {
-    in-out property <bool> test: false;
+    in-out property <bool> test;
 }
 
 export component TestCase implements TestInterface inherits Rectangle {

--- a/tests/cases/interfaces/implements_inherits_aliased_property.slint
+++ b/tests/cases/interfaces/implements_inherits_aliased_property.slint
@@ -10,7 +10,7 @@
 // as `false`.
 
 interface I {
-    in-out property <bool> value: false;
+    in-out property <bool> value;
 }
 
 component Sink implements I {

--- a/tests/cases/interfaces/uses.slint
+++ b/tests/cases/interfaces/uses.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 interface TestInterface {
-    in-out property <bool> test: false;
+    in-out property <bool> test;
     pure public function double(i: int) -> int;
 }
 

--- a/tests/helper_components/export_interfaces.slint
+++ b/tests/helper_components/export_interfaces.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export interface ExportedInterface {
-    in-out property <float> value: 3.14;
+    in-out property <float> value;
 }
 
 export component ExportedBase implements ExportedInterface {
@@ -11,7 +11,6 @@ export component ExportedBase implements ExportedInterface {
 
 export interface ComboBoxInterface {
     in property <[string]> model;
-    in-out property <int> current-index: 0;
-    // The property bindings refer to named references in the interface element.
-    in-out property <string> current-value: root.model[root.current-index];
+    in-out property <int> current-index;
+    in-out property <string> current-value;
 }


### PR DESCRIPTION
Default property bindings, bindings and two-way bindings were initially implemented for interfaces as a convenience for the std-widgets interface implementations. However, this moves implementation detail into the interface, which is not desirable.

As discussed in the [interface review](https://github.com/slint-ui/slint/issues/1870#issuecomment-4778006873) we intend to aim for a more "checking" based implementation for interfaces, rather than allowing interfaces to add properties/behaviour to the implementing component.

The effect of this change on the std-widgets interfaces is relatively minimal. especially for the widgets that already have a base implementation that is reused among the styles. The changes can be viewed [here](https://github.com/slint-ui/slint/compare/master...0x6e:slint:wip/std-interfaces) (the intention being to squash the chain down to one commit per interface once we are happy with the interface feature).

Part of #1870.