### PR TITLE
FlexboxLayout: measure repeated height-for-width cells at the container width

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -36,6 +36,7 @@
         "Unlocalized",
         "unmap",
         "unsync",
+        "vecs", // plural of vec
         "vsync"
       ],
       "ignoreRegExpList": [

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2886,11 +2886,15 @@ fn generate_layout_item_info_decl(
 fn generate_flexbox_layout_item_info_decl(
     root_sc: &llr::SubComponent,
     ctx: &EvaluationContext,
-) -> Declaration {
+) -> Vec<Declaration> {
     const SIGNATURE: &str = "(slint::cbindgen_private::Orientation o, [[maybe_unused]] std::optional<size_t> child_index) const -> slint::cbindgen_private::FlexboxLayoutItemInfo";
 
-    let body = if let Some(expr) = &root_sc.flexbox_layout_item_info_for_repeated {
-        let compiled = compile_expression(&expr.borrow(), ctx);
+    let for_repeated_compiled = root_sc
+        .flexbox_layout_item_info_for_repeated
+        .as_ref()
+        .map(|expr| compile_expression(&expr.borrow(), ctx));
+
+    let body = if let Some(compiled) = &for_repeated_compiled {
         // Break the height-for-width recursion for a repeated instance in a
         // column FlexboxLayout: use the constrained vertical info (measured at
         // its preferred width via layoutinfo-v-with-constraint) instead of
@@ -2919,12 +2923,50 @@ fn generate_flexbox_layout_item_info_decl(
             .to_owned()
     };
 
-    Declaration::Function(Function {
-        name: "flexbox_layout_item_info".into(),
-        signature: SIGNATURE.to_owned(),
-        statements: Some(vec![body]),
-        ..Function::default()
-    })
+    // A column FlexboxLayout calls this with its real container width so a
+    // height-for-width instance wraps to the same height as a static cell. The
+    // expression reads the `flex_cross_width` parameter.
+    //
+    // `layout_info_v_at_cross_width_for_repeated` is only set for a
+    // height-for-width root, which also forces `flexbox_layout_item_info_for_repeated`
+    // (see `lower_to_item_tree`), so the other cases have no width-dependent
+    // height and just delegate. Unlike Rust, where `RepeatedItemTree` provides
+    // defaults and the generator emits nothing when there is no flex info, a C++
+    // repeated struct has no base class: both members are always emitted, and the
+    // delegating body below is the equivalent of the Rust trait default.
+    let at_cross_width_body = match (
+        &for_repeated_compiled,
+        root_sc.layout_info_v_at_cross_width_for_repeated.as_ref(),
+    ) {
+        (Some(compiled), Some(e)) => {
+            let v = compile_expression(&e.borrow(), ctx);
+            format!(
+                "[[maybe_unused]] auto self = this; \
+                 auto info = {compiled}; \
+                 info.constraint = {v}; \
+                 return info;"
+            )
+        }
+        _ => "return flexbox_layout_item_info(slint::cbindgen_private::Orientation::Vertical, std::nullopt);"
+            .to_owned(),
+    };
+
+    vec![
+        Declaration::Function(Function {
+            name: "flexbox_layout_item_info".into(),
+            signature: SIGNATURE.to_owned(),
+            statements: Some(vec![body]),
+            ..Function::default()
+        }),
+        Declaration::Function(Function {
+            name: "flexbox_layout_item_info_at_cross_width".into(),
+            signature:
+                "([[maybe_unused]] float flex_cross_width) const -> slint::cbindgen_private::FlexboxLayoutItemInfo"
+                    .to_owned(),
+            statements: Some(vec![at_cross_width_body]),
+            ..Function::default()
+        }),
+    ]
 }
 
 /// Generates the `grid_layout_input_for_repeated` member function for a repeated component struct,
@@ -3118,9 +3160,9 @@ fn generate_repeated_component(
             Access::Public, // Because Repeater accesses it
             generate_layout_item_info_decl(root_sc, &ctx),
         ));
-        repeater_struct
-            .members
-            .push((Access::Public, generate_flexbox_layout_item_info_decl(root_sc, &ctx)));
+        for decl in generate_flexbox_layout_item_info_decl(root_sc, &ctx) {
+            repeater_struct.members.push((Access::Public, decl));
+        }
         if let Some(decl) = generate_grid_layout_input_decl(root_sc, &ctx) {
             repeater_struct.members.push((Access::Public, decl));
         }
@@ -4446,12 +4488,14 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             cells_v_variable,
             repeater_indices_var_name,
             elements,
+            repeated_cross_width,
             sub_expression,
         } => generate_with_flexbox_layout_item_info(
             cells_h_variable,
             cells_v_variable,
             repeater_indices_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
+            repeated_cross_width.as_deref(),
             sub_expression,
             ctx,
         ),
@@ -5421,10 +5465,14 @@ fn generate_with_flexbox_layout_item_info(
     cells_v_variable: &str,
     repeated_indices_var_name: Option<&str>,
     elements: &[Either<(llr::Expression, llr::Expression), llr::LayoutRepeatedElement>],
+    repeated_cross_width: Option<&llr::Expression>,
     sub_expression: &llr::Expression,
     ctx: &llr_EvaluationContext<CppGeneratorContext>,
 ) -> String {
     let repeated_indices_var_name = repeated_indices_var_name.map(ident);
+    // Container width forwarded to repeated cells' vertical query (column flex),
+    // so a height-for-width instance wraps to the real width like a static cell.
+    let cross_width = repeated_cross_width.map(|w| compile_expression(w, ctx));
     let mut push_code =
         "std::vector<slint::cbindgen_private::FlexboxLayoutItemInfo> cells_vector_h; std::vector<slint::cbindgen_private::FlexboxLayoutItemInfo> cells_vector_v;".to_owned();
     let mut repeater_idx = 0usize;
@@ -5463,13 +5511,21 @@ fn generate_with_flexbox_layout_item_info(
                 // for_each only visits instantiated slots; pad the cells up to len() afterwards so
                 // the cell count matches the repeater length recorded in the repeater_indices array
                 // (not-yet-instantiated rows get placeholders).
+                // For a column flex, measure each instance's vertical info at the
+                // container width; otherwise use its preferred-width default.
+                let v_push = match &cross_width {
+                    Some(w) => format!(
+                        "sub_comp->flexbox_layout_item_info_at_cross_width(static_cast<float>({w}))"
+                    ),
+                    None => "sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Vertical, std::nullopt)".to_owned(),
+                };
                 write!(
                     push_code,
                     "{{ \
                      auto start_offset = cells_vector_h.size(); \
                      self->repeater_{repeater_index}.for_each([&](const auto &sub_comp){{ \
                      cells_vector_h.push_back(sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Horizontal, std::nullopt)); \
-                     cells_vector_v.push_back(sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Vertical, std::nullopt)); }}); \
+                     cells_vector_v.push_back({v_push}); }}); \
                      auto repeater_len = self->repeater_{repeater_index}.len(); \
                      cells_vector_h.resize(start_offset + repeater_len); \
                      cells_vector_v.resize(start_offset + repeater_len); }}"

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2725,6 +2725,24 @@ fn generate_repeated_component(
                             }
                         }
                     });
+                // A column FlexboxLayout calls this with its real container width
+                // so a height-for-width instance wraps to the same height as an
+                // equivalent static cell (instead of the preferred-width single
+                // line that `flexbox_layout_item_info` returns). The expression
+                // reads the `flex_cross_width` local (matches FLEX_CROSS_WIDTH_LOCAL).
+                let at_cross_width_body = root_sc
+                    .layout_info_v_at_cross_width_for_repeated
+                    .as_ref()
+                    .map(|e| {
+                        let v_info = compile_expression(&e.borrow(), &ctx);
+                        quote! { info.constraint = #v_info; }
+                    })
+                    .unwrap_or_else(|| {
+                        quote! {
+                            info.constraint =
+                                self.layout_item_info(sp::Orientation::Vertical, sp::None).constraint;
+                        }
+                    });
                 quote! {
                     fn flexbox_layout_item_info(
                         self: ::core::pin::Pin<&Self>,
@@ -2736,6 +2754,17 @@ fn generate_repeated_component(
                         let mut info = self.as_ref().flexbox_layout_item_info_for_repeated();
                         #v_constrained
                         info.constraint = self.layout_item_info(o, child_index).constraint;
+                        info
+                    }
+                    #[allow(unused_variables)]
+                    fn flexbox_layout_item_info_at_cross_width(
+                        self: ::core::pin::Pin<&Self>,
+                        flex_cross_width: f32,
+                    ) -> sp::FlexboxLayoutItemInfo {
+                        #[allow(unused)]
+                        let _self = self.as_ref();
+                        let mut info = self.as_ref().flexbox_layout_item_info_for_repeated();
+                        #at_cross_width_body
                         info
                     }
                 }
@@ -3743,12 +3772,14 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             cells_v_variable,
             repeater_indices_var_name,
             elements,
+            repeated_cross_width,
             sub_expression,
         } => generate_with_flexbox_layout_item_info(
             cells_h_variable,
             cells_v_variable,
             repeater_indices_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
+            repeated_cross_width.as_deref(),
             sub_expression,
             ctx,
         ),
@@ -5053,10 +5084,14 @@ fn generate_with_flexbox_layout_item_info(
     cells_v_variable: &str,
     repeated_indices_var_name: Option<&str>,
     elements: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
+    repeated_cross_width: Option<&Expression>,
     sub_expression: &Expression,
     ctx: &EvaluationContext,
 ) -> TokenStream {
     let repeated_indices_var_name = repeated_indices_var_name.map(ident);
+    // Container width forwarded to repeated cells' vertical query (column flex),
+    // so a height-for-width instance wraps to the real width like a static cell.
+    let cross_width = repeated_cross_width.map(|w| compile_expression(w, ctx));
     let mut fixed_count = 0usize;
     let mut repeated_count_code = quote!();
     let mut push_code = Vec::new();
@@ -5084,14 +5119,23 @@ fn generate_with_flexbox_layout_item_info(
                     ctx,
                 );
                 let repeater_id = format_ident!("repeater{}", usize::from(repeater.repeater_index));
+                // For a column flex, measure each instance's vertical info at the
+                // container width; otherwise use its preferred-width default.
+                let v_push = if let Some(w) = &cross_width {
+                    quote!(sub_comp.as_pin_ref().flexbox_layout_item_info_at_cross_width((#w) as f32))
+                } else {
+                    quote!(
+                        sub_comp
+                            .as_pin_ref()
+                            .flexbox_layout_item_info(sp::Orientation::Vertical, None)
+                    )
+                };
                 let loop_code = quote!(for i in 0.._self.#repeater_id.len() {
                     if let Some(sub_comp) = _self.#repeater_id.instance_at(i) {
                         items_vec_h.push(
                             sub_comp.as_pin_ref().flexbox_layout_item_info(sp::Orientation::Horizontal, None),
                         );
-                        items_vec_v.push(
-                            sub_comp.as_pin_ref().flexbox_layout_item_info(sp::Orientation::Vertical, None),
-                        );
+                        items_vec_v.push(#v_push);
                     } else {
                         // Not-yet-instantiated slot: push placeholder cells so the cell
                         // count stays in sync with the repeater length written above.

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -239,6 +239,11 @@ pub enum Expression {
         repeater_indices_var_name: Option<SmolStr>,
         /// Either an expression pair of type (LayoutItemInfo, LayoutItemInfo), or information about the repeater
         elements: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
+        /// Container (cross-axis) width for a column flex: passed to each
+        /// repeated cell's `flexbox_layout_item_info_at_cross_width` so a
+        /// height-for-width instance wraps to the real width instead of its
+        /// preferred width. `None` for a row flex (no cross-width to forward).
+        repeated_cross_width: Option<Box<Expression>>,
         sub_expression: Box<Expression>,
     },
     /// Calls `solve_flexbox_layout_with_measure` with a generated measure
@@ -530,8 +535,16 @@ macro_rules! visit_impl {
                 $visitor(sub_expression);
                 elements.$iter().filter_map(|x| x.$as_ref().left()).for_each($visitor);
             }
-            Expression::WithFlexboxLayoutItemInfo { elements, sub_expression, .. } => {
+            Expression::WithFlexboxLayoutItemInfo {
+                elements,
+                repeated_cross_width,
+                sub_expression,
+                ..
+            } => {
                 $visitor(sub_expression);
+                if let Some(w) = repeated_cross_width {
+                    $visitor(w);
+                }
                 elements.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
                     $visitor(h);
                     $visitor(v);

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -493,6 +493,12 @@ pub struct SubComponent {
     /// parent flex cache. `Some` only when the element carries a
     /// `layoutinfo-v-with-constraint`. See `flexbox_layout_item_info`.
     pub layout_info_v_constrained_for_repeated: Option<MutExpression>,
+    /// Same as `layout_info_v_constrained_for_repeated`, but measured at the
+    /// width passed in the `flex_cross_width` local instead of the preferred
+    /// width. Drives the generated `flexbox_layout_item_info_at_cross_width` method,
+    /// which a column FlexboxLayout calls with its real container width so a
+    /// repeated cell wraps to the same height as an equivalent static cell.
+    pub layout_info_v_at_cross_width_for_repeated: Option<MutExpression>,
     /// True when this is a repeated Row in a GridLayout, meaning layout_item_info
     /// needs to be able to return layout info for individual children
     pub is_repeated_row: bool,
@@ -683,6 +689,9 @@ impl CompilationUnit {
                 visitor(e, ctx);
             }
             if let Some(e) = &sc.layout_info_v_constrained_for_repeated {
+                visitor(e, ctx);
+            }
+            if let Some(e) = &sc.layout_info_v_at_cross_width_for_repeated {
                 visitor(e, ctx);
             }
             for e in sc.accessible_prop.values() {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -408,12 +408,19 @@ pub(super) fn solve_flexbox_layout(
             ("cells_v", fld.cells_v.ty(ctx), fld.cells_v),
         ],
     );
+    // Forward the container width to repeated cells so a column flex re-measures
+    // each height-for-width instance at the real width (parity with static cells,
+    // which use the same `width_override`). `None` for a row flex.
+    let repeated_cross_width = container_width_for_cells
+        .as_ref()
+        .map(|e| Box::new(super::lower_expression::lower_expression(e, ctx)));
     match fld.compute_cells {
         Some((cells_h_var, cells_v_var, elements)) => llr_Expression::WithFlexboxLayoutItemInfo {
             cells_h_variable: cells_h_var,
             cells_v_variable: cells_v_var,
             repeater_indices_var_name: Some("repeated_indices".into()),
             elements,
+            repeated_cross_width,
             sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
                 function: "solve_flexbox_layout".into(),
                 arguments: vec![
@@ -670,6 +677,8 @@ fn compute_flexbox_layout_info_for_direction(
                     cells_v_variable: cells_v_var,
                     repeater_indices_var_name: None,
                     elements,
+                    // Info computation, not a solve: no container width to forward.
+                    repeated_cross_width: None,
                     sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
                         function: "flexbox_layout_info_cross_axis".into(),
                         arguments,
@@ -701,6 +710,8 @@ fn compute_flexbox_layout_info_for_direction(
                     cells_v_variable: cells_v_var,
                     repeater_indices_var_name: None,
                     elements,
+                    // Info computation, not a solve: no container width to forward.
+                    repeated_cross_width: None,
                     sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
                         function: "flexbox_layout_info_main_axis".into(),
                         arguments: vec![
@@ -1202,6 +1213,8 @@ fn flexbox_unwrapped_main_expr(
                 cells_v_variable,
                 repeater_indices_var_name: None,
                 elements,
+                // Info computation, not a solve: no container width to forward.
+                repeated_cross_width: None,
                 sub_expression: Box::new(call),
             }
         }
@@ -1910,7 +1923,8 @@ pub fn get_layout_info_v_constrained_for_repeated(
     }
     // Use the preferred width as the cross-axis constraint, the same default
     // static height-for-width cells use. This is a single-line-height
-    // approximation; measuring at the real column width is a follow-up commit.
+    // approximation; a column flex re-measures at the real container width via
+    // `get_layout_info_v_at_cross_width_for_repeated`.
     //
     // The h-constraint may be absent even when the v one exists; fall back to
     // unbounded then.
@@ -1920,5 +1934,30 @@ pub fn get_layout_info_v_constrained_for_repeated(
             crate::expression_tree::Unit::Px,
         )
     });
+    Some(get_layout_info(element, ctx, constraints, Orientation::Vertical, Some(width_constraint)))
+}
+
+/// Name of the local that carries the cross-axis (container) width into the
+/// generated `flexbox_layout_item_info_at_cross_width` method body.
+pub const FLEX_CROSS_WIDTH_LOCAL: &str = "flex_cross_width";
+
+/// Like [`get_layout_info_v_constrained_for_repeated`], but measures at the
+/// width passed in the [`FLEX_CROSS_WIDTH_LOCAL`] local instead of the
+/// element's preferred width. A column FlexboxLayout supplies its real
+/// container width here at solve time, so a repeated height-for-width instance
+/// gets the same wrapped height as an equivalent static cell. Returns `None`
+/// when the element has no constrained vertical layout-info.
+pub fn get_layout_info_v_at_cross_width_for_repeated(
+    ctx: &mut ExpressionLoweringCtx,
+    element: &ElementRc,
+    constraints: &crate::layout::LayoutConstraints,
+) -> Option<llr_Expression> {
+    if !element.borrow().has_inherited_layout_info_v_with_constraint() {
+        return None;
+    }
+    let width_constraint = crate::expression_tree::Expression::ReadLocalVariable {
+        name: FLEX_CROSS_WIDTH_LOCAL.into(),
+        ty: Type::LogicalLength,
+    };
     Some(get_layout_info(element, ctx, constraints, Orientation::Vertical, Some(width_constraint)))
 }

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -307,6 +307,7 @@ fn lower_sub_component(
         grid_layout_input_for_repeated: None,
         flexbox_layout_item_info_for_repeated: None,
         layout_info_v_constrained_for_repeated: None,
+        layout_info_v_at_cross_width_for_repeated: None,
         is_repeated_row: component
             .root_element
             .borrow()
@@ -671,6 +672,13 @@ fn lower_sub_component(
             );
         }
         sub_component.layout_info_v_constrained_for_repeated = v_constrained.map(Into::into);
+        sub_component.layout_info_v_at_cross_width_for_repeated =
+            super::lower_layout_expression::get_layout_info_v_at_cross_width_for_repeated(
+                &mut ctx,
+                root_elem,
+                &component.root_constraints.borrow(),
+            )
+            .map(Into::into);
     }
 
     if let Some(grid_layout_cell) = component.root_element.borrow().grid_layout_cell.as_ref() {

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -78,6 +78,9 @@ pub fn count_property_use(root: &CompilationUnit) {
         if let Some(e) = &sc.layout_info_v_constrained_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }
+        if let Some(e) = &sc.layout_info_v_at_cross_width_for_repeated {
+            e.borrow().visit_property_references(ctx, &mut visit_property);
+        }
         for child in &sc.grid_layout_children {
             child.layout_info_h.borrow().visit_property_references(ctx, &mut visit_property);
             child.layout_info_v.borrow().visit_property_references(ctx, &mut visit_property);

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -308,6 +308,7 @@ mod visitor {
             grid_layout_input_for_repeated,
             flexbox_layout_item_info_for_repeated,
             layout_info_v_constrained_for_repeated,
+            layout_info_v_at_cross_width_for_repeated,
             is_repeated_row: _,
             grid_layout_children,
             accessible_prop,
@@ -401,6 +402,9 @@ mod visitor {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some(e) = layout_info_v_constrained_for_repeated {
+            visit_expression(e.get_mut(), &scope, state, visitor);
+        }
+        if let Some(e) = layout_info_v_at_cross_width_for_repeated {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         for child in grid_layout_children {

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -68,6 +68,17 @@ pub trait RepeatedItemTree:
         self.layout_item_info(orientation, child_index).into()
     }
 
+    /// Vertical flexbox info measured at the given cross-axis (container) width.
+    /// A column FlexboxLayout calls this so a height-for-width instance wraps to
+    /// the real width. The default ignores the width (non-height-for-width
+    /// cells); the generated code overrides it for height-for-width instances.
+    fn flexbox_layout_item_info_at_cross_width(
+        self: Pin<&Self>,
+        _flex_cross_width: f32,
+    ) -> crate::layout::FlexboxLayoutItemInfo {
+        self.flexbox_layout_item_info(Orientation::Vertical, None)
+    }
+
     /// Fills in the grid layout input data for this ItemTree if it is in a grid layout.
     /// This will be a single GridLayoutInputData if the repeated item is a single cell,
     /// or multiple GridLayoutInputData if the repeated item is a full Row.

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -362,27 +362,50 @@ pub(crate) fn solve_flexbox_layout(
         /// returns trivial info that doesn't reflect the aggregated
         /// constraints; we read the aggregated property directly.
         has_aggregated_info: bool,
+        /// For a repeated cell, the instance to query — its constrained
+        /// layout-info function lives in the instance's own item tree, not in
+        /// the parent `component`. `None` for a static cell.
+        repeated_instance: Option<crate::dynamic_item_tree::DynamicComponentVRc>,
     }
     let mut child_elems: Vec<Option<ChildElem>> = Vec::new();
     for layout_elem in &flexbox_layout.elems {
-        if layout_elem.item.element.borrow().repeated.is_some() {
+        let placeholder = layout_elem.item.element.borrow();
+        let repeated = placeholder.repeated.is_some();
+        // For a repeated cell, query against the repeated component's root
+        // element (where its `layoutinfo-*-with-constraint` is reachable) in the
+        // instance's own item tree; for a static cell, against the cell element
+        // in the parent `component`.
+        let query_elem = if repeated {
+            placeholder.base_type.as_component().root_element.clone()
+        } else {
+            layout_elem.item.element.clone()
+        };
+        drop(placeholder);
+        let qe = query_elem.borrow();
+        let has_constrained_layoutinfo_v = qe.inherited_layout_info_v_with_constraint().is_some();
+        let has_constrained_layoutinfo_h = qe.inherited_layout_info_h_with_constraint().is_some();
+        let has_aggregated_info = qe.layout_info_prop.is_some();
+        drop(qe);
+        if repeated {
+            // One entry per instance: each is re-measured through its own item
+            // tree at the assigned cross size.
             let component_vec = repeater_instances(component, &layout_elem.item.element);
-            for _ in 0..component_vec.len() {
-                child_elems.push(None);
+            for instance in component_vec {
+                child_elems.push(Some(ChildElem {
+                    elem: query_elem.clone(),
+                    has_constrained_layoutinfo_v,
+                    has_constrained_layoutinfo_h,
+                    has_aggregated_info,
+                    repeated_instance: Some(instance),
+                }));
             }
         } else {
-            let elem_b = layout_elem.item.element.borrow();
-            let has_constrained_layoutinfo_v =
-                elem_b.inherited_layout_info_v_with_constraint().is_some();
-            let has_constrained_layoutinfo_h =
-                elem_b.inherited_layout_info_h_with_constraint().is_some();
-            let has_aggregated_info = elem_b.layout_info_prop.is_some();
-            drop(elem_b);
             child_elems.push(Some(ChildElem {
-                elem: layout_elem.item.element.clone(),
+                elem: query_elem,
                 has_constrained_layoutinfo_v,
                 has_constrained_layoutinfo_h,
                 has_aggregated_info,
+                repeated_instance: None,
             }));
         }
     }
@@ -410,21 +433,51 @@ pub(crate) fn solve_flexbox_layout(
             || ce.has_constrained_layoutinfo_v
             || ce.has_constrained_layoutinfo_h;
 
-        if known_w.is_some() && known_h.is_none() {
-            if use_property_lookup {
-                let v_info = get_layout_info_with_constraint(
+        // Query the cell's constrained layout-info. A repeated cell lives in
+        // its own instance's item tree (where its `layoutinfo-*-with-constraint`
+        // function is), so re-measure it there at the assigned cross size; a
+        // static cell is queried through the parent `component`.
+        let query = |orientation, constraint: Option<f32>| -> core_layout::LayoutInfo {
+            match &ce.repeated_instance {
+                Some(instance) => {
+                    generativity::make_guard!(guard);
+                    let unerased = instance.unerase(guard);
+                    get_layout_info_with_constraint(
+                        &ce.elem,
+                        unerased.borrow_instance(),
+                        &window_adapter,
+                        orientation,
+                        constraint,
+                    )
+                }
+                None => get_layout_info_with_constraint(
                     &ce.elem,
                     component,
                     &window_adapter,
-                    Orientation::Vertical,
-                    ce.has_constrained_layoutinfo_v.then_some(w),
-                );
+                    orientation,
+                    constraint,
+                ),
+            }
+        };
+
+        if known_w.is_some() && known_h.is_none() {
+            if use_property_lookup {
+                let v_info =
+                    query(Orientation::Vertical, ce.has_constrained_layoutinfo_v.then_some(w));
                 return (w, v_info.preferred_bounded());
             }
-            // Builtin path (Text, Image): use the Item vtable's
-            // layout_info, which honors the cross-axis constraint.
-            let elem_id = ce.elem.borrow().id.clone();
-            if let Some(item_within) = component.description.items.get(elem_id.as_str()) {
+            // Builtin path (Text, Image): use the Item vtable's layout_info,
+            // which honors the cross-axis constraint. This resolves the item in
+            // the parent `component`'s item tree, so it does not apply to a
+            // repeated cell (which lives in its own instance): a
+            // height-for-width repeated cell takes the `query` path above, and a
+            // non-height-for-width one keeps its width-independent default `h`.
+            if let Some(item_within) = ce
+                .repeated_instance
+                .is_none()
+                .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
+                .flatten()
+            {
                 let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
                 let item_rc =
                     ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
@@ -441,17 +494,18 @@ pub(crate) fn solve_flexbox_layout(
         }
         if known_h.is_some() && known_w.is_none() {
             if use_property_lookup {
-                let h_info = get_layout_info_with_constraint(
-                    &ce.elem,
-                    component,
-                    &window_adapter,
-                    Orientation::Horizontal,
-                    ce.has_constrained_layoutinfo_h.then_some(h),
-                );
+                let h_info =
+                    query(Orientation::Horizontal, ce.has_constrained_layoutinfo_h.then_some(h));
                 return (h_info.preferred_bounded(), h);
             }
-            let elem_id = ce.elem.borrow().id.clone();
-            if let Some(item_within) = component.description.items.get(elem_id.as_str()) {
+            // Builtin path, symmetric to the known-w branch above: parent-tree
+            // lookup only, so it is skipped for a repeated cell.
+            if let Some(item_within) = ce
+                .repeated_instance
+                .is_none()
+                .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
+                .flatten()
+            {
                 let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
                 let item_rc =
                     ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
@@ -627,6 +681,9 @@ fn flexbox_layout_data(
         flex_order: i32,
     }
     let mut static_children: Vec<Option<ChildInfo>> = Vec::new(); // None = repeater
+    // Instances of each repeater, in `elems` order, so the second pass doesn't walk them again.
+    let mut repeater_instance_vecs: Vec<Vec<crate::dynamic_item_tree::DynamicComponentVRc>> =
+        Vec::new();
 
     for layout_elem in &flexbox_layout.elems {
         if layout_elem.item.element.borrow().repeated.is_some() {
@@ -639,9 +696,8 @@ fn flexbox_layout_data(
             cells_v.extend(component_vec.iter().map(|x| {
                 x.as_pin_ref().flexbox_layout_item_info(to_runtime(Orientation::Vertical), None)
             }));
-            for _ in 0..component_vec.len() {
-                static_children.push(None);
-            }
+            static_children.resize_with(static_children.len() + component_vec.len(), || None);
+            repeater_instance_vecs.push(component_vec);
         } else {
             // Dispatch via `layoutinfo-h-with-constraint` for cells that
             // have one, avoiding the `self.height` read that would cycle.
@@ -709,11 +765,53 @@ fn flexbox_layout_data(
     // For column direction, use the container width (items get stretched to it).
     // Otherwise use the item's horizontal preferred size.
     let mut cell_idx = 0usize;
+    let mut repeater_idx = 0usize;
     for layout_elem in &flexbox_layout.elems {
         if layout_elem.item.element.borrow().repeated.is_some() {
-            let component_vec = repeater_instances(component, &layout_elem.item.element);
-            cell_idx += component_vec.len();
-            // repeater cells_v already filled in first pass
+            // Re-measure each height-for-width repeated instance at the width
+            // constraint (container width for a column flex), mirroring the
+            // static branch below — the first pass filled cells_v at the
+            // instance's preferred width (single line). Keep the flex props set
+            // in the first pass; only overwrite the vertical constraint.
+            let rep_root =
+                layout_elem.item.element.borrow().base_type.as_component().root_element.clone();
+            let is_height_for_width =
+                rep_root.borrow().inherited_layout_info_v_with_constraint().is_some();
+            let component_vec = &repeater_instance_vecs[repeater_idx];
+            repeater_idx += 1;
+            for instance in component_vec {
+                if is_height_for_width {
+                    let width_constraint = width_override
+                        .unwrap_or_else(|| cells_h[cell_idx].constraint.preferred_bounded());
+                    generativity::make_guard!(guard);
+                    let unerased = instance.unerase(guard);
+                    let instance_ref = unerased.borrow_instance();
+                    let mut layout_info_v = get_layout_info_with_constraint(
+                        &rep_root,
+                        instance_ref,
+                        &window_adapter,
+                        Orientation::Vertical,
+                        Some(width_constraint),
+                    );
+                    // The constraints' NamedReferences point to elements inside
+                    // the repeated sub-component, so evaluate them in that
+                    // instance's context, not the outer component's.
+                    let instance_expr_eval = |nr: &NamedReference| -> f32 {
+                        eval::load_property(instance_ref, &nr.element(), nr.name())
+                            .unwrap()
+                            .try_into()
+                            .unwrap()
+                    };
+                    fill_layout_info_constraints(
+                        &mut layout_info_v,
+                        &layout_elem.item.constraints,
+                        Orientation::Vertical,
+                        &instance_expr_eval,
+                    );
+                    cells_v[cell_idx].constraint = layout_info_v;
+                }
+                cell_idx += 1;
+            }
         } else {
             let width_constraint =
                 width_override.unwrap_or_else(|| cells_h[cell_idx].constraint.preferred_bounded());

--- a/tests/cases/layout/flexbox_repeater_component_with_wrap.slint
+++ b/tests/cases/layout/flexbox_repeater_component_with_wrap.slint
@@ -1,19 +1,28 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Regression test: a FlexboxLayout containing a repeater of components with
-// height-for-width content (a wrapped Text) used to panic with "Recursion
-// detected with property .layoutinfo-v". Each repeated instance's vertical
-// info was queried without a cross-axis constraint, so it read self.width —
-// set by the parent flex cache it was feeding — and cycled. The repeater path
-// now routes through the synthesized layoutinfo-v-with-constraint, like static
-// cells do, so the layout resolves instead.
+// Regression test for two fixes to repeated height-for-width cells (a wrapped
+// Text) in a column FlexboxLayout:
+//  1. It used to panic with "Recursion detected with property .layoutinfo-v":
+//     each repeated instance's vertical info was queried without a cross-axis
+//     constraint, so it read self.width (set by the parent flex cache it was
+//     feeding) and cycled. The repeater path now routes through the synthesized
+//     layoutinfo-v-with-constraint, like static cells do.
+//  2. Once it resolved, a repeated instance was still measured at its preferred
+//     (single-line) width while an identical static cell used the real container
+//     width, so the repeated card was too short and its text overflowed. Each
+//     repeated cell is now re-measured at the container width (see the `matched`
+//     assertion, which is what actually catches this second bug).
 
 component Card inherits Rectangle {
     in property <string> label;
+    in property <length> pad: 5px;
     background: #e0e0e0;
     VerticalLayout {
-        padding: 5px;
+        // Uniform padding, incl. horizontal: the height-for-width measurement
+        // must reduce the width constraint by this padding so the wrapped Text
+        // is measured at the width it is laid out at.
+        padding: pad;
         Text {
             text: label;
             wrap: word-wrap;
@@ -29,12 +38,14 @@ component Card2 inherits Card { }
 
 export component TestCase inherits Window {
     width: 320px;
-    height: 400px;
+    height: 820px;
+
+    property <string> long: "A really long card text that will almost certainly need to wrap onto two or more lines when the flex space is tight";
 
     in property <[string]> labels: [
         "Short",
         "A medium-length card text that may or may not wrap",
-        "A really long card text that will almost certainly need to wrap onto two or more lines when the flex space is tight",
+        long,
     ];
 
     // Single-line reference for the card Text, so the height assertions stay
@@ -43,14 +54,27 @@ export component TestCase inherits Window {
     refLine := Text { x: 0; y: -1000px; text: "Short"; wrap: no-wrap; }
     out property <length> line-height: refLine.height;
 
+    // Reference: `long` wrapped at 100px — the content width of the padded
+    // repeated card below (200 flex width − 2×40 flex padding − 2×10 card
+    // padding). The card's height must match this (plus its own padding).
+    refPad := Text { x: -3000px; width: 100px; text: long; wrap: word-wrap; }
+
     FlexboxLayout {
+        x: 0; y: 0; width: 320px; height: 150px;
         flex-direction: column;
         spacing: 6px;
-        padding: 8px;
+        padding: 0px;
 
         for s in labels: Card {
             label: s;
             flex-shrink: 0;
+            // Regression guard: an explicit vertical constraint on a repeated
+            // height-for-width cell must be evaluated in the *instance's*
+            // context. Its NamedReference points inside the repeated
+            // sub-component, so evaluating it against the outer component panics.
+            // A 1px floor is below the natural height (no geometry change), but
+            // still forces the constraint to be resolved.
+            min-height: 1px;
         }
         // Non-repeater anchor whose laid-out position depends on the total
         // height of the repeated Cards above. Reading anchor.y forces the
@@ -63,10 +87,10 @@ export component TestCase inherits Window {
 
     // A second flex of inherited-base cards, to cover the inherited path.
     FlexboxLayout {
-        x: 0; y: 300px; width: 320px; height: 100px;
+        x: 0; y: 150px; width: 320px; height: 140px;
         flex-direction: column;
         spacing: 6px;
-        padding: 8px;
+        padding: 0px;
 
         for s in labels: Card2 {
             label: s;
@@ -75,14 +99,94 @@ export component TestCase inherits Window {
         anchor2 := Rectangle { height: 5px; }
     }
 
+    // Precise measurement flex (zero spacing/padding so adjacent anchors give
+    // exact heights): a static card, a single-line reference card, then two
+    // repeated cards with the same wrapping text. A repeated card must wrap to
+    // the same height as the static one.
+    FlexboxLayout {
+        x: 0; y: 290px; width: 200px; height: 270px;
+        flex-direction: column;
+        spacing: 0px;
+        padding: 0px;
+
+        staticCard := Card { label: long; flex-shrink: 0; }
+        m1 := Rectangle { height: 1px; }
+        refCard := Card { label: "One"; flex-shrink: 0; }
+        m2 := Rectangle { height: 1px; }
+        for s in [long, long]: Card { label: s; flex-shrink: 0; }
+        anchor3 := Rectangle { height: 1px; }
+    }
+
+    // A column flex with repeated non-height-for-width cells (fixed height):
+    // exercises the repeated path when the width override is ignored.
+    FlexboxLayout {
+        x: 0; y: 560px; width: 200px; height: 75px;
+        flex-direction: column;
+        spacing: 0px;
+        padding: 0px;
+
+        b0 := Rectangle { height: 1px; }
+        for k in [0, 1]: Rectangle { height: 30px; flex-shrink: 0; }
+        bAnchor := Rectangle { height: 1px; }
+    }
+
+    // Padded repeated card: the flex has 40px horizontal padding and the card
+    // 10px, so the card's Text is laid out at 200 − 80 − 20 = 100px. Its height
+    // must equal `refPad` (wrapped at 100px) plus the card's own padding —
+    // proving the h4w measurement subtracts BOTH the flex padding and the card
+    // padding for a *repeated* cell. Without the prequel fix the card is
+    // measured wider and comes out too short (`matched`-style checks can't catch
+    // this: a padded static reference would be under-measured the same way).
+    FlexboxLayout {
+        x: 0; y: 635px; width: 200px; height: 180px;
+        flex-direction: column;
+        spacing: 0px;
+        padding-left: 40px;
+        padding-right: 40px;
+
+        pTop := Rectangle { height: 1px; }
+        for s in [long]: Card { label: s; pad: 10px; flex-shrink: 0; }
+        pBot := Rectangle { height: 1px; }
+    }
+
+    // staticCard sits at the top, so its height is the gap up to m1. refCard is
+    // between m1 and m2. The two repeated cards fill between m2 and anchor3.
+    out property <length> static-height: m1.y - staticCard.y;
+    out property <length> ref-height: m2.y - m1.y - 1px;
+    out property <length> repeated-total: anchor3.y - m2.y - 1px;
+
+    // Each repeated card must match the static card. Two instances, so the total
+    // is twice the static height: also covers the per-instance cell bookkeeping.
+    out property <bool> matched: abs(repeated-total - 2 * static-height) < 1px;
+
+    // The two fixed-height repeated cells give 30px each.
+    out property <bool> non-h4w-ok: abs((bAnchor.y - b0.y - 1px) - 60px) < 1px;
+
+    // The padded repeated card wraps to the same height as the reference at the
+    // content width (card padding 10px → +20px). Font-independent: both sides
+    // measure the same text at 100px.
+    out property <length> pad-card-height: pBot.y - pTop.y - 1px;
+    out property <bool> pad-ok: abs(pad-card-height - (refPad.height + 20px)) < 1px;
+
+    // Font-present backends only: the long card must be taller than the
+    // single-line reference, i.e. the text actually wrapped (otherwise `matched`
+    // would hold trivially at the empty-card height on every card).
+    out property <bool> wrapped: static-height > ref-height + 1px;
+
     // anchor.y sits below the three stacked Cards: each card is at least one
-    // text line tall, so the anchor is well past 3 lines and still inside the
-    // window (no infinite/overflowing height). anchor2.y > 0 proves the
-    // inherited-base flex solved without recursing too.
-    out property <bool> test:
+    // text line tall, so the anchor is well past 3 lines and still inside its
+    // flex (no infinite/overflowing height). anchor2.y > 0 proves the
+    // inherited-base flex solved without recursing too. These plus `matched`
+    // and `non-h4w-ok` are font-independent, so nodejs asserts them.
+    out property <bool> font-independent:
         anchor.y > 3 * line-height
-        && anchor.y < self.height
-        && anchor2.y > 0px;
+        && anchor.y < 150px
+        && anchor2.y > 0px
+        && matched
+        && non-h4w-ok
+        && pad-ok;
+
+    out property <bool> test: font-independent && wrapped;
 }
 
 /*
@@ -97,7 +201,9 @@ assert!(instance.get_test());
 ```
 
 ```js
+// nodejs has no test fonts, so the wrapped Text has zero height and `wrapped`
+// cannot be asserted. Check the font-independent invariants instead.
 var instance = new slint.TestCase();
-assert(instance.test);
+assert(instance.font_independent);
 ```
 */


### PR DESCRIPTION
A repeated height-for-width component (e.g. a wrapped Text) in a column
FlexboxLayout was laid out a single line tall, while an identical static cell
wrapped to the full container width: the recursion fix only gave repeated
instances their single-line preferred-width height, never the container width
static cells use, so the card was too short and its text overflowed.

Forward the container width to each repeated cell and re-measure there, so it
wraps to the same height as an equivalent static cell. Done in the interpreter
and both code generators; adds a regression test across all four backends.

Before/After screenshot
<img width="862" height="1106" alt="repeated-in-column-before-after" src="https://github.com/user-attachments/assets/ff75c1ec-c785-4350-89e9-5a06153665f8" />

This commit is for repeated height-for-width items in a *column* flexbox (width is known before the solve step since it comes from the container).
The next commit will be for repeated height-for-width items in a *row* flexbox (height is known during the solve step, very different code).