### PR TITLE
llr: let the inliner reach model, timer and grid-child expressions

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3341,7 +3341,7 @@ fn generate_functions<'a>(
         let ret = if f.ret_ty != Type::Void { "return " } else { "" };
         let body = vec![
             "[[maybe_unused]] auto self = this;".into(),
-            format!("{ret}{};", compile_expression(&f.code, &ctx2)),
+            format!("{ret}{};", compile_expression(&f.code.borrow(), &ctx2)),
         ];
         Declaration::Function(Function {
             name: concatenate_ident(&format_smolstr!("fn_{}", f.name)),

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2523,14 +2523,16 @@ fn generate_sub_component(
             let running = compile_expression(&tmr.running.borrow(), &ctx);
             let interval = compile_expression(&tmr.interval.borrow(), &ctx);
             let callback = compile_expression(&tmr.triggered.borrow(), &ctx);
-            update_timers.push(format!("if ({running}) {{"));
-            update_timers
-                .push(format!("   auto interval = std::chrono::milliseconds({interval});"));
+            update_timers.push(format!(
+                "{{ std::int64_t millis = ({running}) ? static_cast<std::int64_t>({interval}) : -1;"
+            ));
+            update_timers.push("if (millis >= 0) {".into());
+            update_timers.push("   auto interval = std::chrono::milliseconds(millis);".into());
             update_timers.push(format!(
                 "   if (!self->{name}.running() || self->{name}.interval() != interval)"
             ));
             update_timers.push(format!("       self->{name}.start(slint::TimerMode::Repeated, interval, [self] {{ {callback}; }});"));
-            update_timers.push(format!("}} else {{ self->{name}.stop(); }}"));
+            update_timers.push(format!("}} else {{ self->{name}.stop(); }} }}"));
             target_struct.members.push((
                 field_access,
                 Declaration::Var(Var { ty: "slint::Timer".into(), name, ..Default::default() }),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1598,8 +1598,9 @@ fn generate_sub_component(
             let running = compile_expression(&tmr.running.borrow(), &ctx);
             let callback = compile_expression(&tmr.triggered.borrow(), &ctx);
             quote!(
-                if #running {
-                    let interval = ::core::time::Duration::from_millis(#interval as u64);
+                let millis = if #running { (#interval) as i64 } else { -1 };
+                if millis >= 0 {
+                    let interval = ::core::time::Duration::from_millis(millis as u64);
                     if !self.#ident.running() || interval != self.#ident.interval() {
                         let self_weak = self.self_weak.get().unwrap().clone();
                         self.#ident.start(sp::TimerMode::Repeated, interval, move || {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1818,10 +1818,10 @@ fn generate_functions(functions: &[llr::Function], ctx: &EvaluationContext) -> V
         .map(|f| {
             let mut ctx2 = ctx.clone();
             ctx2.argument_types = &f.args;
-            let tokens_for_expression = compile_expression(&f.code, &ctx2);
+            let tokens_for_expression = compile_expression(&f.code.borrow(), &ctx2);
             let as_ = if f.ret_ty == Type::Void {
                 Some(quote!(;))
-            } else if f.code.ty(&ctx2) == Type::Invalid {
+            } else if f.code.borrow().ty(&ctx2) == Type::Invalid {
                 // Don't cast if the Rust code is the never type, as with return statements inside a block, the
                 // type of the return expression is `()` instead of `!`.
                 None

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -329,7 +329,7 @@ pub struct Function {
     pub name: SmolStr,
     pub ret_ty: Type,
     pub args: Vec<Type>,
-    pub code: Expression,
+    pub code: MutExpression,
 }
 
 #[derive(Debug, Clone)]
@@ -692,6 +692,24 @@ impl CompilationUnit {
             for (_, e) in sc.change_callbacks.iter() {
                 visitor(e, ctx);
             }
+            for child in &sc.grid_layout_children {
+                visitor(&child.layout_info_h, ctx);
+                visitor(&child.layout_info_v, ctx);
+            }
+            for r in sc.repeated.iter() {
+                visitor(&r.model, ctx);
+            }
+            for t in sc.timers.iter() {
+                visitor(&t.interval, ctx);
+                visitor(&t.running, ctx);
+                visitor(&t.triggered, ctx);
+            }
+            // Function bodies and popup positions are intentionally not visited:
+            // a function is called from several contexts and a popup position is
+            // evaluated in a nested one, so mutating their expressions here (which
+            // the inlining pass does) would corrupt the parent levels of their
+            // property references. They keep their properties alive through
+            // count_property_use, which only reads them.
         });
         for (idx, g) in self.globals.iter_enumerated() {
             let ctx = EvaluationContext::new_global(self, idx, ());

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -359,7 +359,7 @@ fn lower_sub_component(
                     ret_ty: function.return_type.clone(),
                     args: function.args.clone(),
                     // will be replaced later
-                    code: super::Expression::CodeBlock(Vec::new()),
+                    code: super::Expression::CodeBlock(Vec::new()).into(),
                 });
                 index.into()
             } else if let Type::Callback(callback) = &x.property_type {
@@ -488,8 +488,9 @@ fn lower_sub_component(
                 unreachable!()
             };
 
-            sub_component.functions[function_index].code =
-                super::lower_expression::lower_expression(&binding.expression, &mut ctx);
+            sub_component.functions[function_index]
+                .code
+                .replace(super::lower_expression::lower_expression(&binding.expression, &mut ctx));
 
             return;
         }
@@ -946,7 +947,7 @@ fn lower_global(
                 ret_ty: function.return_type.clone(),
                 args: function.args.clone(),
                 // will be replaced later
-                code: super::Expression::CodeBlock(Vec::new()),
+                code: super::Expression::CodeBlock(Vec::new()).into(),
             });
             state.global_properties.insert(
                 nr.clone(),
@@ -1063,7 +1064,7 @@ fn lower_global_expressions(
             MemberReference::Global {
                 member: LocalMemberIndex::Function(function_index), ..
             } => {
-                lowered.functions[*function_index].code = expression;
+                lowered.functions[*function_index].code.replace(expression);
                 continue;
             }
             MemberReference::Global { member, .. } => member.clone(),

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -107,7 +107,7 @@ pub fn count_property_use(root: &CompilationUnit) {
 
         // 8.functions (TODO: only visit used function)
         for f in &sc.functions {
-            f.code.visit_property_references(ctx, &mut visit_property);
+            f.code.borrow().visit_property_references(ctx, &mut visit_property);
         }
 
         // 9. change callbacks
@@ -139,7 +139,7 @@ pub fn count_property_use(root: &CompilationUnit) {
         let ctx = EvaluationContext::new_global(root, idx, ());
         // TODO: only visit used function
         for f in &g.functions {
-            f.code.visit_property_references(&ctx, &mut visit_property);
+            f.code.borrow().visit_property_references(&ctx, &mut visit_property);
         }
 
         for (p, e) in &g.change_callbacks {

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -496,7 +496,7 @@ mod visitor {
         state: &VisitorState,
         visitor: &mut (impl Visitor + ?Sized),
     ) {
-        visit_expression(code, scope, state, visitor);
+        visit_expression(code.get_mut(), scope, state, visitor);
     }
 
     pub fn visit_expression(
@@ -589,6 +589,79 @@ mod visitor {
                 visitor.visit_callback_idx(c, scope, state);
             }
             LocalMemberIndex::Native { .. } => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Compile `source`, lower it to the LLR (which runs the optimization passes
+    /// including [`remove_unused`]), and return every declared property name
+    /// across all sub-components. The names are prefixed by the element path, so
+    /// callers match with `contains`.
+    fn lowered_property_names(source: &str) -> std::collections::HashSet<String> {
+        let mut config =
+            crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        config.style = Some("fluent".into());
+        let mut diags = crate::diagnostics::BuildDiagnostics::default();
+        let doc_node =
+            crate::parser::parse(source.into(), Some(std::path::Path::new("t.slint")), &mut diags);
+        let (doc, diag, _) =
+            spin_on::spin_on(crate::compile_syntax_node(doc_node, diags, config.clone()));
+        assert!(!diag.has_errors(), "compile error: {:#?}", diag.to_string_vec());
+        let unit = crate::llr::lower_to_item_tree::lower_to_item_tree(&doc, &config);
+        unit.sub_components
+            .iter()
+            .flat_map(|sc| sc.properties.iter().map(|p| p.name.to_string()))
+            .collect()
+    }
+
+    /// The property values below all depend on the `ext` input so they are not
+    /// constant-folded away by the object-tree passes, and therefore actually
+    /// exercise the LLR optimization passes.
+    const SOURCE: &str = r#"
+export component Foo inherits Window {
+    in property <int> ext: 1;
+
+    // KEPT: exposed in the public API.
+    out property <int> kept_public: ext + 1;
+
+    // REMOVED: read only from one other binding, so it is inlined into it and
+    // the reader is itself unused.
+    property <int> gone_inlined: ext * 2;
+    property <int> gone_reader: gone_inlined + 3;
+
+    // REMOVED: only read from a timer's interval, which is inlined.
+    property <duration> gone_timer: ext * 1ms;
+
+    // KEPT: read from a function that is actually called. Function bodies are
+    // not inlined into, so the property cannot be removed.
+    property <int> kept_from_function: ext * 5;
+    pure function f() -> int { kept_from_function }
+    out property <int> function_reader: f();
+
+    // KEPT: has a change callback.
+    property <int> kept_with_change_callback: ext * 7;
+    changed kept_with_change_callback => {}
+
+    Timer { interval: gone_timer; running: true; triggered => {} }
+}
+"#;
+
+    #[test]
+    fn unused_properties_are_removed_and_used_ones_kept() {
+        let names = lowered_property_names(SOURCE);
+        for gone in ["gone-inlined", "gone-reader", "gone-timer"] {
+            assert!(
+                !names.iter().any(|n| n.contains(gone)),
+                "property {gone} should have been removed, got {names:?}"
+            );
+        }
+        for kept in ["kept-public", "kept-from-function", "kept-with-change-callback"] {
+            assert!(
+                names.iter().any(|n| n.contains(kept)),
+                "property {kept} should have been kept, got {names:?}"
+            );
         }
     }
 }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -100,7 +100,7 @@ impl PrettyPrinter<'_> {
                 f.name,
                 f.args.iter().map(|t| DisplayType(t).to_string()).join(", "),
                 DisplayType(&f.ret_ty),
-                DisplayExpression(&f.code, &ctx)
+                DisplayExpression(&f.code.borrow(), &ctx)
             )?;
         }
         for twb in &sc.two_way_bindings {
@@ -341,7 +341,7 @@ impl PrettyPrinter<'_> {
                 f.name,
                 f.args.iter().map(ToString::to_string).join(", "),
                 f.ret_ty,
-                DisplayExpression(&f.code, &ctx)
+                DisplayExpression(&f.code.borrow(), &ctx)
             )?;
         }
         self.indentation -= 1;


### PR DESCRIPTION
for_each_expression, which drives the expression inlining pass, didn't visit repeater models, timer expressions, or grid layout child layout info, while count_property_use counts property references in all of them. A property referenced only from those places therefore kept a non-zero use count and was never inlined or removed, even when its binding was a cheap constant.

Visit them in for_each_expression too. Function bodies and popup positions stay out on purpose: a function runs in several contexts and a popup position in a nested one, so rewriting their expressions for a single context would corrupt the parent levels of their property references. Function::code becomes a MutExpression for the shared traversal.

Add a test that lowers a small component to the LLR and checks that unused properties are removed and used ones (public, read from a function, or with a change callback) are kept.
