### PR TITLE
Let the browser decode images on the web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,6 +3463,7 @@ dependencies = [
  "i-slint-core-macros",
  "icu_normalizer",
  "image",
+ "js-sys",
  "ksni",
  "log",
  "lyon_algorithms",

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -52,6 +52,8 @@ mcp = ["std", "i-slint-backend-selector/mcp"]
 
 std = [
   "i-slint-core/default",
+  "i-slint-core/image-decoders",
+  "i-slint-core/svg",
   "i-slint-core/image-default-formats",
   "i-slint-backend-selector",
   "i-slint-backend-selector/backend-android-activity",

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -99,6 +99,7 @@ raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/ra
 ## and `@image-url`. When this feature is disabled, only PNG and JPEG are supported. When enabled,
 ## the following image formats are supported:
 ## AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
+## This feature has no effect on the web, where the browser decodes images.
 image-default-formats = ["i-slint-core/image-default-formats"]
 
 ## Enable the live preview feature

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2561,6 +2561,7 @@ dependencies = [
  "i-slint-core-macros",
  "icu_normalizer",
  "image",
+ "js-sys",
  "ksni",
  "lyon_algorithms",
  "lyon_extra",

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -391,6 +391,9 @@ For example: `@image-url("data:image/png;base64,iVBORw0KGgo...")`.
 Supported format are SVG, and formats supported by the [`image` crate](https://crates.io/crates/image):
 AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
 
+On the web, the browser decodes images, so every format the browser supports works.
+Compressed SVG (`.svgz`) is the exception: browsers don't render it.
+
 <Tabs syncKey="dev-language">
 <TabItem label="Rust" icon="seti:rust">
 In Rust, properties or struct fields of the image type are mapped to <LangRefLink lang="rust-slint" relpath="struct.Image">`slint::Image`</LangRefLink>.
@@ -398,6 +401,7 @@ In Rust, properties or struct fields of the image type are mapped to <LangRefLin
 By default, only PNG, JPEG, and SVG are supported.
 Enable the `image-default-formats` Cargo feature to support the other formats listed above,
 which comes at a cost of increased binary size and compilation time.
+This feature has no effect on the web, where the browser decodes images.
 :::
 </TabItem>
 <TabItem label="C++" icon="seti:cpp">

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -7191,6 +7191,7 @@ dependencies = [
  "i-slint-core-macros",
  "icu_normalizer 2.2.0",
  "image",
+ "js-sys",
  "ksni",
  "lyon_algorithms",
  "lyon_extra",

--- a/internal/backends/android-activity/Cargo.toml
+++ b/internal/backends/android-activity/Cargo.toml
@@ -26,7 +26,7 @@ unstable-wgpu-29 = ["i-slint-renderer-skia/unstable-wgpu-29"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-renderer-skia = { workspace = true }
-i-slint-core = { workspace = true, features = ["std"] }
+i-slint-core = { workspace = true, features = ["std", "image-decoders", "svg"] }
 i-slint-common = { workspace = true }
 raw-window-handle = { version = "0.6" }
 android-activity-05 = { package = "android-activity", version = "0.5", optional = true }

--- a/internal/backends/qt/Cargo.toml
+++ b/internal/backends/qt/Cargo.toml
@@ -35,6 +35,10 @@ pin-project = { version = "1", optional = true }
 pin-weak = { version = "1", optional = true }
 qttypes = { version = "0.2.7", default-features = false, optional = true }
 
+# The browser decodes images on the web; decode with the image and resvg crates elsewhere.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+i-slint-core = { workspace = true, features = ["image-decoders", "svg"] }
+
 [build-dependencies]
 cpp_build = { version = "0.5.5", optional = true }
 

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -76,6 +76,10 @@ include_dir = { version = "0.7", optional = true }
 i-slint-renderer-software = { workspace = true, optional = true }
 i-slint-renderer-skia = { workspace = true, default-features = false, optional = true }
 
+# The browser decodes images on the web; decode with the image and resvg crates elsewhere.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+i-slint-core = { workspace = true, features = ["image-decoders", "svg"] }
+
 [build-dependencies]
 cfg_aliases = { workspace = true }
 prost = { version = "0.14", optional = true }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -108,6 +108,8 @@ glutin-winit = { version = "0.5", optional = true, default-features = false, fea
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 accesskit = { version = "0.24", optional = true }
 accesskit_winit = { version = "0.33", optional = true, default-features = false, features = ["accesskit_unix", "async-io", "rwh_06"] }
+# The browser decodes images on the web; decode with the image and resvg crates elsewhere.
+i-slint-core = { workspace = true, features = ["image-decoders", "svg"] }
 
 [target.'cfg(not(any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32", target_os = "android")))'.dependencies]
 # Use same version and executor as accesskit

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -405,14 +405,10 @@ impl BuiltinFunction {
             | BuiltinFunction::ColorTransparentize
             | BuiltinFunction::ColorMix
             | BuiltinFunction::ColorWithAlpha => true,
-            // ImageSize is pure, except when loading images via the network. Then the initial size will be 0/0 and
-            // we need to make sure that calls to this function stay within a binding, so that the property
-            // notification when updating kicks in. Only SlintPad (wasm-interpreter) loads images via the network,
-            // which is when this code is targeting wasm.
-            #[cfg(not(target_arch = "wasm32"))]
-            BuiltinFunction::ImageSize => true,
-            #[cfg(target_arch = "wasm32")]
-            BuiltinFunction::ImageSize => false,
+            // On the web, the browser loads images asynchronously, so the size is initially 0/0
+            // and updates once the image is loaded. Calls to this function must stay within a
+            // binding so that the property notification kicks in when the code may run on the web.
+            BuiltinFunction::ImageSize => global_analysis.is_some_and(|x| x.const_image_sizes),
             BuiltinFunction::ArrayLength => true,
             BuiltinFunction::ArrayPush
             | BuiltinFunction::ArrayRemove

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -253,12 +253,12 @@ impl CompilerConfiguration {
             .and_then(|x| x.parse::<f32>().ok())
             .filter(|f| *f > 0.);
 
-        let const_image_sizes = match std::env::var("CARGO_CFG_TARGET_ARCH") {
+        let const_image_sizes = match std::env::var("CARGO_CFG_TARGET_FAMILY") {
             // Set by cargo when running in a build script (slint-build): the target is known.
-            Ok(target_arch) => target_arch != "wasm32",
+            Ok(target_family) => !target_family.split(',').any(|f| f == "wasm"),
             // The target is unknown (slint! macro, C++). The interpreter compiles for the
             // architecture it runs on; otherwise assume the code may run on the web.
-            Err(_) => output_format == OutputFormat::Interpreter && !cfg!(target_arch = "wasm32"),
+            Err(_) => output_format == OutputFormat::Interpreter && !cfg!(target_family = "wasm"),
         };
 
         let enable_experimental = std::env::var_os("SLINT_ENABLE_EXPERIMENTAL_FEATURES").is_some();

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -159,6 +159,12 @@ pub struct CompilerConfiguration {
     /// It will also be set as a const scale factor on the `slint::Window`.
     pub const_scale_factor: Option<f32>,
 
+    /// Whether image sizes are known when a compiled component is instantiated.
+    /// This is false when the generated code may run on the web, where the browser
+    /// decodes images asynchronously and the size updates once an image is loaded,
+    /// so that expressions using an image size stay in bindings.
+    pub const_image_sizes: bool,
+
     /// expose the accessible role and properties
     pub accessibility: bool,
 
@@ -247,6 +253,14 @@ impl CompilerConfiguration {
             .and_then(|x| x.parse::<f32>().ok())
             .filter(|f| *f > 0.);
 
+        let const_image_sizes = match std::env::var("CARGO_CFG_TARGET_ARCH") {
+            // Set by cargo when running in a build script (slint-build): the target is known.
+            Ok(target_arch) => target_arch != "wasm32",
+            // The target is unknown (slint! macro, C++). The interpreter compiles for the
+            // architecture it runs on; otherwise assume the code may run on the web.
+            Err(_) => output_format == OutputFormat::Interpreter && !cfg!(target_arch = "wasm32"),
+        };
+
         let enable_experimental = std::env::var_os("SLINT_ENABLE_EXPERIMENTAL_FEATURES").is_some();
 
         let debug_info = std::env::var_os("SLINT_EMIT_DEBUG_INFO").is_some();
@@ -274,6 +288,7 @@ impl CompilerConfiguration {
             resource_url_mapper: None,
             inline_all_elements,
             const_scale_factor,
+            const_image_sizes,
             accessibility: true,
             enable_experimental,
             translation_domain: None,

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -48,6 +48,7 @@ impl DefaultFontSize {
 pub struct GlobalAnalysis {
     pub default_font_size: DefaultFontSize,
     pub const_scale_factor: Option<f32>,
+    pub const_image_sizes: bool,
 }
 
 /// Maps the alias in the other direction than what the BindingExpression::two_way_binding does.
@@ -62,6 +63,7 @@ pub fn binding_analysis(
 ) -> GlobalAnalysis {
     let mut global_analysis = GlobalAnalysis {
         const_scale_factor: compiler_config.const_scale_factor,
+        const_image_sizes: compiler_config.const_image_sizes,
         ..Default::default()
     };
     let mut reverse_aliases = Default::default();

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -29,8 +29,6 @@ std = [
   "euclid/std",
   "once_cell/std",
   "dep:web-time",
-  "image-decoders",
-  "svg",
   "path",
   "raw-window-handle-06?/std",
   "chrono/std",
@@ -50,6 +48,8 @@ unsafe-single-threaded = []
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
+# Decode encoded images with the image crate. Not needed on wasm, where the
+# browser decodes encoded image data.
 image-decoders = ["dep:image", "dep:clru"]
 image-default-formats = ["image?/default-formats"]
 svg = ["dep:resvg", "i-slint-common/svg-text"]
@@ -172,6 +172,7 @@ async-channel = { version = "2", optional = true }
 web-time = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2" }
 js-sys = { version = "0.3" }
+clru = { workspace = true }
 web-sys = { workspace = true, features = ["HtmlImageElement", "Navigator", "Blob", "BlobPropertyBag", "Url", "DomParser", "SupportedType", "Document", "Element"] }
 
 

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -171,7 +171,8 @@ async-channel = { version = "2", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2" }
-web-sys = { workspace = true, features = ["HtmlImageElement", "Navigator"] }
+js-sys = { version = "0.3" }
+web-sys = { workspace = true, features = ["HtmlImageElement", "Navigator", "Blob", "BlobPropertyBag", "Url", "DomParser", "SupportedType", "Document", "Element"] }
 
 
 [dev-dependencies]

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -14,7 +14,7 @@ use crate::{SharedString, SharedVector};
 use super::{IntRect, IntSize};
 use crate::items::{ImageFit, ImageHorizontalAlignment, ImageTiling, ImageVerticalAlignment};
 
-#[cfg(feature = "image-decoders")]
+#[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]
 pub mod cache;
 #[cfg(target_arch = "wasm32")]
 mod htmlimage;
@@ -296,7 +296,7 @@ pub struct CachedPath {
     last_modified: u32,
 }
 
-#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "image-decoders", not(target_arch = "wasm32")))]
 impl CachedPath {
     fn new<P: AsRef<std::path::Path>>(path: P) -> Self {
         let path_str = path.as_ref().to_string_lossy().as_ref().into();
@@ -565,7 +565,7 @@ impl ImageInner {
     /// which could lead to bad behavior. This constructor should be called from within
     /// `ImageCache::lookup_image_in_cache_or_create`, or `ImageCacheKey::Invalid` should be
     /// supplied.
-    #[cfg(feature = "image-decoders")]
+    #[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]
     pub(crate) fn load_from_data_with_cache_key(
         cache_key: ImageCacheKey,
         data: Slice<'_, u8>,
@@ -801,7 +801,7 @@ impl std::error::Error for LoadImageError {}
 pub struct Image(pub(crate) ImageInner);
 
 impl Image {
-    #[cfg(feature = "image-decoders")]
+    #[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]
     /// Load an Image from a path to a file containing an image.
     ///
     /// Supported formats are SVG, PNG and JPEG.
@@ -999,7 +999,7 @@ impl Image {
     /// Creates a new Image from the specified buffer, which contains SVG raw data.
     ///
     /// On the web, the browser renders the SVG, and compressed SVG data (svgz) is not supported.
-    #[cfg(feature = "svg")]
+    #[cfg(any(feature = "svg", target_arch = "wasm32"))]
     pub fn load_from_svg_data(buffer: &[u8]) -> Result<Self, LoadImageError> {
         // On the web, the browser decodes the SVG.
         #[cfg(target_arch = "wasm32")]
@@ -1073,7 +1073,7 @@ impl Image {
     }
 }
 
-#[cfg(feature = "image-decoders")]
+#[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]
 /// Load an image from the decoded payload of a data URI.
 /// This is called by the interpreter.
 pub fn load_image_from_data_uri(
@@ -1203,7 +1203,7 @@ impl BorrowedOpenGLTextureBuilder {
 /// references that are URLs rather than file-system paths; it is not general
 /// network image loading.
 /// This is called by the interpreter and the generated code.
-#[cfg(all(target_arch = "wasm32", feature = "image-decoders"))]
+#[cfg(all(target_arch = "wasm32", feature = "std"))]
 pub fn load_as_html_image(url: &str) -> Result<Image, LoadImageError> {
     self::cache::IMAGE_CACHE.with(|global_cache| {
         global_cache.borrow_mut().load_as_html_image(url).ok_or(LoadImageError(()))
@@ -1212,7 +1212,7 @@ pub fn load_as_html_image(url: &str) -> Result<Image, LoadImageError> {
 
 /// Load an image from an image embedded in the binary.
 /// This is called by the generated code.
-#[cfg(feature = "image-decoders")]
+#[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]
 pub fn load_image_from_embedded_data(data: Slice<'static, u8>, format: Slice<'_, u8>) -> Image {
     self::cache::IMAGE_CACHE.with(|global_cache| {
         global_cache.borrow_mut().load_image_from_embedded_data(data, format).unwrap_or_default()
@@ -1536,7 +1536,9 @@ pub(crate) mod ffi {
         a: u8,
     }
 
-    #[cfg(feature = "image-decoders")]
+    // Keep the cfg free of target_arch: cbindgen maps target_arch = wasm32 to a C macro and
+    // would guard the declaration, but the C++ API is native only and relies on it being there.
+    #[cfg(all(feature = "std", feature = "image-decoders"))]
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_image_load_from_path(path: &SharedString, image: *mut Image) {
         unsafe {
@@ -1547,7 +1549,7 @@ pub(crate) mod ffi {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", feature = "image-decoders"))]
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_image_load_from_embedded_data(
         data: Slice<'static, u8>,

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -571,43 +571,69 @@ impl ImageInner {
         data: Slice<'_, u8>,
         format: Slice<'_, u8>,
     ) -> Option<Self> {
-        #[cfg(feature = "svg")]
-        if format.as_slice() == b"svg" || format.as_slice() == b"svgz" {
-            return Some(ImageInner::Svg(vtable::VRc::new(
-                svg::load_from_data(data.as_slice(), cache_key).map_or_else(
-                    |svg_err| {
-                        crate::debug_log!("Error loading SVG: {}", svg_err);
-                        None
-                    },
-                    Some,
-                )?,
-            )));
+        // On the web, let the browser decode the image instead of shipping decoders in the binary.
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = cache_key;
+            let mime_type = core::str::from_utf8(format.as_slice())
+                .ok()
+                .and_then(image_mime_type_from_extension)
+                .unwrap_or_else(|| {
+                    if data.starts_with(b"<?xml") || data.starts_with(b"<svg") {
+                        "image/svg+xml"
+                    } else {
+                        // An empty type makes the browser sniff the format from the data.
+                        ""
+                    }
+                });
+            if mime_type == "image/svg+xml" && data.starts_with(&[0x1f, 0x8b]) {
+                crate::debug_log!("Compressed SVG (.svgz) is not supported on the web");
+                return None;
+            }
+            return htmlimage::HTMLImage::new_from_data(data.as_slice(), mime_type)
+                .map(|html_image| ImageInner::HTMLImage(vtable::VRc::new(html_image)));
         }
 
-        let format = std::str::from_utf8(format.as_slice())
-            .ok()
-            .and_then(image::ImageFormat::from_extension);
-        let maybe_image = if let Some(format) = format {
-            image::load_from_memory_with_format(data.as_slice(), format)
-        } else {
-            image::load_from_memory(data.as_slice())
-        };
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            #[cfg(feature = "svg")]
+            if format.as_slice() == b"svg" || format.as_slice() == b"svgz" {
+                return Some(ImageInner::Svg(vtable::VRc::new(
+                    svg::load_from_data(data.as_slice(), cache_key).map_or_else(
+                        |svg_err| {
+                            crate::debug_log!("Error loading SVG: {}", svg_err);
+                            None
+                        },
+                        Some,
+                    )?,
+                )));
+            }
 
-        match maybe_image {
-            Ok(image) => Some(ImageInner::EmbeddedImage {
-                cache_key,
-                buffer: dynamic_image_to_shared_image_buffer(image),
-            }),
-            Err(decode_err) => {
-                crate::debug_log!("Error decoding embedded image: {}", decode_err);
-                None
+            let format = std::str::from_utf8(format.as_slice())
+                .ok()
+                .and_then(image::ImageFormat::from_extension);
+            let maybe_image = if let Some(format) = format {
+                image::load_from_memory_with_format(data.as_slice(), format)
+            } else {
+                image::load_from_memory(data.as_slice())
+            };
+
+            match maybe_image {
+                Ok(image) => Some(ImageInner::EmbeddedImage {
+                    cache_key,
+                    buffer: dynamic_image_to_shared_image_buffer(image),
+                }),
+                Err(decode_err) => {
+                    crate::debug_log!("Error decoding embedded image: {}", decode_err);
+                    None
+                }
             }
         }
     }
 }
 
 /// Convert `image::DynamicImage` to `SharedImageBuffer`
-#[cfg(feature = "image-decoders")]
+#[cfg(all(feature = "image-decoders", not(target_arch = "wasm32")))]
 fn dynamic_image_to_shared_image_buffer(dynamic_image: image::DynamicImage) -> SharedImageBuffer {
     use rgb::AsPixels;
 
@@ -782,6 +808,8 @@ impl Image {
     /// Enable support for additional formats supported by the [`image` crate](https://crates.io/crates/image) (
     /// AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP)
     /// by enabling the `image-default-formats` cargo feature.
+    ///
+    /// This function always fails on the web, where there is no file system.
     pub fn load_from_path(path: &std::path::Path) -> Result<Self, LoadImageError> {
         self::cache::IMAGE_CACHE.with(|global_cache| {
             let path: SharedString = path.to_str().ok_or(LoadImageError(()))?.into();
@@ -969,12 +997,24 @@ impl Image {
     }
 
     /// Creates a new Image from the specified buffer, which contains SVG raw data.
+    ///
+    /// On the web, the browser renders the SVG, and compressed SVG data (svgz) is not supported.
     #[cfg(feature = "svg")]
     pub fn load_from_svg_data(buffer: &[u8]) -> Result<Self, LoadImageError> {
-        let cache_key = ImageCacheKey::Invalid;
-        Ok(Image(ImageInner::Svg(vtable::VRc::new(
-            svg::load_from_data(buffer, cache_key).map_err(|_| LoadImageError(()))?,
-        ))))
+        // On the web, the browser decodes the SVG.
+        #[cfg(target_arch = "wasm32")]
+        {
+            htmlimage::HTMLImage::new_from_data(buffer, "image/svg+xml")
+                .map(|html_image| Image(ImageInner::HTMLImage(vtable::VRc::new(html_image))))
+                .ok_or(LoadImageError(()))
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let cache_key = ImageCacheKey::Invalid;
+            Ok(Image(ImageInner::Svg(vtable::VRc::new(
+                svg::load_from_data(buffer, cache_key).map_err(|_| LoadImageError(()))?,
+            ))))
+        }
     }
 
     /// Sets the nine-slice edges of the image.
@@ -1034,20 +1074,58 @@ impl Image {
 }
 
 #[cfg(feature = "image-decoders")]
-/// Load an Image from a path to a file containing an image.
-///
-/// Supported formats are SVG, PNG and JPEG.
-/// Enable support for additional formats supported by the [`image` crate](https://crates.io/crates/image) (
-/// AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP)
-/// by enabling the `image-default-formats` cargo feature.
-pub fn load_image_from_dynamic_data(bytes: &[u8], format: &str) -> Result<Image, LoadImageError> {
-    ImageInner::load_from_data_with_cache_key(
-        ImageCacheKey::Invalid,
-        bytes.into(),
-        format.as_bytes().into(),
-    )
-    .map(Image)
-    .ok_or(Default::default())
+/// Load an image from the decoded payload of a data URI.
+/// This is called by the interpreter.
+pub fn load_image_from_data_uri(
+    uri: &str,
+    bytes: &[u8],
+    format: &str,
+) -> Result<Image, LoadImageError> {
+    // The browser loads images asynchronously, so every evaluation of the same data URI
+    // must share one image and its loading state: cache under the URI.
+    #[cfg(target_arch = "wasm32")]
+    {
+        self::cache::IMAGE_CACHE.with(|global_cache| {
+            global_cache
+                .borrow_mut()
+                .load_image_from_data_uri(uri, bytes, format)
+                .ok_or(LoadImageError(()))
+        })
+    }
+    // Native decoding is synchronous; don't fill the cache with one-shot images.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = uri;
+        ImageInner::load_from_data_with_cache_key(
+            ImageCacheKey::Invalid,
+            bytes.into(),
+            format.as_bytes().into(),
+        )
+        .map(Image)
+        .ok_or(Default::default())
+    }
+}
+
+/// Returns the MIME type for an image file extension, or None if the extension is unknown.
+/// The extension is matched ASCII case-insensitively and given without the leading dot.
+pub fn image_mime_type_from_extension(extension: &str) -> Option<&'static str> {
+    for (ext, mime) in [
+        ("png", "image/png"),
+        ("jpg", "image/jpeg"),
+        ("jpeg", "image/jpeg"),
+        ("svg", "image/svg+xml"),
+        ("svgz", "image/svg+xml"),
+        ("gif", "image/gif"),
+        ("webp", "image/webp"),
+        ("bmp", "image/bmp"),
+        ("ico", "image/x-icon"),
+        ("avif", "image/avif"),
+    ] {
+        if extension.eq_ignore_ascii_case(ext) {
+            return Some(mime);
+        }
+    }
+    None
 }
 
 /// This enum describes the origin to use when rendering a borrowed OpenGL texture.

--- a/internal/core/graphics/image/cache.rs
+++ b/internal/core/graphics/image/cache.rs
@@ -136,6 +136,23 @@ impl ImageCache {
             ImageInner::load_from_data_with_cache_key(cache_key, data, format)
         })
     }
+
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn load_image_from_data_uri(
+        &mut self,
+        uri: &str,
+        data: &[u8],
+        format: &str,
+    ) -> Option<Image> {
+        let cache_key = ImageCacheKey::URL(uri.into());
+        self.lookup_image_in_cache_or_create(cache_key, |cache_key| {
+            ImageInner::load_from_data_with_cache_key(
+                cache_key,
+                data.into(),
+                format.as_bytes().into(),
+            )
+        })
+    }
 }
 
 /// Replace the cached image key with the given value

--- a/internal/core/graphics/image/cache.rs
+++ b/internal/core/graphics/image/cache.rs
@@ -86,7 +86,8 @@ impl ImageCache {
         }
         let cache_key = ImageCacheKey::Path(CachedPath::new(path.as_str()));
         self.lookup_image_in_cache_or_create(cache_key, |cache_key| {
-            if cfg!(feature = "svg") && (path.ends_with(".svg") || path.ends_with(".svgz")) {
+            #[cfg(feature = "svg")]
+            if path.ends_with(".svg") || path.ends_with(".svgz") {
                 return Some(ImageInner::Svg(vtable::VRc::new(
                     super::svg::load_from_path(path, cache_key).map_or_else(
                         |err| {
@@ -164,7 +165,7 @@ pub fn replace_cached_image(key: ImageCacheKey, value: ImageInner) {
         IMAGE_CACHE.with(|global_cache| global_cache.borrow_mut().0.put_with_weight(key, value));
 }
 
-#[cfg(all(test, feature = "std"))]
+#[cfg(all(test, feature = "image-decoders"))]
 mod tests {
     use crate::graphics::Rgba8Pixel;
 

--- a/internal/core/graphics/image/htmlimage.rs
+++ b/internal/core/graphics/image/htmlimage.rs
@@ -1,7 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore parsererror
+
 use alloc::rc::Rc;
+use alloc::string::String;
 
 use super::ImageCacheKey;
 use crate::Property;
@@ -14,15 +17,54 @@ pub struct HTMLImage {
     /// used for remote HTML image loading and the property will be used to correctly track dependencies
     /// to graphics items that query for the size.
     image_load_pending: core::pin::Pin<Rc<Property<bool>>>,
+    is_svg: bool,
+    /// The size extracted from the SVG source's width/height/viewBox attributes.
+    /// The browser reports no useful natural size for SVGs without intrinsic dimensions,
+    /// so this takes precedence over naturalWidth/naturalHeight.
+    svg_intrinsic_size: Option<IntSize>,
+    /// The blob URL to revoke on drop when the image was created from in-memory data.
+    object_url: Option<String>,
 }
 
 impl HTMLImage {
     pub fn new(url: &str) -> Self {
+        let is_svg = url.ends_with(".svg") || url.ends_with(".svgz");
+        Self::new_impl(url, is_svg, None)
+    }
+
+    /// Creates an image from in-memory encoded data,
+    /// by handing the data to the browser as a blob URL.
+    /// `mime_type` selects the browser's decoder, for example `image/png` or `image/svg+xml`.
+    pub fn new_from_data(data: &[u8], mime_type: &str) -> Option<Self> {
+        let blob_parts = js_sys::Array::new();
+        blob_parts.push(&js_sys::Uint8Array::from(data));
+        let options = web_sys::BlobPropertyBag::new();
+        options.set_type(mime_type);
+        let blob =
+            web_sys::Blob::new_with_u8_array_sequence_and_options(&blob_parts, &options).ok()?;
+        let url = web_sys::Url::create_object_url_with_blob(&blob).ok()?;
+
+        let is_svg = mime_type == "image/svg+xml";
+        let svg_intrinsic_size = if is_svg {
+            core::str::from_utf8(data).ok().and_then(svg_intrinsic_size)
+        } else {
+            None
+        };
+
+        let mut image = Self::new_impl(&url, is_svg, svg_intrinsic_size);
+        image.object_url = Some(url);
+        Some(image)
+    }
+
+    fn new_impl(url: &str, is_svg: bool, svg_intrinsic_size: Option<IntSize>) -> Self {
         let dom_element = web_sys::HtmlImageElement::new().unwrap();
 
         let image_load_pending = Rc::pin(Property::new(true));
 
-        dom_element.set_cross_origin(Some("anonymous"));
+        // Setting crossOrigin on blob: or data: URLs can taint the WebGL canvas.
+        if url.starts_with("http:") || url.starts_with("https:") {
+            dom_element.set_cross_origin(Some("anonymous"));
+        }
         dom_element.set_onload(Some(
             &wasm_bindgen::closure::Closure::once_into_js({
                 let image_load_pending = image_load_pending.clone();
@@ -38,12 +80,28 @@ impl HTMLImage {
             })
             .into(),
         ));
-        dom_element.set_src(&url);
+        // The renderer reads the element's width/height attributes when turning the image
+        // into a texture, so seed them with the intrinsic size.
+        if let Some(size) = svg_intrinsic_size {
+            dom_element.set_width(size.width);
+            dom_element.set_height(size.height);
+        }
+        dom_element.set_src(url);
 
-        Self { dom_element, image_load_pending }
+        Self { dom_element, image_load_pending, is_svg, svg_intrinsic_size, object_url: None }
+    }
+
+    /// Returns true once the browser finished loading the image and it can be turned into a texture.
+    /// Reading this registers a dependency, so a caller within a property binding is re-evaluated
+    /// when loading completes.
+    pub fn is_loaded(&self) -> bool {
+        !self.image_load_pending.as_ref().get()
     }
 
     pub fn size(&self) -> Option<IntSize> {
+        if let Some(size) = self.svg_intrinsic_size {
+            return Some(size);
+        }
         match self.image_load_pending.as_ref().get() {
             true => None,
             false => Some(IntSize::new(
@@ -58,7 +116,15 @@ impl HTMLImage {
     }
 
     pub fn is_svg(&self) -> bool {
-        self.dom_element.current_src().ends_with(".svg")
+        self.is_svg
+    }
+}
+
+impl Drop for HTMLImage {
+    fn drop(&mut self) {
+        if let Some(url) = &self.object_url {
+            let _ = web_sys::Url::revoke_object_url(url);
+        }
     }
 }
 
@@ -69,4 +135,65 @@ impl super::OpaqueImage for HTMLImage {
     fn cache_key(&self) -> ImageCacheKey {
         ImageCacheKey::URL(self.source().into())
     }
+}
+
+/// Extracts the intrinsic size of an SVG from its width/height/viewBox attributes,
+/// the same way the native (resvg) code path determines it.
+fn svg_intrinsic_size(svg_source: &str) -> Option<IntSize> {
+    let document = web_sys::DomParser::new()
+        .ok()?
+        .parse_from_string(svg_source, web_sys::SupportedType::ImageSvgXml)
+        .ok()?;
+    let root = document.document_element()?;
+    // Parse errors produce a <parsererror> root element.
+    if !root.tag_name().eq_ignore_ascii_case("svg") {
+        return None;
+    }
+    let width = root.get_attribute("width").as_deref().and_then(parse_svg_length);
+    let height = root.get_attribute("height").as_deref().and_then(parse_svg_length);
+    let view_box = root.get_attribute("viewBox").as_deref().and_then(parse_view_box);
+    let (width, height) = match (width, height, view_box) {
+        (Some(w), Some(h), _) => (w, h),
+        (Some(w), None, Some((vw, vh))) => (w, w * vh / vw),
+        (None, Some(h), Some((vw, vh))) => (h * vw / vh, h),
+        (None, None, Some((vw, vh))) => (vw, vh),
+        _ => return None,
+    };
+    (width.is_finite() && height.is_finite() && width > 0. && height > 0.)
+        .then(|| IntSize::new(width.round().max(1.) as u32, height.round().max(1.) as u32))
+}
+
+/// Parses an SVG length attribute into CSS pixels.
+/// Percentages and font-relative units have no absolute value and yield None.
+fn parse_svg_length(value: &str) -> Option<f64> {
+    let value = value.trim();
+    let (number, factor) = if let Some(n) = value.strip_suffix("px") {
+        (n, 1.)
+    } else if let Some(n) = value.strip_suffix("pt") {
+        (n, 96. / 72.)
+    } else if let Some(n) = value.strip_suffix("pc") {
+        (n, 16.)
+    } else if let Some(n) = value.strip_suffix("mm") {
+        (n, 96. / 25.4)
+    } else if let Some(n) = value.strip_suffix("cm") {
+        (n, 96. / 2.54)
+    } else if let Some(n) = value.strip_suffix("in") {
+        (n, 96.)
+    } else if value.ends_with(|c: char| c.is_ascii_digit() || c == '.') {
+        (value, 1.)
+    } else {
+        return None;
+    };
+    number.trim().parse::<f64>().ok().map(|n| n * factor)
+}
+
+/// Returns the (width, height) of a viewBox attribute value.
+fn parse_view_box(value: &str) -> Option<(f64, f64)> {
+    let mut parts =
+        value.split(|c: char| c.is_ascii_whitespace() || c == ',').filter(|p| !p.is_empty());
+    let _min_x = parts.next()?;
+    let _min_y = parts.next()?;
+    let width = parts.next()?.parse::<f64>().ok()?;
+    let height = parts.next()?.parse::<f64>().ok()?;
+    Some((width, height))
 }

--- a/internal/core/graphics/image/svg.rs
+++ b/internal/core/graphics/image/svg.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use super::{ImageCacheKey, SharedImageBuffer, SharedPixelBuffer};
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "image-decoders", not(target_arch = "wasm32")))]
 use crate::SharedString;
 use crate::lengths::PhysicalPx;
 use resvg::{tiny_skia, usvg};
@@ -128,7 +128,7 @@ fn svg_options() -> usvg::Options<'static> {
     usvg::Options::default()
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "image-decoders", not(target_arch = "wasm32")))]
 pub fn load_from_path(
     path: &SharedString,
     cache_key: ImageCacheKey,

--- a/internal/core/graphics/image/svg.rs
+++ b/internal/core/graphics/image/svg.rs
@@ -97,7 +97,7 @@ impl ParsedSVG {
 ///
 /// Gated on `shared-parley`: without Slint's text engine there is no text layout, so
 /// SVG text resolution would be moot.
-#[cfg(feature = "shared-parley")]
+#[cfg(all(feature = "shared-parley", not(target_arch = "wasm32")))]
 fn svg_options() -> usvg::Options<'static> {
     use i_slint_common::sharedfontique::{self, fontique};
 
@@ -123,7 +123,7 @@ fn svg_options() -> usvg::Options<'static> {
     sharedfontique::svg::options(find_font)
 }
 
-#[cfg(not(feature = "shared-parley"))]
+#[cfg(all(not(feature = "shared-parley"), not(target_arch = "wasm32")))]
 fn svg_options() -> usvg::Options<'static> {
     usvg::Options::default()
 }
@@ -140,6 +140,7 @@ pub fn load_from_path(
         .map_err(std::io::Error::other)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn load_from_data(slice: &[u8], cache_key: ImageCacheKey) -> Result<ParsedSVG, usvg::Error> {
     usvg::Tree::from_data(slice, &svg_options())
         .map(|svg| ParsedSVG::new(svg, cache_key, slice.len()))

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -164,6 +164,11 @@ unicode-segmentation = { workspace = true }
 i-slint-backend-winit = { workspace = true }
 web-sys = { workspace = true, features = ["Navigator"] }
 
+# The interpreter loads images from the filesystem at runtime, so native builds
+# always need the decoders. The browser decodes images on the web.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+i-slint-core = { workspace = true, features = ["image-decoders", "svg"] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 # this line is there to add the "enable" feature by default, but only on linux
 i-slint-backend-qt = { workspace = true, features = ["enable"], optional = true }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -42,6 +42,7 @@ display-diagnostics = ["i-slint-compiler/display-diagnostics"]
 ## and `@image-url`. When this feature is disabled, only PNG and JPEG are supported. When enabled,
 ## the following image formats are supported:
 ## AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
+## This feature has no effect on the web, where the browser decodes images.
 image-default-formats = ["i-slint-core/image-default-formats"]
 
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -358,11 +358,12 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         Expression::ImageReference { resource_ref, nine_slice, .. } => {
             let mut image = match resource_ref {
                 i_slint_compiler::expression_tree::ImageReference::None => Ok(Default::default()),
-                i_slint_compiler::expression_tree::ImageReference::DataUri(data) => {
-                    i_slint_compiler::data_uri::decode_data_uri(data)
+                i_slint_compiler::expression_tree::ImageReference::DataUri(data_uri) => {
+                    i_slint_compiler::data_uri::decode_data_uri(data_uri)
                         .ok()
                         .and_then(|(data, extension)| {
-                            corelib::graphics::load_image_from_dynamic_data(&data, &extension).ok()
+                            corelib::graphics::load_image_from_data_uri(data_uri, &data, &extension)
+                                .ok()
                         })
                         .ok_or_else(Default::default)
                 }

--- a/internal/live-preview/remote/compilation.rs
+++ b/internal/live-preview/remote/compilation.rs
@@ -54,15 +54,8 @@ pub fn init_compiler(connection: Weak<Connection>) -> slint_interpreter::Compile
                     .extension()
                     .and_then(|e| e.to_str())
                     .unwrap_or("png");
-                let mime_type = match extension {
-                    "svg" | "svgz" => "image/svg+xml",
-                    "png" => "image/png",
-                    "jpg" | "jpeg" => "image/jpeg",
-                    "gif" => "image/gif",
-                    "bmp" => "image/bmp",
-                    "webp" => "image/webp",
-                    _ => "application/octet-stream",
-                };
+                let mime_type = i_slint_core::graphics::image_mime_type_from_extension(extension)
+                    .unwrap_or("application/octet-stream");
                 let file_content = connection.request_file(url).await.ok()?;
 
                 use base64::Engine as _;

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -47,6 +47,10 @@ wgpu-29 = { workspace = true, optional = true, default-features = true }
 web-sys = { workspace = true, features = ["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document"] }
 wasm-bindgen = { version = "0.2" }
 
+# The browser decodes images on the web; decode with the image and resvg crates elsewhere.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+i-slint-core = { workspace = true, features = ["image-decoders", "svg"] }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(slint_nightly_test)"] }
 

--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -139,7 +139,7 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
         let image_id = match image {
             #[cfg(target_arch = "wasm32")]
             ImageInner::HTMLImage(html_image) => {
-                if html_image.size().is_some() {
+                if html_image.is_loaded() {
                     // Anecdotal evidence suggests that HTMLImageElement converts to a texture with
                     // pre-multiplied alpha. It's possible that this is not generally applicable, but it
                     // is the case for SVGs.

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -34,7 +34,7 @@ unstable-wgpu-29 = ["i-slint-core/unstable-wgpu-29", "wgpu-29"]
 default = ["softbuffer"]
 
 [dependencies]
-i-slint-core = { workspace = true, features = ["default", "box-shadow-cache", "shared-parley"] }
+i-slint-core = { workspace = true, features = ["default", "box-shadow-cache", "shared-parley", "image-decoders", "svg"] }
 i-slint-core-macros = { workspace = true, features = ["default"] }
 i-slint-common = { workspace = true, features = ["default"] }
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "i-slint-core-macros",
  "icu_normalizer",
  "image",
+ "js-sys",
  "ksni",
  "lyon_algorithms",
  "lyon_extra",


### PR DESCRIPTION
On the web, images are now loaded through an `HTMLImageElement` with a blob URL, and the browser decodes them. This covers embedded resources, the
  builtin widget icons, and `data:` URIs. The `image` and `resvg` crates are no longer part of wasm builds. Native builds keep decoding as before: the
  backends and renderers enable the decoders there.
  
  As a result:
  - Every image format the browser supports now works on the web (WebP, AVIF, GIF, ...). Compressed SVG (`.svgz`) is not supported there.
  - SVGs without `width`/`height` attributes get their size from the `viewBox`, like on native (#6715 for embedded SVGs).
  - The compiler no longer constant-folds image sizes when the generated code may run on the web, so sizes update when an image finishes loading.

  Wasm sizes (release, after wasm-opt):

  | Binary | before | after | gzipped before | gzipped after |
  |---|---|---|---|---|                                                                                                                      
  | SlintPad interpreter | 15.18 MB | 12.89 MB | 6.31 MB | 5.42 MB |
  | SlintPad LSP | 23.81 MB | 20.45 MB | 8.98 MB | 7.74 MB |
  | home-automation demo | 13.14 MB | 10.87 MB | 6.14 MB | 5.24 MB |

  Known limitation: embedded raster images load asynchronously on the web and can appear one frame late. SVGs are not affected, their size is parsed from
  the source.