### PR TITLE
Make non-Web Image URLs consistent across C++, Rust and Interpreter backends

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4158,11 +4158,14 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         Expression::ImageReference { resource_ref, nine_slice } => {
             let image = match resource_ref {
                 crate::expression_tree::ImageReference::None => r#"slint::Image()"#.to_string(),
-                resource_ref @ (crate::expression_tree::ImageReference::Path(_)
-                | crate::expression_tree::ImageReference::Url(_)) => format!(
+                resource_ref @ crate::expression_tree::ImageReference::Path(_) => format!(
                     r#"slint::Image::load_from_path(slint::SharedString(u8"{}"))"#,
                     escape_string(resource_ref.source().unwrap())
                 ),
+                crate::expression_tree::ImageReference::Url(_) => {
+                    // Loading images from URLs only work on the web, which we don't support in C++.
+                    "slint::Image()".to_string()
+                }
                 crate::expression_tree::ImageReference::DataUri(_) => {
                     unreachable!("data: URIs are embedded before code generation")
                 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4249,12 +4249,15 @@ impl std::fmt::Display for crate::expression_tree::ImageReference {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             crate::expression_tree::ImageReference::None => write!(f, r#"slint::Image()"#),
-            resource_ref @ (crate::expression_tree::ImageReference::Path(_)
-            | crate::expression_tree::ImageReference::Url(_)) => write!(
+            resource_ref @ crate::expression_tree::ImageReference::Path(_) => write!(
                 f,
                 r#"slint::Image::load_from_path(slint::SharedString(u8"{}"))"#,
                 escape_string(resource_ref.source().unwrap())
             ),
+            crate::expression_tree::ImageReference::Url(_) => {
+                // Loading images from URLs only work on the web, which we don't support in C++.
+                write!(f, r#"slint::Image()"#)
+            }
             crate::expression_tree::ImageReference::DataUri(_) => {
                 unreachable!("data: URIs are embedded before code generation")
             }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -568,7 +568,18 @@ impl Expression {
                         })
                 }
             };
-            ImageReference::from_resolved(absolute_source_path)
+            let reference = ImageReference::from_resolved(absolute_source_path);
+            #[cfg(not(target_arch = "wasm32"))]
+            if let ImageReference::Url(url) = &reference
+                && (url.scheme() == "http" || url.scheme() == "https")
+            {
+                ctx.diag.push_warning(
+                    "Loading images from HTTP/HTTPS is only supported for Web targets".into(),
+                    &node,
+                );
+            }
+
+            reference
         };
 
         let nine_slice = node

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -831,7 +831,18 @@ impl Expression {
                         })
                 }
             };
-            ImageReference::from_resolved(absolute_source_path)
+            let reference = ImageReference::from_resolved(absolute_source_path);
+            #[cfg(all(not(target_arch = "wasm32"), not(feature = "slint-sc")))]
+            if let ImageReference::Url(url) = &reference
+                && url.scheme() != "builtin"
+            {
+                ctx.diag.push_warning(
+                    "Loading images from HTTP/HTTPS is only supported for Web targets".into(),
+                    &node,
+                );
+            }
+
+            reference
         };
 
         // Slint SC decodes the image at compile time, so only a file on disk

--- a/internal/compiler/tests/syntax/basic/image-skip-slint-sc.slint
+++ b/internal/compiler/tests/syntax/basic/image-skip-slint-sc.slint
@@ -1,0 +1,35 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+export SubElements := Rectangle {
+//                 ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
+
+    background: blue;
+
+    Image {
+        source: @image-url("https://slint.dev/logo.png");
+//              >                                      <warning{Loading images from HTTP/HTTPS is only supported for Web targets}
+    }
+
+    Image {
+        source: @image-url("ftp:/slint.dev/logo.png");
+//              >                                   <warning{Loading images from HTTP/HTTPS is only supported for Web targets}
+    }
+
+    Image {
+        source: @image-url("foobar:/slint.dev/logo.png");
+//              >                                      <warning{Loading images from HTTP/HTTPS is only supported for Web targets}
+    }
+
+    Image {
+        source: @image-url("file:/slint.dev/logo.png");
+//              >                                    <warning{Loading images from HTTP/HTTPS is only supported for Web targets}
+    }
+
+    Rectangle {
+        background: red;
+    }
+
+
+}

--- a/internal/compiler/tests/syntax/basic/image.slint
+++ b/internal/compiler/tests/syntax/basic/image.slint
@@ -31,6 +31,12 @@ export SubElements := Rectangle {
 //              >                                                      <error{Invalid data URI payload: symbol with codepoint 33 not expected}
     }
 
+    Image {
+        source: @image-url("https://slint.dev/logo.png");
+//              >                                      <warning{Loading images from HTTP/HTTPS is only supported for Web targets}
+    }
+
+
     Rectangle {
         background: red;
     }

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -70,6 +70,11 @@ fn syntax_tests() -> std::io::Result<()> {
             for test_entry in path.read_dir()? {
                 let test_entry = test_entry?;
                 let path = test_entry.path();
+                // Skip any tests
+                #[cfg(feature = "slint-sc")]
+                if path.file_name().is_some_and(|n| n.to_str().unwrap().contains("skip-slint-sc")) {
+                    continue;
+                }
                 if let Some(ext) = path.extension()
                     && (ext == "60" || ext == "slint")
                     && pattern.as_ref().map(|p| p.is_match(&path.to_string_lossy())).unwrap_or(true)

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -403,7 +403,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     #[cfg(not(target_arch = "wasm32"))]
                     {
                         let _ = url;
-                        Err(Default::default())
+                        Ok(Default::default())
                     }
                 }
                 i_slint_compiler::expression_tree::ImageReference::EmbeddedData { .. } => {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1788,7 +1788,7 @@ fn load_image_reference(
             #[cfg(not(target_arch = "wasm32"))]
             {
                 let _ = url;
-                Err(Default::default())
+                Ok(Default::default())
             }
         }
         Ref::EmbeddedData { .. } | Ref::EmbeddedTexture { .. } => Ok(Default::default()),


### PR DESCRIPTION
Something weird I noticed while rebasing the mouse cursor stuff. When plugging in a web resource into an Image like this:

```slint
Image {
    source: @image-url("https://images.redstrate.com/lolphin.jpg");
}
```

The three backends I tried had different behavior:

- Interpreter: Warned in stdout that the image failed to load (but didn't actually try to load the image from that path)
- Rust: Silently replaced it with a default Image
- C++: Warned that it could not load it, because it actually tried to load it as a regular local filesystem path which seems bad

I chose to make them consistent with Rust, although it would be nice to have a standard warning emitted for this. I'm unsure if the generators were the right place though.