### PR TITLE
Solve single-cell box layouts at compile time

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -200,6 +200,16 @@ pub struct LayoutConstraints {
     pub fixed_height: bool,
 }
 
+/// The [`LayoutConstraints`] fields along one orientation.
+pub struct OrientationConstraints<'a> {
+    pub min: &'a Option<NamedReference>,
+    pub max: &'a Option<NamedReference>,
+    pub preferred: &'a Option<NamedReference>,
+    pub stretch: &'a Option<NamedReference>,
+    /// The size is set by an explicit `width`/`height` binding.
+    pub fixed: bool,
+}
+
 impl LayoutConstraints {
     /// Build the constraints for the given element.
     ///
@@ -287,36 +297,48 @@ impl LayoutConstraints {
         }
     }
 
+    pub fn for_orientation(&self, orientation: Orientation) -> OrientationConstraints<'_> {
+        match orientation {
+            Orientation::Horizontal => OrientationConstraints {
+                min: &self.min_width,
+                max: &self.max_width,
+                preferred: &self.preferred_width,
+                stretch: &self.horizontal_stretch,
+                fixed: self.fixed_width,
+            },
+            Orientation::Vertical => OrientationConstraints {
+                min: &self.min_height,
+                max: &self.max_height,
+                preferred: &self.preferred_height,
+                stretch: &self.vertical_stretch,
+                fixed: self.fixed_height,
+            },
+        }
+    }
+
     // Iterate over the constraint with a reference to a property, and the corresponding member in the i_slint_core::layout::LayoutInfo struct
     pub fn for_each_restrictions(
         &self,
         orientation: Orientation,
     ) -> impl Iterator<Item = (&NamedReference, &'static str)> {
-        let (min, max, preferred, stretch) = match orientation {
-            Orientation::Horizontal => {
-                (&self.min_width, &self.max_width, &self.preferred_width, &self.horizontal_stretch)
-            }
-            Orientation::Vertical => {
-                (&self.min_height, &self.max_height, &self.preferred_height, &self.vertical_stretch)
-            }
-        };
+        let c = self.for_orientation(orientation);
         std::iter::empty()
-            .chain(min.as_ref().map(|x| {
+            .chain(c.min.as_ref().map(|x| {
                 if Expression::PropertyReference(x.clone()).ty() != Type::Percent {
                     (x, "min")
                 } else {
                     (x, "min_percent")
                 }
             }))
-            .chain(max.as_ref().map(|x| {
+            .chain(c.max.as_ref().map(|x| {
                 if Expression::PropertyReference(x.clone()).ty() != Type::Percent {
                     (x, "max")
                 } else {
                     (x, "max_percent")
                 }
             }))
-            .chain(preferred.as_ref().map(|x| (x, "preferred")))
-            .chain(stretch.as_ref().map(|x| (x, "stretch")))
+            .chain(c.preferred.as_ref().map(|x| (x, "preferred")))
+            .chain(c.stretch.as_ref().map(|x| (x, "stretch")))
     }
 
     pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -894,6 +894,16 @@ pub fn implicit_layout_info_call(
     }
 }
 
+/// The stretch factor of elements based on text or image items, which never
+/// stretch: their `layout_info` always reports stretch 0, and a layoutinfo
+/// property synthesized later can only merge it with smaller values.
+pub fn static_native_stretch(elem: &ElementRc) -> Option<Expression> {
+    elem.borrow()
+        .builtin_type()
+        .filter(|b| matches!(b.name.as_str(), "Text" | "StyledText" | "TextInput" | "Image"))
+        .map(|_| Expression::NumberLiteral(0., Unit::None))
+}
+
 /// Create a new property based on the name. (it might get a different name if that property exist)
 pub fn create_new_prop(elem: &ElementRc, tentative_name: SmolStr, ty: Type) -> NamedReference {
     let mut e = elem.borrow_mut();

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -158,6 +158,7 @@ pub async fn run_passes(
         flickable::handle_flickable(component, &global_type_registry.borrow());
         lower_layout::lower_layouts(component, type_loader, &style_metrics, diag);
         default_geometry::default_geometry(component, diag, &symbol_counters);
+        lower_layout::optimize_single_cell_layouts(component);
         lower_layout::synthesize_layoutinfo_v_with_constraint(component);
         lower_layout::synthesize_layoutinfo_h_with_constraint(component);
         lower_absolute_coordinates::lower_absolute_coordinates(component);

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1245,12 +1245,206 @@ impl GridLayout {
     }
 }
 
+/// Solve box layouts with a single non-repeated cell and constant alignment at
+/// compile time: closed-form bindings replace the layout-cache property, the
+/// runtime solver, and the layout info computation.
+///
+/// Runs after the default_geometry pass so that every cell's layout info
+/// property exists.
+pub fn optimize_single_cell_layouts(component: &Rc<Component>) {
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
+        // Collect first: the rewrite modifies the bindings.
+        let solves = elem
+            .borrow()
+            .bindings
+            .iter()
+            .filter_map(|(name, b)| match &b.borrow().expression {
+                Expression::SolveBoxLayout(l, o) if *o == l.orientation && l.elems.len() == 1 => {
+                    Some((name.clone(), l.clone()))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        for (cache_name, layout) in solves {
+            optimize_single_cell_layout(elem, &cache_name, &layout);
+        }
+    });
+}
+
+fn optimize_single_cell_layout(
+    layout_element: &ElementRc,
+    cache_name: &SmolStr,
+    layout: &BoxLayout,
+) {
+    let Some(single_cell) = single_cell_box_layout(layout) else { return };
+    let orientation = layout.orientation;
+    let cell = &layout.elems[0].element;
+    let (pos, size) = match orientation {
+        Orientation::Horizontal => ("x", "width"),
+        Orientation::Vertical => ("y", "height"),
+    };
+    let replace = |prop: &str, expr: Expression| {
+        let elem = cell.borrow();
+        let binding = elem.bindings.get(prop).expect("the layout has set the cell's geometry");
+        debug_assert!(matches!(binding.borrow().expression, Expression::LayoutCacheAccess { .. }));
+        binding.borrow_mut().expression = expr;
+    };
+    let pads = layout.geometry.padding.begin_end(orientation);
+    let available = || size_minus_padding(layout_element, size, pads);
+    let mut pos_expr = pads.0.map_or(Expression::NumberLiteral(0., Unit::Px), |nr| {
+        Expression::PropertyReference(nr.clone())
+    });
+    if single_cell.pos_factor != 0. {
+        // Read the size through the cell's property so the size expression
+        // isn't duplicated.
+        let cell_size =
+            Expression::PropertyReference(NamedReference::new(cell, SmolStr::new_static(size)));
+        let leftover = min_max(
+            MinMaxOp::Max,
+            Expression::NumberLiteral(0., Unit::Px),
+            bin('-', available(), cell_size),
+        );
+        let factor = Expression::NumberLiteral(single_cell.pos_factor, Unit::None);
+        pos_expr = bin('+', pos_expr, bin('*', leftover, factor));
+    }
+    replace(pos, pos_expr);
+    if let Some((min_expr, max_expr, pref_expr)) = &single_cell.size {
+        let mut size_expr = available();
+        if let Some(pref) = pref_expr {
+            size_expr = min_max(MinMaxOp::Min, size_expr, pref.clone());
+        }
+        // Clamp like the runtime solver: the minimum wins over the maximum.
+        size_expr = min_max(
+            MinMaxOp::Max,
+            min_max(MinMaxOp::Min, size_expr, max_expr.clone()),
+            min_expr.clone(),
+        );
+        replace(size, size_expr);
+    }
+    layout_element.borrow_mut().bindings.remove(cache_name);
+    layout_element.borrow_mut().property_declarations.remove(cache_name);
+}
+
+/// Compile-time solution for a box layout with a single non-repeated cell and
+/// constant alignment: `size = clamp(min(available, preferred), min, max)`
+/// (no preferred term when stretching), `pos = padding + pos_factor * leftover`.
+struct SingleCellBoxLayout {
+    /// Fraction of the leftover space placed before the cell:
+    /// 0 for stretch/start/space-between, ½ for center/space-around/space-evenly, 1 for end.
+    pos_factor: f64,
+    /// The `(min, max, preferred)` expressions clamping the size; the preferred
+    /// term is `None` when stretching. The whole option is `None` when the size
+    /// is fixed by an explicit binding that stays in place.
+    size: Option<(Expression, Expression, Option<Expression>)>,
+}
+
+fn single_cell_box_layout(layout: &BoxLayout) -> Option<SingleCellBoxLayout> {
+    let orientation = layout.orientation;
+    let [item] = layout.elems.as_slice() else { return None };
+    if item.element.borrow().repeated.is_some() {
+        return None;
+    }
+    // Cells with a cross-axis-parametrized layout info need the runtime cells machinery.
+    if orientation == Orientation::Horizontal
+        && item.element.borrow().inherited_layout_info_h_with_constraint().is_some()
+    {
+        return None;
+    }
+    // The alignment must be a compile-time constant. A state-dependent
+    // alignment was already rewritten into a condition by the lower_states pass.
+    let alignment = match &layout.geometry.alignment {
+        None => None,
+        Some(nr) => {
+            let elem = nr.element();
+            let elem = elem.borrow();
+            let analysis = elem.property_analysis.borrow();
+            if analysis.get(nr.name()).is_some_and(|a| a.is_set || a.is_set_externally) {
+                return None;
+            }
+            let binding = elem.bindings.get(nr.name())?;
+            let binding = binding.borrow();
+            if !binding.two_way_bindings.is_empty() {
+                return None;
+            }
+            let Expression::EnumerationValue(ev) = binding.expression.ignore_debug_hooks() else {
+                return None;
+            };
+            Some(ev.enumeration.values[ev.value].clone())
+        }
+    };
+    let (stretch, pos_factor) = match alignment.as_deref() {
+        None | Some("stretch") => (true, 0.),
+        Some("start" | "space-between") => (false, 0.),
+        Some("center" | "space-around" | "space-evenly") => (false, 0.5),
+        Some("end") => (false, 1.),
+        _ => return None,
+    };
+    let c = item.constraints.for_orientation(orientation);
+    // Percent constraints scale with the available size; leave them to the solver.
+    if [c.min, c.max, c.preferred].into_iter().flatten().any(|nr| nr.ty() == Type::Percent) {
+        return None;
+    }
+    if c.fixed {
+        return Some(SingleCellBoxLayout { pos_factor, size: None });
+    }
+    let implicit = cell_implicit_info(&item.element, orientation);
+    let side = |explicit: &Option<NamedReference>, name: &str| {
+        explicit
+            .clone()
+            .map(Expression::PropertyReference)
+            .or_else(|| implicit.as_ref().and_then(|info| implicit_info_field(info, name)))
+    };
+    let pref = if stretch { None } else { Some(side(c.preferred, "preferred")?) };
+    Some(SingleCellBoxLayout {
+        pos_factor,
+        size: Some((side(c.min, "min")?, side(c.max, "max")?, pref)),
+    })
+}
+
 fn bin(op: char, lhs: Expression, rhs: Expression) -> Expression {
     Expression::BinaryExpression { lhs: Box::new(lhs), rhs: Box::new(rhs), op }
 }
 
 fn min_max(op: MinMaxOp, lhs: Expression, rhs: Expression) -> Expression {
     crate::builtin_macros::min_max_expression(lhs, rhs, op)
+}
+
+fn size_minus_padding(
+    layout_element: &ElementRc,
+    size_prop: &'static str,
+    (begin_padding, end_padding): (Option<&NamedReference>, Option<&NamedReference>),
+) -> Expression {
+    let mut e = Expression::PropertyReference(NamedReference::new(
+        layout_element,
+        SmolStr::new_static(size_prop),
+    ));
+    for p in [begin_padding, end_padding].into_iter().flatten() {
+        e = bin('-', e, Expression::PropertyReference(p.clone()));
+    }
+    e
+}
+
+/// The implicit layout info of a layout cell, resolved like `get_layout_info`
+/// in the LLR lowering: the element's own layoutinfo property when it has one,
+/// otherwise [`implicit_layout_info_call`].
+fn cell_implicit_info(elem: &ElementRc, orientation: Orientation) -> Option<Expression> {
+    let own_info = elem.borrow().layout_info_prop(orientation).cloned();
+    match own_info {
+        Some(nr) => Some(Expression::PropertyReference(nr)),
+        None => implicit_layout_info_call(elem, orientation, BuiltinFilter::All, None),
+    }
+}
+
+/// A cheap expression for one field of a [`cell_implicit_info`] result.
+/// `None` when the info needs a runtime call.
+fn implicit_info_field(info: &Expression, name: &str) -> Option<Expression> {
+    match info {
+        Expression::Struct { values, .. } => values.get(name).cloned(),
+        base @ Expression::PropertyReference(_) => {
+            Some(Expression::StructFieldAccess { base: Box::new(base.clone()), name: name.into() })
+        }
+        _ => None,
+    }
 }
 
 /// Clamp a cross-axis stretch size to the cell's explicit min/max constraints,
@@ -1325,27 +1519,9 @@ fn lower_box_layout(
     };
     // Default stretch bindings, only used when there is no `cross-axis-alignment`.
     let stretch_bindings = layout_cache_ortho_prop.is_none().then(|| {
-        let (begin_padding, end_padding) = match orientation {
-            Orientation::Horizontal => {
-                (&layout.geometry.padding.top, &layout.geometry.padding.bottom)
-            }
-            Orientation::Vertical => {
-                (&layout.geometry.padding.left, &layout.geometry.padding.right)
-            }
-        };
-        let pad_expr = begin_padding.clone().map(Expression::PropertyReference);
-        let mut size_expr = Expression::PropertyReference(NamedReference::new(
-            layout_element,
-            SmolStr::new_static(ortho),
-        ));
-        for p in [begin_padding, end_padding].into_iter().flatten() {
-            size_expr = Expression::BinaryExpression {
-                lhs: Box::new(std::mem::take(&mut size_expr)),
-                rhs: Box::new(Expression::PropertyReference(p.clone())),
-                op: '-',
-            };
-        }
-        (pad_expr, size_expr)
+        let pads = layout.geometry.padding.begin_end(orientation.orthogonal());
+        let pad_expr = pads.0.map(|nr| Expression::PropertyReference(nr.clone()));
+        (pad_expr, size_minus_padding(layout_element, ortho, pads))
     });
 
     for layout_child in &layout_children {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1323,12 +1323,25 @@ fn optimize_single_cell_layout(
     }
     layout_element.borrow_mut().bindings.remove(cache_name);
     layout_element.borrow_mut().property_declarations.remove(cache_name);
+    for o in [Orientation::Horizontal, Orientation::Vertical] {
+        let Some(nr) = layout_element.borrow().layout_info_prop(o).cloned() else { continue };
+        let Some(info) =
+            single_cell_layout_info_binding(layout, &layout.elems[0], o, single_cell.stretch)
+        else {
+            continue;
+        };
+        if let Some(binding) = nr.element().borrow().bindings.get(nr.name()) {
+            binding.borrow_mut().expression = info;
+        }
+    }
 }
 
 /// Compile-time solution for a box layout with a single non-repeated cell and
 /// constant alignment: `size = clamp(min(available, preferred), min, max)`
 /// (no preferred term when stretching), `pos = padding + pos_factor * leftover`.
 struct SingleCellBoxLayout {
+    /// Whether the (constant) alignment is the default stretch.
+    stretch: bool,
     /// Fraction of the leftover space placed before the cell:
     /// 0 for stretch/start/space-between, ½ for center/space-around/space-evenly, 1 for end.
     pos_factor: f64,
@@ -1385,7 +1398,7 @@ fn single_cell_box_layout(layout: &BoxLayout) -> Option<SingleCellBoxLayout> {
         return None;
     }
     if c.fixed {
-        return Some(SingleCellBoxLayout { pos_factor, size: None });
+        return Some(SingleCellBoxLayout { stretch, pos_factor, size: None });
     }
     let implicit = cell_implicit_info(&item.element, orientation);
     let side = |explicit: &Option<NamedReference>, name: &str| {
@@ -1396,6 +1409,7 @@ fn single_cell_box_layout(layout: &BoxLayout) -> Option<SingleCellBoxLayout> {
     };
     let pref = if stretch { None } else { Some(side(c.preferred, "preferred")?) };
     Some(SingleCellBoxLayout {
+        stretch,
         pos_factor,
         size: Some((side(c.min, "min")?, side(c.max, "max")?, pref)),
     })
@@ -1422,6 +1436,151 @@ fn size_minus_padding(
         e = bin('-', e, Expression::PropertyReference(p.clone()));
     }
     e
+}
+
+/// Closed-form `layoutinfo-{h,v}` binding for a single-cell box layout: what
+/// `box_layout_info` / `box_layout_info_ortho` compute at runtime. `None` when
+/// a needed side of the cell's implicit layout info requires a runtime call.
+fn single_cell_layout_info_binding(
+    layout: &BoxLayout,
+    item: &LayoutItem,
+    o: Orientation,
+    stretch: bool,
+) -> Option<Expression> {
+    let c = item.constraints.for_orientation(o);
+    let size_prop = match o {
+        Orientation::Horizontal => "width",
+        Orientation::Vertical => "height",
+    };
+    let info_ty = crate::typeregister::layout_info_type();
+    // Literal fields for built-ins with static info; otherwise a local holding
+    // the cell's layout info property, stored only when a field is read.
+    enum Implicit {
+        Literal(std::collections::BTreeMap<SmolStr, Expression>),
+        Prop(Expression),
+        Expensive,
+    }
+    let implicit = match cell_implicit_info(&item.element, o) {
+        Some(Expression::Struct { values, .. }) => Implicit::Literal(values),
+        Some(base @ Expression::PropertyReference(_)) => Implicit::Prop(base),
+        _ => Implicit::Expensive,
+    };
+    let mut implicit_used = false;
+    let mut implicit_field = |name: &str| match &implicit {
+        Implicit::Literal(values) => values.get(name).cloned(),
+        Implicit::Prop(_) => {
+            implicit_used = true;
+            Some(Expression::StructFieldAccess {
+                base: Box::new(Expression::ReadLocalVariable {
+                    name: "cell_layout_info".into(),
+                    ty: info_ty.clone().into(),
+                }),
+                name: name.into(),
+            })
+        }
+        Implicit::Expensive => None,
+    };
+    // Percent constraints don't restrict the reported layout info.
+    let explicit = |nr: &Option<NamedReference>| {
+        nr.clone().filter(|nr| nr.ty() != Type::Percent).map(Expression::PropertyReference)
+    };
+    let (cell_min, cell_max, cell_pref) = if c.fixed {
+        let sz =
+            Expression::ReadLocalVariable { name: "cell_size".into(), ty: Type::LogicalLength };
+        (sz.clone(), sz.clone(), sz)
+    } else {
+        (
+            explicit(c.min).or_else(|| implicit_field("min"))?,
+            explicit(c.max).or_else(|| implicit_field("max"))?,
+            explicit(c.preferred).or_else(|| implicit_field("preferred"))?,
+        )
+    };
+    let cell_stretch = c
+        .stretch
+        .clone()
+        .map(Expression::PropertyReference)
+        .or_else(|| implicit_field("stretch"))
+        .or_else(|| static_native_stretch(&item.element))?;
+
+    let mut prelude = Vec::new();
+    if implicit_used && let Implicit::Prop(base) = implicit {
+        prelude.push(Expression::StoreLocalVariable {
+            name: "cell_layout_info".into(),
+            value: Box::new(base),
+        });
+    }
+    if c.fixed {
+        prelude.push(Expression::StoreLocalVariable {
+            name: "cell_size".into(),
+            value: Box::new(Expression::PropertyReference(NamedReference::new(
+                &item.element,
+                SmolStr::new_static(size_prop),
+            ))),
+        });
+    }
+    let (pad_begin, pad_end) = layout.geometry.padding.begin_end(o);
+    let pad_sum = [pad_begin, pad_end]
+        .into_iter()
+        .flatten()
+        .map(|nr| Expression::PropertyReference(nr.clone()))
+        .reduce(|lhs, rhs| bin('+', lhs, rhs));
+    if let Some(pad_sum) = pad_sum.clone() {
+        prelude.push(Expression::StoreLocalVariable {
+            name: "layout_padding".into(),
+            value: Box::new(pad_sum),
+        });
+    }
+    let plus_pads = |e: Expression| {
+        if pad_sum.is_none() {
+            e
+        } else {
+            let pads = Expression::ReadLocalVariable {
+                name: "layout_padding".into(),
+                ty: Type::LogicalLength,
+            };
+            bin('+', e, pads)
+        }
+    };
+    let (min, max, preferred) = if o == layout.orientation {
+        let min = plus_pads(cell_min.clone());
+        let max = if stretch {
+            min_max(MinMaxOp::Max, plus_pads(cell_max.clone()), min.clone())
+        } else {
+            Expression::NumberLiteral(f32::MAX as f64, Unit::Px)
+        };
+        let pref = plus_pads(min_max(
+            MinMaxOp::Max,
+            min_max(MinMaxOp::Min, cell_pref, cell_max),
+            cell_min,
+        ));
+        (min, max, pref)
+    } else {
+        let bounded_max = min_max(MinMaxOp::Max, cell_max, cell_min.clone());
+        let pref = plus_pads(min_max(
+            MinMaxOp::Max,
+            min_max(MinMaxOp::Min, cell_pref, bounded_max.clone()),
+            cell_min.clone(),
+        ));
+        (plus_pads(cell_min), plus_pads(bounded_max), pref)
+    };
+    let values = [
+        ("min", min),
+        ("max", max),
+        ("min_percent", Expression::NumberLiteral(0., Unit::None)),
+        ("max_percent", Expression::NumberLiteral(100., Unit::None)),
+        ("preferred", preferred),
+        ("stretch", cell_stretch),
+    ]
+    .into_iter()
+    .map(|(name, e)| (SmolStr::new_static(name), e))
+    .collect();
+    let info = Expression::Struct { ty: info_ty, values };
+    Some(if prelude.is_empty() {
+        info
+    } else {
+        prelude.push(info);
+        Expression::CodeBlock(prelude)
+    })
 }
 
 /// The implicit layout info of a layout cell, resolved like `get_layout_info`
@@ -1491,8 +1650,6 @@ fn lower_box_layout(
         cross_alignment: binding_reference(layout_element, "cross-axis-alignment"),
     };
 
-    let layout_cache_prop =
-        create_new_prop(layout_element, SmolStr::new_static("layout-cache"), Type::LayoutCache);
     let layout_cache_ortho_prop = layout.cross_alignment.is_some().then(|| {
         create_new_prop(
             layout_element,
@@ -1517,6 +1674,9 @@ fn lower_box_layout(
         Orientation::Horizontal => ("x", "width", "y", "height"),
         Orientation::Vertical => ("y", "height", "x", "width"),
     };
+
+    let layout_cache_prop =
+        create_new_prop(layout_element, SmolStr::new_static("layout-cache"), Type::LayoutCache);
     // Default stretch bindings, only used when there is no `cross-axis-alignment`.
     let stretch_bindings = layout_cache_ortho_prop.is_none().then(|| {
         let pads = layout.geometry.padding.begin_end(orientation.orthogonal());

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1245,6 +1245,46 @@ impl GridLayout {
     }
 }
 
+fn bin(op: char, lhs: Expression, rhs: Expression) -> Expression {
+    Expression::BinaryExpression { lhs: Box::new(lhs), rhs: Box::new(rhs), op }
+}
+
+fn min_max(op: MinMaxOp, lhs: Expression, rhs: Expression) -> Expression {
+    crate::builtin_macros::min_max_expression(lhs, rhs, op)
+}
+
+/// Clamp a cross-axis stretch size to the cell's explicit min/max constraints,
+/// like the runtime solver: percent constraints scale with the available size,
+/// and the minimum wins over the maximum.
+///
+/// Implicit constraints are not consulted: an element's layout info may depend
+/// on its own geometry (a percent spacing, for example), and reading it from
+/// the geometry binding would create a binding loop.
+fn clamp_cross_stretch_size(
+    available: &Expression,
+    c: &LayoutConstraints,
+    ortho: Orientation,
+) -> Expression {
+    let c = c.for_orientation(ortho);
+    let side = |explicit: &Option<NamedReference>| match explicit {
+        Some(nr) if nr.ty() == Type::Percent => Some(bin(
+            '/',
+            bin('*', available.clone(), Expression::PropertyReference(nr.clone())),
+            Expression::NumberLiteral(100., Unit::None),
+        )),
+        Some(nr) => Some(Expression::PropertyReference(nr.clone())),
+        None => None,
+    };
+    let mut size_expr = available.clone();
+    if let Some(max_expr) = side(c.max) {
+        size_expr = min_max(MinMaxOp::Min, size_expr, max_expr);
+    }
+    if let Some(min_expr) = side(c.min) {
+        size_expr = min_max(MinMaxOp::Max, size_expr, min_expr);
+    }
+    size_expr
+}
+
 fn lower_box_layout(
     layout_element: &ElementRc,
     diag: &mut BuildDiagnostics,
@@ -1356,10 +1396,15 @@ fn lower_box_layout(
                     .insert(pad.into(), RefCell::new(pad_expr.clone().into()));
             }
             if !fixed_ortho {
+                let clamped = clamp_cross_stretch_size(
+                    size_expr,
+                    &item.item.constraints,
+                    orientation.orthogonal(),
+                );
                 actual_elem
                     .borrow_mut()
                     .bindings
-                    .insert(ortho.into(), RefCell::new(size_expr.clone().into()));
+                    .insert(ortho.into(), RefCell::new(clamped.into()));
             }
         }
         layout.elems.push(item.item);

--- a/internal/compiler/tests/single_cell_box_layout.rs
+++ b/internal/compiler/tests/single_cell_box_layout.rs
@@ -1,0 +1,106 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! The `.slint` behavior tests (`box_single_cell.slint`, `box_cross_stretch_constraints.slint`)
+//! pass whether the geometry comes from the compile-time lowering or from the runtime solver, so
+//! they can't tell whether the optimization actually fired. These tests inspect the lowered LLR
+//! instead: a compile-time-solvable single-cell box layout must not emit a `solve_box_layout`
+//! runtime call, while the cases that keep the solver must still emit it.
+
+use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::generator::{self, OutputFormat};
+use i_slint_compiler::parser::parse;
+use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
+
+/// Compile `source`, lower it through the LLR back-end (the way the native code generators do) and
+/// return the pretty-printed LLR. `debug_info` is left at its default (false), matching real
+/// `slint-build` / `slint!` users.
+fn lower_to_llr_text(source: &str) -> String {
+    let mut diagnostics = BuildDiagnostics::default();
+    let syntax_node = parse(source.into(), None, &mut diagnostics);
+    let config = CompilerConfiguration::new(OutputFormat::Llr);
+    let (doc, diagnostics, loader) =
+        spin_on::spin_on(compile_syntax_node(syntax_node, diagnostics, config));
+    assert!(!diagnostics.has_errors(), "{:?}", diagnostics.to_string_vec());
+    let mut output = Vec::new();
+    generator::generate(OutputFormat::Llr, &mut output, None, &doc, &loader.compiler_config)
+        .unwrap();
+    String::from_utf8(output).unwrap()
+}
+
+/// The runtime box layout solver appears as a `solve_box_layout` / `solve_box_layout_ortho` call in
+/// the lowered expressions.
+fn uses_runtime_solver(llr: &str) -> bool {
+    llr.contains("solve_box_layout")
+}
+
+#[test]
+fn single_cell_stretch_solved_at_compile_time() {
+    let llr = lower_to_llr_text(
+        r#"
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    VerticalLayout {
+        padding: 0px;
+        Rectangle { max-height: 150px; }
+    }
+}
+"#,
+    );
+    assert!(!uses_runtime_solver(&llr), "the solver should have been elided:\n{llr}");
+}
+
+#[test]
+fn single_cell_center_solved_at_compile_time() {
+    let llr = lower_to_llr_text(
+        r#"
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    VerticalLayout {
+        padding: 0px;
+        alignment: center;
+        Rectangle { preferred-height: 50px; }
+    }
+}
+"#,
+    );
+    assert!(!uses_runtime_solver(&llr), "the solver should have been elided:\n{llr}");
+}
+
+#[test]
+fn percent_size_keeps_runtime_solver() {
+    // A percent size can't be resolved at compile time, so the solver stays. This is the control
+    // that proves the checks above are meaningful.
+    let llr = lower_to_llr_text(
+        r#"
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    VerticalLayout {
+        padding: 0px;
+        Rectangle { height: 25%; }
+    }
+}
+"#,
+    );
+    assert!(uses_runtime_solver(&llr), "a percent constraint needs the solver:\n{llr}");
+}
+
+#[test]
+fn repeated_cell_keeps_runtime_solver() {
+    let llr = lower_to_llr_text(
+        r#"
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    VerticalLayout {
+        padding: 0px;
+        for i in [0]: Rectangle { min-height: 200px; }
+    }
+}
+"#,
+    );
+    assert!(uses_runtime_solver(&llr), "a repeated cell needs the solver:\n{llr}");
+}

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -68,6 +68,8 @@ impl Item for ImageItem {
                     natural_size.height as Coord * w / natural_size.width as Coord
                 }
             },
+            // The compiler's single-cell box layout lowering relies on image items
+            // keeping the default stretch of 0 in their layout info.
             ..Default::default()
         }
     }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -635,6 +635,8 @@ impl SimpleText {
     }
 }
 
+// The compiler's single-cell box layout lowering relies on text and image
+// items keeping the default stretch of 0 in their layout info.
 fn text_layout_info(
     text: Pin<&dyn RenderText>,
     self_rc: &ItemRc,

--- a/tests/cases/layout/box_cross_stretch_constraints.slint
+++ b/tests/cases/layout/box_cross_stretch_constraints.slint
@@ -1,0 +1,120 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The default cross axis (no `cross-axis-alignment`) stretches, but must still
+// honor the cells' min/max and percent constraints, like the runtime solver
+// does when `cross-axis-alignment: stretch` is set explicitly.
+
+component TestMaxClamp inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        r1 := Rectangle { background: red; max-height: 80phx; }
+        r2 := Rectangle { background: green; }
+    }
+
+    out property <bool> test:
+        r1.y == 0phx && r1.height == 80phx
+        && r2.y == 0phx && r2.height == 200phx;
+}
+
+component TestMinWins inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        r1 := Rectangle { background: red; min-height: 250phx; }
+    }
+
+    out property <bool> test: r1.y == 0phx && r1.height == 250phx;
+}
+
+component TestPercent inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        r1 := Rectangle { background: red; height: 30%; }
+    }
+
+    out property <bool> test: r1.y == 0phx && r1.height == 60phx;
+}
+
+component TestPercentWithPadding inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding-top: 30phx;
+        padding-bottom: 10phx;
+        padding-left: 0phx;
+        padding-right: 0phx;
+        r1 := Rectangle { background: red; height: 50%; }
+    }
+
+    // content box: 200 - 30 - 10 = 160phx
+    out property <bool> test: r1.y == 30phx && r1.height == 80phx;
+}
+
+component TestVerticalMaxClamp inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        r1 := Rectangle { background: red; max-width: 120phx; }
+    }
+
+    out property <bool> test: r1.x == 0phx && r1.width == 120phx;
+}
+
+// The explicit `cross-axis-alignment: stretch` must behave the same as the default.
+component TestExplicitStretchSame inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        cross-axis-alignment: stretch;
+        r1 := Rectangle { background: red; max-height: 80phx; }
+    }
+
+    out property <bool> test: r1.y == 0phx && r1.height == 80phx;
+}
+
+export component TestCase inherits Rectangle {
+    max_clamp := TestMaxClamp {}
+    min_wins := TestMinWins {}
+    percent := TestPercent {}
+    percent_pad := TestPercentWithPadding {}
+    v_max := TestVerticalMaxClamp {}
+    explicit_same := TestExplicitStretchSame {}
+
+    out property <bool> test:
+        max_clamp.test && min_wins.test && percent.test && percent_pad.test
+        && v_max.test && explicit_same.test;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/

--- a/tests/cases/layout/box_single_cell.slint
+++ b/tests/cases/layout/box_single_cell.slint
@@ -1,0 +1,281 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Box layouts with a single cell: the compiler solves most of them at compile
+// time (constant alignment, cheap constraints), the rest keep the runtime
+// solver. Both must behave exactly the same.
+
+// Compile-time: stretch fills the available space, minus the padding.
+component TestStretchPadding inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding-top: 10phx;
+        padding-bottom: 30phx;
+        padding-left: 5phx;
+        padding-right: 15phx;
+        r := Rectangle { background: red; }
+    }
+
+    out property <bool> test:
+        r.x == 5phx && r.y == 10phx && r.width == 280phx && r.height == 160phx;
+}
+
+// Compile-time: stretch clamps to the cell's max.
+component TestStretchMaxClamp inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        r := Rectangle { background: red; max-height: 150phx; }
+    }
+
+    out property <bool> test: r.y == 0phx && r.height == 150phx;
+}
+
+// Compile-time: the minimum wins when the layout is smaller.
+component TestStretchMinWins inherits Rectangle {
+    width: 100phx;
+    height: 100phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        r := Rectangle { background: red; min-height: 150phx; }
+    }
+
+    out property <bool> test: r.y == 0phx && r.height == 150phx;
+}
+
+// Compile-time: center gives the cell its preferred size.
+component TestCenterPreferred inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        alignment: center;
+        r := Rectangle { background: red; preferred-height: 50phx; }
+    }
+
+    out property <bool> test: r.y == 75phx && r.height == 50phx;
+}
+
+// Compile-time: center with a fixed size cell.
+component TestCenterFixed inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding-top: 20phx;
+        padding-bottom: 0phx;
+        alignment: center;
+        r := Rectangle { background: red; height: 60phx; }
+    }
+
+    // content box: 180phx starting at 20phx; leftover 120phx, half before the cell
+    out property <bool> test: r.y == 20phx + 60phx && r.height == 60phx;
+}
+
+// Compile-time: end alignment puts the leftover before the cell.
+component TestEnd inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        alignment: end;
+        r := Rectangle { background: red; preferred-height: 50phx; }
+    }
+
+    out property <bool> test: r.y == 150phx && r.height == 50phx;
+}
+
+// Compile-time: a fixed-size text cell; text never stretches, so the layout
+// reports a fixed layout info and its sibling takes the remaining space.
+component TestFixedTextInfo inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        spacing: 0phx;
+        inner := VerticalLayout {
+            padding: 0phx;
+            alignment: center;
+            t := Text { width: 20phx; height: 10phx; text: "x"; }
+        }
+        sibling := Rectangle { background: green; }
+    }
+
+    out property <bool> test:
+        inner.width == 20phx && sibling.width == 280phx
+        && t.y == (200phx - 10phx) / 2 && t.height == 10phx;
+}
+
+// Compile-time: the constraint comes from the cell component's layout info.
+component ConstrainedPanel {
+    VerticalLayout {
+        padding: 0phx;
+        Rectangle { min-width: 70phx; }
+    }
+}
+component TestComponentMin inherits Rectangle {
+    width: 50phx;
+    height: 50phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        p := ConstrainedPanel { }
+    }
+
+    out property <bool> test: p.width == 70phx;
+}
+
+// Runtime solver: a percent size needs the solver.
+component TestPercentSize inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        r := Rectangle { background: red; height: 25%; }
+    }
+
+    out property <bool> test: r.y == 0phx && r.height == 50phx;
+}
+
+// Runtime solver: the alignment is dynamic.
+component TestDynamicAlignment inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    in property <bool> centered: true;
+
+    VerticalLayout {
+        padding: 0phx;
+        alignment: root.centered ? LayoutAlignment.center : LayoutAlignment.end;
+        r := Rectangle { background: red; preferred-height: 50phx; }
+    }
+
+    out property <bool> test: r.y == 75phx && r.height == 50phx;
+}
+
+// The cell constraints come from a wrapper's children.
+component TestWrapperMin inherits Rectangle {
+    width: 50phx;
+    height: 50phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        w := Rectangle {
+            VerticalLayout {
+                padding: 0phx;
+                Rectangle { min-width: 80phx; }
+            }
+        }
+    }
+
+    out property <bool> test: w.width == 80phx;
+}
+
+// The wrapper's maximum, coming from its children, caps the cell.
+component TestWrapperMax inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 0phx;
+        w := Rectangle {
+            VerticalLayout {
+                padding: 0phx;
+                Rectangle { max-height: 90phx; }
+            }
+        }
+    }
+
+    out property <bool> test: w.y == 0phx && w.height == 90phx;
+}
+
+// A directly nested layout as the single cell.
+component TestNestedLayoutCell inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    VerticalLayout {
+        padding: 10phx;
+        inner := HorizontalLayout {
+            padding: 0phx;
+            Rectangle { background: red; }
+        }
+    }
+
+    out property <bool> test:
+        inner.x == 10phx && inner.y == 10phx
+        && inner.width == 280phx && inner.height == 180phx;
+}
+
+// Runtime solver: a repeated cell; its constraints still propagate.
+component TestRepeatedCell inherits Rectangle {
+    width: 300phx;
+    height: 200phx;
+
+    HorizontalLayout {
+        padding: 0phx;
+        spacing: 0phx;
+        il := VerticalLayout {
+            padding: 0phx;
+            for i in [0]: Rectangle { background: red; min-width: 200phx; }
+        }
+        sib := Rectangle { background: green; }
+    }
+
+    // the cell's minimum bounds il's starting size; the remaining 100phx is
+    // distributed evenly between the two stretching cells
+    out property <bool> test: il.width == 250phx && sib.width == 50phx;
+}
+
+export component TestCase inherits Rectangle {
+    stretch_pad := TestStretchPadding {}
+    stretch_max := TestStretchMaxClamp {}
+    stretch_min := TestStretchMinWins {}
+    center_pref := TestCenterPreferred {}
+    center_fixed := TestCenterFixed {}
+    end := TestEnd {}
+    fixed_text := TestFixedTextInfo {}
+    component_min := TestComponentMin {}
+    percent := TestPercentSize {}
+    dynamic := TestDynamicAlignment {}
+    wrapper_min := TestWrapperMin {}
+    wrapper_max := TestWrapperMax {}
+    nested := TestNestedLayoutCell {}
+    repeated := TestRepeatedCell {}
+
+    out property <bool> test:
+        stretch_pad.test && stretch_max.test && stretch_min.test
+        && center_pref.test && center_fixed.test && end.test
+        && fixed_text.test && component_min.test
+        && percent.test && dynamic.test && wrapper_min.test
+        && wrapper_max.test && nested.test && repeated.test;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
  A box layout with a single non-repeated cell and a constant alignment does not
  need the runtime solver: the cell geometry and the layout info are closed-form
  expressions of the layout size. A new pass running after `default_geometry`
  replaces the geometry bindings, gives the layoutinfo-h/v properties a struct
  binding that the LLR inliner can eliminate, and removes the layout-cache
  property. The solver stays in place for repeated cells, percent constraints,
  dynamic alignment, and cells whose implicit layout info needs a runtime call.
  
  Single-cell layouts are very common (in a 65k-line real-world app, almost half
  of all box layouts). There, this removes 37% of the solver calls, 30% of the
  layoutinfo properties, and 17% of all generated property fields; the generated
  Rust code shrinks by 3.5%, with corresponding runtime savings in memory and
  layout work.
  
  The first commit is a related bug fix: the default cross axis (no
  `cross-axis-alignment`) ignored the cells' explicit min/max and percent
  constraints, so `max-height: 80px` on a HorizontalLayout cell had no effect
  unless `cross-axis-alignment: stretch` was also set. It now clamps like the
  runtime solver. This is a behavior change for code that relied on such
  constraints being ignored.
  
  New test cases cover both the compile-time-solved shapes and the
  solver fallbacks.
