### PR TITLE
Add WindowMoveArea element to start an interactive window move 

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -417,6 +417,7 @@ fn gen_corelib(
         "BorderRectangle",
         "DragArea",
         "DropArea",
+        "WindowMoveArea",
         "ImageItem",
         "ClippedImage",
         "TouchArea",

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2591,6 +2591,15 @@ impl WindowAdapterInternal for QtWindow {
         true
     }
 
+    fn start_window_move(&self) {
+        let widget_ptr = self.widget_ptr();
+        cpp! {unsafe [widget_ptr as "QWidget*"] {
+            if (QWindow *window = widget_ptr->window()->windowHandle()) {
+                window->startSystemMove();
+            }
+        }}
+    }
+
     fn register_item_tree(&self, _: ItemTreeRefPin) {
         self.tree_structure_changed.replace(true);
     }

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -195,6 +195,7 @@ impl i_slint_core::platform::Platform for TestingBackend {
             native_popup: Cell::new(false),
             simulate_native_drag: Cell::new(false),
             native_drag: Default::default(),
+            window_move_requests: Default::default(),
             #[cfg(supports_headless)]
             renderer_name: self.renderer_name.clone(),
             #[cfg(supports_headless)]
@@ -297,6 +298,7 @@ pub struct TestingWindow {
     /// Payload and allowed actions recorded by `start_drag` while simulating a native drag,
     /// so the receive-side helpers can build the drop they deliver to a target window.
     native_drag: RefCell<Option<(i_slint_core::data_transfer::DataTransfer, AllowedDragActions)>>,
+    window_move_requests: Cell<usize>,
     /// Remembered for child popups, so they pick the same rasterizer.
     #[cfg(supports_headless)]
     renderer_name: Option<SharedString>,
@@ -315,6 +317,11 @@ impl TestingWindow {
     #[allow(dead_code)] // Used by various tests
     pub fn mouse_cursor(&self) -> i_slint_core::cursor::MouseCursorInner {
         self.mouse_cursor.borrow().clone()
+    }
+
+    /// Number of interactive window moves requested via `WindowMoveArea`.
+    pub fn window_move_request_count(&self) -> usize {
+        self.window_move_requests.get()
     }
 
     #[allow(dead_code)]
@@ -396,6 +403,10 @@ impl WindowAdapterInternal for TestingWindow {
         true
     }
 
+    fn start_window_move(&self) {
+        self.window_move_requests.set(self.window_move_requests.get() + 1);
+    }
+
     fn set_mouse_cursor(&self, cursor: i_slint_core::cursor::MouseCursorInner) {
         self.mouse_cursor.replace(cursor);
     }
@@ -438,6 +449,7 @@ impl WindowAdapterInternal for TestingWindow {
                 native_popup: self.native_popup.clone(),
                 simulate_native_drag: self.simulate_native_drag.clone(),
                 native_drag: Default::default(),
+                window_move_requests: Default::default(),
                 #[cfg(supports_headless)]
                 renderer_name: self.renderer_name.clone(),
                 #[cfg(supports_headless)]

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1452,6 +1452,12 @@ impl WindowAdapter for WinitWindowAdapter {
 }
 
 impl WindowAdapterInternal for WinitWindowAdapter {
+    fn start_window_move(&self) {
+        if let Some(winit_window) = self.winit_window_or_none.borrow().as_window() {
+            let _ = winit_window.drag_window();
+        }
+    }
+
     fn set_mouse_cursor(&self, cursor: MouseCursorInner) {
         let winit_cursor = match &cursor {
             MouseCursorInner::BuiltIn(cursor) => match cursor {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1592,6 +1592,52 @@ export component Window inherits WindowItem {
     MenuBar { }
 }
 
+/// Use `WindowMoveArea` to let the user move the window by dragging a region of your UI,
+/// such as a custom title bar in a window without native decorations (`no-frame: true`).
+///
+/// The move starts when the user presses the left mouse button inside the area and drags past a small threshold.
+/// A plain click doesn't move the window, so child elements like <Link type="TouchArea" /> stay interactive.
+///
+/// The windowing system performs the move.
+/// It requires a backend and platform with support for it (winit on Windows, macOS, X11, and Wayland; Qt).
+/// On platforms without support, the element does nothing.
+///
+/// When not part of a layout, its width and height default to 100% of the parent element.
+///
+/// ```slint playground
+/// export component Example inherits Window {
+///     no-frame: true;
+///     preferred-width: 400px;
+///     preferred-height: 300px;
+///     VerticalLayout {
+///         Rectangle {
+///             height: 32px;
+///             background: #444444;
+///             WindowMoveArea {
+///                 HorizontalLayout {
+///                     Text {
+///                         text: "My Application";
+///                         color: white;
+///                         vertical-alignment: center;
+///                         horizontal-alignment: center;
+///                     }
+///                 }
+///             }
+///         }
+///         Rectangle {
+///             background: white;
+///         }
+///     }
+/// }
+/// ```
+/// \group:window
+export component WindowMoveArea {
+    /// Set to `false` to stop the `WindowMoveArea` from initiating window moves.
+    /// Events still reach the child elements.
+    in property <bool> enabled: true;
+    //-default_size_binding:expands_to_parent_geometry
+}
+
 export component BoxShadow inherits Empty {
     in property <length> border-top-left-radius;
     in property <length> border-top-right-radius;

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1212,6 +1212,10 @@ declare_item_vtable! {
     fn slint_get_DropAreaVTable() -> DropAreaVTable for DropArea
 }
 
+declare_item_vtable! {
+    fn slint_get_WindowMoveAreaVTable() -> WindowMoveAreaVTable for WindowMoveArea
+}
+
 /// The implementation of the `PropertyAnimation` element
 /// This animation has the time as animation limit
 #[repr(C)]

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -44,6 +44,64 @@ impl AllowedDragActions {
     }
 }
 
+/// Filter step of the "left press, then drag past the threshold" gesture shared by
+/// `DragArea` and `WindowMoveArea`: tracks the press in the item's `pressed`/
+/// `pressed_position` cells and intercepts the children's events once the threshold is
+/// crossed. The caller handles its disabled/precondition case before calling this.
+pub(super) fn press_drag_filter(
+    pressed: &Cell<bool>,
+    pressed_position: &Cell<LogicalPoint>,
+    event: &MouseEvent,
+) -> InputEventFilterResult {
+    match event {
+        MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
+            pressed_position.set(*position);
+            pressed.set(true);
+            InputEventFilterResult::ForwardAndInterceptGrab
+        }
+        MouseEvent::Exit => {
+            pressed.set(false);
+            InputEventFilterResult::ForwardAndIgnore
+        }
+        MouseEvent::Released { button: PointerEventButton::Left, .. } => {
+            pressed.set(false);
+            InputEventFilterResult::ForwardAndIgnore
+        }
+        MouseEvent::Moved { position, .. } => {
+            if !pressed.get() {
+                InputEventFilterResult::ForwardEvent
+            } else if exceeds_drag_threshold(pressed_position.get(), *position) {
+                InputEventFilterResult::Intercept
+            } else {
+                InputEventFilterResult::ForwardAndInterceptGrab
+            }
+        }
+        MouseEvent::Wheel { .. } => InputEventFilterResult::ForwardAndIgnore,
+        // Not the left button
+        MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
+            InputEventFilterResult::ForwardAndIgnore
+        }
+        MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
+            InputEventFilterResult::ForwardAndIgnore
+        }
+        MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
+            InputEventFilterResult::ForwardAndIgnore
+        }
+    }
+}
+
+/// True once the pointer has moved far enough from the press position to count as a
+/// drag rather than a click.
+pub(super) fn exceeds_drag_threshold(
+    pressed_position: LogicalPoint,
+    position: LogicalPoint,
+) -> bool {
+    let dx = (position.x - pressed_position.x).abs();
+    let dy = (position.y - pressed_position.y).abs();
+    let threshold = super::flickable::DISTANCE_THRESHOLD.get();
+    dx > threshold || dy > threshold
+}
+
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
@@ -90,49 +148,7 @@ impl Item for DragArea {
             self.cancel();
             return InputEventFilterResult::ForwardAndIgnore;
         }
-
-        match event {
-            MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
-                self.pressed_position.set(*position);
-                self.pressed.set(true);
-                InputEventFilterResult::ForwardAndInterceptGrab
-            }
-            MouseEvent::Exit => {
-                self.cancel();
-                InputEventFilterResult::ForwardAndIgnore
-            }
-            MouseEvent::Released { button: PointerEventButton::Left, .. } => {
-                self.pressed.set(false);
-                InputEventFilterResult::ForwardAndIgnore
-            }
-
-            MouseEvent::Moved { position, .. } => {
-                if !self.pressed.get() {
-                    InputEventFilterResult::ForwardEvent
-                } else {
-                    let pressed_pos = self.pressed_position.get();
-                    let dx = (position.x - pressed_pos.x).abs();
-                    let dy = (position.y - pressed_pos.y).abs();
-                    let threshold = super::flickable::DISTANCE_THRESHOLD.get();
-                    if dy > threshold || dx > threshold {
-                        InputEventFilterResult::Intercept
-                    } else {
-                        InputEventFilterResult::ForwardAndInterceptGrab
-                    }
-                }
-            }
-            MouseEvent::Wheel { .. } => InputEventFilterResult::ForwardAndIgnore,
-            // Not the left button
-            MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
-                InputEventFilterResult::ForwardAndIgnore
-            }
-            MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
-                InputEventFilterResult::ForwardAndIgnore
-            }
-            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => {
-                InputEventFilterResult::ForwardAndIgnore
-            }
-        }
+        press_drag_filter(&self.pressed, &self.pressed_position, event)
     }
 
     fn input_event(
@@ -160,11 +176,7 @@ impl Item for DragArea {
                 {
                     return InputEventResult::EventIgnored;
                 }
-                let pressed_pos = self.pressed_position.get();
-                let dx = (position.x - pressed_pos.x).abs();
-                let dy = (position.y - pressed_pos.y).abs();
-                let threshold = super::flickable::DISTANCE_THRESHOLD.get();
-                let start_drag = dx > threshold || dy > threshold;
+                let start_drag = exceeds_drag_threshold(self.pressed_position.get(), *position);
                 if start_drag {
                     self.pressed.set(false);
                     InputEventResult::StartDrag

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -282,6 +282,140 @@ impl ItemConsts for KeyBinding {
     > = KeyBinding::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
 }
 
+/// The implementation of the `WindowMoveArea` element
+#[repr(C)]
+#[derive(FieldOffsets, Default, SlintElement)]
+#[pin]
+pub struct WindowMoveArea {
+    pub enabled: Property<bool>,
+    pressed: Cell<bool>,
+    pressed_position: Cell<LogicalPoint>,
+    pub cached_rendering_data: CachedRenderingData,
+}
+
+impl Item for WindowMoveArea {
+    fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
+
+    fn deinit(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
+
+    fn layout_info(
+        self: Pin<&Self>,
+        _: Orientation,
+        _cross_axis_constraint: Coord,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> LayoutInfo {
+        LayoutInfo { stretch: 1., ..LayoutInfo::default() }
+    }
+
+    fn input_event_filter_before_children(
+        self: Pin<&Self>,
+        event: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        _: &mut MouseCursorInner,
+    ) -> InputEventFilterResult {
+        if !self.enabled() {
+            self.pressed.set(false);
+            return InputEventFilterResult::ForwardAndIgnore;
+        }
+        super::drag_n_drop::press_drag_filter(&self.pressed, &self.pressed_position, event)
+    }
+
+    fn input_event(
+        self: Pin<&Self>,
+        event: &MouseEvent,
+        window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        _: &mut MouseCursorInner,
+    ) -> InputEventResult {
+        match event {
+            MouseEvent::Pressed { .. } => InputEventResult::EventAccepted,
+            MouseEvent::Exit | MouseEvent::Released { .. } => {
+                self.pressed.set(false);
+                InputEventResult::EventIgnored
+            }
+            MouseEvent::Moved { position, .. } => {
+                if !self.pressed.get() || !self.enabled() {
+                    return InputEventResult::EventIgnored;
+                }
+                if super::drag_n_drop::exceeds_drag_threshold(
+                    self.pressed_position.get(),
+                    *position,
+                ) {
+                    self.pressed.set(false);
+                    if let Some(internal) = window_adapter.internal(crate::InternalToken) {
+                        internal.start_window_move();
+                    }
+                }
+                InputEventResult::EventAccepted
+            }
+            MouseEvent::Wheel { .. } => InputEventResult::EventIgnored,
+            MouseEvent::PinchGesture { .. } | MouseEvent::RotationGesture { .. } => {
+                InputEventResult::EventIgnored
+            }
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } => InputEventResult::EventIgnored,
+        }
+    }
+
+    fn capture_key_event(
+        self: Pin<&Self>,
+        _: &InternalKeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn key_event(
+        self: Pin<&Self>,
+        _: &InternalKeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> FocusEventResult {
+        FocusEventResult::FocusIgnored
+    }
+
+    fn render(
+        self: Pin<&Self>,
+        _: &mut ItemRendererRef,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+    ) -> RenderingResult {
+        RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect(
+        self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        mut geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry.size = LogicalSize::zero();
+        geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
+}
+
+impl ItemConsts for WindowMoveArea {
+    const cached_rendering_data_offset: const_field_offset::FieldOffset<
+        WindowMoveArea,
+        CachedRenderingData,
+    > = WindowMoveArea::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
+}
+
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -322,6 +322,13 @@ pub trait WindowAdapterInternal: core::any::Any {
     fn start_drag(&self, _request: &DragRequest) -> bool {
         false
     }
+
+    /// Ask the windowing system to start an interactive, user-driven move of the window,
+    /// as if the user had dragged the window's title bar.
+    ///
+    /// This is called while the user holds a mouse button pressed.
+    /// The default implementation does nothing; backends without support ignore the request.
+    fn start_window_move(&self) {}
 }
 
 /// This is the parameter from [`WindowAdapterInternal::input_method_request()`] which lets the editable text input field

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1039,6 +1039,7 @@ fn generate_rtti() -> HashMap<&'static str, Rc<ItemRTTI>> {
             rtti_for::<Layer>(),
             rtti_for::<DragArea>(),
             rtti_for::<DropArea>(),
+            rtti_for::<WindowMoveArea>(),
             rtti_for::<ContextMenu>(),
             rtti_for::<MenuItem>(),
             rtti_for::<SystemTrayIcon>(),

--- a/tests/cases/elements/window_move_area.slint
+++ b/tests/cases/elements/window_move_area.slint
@@ -1,0 +1,108 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 200px;
+    in property <bool> area-enabled: true;
+    in-out property <string> result;
+    out property <bool> inner-touch-area-has-hover <=> inner-touch-area.has-hover;
+
+    Rectangle {
+        y: 0;
+        height: 100px;
+        WindowMoveArea {
+            enabled: root.area-enabled;
+            inner-touch-area := TouchArea {
+                x: 50px;
+                width: 50px;
+                clicked => { result += "InnerClicked;"; }
+            }
+        }
+    }
+}
+
+/*
+```rust
+use slint::{platform::WindowEvent, LogicalPosition, platform::PointerEventButton};
+
+let instance = TestCase::new().unwrap();
+let move_count = || slint_testing::access_testing_window(instance.window(), |window| window.window_move_request_count());
+
+// A plain click on the inner touch area doesn't move the window.
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(60.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(move_count(), 0);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(60.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "InnerClicked;");
+assert_eq!(move_count(), 0);
+
+// A click with movement below the threshold is still a click.
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(60.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(63.0, 28.0) });
+slint_testing::mock_elapsed_time(20);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(63.0, 28.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "InnerClicked;");
+assert_eq!(move_count(), 0);
+
+// Dragging past the threshold requests a window move, even when the drag starts on the touch area.
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(60.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert!(instance.get_inner_touch_area_has_hover());
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(60.0, 45.0) });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(move_count(), 1);
+// The touch area's press was cancelled when the move started, so the release is not a click.
+// (In a real session the windowing system also sends a leave event once it takes the pointer over.)
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(60.0, 45.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "");
+assert_eq!(move_count(), 1);
+
+// Input still works normally after the window move.
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(60.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(500);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(60.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "InnerClicked;");
+assert_eq!(move_count(), 1);
+
+// Dragging outside of any touch area also requests a window move.
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(10.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(30.0, 25.0) });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(move_count(), 2);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(30.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "");
+
+// Dragging outside of the WindowMoveArea doesn't move the window.
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(50.0, 150.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 175.0) });
+slint_testing::mock_elapsed_time(20);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(50.0, 175.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(move_count(), 2);
+
+// A disabled WindowMoveArea never requests a move, and events pass through.
+instance.set_area_enabled(false);
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(60.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(60.0, 45.0) });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(move_count(), 2);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(60.0, 45.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "InnerClicked;");
+assert_eq!(move_count(), 2);
+```
+*/

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -145,8 +145,7 @@ fn start_processing_lsp_messages_thread(
     // process messages before the event loop was running.
     let selector = slint::BackendSelector::new();
     // On macOS, request a unified title bar: the editor content extends underneath
-    // a transparent title bar. The title-bar metrics are reported back to the UI
-    // via the `Api` global (see `preview::macos_titlebar`).
+    // a transparent title bar (see `preview::macos_titlebar`).
     #[cfg(target_os = "macos")]
     let selector = selector
         .with_winit_window_attributes_hook(crate::preview::macos_titlebar::apply_unified_titlebar);

--- a/tools/lsp/preview/macos_titlebar.rs
+++ b/tools/lsp/preview/macos_titlebar.rs
@@ -7,7 +7,7 @@ use slint::winit_030::winit;
 use winit::platform::macos::WindowAttributesExtMacOS;
 use winit::window::WindowAttributes;
 
-use crate::preview::ui::{Api, EditorUi};
+use crate::preview::ui::EditorUi;
 
 /// Window-attributes hook that makes the content view fill the whole window
 /// underneath a transparent, title-less title bar.
@@ -25,8 +25,7 @@ pub fn apply_unified_titlebar(attributes: WindowAttributes) -> WindowAttributes 
         .with_title_hidden(true)
 }
 
-/// Configures the unified title bar once the winit window exists and publishes
-/// the resulting title-bar metrics to the `Api` global.
+/// Configures the unified title bar once the winit window exists.
 pub fn setup(editor: slint::Weak<EditorUi>) {
     use objc2::{MainThreadMarker, MainThreadOnly};
     use objc2_app_kit::{
@@ -38,21 +37,7 @@ pub fn setup(editor: slint::Weak<EditorUi>) {
     use slint::winit_030::WinitWindowAccessor;
 
     slint::spawn_local(async move {
-        let editor_weak = editor.clone();
         let editor = editor.upgrade()?;
-        let api = editor.global::<Api>();
-
-        // Drive window dragging ourselves: the unified title bar requests an
-        // interactive drag, which we start via winit's `drag_window` (using the
-        // current mouse event) rather than letting macOS perform a native
-        // title-bar drag.
-        api.on_request_window_drag(move || {
-            if let Some(editor) = editor_weak.upgrade() {
-                editor.window().with_winit_window(|w| {
-                    let _ = w.drag_window();
-                });
-            }
-        });
         let Ok(winit_window) = editor.window().winit_window().await else {
             return None;
         };

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -323,9 +323,6 @@ export global Api {
     // control, but command on macOS
     in-out property <string> control-key-name: "control";
 
-    // Start an interactive window drag (implemented by the editor host on macOS).
-    callback request-window-drag();
-
     // ## Log Output
     in-out property <[LogMessage]> log-output;
     in-out property <bool> auto-clear-console: true;

--- a/tools/lsp/ui/editor.slint
+++ b/tools/lsp/ui/editor.slint
@@ -28,38 +28,36 @@ export component EditorUi inherits Window {
         height: root.titlebar-height;
         background: #3a3a3c;
 
-        if Platform.os == OperatingSystemType.macos: TouchArea {
-            pointer-event(e) => {
-                if e.kind == PointerEventKind.down && e.button == PointerEventButton.left {
-                    Api.request-window-drag();
-                }
-            }
-        }
+        WindowMoveArea {
+            // The custom title bar only exists on macOS; elsewhere the
+            // window keeps its native decorations.
+            enabled: Platform.os == OperatingSystemType.macos;
 
-        HorizontalLayout {
-            padding-left: 8px;
-            padding-right: 8px;
-            alignment: start;
+            HorizontalLayout {
+                padding-left: 8px;
+                padding-right: 8px;
+                alignment: start;
 
-            VerticalLayout {
-                alignment: center;
+                VerticalLayout {
+                    alignment: center;
 
-                // Fake toolbar button.
-                Rectangle {
-                    width: 64px;
-                    height: 22px;
-                    border-radius: 5px;
-                    background: touch.pressed ? #5a5a5e : #505054;
+                    // Fake toolbar button.
+                    Rectangle {
+                        width: 64px;
+                        height: 22px;
+                        border-radius: 5px;
+                        background: touch.pressed ? #5a5a5e : #505054;
 
-                    Text {
-                        text: "Run";
-                        color: #ffffff;
-                        font-size: 12px;
-                        horizontal-alignment: center;
-                        vertical-alignment: center;
+                        Text {
+                            text: "Run";
+                            color: #ffffff;
+                            font-size: 12px;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+
+                        touch := TouchArea { }
                     }
-
-                    touch := TouchArea { }
                 }
             }
         }


### PR DESCRIPTION
Pressing the left mouse button inside the area and dragging past a
small threshold asks the windowing system to move the window, like
dragging a native title bar. A plain click doesn't move the window,
so child elements stay interactive. The press-drag gesture is shared
with DragArea.

Implemented for the winit backend (drag_window) and the Qt backend
(QWindow::startSystemMove).

Fixes: https://github.com/slint-ui/slint/issues/613