### PR TITLE
software_renderer: skip drawing behind opaque spans

### DIFF
--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore frontmost
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -1304,8 +1305,23 @@ fn render_window_frame_by_line(
                 |line_buffer| {
                     let offset = r.start;
 
-                    line_buffer.fill(background_color);
-                    for span in scene.items[0..scene.current_items_index].iter().rev() {
+                    let items = &scene.items[0..scene.current_items_index];
+                    // A span that opaquely covers the whole range hides
+                    // everything behind it, background included. Draw from the
+                    // frontmost such span and drop the rest.
+                    let first_cover = items.iter().position(|span| {
+                        span.pos.x <= r.start
+                            && span.pos.x + span.size.width >= r.end
+                            && scene.is_guaranteed_opaque(&span.command)
+                    });
+                    let items = match first_cover {
+                        Some(i) => &items[..=i],
+                        None => {
+                            line_buffer.fill(background_color);
+                            items
+                        }
+                    };
+                    for span in items.iter().rev() {
                         debug_assert!(scene.current_line >= span.pos.y_length());
                         debug_assert!(
                             scene.current_line < span.pos.y_length() + span.size.height_length(),

--- a/internal/renderers/software/scene.rs
+++ b/internal/renderers/software/scene.rs
@@ -232,6 +232,27 @@ impl Scene {
         self.range_valid_until_line = Length::new(validity.unwrap_or_default());
         false
     }
+
+    pub fn is_guaranteed_opaque(&self, command: &SceneCommand) -> bool {
+        match command {
+            SceneCommand::Rectangle { color } => color.alpha == 255,
+            SceneCommand::Texture { texture_index } => {
+                let texture = &self.vectors.textures[*texture_index as usize];
+                // Below alpha 255 an RGB texture blends rather than overwrites (see
+                // draw_texture_line), so it is not opaque.
+                texture.format == TexturePixelFormat::Rgb && texture.extra.alpha == 255
+            }
+            SceneCommand::SharedBuffer { shared_buffer_index } => {
+                let buffer = &self.vectors.shared_buffers[*shared_buffer_index as usize];
+                buffer.extra.alpha == 255
+                    && matches!(
+                        buffer.buffer,
+                        SharedBufferData::SharedImage(SharedImageBuffer::RGB8(_))
+                    )
+            }
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
We have a hardware where rendering is bottlenecked on pixel fillrate, so every bit of overdraw hurts. We also have a pattern of using full screen background images for screens.

This patch eliminates a whole screen worth of fills in this (for us) common case.