### PR TITLE
layout: subtract padding in the flexbox layout-info path too

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -544,7 +544,13 @@ pub(super) fn compute_flexbox_layout_info(
         Orientation::Vertical => (cross_axis_size_override, None),
         Orientation::Horizontal => (None, cross_axis_size_override),
     };
-    let fld = flexbox_layout_data(layout, ctx, width_override, height_override);
+    // Subtract padding so height-for-width cells are measured at the content
+    // width they are actually laid out at, not the padded outer width.
+    let width_override = width_override
+        .map(|e| subtract_padding(e.clone(), &layout.geometry, Orientation::Horizontal));
+    let height_override = height_override
+        .map(|e| subtract_padding(e.clone(), &layout.geometry, Orientation::Vertical));
+    let fld = flexbox_layout_data(layout, ctx, width_override.as_ref(), height_override.as_ref());
 
     match layout.axis_relation(orientation) {
         crate::layout::FlexboxAxisRelation::MainAxis => {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -517,6 +517,18 @@ pub(crate) fn compute_flexbox_layout_info(
         Orientation::Vertical => (cross_axis_size, None),
         Orientation::Horizontal => (None, cross_axis_size),
     };
+    // Subtract padding so height-for-width cells are measured at the content
+    // width they are actually laid out at, not the padded outer width.
+    let width_override = width_override.map(|w| {
+        let (pad_h, _) =
+            padding_and_spacing(&flexbox_layout.geometry, Orientation::Horizontal, &expr_eval);
+        w - pad_h.begin - pad_h.end
+    });
+    let height_override = height_override.map(|h| {
+        let (pad_v, _) =
+            padding_and_spacing(&flexbox_layout.geometry, Orientation::Vertical, &expr_eval);
+        h - pad_v.begin - pad_v.end
+    });
     let (cells_h, cells_v, _repeated_indices) = flexbox_layout_data(
         flexbox_layout,
         component,


### PR DESCRIPTION
Commit 6fd84601f8 fixed the box-layout info path and the flexbox solve path,
but left the flexbox layout-info path (compute_flexbox_layout_info)
forwarding the raw outer width to height-for-width cells. A padded column
FlexboxLayout nested as a cell of an outer layout thus reported a
preferred height one line too short and its text overflowed.

Subtract the padding there too, in both the interpreter and the LLR
lowering, mirroring the sibling box-layout fix.

No unit test: observing the info path requires a parent that sizes the
flexbox to its preferred height, which forms a height-for-width binding
loop (layoutinfo-v reads the flexbox's own layout-cache). The bug only
shows as visual text overflow, which a numeric .slint assertion cannot
capture.