### PR TITLE
Automate the crates.io publish on the CI

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -13,7 +13,7 @@ on:
                 required: false
                 description: "What to build and publish"
                 options:
-                    - release       # Publish a versioned release: a draft GitHub release and a non-nightly extension.
+                    - release       # Publish a versioned release: crates.io, a draft GitHub release and a non-nightly extension.
                     - full-nightly  # Publish the website snapshot, plus the VS Code extension and the `nightly` release tag.
                     - website-only  # Publish the website snapshot (docs, demos, editor) only.
                     - test          # Build everything, publish nothing.
@@ -730,6 +730,37 @@ jobs:
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 https://api.github.com/repos/slint-ui/slint-cpp-templates-stm32/actions/workflows/ci.yaml/dispatches \
                 -d '{"ref":"main"}'
+
+    publish_crates_io:
+        runs-on: ubuntu-22.04
+        permissions:
+            id-token: write # required for crates.io trusted publishing
+            contents: read
+        env:
+            CARGO_PROFILE_DEV_DEBUG: 0
+        steps:
+            - uses: actions/checkout@v6
+            - uses: ./.github/actions/install-linux-dependencies
+            - name: Install Qt
+              uses: jurplel/install-qt-action@v4
+              with:
+                  version: 6.5.1
+                  cache: true
+            - uses: ./.github/actions/setup-rust
+            - name: Package and verify all crates (dry run)
+              run: ./scripts/publish.sh --dry-run
+            # The trusted-publishing token only lives 30 minutes, less than the
+            # verification above takes. Mint it afterwards and upload the
+            # already-verified packages with --no-verify.
+            - name: Authenticate with crates.io
+              if: github.event.inputs.mode == 'release'
+              id: auth
+              uses: rust-lang/crates-io-auth-action@v1
+            - name: Publish to crates.io
+              if: github.event.inputs.mode == 'release'
+              run: ./scripts/publish.sh --no-verify
+              env:
+                  CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
     trigger_package_publishing:
         if: github.event.inputs.mode == 'release'

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -12,6 +12,10 @@ This document describes the Slint release process
 
 * Verify that the list of supported platforms in docs/astro/src/content/docs/guide/platforms/desktop.mdx matches what we * Publish the helper_crates, if needed
 
+* If a new crate was added since the last release, publish a dummy 0.0.0 version manually so
+  that the crate exists on crates.io, then configure trusted publishing
+  (see the comment in `scripts/publish.sh`)
+
 * Update version number in the documentation  (Only for major release)
   - Crate documentation have sample .toml files (api/rs/lib.rs, api/rs/build/lib.rs, api/rs/README)
       - `sed --follow-symlinks -i 's/^\(slint.*\) = ".*"$/\1 = "1.16.0"/' **/*.rs **/*.md`
@@ -76,11 +80,6 @@ In the mean time, the version in the master branch can be updated
  - **Trigger a build of binary artifacts** (docs, demos, etc.) on https://github.com/slint-ui/slint/actions/workflows/nightly_snapshot.yaml
     Select the right `pre-release/x.y` branch, and choose `release` for the mode.
     As a result artifacts will be built and made available for download, a new VS code extension be built and uploaded to the market places (open-vsx.org and microsoft), and the Android viewer uploaded to Google Play as a draft.
-
- - **Publish to crates.io** using the `./scripts/publish.sh`.
-    (This can be done in parallel to the nightly_snapshot build)
-    Before running the script, make sure that your working directory is clean and that you are checked out on the same commit as the one for which the nightly_snapshot.
-    - If new crates were uploaded to crates.io, go to the crates.io settings and send permission invitations
 
  - **Approve to Python Package Index Uploads:** The nightly snapshot workflow also kicks off the different uploads for the Python Package Index. When completed,
    the deployments from the following jobs will need to be approved (GitHub notifies about pending approvals):

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,24 +2,37 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-cargo publish --manifest-path internal/common/Cargo.toml
-cargo publish --manifest-path internal/core-macros/Cargo.toml
-cargo publish --manifest-path internal/compiler/Cargo.toml
-cargo publish --manifest-path internal/core/Cargo.toml
-cargo publish --manifest-path api/rs/macros/Cargo.toml
-cargo publish --manifest-path internal/renderers/skia/Cargo.toml --features x11
-cargo publish --manifest-path internal/renderers/femtovg/Cargo.toml
-cargo publish --manifest-path internal/renderers/software/Cargo.toml
-cargo publish --manifest-path internal/backends/winit/Cargo.toml --features x11,renderer-femtovg
-cargo publish --manifest-path api/rs/build/Cargo.toml
-cargo publish --manifest-path internal/backends/qt/Cargo.toml
-cargo publish --manifest-path internal/backends/linuxkms/Cargo.toml
-cargo publish --manifest-path internal/backends/android-activity/Cargo.toml --features native-activity
-cargo publish --manifest-path internal/backends/testing/Cargo.toml
-cargo publish --manifest-path internal/backends/selector/Cargo.toml --features backend-winit-x11,renderer-femtovg
-cargo publish --manifest-path internal/interpreter/Cargo.toml
-cargo publish --manifest-path internal/live-preview/Cargo.toml
-cargo publish --manifest-path api/rs/slint/Cargo.toml
-cargo publish --manifest-path tools/lsp/Cargo.toml
-cargo publish --manifest-path tools/viewer/Cargo.toml
-cargo publish --manifest-path tools/tr-extractor/Cargo.toml
+# Publish all public crates to crates.io in one `cargo publish` invocation,
+# which uploads them in dependency order.
+# Extra arguments (e.g. --dry-run, --no-verify) are forwarded to cargo publish.
+#
+# The helper crates (vtable, const-field-offset) have their own version
+# numbers and are published manually when needed.
+#
+# The release CI authenticates via crates.io trusted publishing, which only
+# works for existing crates. To add a crate to this list, publish a dummy
+# 0.0.0 version manually, then configure trusted publishing in the crate's
+# settings on crates.io (repository slint-ui/slint, workflow nightly_snapshot.yaml).
+
+exec cargo publish "$@" \
+    -p i-slint-common \
+    -p i-slint-core-macros \
+    -p i-slint-compiler \
+    -p i-slint-core \
+    -p slint-macros \
+    -p i-slint-renderer-skia --features i-slint-renderer-skia/x11 \
+    -p i-slint-renderer-femtovg \
+    -p i-slint-renderer-software \
+    -p i-slint-backend-winit --features i-slint-backend-winit/x11,i-slint-backend-winit/renderer-femtovg \
+    -p slint-build \
+    -p i-slint-backend-qt \
+    -p i-slint-backend-linuxkms \
+    -p i-slint-backend-android-activity --features i-slint-backend-android-activity/native-activity \
+    -p i-slint-backend-testing \
+    -p i-slint-backend-selector --features i-slint-backend-selector/backend-winit-x11,i-slint-backend-selector/renderer-femtovg \
+    -p slint-interpreter \
+    -p i-slint-live-preview \
+    -p slint \
+    -p slint-lsp \
+    -p slint-viewer \
+    -p slint-tr-extractor


### PR DESCRIPTION
Rewrite scripts/publish.sh as a single multi-package cargo publish invocation, so that cargo resolves the not-yet-published workspace dependencies through its local registry overlay. This makes a full dry run possible.

The new publish_crates_io job in the nightly snapshot workflow runs that dry run in every mode, so packaging or verification failures show up in nightly builds. In release mode, it then uploads the verified packages using a short-lived token from crates.io trusted publishing.

(At this point, i haven't activated trusted publishing on the crates yet)