### PR TITLE
generator/rust: make the static vtable an associated const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-field-offset"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset-macro"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "const-field-offset",
  "memoffset",
@@ -12484,7 +12484,7 @@ dependencies = [
 
 [[package]]
 name = "vtable"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -12494,7 +12494,7 @@ dependencies = [
 
 [[package]]
 name = "vtable-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ slint-cpp = { version = "=1.17.1", path = "api/cpp", default-features = false }
 slint-interpreter = { version = "=1.17.1", path = "internal/interpreter", default-features = false }
 slint-macros = { version = "=1.17.1", path = "api/rs/macros", default-features = false }
 
-vtable = { version = "0.4", path = "helper_crates/vtable" }
+vtable = { version = "0.5", path = "helper_crates/vtable" }
 
 by_address = { version = "1.0.4" }
 bytemuck = { version = "1.13.1" }

--- a/examples/bevy/Cargo.lock
+++ b/examples/bevy/Cargo.lock
@@ -1410,7 +1410,7 @@ dependencies = [
  "glam",
  "itertools 0.14.0",
  "libm",
- "rand 0.10.2",
+ "rand",
  "rand_distr",
  "serde",
  "thiserror 2.0.18",
@@ -2106,7 +2106,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn",
 ]
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2344,6 +2344,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
 ]
 
 [[package]]
@@ -2457,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -2465,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset-macro"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3155,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bf886368962a7d8456f136073ed33ed1b0770c690d2063731bb6a776e99f33"
+checksum = "ad67eced03f5504d9cbd3a879b5958b5c54d4e5fd794361c6eb21b05fb703411"
 dependencies = [
  "bytemuck",
 ]
@@ -3414,11 +3425,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3428,8 +3437,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3496,7 +3508,7 @@ dependencies = [
  "bytemuck",
  "encase",
  "libm",
- "rand 0.10.2",
+ "rand",
  "serde_core",
 ]
 
@@ -4660,11 +4672,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -5145,9 +5157,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -6026,15 +6038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6095,9 +6098,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -6126,7 +6129,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -6137,17 +6140,18 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
+ "rand_pcg",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -6159,16 +6163,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6200,41 +6204,13 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
+ "chacha20",
  "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -6250,7 +6226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.2",
+ "rand",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -6294,7 +6279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
 dependencies = [
  "bytemuck",
- "font-types 0.12.0",
+ "font-types 0.12.1",
  "once_cell",
 ]
 
@@ -6504,9 +6489,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -7944,7 +7929,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vtable"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -7954,7 +7939,7 @@ dependencies = [
 
 [[package]]
 name = "vtable-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8627,15 +8612,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -8682,28 +8658,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8734,12 +8693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8756,12 +8709,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8782,22 +8729,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8818,12 +8753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8840,12 +8769,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8866,12 +8789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8888,12 +8805,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
@@ -8968,7 +8879,7 @@ version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f3a5b8704f80b1cbe2fa5590b8aeda7e4b7c715de0a4266674a2f899fcf2a8"
 dependencies = [
- "font-types 0.12.0",
+ "font-types 0.12.1",
  "indexmap",
  "kurbo",
  "log",

--- a/helper_crates/const-field-offset/CHANGELOG.md
+++ b/helper_crates/const-field-offset/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+## [0.2.1]
+
+ - Added `const fn compose_field_offsets` as an alternative to `Add`
+   in `const` contexts.
+
 ## [0.2.0]
 
  - Breaking change: `FIELD_OFFSETS` is now a zero-sized type with a `const fn`

--- a/helper_crates/const-field-offset/Cargo.toml
+++ b/helper_crates/const-field-offset/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "const-field-offset"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2024"
 rust-version = "1.88"
@@ -13,5 +13,5 @@ repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint.dev"
 
 [dependencies]
-const-field-offset-macro = { version = "=0.2.0", path = "./macro" }
+const-field-offset-macro = { version = "=0.2.1", path = "./macro" }
 field-offset = "0.3.2"

--- a/helper_crates/const-field-offset/macro/Cargo.toml
+++ b/helper_crates/const-field-offset/macro/Cargo.toml
@@ -4,7 +4,7 @@
 # cSpell: ignore memoffset
 [package]
 name = "const-field-offset-macro"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2024"
 rust-version = "1.88"

--- a/helper_crates/const-field-offset/src/lib.rs
+++ b/helper_crates/const-field-offset/src/lib.rs
@@ -53,6 +53,19 @@ pub use const_field_offset_macro::FieldOffsets;
 
 pub use field_offset::{AllowPin, FieldOffset, NotPinned};
 
+/// Compose two pinned field offsets into the offset of the nested field.
+///
+/// Same as the `Add` implementation on [`FieldOffset`], but usable in const
+/// context.
+pub const fn compose_field_offsets<T, U, V>(
+    a: FieldOffset<T, U, AllowPin>,
+    b: FieldOffset<U, V, AllowPin>,
+) -> FieldOffset<T, V, AllowPin> {
+    // Safety: a field of a field of T is at the sum of both offsets within T,
+    // and both projections preserve pinning.
+    unsafe { FieldOffset::new_from_offset_pinned(a.get_byte_offset() + b.get_byte_offset()) }
+}
+
 /// This trait needs to be implemented if you use the `#[pin_drop]` attribute. It enables
 /// you to implement Drop for your type safely.
 pub trait PinnedDrop {

--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Changelog
 All notable changes to this crate will be documented in this file.
 
+## [0.5.0]
+
+ - Replaced the `static_vtable` function with `STATIC_VTABLE` associated
+   const.
+
 ## [0.4.0]
 
  - Bumped the `const-field-offset` dependency to 0.2 (breaking change in the

--- a/helper_crates/vtable/Cargo.toml
+++ b/helper_crates/vtable/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "vtable"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2024"
 rust-version = "1.88"
@@ -15,7 +15,7 @@ homepage = "https://slint.dev"
 [lib]
 
 [dependencies]
-vtable-macro = { version = "=0.4.0", path = "./macro" }
+vtable-macro = { version = "=0.5.0", path = "./macro" }
 const-field-offset = { version = "0.2", path = "../const-field-offset" }
 stable_deref_trait = { version = "1.2.0", default-features = false }
 portable-atomic = "1"

--- a/helper_crates/vtable/macro/Cargo.toml
+++ b/helper_crates/vtable/macro/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "vtable-macro"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -425,7 +425,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         fn new_box<X: HasStaticVTable<#vtable_name>>(value: X) -> VBox<#vtable_name> {
                             // Put the object on the heap and get a pointer to it
                             let ptr = ::core::ptr::NonNull::from(Box::leak(Box::new(value)));
-                            unsafe { VBox::from_raw(core::ptr::NonNull::from(X::static_vtable()), ptr.cast()) }
+                            unsafe { VBox::from_raw(core::ptr::NonNull::from(X::STATIC_VTABLE), ptr.cast()) }
                         }
                     }
                 });
@@ -750,9 +750,7 @@ and implements HasStaticVTable for it.
                     };
                     #[allow(unsafe_code)]
                     unsafe impl vtable::HasStaticVTable<#vtable_name> for $ty {
-                        fn static_vtable() -> &'static #vtable_name {
-                            &$ident
-                        }
+                        const STATIC_VTABLE: &'static #vtable_name = &$ident;
                     }
                 }
             }

--- a/helper_crates/vtable/src/lib.rs
+++ b/helper_crates/vtable/src/lib.rs
@@ -113,8 +113,9 @@ pub unsafe trait HasStaticVTable<VT>
 where
     VT: ?Sized + VTableMeta,
 {
-    /// Safety: must be a valid VTable for Self
-    fn static_vtable() -> &'static VT::VTable;
+    /// Safety: must point to the single static VTable for Self. Downcasts
+    /// compare vtables by address, so it must not be a promoted temporary.
+    const STATIC_VTABLE: &'static VT::VTable;
 }
 
 #[derive(Copy, Clone)]
@@ -248,7 +249,7 @@ impl<'a, T: ?Sized + VTableMeta> VRef<'a, T> {
     pub fn new<X: HasStaticVTable<T>>(value: &'a X) -> Self {
         Self {
             inner: Inner {
-                vtable: NonNull::from(X::static_vtable()).cast(),
+                vtable: NonNull::from(X::STATIC_VTABLE).cast(),
                 ptr: NonNull::from(value).cast(),
             },
             phantom: PhantomData,
@@ -261,7 +262,7 @@ impl<'a, T: ?Sized + VTableMeta> VRef<'a, T> {
         unsafe {
             Pin::new_unchecked(Self {
                 inner: Inner {
-                    vtable: NonNull::from(X::static_vtable()).cast(),
+                    vtable: NonNull::from(X::STATIC_VTABLE).cast(),
                     ptr: NonNull::from(value.get_ref()).cast(),
                 },
                 phantom: PhantomData,
@@ -283,7 +284,7 @@ impl<'a, T: ?Sized + VTableMeta> VRef<'a, T> {
 
     /// Return a reference of the given type if the type is matching.
     pub fn downcast<X: HasStaticVTable<T>>(&self) -> Option<&X> {
-        if self.inner.vtable == NonNull::from(X::static_vtable()).cast() {
+        if self.inner.vtable == NonNull::from(X::STATIC_VTABLE).cast() {
             // Safety: We just checked that the vtable fits
             unsafe { Some(self.inner.ptr.cast().as_ref()) }
         } else {
@@ -294,7 +295,7 @@ impl<'a, T: ?Sized + VTableMeta> VRef<'a, T> {
     /// Return a reference of the given type if the type is matching
     pub fn downcast_pin<X: HasStaticVTable<T>>(this: Pin<Self>) -> Option<Pin<&'a X>> {
         let inner = unsafe { Pin::into_inner_unchecked(this).inner };
-        if inner.vtable == NonNull::from(X::static_vtable()).cast() {
+        if inner.vtable == NonNull::from(X::STATIC_VTABLE).cast() {
             // Safety: We just checked that the vtable fits
             unsafe { Some(Pin::new_unchecked(inner.ptr.cast().as_ref())) }
         } else {
@@ -338,7 +339,7 @@ impl<'a, T: ?Sized + VTableMeta> VRefMut<'a, T> {
     pub fn new<X: HasStaticVTable<T>>(value: &'a mut X) -> Self {
         Self {
             inner: Inner {
-                vtable: NonNull::from(X::static_vtable()).cast(),
+                vtable: NonNull::from(X::STATIC_VTABLE).cast(),
                 ptr: NonNull::from(value).cast(),
             },
             phantom: PhantomData,
@@ -376,7 +377,7 @@ impl<'a, T: ?Sized + VTableMeta> VRefMut<'a, T> {
 
     /// Return a reference of the given type if the type is matching.
     pub fn downcast<X: HasStaticVTable<T>>(&mut self) -> Option<&mut X> {
-        if self.inner.vtable == NonNull::from(X::static_vtable()).cast() {
+        if self.inner.vtable == NonNull::from(X::STATIC_VTABLE).cast() {
             // Safety: We just checked that the vtable fits
             unsafe { Some(self.inner.ptr.cast().as_mut()) }
         } else {
@@ -506,8 +507,8 @@ impl<Base, T: ?Sized + VTableMeta, Flag> VOffset<Base, T, Flag> {
     /// Create an new VOffset from a [`FieldOffset`] where the target type implement the
     /// [`HasStaticVTable`] trait.
     #[inline]
-    pub fn new<X: HasStaticVTable<T>>(o: FieldOffset<Base, X, Flag>) -> Self {
-        Self { vtable: X::static_vtable(), offset: o.get_byte_offset(), phantom: PhantomData }
+    pub const fn new<X: HasStaticVTable<T>>(o: FieldOffset<Base, X, Flag>) -> Self {
+        Self { vtable: X::STATIC_VTABLE, offset: o.get_byte_offset(), phantom: PhantomData }
     }
 
     /// Create a new VOffset from raw data

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -157,7 +157,7 @@ impl<VTable: VTableMetaDropInPlace, X: HasStaticVTable<VTable>> VRc<VTable, X> {
 
         unsafe {
             mem.write(VRcInner {
-                vtable: X::static_vtable(),
+                vtable: X::STATIC_VTABLE,
                 strong_ref: AtomicU32::new(1),
                 weak_ref: AtomicU32::new(1), // All the VRc together hold a weak_ref to the memory
                 data_offset: 0,

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore conv gdata powf punct vref rescope updt
+// cSpell: ignore conv gdata powf punct vref rescope rfold updt
 
 /*! module for the Rust code generator
 
@@ -2116,7 +2116,7 @@ fn generate_item_tree(
     let mut item_array = Vec::new();
     sub_tree.tree.visit_in_array(&mut |node, children_offset, parent_index| {
         let parent_index = parent_index as u32;
-        let (path, component) =
+        let (_, component) =
             follow_sub_component_path(root, sub_tree.root, &node.sub_component_path);
         match node.item_index {
             Either::Right(mut repeater_index) => {
@@ -2135,10 +2135,6 @@ fn generate_item_tree(
             }
             Either::Left(item_index) => {
                 let item = &component.items[item_index];
-                let field = access_component_field_offset(
-                    &self::inner_component_id(component),
-                    &ident(&item.name),
-                );
 
                 let children_count = node.children.len() as u32;
                 let children_index = children_offset as u32;
@@ -2153,7 +2149,26 @@ fn generate_item_tree(
                         item_array_index: #item_array_len,
                     }
                 ));
-                item_array.push(quote!(sp::VOffset::new(#path #field)));
+
+                // The array is const, so nested offsets are composed with the
+                // const compose_field_offsets rather than the non-const `+`.
+                let mut sc = &root.sub_components[sub_tree.root];
+                let mut offsets = Vec::new();
+                for i in &node.sub_component_path {
+                    offsets.push(access_component_field_offset(
+                        &self::inner_component_id(sc),
+                        &ident(&sc.sub_components[*i].name),
+                    ));
+                    sc = &root.sub_components[sc.sub_components[*i].ty];
+                }
+                let offset = offsets.into_iter().rfold(
+                    access_component_field_offset(
+                        &self::inner_component_id(component),
+                        &ident(&item.name),
+                    ),
+                    |acc, seg| quote!(sp::compose_field_offsets(#seg, #acc)),
+                );
+                item_array.push(quote!(sp::VOffset::new(#offset)));
             }
         }
     });
@@ -2235,11 +2250,9 @@ fn generate_item_tree(
             }
 
             fn item_array() -> &'static [sp::VOffset<Self, sp::ItemVTable, sp::AllowPin>] {
-                // FIXME: ideally this should be a const, but we can't because of the pointer to the vtable
-                static ITEM_ARRAY : sp::OnceBox<
-                    [sp::VOffset<#inner_component_id, sp::ItemVTable, sp::AllowPin>; #item_array_len]
-                > = sp::OnceBox::new();
-                &*ITEM_ARRAY.get_or_init(|| sp::vec![#(#item_array),*].into_boxed_slice().try_into().unwrap())
+                const ITEM_ARRAY : [sp::VOffset<#inner_component_id, sp::ItemVTable, sp::AllowPin>; #item_array_len]
+                    = [#(#item_array),*];
+                &ITEM_ARRAY
             }
         }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -95,7 +95,7 @@ macro_rules! declare_item_vtable {
         #[unsafe(no_mangle)]
         pub extern "C" fn $getter() -> *const ItemVTable {
             use vtable::HasStaticVTable;
-            <$item_ty>::static_vtable()
+            <$item_ty>::STATIC_VTABLE
         }
     };
 }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -837,7 +837,7 @@ pub(crate) struct ItemRTTI {
 fn rtti_for<T: 'static + Default + rtti::BuiltinItem + vtable::HasStaticVTable<ItemVTable>>()
 -> (&'static str, Rc<ItemRTTI>) {
     let rtti = ItemRTTI {
-        vtable: T::static_vtable(),
+        vtable: T::STATIC_VTABLE,
         type_info: dynamic_type::StaticTypeInfo::new::<T>(),
         properties: T::properties()
             .into_iter()


### PR DESCRIPTION
In the current code, `HasStaticVTable::static_vtable()` is a trait *method*, and trait-method calls can't appear in const context on stable. That kept `VOffset::new` non-const, which in turn kept the generated per-component item arrays out of const context, so the Rust generator built them lazily at runtime: a `OnceBox` initialized on first use, monomorphized for every component type.

This patch replaces the method with a `const STATIC_VTABLE`, makes `VOffset::new` `const`, and adds a new `const fn compose_field_offsets` (same as `+`, but `const`), and emits the item arrays as plain `const` arrays.
As a nice bonus, `const` rather than `static` allows merging across components.

(the `VTABLE` `const` is not merged because they are all different; and this is a good thing because it's ptr value used to check sameness)

Generated `item_array()`, before -> after:

```rust
// before: built once at runtime, cached in a OnceBox
static ITEM_ARRAY: sp::OnceBox<[sp::VOffset<..>; 3]> = sp::OnceBox::new();
&*ITEM_ARRAY.get_or_init(|| sp::vec![
    sp::VOffset::new(A.inner() + B.root()),   // FieldOffset `+` (non-const)
    ..
].into_boxed_slice().try_into().unwrap())

// after: a plain const, no init
const ITEM_ARRAY: [sp::VOffset<..>; 3] = [
    sp::VOffset::new(sp::compose_field_offsets(A.inner(), B.root())),  // const
    ..
];
&ITEM_ARRAY
```

### Advantages

- No lazy init, no `OnceBox`, no `vec!`: **one fewer heap allocation per component type**, and the arrays are baked into `.rodata`.
- Much less monomorphized code (the per-component init closure is gone).
- As an example one of our stripped binaries went **9875KB -> 9707KB (−168KB, −1.7%)**, llvm-lines **−292k (−8.5%)**, **−14.6k** function copies.