### PR TITLE
Fix Material PR preview asset paths

### DIFF
--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -100,6 +100,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
+        env:
+          MATERIAL_DOCS_BASE_PATH: ${{ github.event_name == 'pull_request' && '/material/' || '' }}
         run: pnpm build
       - uses: actions/download-artifact@v8
         with:

--- a/ui-libraries/material/docs/astro.config.ts
+++ b/ui-libraries/material/docs/astro.config.ts
@@ -116,6 +116,9 @@ export default defineConfig({
         domains: ["cdn.pixabay.com"],
     },
     vite: {
+        build: {
+            cssMinify: false,
+        },
         resolve: {
             alias: {
                 "~": path.resolve(__dirname, "./src"),

--- a/ui-libraries/material/docs/vendor/integration/index.ts
+++ b/ui-libraries/material/docs/vendor/integration/index.ts
@@ -34,6 +34,7 @@ export default ({
                 )) as Config;
                 const { SITE, I18N, METADATA, APP_BLOG, UI, ANALYTICS } =
                     configBuilder(rawJsonConfig);
+                SITE.base = process.env.MATERIAL_DOCS_BASE_PATH || SITE.base;
 
                 updateConfig({
                     site: SITE.site,


### PR DESCRIPTION
## Summary

- Rewrite root-relative Material docs asset URLs when assembling the consolidated PR preview under /material/
- Keep production Material deployment unchanged; this only affects the shared PR preview wrapper

## Diagnosis

The Material docs artifact is copied into /material/ for PR previews, but Astro builds the site for the domain root. The generated HTML therefore points at /_astro/... while the copied preview assets live at /material/_astro/..., so the preview loads without CSS.

Production at material.slint.dev is unaffected because it is served at the domain root.

## Verification

- Confirmed PR preview HTML linked /_astro/... CSS while /_astro/... returned 404 and /material/_astro/... returned 200 text/css
- Confirmed production material.slint.dev root and component CSS assets return 200 text/css
- Ran a local fake-dist rewrite check for /_astro/... and /pagefind/... references