### PR TITLE
compiler: fold some more arithmetic identities in const propagation

### DIFF
--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -16,10 +16,7 @@ type ConstPropCache = HashMap<NamedReference, Option<Expression>>;
 
 pub fn const_propagation(component: &Component, global_analysis: &GlobalAnalysis) {
     let mut cache = ConstPropCache::new();
-    visit_all_expressions(component, |expr, ty| {
-        if matches!(ty(), Type::Callback { .. }) {
-            return;
-        }
+    visit_all_expressions(component, |expr, _ty| {
         simplify_expression(expr, global_analysis, &mut cache);
     });
 
@@ -72,6 +69,7 @@ fn simplify_expression(
             can_inline &= simplify_expression(rhs, ga, cache);
 
             let new = match (*op, &mut **lhs, &mut **rhs) {
+                // constant folding
                 ('+', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
                     Some(Expression::StringLiteral(format_smolstr!("{}{}", a, b)))
                 }
@@ -92,43 +90,72 @@ fn simplify_expression(
                     Expression::NumberLiteral(a, un1),
                     Expression::NumberLiteral(b, Unit::None),
                 ) => Some(Expression::NumberLiteral(*a / *b, *un1)),
-                // TODO: take care of * and / when both numbers have units
-                ('=' | '!', Expression::NumberLiteral(a, _), Expression::NumberLiteral(b, _)) => {
-                    Some(Expression::BoolLiteral((a == b) == (*op == '=')))
+                ('/', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
+                    if un1 == un2 =>
+                {
+                    Some(Expression::NumberLiteral(*a / *b, Unit::None))
                 }
+                // TODO: fold * and / that produce a unit product
+
+                // arithmetic identities
+                ('+', e, Expression::NumberLiteral(n, _))
+                | ('+', Expression::NumberLiteral(n, _), e)
+                | ('-', e, Expression::NumberLiteral(n, _))
+                    if *n == 0. =>
+                {
+                    Some(std::mem::take(e))
+                }
+                ('*', e, Expression::NumberLiteral(n, Unit::None))
+                | ('*', Expression::NumberLiteral(n, Unit::None), e)
+                | ('/', e, Expression::NumberLiteral(n, Unit::None))
+                    if *n == 1. =>
+                {
+                    Some(std::mem::take(e))
+                }
+
+                // comparisons
+                (
+                    '=' | '!' | '<' | '>' | '≤' | '≥',
+                    Expression::NumberLiteral(a, _),
+                    Expression::NumberLiteral(b, _),
+                ) => Some(Expression::BoolLiteral(match op {
+                    '=' => a == b,
+                    '!' => a != b,
+                    '<' => a < b,
+                    '>' => a > b,
+                    '≤' => a <= b,
+                    _ => a >= b,
+                })),
                 ('=' | '!', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
                     Some(Expression::BoolLiteral((a == b) == (*op == '=')))
                 }
                 ('=' | '!', Expression::EnumerationValue(a), Expression::EnumerationValue(b)) => {
                     Some(Expression::BoolLiteral((a == b) == (*op == '=')))
                 }
+                ('=' | '!', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
+                    Some(Expression::BoolLiteral((a == b) == (*op == '=')))
+                }
                 // TODO: more types and more comparison operators
+
+                // boolean logic
+                ('&', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
+                    Some(Expression::BoolLiteral(*a && *b))
+                }
+                ('|', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
+                    Some(Expression::BoolLiteral(*a || *b))
+                }
                 ('&', Expression::BoolLiteral(false), _) => {
                     can_inline = true;
                     Some(Expression::BoolLiteral(false))
                 }
-                ('&', _, Expression::BoolLiteral(false)) => {
-                    can_inline = true;
-                    Some(Expression::BoolLiteral(false))
-                }
-                ('&', Expression::BoolLiteral(true), e) => Some(std::mem::take(e)),
-                ('&', e, Expression::BoolLiteral(true)) => Some(std::mem::take(e)),
                 ('|', Expression::BoolLiteral(true), _) => {
                     can_inline = true;
                     Some(Expression::BoolLiteral(true))
                 }
-                ('|', _, Expression::BoolLiteral(true)) => {
-                    can_inline = true;
-                    Some(Expression::BoolLiteral(true))
-                }
-                ('|', Expression::BoolLiteral(false), e) => Some(std::mem::take(e)),
-                ('|', e, Expression::BoolLiteral(false)) => Some(std::mem::take(e)),
-                ('>', Expression::NumberLiteral(a, _), Expression::NumberLiteral(b, _)) => {
-                    Some(Expression::BoolLiteral(*a > *b))
-                }
-                ('<', Expression::NumberLiteral(a, _), Expression::NumberLiteral(b, _)) => {
-                    Some(Expression::BoolLiteral(*a < *b))
-                }
+                ('&', Expression::BoolLiteral(true), e)
+                | ('&', e, Expression::BoolLiteral(true))
+                | ('|', Expression::BoolLiteral(false), e)
+                | ('|', e, Expression::BoolLiteral(false)) => Some(std::mem::take(e)),
                 _ => None,
             };
             if let Some(new) = new {
@@ -174,6 +201,9 @@ fn simplify_expression(
                 match (&**from, to) {
                     (Expression::NumberLiteral(x, Unit::None), Type::String) => {
                         locale_independent_number_to_string(*x).map(Expression::StringLiteral)
+                    }
+                    (Expression::NumberLiteral(x, _), Type::Float32) => {
+                        Some(Expression::NumberLiteral(*x, Unit::None))
                     }
                     (Expression::Struct { values, .. }, Type::Struct(ty)) => {
                         Some(Expression::Struct { ty: ty.clone(), values: values.clone() })
@@ -715,4 +745,20 @@ fn test_unit_normalization() {
     assert!(matches!(fold("bool", "1s == 1000ms"), Expression::BoolLiteral(true)));
     assert!(matches!(fold("bool", "12cm < 12px"), Expression::BoolLiteral(false)));
     assert!(matches!(fold("bool", "1turn == 360deg"), Expression::BoolLiteral(true)));
+
+    // Multiplying by a unitless 0 yields 0 in the other factor's unit.
+    assert!(
+        matches!(fold("length", "10px * 0.0"), Expression::NumberLiteral(v, Unit::Px) if v == 0.0)
+    );
+    assert!(
+        matches!(fold("float", "10 * 0.0"), Expression::NumberLiteral(v, Unit::None) if v == 0.0)
+    );
+
+    // Dividing equal units cancels to a unitless ratio.
+    assert!(
+        matches!(fold("float", "3px / 6px"), Expression::NumberLiteral(v, Unit::None) if v == 0.5)
+    );
+    // Equality folds for numbers (now via the ordering arm) and bools.
+    assert!(matches!(fold("bool", "1px != 2px"), Expression::BoolLiteral(true)));
+    assert!(matches!(fold("bool", "true == false"), Expression::BoolLiteral(false)));
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -321,6 +321,13 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         }
         Expression::BinaryExpression { lhs, rhs, op } => {
             let lhs = eval_expression(lhs, local_context);
+            // && and || short circuit like in the generated code, or else side
+            // effects in the rhs would run in the interpreter only
+            match (op, &lhs) {
+                ('&', Value::Bool(false)) => return Value::Bool(false),
+                ('|', Value::Bool(true)) => return Value::Bool(true),
+                _ => {}
+            }
             let rhs = eval_expression(rhs, local_context);
 
             match (op, lhs, rhs) {

--- a/tests/cases/expr/const_fold_side_effects.slint
+++ b/tests/cases/expr/const_fold_side_effects.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Const propagation must not fold away the non-pure calls next to statically
+// known operands, or else counter stops incrementing.
+
+component TestCase inherits Rectangle {
+    in-out property <int> counter;
+    function bump() -> bool { counter += 1; return true; }
+    function bump_num() -> float { counter += 1; return 2; }
+
+    private property <bool> or_true;
+    private property <bool> and_false;
+    private property <bool> mul_zero;
+    init => {
+        or_true = bump() || true;
+        and_false = bump() && false;
+        mul_zero = (0 * bump_num()) == 0;
+        if (bump() && false) { counter = 100; }
+    }
+    out property <bool> test: or_true && !and_false && mul_zero;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(instance.get_counter(), 4);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+assert_eq(instance.get_counter(), 4);
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+assert.equal(instance.counter, 4);
+```
+*/

--- a/tests/cases/expr/logical_short_circuit.slint
+++ b/tests/cases/expr/logical_short_circuit.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// && and || short circuit: the rhs must not run once the lhs decides the result.
+
+component TestCase inherits Rectangle {
+    in-out property <int> counter;
+    function bump() -> bool { counter += 1; return true; }
+    function dynamic_and(v: bool) -> bool { return v && bump(); }
+
+    private property <bool> false_and;
+    private property <bool> true_or;
+    private property <bool> dynamic_false;
+    private property <bool> true_and;
+    private property <bool> false_or;
+    private property <bool> dynamic_true;
+    out property <int> counter_after_skips;
+    init => {
+        false_and = false && bump();
+        true_or = true || bump();
+        dynamic_false = dynamic_and(false);
+        counter_after_skips = counter;
+        true_and = true && bump();
+        false_or = false || bump();
+        dynamic_true = dynamic_and(true);
+    }
+    out property <bool> skipped_correct: !false_and && true_or && !dynamic_false;
+    out property <bool> ran_correct: true_and && false_or && dynamic_true;
+    out property <bool> test: skipped_correct && ran_correct;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_skipped_correct());
+assert_eq!(instance.get_counter_after_skips(), 0);
+assert!(instance.get_ran_correct());
+assert_eq!(instance.get_counter(), 3);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_skipped_correct());
+assert_eq(instance.get_counter_after_skips(), 0);
+assert(instance.get_ran_correct());
+assert_eq(instance.get_counter(), 3);
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.skipped_correct);
+assert.equal(instance.counter_after_skips, 0);
+assert(instance.ran_correct);
+assert.equal(instance.counter, 3);
+```
+*/


### PR DESCRIPTION
We have some patterns in our code that can be optimized, such as + 0.0, big numbers for min and max, etc.