### PR TITLE
Ignore the SVG tests under Miri

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -230,6 +230,7 @@
     "xcworkspace",
     "xtask",
     "xtensa",
+    "Zmiri",
     // CSS Color 4 named-color keywords not accepted by the default English dictionary (W3C CSS Color Module Level 4).
     "aliceblue",
     "antiquewhite",

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1142,6 +1142,8 @@ fn test_image_size_from_buffer_without_backend() {
 
 #[cfg(feature = "svg")]
 #[test]
+// memchr's manually aligned SIMD loads are a false positive under -Zmiri-symbolic-alignment-check
+#[cfg_attr(miri, ignore)]
 fn test_image_size_from_svg() {
     let simple_svg = r#"<svg width="320" height="200" xmlns="http://www.w3.org/2000/svg"></svg>"#;
     let image = Image::load_from_svg_data(simple_svg.as_bytes()).unwrap();
@@ -1151,6 +1153,8 @@ fn test_image_size_from_svg() {
 
 #[cfg(feature = "svg")]
 #[test]
+// memchr's manually aligned SIMD loads are a false positive under -Zmiri-symbolic-alignment-check
+#[cfg_attr(miri, ignore)]
 fn test_image_invalid_svg() {
     let invalid_svg = r#"AaBbCcDd"#;
     let result = Image::load_from_svg_data(invalid_svg.as_bytes());


### PR DESCRIPTION
memchr aligns pointers by masking the address, a documented false positive of -Zmiri-symbolic-alignment-check. The SVG tests reach memchr's SIMD loads through roxmltree, and whether the check trips depends on the addresses Miri hands out, so it breaks with toolchain or dependency bumps.
