### PR TITLE
lsp/fmt: allow returning full expressions

### DIFF
--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -1144,7 +1144,7 @@ fn format_return_statement(
     let mut sub = node.children_with_tokens();
     whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?;
     if node.child_node(SyntaxKind::Expression).is_some() {
-        whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, " ")?;
+        whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, " ")?;
     }
     whitespace_to(&mut sub, SyntaxKind::Semicolon, writer, state, "")?;
     state.new_line();


### PR DESCRIPTION
It's an absolutely tiny change that fixes an slint-fmt warning and makes it work.

Fixes a small "Inconsistency" warning when formatting.