### PR TITLE
layout: measure height-for-width cells at their content width (subtract padding)

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -89,7 +89,9 @@ pub(super) fn compute_box_layout_info(
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
 ) -> llr_Expression {
     let (padding, spacing) = generate_layout_padding_and_spacing(&layout.geometry, o, ctx);
-    let bld = box_layout_data(layout, o, ctx, cross_axis_size_override, None);
+    let adjusted_override = cross_axis_size_override
+        .map(|o_expr| subtract_padding(o_expr.clone(), &layout.geometry, o.orthogonal()));
+    let bld = box_layout_data(layout, o, ctx, adjusted_override.as_ref(), None);
     let sub_expression = if o == layout.orientation {
         llr_Expression::ExtraBuiltinFunctionCall {
             function: "box_layout_info".into(),
@@ -350,12 +352,13 @@ pub(super) fn solve_flexbox_layout(
         layout.axis_relation(Orientation::Vertical),
         crate::layout::FlexboxAxisRelation::MainAxis
     ) {
-        layout
-            .geometry
-            .rect
-            .width_reference
-            .as_ref()
-            .map(|nr| crate::expression_tree::Expression::PropertyReference(nr.clone()))
+        layout.geometry.rect.width_reference.as_ref().map(|nr| {
+            subtract_padding(
+                crate::expression_tree::Expression::PropertyReference(nr.clone()),
+                &layout.geometry,
+                Orientation::Horizontal,
+            )
+        })
     } else {
         None
     };
@@ -1634,6 +1637,30 @@ pub(crate) fn default_cross_axis_constraint(
     })
 }
 
+/// Subtract `geometry`'s padding on the `axis` from `base`. Turns an outer size
+/// into the content size a child is actually laid out at (used to constrain a
+/// height-for-width child at its real width rather than the padded outer width).
+fn subtract_padding(
+    base: crate::expression_tree::Expression,
+    geometry: &crate::layout::LayoutGeometry,
+    axis: Orientation,
+) -> crate::expression_tree::Expression {
+    use crate::expression_tree::Expression;
+    let pads = match axis {
+        Orientation::Horizontal => [&geometry.padding.left, &geometry.padding.right],
+        Orientation::Vertical => [&geometry.padding.top, &geometry.padding.bottom],
+    };
+    let mut expr = base;
+    for p in pads.into_iter().flatten() {
+        expr = Expression::BinaryExpression {
+            lhs: Box::new(expr),
+            rhs: Box::new(Expression::PropertyReference(p.clone())),
+            op: '-',
+        };
+    }
+    expr
+}
+
 /// Build an expression for the layout's cross-axis *content* size
 /// (`self.height` minus top/bottom padding, for a horizontal layout).
 fn layout_cross_content_size(
@@ -1642,19 +1669,7 @@ fn layout_cross_content_size(
     use crate::expression_tree::Expression;
     let cross = layout.orientation.orthogonal();
     let size_nr = layout.geometry.rect.size_reference(cross)?.clone();
-    let mut expr = Expression::PropertyReference(size_nr);
-    let pads = match cross {
-        Orientation::Horizontal => [&layout.geometry.padding.left, &layout.geometry.padding.right],
-        Orientation::Vertical => [&layout.geometry.padding.top, &layout.geometry.padding.bottom],
-    };
-    for p in pads.into_iter().flatten() {
-        expr = Expression::BinaryExpression {
-            lhs: Box::new(expr),
-            rhs: Box::new(Expression::PropertyReference(p.clone())),
-            op: '-',
-        };
-    }
-    Some(expr)
+    Some(subtract_padding(Expression::PropertyReference(size_nr), &layout.geometry, cross))
 }
 
 fn layout_geometry_size(

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -77,6 +77,11 @@ pub(crate) fn compute_box_layout_info(
     let expr_eval = |nr: &NamedReference| -> f32 {
         eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
     };
+    let cross_axis_size = cross_axis_size.map(|w| {
+        let (cross_pad, _) =
+            padding_and_spacing(&box_layout.geometry, orientation.orthogonal(), &expr_eval);
+        w - cross_pad.begin - cross_pad.end
+    });
     let (cells, alignment) = box_layout_data(
         box_layout,
         orientation,
@@ -260,12 +265,20 @@ pub(crate) fn solve_flexbox_layout(
     let height_ref = &flexbox_layout.geometry.rect.height_reference;
     let direction = flexbox_layout_direction(flexbox_layout, local_context);
 
-    // For column direction, pass the container width so cells_v can use it
-    // as the constraint for height-for-width items (items stretch to it).
+    // For column direction, pass the container content width (outer width minus
+    // horizontal padding) so cells_v can use it as the constraint for
+    // height-for-width items — the width they are actually laid out at.
     let container_width_for_cells = match direction {
         i_slint_core::items::FlexboxLayoutDirection::Column
         | i_slint_core::items::FlexboxLayoutDirection::ColumnReverse => {
-            width_ref.as_ref().map(&expr_eval)
+            width_ref.as_ref().map(|w| {
+                let (pad_h, _) = padding_and_spacing(
+                    &flexbox_layout.geometry,
+                    Orientation::Horizontal,
+                    &expr_eval,
+                );
+                expr_eval(w) - pad_h.begin - pad_h.end
+            })
         }
         _ => None,
     };

--- a/tests/cases/layout/flexbox_column_text_wrap.slint
+++ b/tests/cases/layout/flexbox_column_text_wrap.slint
@@ -9,25 +9,43 @@ export component TestCase inherits Window {
     width: 150px;
     height: 300px;
 
+    property <string> long-text: "This is a long text that should word-wrap inside a column FlexboxLayout";
+
     FlexboxLayout {
         flex-direction: column;
         spacing: 10px;
+        // Padding: the text is laid out at the content width (150 - 2*20 = 110px),
+        // so its height-for-width must be measured at that width too, not the raw
+        // container width. Otherwise it wraps to fewer lines than it is drawn with
+        // and overflows its cell.
+        padding: 20px;
 
         r := Rectangle {
             height: 50px;
             background: red;
         }
         t := Text {
-            text: "This is a long text that should word-wrap inside a column FlexboxLayout";
+            text: long-text;
             wrap: word-wrap;
             horizontal-alignment: left;
         }
     }
 
-    // In column direction, items stack vertically.
-    // The text should be below the rectangle and wrap within the container width.
+    // Ground truth: the same text wrapped at the cell's actual width.
+    ref := Text {
+        x: -1000px;
+        width: t.width;
+        text: long-text;
+        wrap: word-wrap;
+        horizontal-alignment: left;
+    }
+
+    // In column direction, items stack vertically below the 20px top padding.
     out property <bool> test_r: r.height == 50px;
-    out property <bool> test_t: t.y == 60px && t.width <= 150px && t.height > 30px;
+    // The text sits below the rectangle (+spacing), spans the content width, and
+    // — the point of this test — is exactly as tall as the reference wrapped at
+    // that same width. Without measuring at the content width it would be shorter.
+    out property <bool> test_t: t.y == 80px && t.width <= 110px && t.height == ref.height;
 
     out property <bool> test: test_r && test_t;
 }


### PR DESCRIPTION
A height-for-width cell (a wrapped Text) inside a padded layout was measured
at the padded outer width but laid out at the narrower content width, so its
box came out a line too short and the text overflowed the box.

Subtract the enclosing layout's padding from the width forwarded to
height-for-width cells, in the box-layout and flexbox layout-info paths, in
both the interpreter and the LLR lowering used by the code generators.