### PR TITLE
DRAFT: Support for Dynamic Tab views (WIP)

### DIFF
--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -9,7 +9,7 @@
 //! be further inlined as it may expand to a native widget that needs inlining
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedReference, Unit};
+use crate::expression_tree::{BindingExpression, Callable, Expression, MinMaxOp, NamedReference, Unit};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use smol_str::{SmolStr, format_smolstr};
@@ -94,7 +94,16 @@ fn process_tabwidget(
 ) {
     elem.borrow_mut().base_type = tabwidget_impl;
     let mut children = std::mem::take(&mut elem.borrow_mut().children);
-    let num_tabs = children.len();
+
+    let num_tabs_expr = match children.first().and_then(|c| c.borrow().repeated.clone()) {
+        Some(rep) if children.len() == 1 => Expression::FunctionCall {
+            function: Callable::Builtin(crate::expression_tree::BuiltinFunction::ArrayLength),
+            arguments: vec![rep.model],
+            source_location: None,
+        },
+        _ => Expression::NumberLiteral(children.len() as f64, Unit::None),
+    };
+
     let mut tabs = Vec::new();
     for (position, child) in children.iter_mut().enumerate() {
         if child.borrow().base_type.to_string() != "Tab" {
@@ -192,7 +201,7 @@ fn process_tabwidget(
         tab.bindings
             .insert(SmolStr::new_static("tab-index"), RefCell::new(index_expr.clone().into()));
         tab.bindings
-            .insert(SmolStr::new_static("num-tabs"), RefCell::new(index_expr.clone().into()));
+            .insert(SmolStr::new_static("num-tabs"), RefCell::new(num_tabs_expr.clone().into()));
         tabs.push(Element::make_rc(tab));
     }
 
@@ -225,7 +234,7 @@ fn process_tabwidget(
     set_tabbar_geometry_prop(elem, &tabbar, "height");
     tabbar.borrow_mut().bindings.insert(
         SmolStr::new_static("num-tabs"),
-        RefCell::new(Expression::NumberLiteral(num_tabs as _, Unit::None).into()),
+        RefCell::new(num_tabs_expr.into()),
     );
     tabbar.borrow_mut().bindings.insert(
         SmolStr::new_static("current"),

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -96,14 +96,7 @@ fn process_tabwidget(
     let mut children = std::mem::take(&mut elem.borrow_mut().children);
     let num_tabs = children.len();
     let mut tabs = Vec::new();
-    for child in &mut children {
-        if child.borrow().repeated.is_some() {
-            diag.push_error(
-                "dynamic tabs ('if' or 'for') are currently not supported".into(),
-                &*child.borrow(),
-            );
-            continue;
-        }
+    for (position, child) in children.iter_mut().enumerate() {
         if child.borrow().base_type.to_string() != "Tab" {
             assert!(diag.has_errors());
             continue;
@@ -118,13 +111,20 @@ fn process_tabwidget(
         set_geometry_prop(elem, child, "y", diag);
         set_geometry_prop(elem, child, "width", diag);
         set_geometry_prop(elem, child, "height", diag);
+
+        let index_expr = match &child.borrow().repeated {
+            Some(_) => Expression::RepeaterIndexReference {
+                element: Rc::downgrade(child),
+            },
+            None => Expression::NumberLiteral(position as _, Unit::None),
+        };
         let condition = Expression::BinaryExpression {
             lhs: Expression::PropertyReference(NamedReference::new(
                 elem,
                 SmolStr::new_static("current-index"),
             ))
             .into(),
-            rhs: Expression::NumberLiteral(index as _, Unit::None).into(),
+            rhs: index_expr.clone().into(),
             op: '=',
         };
         let old = child
@@ -193,11 +193,11 @@ fn process_tabwidget(
         );
         tab.bindings.insert(
             SmolStr::new_static("tab-index"),
-            RefCell::new(Expression::NumberLiteral(index as _, Unit::None).into()),
+            RefCell::new(index_expr.clone().into()),
         );
         tab.bindings.insert(
             SmolStr::new_static("num-tabs"),
-            RefCell::new(Expression::NumberLiteral(num_tabs as _, Unit::None).into()),
+            RefCell::new(index_expr.clone().into()),
         );
         tabs.push(Element::make_rc(tab));
     }

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -9,7 +9,9 @@
 //! be further inlined as it may expand to a native widget that needs inlining
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{BindingExpression, Callable, Expression, MinMaxOp, NamedReference, Unit};
+use crate::expression_tree::{
+    BindingExpression, Callable, Expression, MinMaxOp, NamedReference, Unit,
+};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use smol_str::{SmolStr, format_smolstr};
@@ -232,10 +234,10 @@ fn process_tabwidget(
     set_tabbar_geometry_prop(elem, &tabbar, "y");
     set_tabbar_geometry_prop(elem, &tabbar, "width");
     set_tabbar_geometry_prop(elem, &tabbar, "height");
-    tabbar.borrow_mut().bindings.insert(
-        SmolStr::new_static("num-tabs"),
-        RefCell::new(num_tabs_expr.into()),
-    );
+    tabbar
+        .borrow_mut()
+        .bindings
+        .insert(SmolStr::new_static("num-tabs"), RefCell::new(num_tabs_expr.into()));
     tabbar.borrow_mut().bindings.insert(
         SmolStr::new_static("current"),
         BindingExpression::new_two_way(

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -177,6 +177,7 @@ fn process_tabwidget(
             id: format_smolstr!("{}-tab{}", elem.borrow().id, index),
             base_type: tab_impl.clone(),
             enclosing_component: elem.borrow().enclosing_component.clone(),
+            repeated: child.borrow().repeated.clone(),
             ..Default::default()
         };
         tab.bindings.insert(

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -113,9 +113,7 @@ fn process_tabwidget(
         set_geometry_prop(elem, child, "height", diag);
 
         let index_expr = match &child.borrow().repeated {
-            Some(_) => Expression::RepeaterIndexReference {
-                element: Rc::downgrade(child),
-            },
+            Some(_) => Expression::RepeaterIndexReference { element: Rc::downgrade(child) },
             None => Expression::NumberLiteral(position as _, Unit::None),
         };
         let condition = Expression::BinaryExpression {
@@ -191,14 +189,10 @@ fn process_tabwidget(
             )
             .into(),
         );
-        tab.bindings.insert(
-            SmolStr::new_static("tab-index"),
-            RefCell::new(index_expr.clone().into()),
-        );
-        tab.bindings.insert(
-            SmolStr::new_static("num-tabs"),
-            RefCell::new(index_expr.clone().into()),
-        );
+        tab.bindings
+            .insert(SmolStr::new_static("tab-index"), RefCell::new(index_expr.clone().into()));
+        tab.bindings
+            .insert(SmolStr::new_static("num-tabs"), RefCell::new(index_expr.clone().into()));
         tabs.push(Element::make_rc(tab));
     }
 


### PR DESCRIPTION
This is an incomplete attempt to introduce support for dynamic tabs in Slint.  I'm still running into issues, and I'm looking forward to the drip feed of hints to bring this to completion.

Looking at the last discussion (https://github.com/slint-ui/slint/discussions/7771), it was suggested that the generated tab needed a repeater, and `current-index`, `tab-index` and `num-tab` need to account for the dynamic tabs and it was suggested that `Expression::RepeaterIndexReference` could be used.  I am doing so now, hopefully correctly.

Running this in `slint-viewer`, I get a panic in `internal\interpreter\eval.rs` "accessing deleted parent".  It isn't clear (to me) what this is.

Further down, there is a place where the `num-tabs` (plural) propery is set on the tab bar.  I suspect that this needs to be updated but it isn't clear how to do so yet.

I should also add that in my use case, I want to do something along these lines:

```
        if something-cool: Tab {
            ...
        }
        if something-else-cool: Tab {
            ...
        }
```

I suspect that `Expression::RepeaterIndexReference` will be insufficient for this use case, but of course we can wait on that.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
