### PR TITLE
Fix crash when instantiating a styled RadioGroup or TabWidget directly

### DIFF
--- a/internal/compiler/passes/lower_radiogroup.rs
+++ b/internal/compiler/passes/lower_radiogroup.rs
@@ -15,6 +15,7 @@ use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use smol_str::SmolStr;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 pub async fn lower_radiogroup(
@@ -22,15 +23,21 @@ pub async fn lower_radiogroup(
     type_loader: &mut crate::typeloader::TypeLoader,
     diag: &mut BuildDiagnostics,
 ) {
-    let mut has_radiogroup = false;
+    // Collect before lowering: lowering rewrites base_type, which would hide
+    // other RadioGroup elements from builtin_type() (an instance and the style
+    // wrapper both match). Dedup a sub-component root visited more than once.
+    let mut seen = HashSet::new();
+    let mut radio_groups = Vec::new();
     doc.visit_all_used_components(|component| {
         recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
-            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "RadioGroup") {
-                has_radiogroup = true;
+            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "RadioGroup")
+                && seen.insert(Rc::as_ptr(elem))
+            {
+                radio_groups.push(elem.clone());
             }
         })
     });
-    if !has_radiogroup {
+    if radio_groups.is_empty() {
         return;
     }
 
@@ -44,18 +51,14 @@ pub async fn lower_radiogroup(
         .await
         .expect("RadioButtonImpl should be in std-widgets-impl.slint");
 
-    doc.visit_all_used_components(|component| {
-        recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
-            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "RadioGroup") {
-                process_radiogroup(
-                    elem,
-                    ElementType::Component(radio_group_impl.clone()),
-                    ElementType::Component(radio_button_impl.clone()),
-                    diag,
-                );
-            }
-        })
-    });
+    for elem in &radio_groups {
+        process_radiogroup(
+            elem,
+            ElementType::Component(radio_group_impl.clone()),
+            ElementType::Component(radio_button_impl.clone()),
+            diag,
+        );
+    }
 }
 
 fn process_radiogroup(
@@ -64,19 +67,11 @@ fn process_radiogroup(
     radio_button_impl: ElementType,
     diag: &mut BuildDiagnostics,
 ) {
-    // Skip the style's re-export wrapper, which has the builtin RadioGroup as a
-    // direct base_type. Only the user instance is processed.
-    if matches!(&elem.borrow().base_type, ElementType::Builtin(_)) {
-        return;
-    }
-
     // Borrow the children read-only for validation; do not take them out of
     // the element yet, so that any early-return error path leaves the element
     // intact for downstream passes (LSP/live-preview keep going past errors).
     let children = elem.borrow().children.clone();
 
-    // Validate: every direct child must be a RadioButton, plain or wrapped in a
-    // `for` / `if` repeater.
     for child in &children {
         if !matches!(&child.borrow().base_type, ElementType::Builtin(b) if b.name == "RadioButton")
         {
@@ -125,9 +120,6 @@ fn process_radiogroup(
 
     elem.borrow_mut().base_type = radio_group_impl;
 
-    // item-count: model length for the sole-`for` case, otherwise the static
-    // children count. item-index: the repeater index for `for`, otherwise the
-    // child's source position.
     let count_expr = match children.first().and_then(|c| c.borrow().repeated.clone()) {
         Some(rep) if children.len() == 1 => Expression::FunctionCall {
             function: Callable::Builtin(crate::expression_tree::BuiltinFunction::ArrayLength),

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -14,23 +14,31 @@ use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use smol_str::{SmolStr, format_smolstr};
 use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
 
 pub async fn lower_tabwidget(
     doc: &Document,
     type_loader: &mut crate::typeloader::TypeLoader,
     diag: &mut BuildDiagnostics,
 ) {
-    // First check if any TabWidget is used - avoid loading std-widgets.slint if not needed
-    let mut has_tabwidget = false;
+    // Collect before lowering: lowering rewrites base_type, which would hide
+    // other TabWidget elements from builtin_type() (an instance and the style
+    // wrapper both match). Dedup a sub-component root visited more than once.
+    // The empty check below also avoids loading std-widgets.slint when unused.
+    let mut seen = HashSet::new();
+    let mut tabwidgets = Vec::new();
     doc.visit_all_used_components(|component| {
         recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
-            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "TabWidget") {
-                has_tabwidget = true;
+            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "TabWidget")
+                && seen.insert(Rc::as_ptr(elem))
+            {
+                tabwidgets.push(elem.clone());
             }
         })
     });
 
-    if !has_tabwidget {
+    if tabwidgets.is_empty() {
         return;
     }
 
@@ -62,21 +70,17 @@ pub async fn lower_tabwidget(
         .expect("can't load TabBarVerticalImpl from std-widgets-impl.slint");
     let empty_type = type_loader.global_type_registry.borrow().empty_type();
 
-    doc.visit_all_used_components(|component| {
-        recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
-            if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "TabWidget") {
-                process_tabwidget(
-                    elem,
-                    ElementType::Component(tabwidget_impl.clone()),
-                    ElementType::Component(tab_impl.clone()),
-                    ElementType::Component(tabbar_horizontal_impl.clone()),
-                    ElementType::Component(tabbar_vertical_impl.clone()),
-                    &empty_type,
-                    diag,
-                );
-            }
-        })
-    });
+    for elem in &tabwidgets {
+        process_tabwidget(
+            elem,
+            ElementType::Component(tabwidget_impl.clone()),
+            ElementType::Component(tab_impl.clone()),
+            ElementType::Component(tabbar_horizontal_impl.clone()),
+            ElementType::Component(tabbar_vertical_impl.clone()),
+            &empty_type,
+            diag,
+        );
+    }
 }
 
 fn process_tabwidget(
@@ -88,11 +92,6 @@ fn process_tabwidget(
     empty_type: &ElementType,
     diag: &mut BuildDiagnostics,
 ) {
-    if matches!(&elem.borrow_mut().base_type, ElementType::Builtin(_)) {
-        // That's the TabWidget re-exported from the style, it doesn't need to be processed
-        return;
-    }
-
     elem.borrow_mut().base_type = tabwidget_impl;
     let mut children = std::mem::take(&mut elem.borrow_mut().children);
     let num_tabs = children.len();

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -27,18 +27,18 @@ pub async fn lower_tabwidget(
     // wrapper both match). Dedup a sub-component root visited more than once.
     // The empty check below also avoids loading std-widgets.slint when unused.
     let mut seen = HashSet::new();
-    let mut tabwidgets = Vec::new();
+    let mut tab_widgets = Vec::new();
     doc.visit_all_used_components(|component| {
         recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
             if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "TabWidget")
                 && seen.insert(Rc::as_ptr(elem))
             {
-                tabwidgets.push(elem.clone());
+                tab_widgets.push(elem.clone());
             }
         })
     });
 
-    if tabwidgets.is_empty() {
+    if tab_widgets.is_empty() {
         return;
     }
 
@@ -70,7 +70,7 @@ pub async fn lower_tabwidget(
         .expect("can't load TabBarVerticalImpl from std-widgets-impl.slint");
     let empty_type = type_loader.global_type_registry.borrow().empty_type();
 
-    for elem in &tabwidgets {
+    for elem in &tab_widgets {
         process_tabwidget(
             elem,
             ElementType::Component(tabwidget_impl.clone()),

--- a/tests/cases/issues/issue_12332_subclass.slint
+++ b/tests/cases/issues/issue_12332_subclass.slint
@@ -7,6 +7,9 @@
 // TabWidget, so its child (RadioButton / Tab) is never lowered. That panics the
 // interpreter and fails codegen with an unknown native type. The code blocks
 // also check that the widgets work, not just that they compile.
+//
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
 import { RadioGroup, TabWidget } from "std-widgets.slint";
 
 export component FooRadio inherits RadioGroup { }

--- a/tests/cases/issues/issue_12332_subclass.slint
+++ b/tests/cases/issues/issue_12332_subclass.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Subclassing a styled widget and instantiating the subclass with children.
-// The lowering pass rewrites base types as it walks the tree; if the empty
-// subclass is lowered first, the instance stops looking like a RadioGroup /
+// A subclass of a styled widget, instantiated with children. The lowering pass
+// rewrites base types as it walks the tree; if the empty subclass is lowered
+// first, the instance stops looking like a RadioGroup /
 // TabWidget, so its child (RadioButton / Tab) is never lowered. That panics the
 // interpreter and fails codegen with an unknown native type. The code blocks
 // also check that the widgets work, not just that they compile.

--- a/tests/cases/issues/issue_12332_subclass.slint
+++ b/tests/cases/issues/issue_12332_subclass.slint
@@ -1,3 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 // Subclassing a styled widget and instantiating the subclass with children.
 // The lowering pass rewrites base types as it walks the tree; if the empty
 // subclass is lowered first, the instance stops looking like a RadioGroup /

--- a/tests/cases/issues/issue_12332_subclass.slint
+++ b/tests/cases/issues/issue_12332_subclass.slint
@@ -1,0 +1,68 @@
+// Subclassing a styled widget and instantiating the subclass with children.
+// The lowering pass rewrites base types as it walks the tree; if the empty
+// subclass is lowered first, the instance stops looking like a RadioGroup /
+// TabWidget, so its child (RadioButton / Tab) is never lowered. That panics the
+// interpreter and fails codegen with an unknown native type. The code blocks
+// also check that the widgets work, not just that they compile.
+import { RadioGroup, TabWidget } from "std-widgets.slint";
+
+export component FooRadio inherits RadioGroup { }
+export component FooTab inherits TabWidget { }
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    out property <string> radio-value: radio.current-value;
+    in-out property <int> tab-index <=> tab.current-index;
+
+    HorizontalLayout {
+        radio := FooRadio {
+            RadioButton { text: "A"; }
+            RadioButton { text: "B"; }
+        }
+        tab := FooTab {
+            Tab { title: "One"; }
+            Tab { title: "Two"; }
+        }
+    }
+
+    out property <bool> test: radio-value == "" && tab-index == 0;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+// The RadioGroup subclass renders working radio buttons.
+let a = slint_testing::ElementHandle::find_by_accessible_label(&instance, "A").next().unwrap();
+a.invoke_accessible_default_action();
+assert_eq!(instance.get_radio_value(), slint::SharedString::from("A"));
+// The TabWidget subclass renders working tabs.
+let two = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Two").next().unwrap();
+two.invoke_accessible_default_action();
+assert_eq!(instance.get_tab_index(), 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+auto radios = slint::testing::ElementHandle::find_by_accessible_label(handle, "A");
+assert(radios.size() >= 1);
+radios[0].invoke_accessible_default_action();
+assert_eq(instance.get_radio_value(), "A");
+auto tabs = slint::testing::ElementHandle::find_by_accessible_label(handle, "Two");
+assert(tabs.size() >= 1);
+tabs[0].invoke_accessible_default_action();
+assert_eq(instance.get_tab_index(), 1);
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+assert.equal(instance.radio_value, "");
+instance.tab_index = 1;
+assert.equal(instance.tab_index, 1);
+```
+*/

--- a/tests/cases/issues/widgets-reexport.slint
+++ b/tests/cases/issues/widgets-reexport.slint
@@ -1,0 +1,23 @@
+// Re-exporting a widget makes the test driver instantiate its wrapper. Only
+// RadioGroup and TabWidget lower a builtin root that must not be left bare, so
+// they come last (the interpreter driver instantiates the last export); the
+// others are re-exported for completeness. Using two of them in TestCase also
+// reaches a wrapper both as a used component and through an instance, which
+// exercises the deduplication.
+import {
+    Button, CheckBox, ComboBox, GroupBox, LineEdit, ListView, ProgressIndicator,
+    ScrollView, Slider, SpinBox, Spinner, StandardButton, Switch, TextEdit,
+    RadioGroup, TabWidget,
+} from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    RadioGroup { RadioButton {} }
+    TabWidget { Tab { } }
+    out property <bool> test: true;
+}
+
+export {
+    Button, CheckBox, ComboBox, GroupBox, LineEdit, ListView, ProgressIndicator,
+    ScrollView, Slider, SpinBox, Spinner, StandardButton, Switch, TextEdit,
+    RadioGroup, TabWidget,
+}

--- a/tests/cases/issues/widgets-reexport.slint
+++ b/tests/cases/issues/widgets-reexport.slint
@@ -1,3 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 // Re-exporting a widget makes the test driver instantiate its wrapper. Only
 // RadioGroup and TabWidget lower a builtin root that must not be left bare, so
 // they come last (the interpreter driver instantiates the last export); the


### PR DESCRIPTION
The lowering passes skipped any element whose base is the builtin, taking it for the style's re-export wrapper. But the wrapper can be instantiated on its own — the live preview can select the widget directly — and was then left as a bare builtin, panicking the interpreter with "Native type not registered".

Collect the elements before lowering any, so lowering one does not hide another from builtin_type() (an instance and the wrapper both match), deduplicate a wrapper root visited more than once, and lower the wrapper too.

Fixes #12332
