### PR TITLE
core: fix misaligned pointer dereference in SharedVector on wasm32

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1065,5 +1065,5 @@ jobs:
               run: cargo miri test -p vtable -p const-field-offset -p i-slint-common
             - name: Run Miri on i-slint-core
               env:
-                  MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-tree-borrows
+                  MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-tree-borrows -Zmiri-symbolic-alignment-check
               run: cargo miri test -p i-slint-core --lib --features ffi,rtti

--- a/internal/core/sharedvector.rs
+++ b/internal/core/sharedvector.rs
@@ -430,11 +430,25 @@ impl<T: Clone> Extend<T> for SharedVector<T> {
     }
 }
 
-static SHARED_NULL: SharedVectorHeader =
-    SharedVectorHeader { refcount: atomic::AtomicIsize::new(-1), size: 0, capacity: 0 };
+/// The empty singleton that `SharedVector::default()` for every element type T points to.
+/// It only consists of a header, but the pointer is dereferenced as `SharedVectorInner<T>`,
+/// so the static must satisfy the alignment of the most aligned `SharedVectorInner<T>` in
+/// the program - not just `SharedVectorHeader`'s own alignment.
+#[repr(C, align(16))]
+struct SharedNull(SharedVectorHeader);
+
+static SHARED_NULL: SharedNull =
+    SharedNull(SharedVectorHeader { refcount: atomic::AtomicIsize::new(-1), size: 0, capacity: 0 });
 
 impl<T> Default for SharedVector<T> {
     fn default() -> Self {
+        const {
+            assert!(
+                core::mem::align_of::<SharedVectorInner<T>>()
+                    <= core::mem::align_of::<SharedNull>(),
+                "SharedVector element type is more aligned than the empty singleton"
+            );
+        }
         SharedVector { inner: NonNull::from(&SHARED_NULL).cast() }
     }
 }
@@ -770,4 +784,31 @@ fn test_replace_range() {
     let mut v = SharedVector::from([1, 2, 3, 4]);
     v.replace_range(&[2, 3, 4, 5], &[7, 8, 9, 9], 1);
     assert_eq!(v.as_slice(), &[1, 2, 3, 4]);
+}
+
+#[test]
+fn test_aligned_element_type() {
+    // The empty singleton behind `SharedVector::default()` must satisfy the element
+    // type's alignment (it is dereferenced as `SharedVectorInner<T>`). Use an element
+    // type with the maximum supported alignment so Miri catches a misaligned singleton
+    // on any host, like the 8-aligned element types on wasm32 did.
+    #[repr(align(16))]
+    #[derive(Clone, Debug, PartialEq)]
+    struct Aligned(u8);
+
+    let mut x: SharedVector<Aligned> = Default::default();
+    assert!(x.is_empty());
+    for i in 0..8 {
+        x.push(Aligned(i));
+    }
+    let y = x.clone();
+    assert_eq!(x.pop(), Some(Aligned(7)));
+    x.resize(4, Aligned(0));
+    x.clear();
+    assert!(x.is_empty());
+    assert_eq!(y.len(), 8);
+    assert_eq!(
+        y.as_slice().iter().map(|a| a.0).collect::<std::vec::Vec<_>>(),
+        std::vec![0, 1, 2, 3, 4, 5, 6, 7]
+    );
 }


### PR DESCRIPTION
SharedVector::default() points at a static that only consists of a SharedVectorHeader, but the pointer is dereferenced as SharedVectorInner<T>, which inherits T's alignment. On wasm32 the header is only 4-aligned, so for an 8-aligned element type the very first deref (e.g. in len()) is a misaligned pointer dereference, panicking in debug builds.

This is triggered when the unstable-wgpu-29 feature is enabled: the WGPUTexture variant it adds to ImageInner makes slint::Image 8-aligned on wasm32, and with it structs containing an Image, such as MenuEntry. The menu shadow tree then panics on the first is_empty() call on a default-constructed SharedVector<MenuEntry>.

Over-align the static to 16 and add a compile-time assertion in default() so element types with an even larger alignment become a build error instead of UB.

changelog: Fixed a debug-build panic on wasm32 when using `SharedVector` with element types that require 8-byte alignment, e.g. `MenuEntry` when `slint::Image` can contain a WGPU texture

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
