### PR TITLE
lsp: fix flaky temp-dir test helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10651,6 +10651,7 @@ dependencies = [
  "slint-interpreter",
  "smol_str 0.3.2",
  "spin_on",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "tokio-tungstenite-wasm",

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -151,6 +151,7 @@ tokio = { version = "1.50.0", features = ["rt", "sync", "macros"] }
 [dev-dependencies]
 i-slint-backend-testing = { path = "../../internal/backends/testing" }
 spin_on = { workspace = true }
+tempfile = "3"
 # The remote connector tests talk to the real viewer-side connection.
 i-slint-live-preview = { path = "../../internal/live-preview", features = ["remote"] }
 

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -759,34 +759,7 @@ mod tests {
         assert!(matches!(err, HostLanguageScanError::TooManyFiles { limit: 3 }));
     }
 
-    /// A throwaway directory that cleans itself up on drop.
-    struct TempDir {
-        path: PathBuf,
-    }
-
-    impl TempDir {
-        fn path(&self) -> &Path {
-            &self.path
-        }
-    }
-
-    impl Drop for TempDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.path);
-        }
-    }
-
-    fn tempdir() -> TempDir {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "slint-lsp-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir(&path).unwrap();
-        TempDir { path }
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
     }
 }


### PR DESCRIPTION
The hand-rolled tempdir() named directories from the pid and a timestamp. Tests in the module run in parallel threads of the same process, so two calls within one clock tick collided and create_dir panicked with AlreadyExists. Use the tempfile crate instead.


Example of flacky faillure: https://github.com/slint-ui/slint/actions/runs/28940078825/job/85860240399?pr=11614
