### PR TITLE
docs: fix test/example commands broken by the workspace split

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -117,9 +117,6 @@ cargo build
 cargo test
 ```
 
-**Important:** Note that `cargo test` does not work without first calling `cargo build` because the
-the required dynamic library won't be found.
-
 ### Workspace layout
 
 The repository is split into several Cargo workspaces that all share the same

--- a/docs/development/custom-renderer.md
+++ b/docs/development/custom-renderer.md
@@ -218,12 +218,15 @@ Platform (winit/qt/linuxkms)
 
 ### Screenshot Tests
 
+`test-driver-screenshots` lives in the separate `tests/` Cargo workspace, so these need
+`--manifest-path tests/Cargo.toml` when run from the repository root:
+
 ```sh
 # Run screenshot comparison tests
-cargo test -p test-driver-screenshots
+cargo test --manifest-path tests/Cargo.toml -p test-driver-screenshots
 
 # Generate new reference screenshots (run when intentionally changing rendering)
-SLINT_CREATE_SCREENSHOTS=1 cargo test -p test-driver-screenshots
+SLINT_CREATE_SCREENSHOTS=1 cargo test --manifest-path tests/Cargo.toml -p test-driver-screenshots
 ```
 
 ### Testing Backend
@@ -242,8 +245,8 @@ The testing backend (`internal/backends/testing/`) provides:
 ### Visual Verification
 
 ```sh
-# Run gallery to visually inspect rendering
-cargo run -p gallery
+# Run gallery to visually inspect rendering (in the separate examples/ workspace)
+cargo run --manifest-path examples/Cargo.toml -p gallery
 
 # View specific .slint file with hot reload
 cargo run --bin slint-viewer -- path/to/file.slint

--- a/docs/development/item-tree.md
+++ b/docs/development/item-tree.md
@@ -251,13 +251,17 @@ Repeaters create dynamic subtrees:
 
 ## Testing
 
+`test-driver-interpreter` and `test-driver-rust` live in the separate `tests/` Cargo
+workspace, and `gallery` lives in the separate `examples/` workspace, so these need an
+explicit `--manifest-path` when run from the repository root:
+
 ```sh
 # Run interpreter tests (exercises dynamic item tree)
-cargo test -p test-driver-interpreter
+cargo test --manifest-path tests/Cargo.toml -p test-driver-interpreter
 
 # Run Rust API tests
-cargo test -p test-driver-rust
+cargo test --manifest-path tests/Cargo.toml -p test-driver-rust
 
 # Visual inspection
-cargo run -p gallery
+cargo run --manifest-path examples/Cargo.toml -p gallery
 ```

--- a/docs/development/layout-system.md
+++ b/docs/development/layout-system.md
@@ -334,10 +334,15 @@ the code generators compile to the appropriate runtime access pattern.
 
 ## Testing Layout Changes
 
+`test-driver-rust` and `test-driver-interpreter` live in the separate `tests/` Cargo
+workspace, and `gallery` lives in the separate `examples/` workspace, so these need an
+explicit `--manifest-path` when run from the repository root (`tests/run_tests.sh`
+already handles this for you):
+
 ```sh
 # Run all layout-specific tests
-cargo test -p test-driver-rust --test layout
-cargo test -p test-driver-interpreter layout
+cargo test --manifest-path tests/Cargo.toml -p test-driver-rust --test layout
+cargo test --manifest-path tests/Cargo.toml -p test-driver-interpreter layout
 
 # Run a specific test case, filtered by substring (don't prepend sh/bash, run_tests.sh is executable)
 tests/run_tests.sh rust grid_conditional_row
@@ -345,8 +350,8 @@ tests/run_tests.sh interpreter grid_conditional_row
 tests/run_tests.sh cpp grid_conditional_row
 
 # Run all interpreter tests (fast)
-cargo test -p test-driver-interpreter
+cargo test --manifest-path tests/Cargo.toml -p test-driver-interpreter
 
 # Visual verification (for humans)
-cargo run -p gallery
+cargo run --manifest-path examples/Cargo.toml -p gallery
 ```

--- a/docs/development/python-tests.md
+++ b/docs/development/python-tests.md
@@ -20,11 +20,12 @@ The Rust test driver (`tests/driver/python/python.rs`) processes `.slint` test c
 
 2. **Runs the generated `.py` file** as a subprocess using `uv run`. The subprocess loads the `slint` Python module, which re-compiles the `.slint` source using `slint-interpreter` (with full inlining enabled).
 
-Run with:
+`test-driver-python` lives in the separate `tests/` Cargo workspace, so it needs
+`--manifest-path tests/Cargo.toml` when run from the repository root:
 ```sh
-cargo test -p test-driver-python
+cargo test --manifest-path tests/Cargo.toml -p test-driver-python
 # or with a filter:
-cargo test -p test-driver-python -- test_name
+cargo test --manifest-path tests/Cargo.toml -p test-driver-python -- test_name
 ```
 
 ## Rebuilding slint-python
@@ -43,7 +44,7 @@ cd api/python/slint && uv sync --reinstall-package slint && cd -
 
 Issues can occur in two places:
 
-- **Test driver process** (compilation): the test driver compiles the `.slint` source with `OutputFormat::Python` and generates the `.py` file. To debug, modify compiler code and rebuild with `cargo build -p test-driver-python`.
+- **Test driver process** (compilation): the test driver compiles the `.slint` source with `OutputFormat::Python` and generates the `.py` file. To debug, modify compiler code and rebuild with `cargo build --manifest-path tests/Cargo.toml -p test-driver-python`.
 
 - **Python subprocess** (runtime): the `slint` Python module re-compiles the `.slint` source via `slint-interpreter` and executes it. To debug, modify compiler/runtime code AND rebuild slint-python (`cd api/python/slint && uv sync --reinstall-package slint`).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,6 +2,14 @@
 
 This documents describe the testing infrastructure of Slint
 
+## Workspace layout
+
+Most of the test crates below (`test-driver-*`, `doctests`, `test-driver-screenshots`)
+live in the separate `tests/` Cargo workspace, not the root workspace. Running their
+`cargo test -p <crate>` commands from the repository root requires
+`--manifest-path tests/Cargo.toml`, as shown below. `tests/run_tests.sh` already passes
+this for you, so prefer it when it covers your driver (see the Rust driver section).
+
 ## Syntax tests
 
 The syntax tests are testing that the compiler show the right error messages in case of error.
@@ -47,7 +55,7 @@ The interpreter test is the faster test to compile and run. It test the compiler
 as run by the viewer or such. It can be run like so:
 
 ```
-cargo test -p test-driver-interpreter --
+cargo test --manifest-path tests/Cargo.toml -p test-driver-interpreter --
 ```
 
 You can add an argument to test only for particular tests.
@@ -73,7 +81,7 @@ that matches the filter.
 Example: to run all the layout tests:
 
 ```
-SLINT_TEST_FILTER=layout cargo test -p test-driver-rust
+SLINT_TEST_FILTER=layout cargo test --manifest-path tests/Cargo.toml -p test-driver-rust
 ```
 or
 ```
@@ -84,7 +92,7 @@ Instead of putting everything in a slint! macro, it's possible to tell the drive
 compilation in the build.rs, with the build-time feature:
 
 ```
-SLINT_TEST_FILTER=layout cargo test -p test-driver-rust --features build-time
+SLINT_TEST_FILTER=layout cargo test --manifest-path tests/Cargo.toml -p test-driver-rust --features build-time
 ```
 or
 ```
@@ -100,7 +108,7 @@ Each program is compiled separately. And then run.
 Some macro like `assert_eq` are defined to look similar to the rust equivalent.
 
 ```
-cargo test -p  test-driver-cpp --
+cargo test --manifest-path tests/Cargo.toml -p test-driver-cpp --
 ```
 
 Note that there are also C++ unit tests that can be run by CMake
@@ -112,7 +120,7 @@ with it that loads the .slint and runs node with it.
 Each test is run in a different node process.
 
 ```
-cargo  test -p test-driver-nodejs
+cargo test --manifest-path tests/Cargo.toml -p test-driver-nodejs
 ```
 
 ## Screenshot tests
@@ -123,13 +131,13 @@ rendered and the results will be compared to the reference images in `tests/scre
 To generate references images for all test files in `tests/screenshots/cases` run:
 
 ```
-SLINT_CREATE_SCREENSHOTS=1 cargo test -p test-driver-screenshots
+SLINT_CREATE_SCREENSHOTS=1 cargo test --manifest-path tests/Cargo.toml -p test-driver-screenshots
 ```
 
 To start the tests run and compare images:
 
 ```
-cargo test -p test-driver-screenshots
+cargo test --manifest-path tests/Cargo.toml -p test-driver-screenshots
 ```
 
 ## Embedded MCP Server
@@ -145,7 +153,7 @@ and [docs/development/mcp-server.md](development/mcp-server.md) for architecture
 ## Doctests
 
 ```
-cargo test -p doctests
+cargo test --manifest-path tests/Cargo.toml -p doctests
 ```
 
 The doctests extracts the ```` ```slint ````  from the files in the docs folder and make  sure that


### PR DESCRIPTION
## Summary
- The workspace split (#873ff5994 / the PR that moved `examples/`, `demos/`, `tests/`, and `ui-libraries/material/` into their own Cargo workspaces) left several documented `cargo -p <crate>` commands broken: they target crates that no longer live in the root workspace, so they fail with "package not found" when run from the repo root as written.
- Adds `--manifest-path tests/Cargo.toml` / `--manifest-path examples/Cargo.toml` to the affected commands in `docs/testing.md`, `docs/development/python-tests.md`, `docs/development/custom-renderer.md`, `docs/development/item-tree.md`, and `docs/development/layout-system.md`.
- Removes an obsolete note in `docs/building.md` claiming `cargo test` requires a prior `cargo build` — left over from before the split, it directly contradicted `AGENTS.md` and only ever applied to the C++ test driver (which already has its own correct instructions).

## Test plan
- [x] Diffed each changed command against the relevant `Cargo.toml` `[workspace] members` list to confirm the crate now lives outside the root workspace and the manifest path is correct.
- [x] Prose-only changes — no code affected.

https://claude.ai/code/session_01TVXqXMjRWrBgrxTBcLTQFc