### PR TITLE
todo-mvc example: Remove the slint re-export 

### DIFF
--- a/examples/todo-mvc/rust/src/lib.rs
+++ b/examples/todo-mvc/rust/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
+use slint::ComponentHandle;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
@@ -9,7 +10,6 @@ pub mod ui;
 
 mod callback;
 pub use callback::*;
-pub use slint::*;
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {


### PR DESCRIPTION
The glob re-export was only there to bring the ComponentHandle trait into scope for main_window.run(); import the trait explicitly instead. It also made rustdoc inline all of slint's docs into the example's docs, and crash on current nightly (rust-lang/rust#158686).
