### PR TITLE
compiler: Fix clippy warnings from the new clippy version

### DIFF
--- a/internal/compiler/lexer.rs
+++ b/internal/compiler/lexer.rs
@@ -331,36 +331,32 @@ pub fn locate_slint_macro(rust_source: &str) -> impl Iterator<Item = core::ops::
     let mut begin = 0;
     std::iter::from_fn(move || {
         let (open, close) = loop {
-            if let Some(m) = rust_source[begin..].find("slint") {
-                // heuristics to find if we are not in a comment or a string literal. Not perfect, but should work in most cases
-                if let Some(x) = rust_source[begin..(begin + m)].rfind(['\\', '\n', '/', '\"'])
-                    && rust_source.as_bytes()[begin + x] != b'\n'
-                {
-                    begin += m + 5;
-                    begin += rust_source[begin..].find(['\n']).unwrap_or(0);
-                    continue;
-                }
+            let m = rust_source[begin..].find("slint")?;
+            // heuristics to find if we are not in a comment or a string literal. Not perfect, but should work in most cases
+            if let Some(x) = rust_source[begin..(begin + m)].rfind(['\\', '\n', '/', '\"'])
+                && rust_source.as_bytes()[begin + x] != b'\n'
+            {
                 begin += m + 5;
-                while rust_source[begin..].starts_with(' ') {
-                    begin += 1;
-                }
-                if !rust_source[begin..].starts_with('!') {
-                    continue;
-                }
+                begin += rust_source[begin..].find(['\n']).unwrap_or(0);
+                continue;
+            }
+            begin += m + 5;
+            while rust_source[begin..].starts_with(' ') {
                 begin += 1;
-                while rust_source[begin..].starts_with(' ') {
-                    begin += 1;
-                }
-                let Some(open) = rust_source.as_bytes().get(begin) else { continue };
-                match open {
-                    b'{' => break (SyntaxKind::LBrace, SyntaxKind::RBrace),
-                    b'[' => break (SyntaxKind::LBracket, SyntaxKind::RBracket),
-                    b'(' => break (SyntaxKind::LParent, SyntaxKind::RParent),
-                    _ => continue,
-                }
-            } else {
-                // No macro found, just return
-                return None;
+            }
+            if !rust_source[begin..].starts_with('!') {
+                continue;
+            }
+            begin += 1;
+            while rust_source[begin..].starts_with(' ') {
+                begin += 1;
+            }
+            let Some(open) = rust_source.as_bytes().get(begin) else { continue };
+            match open {
+                b'{' => break (SyntaxKind::LBrace, SyntaxKind::RBrace),
+                b'[' => break (SyntaxKind::LBracket, SyntaxKind::RBracket),
+                b'(' => break (SyntaxKind::LParent, SyntaxKind::RParent),
+                _ => continue,
             }
         };
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3422,7 +3422,7 @@ impl Exports {
                     diag.push_warning(
                         format!(
                             "'{}' is already exported in this file; it will not be re-exported",
-                            &*export.0
+                            *export.0
                         ),
                         &export.0.name_ident,
                     );

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -644,7 +644,7 @@ fn filter_conflicting_uses_statements(
             seen_interfaces.push(interface_name.clone());
 
             let mut valid = true;
-            for (prop_name, _) in vus.interface.borrow().property_declarations.iter() {
+            for prop_name in vus.interface.borrow().property_declarations.keys() {
                 if let Some(existing_interface) = seen_interface_api.get(prop_name) {
                     diag.push_error(
                         format!(

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -973,7 +973,7 @@ impl TypeLoader {
             diag.push_diagnostic_with_span(
                 format!(
                     "Style {} is not known. Use one of the builtin styles [{}] or make sure your custom style is found in the include directories",
-                    &style,
+                    style,
                     known_styles.join(", ")
                 ),
                 Default::default(),


### PR DESCRIPTION
Use the ? operator, iterate over map keys, and drop redundant references in format arguments.
