### PR TITLE
Ignore pnpm store files in worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 tsconfig.tsbuildinfo
 /target
 node_modules
+.pnpm-store
 /tools/figma_import/target
 /tools/figma_import/figma_output
 *.code-workspace


### PR DESCRIPTION
When using git worktrees pnpm can create caches stores. They should be ignored.