### PR TITLE
software_renderer: Add support for non-bundled vector fonts

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -89,6 +89,9 @@ pub enum EmbedResourcesKind {
     /// Useful for MCUs with no file system and little RAM.
     /// Only the Slint software renderer can use these resources; Skia and FemtoVG can't.
     EmbedForSoftwareRenderer,
+    #[cfg(feature = "renderer-software")]
+    /// Same as EmbedForSoftwareRenderer, except fonts are not embedded.
+    EmbedForSoftwareRendererNoFonts,
 }
 
 impl Default for CompilerConfiguration {
@@ -173,6 +176,10 @@ impl CompilerConfiguration {
             #[cfg(feature = "renderer-software")]
             EmbedResourcesKind::EmbedForSoftwareRenderer => {
                 i_slint_compiler::EmbedResourcesKind::EmbedTextures
+            }
+            #[cfg(feature = "renderer-software")]
+            EmbedResourcesKind::EmbedForSoftwareRendererNoFonts => {
+                i_slint_compiler::EmbedResourcesKind::EmbedTexturesOnly
             }
         };
         Self { config }

--- a/internal/common/sharedfontique.rs
+++ b/internal/common/sharedfontique.rs
@@ -191,6 +191,22 @@ pub const FALLBACK_FAMILIES: [fontique::GenericFamily; 2] = [
     fontique::GenericFamily::SystemUi,
 ];
 
+/// Point the sans-serif / system-ui generic families at `family_name`, so text with no explicit
+/// family resolves to it. Returns false if the family isn't registered.
+pub fn set_default_font_family(collection: &mut fontique::Collection, family_name: &str) -> bool {
+    let Some(id) = collection.family_id(family_name) else {
+        return false;
+    };
+    for generic in [
+        fontique::GenericFamily::SansSerif,
+        fontique::GenericFamily::SystemUi,
+        fontique::GenericFamily::UiSansSerif,
+    ] {
+        collection.set_generic_families(generic, core::iter::once(id));
+    }
+    true
+}
+
 /// Wrapper around fontique::Blob to permit use of the blob as a key in the cache in the different renderers,
 /// to map the blob to the native type face representation (skia_safe::Typeface, femtovg::FontId, QRawFont, etc.).
 /// The use as key also ensures the blob remains strongly referenced, so that it doesn't vanish from the

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -70,6 +70,9 @@ pub enum EmbedResourcesKind {
     /// Useful for MCUs with no file system and little RAM.
     /// Only the Slint software renderer can use these resources; Skia and FemtoVG can't.
     EmbedTextures,
+    #[cfg(feature = "renderer-software")]
+    /// Embed raw texture (process images)
+    EmbedTexturesOnly,
 }
 
 /// This enum specifies the default translation context when no context is explicitly
@@ -306,7 +309,9 @@ fn prepare_for_compile(
     #[allow(unused_mut)] mut compiler_config: CompilerConfiguration,
 ) -> typeloader::TypeLoader {
     #[cfg(feature = "renderer-software")]
-    if compiler_config.embed_resources == EmbedResourcesKind::EmbedTextures {
+    if compiler_config.embed_resources == EmbedResourcesKind::EmbedTextures
+        || compiler_config.embed_resources == EmbedResourcesKind::EmbedTexturesOnly
+    {
         // HACK: disable accessibility when compiling for the software renderer
         // accessibility is not supported with backend that support software renderer anyway
         compiler_config.accessibility = false;

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -327,6 +327,10 @@ pub async fn run_passes(
                 diag,
             );
         }
+        #[cfg(feature = "renderer-software")]
+        crate::EmbedResourcesKind::EmbedTexturesOnly => {
+            // Don't do anything, we will get fonts from outside
+        }
         _ => {
             // Create font registration calls for custom fonts, unless we're embedding pre-rendered glyphs
             collect_custom_fonts::collect_custom_fonts(

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -242,7 +242,9 @@ fn embed_image(
     };
 
     #[cfg(feature = "renderer-software")]
-    if embed_files == EmbedResourcesKind::EmbedTextures {
+    if embed_files == EmbedResourcesKind::EmbedTextures
+        || embed_files == EmbedResourcesKind::EmbedTexturesOnly
+    {
         return match load_image(_file, _scale_factor, _font_collection) {
             Ok((img, source_format, original_size)) => {
                 let resource_id = push(EmbeddedResourcesKind::TextureData(generate_texture(
@@ -586,7 +588,9 @@ fn embed_data_uri(
     };
 
     #[cfg(feature = "renderer-software")]
-    if _embed_files == EmbedResourcesKind::EmbedTextures {
+    if _embed_files == EmbedResourcesKind::EmbedTextures
+        || _embed_files == EmbedResourcesKind::EmbedTexturesOnly
+    {
         match load_image_from_bytes(
             &decoded_data,
             Some(&extension),

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -53,6 +53,10 @@ impl FontContext {
     pub fn clear_registered_static_fonts(&mut self) {
         self.registered_static_fonts.clear();
     }
+
+    pub fn set_default_font_family(&mut self, family_name: &str) -> bool {
+        sharedfontique::set_default_font_family(&mut self.inner.collection, family_name)
+    }
 }
 
 type InnerTextLayoutCache = crate::item_rendering::ItemCache<Vec<TextParagraph>>;


### PR DESCRIPTION
We have a somewhat special use-case: multiple apps in an embedded setting, using the software renderer. To conserve memory, we memory-map shared vector fonts to all apps instead of bundling them.

It looks something like this:
```
    fn bind_context(&self, ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
        let ctx = ctx.upgrade().expect("Slint context alive during bind_context");
        let mut fc = ctx.font_context().borrow_mut();
        for data in self.pending_fonts.borrow_mut().drain(..) {
            fc.register_static_font(data);
        }
        fc.set_default_font_family(DEFAULT_FONT);
    }
```