### PR TITLE
compiler: remove conditional elements with a constant false condition

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -13,6 +13,9 @@ use smol_str::{SmolStr, ToSmolStr, format_smolstr};
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
+/// Number of slots a cell occupies in a box layout cache: position and size.
+pub const BOX_LAYOUT_CACHE_ENTRIES_PER_CELL: usize = 2;
+
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]
 pub enum Orientation {
     Horizontal,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -232,12 +232,7 @@ pub async fn run_passes(
         if !diag.has_errors() {
             // binding loop causes panics in const_propagation
             const_propagation::const_propagation(component, &global_analysis);
-            if !type_loader.compiler_config.debug_info {
-                remove_constant_conditions::remove_constant_conditions(component);
-                // The removed elements were in the way of further simplification,
-                // and the first round promoted bindings to constant: run again.
-                const_propagation::const_propagation(component, &global_analysis);
-            }
+            remove_constant_conditions::remove_constant_conditions(component);
         }
         deduplicate_property_read::deduplicate_property_read(component);
         if !component.is_global() && !component.is_interface() {

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -51,6 +51,7 @@ pub mod move_declarations;
 mod optimize_useless_rectangles;
 mod purity_check;
 mod remove_aliases;
+mod remove_constant_conditions;
 mod remove_return;
 mod remove_unused_properties;
 mod repeater_component;
@@ -231,6 +232,12 @@ pub async fn run_passes(
         if !diag.has_errors() {
             // binding loop causes panics in const_propagation
             const_propagation::const_propagation(component, &global_analysis);
+            if !type_loader.compiler_config.debug_info {
+                remove_constant_conditions::remove_constant_conditions(component);
+                // The removed elements were in the way of further simplification,
+                // and the first round promoted bindings to constant: run again.
+                const_propagation::const_propagation(component, &global_analysis);
+            }
         }
         deduplicate_property_read::deduplicate_property_read(component);
         if !component.is_global() && !component.is_interface() {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1310,7 +1310,7 @@ fn lower_box_layout(
 
     for layout_child in &layout_children {
         let item = create_layout_item(layout_child, diag);
-        let index = layout.elems.len() * 2;
+        let index = layout.elems.len() * BOX_LAYOUT_CACHE_ENTRIES_PER_CELL;
         let rep_idx = &item.repeater_index;
         let (fixed_size, fixed_ortho) = match orientation {
             Orientation::Horizontal => {
@@ -1321,14 +1321,31 @@ fn lower_box_layout(
             }
         };
         let actual_elem = &item.elem;
-        set_prop_from_cache(actual_elem, pos, &layout_cache_prop, index, rep_idx, 2, diag);
+        let entries = BOX_LAYOUT_CACHE_ENTRIES_PER_CELL;
+        set_prop_from_cache(actual_elem, pos, &layout_cache_prop, index, rep_idx, entries, diag);
         if !fixed_size {
-            set_prop_from_cache(actual_elem, size, &layout_cache_prop, index + 1, rep_idx, 2, diag);
+            set_prop_from_cache(
+                actual_elem,
+                size,
+                &layout_cache_prop,
+                index + 1,
+                rep_idx,
+                entries,
+                diag,
+            );
         }
         if let Some(cache_ortho) = &layout_cache_ortho_prop {
-            set_prop_from_cache(actual_elem, pad, cache_ortho, index, rep_idx, 2, diag);
+            set_prop_from_cache(actual_elem, pad, cache_ortho, index, rep_idx, entries, diag);
             if !fixed_ortho {
-                set_prop_from_cache(actual_elem, ortho, cache_ortho, index + 1, rep_idx, 2, diag);
+                set_prop_from_cache(
+                    actual_elem,
+                    ortho,
+                    cache_ortho,
+                    index + 1,
+                    rep_idx,
+                    entries,
+                    diag,
+                );
             }
         } else {
             let (pad_expr, size_expr) = stretch_bindings.as_ref().unwrap();

--- a/internal/compiler/passes/remove_constant_conditions.rs
+++ b/internal/compiler/passes/remove_constant_conditions.rs
@@ -110,3 +110,44 @@ pub fn remove_constant_conditions(component: &Rc<Component>) {
         })
     });
 }
+
+#[test]
+fn removes_constant_false_conditionals() {
+    let mut compiler_config =
+        crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+export component Foo {
+    in property <bool> dynamic;
+    property <bool> never: false;
+    if false: Rectangle {}
+    if never: Rectangle {}
+    if dynamic: Rectangle {}
+}
+"#
+        .into(),
+        Some(std::path::Path::new("test.slint")),
+        &mut test_diags,
+    );
+    let (doc, diag, _) =
+        spin_on::spin_on(crate::compile_syntax_node(doc_node, test_diags, compiler_config));
+    assert!(!diag.has_errors(), "slint compile error {:#?}", diag.to_string_vec());
+
+    let foo = doc.inner_components.iter().find(|c| c.id == "Foo").unwrap();
+    let mut models = Vec::new();
+    recurse_elem_including_sub_components(foo, &(), &mut |elem, _| {
+        if let Some(r) = &elem.borrow().repeated
+            && r.is_conditional_element
+        {
+            models.push(r.model.clone());
+        }
+    });
+
+    // `never` folds to false during const propagation and is removed like the literal
+    // `if false`; only `dynamic`, an `in` property, stays non-constant and survives, its
+    // model still a runtime expression rather than a folded literal.
+    assert_eq!(models.len(), 1, "{models:?}");
+    assert!(!matches!(models[0], Expression::BoolLiteral(_)), "{:?}", models[0]);
+}

--- a/internal/compiler/passes/remove_constant_conditions.rs
+++ b/internal/compiler/passes/remove_constant_conditions.rs
@@ -1,0 +1,112 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Remove `if false` conditional elements
+//!
+//! Conditions often fold to a literal only during const propagation, long
+//! after the repeater machinery for the dead subtree was built; this pass
+//! deletes it again.
+
+use crate::expression_tree::Expression;
+use crate::layout::{BOX_LAYOUT_CACHE_ENTRIES_PER_CELL, Layout};
+use crate::namedreference::NamedReference;
+use crate::object_tree::*;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+pub fn remove_constant_conditions(component: &Rc<Component>) {
+    let mut dead = Vec::new();
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
+        let e = elem.borrow();
+        // Grid cells keep their per-child repeater; the ComponentContainer placeholder is a
+        // permanent false repeater that must survive as the embed slot.
+        if e.repeated.as_ref().is_some_and(|r| {
+            r.is_conditional_element && matches!(r.model, Expression::BoolLiteral(false))
+        }) && e.grid_layout_cell.is_none()
+            && !e.is_component_placeholder
+        {
+            dead.push(elem.clone());
+        }
+    });
+    if dead.is_empty() {
+        return;
+    }
+
+    // Flexbox cells keep their length-zero repeater; the measure path queries
+    // cells individually.
+    visit_all_expressions(component, |expr, _| {
+        expr.visit_recursive_mut(&mut |e| {
+            if let Expression::SolveFlexboxLayout(l)
+            | Expression::ComputeFlexboxLayoutInfo { layout: l, .. } = e
+            {
+                dead.retain(|c| !l.elems.iter().any(|it| Rc::ptr_eq(&it.item.element, c)));
+            }
+        })
+    });
+    if dead.is_empty() {
+        return;
+    }
+    let is_dead = |e: &ElementRc| dead.iter().any(|d| Rc::ptr_eq(d, e));
+
+    // The component root of each removed conditional. Its box cell's constraints reference this
+    // root, so a stale debug snapshot below is left still naming it.
+    let mut dead_roots = std::collections::HashSet::new();
+    for c in &dead {
+        if let crate::langtype::ElementType::Component(base) = &c.borrow().base_type {
+            dead_roots.insert(Rc::as_ptr(&base.root_element));
+        }
+    }
+
+    let mut fixes: HashMap<NamedReference, Vec<usize>> = HashMap::new();
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
+        visit_element_expressions(elem, |expr, name, _| {
+            let Some(name) = name else { return };
+            expr.visit_recursive_mut(&mut |e| match e {
+                Expression::SolveBoxLayout(l, _) => {
+                    let bases: Vec<usize> = l
+                        .elems
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, it)| is_dead(&it.element))
+                        .map(|(k, _)| BOX_LAYOUT_CACHE_ENTRIES_PER_CELL * k)
+                        .collect();
+                    if !bases.is_empty() {
+                        fixes.insert(NamedReference::new(elem, name.into()), bases);
+                        l.elems.retain(|it| !is_dead(&it.element));
+                    }
+                }
+                Expression::ComputeBoxLayoutInfo { layout: l, .. } => {
+                    l.elems.retain(|it| !is_dead(&it.element))
+                }
+                _ => {}
+            });
+        });
+        // Drop debug cells naming a removed root, or a NamedReference to a dropped element crashes
+        // a later pass; the layout-expression removal above does not reach these snapshots.
+        for d in elem.borrow_mut().debug.iter_mut() {
+            if let Some(Layout::BoxLayout(l)) = d.layout.as_mut() {
+                l.elems.retain(|it| {
+                    let mut hit = false;
+                    it.constraints.clone().visit_named_references(&mut |nr| {
+                        hit |= dead_roots.contains(&Rc::as_ptr(&nr.element()))
+                    });
+                    !hit
+                });
+            }
+        }
+        elem.borrow_mut().children.retain(|c| !is_dead(c));
+    });
+
+    // Each removed cell freed BOX_LAYOUT_CACHE_ENTRIES_PER_CELL cache slots whose indices were
+    // baked into geometry bindings, so shift every surviving access behind it down.
+    visit_all_expressions(component, |expr, _| {
+        expr.visit_recursive_mut(&mut |e| {
+            if let Expression::LayoutCacheAccess { layout_cache_prop, index, .. } = e
+                && let Some(bases) = fixes.get(layout_cache_prop)
+            {
+                *index -= BOX_LAYOUT_CACHE_ENTRIES_PER_CELL
+                    * bases.iter().filter(|b| **b < *index).count();
+            }
+        })
+    });
+}

--- a/tests/cases/crashes/layout_if_in_component.slint
+++ b/tests/cases/crashes/layout_if_in_component.slint
@@ -3,9 +3,10 @@
 
 
 export Btn := Rectangle {
+    property <bool> show: false;
     min-height: max(32px, l.min-height);
     l := HorizontalLayout {
-        if (false): button_in_image := Image {
+        if (show): button_in_image := Image {
             width: 24px;
         }
         text := Text {  }
@@ -13,7 +14,8 @@ export Btn := Rectangle {
 }
 
 export TestCase := Window {
+    property <bool> show: false;
     x := HorizontalLayout {
-        btn := Btn {}
+        btn := Btn { show: root.show; }
     }
 }

--- a/tests/cases/focus/event_propagation.slint
+++ b/tests/cases/focus/event_propagation.slint
@@ -5,6 +5,7 @@ component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
     forward-focus: input2;
+    in property <bool> show: false;
 
     input1 := TextInput {
         y:0;
@@ -21,7 +22,7 @@ component TestCase inherits Rectangle {
                     accept
                 }
 
-                if (false) : Rectangle { FocusScope {} }
+                if (root.show) : Rectangle { FocusScope {} }
 
                 input2 := TextInput {
                     x:0;

--- a/tests/cases/focus/focus_change_through_signal.slint
+++ b/tests/cases/focus/focus_change_through_signal.slint
@@ -35,7 +35,8 @@ component TestCase inherits Rectangle {
         height: 200phx;
     }
 
-    if (false) : SubElement {  }
+    in property <bool> show: false;
+    if (root.show) : SubElement {  }
 
     in-out property<bool> input1_focused: input1.has_focus;
     in-out property<string> input1_text: input1.text;

--- a/tests/cases/issues/issue_3107_if_optimized_rect.slint
+++ b/tests/cases/issues/issue_3107_if_optimized_rect.slint
@@ -10,8 +10,10 @@ export component App inherits Window {
     min-height: 600px;
     title: "Test";
 
+    in property <bool> cond: false;
+
     Rectangle {
-        i-test := TestComponent {}
+        i-test := TestComponent { check: root.cond; }
 
         if (i-test.check) : Rectangle {  }
     }

--- a/tests/cases/layout/box_constant_condition.slint
+++ b/tests/cases/layout/box_constant_condition.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Conditional cells whose condition is a compile time constant false are
+// removed from the layout; the cells around them must keep their positions.
+
+export component TestCase inherits Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    property <bool> never: false;
+
+    VerticalLayout {
+        alignment: start;
+        padding: 0phx;
+        spacing: 8phx;
+        r1 := Rectangle { height: 50phx; }
+        if false : Rectangle { height: 50phx; }
+        for i in 2 : Rectangle { height: 20phx; }
+        if never : Rectangle { height: 50phx; }
+        r2 := Rectangle { height: 50phx; }
+    }
+
+    out property <bool> test: r1.y == 0phx && r2.y == 114phx;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/legacy/repeaters.slint
+++ b/tests/cases/legacy/repeaters.slint
@@ -24,8 +24,9 @@ TestCase := Rectangle {
     width: 300phx;
     height: 300phx;
     property clicked <=> c.clicked;
+    property <bool> show: false;
     Text {
-        if (false): TouchArea {
+        if (root.show): TouchArea {
         }
     }
     c := SubCompo {

--- a/tests/cases/subcomponents/repeaters.slint
+++ b/tests/cases/subcomponents/repeaters.slint
@@ -25,9 +25,10 @@ component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
     in-out property clicked <=> c.clicked;
+    in property <bool> show: false;
     Text {
         x:0;y:0;
-        if (false): TouchArea {
+        if (root.show): TouchArea {
         }
     }
     c := SubCompo {

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -7,6 +7,7 @@ export component TestCase inherits Window {
     height: 200px;
 
     in-out property <string> output;
+    in property <bool> show: false;
     TouchArea {
         clicked => { output += "clicked-under\n"; }
     }
@@ -21,7 +22,7 @@ export component TestCase inherits Window {
         }
     }
 
-    if false : Rectangle {
+    if root.show : Rectangle {
         test-no-loop := ComboBox {
             width: 10 * self.height; // Test that there is no height for width dependency (loop)
         }


### PR DESCRIPTION
Conditions often fold to a literal only during const propagation, long after the repeater machinery for the dead subtree was built. Box layout caches needed to be fixed up, and I opted not to touch grid or flexbox layouted elements.

This change resulted in -16% code size  in one of our apps that had this as a common pattern:

```
component MenuRow inherits HorizontalLayout {
    in property <bool> has-icon;
    in property <bool> text;
    out property <length> label-x: label.x;
    spacing: 8phx;
    if has-icon : Image { ... }
    Text { text: root.text; }
}

export component SettingsMenu inherits VerticalLayout {
    bluetooth := MenuRow { has-icon: true; text: "Bluetooth" }
    about := MenuRow { has-icon: false; text: "About" }
}
```

Added a test case to make sure things don't drift, because this has a semi-hidden dependency between this new pass and the box cache layout internals.