### PR TITLE
Popup Fix Rendering Issue

### DIFF
--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -1436,8 +1436,8 @@ fn partial_rendering_popup_position_size_change() {
 
             callback increment_properties();
             increment_properties() => {
-                debug("Increment called");
                 MyProperty.popup-increment += 1;
+                debug("Increment called: ", MyProperty.popup-increment);
             }
 
             popup:= PopupWindow {
@@ -1455,13 +1455,14 @@ fn partial_rendering_popup_position_size_change() {
                         if click-count == 0 {
                             change_popup();
                         } else {
-                            properties-change += 1;
+                            increment_properties();
                         }
                         click-count += 1;
                     }
                 }
 
                 changed properties-change => {
+                    debug("Popup properties-change: ", properties-change);
                     self.x += 10px;
                     self.y += 20px;
                     self.width += 30px;
@@ -1596,6 +1597,7 @@ fn partial_rendering_popup_position_size_change() {
 
     ui.invoke_increment_properties();
     // The popup properties change trigger a tracker with a timer we have to process before the next draw.
+    slint::platform::update_timers_and_animations();
     slint::platform::update_timers_and_animations();
     assert!(window.draw_if_needed());
     slint::platform::update_timers_and_animations();

--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -1400,6 +1400,9 @@ fn partial_rendering_popup_position_size_change() {
             in-out property<length> popup-y: 0px;
             in-out property<length> popup-width: 100px;
             in-out property<length> popup-height: 200px;
+
+            in-out property <int> update-popup: 0;
+            in-out property <int> popup-increment: 0;
         }
 
         export component Ui inherits Window {
@@ -1431,6 +1434,12 @@ fn partial_rendering_popup_position_size_change() {
                 MyProperty.popup-height = 30px;
             }
 
+            callback increment_properties();
+            increment_properties() => {
+                debug("Increment called");
+                MyProperty.popup-increment += 1;
+            }
+
             popup:= PopupWindow {
                 x: MyProperty.popup-x;
                 y: MyProperty.popup-y;
@@ -1438,10 +1447,25 @@ fn partial_rendering_popup_position_size_change() {
                 height: MyProperty.popup-height;
                 close-policy: PopupClosePolicy.no-auto-close;
 
+                property <int> click-count: 0;
+                property <int> properties-change <=> MyProperty.popup-increment;
+
                 TouchArea {
                     clicked => {
-                        change_popup();
+                        if click-count == 0 {
+                            change_popup();
+                        } else {
+                            properties-change += 1;
+                        }
+                        click-count += 1;
                     }
+                }
+
+                changed properties-change => {
+                    self.x += 10px;
+                    self.y += 20px;
+                    self.width += 30px;
+                    self.height += 40px;
                 }
 
                 changed width => {
@@ -1545,6 +1569,45 @@ fn partial_rendering_popup_position_size_change() {
         const POPUP_POS_Y: usize = 20;
         const POPUP_WIDTH: usize = 150;
         const POPUP_HEIGHT: usize = 30;
+        for v_pixel in 0..WINDOW_HEIGHT {
+            for h_pixel in 0..WINDOW_WIDTH {
+                let pixel_idx = WINDOW_WIDTH * v_pixel + h_pixel;
+
+                if h_pixel >= POPUP_POS_X
+                    && h_pixel < POPUP_POS_X + POPUP_WIDTH
+                    && v_pixel >= POPUP_POS_Y
+                    && v_pixel < POPUP_POS_Y + POPUP_HEIGHT
+                {
+                    let rgb = get_pixel_values(pixel_idx);
+                    assert_eq!(
+                        rgb, RGB_COLOR_POPUP,
+                        "Wrong color at pixel ({h_pixel}, {v_pixel}). Expected popup color."
+                    );
+                } else {
+                    let rgb = get_pixel_values(pixel_idx);
+                    assert_eq!(
+                        rgb, RGB_COLOR_WINDOW,
+                        "Wrong color at pixel ({h_pixel}, {v_pixel}). Expected window color"
+                    );
+                }
+            }
+        }
+    }
+
+    ui.invoke_increment_properties();
+    // The popup properties change trigger a tracker with a timer we have to process before the next draw.
+    slint::platform::update_timers_and_animations();
+    assert!(window.draw_if_needed());
+    slint::platform::update_timers_and_animations();
+    assert!(!window.draw_if_needed());
+
+    // Increment
+    {
+        // New popup properties
+        const POPUP_POS_X: usize = 10 + 10;
+        const POPUP_POS_Y: usize = 20 + 20;
+        const POPUP_WIDTH: usize = 150 + 30;
+        const POPUP_HEIGHT: usize = 30 + 40;
         for v_pixel in 0..WINDOW_HEIGHT {
             for h_pixel in 0..WINDOW_WIDTH {
                 let pixel_idx = WINDOW_WIDTH * v_pixel + h_pixel;

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -416,18 +416,6 @@ impl crate::properties::PropertyDirtyHandler for PopupWindowPropertiesTracker {
     }
 }
 
-struct WindowRedrawTracker {
-    window_adapter_weak: Weak<dyn WindowAdapter>,
-}
-
-impl crate::properties::PropertyDirtyHandler for WindowRedrawTracker {
-    fn notify(self: Pin<&Self>) {
-        if let Some(window_adapter) = self.window_adapter_weak.upgrade() {
-            window_adapter.request_redraw();
-        };
-    }
-}
-
 /// This enum describes the different ways a popup can be rendered by the back-end.
 pub enum PopupWindowLocation {
     /// The popup is rendered in its own top-level window that is know to the windowing system.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -400,28 +400,11 @@ pub(crate) struct PopupWindowPropertiesTracker {
     parent_window_adapter_weak: Weak<dyn WindowAdapter>,
     /// ID of the popup this tracker belongs to, used to re-evaluate after notification
     popup_id: NonZeroU32,
-    /// Whether the popup is rendered as an embedded child window (as opposed to its own top-level
-    /// window). Child-window popups have their geometry re-evaluated synchronously from the parent's
-    /// render path (see [`WindowInner::update_active_popups_geometry`]), so that their size, position
-    /// and dirty region are updated within the same frame. Otherwise a resize takes effect via live
-    /// layout one frame before the position and dirty region catch up, leaving artifacts.
-    is_child_window: bool,
 }
 
 impl crate::properties::PropertyDirtyHandler for PopupWindowPropertiesTracker {
     fn notify(self: Pin<&Self>) {
         let parent = self.parent_window_adapter_weak.clone();
-        if self.is_child_window {
-            // Defer the geometry re-evaluation to the next frame's render, where the popup's size,
-            // position and dirty region are updated atomically in `update_active_popups_geometry`.
-            // Just make sure a frame happens. `request_redraw` merely sets a flag, so it is safe to
-            // call even while `update_popup_properties` holds the `active_popups` borrow (setting the
-            // window item size there re-notifies this tracker).
-            if let Some(parent_adapter) = parent.upgrade() {
-                parent_adapter.request_redraw();
-            }
-            return;
-        }
         let popup_id = self.popup_id;
         // Use a timer here, so if we change multiple properties at the same time not multiple notifications are send
         // This timer will delay for the next evaluation
@@ -1523,9 +1506,7 @@ impl WindowInner {
                     if !new_popup_region.is_empty() {
                         adapter.renderer().mark_dirty_region(new_popup_region.into());
                     }
-                    // No `request_redraw` here: for child-window popups this runs from the parent's
-                    // render path (`update_active_popups_geometry`) and the regions just marked are
-                    // consumed in the same frame
+                    adapter.request_redraw();
                 }
             }
             PopupWindowLocation::TopLevel(adapter) => {
@@ -1551,31 +1532,6 @@ impl WindowInner {
     /// of any item tree.
     ///
     /// Returns None if no component is set yet.
-    /// Re-evaluate the geometry of every active child-window popup whose tracked properties changed
-    /// since the last evaluation, committing the new location and marking the affected regions dirty.
-    ///
-    /// This runs from the parent's render path (the start of [`Self::draw_contents`]), *before* the
-    /// renderer collects the dirty region and reads the popup locations. Doing it here keeps a popup's
-    /// size (applied via live layout during rendering), its position and its dirty region in sync
-    /// within a single frame. Evaluating it out of band — e.g. from a timer between frames — lets a
-    /// resize reach the framebuffer one frame before the position and dirty region catch up, which
-    /// leaves the stale, differently-sized popup content behind as artifacts.
-    fn update_active_popups_geometry(&self) {
-        let dirty_child_popups: Vec<NonZeroU32> = self
-            .active_popups
-            .borrow()
-            .iter()
-            .filter(|popup| {
-                matches!(popup.location, PopupWindowLocation::ChildWindow(..))
-                    && popup.properties_tracker.is_dirty()
-            })
-            .map(|popup| popup.popup_id)
-            .collect();
-        for popup_id in dirty_child_popups {
-            self.update_popup_properties(popup_id);
-        }
-    }
-
     pub fn draw_contents<T>(
         &self,
         render_components: impl FnOnce(
@@ -1584,7 +1540,6 @@ impl WindowInner {
         ) -> T,
     ) -> Option<T> {
         crate::properties::evaluate_no_tracking(|| self.ensure_tree_instantiated());
-        self.update_active_popups_geometry();
         let component_weak = ItemTreeRc::downgrade(&self.try_component()?);
         let post_render = |renderer: &mut dyn crate::item_rendering::ItemRenderer| {
             self.render_drag_image_overlay(renderer);
@@ -1881,7 +1836,6 @@ impl WindowInner {
                         PopupWindowPropertiesTracker {
                             parent_window_adapter_weak: parent_window_adapter_weak.clone(),
                             popup_id,
-                            is_child_window: true,
                         },
                     )),
                 )
@@ -1898,7 +1852,6 @@ impl WindowInner {
                         PopupWindowPropertiesTracker {
                             parent_window_adapter_weak: parent_window_adapter_weak.clone(),
                             popup_id,
-                            is_child_window: false,
                         },
                     )),
                 )
@@ -1932,8 +1885,6 @@ impl WindowInner {
         });
 
         self.update_popup_properties(popup_id);
-        // redraw_request for the ChildWindow Popup is already done
-        // above so we don't have to do it here again
 
         popup_id
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -400,11 +400,28 @@ pub(crate) struct PopupWindowPropertiesTracker {
     parent_window_adapter_weak: Weak<dyn WindowAdapter>,
     /// ID of the popup this tracker belongs to, used to re-evaluate after notification
     popup_id: NonZeroU32,
+    /// Whether the popup is rendered as an embedded child window (as opposed to its own top-level
+    /// window). Child-window popups have their geometry re-evaluated synchronously from the parent's
+    /// render path (see [`WindowInner::update_active_popups_geometry`]), so that their size, position
+    /// and dirty region are updated within the same frame. Otherwise a resize takes effect via live
+    /// layout one frame before the position and dirty region catch up, leaving artifacts.
+    is_child_window: bool,
 }
 
 impl crate::properties::PropertyDirtyHandler for PopupWindowPropertiesTracker {
     fn notify(self: Pin<&Self>) {
         let parent = self.parent_window_adapter_weak.clone();
+        if self.is_child_window {
+            // Defer the geometry re-evaluation to the next frame's render, where the popup's size,
+            // position and dirty region are updated atomically in `update_active_popups_geometry`.
+            // Just make sure a frame happens. `request_redraw` merely sets a flag, so it is safe to
+            // call even while `update_popup_properties` holds the `active_popups` borrow (setting the
+            // window item size there re-notifies this tracker).
+            if let Some(parent_adapter) = parent.upgrade() {
+                parent_adapter.request_redraw();
+            }
+            return;
+        }
         let popup_id = self.popup_id;
         // Use a timer here, so if we change multiple properties at the same time not multiple notifications are send
         // This timer will delay for the next evaluation
@@ -1506,7 +1523,9 @@ impl WindowInner {
                     if !new_popup_region.is_empty() {
                         adapter.renderer().mark_dirty_region(new_popup_region.into());
                     }
-                    adapter.request_redraw();
+                    // No `request_redraw` here: for child-window popups this runs from the parent's
+                    // render path (`update_active_popups_geometry`) and the regions just marked are
+                    // consumed in the same frame
                 }
             }
             PopupWindowLocation::TopLevel(adapter) => {
@@ -1532,6 +1551,31 @@ impl WindowInner {
     /// of any item tree.
     ///
     /// Returns None if no component is set yet.
+    /// Re-evaluate the geometry of every active child-window popup whose tracked properties changed
+    /// since the last evaluation, committing the new location and marking the affected regions dirty.
+    ///
+    /// This runs from the parent's render path (the start of [`Self::draw_contents`]), *before* the
+    /// renderer collects the dirty region and reads the popup locations. Doing it here keeps a popup's
+    /// size (applied via live layout during rendering), its position and its dirty region in sync
+    /// within a single frame. Evaluating it out of band — e.g. from a timer between frames — lets a
+    /// resize reach the framebuffer one frame before the position and dirty region catch up, which
+    /// leaves the stale, differently-sized popup content behind as artifacts.
+    fn update_active_popups_geometry(&self) {
+        let dirty_child_popups: Vec<NonZeroU32> = self
+            .active_popups
+            .borrow()
+            .iter()
+            .filter(|popup| {
+                matches!(popup.location, PopupWindowLocation::ChildWindow(..))
+                    && popup.properties_tracker.is_dirty()
+            })
+            .map(|popup| popup.popup_id)
+            .collect();
+        for popup_id in dirty_child_popups {
+            self.update_popup_properties(popup_id);
+        }
+    }
+
     pub fn draw_contents<T>(
         &self,
         render_components: impl FnOnce(
@@ -1540,6 +1584,7 @@ impl WindowInner {
         ) -> T,
     ) -> Option<T> {
         crate::properties::evaluate_no_tracking(|| self.ensure_tree_instantiated());
+        self.update_active_popups_geometry();
         let component_weak = ItemTreeRc::downgrade(&self.try_component()?);
         let post_render = |renderer: &mut dyn crate::item_rendering::ItemRenderer| {
             self.render_drag_image_overlay(renderer);
@@ -1836,6 +1881,7 @@ impl WindowInner {
                         PopupWindowPropertiesTracker {
                             parent_window_adapter_weak: parent_window_adapter_weak.clone(),
                             popup_id,
+                            is_child_window: true,
                         },
                     )),
                 )
@@ -1852,6 +1898,7 @@ impl WindowInner {
                         PopupWindowPropertiesTracker {
                             parent_window_adapter_weak: parent_window_adapter_weak.clone(),
                             popup_id,
+                            is_child_window: false,
                         },
                     )),
                 )
@@ -1885,6 +1932,8 @@ impl WindowInner {
         });
 
         self.update_popup_properties(popup_id);
+        // redraw_request for the ChildWindow Popup is already done
+        // above so we don't have to do it here again
 
         popup_id
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -479,8 +479,6 @@ impl Drop for PopupWindow {
 
 #[pin_project::pin_project]
 struct WindowPinnedFields {
-    #[pin]
-    redraw_tracker: PropertyTracker<false, WindowRedrawTracker>,
     /// Gets dirty when the layout restrictions, or some other property of the windows change
     #[pin]
     window_properties_tracker: PropertyTracker<true, WindowPropertiesTracker>,
@@ -557,15 +555,10 @@ impl WindowInner {
                 window_adapter_weak: window_adapter_weak.clone(),
             });
 
-        let mut redraw_tracker = PropertyTracker::new_with_dirty_handler(WindowRedrawTracker {
-            window_adapter_weak: window_adapter_weak.clone(),
-        });
-
         #[cfg(slint_debug_property)]
         {
             window_properties_tracker
                 .set_debug_name("i_slint_core::Window::window_properties_tracker".into());
-            redraw_tracker.set_debug_name("i_slint_core::Window::redraw_tracker".into());
         }
 
         Self {
@@ -575,7 +568,6 @@ impl WindowInner {
             mouse_input_state: Default::default(),
             touch_state: Default::default(),
             pinned_fields: Box::pin(WindowPinnedFields {
-                redraw_tracker,
                 window_properties_tracker,
                 scale_factor: Property::new_named(1., "i_slint_core::Window::scale_factor"),
                 active: Property::new_named(false, "i_slint_core::Window::active"),
@@ -1544,32 +1536,30 @@ impl WindowInner {
         let post_render = |renderer: &mut dyn crate::item_rendering::ItemRenderer| {
             self.render_drag_image_overlay(renderer);
         };
-        Some(self.pinned_fields.as_ref().project_ref().redraw_tracker.evaluate_as_dependency_root(
-            || {
-                if !self
-                    .active_popups
-                    .borrow()
-                    .iter()
-                    .any(|p| matches!(p.location, PopupWindowLocation::ChildWindow(..)))
-                {
-                    render_components(&[(component_weak, LogicalPoint::default())], &post_render)
-                } else {
-                    let borrow = self.active_popups.borrow();
-                    let mut item_trees = Vec::with_capacity(borrow.len() + 1);
-                    item_trees.push((component_weak, LogicalPoint::default()));
-                    for popup in borrow.iter() {
-                        // If the popup is not a real window and does not have its own coordinate system.
-                        // We have to draw the popup and consider the location for subelements because everything must
-                        // be rendered relative to the main window position
-                        if let PopupWindowLocation::ChildWindow(location) = &popup.location {
-                            item_trees.push((ItemTreeRc::downgrade(&popup.component), *location));
-                        }
+        Some(
+            if !self
+                .active_popups
+                .borrow()
+                .iter()
+                .any(|p| matches!(p.location, PopupWindowLocation::ChildWindow(..)))
+            {
+                render_components(&[(component_weak, LogicalPoint::default())], &post_render)
+            } else {
+                let borrow = self.active_popups.borrow();
+                let mut item_trees = Vec::with_capacity(borrow.len() + 1);
+                item_trees.push((component_weak, LogicalPoint::default()));
+                for popup in borrow.iter() {
+                    // If the popup is not a real window and does not have its own coordinate system.
+                    // We have to draw the popup and consider the location for subelements because everything must
+                    // be rendered relative to the main window position
+                    if let PopupWindowLocation::ChildWindow(location) = &popup.location {
+                        item_trees.push((ItemTreeRc::downgrade(&popup.component), *location));
                     }
-                    drop(borrow);
-                    render_components(&item_trees, &post_render)
                 }
+                drop(borrow);
+                render_components(&item_trees, &post_render)
             },
-        ))
+        )
     }
 
     /// Draws the source `DragArea`'s `drag-image` under the cursor when a drag is in flight.
@@ -1829,7 +1819,8 @@ impl WindowInner {
                     popup::Placement::Fixed(LogicalRect::new(position, size)),
                     &clip_region,
                 );
-                self.window_adapter().request_redraw();
+                // Not needed here, because we will do it in update_popup_properties()
+                //self.window_adapter().request_redraw();
                 (
                     PopupWindowLocation::ChildWindow(rect.origin),
                     Box::pin(PropertyTracker::new_with_dirty_handler(


### PR DESCRIPTION
The problem is that we have two trackers running:
- redraw_tracker (tracks the geometry, width/height of the popup)
- properties_tracker (tracks the geometry, width/height + the position of the popup)

When the redraw_tracker is notified because the width changes, the bounding rect of the popup will be changed. After the timer of the properties_tracker of the Popup triggers a update_popup_properties the visual of the popup already changed and therefore old_popup_region is not the correct region because it is already with the new sized but with the old position

- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] ~~If the change is noteworthy, the commit message should contain `ChangeLog: ...`~~


# Old

1. One Click on the window -> popup shows up
2. First Click on the popup -> popup changes position and width
   - First frame: Width will be changed because of the WindowTracker
   - Second Frame: Position will be changed
4. Second and more clicks -> Artifacts are visible

https://github.com/user-attachments/assets/62d60bec-c97d-4567-945f-a5033d1aa253

# New

https://github.com/user-attachments/assets/f3d05662-b1a8-4bd9-8059-7551d07606c1

