### PR TITLE
Don't panic when a component with custom fonts can't create its window adapter

### DIFF
--- a/api/rs/slint/tests/window_adapter_creation_error.rs
+++ b/api/rs/slint/tests/window_adapter_creation_error.rs
@@ -1,0 +1,66 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! A window adapter creation failure must surface as an `Err` from `new()`. With a custom
+//! font import, the font registration in `init()` is the first window adapter access and
+//! used to panic instead. The attempt counter in the error message checks that each `new()`
+//! makes exactly one creation attempt, i.e. that the error is reported by the first access
+//! and not swallowed and re-triggered later.
+
+use slint::platform::{Platform, PlatformError, WindowAdapter};
+use std::cell::Cell;
+use std::rc::Rc;
+
+mod without_font {
+    slint::slint! {
+        export component WithoutFont inherits Window {
+            Text {
+                text: "Hello";
+            }
+        }
+    }
+}
+
+mod with_font {
+    slint::slint! {
+        import "../../../examples/slide_puzzle/plaster-font/Plaster-Regular.ttf";
+
+        export component WithFont inherits Window {
+            Text {
+                font-family: "Plaster";
+                text: "Hello";
+            }
+        }
+    }
+}
+
+struct FailingPlatform {
+    attempts: Cell<u32>,
+}
+
+impl Platform for FailingPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        self.attempts.set(self.attempts.get() + 1);
+        Err(PlatformError::Other(format!(
+            "cannot create window adapter (attempt {})",
+            self.attempts.get()
+        )))
+    }
+}
+
+#[test]
+fn window_adapter_creation_error_is_returned() {
+    slint::platform::set_platform(Box::new(FailingPlatform { attempts: Cell::new(0) })).unwrap();
+
+    // Without fonts, the eager window adapter creation in `new()` reports the error.
+    let Err(PlatformError::Other(message)) = without_font::WithoutFont::new() else {
+        panic!("expected new() to fail with the platform error");
+    };
+    assert_eq!(message, "cannot create window adapter (attempt 1)");
+
+    // With a custom font, the font registration in `init()` reports the error.
+    let Err(PlatformError::Other(message)) = with_font::WithFont::new() else {
+        panic!("expected new() to fail with the platform error");
+    };
+    assert_eq!(message, "cannot create window adapter (attempt 2)");
+}

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1399,7 +1399,7 @@ fn generate_sub_component(
         init.push(quote!(#sub_component_id::init(
             sp::VRcMapped::map(self_rc.clone(), |x| #sub_compo_field.apply_pin(x)),
             #global_access.clone(), #global_index, #global_children
-        );));
+        )?;));
         user_init_code.push(quote!(#sub_component_id::user_init(
             sp::VRcMapped::map(self_rc.clone(), |x| #sub_compo_field.apply_pin(x)),
         );));
@@ -1653,7 +1653,9 @@ fn generate_sub_component(
         impl #inner_component_id {
             fn init(self_rc: sp::VRcMapped<sp::ItemTreeVTable, Self>,
                     globals : sp::Rc<SharedGlobals>,
-                    tree_index: u32, tree_index_of_first_child: u32) {
+                    tree_index: u32, tree_index_of_first_child: u32)
+                -> ::core::result::Result<(), slint::PlatformError>
+            {
                 #![allow(unused)]
                 let _self = self_rc.as_pin_ref();
                 let _ = _self.self_weak.set(sp::VRcMapped::downgrade(&self_rc));
@@ -1661,6 +1663,7 @@ fn generate_sub_component(
                 _self.tree_index.set(tree_index);
                 _self.tree_index_of_first_child.set(tree_index_of_first_child);
                 #(#init)*
+                ::core::result::Result::Ok(())
             }
 
             fn user_init(self_rc: sp::VRcMapped<sp::ItemTreeVTable, Self>) {
@@ -2240,7 +2243,7 @@ fn generate_item_tree(
                 let globals = #globals;
                 #set_and_init_globals
                 sp::register_item_tree(&self_dyn_rc, #register_window_adapter_arg);
-                Self::init(sp::VRc::map(self_rc.clone(), |x| x), globals, 0, 1);
+                Self::init(sp::VRc::map(self_rc.clone(), |x| x), globals, 0, 1)?;
                 ::core::result::Result::Ok(self_rc)
             }
 
@@ -4021,29 +4024,31 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::RegisterCustomFontByPath => {
             if let [Expression::StringLiteral(path)] = arguments {
-                let window_adapter_tokens = access_window_adapter_field(ctx);
+                let global_access = &ctx.generator_state.global_access;
                 let path = path.as_str();
-                quote!(#window_adapter_tokens.renderer().register_font_from_path(&std::path::PathBuf::from(#path)).unwrap())
+                // The `?` requires the enclosing generated function to return `Result`: font
+                // registration is only emitted in `init()`, which does.
+                quote!(#global_access.window_adapter_ref()?.renderer().register_font_from_path(&std::path::PathBuf::from(#path)).unwrap())
             } else {
                 panic!("internal error: invalid args to RegisterCustomFontByPath {arguments:?}")
             }
         }
         BuiltinFunction::RegisterCustomFontByMemory => {
             if let [Expression::NumberLiteral(resource_id)] = &arguments {
+                let global_access = &ctx.generator_state.global_access;
                 let resource_id: usize = *resource_id as _;
                 let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);
-                let window_adapter_tokens = access_window_adapter_field(ctx);
-                quote!(#window_adapter_tokens.renderer().register_font_from_memory(#symbol.into()).unwrap())
+                quote!(#global_access.window_adapter_ref()?.renderer().register_font_from_memory(#symbol.into()).unwrap())
             } else {
                 panic!("internal error: invalid args to RegisterCustomFontByMemory {arguments:?}")
             }
         }
         BuiltinFunction::RegisterBitmapFont => {
             if let [Expression::NumberLiteral(resource_id)] = &arguments {
+                let global_access = &ctx.generator_state.global_access;
                 let resource_id: usize = *resource_id as _;
                 let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);
-                let window_adapter_tokens = access_window_adapter_field(ctx);
-                quote!(#window_adapter_tokens.renderer().register_bitmap_font(&#symbol))
+                quote!(#global_access.window_adapter_ref()?.renderer().register_bitmap_font(&#symbol))
             } else {
                 panic!("internal error: invalid args to RegisterBitmapFont must be a number")
             }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2679,18 +2679,11 @@ impl<'a, 'id> InstanceRef<'a, 'id> {
     }
 
     pub fn window_adapter(&self) -> WindowAdapterRc {
-        let root_weak = vtable::VWeak::into_dyn(self.root_weak().clone());
-        let root = self.root_weak().upgrade().unwrap();
-        generativity::make_guard!(guard);
-        let comp = root.unerase(guard);
-        Self::get_or_init_window_adapter_ref(
-            &comp.description,
-            root_weak,
-            true,
-            comp.instance.as_pin_ref().get_ref(),
-        )
-        .unwrap()
-        .clone()
+        self.try_window_adapter().unwrap()
+    }
+
+    pub fn try_window_adapter(&self) -> Result<WindowAdapterRc, PlatformError> {
+        self.root_weak().upgrade().unwrap().window_adapter_ref().cloned()
     }
 
     pub fn get_or_init_window_adapter_ref<'b, 'id2>(

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1775,13 +1775,19 @@ fn call_builtin_function(
             }
             let component = local_context.component_instance;
             if let Value::String(s) = eval_expression(&arguments[0], local_context) {
-                if let Some(err) = component
-                    .window_adapter()
-                    .renderer()
-                    .register_font_from_path(&std::path::PathBuf::from(s.as_str()))
-                    .err()
-                {
-                    corelib::debug_log!("Error loading custom font {}: {}", s.as_str(), err);
+                // If the window adapter can't be created, log and skip the registration
+                // instead of panicking: the same error resurfaces when the window is
+                // actually used.
+                let result = component.try_window_adapter().map_err(|e| e.to_string()).and_then(
+                    |window_adapter| {
+                        window_adapter
+                            .renderer()
+                            .register_font_from_path(&std::path::PathBuf::from(s.as_str()))
+                            .map_err(|e| format!("Cannot load custom font {}: {e}", s.as_str()))
+                    },
+                );
+                if let Err(err) = result {
+                    corelib::debug_log!("{err}");
                 }
                 Value::Void
             } else {

--- a/internal/interpreter/tests/window_adapter_creation_error.rs
+++ b/internal/interpreter/tests/window_adapter_creation_error.rs
@@ -1,0 +1,92 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! A window adapter creation failure must surface as an `Err` from `create()`. With a custom
+//! font import, the font registration during instantiation is the first window adapter access
+//! and used to panic instead. The attempt counter in the error message documents the flow:
+//! `instantiate()` has no error channel, so the registration logs and skips its failed attempt,
+//! and the eager creation in `create()` reports the error of the next attempt. The test also
+//! checks that the skipped registration is logged rather than swallowed silently.
+
+use i_slint_core::platform::{Platform, PlatformError, WindowAdapter, set_platform};
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+struct FailingPlatform {
+    attempts: Cell<u32>,
+}
+
+impl Platform for FailingPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        self.attempts.set(self.attempts.get() + 1);
+        Err(PlatformError::Other(format!(
+            "cannot create window adapter (attempt {})",
+            self.attempts.get()
+        )))
+    }
+}
+
+fn compile(code: &str) -> slint_interpreter::ComponentDefinition {
+    let mut compiler = slint_interpreter::Compiler::default();
+    compiler.set_style("fluent".into());
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test.slint");
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), path.into()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    result.component("TestCase").unwrap()
+}
+
+#[test]
+fn window_adapter_creation_error_is_returned() {
+    set_platform(Box::new(FailingPlatform { attempts: Cell::new(0) })).unwrap();
+
+    // Without fonts, the eager window adapter creation in `create()` reports the error.
+    let definition = compile(
+        r#"
+        export component TestCase inherits Window {
+            Text {
+                text: "Hello";
+            }
+        }
+    "#,
+    );
+    let Err(PlatformError::Other(message)) = definition.create() else {
+        panic!("expected create() to fail with the platform error");
+    };
+    assert_eq!(message, "cannot create window adapter (attempt 1)");
+
+    // With a custom font, the registration during instantiation logs and skips attempt 2,
+    // and the eager creation in `create()` reports attempt 3.
+    let logs = Rc::new(RefCell::new(Vec::<String>::new()));
+    let logs_handler = logs.clone();
+    i_slint_backend_selector::with_global_context(|ctx| {
+        ctx.set_log_message_handler(Some(Box::new(move |message| {
+            logs_handler.borrow_mut().push(message.message_arguments().to_string());
+        })))
+    })
+    .unwrap();
+
+    let definition = compile(
+        r#"
+        import "../../../examples/slide_puzzle/plaster-font/Plaster-Regular.ttf";
+
+        export component TestCase inherits Window {
+            Text {
+                font-family: "Plaster";
+                text: "Hello";
+            }
+        }
+    "#,
+    );
+    let Err(PlatformError::Other(message)) = definition.create() else {
+        panic!("expected create() to fail with the platform error");
+    };
+    assert_eq!(message, "cannot create window adapter (attempt 3)");
+
+    // The window adapter failure that skipped the registration (attempt 2) is logged rather
+    // than swallowed silently, and the log is about creating the window, not the font.
+    let logs = logs.borrow();
+    assert!(
+        logs.iter().any(|l| l == "cannot create window adapter (attempt 2)"),
+        "expected a log about the window adapter creation failure, got {logs:?}"
+    );
+}


### PR DESCRIPTION
Font registration in the generated init() is the first window adapter access, and it unwrapped the adapter creation error. This panicked for example in the live-preview when the LinuxKMS backend finds no display.

Make the generated init() return a Result so the registration can use window_adapter_ref()? and the error reaches the caller of new().

The interpreter's instantiate() has no error channel, so it logs and skips the registration; ComponentDefinition::create() then reports the same error from its eager window adapter creation.

The failing test platform counts its creation attempts so the tests check which access reports the error: in generated Rust code the font registration itself, in the interpreter the eager creation in create() after the registration logged and skipped its attempt. The interpreter test needs its own test binary because set_platform is once per process and the lib tests install the working testing backend.
