### PR TITLE
Don't inline the whole wgpu API into the documentation

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -42,7 +42,7 @@ jobs:
             - name: Set up crate rustdoc link
               run: |
                   rgb_version=`grep 'rgb = '  internal/core/Cargo.toml | sed 's/^.*"\(.*\)"/\1/'`
-                  echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ --extern-html-root-url android_activity=https://docs.rs/android-activity/0.5/ --extern-html-root-url raw_window_handle=https://docs.rs/raw_window_handle/0.6 --extern-html-root-url winit=https://docs.rs/winit/0.30 --extern-html-root-url wgpu=https://docs.rs/wgpu/26 --extern-html-root-url input=https://docs.rs/input/0.9 --extern-html-root-url fontique=https://docs.rs/fontique/0.8" >> $GITHUB_ENV
+                  echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ --extern-html-root-url android_activity=https://docs.rs/android-activity/0.5/ --extern-html-root-url raw_window_handle=https://docs.rs/raw_window_handle/0.6 --extern-html-root-url winit=https://docs.rs/winit/0.30 --extern-html-root-url wgpu=https://docs.rs/wgpu/29 --extern-html-root-url input=https://docs.rs/input/0.9 --extern-html-root-url fontique=https://docs.rs/fontique/0.8" >> $GITHUB_ENV
             - uses: ./.github/actions/install-linux-dependencies
             - uses: pnpm/action-setup@v6.0.8
               with:

--- a/internal/core/graphics/wgpu_28.rs
+++ b/internal/core/graphics/wgpu_28.rs
@@ -18,6 +18,7 @@ pub mod api {
     This module contains types that are public and re-exported in the slint-rs as well as the slint-interpreter crate as public API.
     */
 
+    #[doc(no_inline)]
     pub use super::wgpu;
 
     /// This data structure provides settings for initializing WGPU renderers.

--- a/internal/core/graphics/wgpu_29.rs
+++ b/internal/core/graphics/wgpu_29.rs
@@ -18,6 +18,7 @@ pub mod api {
     This module contains types that are public and re-exported in the slint-rs as well as the slint-interpreter crate as public API.
     */
 
+    #[doc(no_inline)]
     pub use super::wgpu;
 
     /// This data structure provides settings for initializing WGPU renderers.


### PR DESCRIPTION
The slint::wgpu_2x modules re-export the wgpu crate, which made rustdoc inline the entire wgpu API into Slint's documentation and search index. Add #[doc(no_inline)] so wgpu is shown as a re-export instead.

Also fix the wgpu version in the docs --extern-html-root-url so links to wgpu types point to the right version.
