### PR TITLE
Fix out-of-memory abort when a repeater count is huge

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3934,7 +3934,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 }
                 (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
                     format!(
-                        "std::make_shared<slint::private_api::UIntModel>(std::max<int>(0, {f}))"
+                        "std::make_shared<slint::private_api::UIntModel>(std::max(0, slint::private_api::saturating_float_to_int({f})))"
                     )
                 }
                 (Type::Array(_), Type::Model) => f,

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -140,8 +140,17 @@ trait RepeaterInstanceOps {
     fn listview_layout(&self, instance_idx: usize, y: &mut Coord) -> Coord;
 }
 
+/// More rows than this is presumably a bug (e.g. a division by zero) and would run out of memory
+const MAX_EAGER_INSTANCE_COUNT: usize = 1 << 20;
+
 /// Update all instances in the repeater, creating any that are missing.
 fn update_all_instances(ops: &mut impl RepeaterInstanceOps, offset: usize, count: usize) {
+    let count = if count > MAX_EAGER_INSTANCE_COUNT {
+        crate::debug_log!("A repeater's model has {count} rows: too many to instantiate");
+        0
+    } else {
+        count
+    };
     let cur = ops.len();
     if count > cur {
         ops.splice(cur, 0, count - cur);

--- a/tests/cases/crashes/issue_12400_repeater_div_by_zero.slint
+++ b/tests/cases/crashes/issue_12400_repeater_div_by_zero.slint
@@ -1,0 +1,34 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A huge repeater count (e.g. from a division by zero) must not cause a giant allocation
+
+export component TestCase inherits Window {
+    in property <int> columns: 0;
+    out property <int> rows: Math.ceil(7 / columns);
+    for i in rows: Rectangle { }
+    for j in 7 / columns: Rectangle { }
+    for k in 2000000000: Rectangle { }
+    out property <bool> test: true;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+instance.set_columns(2);
+assert_eq(instance.get_rows(), 4);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+instance.set_columns(2);
+assert_eq!(instance.get_rows(), 4);
+```
+
+```js
+var instance = new slint.TestCase({});
+instance.columns = 2;
+assert.equal(instance.rows, 4);
+```
+*/


### PR DESCRIPTION
A division by zero used as a repeater count saturates to i32::MAX when converted to int, and the repeater then tried to instantiate two billion items. Leave the repeater empty above a sanity limit instead.

Also convert the count with saturating_float_to_int in the generated C++ code, as the implicit float to int conversion is undefined behavior for out-of-range values.

Fixes: #12400
