### PR TITLE
skia: fix metal command queue sharing with wgpu properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,7 +3729,7 @@ dependencies = [
  "swash",
  "wasm-bindgen",
  "web-sys",
- "wgpu 29.0.3",
+ "wgpu 29.0.4",
 ]
 
 [[package]]
@@ -5498,7 +5498,7 @@ dependencies = [
  "web-sys",
  "web-time",
  "wgpu 28.0.0",
- "wgpu 29.0.3",
+ "wgpu 29.0.4",
  "windows 0.62.2",
 ]
 
@@ -5561,7 +5561,7 @@ dependencies = [
  "rgb",
  "wasm-bindgen",
  "web-sys",
- "wgpu 29.0.3",
+ "wgpu 29.0.4",
 ]
 
 [[package]]
@@ -5600,7 +5600,7 @@ dependencies = [
  "vtable",
  "vulkano",
  "wgpu 28.0.0",
- "wgpu 29.0.3",
+ "wgpu 29.0.4",
  "windows 0.62.2",
  "windows-core 0.62.2",
  "write-fonts",
@@ -7165,9 +7165,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -10460,7 +10460,7 @@ dependencies = [
  "unicode-segmentation",
  "vtable",
  "wgpu 28.0.0",
- "wgpu 29.0.3",
+ "wgpu 29.0.4",
 ]
 
 [[package]]
@@ -12879,9 +12879,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
@@ -12892,7 +12892,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga 29.0.3",
+ "naga 29.0.4",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -12902,9 +12902,9 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 29.0.3",
- "wgpu-hal 29.0.3",
- "wgpu-types 29.0.3",
+ "wgpu-core 29.0.4",
+ "wgpu-hal 29.0.4",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -12940,9 +12940,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -12954,7 +12954,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "log",
- "naga 29.0.3",
+ "naga 29.0.4",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -12963,12 +12963,12 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple 29.0.3",
+ "wgpu-core-deps-apple 29.0.4",
  "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android 29.0.3",
- "wgpu-hal 29.0.3",
+ "wgpu-core-deps-windows-linux-android 29.0.4",
+ "wgpu-hal 29.0.4",
  "wgpu-naga-bridge",
- "wgpu-types 29.0.3",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -12982,20 +12982,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
 dependencies = [
- "wgpu-hal 29.0.3",
+ "wgpu-hal 29.0.4",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
 dependencies = [
- "wgpu-hal 29.0.3",
+ "wgpu-hal 29.0.4",
 ]
 
 [[package]]
@@ -13009,11 +13009,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
 dependencies = [
- "wgpu-hal 29.0.3",
+ "wgpu-hal 29.0.4",
 ]
 
 [[package]]
@@ -13059,9 +13059,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -13082,7 +13082,7 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "log",
- "naga 29.0.3",
+ "naga 29.0.4",
  "ndk-sys 0.6.0+11769913",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -13105,7 +13105,7 @@ dependencies = [
  "wayland-sys",
  "web-sys",
  "wgpu-naga-bridge",
- "wgpu-types 29.0.3",
+ "wgpu-types 29.0.4",
  "windows 0.62.2",
  "windows-core 0.62.2",
  "windows-result 0.4.1",
@@ -13113,12 +13113,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
 dependencies = [
- "naga 29.0.3",
- "wgpu-types 29.0.3",
+ "naga 29.0.4",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -13134,9 +13134,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -13153,7 +13153,7 @@ dependencies = [
  "bytemuck",
  "slint",
  "slint-build",
- "wgpu 29.0.3",
+ "wgpu 29.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ icu_normalizer = { version = "2", default-features = false, features = ["compile
 glow = { version = "0.17" }
 tikv-jemallocator = { version = "0.7" }
 wgpu-28 = { package = "wgpu", version = "28", default-features = false }
-wgpu-29 = { package = "wgpu", version = "29", default-features = false }
+wgpu-29 = { package = "wgpu", version = "29.0.4", default-features = false }
 input = { version = "0.10.0", default-features = false }
 tr = { version = "0.1", default-features = false }
 fontique = { version = "0.10.0" }

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -5035,9 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -8301,9 +8301,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
@@ -8331,9 +8331,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -8365,45 +8365,45 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2f2fb042f36920771deb0b966543c5751b18f3d327760ffc90f74e20b2dcd4"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -8455,9 +8455,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -8465,9 +8465,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",

--- a/internal/core/graphics/wgpu_29.rs
+++ b/internal/core/graphics/wgpu_29.rs
@@ -214,30 +214,12 @@ impl From<Box<dyn wgpu::DisplayAndWindowHandle + 'static>> for SurfaceTarget {
     }
 }
 
-/// Optional override for creating the wgpu device and queue once an adapter has been selected.
-///
-/// Returning `None` lets [`init_instance_adapter_device_queue_surface`] fall back to the default
-/// `adapter.request_device()`. A renderer can use this to build the device from resources it also
-/// uses elsewhere — for example a command queue it shares with another graphics library, so a
-/// single-queue driver keeps the two ordered. It is only consulted when Slint creates the device
-/// itself; a developer-provided (`Manual`) device/queue is used as-is.
-pub type DeviceQueueFactory<'a> = dyn FnMut(
-        &wgpu_29::Adapter,
-        &wgpu_29::DeviceDescriptor<'_>,
-    ) -> Option<
-        Result<
-            (wgpu_29::Device, wgpu_29::Queue),
-            Box<dyn std::error::Error + Send + Sync + 'static>,
-        >,
-    > + 'a;
-
 /// Internal helper function to initialize the wgpu instance/adapter/device/queue from either scratch or
 /// developer-provided config. This is called by any renderer intending to support WGPU.
 pub fn init_instance_adapter_device_queue_surface(
     surface_target: impl Into<SurfaceTarget>,
     requested_graphics_api: Option<RequestedGraphicsAPI>,
     backends_to_avoid: wgpu::Backends,
-    mut device_queue_factory: Option<&mut DeviceQueueFactory<'_>>,
 ) -> Result<
     (
         wgpu_29::Instance,
@@ -267,26 +249,6 @@ pub fn init_instance_adapter_device_queue_surface(
                 "Error creating wgpu window surface: {e}"
             ))
         })
-    };
-
-    // Create the device and queue, giving a renderer-provided factory the first chance (so it can,
-    // for example, share its Metal command queue with wgpu). Falls back to `request_device`.
-    let mut make_device_queue = |adapter: &wgpu::Adapter,
-                                 descriptor: wgpu::DeviceDescriptor<'_>|
-     -> Result<
-        (wgpu::Device, wgpu::Queue),
-        Box<dyn std::error::Error + Send + Sync + 'static>,
-    > {
-        if let Some(factory) = device_queue_factory.as_deref_mut()
-            && let Some(result) = factory(adapter, &descriptor)
-        {
-            return result;
-        }
-        // wgpu uses async here, but the returned future is ready on first poll on all platforms
-        // except WASM, which we don't support right now.
-        Ok(poll_once(async { adapter.request_device(&descriptor).await })
-            .expect("internal error: wgpu device creation is not expected to be async")
-            .expect("Failed to create device"))
     };
 
     let (instance, adapter, device, queue, surface) = match requested_graphics_api {
@@ -337,20 +299,23 @@ pub fn init_instance_adapter_device_queue_surface(
             })
             .expect("internal error: wgpu adapter creation is not expected to be async");
 
-            let (device, queue) = make_device_queue(
-                &adapter,
-                wgpu::DeviceDescriptor {
-                    label: wgpu29_settings.device_label.as_deref(),
-                    required_features: wgpu29_settings.device_required_features,
-                    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
-                    required_limits: wgpu29_settings
-                        .device_required_limits
-                        .using_resolution(adapter.limits()),
-                    experimental_features: wgpu29_settings.device_experimental_features,
-                    memory_hints: wgpu29_settings.device_memory_hints,
-                    trace: wgpu::Trace::default(),
-                },
-            )?;
+            let (device, queue) = poll_once(async {
+                adapter
+                    .request_device(&wgpu::DeviceDescriptor {
+                        label: wgpu29_settings.device_label.as_deref(),
+                        required_features: wgpu29_settings.device_required_features,
+                        // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+                        required_limits: wgpu29_settings
+                            .device_required_limits
+                            .using_resolution(adapter.limits()),
+                        experimental_features: wgpu29_settings.device_experimental_features,
+                        memory_hints: wgpu29_settings.device_memory_hints,
+                        trace: wgpu::Trace::default(),
+                    })
+                    .await
+                    .expect("Failed to create device")
+            })
+            .expect("internal error: wgpu device creation is not expected to be async");
 
             (instance, adapter, device, queue, surface)
         }
@@ -382,19 +347,23 @@ pub fn init_instance_adapter_device_queue_surface(
             })
             .expect("internal error: wgpu adapter creation is not expected to be async");
 
-            let (device, queue) = make_device_queue(
-                &adapter,
-                wgpu::DeviceDescriptor {
-                    label: None,
-                    // Request all non-experimental features the adapter supports,
-                    // so that embedders like Bevy can use full GPU capabilities.
-                    required_features: adapter.features() - wgpu::Features::all_experimental_mask(),
-                    required_limits: adapter.limits(),
-                    experimental_features: wgpu::ExperimentalFeatures::disabled(),
-                    memory_hints: wgpu::MemoryHints::MemoryUsage,
-                    trace: wgpu::Trace::default(),
-                },
-            )?;
+            let (device, queue) = poll_once(async {
+                adapter
+                    .request_device(&wgpu::DeviceDescriptor {
+                        label: None,
+                        // Request all non-experimental features the adapter supports,
+                        // so that embedders like Bevy can use full GPU capabilities.
+                        required_features: adapter.features()
+                            - wgpu::Features::all_experimental_mask(),
+                        required_limits: adapter.limits(),
+                        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                        memory_hints: wgpu::MemoryHints::MemoryUsage,
+                        trace: wgpu::Trace::default(),
+                    })
+                    .await
+                    .expect("Failed to create device")
+            })
+            .expect("internal error: wgpu device creation is not expected to be async");
             (instance, adapter, device, queue, surface)
         }
         Some(_) => {

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -318,8 +318,6 @@ impl FemtoVGRenderer<WGPUBackend> {
                 requested_graphics_api,
                 /* rendering artifacts :( */
                 wgpu::Backends::GL,
-                // FemtoVG renders through wgpu directly, so it has no separate command queue to share.
-                None,
             )?;
 
         let mut surface_config =

--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -42,48 +42,16 @@ impl WGPUSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, PlatformError> {
-        let backends_to_avoid = wgpu::Backends::GL /* we're not mapping that to skia because we can't save/restore state */
-            .union(if cfg!(target_os = "windows") {
-                wgpu::Backends::VULKAN
-            } else {
-                wgpu::Backends::empty()
-            });
-
-        // On Metal, build wgpu's device from a command queue we allocate ourselves, so we can hand
-        // the same `MTLCommandQueue` to Skia. Metal's automatic hazard tracking only synchronizes
-        // accesses within a single queue, so sharing the queue lets it order wgpu's work (e.g. a
-        // texture render) before Skia samples it; otherwise Skia can read not-yet-produced content
-        // (magenta under Metal validation). wgpu 29 doesn't expose the queue it would create itself.
-        #[cfg(target_vendor = "apple")]
-        let mut shared_metal_queue: Option<
-            objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLCommandQueue>>,
-        > = None;
-        #[cfg(target_vendor = "apple")]
-        let mut metal_factory =
-            |adapter: &wgpu::Adapter, descriptor: &wgpu::DeviceDescriptor<'_>| {
-                (adapter.get_info().backend == wgpu::Backend::Metal).then(|| {
-                    metal::create_shared_metal_device_queue(
-                        adapter,
-                        descriptor,
-                        &mut shared_metal_queue,
-                    )
-                })
-            };
-        #[cfg(target_vendor = "apple")]
-        let device_queue_factory: Option<
-            &mut i_slint_core::graphics::wgpu_29::DeviceQueueFactory,
-        > = Some(&mut metal_factory);
-        #[cfg(not(target_vendor = "apple"))]
-        let device_queue_factory: Option<
-            &mut i_slint_core::graphics::wgpu_29::DeviceQueueFactory,
-        > = None;
-
         let (instance, adapter, device, queue, surface) =
             i_slint_core::graphics::wgpu_29::init_instance_adapter_device_queue_surface(
                 surface_target,
                 requested_graphics_api,
-                backends_to_avoid,
-                device_queue_factory,
+                wgpu::Backends::GL /* we're not mapping that to skia because we can't save/restore state */
+                    .union(if cfg!(target_os = "windows") {
+                        wgpu::Backends::VULKAN
+                    } else {
+                        wgpu::Backends::empty()
+                    }),
             )?;
 
         let mut surface_config =
@@ -103,18 +71,7 @@ impl WGPUSurface {
 
         let backend: Backend = adapter.get_info().backend.try_into()?;
 
-        // The command queue we shared with wgpu (if any). `shared_metal_queue` is kept alive until
-        // after `make_context`, which retains it into Skia's backend context; wgpu's device retains
-        // it too via the queue.
-        #[cfg(target_vendor = "apple")]
-        let shared_command_queue_handle: Option<*const core::ffi::c_void> = shared_metal_queue
-            .as_ref()
-            .map(|q| objc2::rc::Retained::as_ptr(q) as *const core::ffi::c_void);
-        #[cfg(not(target_vendor = "apple"))]
-        let shared_command_queue_handle: Option<*const core::ffi::c_void> = None;
-
-        let gr_context =
-            backend.make_context(&adapter, &device, &queue, shared_command_queue_handle);
+        let gr_context = backend.make_context(&adapter, &device, &queue);
 
         Ok(Self {
             gr_context: RefCell::new(
@@ -322,14 +279,6 @@ impl crate::Surface for WGPUSurface {
             i_slint_core::graphics::WGPUTexture::WGPU29Texture(texture) => texture.clone(),
         };
 
-        // NOTE: correct synchronization here relies on Skia sharing wgpu's command queue, so that
-        // Metal's per-queue hazard tracking orders the producing work before Skia's sample. That
-        // sharing only happens when Slint creates the device itself (`Automatic`). With a
-        // developer-provided device/queue (`Manual` config or `SkiaWGPURenderer`), Skia runs on its
-        // own queue and this sample can race the producer, since wgpu 29 exposes neither the queue
-        // to share (`Queue::as_raw`) nor an event to synchronize across queues. Both are restored on
-        // wgpu trunk; revisit once a release ships them.
-
         // Skia won't submit commands right away, so remember the texture and transition before
         // submitting.
         self.textures_to_transition_for_sampling.borrow_mut().push(texture.clone());
@@ -396,13 +345,10 @@ impl Backend {
         _adapter: &wgpu::Adapter,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        // On Metal, the `MTLCommandQueue` we shared with wgpu (see `make_metal_context`). `None` on
-        // other backends and when we didn't create the device ourselves.
-        _shared_metal_command_queue: Option<*const core::ffi::c_void>,
     ) -> Option<skia_safe::gpu::DirectContext> {
         match self {
             #[cfg(target_vendor = "apple")]
-            Self::Metal => metal::make_metal_context(device, queue, _shared_metal_command_queue),
+            Self::Metal => metal::make_metal_context(device, queue),
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_context(&_adapter, &device, &queue) },
             #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]

--- a/internal/renderers/skia/wgpu_29_surface/metal.rs
+++ b/internal/renderers/skia/wgpu_29_surface/metal.rs
@@ -3,7 +3,7 @@
 
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLDevice, MTLTexture};
+use objc2_metal::{MTLCommandQueue, MTLTexture};
 use skia_safe::gpu::mtl;
 
 use wgpu_29 as wgpu;
@@ -94,18 +94,26 @@ pub unsafe fn import_metal_texture(
 
 pub fn make_metal_context(
     device: &wgpu::Device,
-    _queue: &wgpu::Queue,
+    queue: &wgpu::Queue,
 ) -> Option<skia_safe::gpu::DirectContext> {
     let backend = unsafe {
-        let metal_device = device.as_hal::<wgpu::wgc::api::Metal>()?;
-        let metal_device_raw: &Retained<ProtocolObject<dyn MTLDevice>> = metal_device.raw_device();
-        // wgpu-29's Metal `Queue` no longer exposes its underlying `MTLCommandQueue`,
-        // so create a dedicated queue from the same device for Skia to submit on.
-        let skia_command_queue = metal_device_raw.newCommandQueue()?;
-        mtl::BackendContext::new(
-            Retained::as_ptr(metal_device_raw) as mtl::Handle,
-            Retained::as_ptr(&skia_command_queue) as mtl::Handle,
-        )
+        let maybe_metal_device = device.as_hal::<wgpu::wgc::api::Metal>();
+        let maybe_metal_queue = queue.as_hal::<wgpu::wgc::api::Metal>();
+
+        maybe_metal_device.and_then(|metal_device| {
+            let metal_device_raw = metal_device.raw_device();
+
+            maybe_metal_queue.map(|metal_queue| {
+                // Share wgpu's command queue with Skia, so that Metal's per-queue hazard tracking
+                // orders wgpu's texture writes before Skia samples them.
+                let metal_queue_raw: *const ProtocolObject<dyn MTLCommandQueue> =
+                    metal_queue.as_raw();
+                mtl::BackendContext::new(
+                    Retained::as_ptr(metal_device_raw) as mtl::Handle,
+                    metal_queue_raw as mtl::Handle,
+                )
+            })
+        })?
     };
 
     skia_safe::gpu::direct_contexts::make_metal(&backend, None)

--- a/internal/renderers/skia/wgpu_29_surface/metal.rs
+++ b/internal/renderers/skia/wgpu_29_surface/metal.rs
@@ -3,22 +3,10 @@
 
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLCommandQueue, MTLDevice, MTLTexture};
+use objc2_metal::{MTLDevice, MTLTexture};
 use skia_safe::gpu::mtl;
 
 use wgpu_29 as wgpu;
-
-/// Matches the limit wgpu's own Metal backend uses when creating its command queue
-/// (`wgpu_hal::metal::adapter::MAX_COMMAND_BUFFERS`).
-const MAX_COMMAND_BUFFERS: usize = 4096;
-
-/// Creates an `MTLCommandQueue` on `device`, sized like wgpu's own queue so the two agree on the
-/// in-flight command-buffer limit.
-fn make_command_queue(
-    device: &ProtocolObject<dyn MTLDevice>,
-) -> Option<Retained<ProtocolObject<dyn MTLCommandQueue>>> {
-    device.newCommandQueueWithMaxCommandBufferCount(MAX_COMMAND_BUFFERS)
-}
 
 /// # Safety
 /// `metal_handle` must be a valid Metal texture handle for the lifetime of the returned Surface.
@@ -104,96 +92,21 @@ pub unsafe fn import_metal_texture(
     }
 }
 
-/// Builds the Skia Metal context.
-///
-/// When `shared_command_queue` is `Some`, it is the `MTLCommandQueue` that wgpu's device was also
-/// built from (see [`create_shared_metal_device_queue`]). Sharing one queue lets Metal's automatic
-/// per-queue hazard tracking order wgpu's work (e.g. rendering into a texture) before Skia samples
-/// it, avoiding reads of not-yet-produced (magenta under Metal validation) content.
-///
-/// When it is `None` (a developer-provided `Manual` device/queue, whose `MTLCommandQueue` wgpu 29
-/// doesn't expose), Skia falls back to its own queue. Cross-queue accesses are then not
-/// synchronized; see the note in `WGPUSurface::import_wgpu_texture`.
 pub fn make_metal_context(
     device: &wgpu::Device,
     _queue: &wgpu::Queue,
-    shared_command_queue: Option<*const core::ffi::c_void>,
 ) -> Option<skia_safe::gpu::DirectContext> {
-    let metal_device = unsafe { device.as_hal::<wgpu::wgc::api::Metal>() }?;
-    let metal_device_raw: &Retained<ProtocolObject<dyn MTLDevice>> = metal_device.raw_device();
-
-    // When wgpu's queue isn't shared with us, create our own; keep it owned so it outlives the
-    // `BackendContext` creation below, which retains it.
-    let owned_command_queue = match shared_command_queue {
-        Some(_) => None,
-        None => Some(make_command_queue(metal_device_raw)?),
-    };
-    let command_queue_handle: mtl::Handle = match &owned_command_queue {
-        Some(queue) => Retained::as_ptr(queue) as mtl::Handle,
-        None => shared_command_queue.expect("present when we didn't create our own queue") as _,
-    };
-
     let backend = unsafe {
+        let metal_device = device.as_hal::<wgpu::wgc::api::Metal>()?;
+        let metal_device_raw: &Retained<ProtocolObject<dyn MTLDevice>> = metal_device.raw_device();
+        // wgpu-29's Metal `Queue` no longer exposes its underlying `MTLCommandQueue`,
+        // so create a dedicated queue from the same device for Skia to submit on.
+        let skia_command_queue = metal_device_raw.newCommandQueue()?;
         mtl::BackendContext::new(
             Retained::as_ptr(metal_device_raw) as mtl::Handle,
-            command_queue_handle,
+            Retained::as_ptr(&skia_command_queue) as mtl::Handle,
         )
     };
 
     skia_safe::gpu::direct_contexts::make_metal(&backend, None)
-}
-
-/// Creates the wgpu device and queue from an `MTLCommandQueue` we allocate ourselves, and returns
-/// that queue through `shared_command_queue_out` so the Skia context can submit on it too.
-///
-/// This is the device/queue factory passed to `init_instance_adapter_device_queue_surface` for the
-/// Metal backend when Slint owns device creation. wgpu 29 doesn't let us read back the queue it would
-/// create itself, so we substitute our own before building the device.
-///
-/// TODO(wgpu>29): once a wgpu release restores `Queue::as_raw` (gfx-rs/wgpu#9560), drop this whole
-/// hal-interop dance and just read the queue back from the device wgpu creates normally.
-pub fn create_shared_metal_device_queue(
-    adapter: &wgpu::Adapter,
-    descriptor: &wgpu::DeviceDescriptor<'_>,
-    shared_command_queue_out: &mut Option<Retained<ProtocolObject<dyn MTLCommandQueue>>>,
-) -> Result<(wgpu::Device, wgpu::Queue), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    // The hal `Adapter::open` trait method; aliased so it doesn't clash with `wgpu::Adapter`.
-    use wgpu::hal::Adapter as _;
-
-    unsafe {
-        let hal_adapter = adapter
-            .as_hal::<wgpu::wgc::api::Metal>()
-            .ok_or("Skia: expected a Metal hal adapter to share the command queue")?;
-
-        // `open` also builds a queue we can't read back, so we replace it with our own below.
-        let mut open_device = hal_adapter
-            .open(
-                descriptor.required_features,
-                &descriptor.required_limits,
-                &descriptor.memory_hints,
-            )
-            .map_err(|e| format!("Skia: failed to open Metal device for queue sharing: {e}"))?;
-
-        let metal_device: Retained<ProtocolObject<dyn MTLDevice>> =
-            open_device.device.raw_device().clone();
-
-        let shared_command_queue = make_command_queue(&metal_device)
-            .ok_or("Skia: failed to create a shared Metal command queue")?;
-
-        // Mirror wgpu's own timestamp-period heuristic (wgpu_hal::metal::adapter::open). Slint never
-        // reads GPU timestamps, so the exact value only matters for API parity.
-        let timestamp_period =
-            if metal_device.name().to_string().starts_with("Intel") { 83.333 } else { 1.0 };
-
-        open_device.queue =
-            wgpu::hal::metal::Queue::queue_from_raw(shared_command_queue.clone(), timestamp_period);
-
-        let (device, queue) = adapter
-            .create_device_from_hal::<wgpu::wgc::api::Metal>(open_device, descriptor)
-            .map_err(|e| format!("Skia: failed to create wgpu device from shared queue: {e}"))?;
-
-        *shared_command_queue_out = Some(shared_command_queue);
-
-        Ok((device, queue))
-    }
 }

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -46,13 +46,9 @@ impl SkiaWGPURenderer {
     ) -> Result<Self, PlatformError> {
         let backend: Backend = adapter.get_info().backend.try_into()?;
 
-        // The device and queue are provided by the caller, so we can't share wgpu's command queue
-        // with Skia (wgpu 29 doesn't expose it). Skia therefore runs on its own queue; see the note
-        // in `WGPUSurface::import_wgpu_texture` about the cross-queue synchronization limitation.
-        let gr_context =
-            backend.make_context(&adapter, &device, &queue, None).ok_or_else(|| {
-                PlatformError::from("Failed to create Skia graphics context from WGPU")
-            })?;
+        let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
+            PlatformError::from("Failed to create Skia graphics context from WGPU")
+        })?;
 
         let surface = WGPUSurface::new_offscreen(instance, device, queue, backend, gr_context);
 


### PR DESCRIPTION
The latest wgpu 0.29 patch release re-adds the missing API to fix this properly.