### PR TITLE
FlexboxLayout: wrap a non-stretch perpendicular flex only when needed

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -265,6 +265,13 @@ inline cbindgen_private::LayoutInfo flexbox_layout_info_main_axis(
                                                                  flex_wrap);
 }
 
+inline float flexbox_layout_unwrapped_main(
+        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells, float spacing,
+        const cbindgen_private::Padding &padding)
+{
+    return cbindgen_private::slint_flexbox_layout_unwrapped_main(cells, spacing, &padding);
+}
+
 inline cbindgen_private::LayoutInfo flexbox_layout_info_cross_axis(
         cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_h,
         cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_v, float spacing_h,

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -648,6 +648,29 @@ pub struct FlexboxLayout {
 }
 
 impl FlexboxLayout {
+    /// If `elem` is a (lowered, inline) FlexboxLayout, return its layout
+    /// description. The struct is embedded in the synthesized
+    /// `layoutinfo-{h,v}` / `layout-cache` bindings on the element.
+    pub fn from_element(elem: &ElementRc) -> Option<FlexboxLayout> {
+        use crate::expression_tree::Expression;
+        // The `layoutinfo-{h,v}` property's binding (on this element or its
+        // base component's root) holds a `ComputeFlexboxLayoutInfo` with the
+        // layout when the element is a FlexboxLayout.
+        let nr = {
+            let eb = elem.borrow();
+            eb.layout_info_prop(Orientation::Vertical)
+                .or_else(|| eb.layout_info_prop(Orientation::Horizontal))
+                .cloned()
+        }?;
+        let target = nr.element();
+        let target = target.borrow();
+        let binding = target.bindings.get(nr.name())?;
+        match binding.borrow().expression.ignore_debug_hooks() {
+            Expression::ComputeFlexboxLayoutInfo { layout, .. } => Some(layout.clone()),
+            _ => None,
+        }
+    }
+
     /// Try to determine the flex direction at compile time from a constant binding.
     /// Returns None if the direction is set at runtime.
     fn compile_time_direction(&self) -> Option<FlexboxLayoutDirection> {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -9,8 +9,9 @@ use smol_str::SmolStr;
 
 use super::lower_to_item_tree::LoweredElement;
 use super::{GridLayoutRepeatedElement, LayoutRepeatedElement};
+use crate::expression_tree::MinMaxOp;
 use crate::langtype::{BuiltinStruct, EnumerationValue, Struct, Type};
-use crate::layout::{GridLayoutCell, Orientation, RowColExpr};
+use crate::layout::{FlexboxAxisRelation, GridLayoutCell, Orientation, RowColExpr};
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
 use crate::namedreference::NamedReference;
@@ -88,7 +89,7 @@ pub(super) fn compute_box_layout_info(
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
 ) -> llr_Expression {
     let (padding, spacing) = generate_layout_padding_and_spacing(&layout.geometry, o, ctx);
-    let bld = box_layout_data(layout, o, ctx, cross_axis_size_override);
+    let bld = box_layout_data(layout, o, ctx, cross_axis_size_override, None);
     let sub_expression = if o == layout.orientation {
         llr_Expression::ExtraBuiltinFunctionCall {
             function: "box_layout_info".into(),
@@ -259,7 +260,12 @@ pub(super) fn solve_box_layout(
     let cross_override = (o == layout.orientation && o == Orientation::Horizontal)
         .then(|| layout_cross_content_size(layout))
         .flatten();
-    let bld = box_layout_data(layout, o, ctx, cross_override.as_ref());
+    // On the cross pass, the layout's content size along `o` is its
+    // cross content size; forward it so a wrapping perpendicular flex cell
+    // gets its natural single-line size instead of the compact sqrt preferred.
+    let cross_clamp =
+        (o != layout.orientation).then(|| layout_cross_content_size(layout)).flatten();
+    let bld = box_layout_data(layout, o, ctx, cross_override.as_ref(), cross_clamp.as_ref());
     let size = layout_geometry_size(&layout.geometry.rect, o, ctx);
     let (data, function) = if o == layout.orientation {
         let data = make_struct(
@@ -1025,6 +1031,7 @@ fn box_layout_data(
     orientation: Orientation,
     ctx: &mut ExpressionLoweringCtx,
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
+    cross_clamp: Option<&crate::expression_tree::Expression>,
 ) -> BoxLayoutDataResult {
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
@@ -1053,6 +1060,7 @@ fn box_layout_data(
                         ctx,
                         orientation,
                         cross_axis_size_override,
+                        cross_clamp,
                     );
                     make_layout_cell_data_struct(layout_info)
                 })
@@ -1081,6 +1089,7 @@ fn box_layout_data(
                     ctx,
                     orientation,
                     cross_axis_size_override,
+                    cross_clamp,
                 );
                 elements.push(Either::Left(make_layout_cell_data_struct(layout_info)));
             }
@@ -1099,6 +1108,7 @@ fn cell_layout_info(
     ctx: &mut ExpressionLoweringCtx,
     orientation: Orientation,
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
+    cross_clamp: Option<&crate::expression_tree::Expression>,
 ) -> llr_Expression {
     let constraint = match orientation {
         Orientation::Vertical => {
@@ -1122,7 +1132,189 @@ fn cell_layout_info(
             }
         }
     };
-    get_layout_info(elem, ctx, constraints, orientation, constraint)
+    let layout_info = get_layout_info(elem, ctx, constraints, orientation, constraint);
+    // On a box layout's cross pass (`cross_clamp` set), give a wrapping
+    // perpendicular flex cell its natural single-line size clamped to the
+    // available space instead of its compact sqrt preferred. An explicit
+    // preferred size wins over the clamp, like in the interpreter (which applies
+    // constraints after the clamp), so skip the clamp then.
+    let has_explicit_preferred = match orientation {
+        Orientation::Horizontal => constraints.preferred_width.is_some(),
+        Orientation::Vertical => constraints.preferred_height.is_some(),
+    };
+    match cross_clamp {
+        Some(available) if !has_explicit_preferred => {
+            clamp_wrapping_flex_cross_preferred(layout_info, elem, orientation, available, ctx)
+        }
+        _ => layout_info,
+    }
+}
+
+/// Build the `flexbox_layout_unwrapped_main(cells, spacing, padding)` call for
+/// `layout`'s main axis (= `orientation`). Returns the flex's natural
+/// single-line main size as a float expression.
+fn flexbox_unwrapped_main_expr(
+    layout: &crate::layout::FlexboxLayout,
+    orientation: Orientation,
+    ctx: &mut ExpressionLoweringCtx,
+) -> llr_Expression {
+    let (padding_h, spacing_h) =
+        generate_layout_padding_and_spacing(&layout.geometry, Orientation::Horizontal, ctx);
+    let (padding_v, spacing_v) =
+        generate_layout_padding_and_spacing(&layout.geometry, Orientation::Vertical, ctx);
+    let fld = flexbox_layout_data(layout, ctx, None, None);
+    let (spacing, padding) = match orientation {
+        Orientation::Horizontal => (spacing_h, padding_h),
+        Orientation::Vertical => (spacing_v, padding_v),
+    };
+    let array_ty = Type::Array(Rc::new(crate::typeregister::flexbox_layout_item_info_type()));
+    let cells_expr = match &fld.compute_cells {
+        Some((cells_h_var, cells_v_var, _)) => {
+            let cells_var = match orientation {
+                Orientation::Horizontal => cells_h_var.clone(),
+                Orientation::Vertical => cells_v_var.clone(),
+            };
+            llr_Expression::ReadLocalVariable { name: cells_var.into(), ty: array_ty }
+        }
+        None => match orientation {
+            Orientation::Horizontal => fld.cells_h.clone(),
+            Orientation::Vertical => fld.cells_v.clone(),
+        },
+    };
+    let call = llr_Expression::ExtraBuiltinFunctionCall {
+        function: "flexbox_layout_unwrapped_main".into(),
+        arguments: vec![cells_expr, spacing, padding],
+        return_ty: Type::Float32,
+    };
+    match fld.compute_cells {
+        Some((cells_h_variable, cells_v_variable, elements)) => {
+            llr_Expression::WithFlexboxLayoutItemInfo {
+                cells_h_variable,
+                cells_v_variable,
+                repeater_indices_var_name: None,
+                elements,
+                sub_expression: Box::new(call),
+            }
+        }
+        None => call,
+    }
+}
+
+/// If `elem` is a wrapping FlexboxLayout whose main axis is the parent's cross
+/// axis (`orientation`), replace its `preferred` with
+/// `min(available, unwrapped)`, where `unwrapped` is the flex's natural
+/// single-line main size. Mirrors the interpreter's
+/// `clamp_wrapping_flex_cross_preferred`. `available` is the layout's cross
+/// content size (`layout_cross_content_size`).
+fn clamp_wrapping_flex_cross_preferred(
+    layout_info: llr_Expression,
+    elem: &ElementRc,
+    orientation: Orientation,
+    available: &crate::expression_tree::Expression,
+    ctx: &mut ExpressionLoweringCtx,
+) -> llr_Expression {
+    let Some(flex) = crate::layout::FlexboxLayout::from_element(elem) else {
+        return layout_info;
+    };
+    let axis_relation = flex.axis_relation(orientation);
+    // The flex's main axis must be this cross axis. When the direction is known
+    // at compile time to be the cross axis, there is nothing to clamp.
+    if axis_relation == FlexboxAxisRelation::CrossAxis {
+        return layout_info;
+    }
+
+    let unwrapped = flexbox_unwrapped_main_expr(&flex, orientation, ctx);
+    let available = super::lower_expression::lower_expression(available, ctx);
+    let clamped = llr_Expression::MinMax {
+        ty: Type::Float32,
+        op: MinMaxOp::Min,
+        lhs: Box::new(available),
+        rhs: Box::new(unwrapped),
+    };
+
+    // Rebuild the LayoutInfo struct, overriding only `preferred`.
+    let ty = crate::typeregister::layout_info_type();
+    let store = llr_Expression::StoreLocalVariable {
+        name: "layout_info".into(),
+        value: layout_info.into(),
+    };
+    let stored =
+        || llr_Expression::ReadLocalVariable { name: "layout_info".into(), ty: ty.clone().into() };
+    let stored_field = |name: &str| llr_Expression::StructFieldAccess {
+        base: Box::new(stored()),
+        name: name.into(),
+    };
+    // A no-wrap flex keeps its preferred (single line == its preferred); only a
+    // wrapping flex is clamped. Decide at runtime when flex-wrap is dynamic.
+    let new_preferred = match &flex.flex_wrap {
+        Some(nr) => {
+            let wrap_enum =
+                crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutWrap.clone());
+            let is_no_wrap = llr_Expression::BinaryExpression {
+                lhs: Box::new(llr_Expression::PropertyReference(ctx.map_property_reference(nr))),
+                rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
+                    value: 1, // FlexboxLayoutWrap::NoWrap
+                    enumeration: wrap_enum,
+                })),
+                op: '=',
+            };
+            llr_Expression::Condition {
+                condition: Box::new(is_no_wrap),
+                true_expr: Box::new(stored_field("preferred")),
+                false_expr: Box::new(clamped),
+            }
+        }
+        None => clamped, // default flex-wrap is `wrap`
+    };
+
+    let mut values =
+        ty.fields.keys().map(|p| (p.clone(), stored_field(p))).collect::<BTreeMap<_, _>>();
+    values.insert("preferred".into(), new_preferred);
+    let clamped_struct = llr_Expression::Struct { ty: ty.clone(), values };
+
+    // When the direction is known at compile time to be the main axis, clamp
+    // unconditionally. When it is only known at runtime, clamp only in the
+    // branch where the main axis is this cross axis and keep the computed
+    // layout-info otherwise -- mirrors the runtime dispatch in
+    // `compute_flexbox_layout_info` and the interpreter's runtime direction eval.
+    let result = match axis_relation {
+        FlexboxAxisRelation::MainAxis => clamped_struct,
+        FlexboxAxisRelation::CrossAxis => unreachable!("returned early above"),
+        FlexboxAxisRelation::Unknown => {
+            let direction_enum =
+                crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
+            let direction_ref = llr_Expression::PropertyReference(
+                ctx.map_property_reference(flex.direction.as_ref().unwrap()),
+            );
+            // The main axis is this cross axis when the direction is, for
+            // Horizontal: Row (0) or RowReverse (1); for Vertical: Column (2) or
+            // ColumnReverse (3).
+            let (main_a, main_b) = match orientation {
+                Orientation::Horizontal => (0, 1),
+                Orientation::Vertical => (2, 3),
+            };
+            let is_direction = |value: usize| llr_Expression::BinaryExpression {
+                lhs: Box::new(direction_ref.clone()),
+                rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
+                    value,
+                    enumeration: direction_enum.clone(),
+                })),
+                op: '=',
+            };
+            let main_is_cross = llr_Expression::BinaryExpression {
+                lhs: Box::new(is_direction(main_a)),
+                rhs: Box::new(is_direction(main_b)),
+                op: '|',
+            };
+            llr_Expression::Condition {
+                condition: Box::new(main_is_cross),
+                true_expr: Box::new(clamped_struct),
+                false_expr: Box::new(stored()),
+            }
+        }
+    };
+
+    llr_Expression::CodeBlock([store, result].into())
 }
 
 struct GridLayoutCellConstraintsResult {
@@ -1156,6 +1348,7 @@ fn grid_layout_cell_constraints(
                         ctx,
                         orientation,
                         cross_axis_size_override,
+                        None,
                     );
                     make_layout_cell_data_struct(layout_info)
                 })
@@ -1188,6 +1381,7 @@ fn grid_layout_cell_constraints(
                     ctx,
                     orientation,
                     cross_axis_size_override,
+                    None,
                 );
                 elements.push(Either::Left(make_layout_cell_data_struct(layout_info)));
             }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1878,6 +1878,27 @@ pub fn solve_flexbox_layout_with_measure(
     result
 }
 
+/// The flex's natural single-line (no-wrap) main-axis size: the size it
+/// occupies when all items sit on one line. A perpendicular parent uses this
+/// to give a non-stretch wrapping-flex cell its natural size (and only wrap
+/// when the available cross size is smaller), instead of the compact
+/// `sqrt`-area "square" that [`flexbox_layout_info_main_axis`] reports as
+/// `preferred`.
+pub fn flexbox_layout_unwrapped_main(
+    cells: Slice<FlexboxLayoutItemInfo>,
+    spacing: Coord,
+    padding: &Padding,
+) -> Coord {
+    let extra_pad = padding.begin + padding.end;
+    if cells.is_empty() {
+        return extra_pad;
+    }
+    let num_spacings = cells.len().saturating_sub(1) as Coord;
+    cells.iter().map(|c| c.constraint.preferred_bounded()).sum::<Coord>()
+        + spacing * num_spacings
+        + extra_pad
+}
+
 /// Return main-axis LayoutInfo for a FlexboxLayout.
 /// Only needs the same-axis cells, avoiding a cross-axis binding loop.
 pub fn flexbox_layout_info_main_axis(
@@ -1904,9 +1925,7 @@ pub fn flexbox_layout_info_main_axis(
     };
     let preferred = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
         // No wrapping: all items on one line
-        cells.iter().map(|c| c.constraint.preferred_bounded()).sum::<Coord>()
-            + spacing * num_spacings
-            + extra_pad
+        flexbox_layout_unwrapped_main(cells, spacing, padding)
     } else {
         // Wrapping: aim for a roughly square (pixel-area) arrangement, using only
         // main-axis sizes so this stays independent of the cross axis. The square
@@ -2268,6 +2287,16 @@ pub(crate) mod ffi {
         flex_wrap: FlexboxLayoutWrap,
     ) -> LayoutInfo {
         super::flexbox_layout_info_main_axis(cells, spacing, padding, flex_wrap)
+    }
+
+    #[unsafe(no_mangle)]
+    /// Return the flex's natural single-line (no-wrap) main-axis size.
+    pub extern "C" fn slint_flexbox_layout_unwrapped_main(
+        cells: Slice<FlexboxLayoutItemInfo>,
+        spacing: Coord,
+        padding: &Padding,
+    ) -> Coord {
+        super::flexbox_layout_unwrapped_main(cells, spacing, padding)
     }
 
     #[unsafe(no_mangle)]

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -77,8 +77,16 @@ pub(crate) fn compute_box_layout_info(
     let expr_eval = |nr: &NamedReference| -> f32 {
         eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
     };
-    let (cells, alignment) =
-        box_layout_data(box_layout, orientation, component, &expr_eval, None, cross_axis_size);
+    let (cells, alignment) = box_layout_data(
+        box_layout,
+        orientation,
+        component,
+        &expr_eval,
+        None,
+        cross_axis_size,
+        local_context,
+        None,
+    );
     let (padding, spacing) = padding_and_spacing(&box_layout.geometry, orientation, &expr_eval);
     if orientation == box_layout.orientation {
         core_layout::box_layout_info(Slice::from(cells.as_slice()), spacing, &padding, alignment)
@@ -179,6 +187,18 @@ pub(crate) fn solve_box_layout(
         })
     })
     .flatten();
+    // On the cross pass, the layout's real cross size (its own content size
+    // along this orientation) is known. Forward it so a wrapping perpendicular
+    // flex cell can be given its natural single-line size instead of the
+    // compact sqrt preferred (see `clamp_wrapping_flex_cross_preferred`).
+    let available_cross = (orientation != box_layout.orientation)
+        .then(|| {
+            box_layout.geometry.rect.size_reference(orientation).map(&expr_eval).map(|s| {
+                let (pad, _) = padding_and_spacing(&box_layout.geometry, orientation, &expr_eval);
+                s - pad.begin - pad.end
+            })
+        })
+        .flatten();
     let (cells, alignment) = box_layout_data(
         box_layout,
         orientation,
@@ -186,6 +206,8 @@ pub(crate) fn solve_box_layout(
         &expr_eval,
         Some(&mut repeated_indices),
         cross_axis_size,
+        local_context,
+        available_cross,
     );
     let (padding, spacing) = padding_and_spacing(&box_layout.geometry, orientation, &expr_eval);
     let size = box_layout.geometry.rect.size_reference(orientation).map(&expr_eval).unwrap_or(0.);
@@ -1089,6 +1111,8 @@ fn box_layout_data(
     expr_eval: &impl Fn(&NamedReference) -> f32,
     mut repeater_indices: Option<&mut Vec<u32>>,
     cross_axis_size: Option<f32>,
+    local_context: &mut EvalLocalContext,
+    available_cross: Option<f32>,
 ) -> (Vec<core_layout::LayoutItemInfo>, i_slint_core::items::LayoutAlignment) {
     let window_adapter = component.window_adapter();
     let mut cells = Vec::with_capacity(box_layout.elems.len());
@@ -1115,6 +1139,16 @@ fn box_layout_data(
                 orientation,
                 cross_axis,
             );
+            clamp_wrapping_flex_cross_preferred(
+                &mut layout_info,
+                &cell.element,
+                box_layout,
+                orientation,
+                component,
+                &expr_eval,
+                local_context,
+                available_cross,
+            );
             fill_layout_info_constraints(
                 &mut layout_info,
                 &cell.constraints,
@@ -1136,6 +1170,76 @@ fn box_layout_data(
         })
         .unwrap_or_default();
     (cells, alignment)
+}
+
+/// When a wrapping FlexboxLayout is a cell of a perpendicular box layout (its
+/// main axis is the parent's cross axis), a non-stretch parent gives the cell
+/// its `preferred` cross size. The flex's plain preferred is the compact
+/// sqrt-area "square" (it wraps), but with room it should fill a single line
+/// and only wrap when the available cross size can't hold it. Clamp the
+/// preferred to `min(available, unwrapped)`, so the height it is given equals
+/// the height its width was computed at: no wrap when tall, no overlap with
+/// siblings. Only at solve time (`available_cross` is `Some`); during
+/// layout-info aggregation the sqrt preferred is kept so the flex can still
+/// size a window.
+#[allow(clippy::too_many_arguments)]
+fn clamp_wrapping_flex_cross_preferred(
+    layout_info: &mut core_layout::LayoutInfo,
+    elem: &ElementRc,
+    box_layout: &i_slint_compiler::layout::BoxLayout,
+    orientation: Orientation,
+    component: InstanceRef,
+    expr_eval: &impl Fn(&NamedReference) -> f32,
+    local_context: &mut EvalLocalContext,
+    available_cross: Option<f32>,
+) {
+    let Some(available) = available_cross else { return };
+    if orientation == box_layout.orientation {
+        return;
+    }
+    let Some(fl) = i_slint_compiler::layout::FlexboxLayout::from_element(elem) else { return };
+
+    // The flex's main axis must be the parent's cross axis, and it must wrap.
+    let direction = flexbox_layout_direction(&fl, local_context);
+    let main_is_cross = matches!(
+        (direction, orientation),
+        (FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse, Orientation::Horizontal)
+            | (
+                FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse,
+                Orientation::Vertical
+            )
+    );
+    if !main_is_cross {
+        return;
+    }
+    let flex_wrap =
+        fl.flex_wrap.as_ref().map_or(i_slint_core::items::FlexboxLayoutWrap::default(), |nr| {
+            eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
+        });
+    if matches!(flex_wrap, i_slint_core::items::FlexboxLayoutWrap::NoWrap) {
+        return;
+    }
+
+    let (cells_h, cells_v, _ri) =
+        flexbox_layout_data(&fl, component, expr_eval, local_context, None, None);
+    let (cells, padding, spacing) = match orientation {
+        Orientation::Horizontal => {
+            let (padding, spacing) =
+                padding_and_spacing(&fl.geometry, Orientation::Horizontal, expr_eval);
+            (cells_h, padding, spacing)
+        }
+        Orientation::Vertical => {
+            let (padding, spacing) =
+                padding_and_spacing(&fl.geometry, Orientation::Vertical, expr_eval);
+            (cells_v, padding, spacing)
+        }
+    };
+    let unwrapped = core_layout::flexbox_layout_unwrapped_main(
+        Slice::from(cells.as_slice()),
+        spacing,
+        &padding,
+    );
+    layout_info.preferred = available.min(unwrapped);
 }
 
 pub(crate) fn fill_layout_info_constraints(

--- a/tests/cases/layout/flexbox_column_wrap_when_needed.slint
+++ b/tests/cases/layout/flexbox_column_wrap_when_needed.slint
@@ -1,0 +1,214 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A column FlexboxLayout that is a child of a HorizontalLayout with a
+// non-stretch cross-axis-alignment (start) must wrap into extra columns only
+// when there isn't enough height. With room it stays a single natural-height
+// column. Its reported width must match the columns it lays out, so it never
+// overlaps a sibling. Fixed-size Rectangles keep the geometry deterministic
+// across backends (no fonts).
+//
+// unwrapped single-line height = 40 + 5 + 40 + 5 + 40 = 130px.
+//
+// The rotated cases below mirror this 90°: a row FlexboxLayout that is a child
+// of a VerticalLayout. There the flex main axis is horizontal, so it must wrap
+// into extra rows only when there isn't enough width, and its reported height
+// must match the rows it lays out so it never overlaps a sibling below it.
+// unwrapped single-line width = 40 + 5 + 40 + 5 + 40 = 130px, row height 50px.
+//
+// Visual aids: the magenta outline is each flex's reported box; the sibling is
+// translucent orange. Before the fix the flex reserved less than it drew, so
+// items spilled past the outline into the sibling; now the outline hugs the
+// items and stops before the sibling.
+
+export component TestCase inherits Window {
+    width: 800px;
+    height: 490px;
+
+    // Column of "flex-direction: column" cases on the left, "flex-direction:
+    // row" cases on the right, each under a title.
+    Text {
+        x: 0; y: 0; width: 400px; height: 35px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        font-size: 15px;
+        text: "flex-direction: column (in a HorizontalLayout)";
+    }
+    Text {
+        x: 400px; y: 0; width: 400px; height: 35px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        font-size: 15px;
+        text: "flex-direction: row (in a VerticalLayout)";
+    }
+
+    // --- Tall: 300px is more than the 130px the column needs -> no wrap ---
+    tallFlexBg := Rectangle {
+        x: 0; y: 40px; width: 400px; height: 300px;
+        border-color: gray;
+        border-width: 1px;
+        HorizontalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            tallFlex := FlexboxLayout {
+                flex-direction: column;
+                spacing: 5px;
+                t1 := Rectangle { width: 50px; height: 40px; background: #c33; }
+                t2 := Rectangle { width: 50px; height: 40px; background: #3c3; }
+                t3 := Rectangle { width: 50px; height: 40px; background: #36c; }
+            }
+            tallSibling := Rectangle { min-width: 100px; height: 130px; background: #ffa50080; }
+        }
+        // Outline of the flex's reported box: it must contain all items and not
+        // reach into the (translucent) sibling.
+        Rectangle {
+            x: tallFlex.x; y: tallFlex.y; width: tallFlex.width; height: tallFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
+    // --- Short: 90px only fits two items -> the third wraps to a 2nd column ---
+    shortFlexBg := Rectangle {
+        x: 0; y: 340px; width: 400px; height: 90px;
+        border-color: gray;
+        border-width: 1px;
+        HorizontalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            shortFlex := FlexboxLayout {
+                flex-direction: column;
+                spacing: 5px;
+                s1 := Rectangle { width: 50px; height: 40px; background: #c33; }
+                s2 := Rectangle { width: 50px; height: 40px; background: #3c3; }
+                s3 := Rectangle { width: 50px; height: 40px; background: #36c; }
+            }
+            shortSibling := Rectangle { min-width: 100px; height: 80px; background: #ffa50080; }
+        }
+        Rectangle {
+            x: shortFlex.x; y: shortFlex.y; width: shortFlex.width; height: shortFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
+    // --- Wide: 300px is more than the 130px the row needs -> no wrap ---
+    wideFlexBg := Rectangle {
+        x: 400px; y: 40px; width: 300px; height: 200px;
+        border-color: gray;
+        border-width: 1px;
+        VerticalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            wideFlex := FlexboxLayout {
+                flex-direction: row;
+                spacing: 5px;
+                w1 := Rectangle { width: 40px; height: 50px; background: #c33; }
+                w2 := Rectangle { width: 40px; height: 50px; background: #3c3; }
+                w3 := Rectangle { width: 40px; height: 50px; background: #36c; }
+            }
+            wideSibling := Rectangle { min-height: 100px; width: 130px; background: #ffa50080; }
+        }
+        Rectangle {
+            x: wideFlex.x; y: wideFlex.y; width: wideFlex.width; height: wideFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
+    // --- Narrow: 90px only fits two items -> the third wraps to a 2nd row ---
+    // Tall enough (240px) to hold the 2-row flex (105px) + spacing (10px) + the
+    // sibling (min 100px) = 215px, so the sibling stays inside the container.
+    narrowFlexBg := Rectangle {
+        x: 400px; y: 240px; width: 90px; height: 240px;
+        border-color: gray;
+        border-width: 1px;
+        VerticalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            narrowFlex := FlexboxLayout {
+                flex-direction: row;
+                spacing: 5px;
+                n1 := Rectangle { width: 40px; height: 50px; background: #c33; }
+                n2 := Rectangle { width: 40px; height: 50px; background: #3c3; }
+                n3 := Rectangle { width: 40px; height: 50px; background: #36c; }
+            }
+            narrowSibling := Rectangle { min-height: 100px; width: 85px; background: #ffa50080; }
+        }
+        Rectangle {
+            x: narrowFlex.x; y: narrowFlex.y; width: narrowFlex.width; height: narrowFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
+    // Tall: the three items form a single column (same x, increasing y) and the
+    // flex stays one column wide.
+    out property <bool> tall_single_column: t1.x == t2.x && t2.x == t3.x
+        && t1.y < t2.y && t2.y < t3.y
+        && tallFlex.width == 50px;
+    // The sibling sits to the right of the flex, no overlap.
+    out property <bool> tall_no_overlap: tallSibling.x >= tallFlex.x + tallFlex.width;
+
+    // Short: the third item wrapped into a second column, so the flex is wider
+    // than a single column.
+    out property <bool> short_wraps: s3.x > s1.x && shortFlex.width > 50px;
+    out property <bool> short_no_overlap: shortSibling.x >= shortFlex.x + shortFlex.width;
+
+    // Rotated: wide row forms a single row (same y, increasing x) and the flex
+    // stays one row tall.
+    out property <bool> wide_single_row: w1.y == w2.y && w2.y == w3.y
+        && w1.x < w2.x && w2.x < w3.x
+        && wideFlex.height == 50px;
+    // The sibling sits below the flex, no overlap.
+    out property <bool> wide_no_overlap: wideSibling.y >= wideFlex.y + wideFlex.height;
+
+    // Rotated narrow: the third item wrapped into a second row, so the flex is
+    // taller than a single row.
+    out property <bool> narrow_wraps: n3.y > n1.y && narrowFlex.height > 50px;
+    out property <bool> narrow_no_overlap: narrowSibling.y >= narrowFlex.y + narrowFlex.height;
+
+    out property <bool> test: tall_single_column && tall_no_overlap && short_wraps && short_no_overlap
+        && wide_single_row && wide_no_overlap && narrow_wraps && narrow_no_overlap;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_tall_single_column());
+assert(handle->get_tall_no_overlap());
+assert(handle->get_short_wraps());
+assert(handle->get_short_no_overlap());
+assert(handle->get_wide_single_row());
+assert(handle->get_wide_no_overlap());
+assert(handle->get_narrow_wraps());
+assert(handle->get_narrow_no_overlap());
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_tall_single_column(), "tall column flex must not wrap");
+assert!(instance.get_tall_no_overlap(), "tall flex overlaps its sibling");
+assert!(instance.get_short_wraps(), "short column flex must wrap into a 2nd column");
+assert!(instance.get_short_no_overlap(), "short flex overlaps its sibling");
+assert!(instance.get_wide_single_row(), "wide row flex must not wrap");
+assert!(instance.get_wide_no_overlap(), "wide flex overlaps its sibling");
+assert!(instance.get_narrow_wraps(), "narrow row flex must wrap into a 2nd row");
+assert!(instance.get_narrow_no_overlap(), "narrow flex overlaps its sibling");
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.tall_single_column);
+assert(instance.tall_no_overlap);
+assert(instance.short_wraps);
+assert(instance.short_no_overlap);
+assert(instance.wide_single_row);
+assert(instance.wide_no_overlap);
+assert(instance.narrow_wraps);
+assert(instance.narrow_no_overlap);
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_explicit_preferred_size.slint
+++ b/tests/cases/layout/flexbox_explicit_preferred_size.slint
@@ -1,0 +1,78 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// An explicit preferred size on a perpendicular flex must win over the "wrap
+// only when needed" clamp -- the same in both layout paths. The interpreter
+// applies constraints after the clamp, so it already honors it; LLR bakes the
+// constraint in before the clamp, so the clamp must not override an explicit
+// preferred.
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 500px;
+
+    // Column flex in a HorizontalLayout: its main axis is the parent's cross
+    // axis, and preferred-height (60px) is set explicitly. Without room the
+    // clamp would report min(available, unwrapped) = 130px instead.
+    Rectangle {
+        x: 0; y: 0; width: 400px; height: 300px;
+        HorizontalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            colFlex := FlexboxLayout {
+                flex-direction: column;
+                preferred-height: 60px;
+                spacing: 5px;
+                Rectangle { width: 50px; height: 40px; }
+                Rectangle { width: 50px; height: 40px; }
+                Rectangle { width: 50px; height: 40px; }
+            }
+            Rectangle { min-width: 100px; }
+        }
+    }
+
+    // Rotated: row flex in a VerticalLayout with an explicit preferred-width.
+    Rectangle {
+        x: 0; y: 300px; width: 400px; height: 200px;
+        VerticalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            rowFlex := FlexboxLayout {
+                flex-direction: row;
+                preferred-width: 60px;
+                spacing: 5px;
+                Rectangle { width: 40px; height: 50px; }
+                Rectangle { width: 40px; height: 50px; }
+                Rectangle { width: 40px; height: 50px; }
+            }
+            Rectangle { min-height: 30px; }
+        }
+    }
+
+    out property <bool> col_honors_preferred: colFlex.height == 60px;
+    out property <bool> row_honors_preferred: rowFlex.width == 60px;
+    out property <bool> test: col_honors_preferred && row_honors_preferred;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_col_honors_preferred());
+assert(handle->get_row_honors_preferred());
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_col_honors_preferred(), "explicit preferred-height must win");
+assert!(instance.get_row_honors_preferred(), "explicit preferred-width must win");
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.col_honors_preferred);
+assert(instance.row_honors_preferred);
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_runtime_direction_wrap_when_needed.slint
+++ b/tests/cases/layout/flexbox_runtime_direction_wrap_when_needed.slint
@@ -1,0 +1,140 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Same "wrap only when needed" behavior as flexbox_column_wrap_when_needed, but
+// with a flex-direction that is only known at runtime (bound to a property, as
+// in the interactive flexbox demo). The compiler cannot tell whether the flex's
+// main axis is the parent's cross axis, so the anti-overlap clamp is emitted
+// behind a runtime direction check. This guards backend parity: the interpreter
+// evaluates the direction at runtime, and LLR codegen must do the same instead
+// of skipping the clamp (which would let the tall column wrap and overlap).
+//
+// Toggle the radio buttons to flip the flex between column and row at runtime.
+// unwrapped single-line height (column) = 40 + 5 + 40 + 5 + 40 = 130px.
+//
+// Visual aids: the magenta outline is each flex's reported box; the sibling is
+// translucent orange. The outline hugs the items and stops before the sibling.
+
+import { RadioGroup } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 400px;
+    // The short container is only 90px in column mode so the column wraps into a
+    // second column; a row flex there is wider than tall, so give it more room in
+    // row mode (and grow the window to match) instead of a cramped fit.
+    height: root.row-direction ? 560px : 450px;
+    // Two radio buttons pick the direction at runtime, through a ternary so it
+    // stays a runtime value rather than a compile-time constant. The "row"
+    // button is unchecked by default, so the default direction is column --
+    // what the assertions check.
+    property <bool> row-direction: row-btn.checked;
+    property <FlexboxLayoutDirection> dir:
+        row-direction ? FlexboxLayoutDirection.row : FlexboxLayoutDirection.column;
+
+    dir-group := RadioGroup {
+        x: 5px; y: 5px;
+        orientation: Orientation.horizontal;
+        RadioButton { text: "column"; checked: true; }
+        row-btn := RadioButton { text: "row"; }
+    }
+    // Both parents are HorizontalLayouts, so "row" here is a row-in-HLayout
+    // (parallel) case -- unlike the static file's row-in-VLayout -- which is why
+    // the two look different.
+    Text {
+        x: 100px; y: 5px; width: 295px; height: 30px;
+        horizontal-alignment: right;
+        vertical-alignment: center;
+        font-size: 14px;
+        text: "(in a HorizontalLayout)";
+    }
+
+    // --- Tall: 300px is more than the 130px the column needs -> no wrap ---
+    tallFlexBg := Rectangle {
+        x: 0; y: 50px; width: 400px; height: 300px;
+        border-color: gray;
+        border-width: 1px;
+        HorizontalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            tallFlex := FlexboxLayout {
+                flex-direction: root.dir;
+                spacing: 5px;
+                t1 := Rectangle { width: 50px; height: 40px; background: #c33; }
+                t2 := Rectangle { width: 50px; height: 40px; background: #3c3; }
+                t3 := Rectangle { width: 50px; height: 40px; background: #36c; }
+            }
+            tallSibling := Rectangle { min-width: 100px; height: 130px; background: #ffa50080; }
+        }
+        // Outline of the flex's reported box: it must contain all items and not
+        // reach into the (translucent) sibling.
+        Rectangle {
+            x: tallFlex.x; y: tallFlex.y; width: tallFlex.width; height: tallFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
+    // --- Short: 90px only fits two items -> the third wraps to a 2nd column ---
+    shortFlexBg := Rectangle {
+        x: 0; y: 350px; width: 400px; height: root.row-direction ? 200px : 90px;
+        border-color: gray;
+        border-width: 1px;
+        HorizontalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            shortFlex := FlexboxLayout {
+                flex-direction: root.dir;
+                spacing: 5px;
+                s1 := Rectangle { width: 50px; height: 40px; background: #c33; }
+                s2 := Rectangle { width: 50px; height: 40px; background: #3c3; }
+                s3 := Rectangle { width: 50px; height: 40px; background: #36c; }
+            }
+            shortSibling := Rectangle { min-width: 100px; height: 80px; background: #ffa50080; }
+        }
+        Rectangle {
+            x: shortFlex.x; y: shortFlex.y; width: shortFlex.width; height: shortFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
+    // Tall: single column (same x, increasing y), one column wide, no overlap.
+    out property <bool> tall_single_column: t1.x == t2.x && t2.x == t3.x
+        && t1.y < t2.y && t2.y < t3.y
+        && tallFlex.width == 50px;
+    out property <bool> tall_no_overlap: tallSibling.x >= tallFlex.x + tallFlex.width;
+    // Short: the third item wrapped into a second column, still no overlap.
+    out property <bool> short_wraps: s3.x > s1.x && shortFlex.width > 50px;
+    out property <bool> short_no_overlap: shortSibling.x >= shortFlex.x + shortFlex.width;
+
+    out property <bool> test: tall_single_column && tall_no_overlap && short_wraps && short_no_overlap;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_tall_single_column());
+assert(handle->get_tall_no_overlap());
+assert(handle->get_short_wraps());
+assert(handle->get_short_no_overlap());
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_tall_single_column(), "tall column flex must not wrap");
+assert!(instance.get_tall_no_overlap(), "tall flex overlaps its sibling");
+assert!(instance.get_short_wraps(), "short column flex must wrap into a 2nd column");
+assert!(instance.get_short_no_overlap(), "short flex overlaps its sibling");
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.tall_single_column);
+assert(instance.tall_no_overlap);
+assert(instance.short_wraps);
+assert(instance.short_no_overlap);
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
A FlexboxLayout whose main axis is its parent's cross axis — a column flex in a
HorizontalLayout, or a row flex in a VerticalLayout — with a non-stretch
cross-axis-alignment was given its plain sqrt-area "square" preferred main size,
so it wrapped into extra lines even when there was room. Worse, its cross size
was computed at the full available main extent while its main size was the
(smaller) sqrt preferred, so the wrapped content stuck out past the reported box
and overlapped its siblings.

On the parent's cross pass, clamp such a cell's preferred to
min(available, unwrapped), where unwrapped is the flex's natural single-line main
size (new core helper flexbox_layout_unwrapped_main). The size the cell is given
then matches the size its cross was computed at: it stays a single natural line
when there is room and wraps only when the available cross size can't hold it,
with no overlap. The clamp is solve-time only, so window auto-sizing still uses
the compact sqrt preferred. Stretch alignment is unchanged.

Done in both layout paths (interpreter and LLR codegen), including when the
flex-direction is only known at runtime.

Before (left half) / After (right half)
<img width="2150" height="1390" alt="before-and-after-wrap-when-needed" src="https://github.com/user-attachments/assets/f9c1e513-5ef8-4bd4-939c-843a7d0177d4" />

The bottom half is about flex direction being determined at runtime, which is always more tricky to handle in the compiler.