### PR TITLE
Added a CustomImage component

### DIFF
--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -173,6 +173,55 @@ impl SkiaRendererAdapter {
             _drm_output: None,
         });
 
+        renderer.renderer.set_pixel_pre_present_callback(Some(Box::new(
+            move |pixels, fb_width, fb_height, color_type| {
+                let (format, bytes_per_pixel) = match color_type {
+                    skia_safe::ColorType::RGBA8888 => {
+                        (i_slint_core::items::FramebufferPixelFormat::Rgba8888, 4)
+                    }
+                    skia_safe::ColorType::BGRA8888 => {
+                        (i_slint_core::items::FramebufferPixelFormat::Bgra8888, 4)
+                    }
+                    skia_safe::ColorType::RGB565 => {
+                        (i_slint_core::items::FramebufferPixelFormat::Rgb565, 2)
+                    }
+                    // No other format currently negotiated by SKIA_SUPPORTED_DRM_FOURCC_FORMATS
+                    // maps to a pixel layout a CustomImage provider can target.
+                    _ => return,
+                };
+                let stride = fb_width * bytes_per_pixel;
+
+                i_slint_core::items::with_custom_image_providers(|item_rc, provider| {
+                    let Some(window_adapter) = item_rc.window_adapter() else { return };
+                    let scale_factor = window_adapter.window().scale_factor();
+                    let geometry = item_rc.geometry();
+                    let origin = item_rc.map_to_window(geometry.origin);
+
+                    // Clip to the framebuffer
+                    let x0 =
+                        ((origin.x * scale_factor).round() as i64).clamp(0, fb_width as i64) as u32;
+                    let y0 = ((origin.y * scale_factor).round() as i64).clamp(0, fb_height as i64)
+                        as u32;
+                    let x1 = (((origin.x + geometry.size.width) * scale_factor).round() as i64)
+                        .clamp(0, fb_width as i64) as u32;
+                    let y1 = (((origin.y + geometry.size.height) * scale_factor).round() as i64)
+                        .clamp(0, fb_height as i64) as u32;
+                    if x0 >= x1 || y0 >= y1 {
+                        return;
+                    }
+
+                    let region = i_slint_core::items::FramebufferRegion {
+                        x: x0,
+                        y: y0,
+                        width: x1 - x0,
+                        height: y1 - y0,
+                        stride,
+                    };
+                    provider(&mut *pixels, region, format);
+                });
+            },
+        )));
+
         eprintln!("Using Skia Software renderer");
 
         Ok(renderer)

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -497,6 +497,15 @@ export component ComponentContainer inherits Empty {
     //-accepts_focus
 }
 
+/// Gives applications the ability to blit pixel data directly to the framebuffer
+/// Only works with the linuxkms software renderer
+/// Use image handles if using a GPU based backend
+/// No visual properties and cannot have children
+export component CustomImage inherits Empty {
+    //-disallow_global_types_as_child_elements
+    //-keep_native_class
+}
+
 export component Transform inherits Empty {
     in property <angle> transform-rotation;
     in property <percent> transform-scale-x;

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -486,9 +486,13 @@ fn generate_public_component(
         }
     };
 
+    let custom_image_accessors = generate_custom_image_accessors(llr, unit, &public_component_id);
+
     quote!(
         #component
         pub struct #public_component_id(sp::VRc<sp::ItemTreeVTable, #inner_component_id>);
+
+        #custom_image_accessors
 
         impl #public_component_id {
             pub fn new() -> ::core::result::Result<Self, slint::PlatformError> {
@@ -2651,6 +2655,80 @@ fn generate_repeated_component(
 /// Return an identifier suitable for this component for internal use
 fn inner_component_id(component: &llr::SubComponent) -> proc_macro2::Ident {
     format_ident!("Inner{}", ident(&component.name))
+}
+
+/// Finds every `CustomImage` item reachable through the *static* component tree
+/// Returns a list of matches with the name and
+/// the path to walk from `root` to `SubComponent` that owns it
+fn find_custom_image_items(
+    unit: &llr::CompilationUnit,
+    root: llr::SubComponentIdx,
+) -> Vec<(SmolStr, Vec<llr::SubComponentInstanceIdx>, llr::ItemInstanceIdx)> {
+    fn visit(
+        unit: &llr::CompilationUnit,
+        sub_component_idx: llr::SubComponentIdx,
+        path: &mut Vec<llr::SubComponentInstanceIdx>,
+        out: &mut Vec<(SmolStr, Vec<llr::SubComponentInstanceIdx>, llr::ItemInstanceIdx)>,
+    ) {
+        let sub_component = &unit.sub_components[sub_component_idx];
+        for (item_idx, item) in sub_component.items.iter_enumerated() {
+            if item.ty.class_name == "CustomImage" {
+                out.push((item.name.clone(), path.clone(), item_idx));
+            }
+        }
+        for (instance_idx, instance) in sub_component.sub_components.iter_enumerated() {
+            path.push(instance_idx);
+            visit(unit, instance.ty, path, out);
+            path.pop();
+        }
+    }
+    let mut out = Vec::new();
+    visit(unit, root, &mut Vec::new(), &mut out);
+    out
+}
+
+/// Generates one accessor per named instance called `custom_image` returning a `CustomImageHandle`
+fn generate_custom_image_accessors(
+    llr: &llr::PublicComponent,
+    unit: &llr::CompilationUnit,
+    public_component_id: &proc_macro2::Ident,
+) -> TokenStream {
+    let items = find_custom_image_items(unit, llr.item_tree.root);
+    let accessors = items.iter().map(|(name, path, item_idx)| {
+        let method_name = if items.len() == 1 {
+            format_ident!("custom_image")
+        } else {
+            ident(name)
+        };
+
+        let mut access_tokens = quote!(_self);
+        let mut sub_component = &unit.sub_components[llr.item_tree.root];
+        for instance_idx in path {
+            let instance_name = ident(&sub_component.sub_components[*instance_idx].name);
+            access_tokens = quote!(#access_tokens . #instance_name);
+            sub_component = &unit.sub_components[sub_component.sub_components[*instance_idx].ty];
+        }
+
+        let local_index_in_tree = sub_component.items[*item_idx].index_in_tree;
+        let item_index_tokens = if local_index_in_tree == 0 {
+            quote!(#access_tokens.tree_index.get())
+        } else {
+            quote!(#access_tokens.tree_index_of_first_child.get() + #local_index_in_tree - 1)
+        };
+
+        quote!(
+            pub fn #method_name(&self) -> sp::CustomImageHandle {
+                let _self = sp::VRc::as_pin_ref(&self.0);
+                let origin = sp::VRcMapped::origin(&#access_tokens.self_weak.get().unwrap().upgrade().unwrap());
+                sp::CustomImageHandle::new(sp::ItemRc::new(origin, #item_index_tokens))
+            }
+        )
+    });
+    quote!(
+        impl #public_component_id {
+            #(#accessors)*
+        }
+    )
 }
 
 fn internal_popup_id(index: usize) -> proc_macro2::Ident {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -783,6 +783,9 @@ pub struct NativeClass {
     /// Type override if class_name is not equal to the name to be used in the
     /// target language API.
     pub builtin_struct: Option<BuiltinStruct>,
+    /// Needed for items whose identity must remain stable throughout codegen regardless if its
+    /// properties are used or not
+    pub keep_native_class: bool,
 }
 
 impl NativeClass {

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -146,6 +146,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
             .collect();
         n.builtin_struct = parse_annotation("builtin_struct", &e)
             .map(|x| x.unwrap().parse::<BuiltinStruct>().unwrap());
+        n.keep_native_class = parse_annotation("keep_native_class", &e).is_some();
         enum Base {
             None,
             Global,

--- a/internal/compiler/passes/resolve_native_classes.rs
+++ b/internal/compiler/passes/resolve_native_classes.rs
@@ -31,21 +31,25 @@ pub fn resolve_native_classes(component: &Component) {
                 }
             };
 
-            let analysis = elem.property_analysis.borrow();
-            let native_properties_used: HashSet<_> = elem
-                .bindings
-                .keys()
-                .chain(analysis.iter().filter(|(_, v)| v.is_used()).map(|(k, _)| k))
-                .filter(|k| {
-                    !elem.property_declarations.contains_key(*k)
-                        && base_type.as_ref().properties.contains_key(*k)
-                })
-                .collect();
+            if base_type.native_class.keep_native_class {
+                base_type.native_class.clone()
+            } else {
+                let analysis = elem.property_analysis.borrow();
+                let native_properties_used: HashSet<_> = elem
+                    .bindings
+                    .keys()
+                    .chain(analysis.iter().filter(|(_, v)| v.is_used()).map(|(k, _)| k))
+                    .filter(|k| {
+                        !elem.property_declarations.contains_key(*k)
+                            && base_type.as_ref().properties.contains_key(*k)
+                    })
+                    .collect();
 
-            select_minimal_class_based_on_property_usage(
-                &elem.base_type.as_builtin().native_class,
-                native_properties_used.into_iter(),
-            )
+                select_minimal_class_based_on_property_usage(
+                    &elem.base_type.as_builtin().native_class,
+                    native_properties_used.into_iter(),
+                )
+            }
         };
 
         elem.borrow_mut().base_type = ElementType::Native(new_native_class);

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -28,8 +28,8 @@ use crate::input::{
     KeyEventResult, KeyEventType, Keys, MouseEvent,
 };
 use crate::item_rendering::{CachedRenderingData, RenderBorderRectangle, RenderRectangle};
-use crate::item_tree::ItemTreeRc;
 pub use crate::item_tree::{ItemRc, ItemTreeVTable};
+use crate::item_tree::{ItemTreeRc, ItemWeak};
 use crate::layout::LayoutInfo;
 use crate::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, PointLengths,
@@ -40,9 +40,11 @@ pub use crate::menus::MenuItem;
 use crate::rtti::*;
 use crate::window::{WindowAdapter, WindowAdapterRc, WindowInner};
 use crate::{Callback, Coord, Property, SharedString};
+use alloc::boxed::Box;
 use alloc::rc::Rc;
+use alloc::vec::Vec;
 use const_field_offset::FieldOffsets;
-use core::cell::Cell;
+use core::cell::{Cell, RefCell};
 use core::num::NonZeroU32;
 use core::pin::Pin;
 use core::time::Duration;
@@ -438,6 +440,197 @@ impl ItemConsts for Rectangle {
 
 declare_item_vtable! {
     fn slint_get_RectangleVTable() -> RectangleVTable for Rectangle
+}
+
+#[repr(C)]
+#[derive(FieldOffsets, Default, SlintElement)]
+#[pin]
+/// Leaf item with geometry but rendered through a custom callback
+/// See `set_frame_provider` in the linuxkms software renderer.
+pub struct CustomImage {
+    pub cached_rendering_data: CachedRenderingData,
+}
+
+impl Item for CustomImage {
+    fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
+
+    fn deinit(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
+
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _cross_axis_constraint: Coord,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> LayoutInfo {
+        LayoutInfo { stretch: 1., ..LayoutInfo::default() }
+    }
+
+    fn input_event_filter_before_children(
+        self: Pin<&Self>,
+        _: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        _: &mut MouseCursor,
+    ) -> InputEventFilterResult {
+        InputEventFilterResult::ForwardAndIgnore
+    }
+
+    fn input_event(
+        self: Pin<&Self>,
+        _: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        _: &mut MouseCursor,
+    ) -> InputEventResult {
+        InputEventResult::EventIgnored
+    }
+
+    fn capture_key_event(
+        self: Pin<&Self>,
+        _: &InternalKeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn key_event(
+        self: Pin<&Self>,
+        _: &InternalKeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> FocusEventResult {
+        FocusEventResult::FocusIgnored
+    }
+
+    fn render(
+        self: Pin<&Self>,
+        _backend: &mut ItemRendererRef,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+    ) -> RenderingResult {
+        // Invisible to renderers, pixels are rendered in the callback before presenting
+        RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect(
+        self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
+}
+
+impl ItemConsts for CustomImage {
+    const cached_rendering_data_offset: const_field_offset::FieldOffset<
+        CustomImage,
+        CachedRenderingData,
+    > = CustomImage::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
+}
+
+declare_item_vtable! {
+    fn slint_get_CustomImageVTable() -> CustomImageVTable for CustomImage
+}
+
+/// Pixel layout of the region the `CustomImage` frame provider writes into
+/// The renderer translate this into the negotiated type when invoking the provider
+/// necessary as to not add skia as a dependency
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FramebufferPixelFormat {
+    Rgba8888,
+    Bgra8888,
+    Rgb565,
+}
+
+/// Region a `CustomImage`'s rect lives within the framebuffer
+#[derive(Debug, Clone, Copy)]
+pub struct FramebufferRegion {
+    /// Left edge of the rect, in physical pixels from the framebuffer's left edge.
+    pub x: u32,
+    /// Top edge of the rect, in physical pixels from the framebuffer's top edge.
+    pub y: u32,
+    /// Width of the rect, in physical pixels.
+    pub width: u32,
+    /// Height of the rect, in physical pixels.
+    pub height: u32,
+    /// Row stride of the *whole* framebuffer, in bytes. Not `width * bytes_per_pixel`: rows in
+    /// the provided buffer continue past this region's own width to the rest of the framebuffer.
+    pub stride: u32,
+}
+
+/// Invoked after painting but before presenting so it is safe to overwrite pixels
+/// callers don't need their own locking for the framebuffer itself
+/// see the linuxkms software renderer's pre-present callback
+pub type FrameProvider = dyn FnMut(&mut [u8], FramebufferRegion, FramebufferPixelFormat);
+
+crate::thread_local! {
+    #[allow(clippy::type_complexity)]
+    static CUSTOM_IMAGE_PROVIDERS: RefCell<Vec<(ItemWeak, Box<FrameProvider>)>>
+        = RefCell::new(Vec::new());
+}
+
+/// A handle to a `CustomImage` item, obtained through the
+/// `<Component>::custom_image()` accessor.
+#[derive(Clone)]
+pub struct CustomImageHandle(ItemRc);
+
+impl CustomImageHandle {
+    #[doc(hidden)]
+    pub fn new(item_rc: ItemRc) -> Self {
+        Self(item_rc)
+    }
+
+    /// The underlying item, for renderers that need to resolve its current geometry.
+    pub fn item_rc(&self) -> &ItemRc {
+        &self.0
+    }
+
+    /// Registers a `provider` to render directly to the pixels once per frame
+    /// Only has an effect when a renderer supports it (currently only the linuxkms software
+    /// renderer)
+    ///
+    /// Registering a new provider for the same `CustomImage` replaces the previous one.
+    pub fn set_frame_provider(
+        &self,
+        provider: impl FnMut(&mut [u8], FramebufferRegion, FramebufferPixelFormat) + 'static,
+    ) {
+        let weak = self.0.downgrade();
+        CUSTOM_IMAGE_PROVIDERS.with(|providers| {
+            let mut providers = providers.borrow_mut();
+            providers.retain(|(w, _)| w.upgrade().is_some_and(|i| i != self.0));
+            providers.push((weak, Box::new(provider)));
+        });
+    }
+}
+
+/// Invokes `f` once for every live
+#[doc(hidden)]
+pub fn with_custom_image_providers(mut f: impl FnMut(&ItemRc, &mut FrameProvider)) {
+    CUSTOM_IMAGE_PROVIDERS.with(|providers| {
+        let mut providers = providers.borrow_mut();
+        providers.retain_mut(|(weak, provider)| {
+            let Some(item_rc) = weak.upgrade() else { return false };
+            f(&item_rc, provider.as_mut());
+            true
+        });
+    });
 }
 
 #[repr(C)]

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -854,6 +854,19 @@ impl SkiaRenderer {
         *self.pre_present_callback.borrow_mut() = callback;
     }
 
+    /// Sets a callback that's invoked with direct, mutable access to the raw pixel buffer right
+    /// after Skia has finished painting, before it's presented. Only has an effect when the
+    /// active surface exposes a CPU-mapped framebuffer (currently the software/DRM-dumb-buffer surface)
+    #[cfg(feature = "kms")]
+    pub fn set_pixel_pre_present_callback(
+        &self,
+        callback: Option<Box<dyn FnMut(&mut [u8], u32, u32, skia_safe::ColorType)>>,
+    ) {
+        if let Some(surface) = self.surface.borrow().as_ref() {
+            surface.set_pixel_pre_present_callback(callback);
+        }
+    }
+
     fn partial_rendering_state(&self) -> Option<&PartialRenderingState> {
         // We don't know where the application might render to, so disable partial rendering.
         if self.rendering_notifier.borrow().is_some() {
@@ -1092,6 +1105,18 @@ pub trait Surface {
         ) -> Option<DirtyRegion>,
         pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<DrawOutcome, i_slint_core::platform::PlatformError>;
+
+    /// Registers a callback that's invoked with direct, mutable access to the raw pixel buffer
+    /// right after Skia has finished painting into it, before it's presented. Only meaningful for
+    /// surfaces that expose a CPU-mapped framebuffer (currently the software/DRM-dumb-buffer
+    /// surface, see `software_surface.rs`); a no-op default for GPU-composited surfaces, which
+    /// have no such buffer to expose.
+    #[cfg(feature = "kms")]
+    fn set_pixel_pre_present_callback(
+        &self,
+        _callback: Option<Box<dyn FnMut(&mut [u8], u32, u32, skia_safe::ColorType)>>,
+    ) {
+    }
     /// Called when the surface should be resized.
     fn resize_event(
         &self,

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -111,6 +111,9 @@ impl RenderBuffer for SoftbufferRenderBuffer {
 /// This surface renders into the given window using Skia's software rasterize.
 pub struct SoftwareSurface {
     render_buffer: Box<dyn RenderBuffer>,
+    #[cfg(feature = "kms")]
+    pixel_pre_present_callback:
+        RefCell<Option<Box<dyn FnMut(&mut [u8], u32, u32, skia_safe::ColorType)>>>,
 }
 
 impl super::Surface for SoftwareSurface {
@@ -133,7 +136,11 @@ impl super::Surface for SoftwareSurface {
         let surface_access =
             Box::new(SoftbufferRenderBuffer { _context, surface: RefCell::new(surface) });
 
-        Ok(Self { render_buffer: surface_access })
+        Ok(Self {
+            render_buffer: surface_access,
+            #[cfg(feature = "kms")]
+            pixel_pre_present_callback: Default::default(),
+        })
     }
 
     #[cfg(not(feature = "softbuffer"))]
@@ -214,10 +221,24 @@ impl super::Surface for SoftwareSurface {
                     pre_present_callback();
                 }
 
+                #[cfg(feature = "kms")]
+                if let Some(pixel_callback) = self.pixel_pre_present_callback.borrow_mut().as_mut()
+                {
+                    pixel_callback(pixels, width.get(), height.get(), pixel_format);
+                }
+
                 Ok(dirty_region)
             },
         )?;
         Ok(DrawOutcome::Success)
+    }
+
+    #[cfg(feature = "kms")]
+    fn set_pixel_pre_present_callback(
+        &self,
+        callback: Option<Box<dyn FnMut(&mut [u8], u32, u32, skia_safe::ColorType)>>,
+    ) {
+        *self.pixel_pre_present_callback.borrow_mut() = callback;
     }
 
     fn bits_per_pixel(&self) -> Result<u8, i_slint_core::platform::PlatformError> {
@@ -231,7 +252,11 @@ impl super::Surface for SoftwareSurface {
 
 impl<T: RenderBuffer + 'static> From<T> for SoftwareSurface {
     fn from(render_buffer: T) -> Self {
-        Self { render_buffer: Box::new(render_buffer) }
+        Self {
+            render_buffer: Box::new(render_buffer),
+            #[cfg(feature = "kms")]
+            pixel_pre_present_callback: Default::default(),
+        }
     }
 }
 


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

This component gives direct access to the framebuffer and currently only works on the linuxkms software renderer. It is similar to getting a image handle on a GPU based backend.