### PR TITLE
Hide the ffi module from the slint-interpreter documentation

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2357,9 +2357,3 @@ export component Foo2 inherits Window  {
         }
     }
 }
-
-#[cfg(feature = "ffi")]
-#[doc(hidden)]
-#[allow(missing_docs)]
-#[path = "ffi.rs"]
-pub mod ffi;

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -6,10 +6,13 @@ use crate::dynamic_item_tree::ErasedItemTreeBox;
 
 use super::*;
 use core::ptr::NonNull;
-use i_slint_core::model::{Model, ModelNotify, SharedVectorModel};
+use i_slint_core::model::{Model, ModelNotify, ModelRc, SharedVectorModel};
 use i_slint_core::slice::Slice;
 use i_slint_core::window::WindowAdapter;
+use smol_str::SmolStr;
 use std::ffi::c_void;
+use std::path::PathBuf;
+use std::rc::Rc;
 use vtable::VRef;
 
 /// Construct a new Value in the given memory location
@@ -854,7 +857,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_get_diagnostics(
     out_diags: &mut SharedVector<Diagnostic>,
 ) {
     #[allow(deprecated)]
-    out_diags.extend(compiler.as_component_compiler().diagnostics.iter().map(|diagnostic| {
+    out_diags.extend(compiler.as_component_compiler().diagnostics().iter().map(|diagnostic| {
         let (line, column) = diagnostic.line_column();
         Diagnostic {
             message: diagnostic.message().into(),

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -83,6 +83,9 @@ mod dynamic_item_tree;
 mod dynamic_type;
 mod eval;
 mod eval_layout;
+#[cfg(feature = "ffi")]
+#[doc(hidden)]
+pub mod ffi;
 mod global_component;
 #[cfg(feature = "internal-highlight")]
 pub mod highlight;


### PR DESCRIPTION
The #[doc(hidden)] on the module was ignored because the module was declared inside the private api module and reached the docs through the inlined `pub use api::*` glob. Declare it at the crate root instead, where rustdoc honors the attribute.
