### PR TITLE
compiler: store number literals in canonical units

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -575,13 +575,13 @@ macro_rules! declare_units {
         ///
         /// These are all the units a user can type. A literal is normalized to the
         /// canonical [`Unit`] of its type the moment it enters the expression tree, so
-        /// only the parser and tooling ever handle a `SurfaceUnit`.
+        /// only the parser and tooling ever handle a `WrittenUnit`.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum::EnumIter)]
-        pub enum SurfaceUnit {
+        pub enum WrittenUnit {
             $($(#[$m])* $ident,)*
         }
 
-        impl std::fmt::Display for SurfaceUnit {
+        impl std::fmt::Display for WrittenUnit {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self {
                     $(Self::$ident => write!(f, $string), )*
@@ -589,7 +589,7 @@ macro_rules! declare_units {
             }
         }
 
-        impl std::str::FromStr for SurfaceUnit {
+        impl std::str::FromStr for WrittenUnit {
             type Err = ();
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
@@ -599,7 +599,7 @@ macro_rules! declare_units {
             }
         }
 
-        impl SurfaceUnit {
+        impl WrittenUnit {
             /// Scale `value`, written in this surface unit, to the value and canonical
             /// [`Unit`] a `NumberLiteral` stores. The scale and the unit come out
             /// together so they can't drift apart.
@@ -657,7 +657,7 @@ declare_units! {
 /// The unit a [`Expression::NumberLiteral`] carries: always the canonical unit of
 /// its type, so the stored value is already scaled and needs no further
 /// conversion. The units a user can type (`cm`, `pt`, `grad`, ...) are
-/// [`SurfaceUnit`] and are normalized to one of these on the way in.
+/// [`WrittenUnit`] and are normalized to one of these on the way in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum Unit {
     /// Dimension-less (`float`, `int`)

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -564,14 +564,24 @@ pub fn operator_class(op: char) -> OperatorClass {
 }
 
 macro_rules! declare_units {
-    ($( $(#[$m:meta])* $ident:ident = $string:literal -> $ty:ident $(* $factor:expr)? ,)*) => {
-        /// The units that can be used after numbers in the language
+    // A unit written without a conversion is already its type's canonical unit.
+    (@normalize $value:ident, $ident:ident) => { ($value, Unit::$ident) };
+    // Otherwise scale by the factor and switch to the named canonical unit.
+    (@normalize $value:ident, $ident:ident, $canon:ident, $factor:expr) => {
+        ($value * ($factor as f64), Unit::$canon)
+    };
+    ($( $(#[$m:meta])* $ident:ident = $string:literal $(-> $canon:ident * $factor:expr)? ,)*) => {
+        /// A unit as written after a number in the source (`px`, `cm`, `grad`, ...).
+        ///
+        /// These are all the units a user can type. A literal is normalized to the
+        /// canonical [`Unit`] of its type the moment it enters the expression tree, so
+        /// only the parser and tooling ever handle a `SurfaceUnit`.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum::EnumIter)]
-        pub enum Unit {
+        pub enum SurfaceUnit {
             $($(#[$m])* $ident,)*
         }
 
-        impl std::fmt::Display for Unit {
+        impl std::fmt::Display for SurfaceUnit {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self {
                     $(Self::$ident => write!(f, $string), )*
@@ -579,7 +589,7 @@ macro_rules! declare_units {
             }
         }
 
-        impl std::str::FromStr for Unit {
+        impl std::str::FromStr for SurfaceUnit {
             type Err = ();
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
@@ -589,69 +599,110 @@ macro_rules! declare_units {
             }
         }
 
-        impl Unit {
-            pub fn ty(self) -> Type {
+        impl SurfaceUnit {
+            /// Scale `value`, written in this surface unit, to the value and canonical
+            /// [`Unit`] a `NumberLiteral` stores. The scale and the unit come out
+            /// together so they can't drift apart.
+            pub fn normalize(self, value: f64) -> (f64, Unit) {
                 match self {
-                    $(Self::$ident => Type::$ty, )*
+                    $(Self::$ident => declare_units!(@normalize value, $ident $(, $canon, $factor)?), )*
                 }
             }
-
-            pub fn normalize(self, x: f64) -> f64 {
-                match self {
-                    $(Self::$ident => x $(* $factor as f64)?, )*
-                }
-            }
-
         }
     };
 }
 
 declare_units! {
     /// No unit was given
-    None = "" -> Float32,
+    None = "",
     /// Percent value
-    Percent = "%" -> Percent,
+    Percent = "%",
 
     // Lengths or Coord
 
     /// Physical pixels
-    Phx = "phx" -> PhysicalLength,
+    Phx = "phx",
     /// Logical pixels
-    Px = "px" -> LogicalLength,
+    Px = "px",
     /// Centimeters
-    Cm = "cm" -> LogicalLength * 37.8,
+    Cm = "cm" -> Px * 37.8,
     /// Millimeters
-    Mm = "mm" -> LogicalLength * 3.78,
+    Mm = "mm" -> Px * 3.78,
     /// inches
-    In = "in" -> LogicalLength * 96,
+    In = "in" -> Px * 96,
     /// Points
-    Pt = "pt" -> LogicalLength * 96./72.,
+    Pt = "pt" -> Px * 96./72.,
     /// Logical pixels multiplied with the window's default-font-size
-    Rem = "rem" -> Rem,
+    Rem = "rem",
 
     // durations
 
     /// Seconds
-    S = "s" -> Duration * 1000,
+    S = "s" -> Ms * 1000,
     /// Milliseconds
-    Ms = "ms" -> Duration,
+    Ms = "ms",
 
     // angles
 
     /// Degree
-    Deg = "deg" -> Angle,
+    Deg = "deg",
     /// Gradians
-    Grad = "grad" -> Angle * 360./180.,
+    Grad = "grad" -> Deg * 360./180.,
     /// Turns
-    Turn = "turn" -> Angle * 360.,
+    Turn = "turn" -> Deg * 360.,
     /// Radians
-    Rad = "rad" -> Angle * 360./std::f32::consts::TAU,
+    Rad = "rad" -> Deg * 360./std::f32::consts::TAU,
 }
 
-#[allow(clippy::derivable_impls)] // more readable this way
-impl Default for Unit {
-    fn default() -> Self {
-        Self::None
+/// The unit a [`Expression::NumberLiteral`] carries: always the canonical unit of
+/// its type, so the stored value is already scaled and needs no further
+/// conversion. The units a user can type (`cm`, `pt`, `grad`, ...) are
+/// [`SurfaceUnit`] and are normalized to one of these on the way in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Unit {
+    /// Dimension-less (`float`, `int`)
+    #[default]
+    None,
+    /// Percent
+    Percent,
+    /// Physical pixels
+    Phx,
+    /// Logical pixels
+    Px,
+    /// Logical pixels multiplied with the window's default-font-size
+    Rem,
+    /// Milliseconds
+    Ms,
+    /// Degrees
+    Deg,
+}
+
+impl Unit {
+    pub fn ty(self) -> Type {
+        match self {
+            Unit::None => Type::Float32,
+            Unit::Percent => Type::Percent,
+            Unit::Px => Type::LogicalLength,
+            Unit::Phx => Type::PhysicalLength,
+            Unit::Rem => Type::Rem,
+            Unit::Ms => Type::Duration,
+            Unit::Deg => Type::Angle,
+        }
+    }
+}
+
+impl std::fmt::Display for Unit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Unit::None => "",
+            Unit::Percent => "%",
+            Unit::Px => "px",
+            Unit::Phx => "phx",
+            Unit::Rem => "rem",
+            Unit::Ms => "ms",
+            Unit::Deg => "deg",
+        };
+        write!(f, "{s}")
     }
 }
 

--- a/internal/compiler/literals.rs
+++ b/internal/compiler/literals.rs
@@ -3,7 +3,7 @@
 
 // cSpell: ignore qsdf
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Span, Spanned};
-use crate::expression_tree::SurfaceUnit;
+use crate::expression_tree::WrittenUnit;
 use itertools::Itertools;
 use smol_str::SmolStr;
 use strum::IntoEnumIterator;
@@ -327,7 +327,7 @@ impl StringLiteralSourceMap {
     }
 }
 
-pub fn parse_number_literal(s: SmolStr) -> Result<(f64, SurfaceUnit), SmolStr> {
+pub fn parse_number_literal(s: SmolStr) -> Result<(f64, WrittenUnit), SmolStr> {
     let bytes = s.as_bytes();
     let mut end = 0;
     while end < bytes.len() && matches!(bytes[end], b'0'..=b'9' | b'.') {
@@ -338,7 +338,7 @@ pub fn parse_number_literal(s: SmolStr) -> Result<(f64, SurfaceUnit), SmolStr> {
         format!(
             "Invalid unit '{}'. Valid units are: {}",
             s.get(end..).unwrap_or(&s),
-            SurfaceUnit::iter().filter(|x| !x.to_string().is_empty()).join(", ")
+            WrittenUnit::iter().filter(|x| !x.to_string().is_empty()).join(", ")
         )
     })?;
     Ok((val, unit))
@@ -346,24 +346,24 @@ pub fn parse_number_literal(s: SmolStr) -> Result<(f64, SurfaceUnit), SmolStr> {
 
 #[test]
 fn test_parse_number_literal() {
-    use crate::expression_tree::SurfaceUnit;
+    use crate::expression_tree::WrittenUnit;
     use smol_str::{ToSmolStr, format_smolstr};
 
-    assert_eq!(parse_number_literal("10".into()), Ok((10., SurfaceUnit::None)));
-    assert_eq!(parse_number_literal("10phx".into()), Ok((10., SurfaceUnit::Phx)));
-    assert_eq!(parse_number_literal("10.0phx".into()), Ok((10., SurfaceUnit::Phx)));
-    assert_eq!(parse_number_literal("10.0".into()), Ok((10., SurfaceUnit::None)));
-    assert_eq!(parse_number_literal("1.1phx".into()), Ok((1.1, SurfaceUnit::Phx)));
-    assert_eq!(parse_number_literal("10.10".into()), Ok((10.10, SurfaceUnit::None)));
-    assert_eq!(parse_number_literal("10000000".into()), Ok((10000000., SurfaceUnit::None)));
-    assert_eq!(parse_number_literal("10000001phx".into()), Ok((10000001., SurfaceUnit::Phx)));
-    assert_eq!(parse_number_literal("5cm".into()), Ok((5., SurfaceUnit::Cm)));
-    assert_eq!(parse_number_literal("90grad".into()), Ok((90., SurfaceUnit::Grad)));
+    assert_eq!(parse_number_literal("10".into()), Ok((10., WrittenUnit::None)));
+    assert_eq!(parse_number_literal("10phx".into()), Ok((10., WrittenUnit::Phx)));
+    assert_eq!(parse_number_literal("10.0phx".into()), Ok((10., WrittenUnit::Phx)));
+    assert_eq!(parse_number_literal("10.0".into()), Ok((10., WrittenUnit::None)));
+    assert_eq!(parse_number_literal("1.1phx".into()), Ok((1.1, WrittenUnit::Phx)));
+    assert_eq!(parse_number_literal("10.10".into()), Ok((10.10, WrittenUnit::None)));
+    assert_eq!(parse_number_literal("10000000".into()), Ok((10000000., WrittenUnit::None)));
+    assert_eq!(parse_number_literal("10000001phx".into()), Ok((10000001., WrittenUnit::Phx)));
+    assert_eq!(parse_number_literal("5cm".into()), Ok((5., WrittenUnit::Cm)));
+    assert_eq!(parse_number_literal("90grad".into()), Ok((90., WrittenUnit::Grad)));
 
     let cannot_parse = Err("Cannot parse number literal".to_smolstr());
     assert_eq!(parse_number_literal("12.10.12phx".into()), cannot_parse);
 
-    let valid_units = SurfaceUnit::iter().filter(|x| !x.to_string().is_empty()).join(", ");
+    let valid_units = WrittenUnit::iter().filter(|x| !x.to_string().is_empty()).join(", ");
     let wrong_unit_spaced =
         Err(format_smolstr!("Invalid unit ' phx'. Valid units are: {}", valid_units));
     assert_eq!(parse_number_literal("10000001 phx".into()), wrong_unit_spaced);

--- a/internal/compiler/literals.rs
+++ b/internal/compiler/literals.rs
@@ -3,8 +3,7 @@
 
 // cSpell: ignore qsdf
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Span, Spanned};
-use crate::expression_tree::Expression;
-use crate::expression_tree::Unit;
+use crate::expression_tree::SurfaceUnit;
 use itertools::Itertools;
 use smol_str::SmolStr;
 use strum::IntoEnumIterator;
@@ -328,7 +327,7 @@ impl StringLiteralSourceMap {
     }
 }
 
-pub fn parse_number_literal(s: SmolStr) -> Result<Expression, SmolStr> {
+pub fn parse_number_literal(s: SmolStr) -> Result<(f64, SurfaceUnit), SmolStr> {
     let bytes = s.as_bytes();
     let mut end = 0;
     while end < bytes.len() && matches!(bytes[end], b'0'..=b'9' | b'.') {
@@ -339,43 +338,38 @@ pub fn parse_number_literal(s: SmolStr) -> Result<Expression, SmolStr> {
         format!(
             "Invalid unit '{}'. Valid units are: {}",
             s.get(end..).unwrap_or(&s),
-            Unit::iter().filter(|x| !x.to_string().is_empty()).join(", ")
+            SurfaceUnit::iter().filter(|x| !x.to_string().is_empty()).join(", ")
         )
     })?;
-    Ok(Expression::NumberLiteral(val, unit))
+    Ok((val, unit))
 }
 
 #[test]
 fn test_parse_number_literal() {
-    use crate::expression_tree::Unit;
+    use crate::expression_tree::SurfaceUnit;
     use smol_str::{ToSmolStr, format_smolstr};
 
-    fn doit(s: &str) -> Result<(f64, Unit), SmolStr> {
-        parse_number_literal(s.into()).map(|e| match e {
-            Expression::NumberLiteral(a, b) => (a, b),
-            _ => panic!(),
-        })
-    }
-
-    assert_eq!(doit("10"), Ok((10., Unit::None)));
-    assert_eq!(doit("10phx"), Ok((10., Unit::Phx)));
-    assert_eq!(doit("10.0phx"), Ok((10., Unit::Phx)));
-    assert_eq!(doit("10.0"), Ok((10., Unit::None)));
-    assert_eq!(doit("1.1phx"), Ok((1.1, Unit::Phx)));
-    assert_eq!(doit("10.10"), Ok((10.10, Unit::None)));
-    assert_eq!(doit("10000000"), Ok((10000000., Unit::None)));
-    assert_eq!(doit("10000001phx"), Ok((10000001., Unit::Phx)));
+    assert_eq!(parse_number_literal("10".into()), Ok((10., SurfaceUnit::None)));
+    assert_eq!(parse_number_literal("10phx".into()), Ok((10., SurfaceUnit::Phx)));
+    assert_eq!(parse_number_literal("10.0phx".into()), Ok((10., SurfaceUnit::Phx)));
+    assert_eq!(parse_number_literal("10.0".into()), Ok((10., SurfaceUnit::None)));
+    assert_eq!(parse_number_literal("1.1phx".into()), Ok((1.1, SurfaceUnit::Phx)));
+    assert_eq!(parse_number_literal("10.10".into()), Ok((10.10, SurfaceUnit::None)));
+    assert_eq!(parse_number_literal("10000000".into()), Ok((10000000., SurfaceUnit::None)));
+    assert_eq!(parse_number_literal("10000001phx".into()), Ok((10000001., SurfaceUnit::Phx)));
+    assert_eq!(parse_number_literal("5cm".into()), Ok((5., SurfaceUnit::Cm)));
+    assert_eq!(parse_number_literal("90grad".into()), Ok((90., SurfaceUnit::Grad)));
 
     let cannot_parse = Err("Cannot parse number literal".to_smolstr());
-    assert_eq!(doit("12.10.12phx"), cannot_parse);
+    assert_eq!(parse_number_literal("12.10.12phx".into()), cannot_parse);
 
-    let valid_units = Unit::iter().filter(|x| !x.to_string().is_empty()).join(", ");
+    let valid_units = SurfaceUnit::iter().filter(|x| !x.to_string().is_empty()).join(", ");
     let wrong_unit_spaced =
         Err(format_smolstr!("Invalid unit ' phx'. Valid units are: {}", valid_units));
-    assert_eq!(doit("10000001 phx"), wrong_unit_spaced);
+    assert_eq!(parse_number_literal("10000001 phx".into()), wrong_unit_spaced);
     let wrong_unit_oo = Err(format_smolstr!("Invalid unit 'oo'. Valid units are: {}", valid_units));
-    assert_eq!(doit("12.12oo"), wrong_unit_oo);
+    assert_eq!(parse_number_literal("12.12oo".into()), wrong_unit_oo);
     let wrong_unit_euro =
         Err(format_smolstr!("Invalid unit '€'. Valid units are: {}", valid_units));
-    assert_eq!(doit("12.12€"), wrong_unit_euro);
+    assert_eq!(parse_number_literal("12.12€".into()), wrong_unit_euro);
 }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -76,9 +76,7 @@ pub fn lower_expression(
         }
         tree_Expression::Uncompiled(_) => panic!(),
         tree_Expression::StringLiteral(s) => llr_Expression::StringLiteral(s.clone()),
-        tree_Expression::NumberLiteral(n, unit) => {
-            llr_Expression::NumberLiteral(unit.normalize(*n))
-        }
+        tree_Expression::NumberLiteral(n, _unit) => llr_Expression::NumberLiteral(*n),
         tree_Expression::BoolLiteral(b) => llr_Expression::BoolLiteral(*b),
         tree_Expression::PropertyReference(nr) => {
             llr_Expression::PropertyReference(ctx.map_property_reference(nr))

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -75,14 +75,10 @@ fn simplify_expression(
                 ('+', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
                     Some(Expression::StringLiteral(format_smolstr!("{}{}", a, b)))
                 }
-                ('+', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
-                    if un1 == un2 =>
-                {
+                ('+', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, _)) => {
                     Some(Expression::NumberLiteral(*a + *b, *un1))
                 }
-                ('-', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
-                    if un1 == un2 =>
-                {
+                ('-', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, _)) => {
                     Some(Expression::NumberLiteral(*a - *b, *un1))
                 }
                 ('*', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
@@ -127,14 +123,10 @@ fn simplify_expression(
                 }
                 ('|', Expression::BoolLiteral(false), e) => Some(std::mem::take(e)),
                 ('|', e, Expression::BoolLiteral(false)) => Some(std::mem::take(e)),
-                ('>', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
-                    if un1 == un2 =>
-                {
+                ('>', Expression::NumberLiteral(a, _), Expression::NumberLiteral(b, _)) => {
                     Some(Expression::BoolLiteral(*a > *b))
                 }
-                ('<', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
-                    if un1 == un2 =>
-                {
+                ('<', Expression::NumberLiteral(a, _), Expression::NumberLiteral(b, _)) => {
                     Some(Expression::BoolLiteral(*a < *b))
                 }
                 _ => None,
@@ -674,4 +666,53 @@ export component Foo inherits Window {
         matches!(test_binding, Expression::NumberLiteral(val, _) if val == 5.0),
         "Expression should be 5.0: {test_binding:?}"
     );
+}
+
+#[test]
+fn test_unit_normalization() {
+    // Compile `out property <ty> a: expr;` and return the folded binding of `a`.
+    fn fold(ty: &str, expr: &str) -> Expression {
+        let mut config =
+            crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        config.style = Some("fluent".into());
+        let mut diags = crate::diagnostics::BuildDiagnostics::default();
+        let doc_node = crate::parser::parse(
+            format!("export component Foo {{ out property <{ty}> a: {expr}; }}").into(),
+            Some(std::path::Path::new("HELLO")),
+            &mut diags,
+        );
+        let (doc, diag, _) = spin_on::spin_on(crate::compile_syntax_node(doc_node, diags, config));
+        assert!(!diag.has_errors(), "{expr}: {:#?}", diag.to_string_vec());
+        doc.inner_components.last().unwrap().root_element.borrow().bindings["a"]
+            .borrow()
+            .expression
+            .clone()
+    }
+
+    // A literal is stored in its type's canonical unit, not the one it was written in.
+    assert!(matches!(fold("length", "1in"), Expression::NumberLiteral(v, Unit::Px) if v == 96.0));
+    assert!(
+        matches!(fold("duration", "2s"), Expression::NumberLiteral(v, Unit::Ms) if v == 2000.0)
+    );
+
+    // Mixed units of one type now fold, because they share a canonical unit.
+    assert!(
+        matches!(fold("length", "5px + 5cm"), Expression::NumberLiteral(v, Unit::Px) if v == 194.0),
+        "{:?}",
+        fold("length", "5px + 5cm")
+    );
+    assert!(
+        matches!(fold("duration", "1s - 500ms"), Expression::NumberLiteral(v, Unit::Ms) if v == 500.0)
+    );
+    assert!(
+        matches!(fold("length", "max(12cm, 12px)"), Expression::NumberLiteral(v, Unit::Px) if v == 12.0 * 37.8),
+        "{:?}",
+        fold("length", "max(12cm, 12px)")
+    );
+
+    // Comparisons fold on the normalized values, so different units compare correctly.
+    assert!(matches!(fold("bool", "12cm == 12px"), Expression::BoolLiteral(false)));
+    assert!(matches!(fold("bool", "1s == 1000ms"), Expression::BoolLiteral(true)));
+    assert!(matches!(fold("bool", "12cm < 12px"), Expression::BoolLiteral(false)));
+    assert!(matches!(fold("bool", "1turn == 360deg"), Expression::BoolLiteral(true)));
 }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -496,6 +496,10 @@ impl Expression {
                         ctx.diag.slint_sc_error("Number literals are", &token);
                         Some(
                             crate::literals::parse_number_literal(token.text().into())
+                                .map(|(value, unit)| {
+                                    let (value, unit) = unit.normalize(value);
+                                    Expression::NumberLiteral(value, unit)
+                                })
                                 .unwrap_or_else(|e| {
                                     ctx.diag.push_error(e.to_string(), &node);
                                     Self::Invalid

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -202,7 +202,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         Expression::Invalid => panic!("invalid expression while evaluating"),
         Expression::Uncompiled(_) => panic!("uncompiled expression while evaluating"),
         Expression::StringLiteral(s) => Value::String(s.as_str().into()),
-        Expression::NumberLiteral(n, unit) => Value::Number(unit.normalize(*n)),
+        Expression::NumberLiteral(n, _unit) => Value::Number(*n),
         Expression::BoolLiteral(b) => Value::Bool(*b),
         Expression::ElementReference(_) => todo!(
             "Element references are only supported in the context of built-in function calls at the moment"

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -38,7 +38,7 @@ fn eval_expression(
 
     match expression {
         Expression::StringLiteral(s) => Value::String(s.as_str().into()),
-        Expression::NumberLiteral(n, unit) => Value::Number(unit.normalize(*n)),
+        Expression::NumberLiteral(n, _unit) => Value::Number(*n),
         Expression::BoolLiteral(b) => Value::Bool(*b),
         Expression::StructFieldAccess { base, name } => {
             if let Value::Struct(o) = eval_expression(

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -468,7 +468,7 @@ fn string_to_code(
     }
 }
 
-fn unit_model(units: &[expression_tree::Unit]) -> ModelRc<SharedString> {
+fn unit_model(units: &[expression_tree::SurfaceUnit]) -> ModelRc<SharedString> {
     Rc::new(VecModel::from(
         units.iter().map(|u| u.to_string().into()).collect::<Vec<SharedString>>(),
     ))
@@ -620,7 +620,7 @@ fn map_value_and_type(
             ..Default::default()
         });
     }
-    use i_slint_compiler::expression_tree::Unit;
+    use i_slint_compiler::expression_tree::SurfaceUnit;
     use langtype::Type;
 
     match ty {
@@ -651,11 +651,11 @@ fn map_value_and_type(
         Type::Duration => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Ms),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Ms),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::S, Unit::Ms]),
+                visual_items: unit_model(&[SurfaceUnit::S, SurfaceUnit::Ms]),
                 value_int: 1,
                 code: get_code(value),
                 default_selection: 1,
@@ -666,18 +666,18 @@ fn map_value_and_type(
         Type::PhysicalLength => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Phx),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Phx),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[
-                    Unit::Px,
-                    Unit::Cm,
-                    Unit::Mm,
-                    Unit::In,
-                    Unit::Pt,
-                    Unit::Phx,
-                    Unit::Rem,
+                    SurfaceUnit::Px,
+                    SurfaceUnit::Cm,
+                    SurfaceUnit::Mm,
+                    SurfaceUnit::In,
+                    SurfaceUnit::Pt,
+                    SurfaceUnit::Phx,
+                    SurfaceUnit::Rem,
                 ]),
                 value_int: 5,
                 code: get_code(value),
@@ -689,18 +689,18 @@ fn map_value_and_type(
         Type::LogicalLength => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Px),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Px),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[
-                    Unit::Px,
-                    Unit::Cm,
-                    Unit::Mm,
-                    Unit::In,
-                    Unit::Pt,
-                    Unit::Phx,
-                    Unit::Rem,
+                    SurfaceUnit::Px,
+                    SurfaceUnit::Cm,
+                    SurfaceUnit::Mm,
+                    SurfaceUnit::In,
+                    SurfaceUnit::Pt,
+                    SurfaceUnit::Phx,
+                    SurfaceUnit::Rem,
                 ]),
                 value_int: 0,
                 code: get_code(value),
@@ -712,18 +712,18 @@ fn map_value_and_type(
         Type::Rem => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Rem),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Rem),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[
-                    Unit::Px,
-                    Unit::Cm,
-                    Unit::Mm,
-                    Unit::In,
-                    Unit::Pt,
-                    Unit::Phx,
-                    Unit::Rem,
+                    SurfaceUnit::Px,
+                    SurfaceUnit::Cm,
+                    SurfaceUnit::Mm,
+                    SurfaceUnit::In,
+                    SurfaceUnit::Pt,
+                    SurfaceUnit::Phx,
+                    SurfaceUnit::Rem,
                 ]),
                 value_int: 6,
                 code: get_code(value),
@@ -735,11 +735,16 @@ fn map_value_and_type(
         Type::Angle => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Deg),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Deg),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::Deg, Unit::Grad, Unit::Turn, Unit::Rad]),
+                visual_items: unit_model(&[
+                    SurfaceUnit::Deg,
+                    SurfaceUnit::Grad,
+                    SurfaceUnit::Turn,
+                    SurfaceUnit::Rad,
+                ]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 0,
@@ -750,11 +755,15 @@ fn map_value_and_type(
         Type::Percent => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Percent),
+                display_string: slint::format!(
+                    "{}{}",
+                    get_value::<f32>(value),
+                    SurfaceUnit::Percent
+                ),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::Percent]),
+                visual_items: unit_model(&[SurfaceUnit::Percent]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 0,

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -468,7 +468,7 @@ fn string_to_code(
     }
 }
 
-fn unit_model(units: &[expression_tree::SurfaceUnit]) -> ModelRc<SharedString> {
+fn unit_model(units: &[expression_tree::WrittenUnit]) -> ModelRc<SharedString> {
     Rc::new(VecModel::from(
         units.iter().map(|u| u.to_string().into()).collect::<Vec<SharedString>>(),
     ))
@@ -620,7 +620,7 @@ fn map_value_and_type(
             ..Default::default()
         });
     }
-    use i_slint_compiler::expression_tree::SurfaceUnit;
+    use i_slint_compiler::expression_tree::WrittenUnit;
     use langtype::Type;
 
     match ty {
@@ -651,11 +651,11 @@ fn map_value_and_type(
         Type::Duration => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Ms),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), WrittenUnit::Ms),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[SurfaceUnit::S, SurfaceUnit::Ms]),
+                visual_items: unit_model(&[WrittenUnit::S, WrittenUnit::Ms]),
                 value_int: 1,
                 code: get_code(value),
                 default_selection: 1,
@@ -666,18 +666,18 @@ fn map_value_and_type(
         Type::PhysicalLength => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Phx),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), WrittenUnit::Phx),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[
-                    SurfaceUnit::Px,
-                    SurfaceUnit::Cm,
-                    SurfaceUnit::Mm,
-                    SurfaceUnit::In,
-                    SurfaceUnit::Pt,
-                    SurfaceUnit::Phx,
-                    SurfaceUnit::Rem,
+                    WrittenUnit::Px,
+                    WrittenUnit::Cm,
+                    WrittenUnit::Mm,
+                    WrittenUnit::In,
+                    WrittenUnit::Pt,
+                    WrittenUnit::Phx,
+                    WrittenUnit::Rem,
                 ]),
                 value_int: 5,
                 code: get_code(value),
@@ -689,18 +689,18 @@ fn map_value_and_type(
         Type::LogicalLength => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Px),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), WrittenUnit::Px),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[
-                    SurfaceUnit::Px,
-                    SurfaceUnit::Cm,
-                    SurfaceUnit::Mm,
-                    SurfaceUnit::In,
-                    SurfaceUnit::Pt,
-                    SurfaceUnit::Phx,
-                    SurfaceUnit::Rem,
+                    WrittenUnit::Px,
+                    WrittenUnit::Cm,
+                    WrittenUnit::Mm,
+                    WrittenUnit::In,
+                    WrittenUnit::Pt,
+                    WrittenUnit::Phx,
+                    WrittenUnit::Rem,
                 ]),
                 value_int: 0,
                 code: get_code(value),
@@ -712,18 +712,18 @@ fn map_value_and_type(
         Type::Rem => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Rem),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), WrittenUnit::Rem),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[
-                    SurfaceUnit::Px,
-                    SurfaceUnit::Cm,
-                    SurfaceUnit::Mm,
-                    SurfaceUnit::In,
-                    SurfaceUnit::Pt,
-                    SurfaceUnit::Phx,
-                    SurfaceUnit::Rem,
+                    WrittenUnit::Px,
+                    WrittenUnit::Cm,
+                    WrittenUnit::Mm,
+                    WrittenUnit::In,
+                    WrittenUnit::Pt,
+                    WrittenUnit::Phx,
+                    WrittenUnit::Rem,
                 ]),
                 value_int: 6,
                 code: get_code(value),
@@ -735,15 +735,15 @@ fn map_value_and_type(
         Type::Angle => {
             mapping.headers.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
-                display_string: slint::format!("{}{}", get_value::<f32>(value), SurfaceUnit::Deg),
+                display_string: slint::format!("{}{}", get_value::<f32>(value), WrittenUnit::Deg),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[
-                    SurfaceUnit::Deg,
-                    SurfaceUnit::Grad,
-                    SurfaceUnit::Turn,
-                    SurfaceUnit::Rad,
+                    WrittenUnit::Deg,
+                    WrittenUnit::Grad,
+                    WrittenUnit::Turn,
+                    WrittenUnit::Rad,
                 ]),
                 value_int: 0,
                 code: get_code(value),
@@ -758,12 +758,12 @@ fn map_value_and_type(
                 display_string: slint::format!(
                     "{}{}",
                     get_value::<f32>(value),
-                    SurfaceUnit::Percent
+                    WrittenUnit::Percent
                 ),
                 kind: PropertyValueKind::Float,
                 value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[SurfaceUnit::Percent]),
+                visual_items: unit_model(&[WrittenUnit::Percent]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 0,

--- a/tools/lsp/preview/ui/property_view.rs
+++ b/tools/lsp/preview/ui/property_view.rs
@@ -81,18 +81,18 @@ fn map_property_to_ui(
 
         fn extract_value_with_unit(
             expression: &syntax_nodes::Expression,
-            units: &[expression_tree::SurfaceUnit],
+            units: &[expression_tree::WrittenUnit],
             value: &mut ui::PropertyValue,
         ) {
             fn extract_value_with_unit_impl(
                 expression: &syntax_nodes::Expression,
-                units: &[i_slint_compiler::expression_tree::SurfaceUnit],
+                units: &[i_slint_compiler::expression_tree::WrittenUnit],
             ) -> Option<(ui::PropertyValueKind, f32, i32, String)> {
                 let (value, unit) = convert_number_literal(expression)?;
 
                 let index = units.iter().position(|u| u == &unit).or_else(|| {
                     (units.is_empty()
-                        && unit == i_slint_compiler::expression_tree::SurfaceUnit::None)
+                        && unit == i_slint_compiler::expression_tree::WrittenUnit::None)
                         .then_some(0_usize)
                 })?;
 
@@ -154,36 +154,36 @@ fn map_property_to_ui(
         }
 
         if value.value_kind == ui::PropertyValueKind::Float {
-            use expression_tree::SurfaceUnit;
+            use expression_tree::WrittenUnit;
             use langtype::Type;
 
             match &property_info.ty {
                 Type::Float32 => extract_value_with_unit(expression, &[], &mut value),
                 Type::Duration => extract_value_with_unit(
                     expression,
-                    &[SurfaceUnit::S, SurfaceUnit::Ms],
+                    &[WrittenUnit::S, WrittenUnit::Ms],
                     &mut value,
                 ),
                 Type::PhysicalLength | Type::LogicalLength | Type::Rem => extract_value_with_unit(
                     expression,
                     &[
-                        SurfaceUnit::Px,
-                        SurfaceUnit::Cm,
-                        SurfaceUnit::Mm,
-                        SurfaceUnit::In,
-                        SurfaceUnit::Pt,
-                        SurfaceUnit::Phx,
-                        SurfaceUnit::Rem,
+                        WrittenUnit::Px,
+                        WrittenUnit::Cm,
+                        WrittenUnit::Mm,
+                        WrittenUnit::In,
+                        WrittenUnit::Pt,
+                        WrittenUnit::Phx,
+                        WrittenUnit::Rem,
                     ],
                     &mut value,
                 ),
                 Type::Angle => extract_value_with_unit(
                     expression,
-                    &[SurfaceUnit::Deg, SurfaceUnit::Grad, SurfaceUnit::Turn, SurfaceUnit::Rad],
+                    &[WrittenUnit::Deg, WrittenUnit::Grad, WrittenUnit::Turn, WrittenUnit::Rad],
                     &mut value,
                 ),
                 Type::Percent => {
-                    extract_value_with_unit(expression, &[SurfaceUnit::Percent], &mut value)
+                    extract_value_with_unit(expression, &[WrittenUnit::Percent], &mut value)
                 }
                 _ => {}
             }
@@ -364,7 +364,7 @@ fn map_property_definition(
 
 fn convert_number_literal(
     node: &syntax_nodes::Expression,
-) -> Option<(f64, i_slint_compiler::expression_tree::SurfaceUnit)> {
+) -> Option<(f64, i_slint_compiler::expression_tree::WrittenUnit)> {
     if let Some(unary) = &node.UnaryOpExpression() {
         let factor = match unary.first_token().unwrap().text() {
             "-" => -1.0,

--- a/tools/lsp/preview/ui/property_view.rs
+++ b/tools/lsp/preview/ui/property_view.rs
@@ -81,17 +81,18 @@ fn map_property_to_ui(
 
         fn extract_value_with_unit(
             expression: &syntax_nodes::Expression,
-            units: &[expression_tree::Unit],
+            units: &[expression_tree::SurfaceUnit],
             value: &mut ui::PropertyValue,
         ) {
             fn extract_value_with_unit_impl(
                 expression: &syntax_nodes::Expression,
-                units: &[i_slint_compiler::expression_tree::Unit],
+                units: &[i_slint_compiler::expression_tree::SurfaceUnit],
             ) -> Option<(ui::PropertyValueKind, f32, i32, String)> {
                 let (value, unit) = convert_number_literal(expression)?;
 
                 let index = units.iter().position(|u| u == &unit).or_else(|| {
-                    (units.is_empty() && unit == i_slint_compiler::expression_tree::Unit::None)
+                    (units.is_empty()
+                        && unit == i_slint_compiler::expression_tree::SurfaceUnit::None)
                         .then_some(0_usize)
                 })?;
 
@@ -153,25 +154,37 @@ fn map_property_to_ui(
         }
 
         if value.value_kind == ui::PropertyValueKind::Float {
-            use expression_tree::Unit;
+            use expression_tree::SurfaceUnit;
             use langtype::Type;
 
             match &property_info.ty {
                 Type::Float32 => extract_value_with_unit(expression, &[], &mut value),
-                Type::Duration => {
-                    extract_value_with_unit(expression, &[Unit::S, Unit::Ms], &mut value)
-                }
+                Type::Duration => extract_value_with_unit(
+                    expression,
+                    &[SurfaceUnit::S, SurfaceUnit::Ms],
+                    &mut value,
+                ),
                 Type::PhysicalLength | Type::LogicalLength | Type::Rem => extract_value_with_unit(
                     expression,
-                    &[Unit::Px, Unit::Cm, Unit::Mm, Unit::In, Unit::Pt, Unit::Phx, Unit::Rem],
+                    &[
+                        SurfaceUnit::Px,
+                        SurfaceUnit::Cm,
+                        SurfaceUnit::Mm,
+                        SurfaceUnit::In,
+                        SurfaceUnit::Pt,
+                        SurfaceUnit::Phx,
+                        SurfaceUnit::Rem,
+                    ],
                     &mut value,
                 ),
                 Type::Angle => extract_value_with_unit(
                     expression,
-                    &[Unit::Deg, Unit::Grad, Unit::Turn, Unit::Rad],
+                    &[SurfaceUnit::Deg, SurfaceUnit::Grad, SurfaceUnit::Turn, SurfaceUnit::Rad],
                     &mut value,
                 ),
-                Type::Percent => extract_value_with_unit(expression, &[Unit::Percent], &mut value),
+                Type::Percent => {
+                    extract_value_with_unit(expression, &[SurfaceUnit::Percent], &mut value)
+                }
                 _ => {}
             }
         }
@@ -351,7 +364,7 @@ fn map_property_definition(
 
 fn convert_number_literal(
     node: &syntax_nodes::Expression,
-) -> Option<(f64, i_slint_compiler::expression_tree::Unit)> {
+) -> Option<(f64, i_slint_compiler::expression_tree::SurfaceUnit)> {
     if let Some(unary) = &node.UnaryOpExpression() {
         let factor = match unary.first_token().unwrap().text() {
             "-" => -1.0,
@@ -361,14 +374,7 @@ fn convert_number_literal(
         convert_number_literal(&unary.Expression()).map(|(v, u)| (factor * v, u))
     } else {
         let literal = node.child_text(SyntaxKind::NumberLiteral)?;
-        let expr = literals::parse_number_literal(literal).ok()?;
-
-        match expr {
-            i_slint_compiler::expression_tree::Expression::NumberLiteral(value, unit) => {
-                Some((value, unit))
-            }
-            _ => None,
-        }
+        literals::parse_number_literal(literal).ok()
     }
 }
 


### PR DESCRIPTION
Based on some findings in #12363:

A NumberLiteral used to carry whatever unit the user typed (cm, pt, grad, ...), and the scale to the canonical unit was only applied at LLR lowering. Every tree pass in between therefore compared raw authored values: const propagation folded `12cm == 12px` to true and `1s == 1000ms` to false, and would not fold `5px + 5cm` at all.

Split the unit into two types: `SurfaceUnit` for the spellings a user can type, kept only in the parser and tooling, and `Unit` for the canonical unit of each type, which is all a `NumberLiteral` stores. A literal is normalized via `SurfaceUnit::normalize` the moment it enters the tree, so a non-canonical unit is unrepresentable there and no pass ever sees one.

Number literals of one type now always share a unit, so const propagation drops the unit-equality guards on `+`, `-` and comparisons and folds these cases correctly.

Generated code is otherwise unchanged; the same scaling now happens at parse time instead of at lowering.