### PR TITLE
FlexboxLayout: fix recursion for a repeater of height-for-width components

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2890,9 +2890,25 @@ fn generate_flexbox_layout_item_info_decl(
 
     let body = if let Some(expr) = &root_sc.flexbox_layout_item_info_for_repeated {
         let compiled = compile_expression(&expr.borrow(), ctx);
+        // Break the height-for-width recursion for a repeated instance in a
+        // column FlexboxLayout: use the constrained vertical info (measured at
+        // its preferred width via layoutinfo-v-with-constraint) instead of
+        // reading self.width through the parent flex cache.
+        let v_constrained = root_sc
+            .layout_info_v_constrained_for_repeated
+            .as_ref()
+            .map(|e| {
+                let v = compile_expression(&e.borrow(), ctx);
+                format!(
+                    "if (o == slint::cbindgen_private::Orientation::Vertical && !child_index.has_value()) {{ \
+                         info.constraint = {v}; return info; }} "
+                )
+            })
+            .unwrap_or_default();
         format!(
             "[[maybe_unused]] auto self = this; \
              auto info = {compiled}; \
+             {v_constrained}\
              info.constraint = layout_item_info(o, child_index).constraint; \
              return info;"
         )

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2591,13 +2591,31 @@ fn generate_repeated_component(
         });
         let flexbox_layout_item_info_fn =
             root_sc.flexbox_layout_item_info_for_repeated.as_ref().map(|_| {
+                // Break the height-for-width recursion for a repeated instance
+                // in a column FlexboxLayout: its vertical info must not read
+                // self.width (set by the parent flex cache it is feeding).
+                // Use the constrained vertical info (computed at the instance's
+                // own preferred width via layoutinfo-v-with-constraint) instead.
+                let v_constrained =
+                    root_sc.layout_info_v_constrained_for_repeated.as_ref().map(|e| {
+                        let v_info = compile_expression(&e.borrow(), &ctx);
+                        quote! {
+                            if matches!(o, sp::Orientation::Vertical) && child_index.is_none() {
+                                info.constraint = #v_info;
+                                return info;
+                            }
+                        }
+                    });
                 quote! {
                     fn flexbox_layout_item_info(
                         self: ::core::pin::Pin<&Self>,
                         o: sp::Orientation,
                         child_index: sp::Option<usize>,
                     ) -> sp::FlexboxLayoutItemInfo {
+                        #[allow(unused)]
+                        let _self = self.as_ref();
                         let mut info = self.as_ref().flexbox_layout_item_info_for_repeated();
+                        #v_constrained
                         info.constraint = self.layout_item_info(o, child_index).constraint;
                         info
                     }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -485,6 +485,12 @@ pub struct SubComponent {
     /// Expression that builds a FlexboxLayoutItemInfo for a repeated element in a FlexboxLayout.
     /// Contains property references to flex-grow, flex-shrink, flex-basis, align-self, order.
     pub flexbox_layout_item_info_for_repeated: Option<MutExpression>,
+    /// Vertical `LayoutInfo` for a repeated element, computed with a width
+    /// constraint (its preferred width) so a height-for-width instance in a
+    /// column FlexboxLayout doesn't read `self.width` and recurse through the
+    /// parent flex cache. `Some` only when the element carries a
+    /// `layoutinfo-v-with-constraint`. See `flexbox_layout_item_info`.
+    pub layout_info_v_constrained_for_repeated: Option<MutExpression>,
     /// True when this is a repeated Row in a GridLayout, meaning layout_item_info
     /// needs to be able to return layout info for individual children
     pub is_repeated_row: bool,
@@ -672,6 +678,9 @@ impl CompilationUnit {
                 visitor(e, ctx);
             }
             if let Some(e) = &sc.flexbox_layout_item_info_for_repeated {
+                visitor(e, ctx);
+            }
+            if let Some(e) = &sc.layout_info_v_constrained_for_repeated {
                 visitor(e, ctx);
             }
             for e in sc.accessible_prop.values() {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1677,3 +1677,33 @@ pub fn get_flexbox_layout_item_info_for_repeated(
         ],
     )
 }
+
+/// Vertical `LayoutInfo` for a repeated element, computed with the element's
+/// preferred width as the cross-axis constraint. Routes through the element's
+/// `layoutinfo-v-with-constraint` (via [`get_layout_info`]), so a
+/// height-for-width instance in a column FlexboxLayout computes its height from
+/// that width instead of reading `self.width` — which would cycle through the
+/// parent flex's layout cache. Returns `None` when the element has no
+/// constrained vertical layout-info (nothing to break).
+pub fn get_layout_info_v_constrained_for_repeated(
+    ctx: &mut ExpressionLoweringCtx,
+    element: &ElementRc,
+    constraints: &crate::layout::LayoutConstraints,
+) -> Option<llr_Expression> {
+    if !element.borrow().has_inherited_layout_info_v_with_constraint() {
+        return None;
+    }
+    // Use the preferred width as the cross-axis constraint, the same default
+    // static height-for-width cells use. This is a single-line-height
+    // approximation; measuring at the real column width is a follow-up commit.
+    //
+    // The h-constraint may be absent even when the v one exists; fall back to
+    // unbounded then.
+    let width_constraint = default_cross_axis_constraint(element).unwrap_or_else(|| {
+        crate::expression_tree::Expression::NumberLiteral(
+            f32::MAX as f64,
+            crate::expression_tree::Unit::Px,
+        )
+    });
+    Some(get_layout_info(element, ctx, constraints, Orientation::Vertical, Some(width_constraint)))
+}

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -306,6 +306,7 @@ fn lower_sub_component(
         child_of_layout: component.root_element.borrow().child_of_layout,
         grid_layout_input_for_repeated: None,
         flexbox_layout_item_info_for_repeated: None,
+        layout_info_v_constrained_for_repeated: None,
         is_repeated_row: component
             .root_element
             .borrow()
@@ -646,14 +647,22 @@ fn lower_sub_component(
         v_cross_constraint,
     )
     .into();
-    // For repeated elements in a FlexboxLayout, generate code to read flex properties
-    if sub_component.child_of_layout {
+    if component.root_element.borrow().child_of_flexbox {
         let root_elem = &component.root_element;
         let has_flex_binding =
             ["flex-grow", "flex-shrink", "flex-basis", "flex-align-self", "flex-order"]
                 .iter()
                 .any(|name| crate::layout::binding_reference(root_elem, name).is_some());
-        if has_flex_binding {
+        let v_constrained =
+            super::lower_layout_expression::get_layout_info_v_constrained_for_repeated(
+                &mut ctx,
+                root_elem,
+                &component.root_constraints.borrow(),
+            );
+        // Generate the flex item-info accessor when the element sets flex
+        // properties, or when it needs the constrained-vertical fix (a
+        // height-for-width instance in a column flex).
+        if has_flex_binding || v_constrained.is_some() {
             sub_component.flexbox_layout_item_info_for_repeated = Some(
                 super::lower_layout_expression::get_flexbox_layout_item_info_for_repeated(
                     &mut ctx, root_elem,
@@ -661,6 +670,7 @@ fn lower_sub_component(
                 .into(),
             );
         }
+        sub_component.layout_info_v_constrained_for_repeated = v_constrained.map(Into::into);
     }
 
     if let Some(grid_layout_cell) = component.root_element.borrow().grid_layout_cell.as_ref() {

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -75,6 +75,9 @@ pub fn count_property_use(root: &CompilationUnit) {
         if let Some(e) = &sc.flexbox_layout_item_info_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }
+        if let Some(e) = &sc.layout_info_v_constrained_for_repeated {
+            e.borrow().visit_property_references(ctx, &mut visit_property);
+        }
         for child in &sc.grid_layout_children {
             child.layout_info_h.borrow().visit_property_references(ctx, &mut visit_property);
             child.layout_info_v.borrow().visit_property_references(ctx, &mut visit_property);

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -306,6 +306,7 @@ mod visitor {
             child_of_layout: _,
             grid_layout_input_for_repeated,
             flexbox_layout_item_info_for_repeated,
+            layout_info_v_constrained_for_repeated,
             is_repeated_row: _,
             grid_layout_children,
             accessible_prop,
@@ -396,6 +397,9 @@ mod visitor {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some(e) = flexbox_layout_item_info_for_repeated {
+            visit_expression(e.get_mut(), &scope, state, visitor);
+        }
+        if let Some(e) = layout_info_v_constrained_for_repeated {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         for child in grid_layout_children {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -883,6 +883,10 @@ pub struct Element {
 
     /// true when this item's geometry is handled by a layout
     pub child_of_layout: bool,
+    /// true when this item is a direct cell of a `FlexboxLayout`. Narrower
+    /// than `child_of_layout`: only flexbox cells need the per-repeater
+    /// `flexbox_layout_item_info` accessor.
+    pub child_of_flexbox: bool,
     /// The property pointing to the layout info. `(horizontal, vertical)`
     pub layout_info_prop: Option<(NamedReference, NamedReference)>,
     /// `pure function layoutinfo-v-with-constraint(width: length) -> LayoutInfo`
@@ -2270,6 +2274,23 @@ impl Element {
             base = root.base_type.clone();
         }
         None
+    }
+
+    /// Whether [`Self::inherited_layout_info_v_with_constraint`] would return
+    /// `Some`, without cloning the `NamedReference`.
+    pub fn has_inherited_layout_info_v_with_constraint(&self) -> bool {
+        if self.layout_info_v_with_constraint.is_some() {
+            return true;
+        }
+        let mut base = self.base_type.clone();
+        while let ElementType::Component(base_comp) = base {
+            let root = base_comp.root_element.borrow();
+            if root.layout_info_v_with_constraint.is_some() {
+                return true;
+            }
+            base = root.base_type.clone();
+        }
+        false
     }
 
     /// Mirror of [`Self::inherited_layout_info_v_with_constraint`] for the

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -409,6 +409,7 @@ fn duplicate_element_with_mapping(
             .map(|t| duplicate_transition(t, mapping, root_component, priority_delta))
             .collect(),
         child_of_layout: elem.child_of_layout,
+        child_of_flexbox: elem.child_of_flexbox,
         layout_info_prop: elem.layout_info_prop.clone(),
         layout_info_v_with_constraint: elem.layout_info_v_with_constraint.clone(),
         layout_info_h_with_constraint: elem.layout_info_h_with_constraint.clone(),

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1449,6 +1449,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
         let index = layout.elems.len() * 4; // 4 values per item: x, y, width, height
         let rep_idx = &item.repeater_index;
         let actual_elem = &item.elem;
+        actual_elem.borrow_mut().child_of_flexbox = true;
 
         // Set x from cache[index]
         set_prop_from_cache(actual_elem, "x", &layout_cache_prop, index, rep_idx, 4, diag);

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -53,6 +53,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 states: std::mem::take(&mut original_elem.states),
                 transitions: std::mem::take(&mut original_elem.transitions),
                 child_of_layout: original_elem.child_of_layout || is_listview.is_some(),
+                child_of_flexbox: original_elem.child_of_flexbox,
                 layout_info_prop: original_elem.layout_info_prop.take(),
                 layout_info_v_with_constraint: original_elem.layout_info_v_with_constraint.take(),
                 layout_info_h_with_constraint: original_elem.layout_info_h_with_constraint.take(),

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -53,6 +53,7 @@ pub fn ensure_window(
         states: Default::default(),
         transitions: Default::default(),
         child_of_layout: false,
+        child_of_flexbox: false,
         has_popup_child: false,
         layout_info_prop: Default::default(),
         layout_info_v_with_constraint: Default::default(),

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -556,6 +556,7 @@ impl Snapshotter {
 
         target_element.change_callbacks = elem.change_callbacks.clone();
         target_element.child_of_layout = elem.child_of_layout;
+        target_element.child_of_flexbox = elem.child_of_flexbox;
         target_element.default_fill_parent = elem.default_fill_parent;
         target_element.has_popup_child = elem.has_popup_child;
         target_element.inline_depth = elem.inline_depth;

--- a/tests/cases/layout/flexbox_repeater_component_with_wrap.slint
+++ b/tests/cases/layout/flexbox_repeater_component_with_wrap.slint
@@ -1,0 +1,103 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test: a FlexboxLayout containing a repeater of components with
+// height-for-width content (a wrapped Text) used to panic with "Recursion
+// detected with property .layoutinfo-v". Each repeated instance's vertical
+// info was queried without a cross-axis constraint, so it read self.width —
+// set by the parent flex cache it was feeding — and cycled. The repeater path
+// now routes through the synthesized layoutinfo-v-with-constraint, like static
+// cells do, so the layout resolves instead.
+
+component Card inherits Rectangle {
+    in property <string> label;
+    background: #e0e0e0;
+    VerticalLayout {
+        padding: 5px;
+        Text {
+            text: label;
+            wrap: word-wrap;
+            horizontal-alignment: left;
+        }
+    }
+}
+
+// Card2 adds nothing: the wrapped Text (height-for-width) lives in the base, so
+// the synthesized layoutinfo-v-with-constraint is reached through inheritance.
+// Exercises the inherited_layout_info_v_with_constraint path of the fix.
+component Card2 inherits Card { }
+
+export component TestCase inherits Window {
+    width: 320px;
+    height: 400px;
+
+    in property <[string]> labels: [
+        "Short",
+        "A medium-length card text that may or may not wrap",
+        "A really long card text that will almost certainly need to wrap onto two or more lines when the flex space is tight",
+    ];
+
+    // Single-line reference for the card Text, so the height assertions stay
+    // font-independent (the nodejs backend has no test fonts): each card holds
+    // at least one such line.
+    refLine := Text { x: 0; y: -1000px; text: "Short"; wrap: no-wrap; }
+    out property <length> line-height: refLine.height;
+
+    FlexboxLayout {
+        flex-direction: column;
+        spacing: 6px;
+        padding: 8px;
+
+        for s in labels: Card {
+            label: s;
+            flex-shrink: 0;
+        }
+        // Non-repeater anchor whose laid-out position depends on the total
+        // height of the repeated Cards above. Reading anchor.y forces the
+        // flexbox to solve, which is what used to recurse.
+        anchor := Rectangle {
+            background: blue;
+            height: 10px;
+        }
+    }
+
+    // A second flex of inherited-base cards, to cover the inherited path.
+    FlexboxLayout {
+        x: 0; y: 300px; width: 320px; height: 100px;
+        flex-direction: column;
+        spacing: 6px;
+        padding: 8px;
+
+        for s in labels: Card2 {
+            label: s;
+            flex-shrink: 0;
+        }
+        anchor2 := Rectangle { height: 5px; }
+    }
+
+    // anchor.y sits below the three stacked Cards: each card is at least one
+    // text line tall, so the anchor is well past 3 lines and still inside the
+    // window (no infinite/overflowing height). anchor2.y > 0 proves the
+    // inherited-base flex solved without recursing too.
+    out property <bool> test:
+        anchor.y > 3 * line-height
+        && anchor.y < self.height
+        && anchor2.y > 0px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
A FlexboxLayout with a repeater of height-for-width components (e.g. a
wrapped Text) panicked with "Recursion detected with property
.layoutinfo-v": each repeated instance queried its vertical layout info
without a cross-axis constraint, so it read self.width — set by the parent
flex cache it was feeding — and cycled. The constrained-layoutinfo machinery
that breaks this for static cells did not cover the per-instance repeater path.

Give each such repeated cell a width-constrained vertical LayoutInfo measured
at its own preferred width, the same default static height-for-width cells use,
so the flex query no longer reads self.width. This is a single-line-height
approximation; measuring at the real column width is a follow-up commit.

Done in both code generators; adds a regression test across all four backends.