### PR TITLE
winit: don't print error when xdg portal is not present

### DIFF
--- a/internal/backends/winit/xdg_desktop_settings.rs
+++ b/internal/backends/winit/xdg_desktop_settings.rs
@@ -170,13 +170,30 @@ fn apply_cursor_blink_time_value(value: zbus::zvariant::OwnedValue, cx: &Setting
 /// whole batch costs roughly one round-trip instead of one per setting.
 async fn read_all_settings(settings_proxy: &zbus::Proxy<'_>, cx: &SettingsContext<'_>) {
     futures::future::join_all(SETTINGS.iter().map(|setting| async move {
-        let value: zbus::Result<zbus::zvariant::OwnedValue> =
-            settings_proxy.call("ReadOne", &(setting.namespace, setting.key)).await;
-        if let Ok(value) = value {
+        if let Ok(value) = read_setting(settings_proxy, setting).await {
             (setting.apply)(value, cx);
         }
     }))
     .await;
+}
+
+/// Reads one setting.
+/// Portals older than 1.15 (Ubuntu 22.04 and earlier) only implement the deprecated `Read`,
+/// whose extra variant wrapping `downcast_ref()` unwraps transparently.
+async fn read_setting(
+    settings_proxy: &zbus::Proxy<'_>,
+    setting: &SettingDescriptor,
+) -> zbus::Result<zbus::zvariant::OwnedValue> {
+    let args = (setting.namespace, setting.key);
+    #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
+    match settings_proxy.call("ReadOne", &args).await {
+        Err(zbus::Error::MethodError(name, ..))
+            if name.as_str() == "org.freedesktop.DBus.Error.UnknownMethod" =>
+        {
+            settings_proxy.call("Read", &args).await
+        }
+        result => result,
+    }
 }
 
 /// Clears the pending flag so the backend creates and shows the first windows.

--- a/internal/backends/winit/xdg_desktop_settings.rs
+++ b/internal/backends/winit/xdg_desktop_settings.rs
@@ -250,6 +250,26 @@ async fn watch(
     Ok(())
 }
 
+/// True when the error only means the session bus or the settings portal is missing,
+/// which is normal on headless systems and bare compositors.
+fn portal_unavailable(err: &zbus::Error) -> bool {
+    #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
+    match err {
+        // No session bus address, or nothing listening on it.
+        zbus::Error::Address(_) | zbus::Error::InputOutput(_) => true,
+        zbus::Error::MethodError(name, ..) => matches!(
+            name.as_str(),
+            "org.freedesktop.DBus.Error.ServiceUnknown"
+                | "org.freedesktop.DBus.Error.NameHasNoOwner"
+        ),
+        zbus::Error::FDO(err) => matches!(
+            **err,
+            zbus::fdo::Error::ServiceUnknown(_) | zbus::fdo::Error::NameHasNoOwner(_)
+        ),
+        _ => false,
+    }
+}
+
 /// Starts the portal watcher and the timeout that releases the first windows if
 /// the portal is slow or missing. Returns the task so the backend can abort it.
 pub(crate) fn spawn(
@@ -265,7 +285,9 @@ pub(crate) fn spawn(
     strong_ctx
         .spawn_local(async move {
             if let Err(err) = watch(&shared_weak, ctx_weak).await {
-                i_slint_core::debug_log!("Error watching for xdg desktop settings: {err}");
+                if !portal_unavailable(&err) {
+                    i_slint_core::debug_log!("Error watching for xdg desktop settings: {err}");
+                }
                 // The portal is unavailable; create the waiting windows anyway.
                 finish_appearance_query(&shared_weak);
             }


### PR DESCRIPTION
And also still support older portal version (Ubuntu 22.04 is still supported)

Fixes: https://github.com/slint-ui/slint/issues/10226
Fixes: https://github.com/slint-ui/slint/issues/9457