### PR TITLE
An interface can inherit from another interface

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -33,6 +33,23 @@ An interface body may contain:
 An interface body may **not** contain bindings, child elements, layouts, `states`, two-way bindings, `animate` blocks, or private properties.
 An interface can be exported with `export interface`.
 
+### Inheritance
+
+An interface may inherit from another interface.
+
+
+```slint no-test
+interface Text {
+    in-out property text;
+}
+
+interface Button inherits Text {
+    callback clicked();
+}
+```
+
+A component implementing Button would have a `text` property and a `clicked` callback.
+
 ## Implementing an interface
 
 A component declares that it implements an interface with the `implements` keyword.

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -210,7 +210,12 @@ module.exports = grammar({
       ),
 
     interface_definition: ($) =>
-      seq("interface", field("name", $.user_type_identifier), $.interface_block),
+      seq(
+        "interface",
+        field("name", $.user_type_identifier),
+        optional(seq("inherits", field("base_type", $.user_type_identifier))),
+        $.interface_block,
+      ),
 
     struct_field_definition: ($) =>
       seq(field("name", $.simple_identifier), ":", field("type", $.type)),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1411,7 +1411,7 @@ impl Element {
         // An interface may inherit another interface, but cannot implement an interface.
         // A component may implement an interface, but cannot inherit an interface.
         // We should never have both at the same time.
-        debug_assert_eq!(implemented_interface.is_some() && inherited_interface.is_some(), false);
+        debug_assert!(!(implemented_interface.is_some() && inherited_interface.is_some()));
         let implemented_interface = implemented_interface.or(inherited_interface);
         interfaces::apply_properties(&mut r, &implemented_interface, diag);
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1144,6 +1144,7 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> ElementRc {
+        let mut inherited_interface: Option<interfaces::ImplementedInterface> = None;
         let base_type = if let Some(base_node) = node.QualifiedName() {
             let base = QualifiedTypeName::from_node(base_node.clone());
             let base_string = base.to_smolstr();
@@ -1154,6 +1155,23 @@ impl Element {
                         &base_node,
                     );
                     ElementType::Error
+                }
+                Ok(ElementType::Component(c)) if c.is_interface() => {
+                    if parent_type == ElementType::Interface {
+                        #[cfg(feature = "slint-sc")]
+                        diag.slint_sc_error("Interface inheritance is", &base_node);
+                        c.used.set(true);
+                        inherited_interface = Some(
+                            interfaces::ImplementedInterface::from_inherits(base_node.clone(), c),
+                        );
+                        ElementType::Interface
+                    } else {
+                        diag.push_error(
+                            "Components cannot inherit from interfaces".into(),
+                            &base_node,
+                        );
+                        ElementType::Error
+                    }
                 }
                 Ok(ty) => {
                     #[cfg(feature = "slint-sc")]
@@ -1180,9 +1198,20 @@ impl Element {
                 }
             }
         } else if parent_type == ElementType::Global || parent_type == ElementType::Interface {
-            // This must be a global component or interface. It can only have properties and callbacks
+            parent_type
+        } else if parent_type != ElementType::Error {
+            // This should normally never happen because the parser does not allow for this
+            assert!(diag.has_errors());
+            return ElementRc::default();
+        } else {
+            tr.empty_type()
+        };
+        let is_interface = base_type == ElementType::Interface;
+
+        // Globals and interfaces can only have properties and callbacks.
+        if base_type == ElementType::Global || is_interface {
             let mut error_on = |node: &dyn Spanned, what: &str| {
-                let element_type = match parent_type {
+                let element_type = match base_type {
                     ElementType::Global => "A global component",
                     ElementType::Interface => "An interface",
                     _ => "An unexpected type",
@@ -1208,20 +1237,12 @@ impl Element {
                 }
             });
 
-            if parent_type == ElementType::Interface {
+            if is_interface {
                 node.Binding().for_each(|n| error_on(&n, "bindings"));
                 node.TwoWayBinding().for_each(|n| error_on(&n, "two-way bindings"));
             }
+        }
 
-            parent_type
-        } else if parent_type != ElementType::Error {
-            // This should normally never happen because the parser does not allow for this
-            assert!(diag.has_errors());
-            return ElementRc::default();
-        } else {
-            tr.empty_type()
-        };
-        let is_interface = base_type == ElementType::Interface;
         // This isn't truly qualified yet, the enclosing component is added at the end of Component::from_node
         let qualified_id = (!id.is_empty()).then(|| id.clone());
         if let ElementType::Component(c) = &base_type {
@@ -1387,6 +1408,11 @@ impl Element {
         }
 
         let implemented_interface = interfaces::get_implemented_interface(&r, &node, tr, diag);
+        // An interface may inherit another interface, but cannot implement an interface.
+        // A component may implement an interface, but cannot inherit an interface.
+        // We should never have both at the same time.
+        debug_assert_eq!(implemented_interface.is_some() && inherited_interface.is_some(), false);
+        let implemented_interface = implemented_interface.or(inherited_interface);
         interfaces::apply_properties(&mut r, &implemented_interface, diag);
 
         for (prop_name, csn, source) in property_bindings {
@@ -1635,6 +1661,8 @@ impl Element {
 
             r.property_declarations.insert(name, declaration);
         }
+
+        interfaces::apply_functions(&mut r, &implemented_interface, diag);
 
         for con_node in node.CallbackConnection() {
             #[cfg(feature = "slint-sc")]

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -124,12 +124,40 @@ fn validate_property_declaration_for_interface(
     }
 }
 
+/// How an interface is attached to an element: by a component's `implements` clause, or by a
+/// derived interface's `inherits` clause.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub(super) enum InterfaceUseKind {
+    /// `component X implements I`
+    Implements,
+    /// `interface D inherits B`
+    Inherits,
+}
+
 /// A reference to an interface element, carrying the QualifiedName syntax node used to refer to it for use in
 /// diagnostics.
 pub(super) struct ImplementedInterface {
     interface_name_node: syntax_nodes::QualifiedName,
     interface: ElementRc,
     interface_name: SmolStr,
+    kind: InterfaceUseKind,
+}
+
+impl ImplementedInterface {
+    /// Construct an ImplementedInterface for a derived interface's `inherits` clause, given the
+    /// already-resolved parent interface Component.
+    pub(super) fn from_inherits(
+        interface_name_node: syntax_nodes::QualifiedName,
+        interface_component: Rc<Component>,
+    ) -> Self {
+        let interface_name = QualifiedTypeName::from_node(interface_name_node.clone()).to_smolstr();
+        Self {
+            interface_name_node,
+            interface: interface_component.root_element.clone(),
+            interface_name,
+            kind: InterfaceUseKind::Inherits,
+        }
+    }
 }
 
 /// If the element implements a valid interface, return the corresponding ImplementedInterface. Otherwise return None.
@@ -171,6 +199,7 @@ pub(super) fn get_implemented_interface(
                 interface_name_node,
                 interface: c.root_element.clone(),
                 interface_name,
+                kind: InterfaceUseKind::Implements,
             })
         }
         Ok(_) => {
@@ -194,7 +223,7 @@ pub(super) fn apply_properties(
     implemented_interface: &Option<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, interface_name_node, interface_name }) =
+    let Some(ImplementedInterface { interface, interface_name_node, interface_name, .. }) =
         implemented_interface
     else {
         return;
@@ -212,13 +241,33 @@ pub(super) fn apply_callbacks(
     implemented_interface: &Option<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, interface_name_node, interface_name }) =
+    let Some(ImplementedInterface { interface, interface_name_node, interface_name, .. }) =
         implemented_interface
     else {
         return;
     };
     apply_declarations(e, interface, interface_name_node, interface_name, diag, |prop_decl| {
         matches!(prop_decl.property_type, Type::Callback { .. })
+    });
+}
+
+/// Apply the function declarations from an inherited parent interface to the derived interface.
+/// This is a no-op for `implements` - components are expected to implement functions manually.
+pub(super) fn apply_functions(
+    e: &mut Element,
+    implemented_interface: &Option<ImplementedInterface>,
+    diag: &mut BuildDiagnostics,
+) {
+    let Some(ImplementedInterface { interface, interface_name_node, interface_name, kind }) =
+        implemented_interface
+    else {
+        return;
+    };
+    if *kind == InterfaceUseKind::Implements {
+        return;
+    }
+    apply_declarations(e, interface, interface_name_node, interface_name, diag, |prop_decl| {
+        matches!(prop_decl.property_type, Type::Function { .. })
     });
 }
 
@@ -378,11 +427,17 @@ pub(super) fn validate_function_implementations(
     implemented_interface: &Option<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, interface_name_node, interface_name }) =
+    let Some(ImplementedInterface { interface, interface_name_node, interface_name, kind }) =
         implemented_interface
     else {
         return;
     };
+
+    // Inherited interfaces propagate function declarations without bodies, so there's nothing to
+    // validate — the implementing component must provide the bodies.
+    if *kind == InterfaceUseKind::Inherits {
+        return;
+    }
 
     for (function_name, function_property_decl) in interface
         .borrow()

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -199,22 +199,10 @@ pub(super) fn apply_properties(
     else {
         return;
     };
-
-    for (unresolved_prop_name, prop_decl) in
-        interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-            // Functions are expected to be implemented manually, so we don't automatically add them.
-            !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
-        })
-    {
-        apply_interface_property_declaration(
-            e,
-            unresolved_prop_name,
-            prop_decl,
-            interface_name_node,
-            interface_name,
-            diag,
-        );
-    }
+    apply_declarations(e, interface, interface_name_node, interface_name, diag, |prop_decl| {
+        // Functions are expected to be implemented manually, so we don't automatically add them.
+        !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
+    });
 }
 
 /// Apply the callbacks declared in the interface to the element, emitting diagnostics if there are any conflicts.
@@ -229,12 +217,24 @@ pub(super) fn apply_callbacks(
     else {
         return;
     };
+    apply_declarations(e, interface, interface_name_node, interface_name, diag, |prop_decl| {
+        matches!(prop_decl.property_type, Type::Callback { .. })
+    });
+}
 
+/// Shared iteration helper: applies each declaration in `interface` matching `filter` to `e`.
+fn apply_declarations<F>(
+    e: &mut Element,
+    interface: &ElementRc,
+    interface_name_node: &syntax_nodes::QualifiedName,
+    interface_name: &SmolStr,
+    diag: &mut BuildDiagnostics,
+    filter: F,
+) where
+    F: Fn(&PropertyDeclaration) -> bool,
+{
     for (unresolved_prop_name, prop_decl) in
-        interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-            // Functions are expected to be implemented manually, so we don't automatically add them.
-            matches!(prop_decl.property_type, Type::Callback { .. })
-        })
+        interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| filter(prop_decl))
     {
         apply_interface_property_declaration(
             e,

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -124,9 +124,10 @@ fn validate_property_declaration_for_interface(
     }
 }
 
-/// An ImplementsSpecifier and the corresponding interface element.
+/// A reference to an interface element, carrying the QualifiedName syntax node used to refer to it for use in
+/// diagnostics.
 pub(super) struct ImplementedInterface {
-    implements_specifier: syntax_nodes::ImplementsSpecifier,
+    interface_name_node: syntax_nodes::QualifiedName,
     interface: ElementRc,
     interface_name: SmolStr,
 }
@@ -152,22 +153,22 @@ pub(super) fn get_implemented_interface(
         return None;
     }
 
-    let interface_name =
-        QualifiedTypeName::from_node(implements_specifier.QualifiedName()).to_smolstr();
+    let interface_name_node = implements_specifier.QualifiedName();
+    let interface_name = QualifiedTypeName::from_node(interface_name_node.clone()).to_smolstr();
 
     match e.base_type.lookup_type_for_child_element(&interface_name, tr) {
         Ok(ElementType::Component(c)) => {
             if !c.is_interface() {
                 diag.push_error(
                     format!("Cannot implement {}. It is not an interface", interface_name),
-                    &implements_specifier.QualifiedName(),
+                    &interface_name_node,
                 );
                 return None;
             }
 
             c.used.set(true);
             Some(ImplementedInterface {
-                implements_specifier,
+                interface_name_node,
                 interface: c.root_element.clone(),
                 interface_name,
             })
@@ -175,12 +176,12 @@ pub(super) fn get_implemented_interface(
         Ok(_) => {
             diag.push_error(
                 format!("Cannot implement {}. It is not an interface", interface_name),
-                &implements_specifier.QualifiedName(),
+                &interface_name_node,
             );
             None
         }
         Err(err) => {
-            diag.push_error(err, &implements_specifier.QualifiedName());
+            diag.push_error(err, &interface_name_node);
             None
         }
     }
@@ -193,7 +194,7 @@ pub(super) fn apply_properties(
     implemented_interface: &Option<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
+    let Some(ImplementedInterface { interface, interface_name_node, interface_name }) =
         implemented_interface
     else {
         return;
@@ -209,7 +210,7 @@ pub(super) fn apply_properties(
             e,
             unresolved_prop_name,
             prop_decl,
-            implements_specifier,
+            interface_name_node,
             interface_name,
             diag,
         );
@@ -223,7 +224,7 @@ pub(super) fn apply_callbacks(
     implemented_interface: &Option<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
+    let Some(ImplementedInterface { interface, interface_name_node, interface_name }) =
         implemented_interface
     else {
         return;
@@ -239,7 +240,7 @@ pub(super) fn apply_callbacks(
             e,
             unresolved_prop_name,
             prop_decl,
-            implements_specifier,
+            interface_name_node,
             interface_name,
             diag,
         );
@@ -252,7 +253,7 @@ fn apply_interface_property_declaration(
     e: &mut Element,
     unresolved_prop_name: &SmolStr,
     prop_decl: &PropertyDeclaration,
-    implements_specifier: &syntax_nodes::ImplementsSpecifier,
+    interface_name_node: &syntax_nodes::QualifiedName,
     interface_name: &SmolStr,
     diag: &mut BuildDiagnostics,
 ) {
@@ -318,7 +319,7 @@ fn apply_interface_property_declaration(
         &e.base_type,
         &interface_name,
     ) {
-        diag.push_error(message, &implements_specifier.QualifiedName());
+        diag.push_error(message, interface_name_node);
         return;
     }
 
@@ -377,7 +378,7 @@ pub(super) fn validate_function_implementations(
     implemented_interface: &Option<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
+    let Some(ImplementedInterface { interface, interface_name_node, interface_name }) =
         implemented_interface
     else {
         return;
@@ -401,12 +402,12 @@ pub(super) fn validate_function_implementations(
                     .get(function_name)
                     .and_then(|decl| decl.node.clone())
                     .map_or_else(
-                        || parser::NodeOrToken::Node(implements_specifier.QualifiedName().into()),
+                        || parser::NodeOrToken::Node(interface_name_node.clone().into()),
                         parser::NodeOrToken::Node,
                     );
                 diag.push_error(error, &source);
             } else {
-                diag.push_error(error, &implements_specifier.QualifiedName());
+                diag.push_error(error, interface_name_node);
             }
         };
 
@@ -415,7 +416,7 @@ pub(super) fn validate_function_implementations(
             Type::Invalid => {
                 diag.push_error(
                     format!("Missing implementation of function '{}'", function_name),
-                    &implements_specifier.QualifiedName(),
+                    interface_name_node,
                 );
                 None
             }

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -104,6 +104,7 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
 /// component C { property<int> xx; }
 /// component C inherits D { }
 /// interface I { property<int> xx; }
+/// interface I inherits J { property<int> xx; }
 /// component E implements I { }
 /// component E implements I inherits D { }
 /// component F uses { I from A } { }
@@ -168,6 +169,9 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
     } else if is_interface {
         if p.peek().kind() == SyntaxKind::ColonEqual {
             p.error("':=' to declare an interface is not supported. Remove the ':='");
+            p.consume();
+        }
+        if p.peek().as_str() == "inherits" {
             p.consume();
         }
     } else if !is_new_component {

--- a/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
@@ -1,7 +1,53 @@
 // Copyright © 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export interface DerivedInterface inherits
- HelloInterface {
-//>            <<error{Syntax error: expected '{'}
+export interface InterfaceA {
+    out property <string> text;
+    callback callback-a();
+    public pure function function-a();
 }
+
+export interface InterfaceB inherits InterfaceA {
+    out property <int> foo;
+    callback callback-b();
+    public pure function function-b();
+}
+
+export interface InterfaceOverrides inherits InterfaceA {
+    out property <string> text;
+//  >                         <error{Conflict with 'InterfaceA' which declares a property with the same name}
+    callback callback-a();
+//  >                    <error{Conflict with 'InterfaceA' which declares a callback with the same name}
+    public pure function function-a();
+//  >                                <error{Conflict with 'InterfaceA' which declares a function with the same name}
+
+    public function function-with-definition(a: int) -> int {
+//                                                          >error{Function declarations in interfaces must not have a body}
+        a * 2
+    }
+//  <error{Function declarations in interfaces must not have a body}
+}
+
+export component MyComponent implements InterfaceB {
+    text: "Hello Inheritance";
+    foo: 32;
+
+    public pure function function-a() {
+        debug("Function A called");
+    }
+
+    public pure function function-b() {
+        debug("Function B called");
+    }
+}
+
+export interface IncorrectInterfaceB inherits InterfaceA {
+    in-out property <string> text;
+//  >                            <error{Conflict with 'InterfaceA' which declares a property with the same name}
+}
+
+export component ComponentsCannotInheritInterfaces1 inherits InterfaceA { }
+//                                                           >         <error{Components cannot inherit from interfaces}
+
+export component ComponentsCannotInheritInterfaces2 inherits InterfaceB { }
+//                                                           >         <error{Components cannot inherit from interfaces}

--- a/tests/cases/interfaces/inheritance.slint
+++ b/tests/cases/interfaces/inheritance.slint
@@ -1,0 +1,79 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface A {
+    out property <int> speed;
+    in-out property <string> greeting;
+    pure callback callback-a() -> int;
+    public pure function function-a() -> int;
+}
+
+interface B inherits A {
+    out property <float> direction;
+    pure callback callback-b() -> int;
+    public pure function function-b() -> int;
+}
+
+export component TestCase implements B {
+    speed: 42;
+    greeting: "Hola";
+    direction: 45.0;
+
+    property <bool> test-properties: self.speed == 42 && self.direction == 45.0 && self.greeting == "Hola";
+    property <bool> test-callbacks: self.callback-a() == 2 && self.callback-b() == 3;
+    property <bool> test-functions: self.function-a() == 4 && self.function-b() == 5;
+
+    out property <bool> test: test-properties && test-callbacks && test-functions;
+
+    callback-a() => {
+        2
+    }
+
+    callback-b() => {
+        3
+    }
+
+    public pure function function-a() -> int {
+        4
+    }
+
+    public pure function function-b() -> int {
+        5
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_speed(), 42);
+assert_eq!(instance.get_direction(), 45.0);
+assert_eq!(instance.get_greeting(), "Hola");
+assert_eq!(instance.invoke_callback_a(), 2);
+assert_eq!(instance.invoke_callback_b(), 3);
+assert_eq!(instance.invoke_function_a(), 4);
+assert_eq!(instance.invoke_function_b(), 5);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_speed(), 42);
+assert_eq(instance.get_direction(), 45.0);
+assert_eq(instance.get_greeting(), "Hola");
+assert_eq(instance.invoke_callback_a(), 2);
+assert_eq(instance.invoke_callback_b(), 3);
+assert_eq(instance.invoke_function_a(), 4);
+assert_eq(instance.invoke_function_b(), 5);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.speed, 42);
+assert.equal(instance.direction, 45.0);
+assert.equal(instance.greeting, "Hola");
+assert.equal(instance.callback_a(), 2);
+assert.equal(instance.callback_b(), 3);
+assert.equal(instance.function_a(), 4);
+assert.equal(instance.function_b(), 5);
+```
+*/


### PR DESCRIPTION
Interface inheritance is desired for std-widgets interfaces to match the inheritance structure of StandardList/TableView -> ListView -> ScrollView.

The inheritance implementation for interfaces is different to the implementation for components. `ElementType::Interface` does not contain an `Rc<Interface>`, instead we follow the existing pattern for interfaces which is to copy the properties/callbacks/functions to the inheriting interface. At the time I wrote this PR this implementation was the path of least resistance. This implementation may no longer be desirable, especially given that we want `uses` statements to require explicit implementation of an interface. As a result I expect I might be reimplementing some of this in a future PR. For now I'd like to submit this for review and discussion, as I have other changes that build upon this.