### PR TITLE
Follow-up fixes for array push/remove/insert.

### DIFF
--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -403,6 +403,15 @@ impl<M: Model> Model for Rc<M> {
     fn set_row_data(&self, row: usize, data: Self::Data) {
         (**self).set_row_data(row, data)
     }
+    fn push_row(&self, data: Self::Data) {
+        (**self).push_row(data)
+    }
+    fn remove_row(&self, row: isize) {
+        (**self).remove_row(row)
+    }
+    fn insert_row(&self, row: isize, data: Self::Data) {
+        (**self).insert_row(row, data)
+    }
 }
 
 /// A [`Model`] backed by a `Vec<T>`, using interior mutability.
@@ -605,14 +614,14 @@ impl<T: Clone + 'static> Model for SharedVectorModel<T> {
     }
 
     fn remove_row(&self, row: isize) {
-        if row >= 0 {
+        if row >= 0 && row < self.row_count() as isize {
             self.array.borrow_mut().remove(row as usize);
             self.notify.row_removed(row as usize, 1);
         }
     }
 
     fn insert_row(&self, row: isize, data: Self::Data) {
-        if row >= 0 {
+        if row >= 0 && row <= self.row_count() as isize {
             self.array.borrow_mut().insert(row as usize, data);
             self.notify.row_added(row as usize, 1);
         }
@@ -997,6 +1006,39 @@ mod tests {
         assert!(!tracker.is_dirty());
         model.set_vec(vec![1, 2, 3]);
         assert!(tracker.is_dirty());
+    }
+
+    #[test]
+    fn test_shared_vector_model_bounds() {
+        let model: Rc<SharedVectorModel<i32>> =
+            Rc::new(SharedVectorModel::from(SharedVector::from_slice(&[1, 2, 3])));
+        let handle = ModelRc::from(model.clone());
+        let tracker = Box::pin(<crate::properties::PropertyTracker>::default());
+        let count = || {
+            tracker.as_ref().evaluate(|| {
+                handle.model_tracker().track_row_count_changes();
+                handle.row_count()
+            })
+        };
+        assert_eq!(count(), 3);
+        assert!(!tracker.is_dirty());
+
+        // Out-of-range operations do nothing and must not notify the views.
+        model.remove_row(3);
+        model.remove_row(-1);
+        model.insert_row(4, 42);
+        model.insert_row(-1, 42);
+        assert!(!tracker.is_dirty());
+        assert_eq!(model.row_count(), 3);
+        assert_eq!(model.row_data(2), Some(3));
+
+        // In-range operations change the data and notify.
+        model.insert_row(3, 4);
+        assert!(tracker.is_dirty());
+        assert_eq!(count(), 4);
+        model.remove_row(0);
+        assert_eq!(model.row_count(), 3);
+        assert_eq!(model.row_data(0), Some(2));
     }
 
     #[test]

--- a/internal/core/sharedvector.rs
+++ b/internal/core/sharedvector.rs
@@ -254,9 +254,7 @@ impl<T: Clone> SharedVector<T> {
             let data = data_ptr(self.inner);
             core::ptr::drop_in_place(data.add(row));
             let size = (*self.inner.as_ptr()).header.size;
-            for i in row..(size - 1) {
-                core::ptr::copy(data.add(i + 1), data.add(i), 1);
-            }
+            core::ptr::copy(data.add(row + 1), data.add(row), size - 1 - row);
             (*self.inner.as_ptr()).header.size = size - 1;
         }
     }
@@ -271,9 +269,7 @@ impl<T: Clone> SharedVector<T> {
         unsafe {
             let data = data_ptr(self.inner);
             let size = (*self.inner.as_ptr()).header.size;
-            for i in (row..size).rev() {
-                core::ptr::copy(data.add(i), data.add(i + 1), 1);
-            }
+            core::ptr::copy(data.add(row), data.add(row + 1), size - row);
             core::ptr::write(data.add(row), value);
             (*self.inner.as_ptr()).header.size = size + 1;
         }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1570,7 +1570,7 @@ fn call_builtin_function(
             };
             let index = match eval_expression(&arguments[1], local_context) {
                 Value::Number(i) => i,
-                _ => panic!("Second argument not an integer: {:?}", arguments[0]),
+                _ => panic!("Second argument not an integer: {:?}", arguments[1]),
             };
 
             let value = eval_expression(&arguments[2], local_context);

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -674,7 +674,7 @@ fn handle_builtin_function(
 
             let index = match eval_expression(&arguments[1], local_context, None) {
                 Value::Number(i) => i,
-                _ => panic!("Second argument not an integer: {:?}", arguments[0]),
+                _ => panic!("Second argument not an integer: {:?}", arguments[1]),
             };
 
             model.remove_row(index as isize);
@@ -692,7 +692,7 @@ fn handle_builtin_function(
             };
             let index = match eval_expression(&arguments[1], local_context, None) {
                 Value::Number(i) => i,
-                _ => panic!("Second argument not an integer: {:?}", arguments[0]),
+                _ => panic!("Second argument not an integer: {:?}", arguments[1]),
             };
 
             let value = eval_expression(&arguments[2], local_context, None);


### PR DESCRIPTION
Few cleanups follow-up after #11614

Fix model push/remove/insert on Rc and SharedVectorModel and other small fixes.