### PR TITLE
Add missing cpp tests for textinput

### DIFF
--- a/tests/cases/accessibility/textinput.slint
+++ b/tests/cases/accessibility/textinput.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 import { LineEdit } from "std-widgets.slint";
 
 export component TestCase inherits Window {
@@ -44,5 +47,33 @@ let instance = TestCase::new().unwrap();
 }
 ```
 
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+{
+    auto text_input = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::ti");
+    assert_eq(text_input.size(), 1);
+    auto textinput = text_input[0];
+
+    assert(textinput.accessible_value() == "123");
+    assert(instance.get_text_input_text() == "123");
+    textinput.set_accessible_value("Hello");
+    assert(textinput.accessible_value() == "Hello");
+    assert(instance.get_text_input_text() == "Hello");
+}
+
+{
+    auto line_edit = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::le");
+    assert_eq(line_edit.size(), 1);
+    auto lineedit = line_edit[0];
+
+    assert(lineedit.accessible_value() == "456");
+    assert(instance.get_line_edit_text() == "456");
+    lineedit.set_accessible_value("World");
+    assert(lineedit.accessible_value() == "World");
+    assert(instance.get_line_edit_text() == "World" );
+}
+```
 
 */


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
