### PR TITLE
compiler: small fixes to LLR pretty print

### DIFF
--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -20,7 +20,7 @@ pub struct CallbackIdx(usize);
 pub struct SubComponentIdx(usize);
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq)]
 pub struct GlobalIdx(usize);
-#[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SubComponentInstanceIdx(usize);
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ItemInstanceIdx(usize);
@@ -221,7 +221,7 @@ impl From<LocalMemberReference> for MemberReference {
 }
 
 /// A reference to something within an ItemTree
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LocalMemberReference {
     pub sub_component_path: Vec<SubComponentInstanceIdx>,
     pub reference: LocalMemberIndex,
@@ -465,7 +465,7 @@ pub struct SubComponent {
     pub property_init: Vec<(MemberReference, BindingExpression)>,
     pub change_callbacks: Vec<(MemberReference, MutExpression)>,
     /// The animation for properties which are animated
-    pub animations: HashMap<LocalMemberReference, Expression>,
+    pub animations: BTreeMap<LocalMemberReference, Expression>,
     /// The two way bindings that map the first property to the second wih optional field access
     pub two_way_bindings: Vec<TwoWayBinding>,
     pub const_properties: Vec<LocalMemberReference>,

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -6,6 +6,7 @@ use std::fmt::{Display, Result, Write};
 use itertools::{Either, Itertools};
 
 use crate::expression_tree::MinMaxOp;
+use crate::langtype::{StructName, Type};
 use crate::layout::Orientation;
 
 use super::{
@@ -15,6 +16,23 @@ use super::{
 
 pub fn pretty_print(root: &CompilationUnit, writer: &mut dyn Write) -> Result {
     PrettyPrinter { writer, indentation: 0 }.print_root(root)
+}
+
+/// Print compiler-internal builtin structs by their name; they have no slint
+/// name, so `Type`'s Display spells out all their fields.
+struct DisplayType<'a>(&'a Type);
+impl Display for DisplayType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result {
+        match self.0 {
+            Type::Struct(s) => match &s.name {
+                StructName::Builtin(b) if b.slint_name().is_none() => {
+                    write!(f, "{}", <&str>::from(b))
+                }
+                _ => write!(f, "{}", self.0),
+            },
+            _ => write!(f, "{}", self.0),
+        }
+    }
 }
 
 struct PrettyPrinter<'a> {
@@ -56,7 +74,13 @@ impl PrettyPrinter<'_> {
         self.indentation += 1;
         for p in &sc.properties {
             self.indent()?;
-            writeln!(self.writer, "property <{}> {}; //use={}", p.ty, p.name, p.use_count.get())?;
+            writeln!(
+                self.writer,
+                "property <{}> {}; //use={}",
+                DisplayType(&p.ty),
+                p.name,
+                p.use_count.get()
+            )?;
         }
         for c in &sc.callbacks {
             self.indent()?;
@@ -64,8 +88,8 @@ impl PrettyPrinter<'_> {
                 self.writer,
                 "callback {} ({}) -> {};",
                 c.name,
-                c.args.iter().map(ToString::to_string).join(", "),
-                c.ret_ty,
+                c.args.iter().map(|t| DisplayType(t).to_string()).join(", "),
+                DisplayType(&c.ret_ty),
             )?;
         }
         for f in &sc.functions {
@@ -74,8 +98,8 @@ impl PrettyPrinter<'_> {
                 self.writer,
                 "function {} ({}) -> {} {{ {} }}; ",
                 f.name,
-                f.args.iter().map(ToString::to_string).join(", "),
-                f.ret_ty,
+                f.args.iter().map(|t| DisplayType(t).to_string()).join(", "),
+                DisplayType(&f.ret_ty),
                 DisplayExpression(&f.code, &ctx)
             )?;
         }
@@ -260,7 +284,7 @@ impl PrettyPrinter<'_> {
             writeln!(
                 self.writer,
                 "property <{}> {}; //use={}{}",
-                p.ty,
+                DisplayType(&p.ty),
                 p.name,
                 p.use_count.get(),
                 if *is_const { "  const" } else { "" }
@@ -272,8 +296,8 @@ impl PrettyPrinter<'_> {
                 self.writer,
                 "callback {} ({}) -> {};",
                 c.name,
-                c.args.iter().map(ToString::to_string).join(", "),
-                c.ret_ty,
+                c.args.iter().map(|t| DisplayType(t).to_string()).join(", "),
+                DisplayType(&c.ret_ty),
             )?;
         }
         for (p, init) in &global.init_values {

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -3,13 +3,14 @@
 
 use std::fmt::{Display, Result, Write};
 
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 
 use crate::expression_tree::MinMaxOp;
+use crate::layout::Orientation;
 
 use super::{
-    CompilationUnit, EvaluationContext, Expression, LocalMemberIndex, LocalMemberReference,
-    MemberReference, ParentScope, SubComponentIdx,
+    Animation, CompilationUnit, EvaluationContext, Expression, LocalMemberIndex,
+    LocalMemberReference, MemberReference, ParentScope, SubComponentIdx,
 };
 
 pub fn pretty_print(root: &CompilationUnit, writer: &mut dyn Write) -> Result {
@@ -28,8 +29,16 @@ impl PrettyPrinter<'_> {
                 self.print_global(root, idx, g)?;
             }
         }
-        for c in root.sub_components.keys() {
-            self.print_component(root, c, None)?
+        // Repeater, popup, and menu trees print inline under their parent,
+        // because their expressions resolve in the parent scope.
+        for c in &root.used_sub_components {
+            self.print_component(root, *c, None)?
+        }
+        for p in &root.public_components {
+            self.print_component(root, p.item_tree.root, None)?
+        }
+        if let Some(p) = &root.popup_menu {
+            self.print_component(root, p.item_tree.root, None)?
         }
 
         Ok(())
@@ -83,12 +92,30 @@ impl PrettyPrinter<'_> {
         }
         for (p, init) in &sc.property_init {
             self.indent()?;
+            write!(
+                self.writer,
+                "{}: {}",
+                DisplayPropertyRef(p, &ctx),
+                DisplayExpression(&init.expression.borrow(), &ctx)
+            )?;
+            match &init.animation {
+                Some(Animation::Static(a)) => {
+                    write!(self.writer, " animate {}", DisplayExpression(a, &ctx))?
+                }
+                Some(Animation::Transition(a)) => {
+                    write!(self.writer, " animate transition {}", DisplayExpression(a, &ctx))?
+                }
+                None => {}
+            }
+            writeln!(self.writer, ";{}", if init.is_constant { " /*const*/" } else { "" })?
+        }
+        for (p, a) in &sc.animations {
+            self.indent()?;
             writeln!(
                 self.writer,
-                "{}: {};{}",
-                DisplayPropertyRef(p, &ctx),
-                DisplayExpression(&init.expression.borrow(), &ctx),
-                if init.is_constant { " /*const*/" } else { "" }
+                "animate {} {{ {} }};",
+                DisplayLocalRef(p, &ctx),
+                DisplayExpression(a, &ctx)
             )?
         }
         for (p, e) in &sc.change_callbacks {
@@ -98,6 +125,56 @@ impl PrettyPrinter<'_> {
                 "changed {} => {};",
                 DisplayPropertyRef(p, &ctx),
                 DisplayExpression(&e.borrow(), &ctx),
+            )?
+        }
+        for e in &sc.pre_init_code {
+            self.indent()?;
+            writeln!(self.writer, "pre-init => {};", DisplayExpression(&e.borrow(), &ctx))?
+        }
+        for e in &sc.init_code {
+            self.indent()?;
+            writeln!(self.writer, "init => {};", DisplayExpression(&e.borrow(), &ctx))?
+        }
+        for (name, e) in
+            [("layout-info-h", &sc.layout_info_h), ("layout-info-v", &sc.layout_info_v)]
+        {
+            self.indent()?;
+            writeln!(self.writer, "{}: {};", name, DisplayExpression(&e.borrow(), &ctx))?
+        }
+        if let Some(e) = &sc.grid_layout_input_for_repeated {
+            self.indent()?;
+            writeln!(
+                self.writer,
+                "grid-layout-input-for-repeated: {};",
+                DisplayExpression(&e.borrow(), &ctx)
+            )?
+        }
+        if let Some(e) = &sc.flexbox_layout_item_info_for_repeated {
+            self.indent()?;
+            writeln!(
+                self.writer,
+                "flexbox-layout-item-info-for-repeated: {};",
+                DisplayExpression(&e.borrow(), &ctx)
+            )?
+        }
+        for (i, c) in sc.grid_layout_children.iter_enumerated() {
+            self.indent()?;
+            writeln!(
+                self.writer,
+                "grid-layout-child[{}] {{ h: {}; v: {} }};",
+                usize::from(i),
+                DisplayExpression(&c.layout_info_h.borrow(), &ctx),
+                DisplayExpression(&c.layout_info_v.borrow(), &ctx)
+            )?
+        }
+        for t in &sc.timers {
+            self.indent()?;
+            writeln!(
+                self.writer,
+                "timer {{ interval: {}; running: {}; triggered => {} }};",
+                DisplayExpression(&t.interval.borrow(), &ctx),
+                DisplayExpression(&t.running.borrow(), &ctx),
+                DisplayExpression(&t.triggered.borrow(), &ctx)
             )?
         }
         for ssc in &sc.sub_components {
@@ -111,18 +188,46 @@ impl PrettyPrinter<'_> {
             });
             writeln!(self.writer, "{} := {} {{ {geometry} }};", item.name, item.ty.class_name)?;
         }
+        for ((item_index, prop), e) in &sc.accessible_prop {
+            self.indent()?;
+            writeln!(
+                self.writer,
+                "{}.accessible-{}: {};",
+                item_name_in_tree(root, sc, *item_index)
+                    .unwrap_or_else(|| format!("@{item_index}")),
+                crate::generator::to_kebab_case(prop),
+                DisplayExpression(&e.borrow(), &ctx)
+            )?
+        }
         for (idx, r) in sc.repeated.iter_enumerated() {
             self.indent()?;
-            write!(self.writer, "for in {} : ", DisplayExpression(&r.model.borrow(), &ctx))?;
+            write!(
+                self.writer,
+                "{} {} : /*@repeater({})*/ ",
+                if r.index_prop.is_none() && r.data_prop.is_none() { "if" } else { "for in" },
+                DisplayExpression(&r.model.borrow(), &ctx),
+                usize::from(idx)
+            )?;
             self.print_component(root, r.sub_tree.root, Some(&ParentScope::new(&ctx, Some(idx))))?
         }
-        for t in &sc.menu_item_trees {
+        for (i, t) in sc.menu_item_trees.iter().enumerate() {
             self.indent()?;
+            write!(self.writer, "menu : /*@menu({i})*/ ")?;
             self.print_component(root, t.root, Some(&ParentScope::new(&ctx, None)))?
         }
-        for w in &sc.popup_windows {
+        for (i, w) in sc.popup_windows.iter().enumerate() {
             self.indent()?;
-            self.print_component(root, w.item_tree.root, Some(&ParentScope::new(&ctx, None)))?
+            let parent = ParentScope::new(&ctx, None);
+            // The position is evaluated in the popup's own scope.
+            let popup_ctx =
+                EvaluationContext::new_sub_component(root, w.item_tree.root, (), Some(&parent));
+            write!(
+                self.writer,
+                "{} at {} : /*@popup({i})*/ ",
+                if w.is_tooltip { "tooltip" } else { "popup" },
+                DisplayExpression(&w.position.borrow(), &popup_ctx)
+            )?;
+            self.print_component(root, w.item_tree.root, Some(&parent))?
         }
         self.indentation -= 1;
         self.indent()?;
@@ -141,7 +246,14 @@ impl PrettyPrinter<'_> {
         }
         let aliases = global.aliases.join(",");
         let aliases = if aliases.is_empty() { String::new() } else { format!(" /*{aliases}*/") };
-        writeln!(self.writer, "global {} {{{aliases}", global.name)?;
+        let emission = if global.from_library {
+            " /*from library*/"
+        } else if !global.must_generate() {
+            " /*not generated*/"
+        } else {
+            ""
+        };
+        writeln!(self.writer, "global {} {{{aliases}{emission}", global.name)?;
         self.indentation += 1;
         for (p, is_const) in std::iter::zip(&global.properties, &global.const_properties) {
             self.indent()?;
@@ -221,6 +333,20 @@ impl PrettyPrinter<'_> {
     }
 }
 
+/// Name an item by its tree index, following sub-component instances to
+/// their root item (the index of an element that is itself a component).
+fn item_name_in_tree(
+    root: &CompilationUnit,
+    sc: &super::SubComponent,
+    tree_index: u32,
+) -> Option<String> {
+    if let Some(item) = sc.items.iter().find(|i| i.index_in_tree == tree_index) {
+        return Some(item.name.to_string());
+    }
+    let ssc = sc.sub_components.iter().find(|s| s.index_in_tree == tree_index)?;
+    Some(format!("{}.{}", ssc.name, item_name_in_tree(root, &root.sub_components[ssc.ty], 0)?))
+}
+
 pub struct DisplayPropertyRef<'a, T>(pub &'a MemberReference, pub &'a EvaluationContext<'a, T>);
 impl<T> Display for DisplayPropertyRef<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result {
@@ -234,6 +360,9 @@ impl<T> Display for DisplayPropertyRef<'_, T> {
                 match member {
                     LocalMemberIndex::Property(property_index) => {
                         write!(f, "{}.{}", g.name, g.properties[*property_index].name)
+                    }
+                    LocalMemberIndex::Callback(callback_index) => {
+                        write!(f, "{}.{}", g.name, g.callbacks[*callback_index].name)
                     }
                     LocalMemberIndex::Function(function_index) => {
                         write!(f, "{}.{}", g.name, g.functions[*function_index].name)
@@ -262,6 +391,9 @@ fn print_local_ref<T>(
         match &local_ref.reference {
             LocalMemberIndex::Property(property_index) => {
                 write!(f, "{}.{}", g.name, g.properties[*property_index].name)
+            }
+            LocalMemberIndex::Callback(callback_index) => {
+                write!(f, "{}.{}", g.name, g.callbacks[*callback_index].name)
             }
             LocalMemberIndex::Function(function_index) => {
                 write!(f, "{}.{}", g.name, g.functions[*function_index].name)
@@ -427,7 +559,7 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             } => {
                 write!(
                     f,
-                    "{}[{} % {} * {}]",
+                    "{0}[{0}[{1}] + {2} * {3}]",
                     DisplayPropertyRef(layout_cache_prop, ctx),
                     index,
                     e(ri),
@@ -467,7 +599,39 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                     )
                 }
             }
-            Expression::WithLayoutItemInfo { .. } => write!(f, "WithLayoutItemInfo(TODO)",),
+            Expression::WithLayoutItemInfo {
+                cells_variable,
+                repeater_indices_var_name,
+                repeater_steps_var_name,
+                elements,
+                orientation,
+                sub_expression,
+            } => {
+                write!(
+                    f,
+                    "{{ {} = [{}] /*{}*/; ",
+                    cells_variable,
+                    elements
+                        .iter()
+                        .map(|x| match x {
+                            Either::Left(x) => e(x).to_string(),
+                            Either::Right(r) =>
+                                format!("@repeater({})", usize::from(r.repeater_index)),
+                        })
+                        .join(", "),
+                    match orientation {
+                        Orientation::Horizontal => "horizontal",
+                        Orientation::Vertical => "vertical",
+                    }
+                )?;
+                if let Some(v) = repeater_indices_var_name {
+                    write!(f, "{v} = @repeater-indices; ")?;
+                }
+                if let Some(v) = repeater_steps_var_name {
+                    write!(f, "{v} = @repeater-steps; ")?;
+                }
+                write!(f, "{} }}", e(sub_expression))
+            }
             Expression::WithFlexboxLayoutItemInfo { .. } => {
                 write!(f, "WithFlexboxLayoutItemInfo(TODO)",)
             }


### PR DESCRIPTION
I'm using `slint-compiler -- -f llr` to debug compiler and const propagation stuff, and these are some fixes that help align the LLR pretty print to the Rust output, and makes it more readable

Namely:
- Item-tree roots of repeaters, popups, and menus were printed a second time at top level where their parent scope is unavailable. This both duplicated their code and wrote a bunch of `<invalid reference>`
- A lot of "implicit" properties were missing, which is confusing when seeing "used = 1" on a property that's only used for the layout info for example. Now these are all printed
- Callback references are now printed properly
- Cache layout access and layout functions containing repeaters now print mostly properly
- SubComponent::animations order is now deterministic
- Struct names are used as type names when available