### PR TITLE
Fix Visual Editor compile names

### DIFF
--- a/tools/lsp/preview/connector/remote.rs
+++ b/tools/lsp/preview/connector/remote.rs
@@ -259,7 +259,7 @@ impl RemoteLspToPreview {
         // component, so the viewer leaves its idle screen on its own.
         let _ = shared
             .preview_to_lsp_sender
-            .send(PreviewToLspMessage::RequestState { files: Vec::new() });
+            .send(PreviewToLspMessage::RequestState { files: Vec::new(), settings: Vec::new() });
 
         Ok(())
     }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -293,8 +293,8 @@ export component PreviewUi inherits Window {
                         preview-area-is-current: preview.preview-is-current;
                         visible-component: root.visible-component;
 
-                        show-preview-for(component-name, defined-at) => {
-                            Api.show-preview-for(component-name, defined-at);
+                        show-preview-for(component_name, defined_at) => {
+                            Api.show-preview-for(component_name, defined_at);
                         }
                     }
 

--- a/tools/lsp/ui/visual-editor/components/editor-tree-view.slint
+++ b/tools/lsp/ui/visual-editor/components/editor-tree-view.slint
@@ -114,7 +114,7 @@ component EditorTreeRow {
                     width: parent.width - self.x;
                     height: parent.height;
                     border-radius: EditorTreeTokens.row-radius;
-                    border-width: row-drop.contains-drag
+                    border-width: row-drop.has-drag
                         && root.drop-allowed
                         && root.active-drop-location == DropLocation.onto
                         ? EditorTreeTokens.drop-target-border-width
@@ -124,7 +124,7 @@ component EditorTreeRow {
                     border-color: EditorTreeTokens.accent;
                     background: root.current
                         ? EditorTreeTokens.row-bg-current
-                        : row-drop.contains-drag
+                        : row-drop.has-drag
                         && root.drop-allowed
                         && root.active-drop-location == DropLocation.onto
                         ? EditorTreeTokens.drop-target-bg
@@ -286,7 +286,7 @@ component EditorTreeRow {
                         }
                     }
 
-                    if row-drop.contains-drag && root.drop-allowed && root.active-drop-location != DropLocation.onto: Rectangle {
+                    if row-drop.has-drag && root.drop-allowed && root.active-drop-location != DropLocation.onto: Rectangle {
                         x: EditorTreeTokens.row-padding-inline
                             + root.gutter-segments * (EditorTreeTokens.toggle-width + EditorTreeTokens.content-gap)
                             + EditorTreeTokens.disclosure-hit-size

--- a/tools/lsp/ui/visual-editor/components/outline-pane.slint
+++ b/tools/lsp/ui/visual-editor/components/outline-pane.slint
@@ -91,13 +91,13 @@ export component OutlinePane inherits Rectangle {
 
                 root-drop-target := Rectangle {
                     width: parent.width;
-                    height: root-drop-area.contains-drag ? 28px : EditorTreeTokens.root-drop-height;
+                    height: root-drop-area.has-drag ? 28px : EditorTreeTokens.root-drop-height;
                     border-radius: EditorTreeTokens.row-radius;
-                    border-width: root-drop-area.contains-drag && self.drop-allowed
+                    border-width: root-drop-area.has-drag && self.drop-allowed
                         ? EditorTreeTokens.drop-target-border-width
                         : 0px;
                     border-color: EditorTreeTokens.accent;
-                    background: root-drop-area.contains-drag && self.drop-allowed
+                    background: root-drop-area.has-drag && self.drop-allowed
                         ? EditorTreeTokens.drop-target-bg
                         : transparent;
                     property <bool> drop-allowed: false;
@@ -147,7 +147,7 @@ export component OutlinePane inherits Rectangle {
                     }
 
                     Text {
-                        visible: root-drop-area.contains-drag && root-drop-target.drop-allowed;
+                        visible: root-drop-area.has-drag && root-drop-target.drop-allowed;
                         x: EditorTreeTokens.row-padding-inline;
                         width: parent.width - 2 * self.x;
                         text: "Drop as child of root";


### PR DESCRIPTION
- update Visual Editor DropArea bindings from contains-drag to has-drag
- rename callback parameters in the library view connection to valid identifiers

