### PR TITLE
docs: fix remaining command/guidance inconsistencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ cmake --build .
 
 ### Node.js Build
 ```sh
-cd api/node && pnpm install
+cd api/node && pnpm install && pnpm build
 ```
 
 ## Testing
@@ -73,8 +73,8 @@ Only drop the filter for a final full-suite run before committing.
 
 ### Writing Slint Test Cases
 
-The `test` property in `tests/cases/*.slint` must be declared `out property<bool> test: ...;`.
-Without `out`, the compiler treats it as private and the driver passes the test vacuously.
+The `test` property in `tests/cases/*.slint` must be declared `out` or `in-out`
+(e.g. `out property<bool> test: ...;`), otherwise the driver passes the test vacuously.
 
 ### Syntax Tests (Compiler Errors)
 ```sh

--- a/docs/building.md
+++ b/docs/building.md
@@ -188,11 +188,11 @@ You can pass `-DCMAKE_INSTALL_PREFIX` in the first cmake command in order to cho
 
 ### Node.js API Build
 
-The Slint Node.js API is implemented as npm build. You can build it locally using the following command line:
+The Slint Node.js API is implemented as a pnpm build. You can build it locally using the following command line:
 
 ```sh
 cd api/node
-npm install
+pnpm install && pnpm build
 ```
 
 To build your own project against the Git version of the Slint Node.js API, add the path to the `api/node` folder

--- a/docs/development/type-system.md
+++ b/docs/development/type-system.md
@@ -441,10 +441,10 @@ if let Some(ty) = register.lookup("MyType") {
 
 ```sh
 # Run type system tests
-cargo test -p slint-compiler langtype
-cargo test -p slint-compiler lookup
-cargo test -p slint-compiler typeregister
+cargo test -p i-slint-compiler langtype
+cargo test -p i-slint-compiler lookup
+cargo test -p i-slint-compiler typeregister
 
 # Run all compiler tests
-cargo test -p slint-compiler
+cargo test -p i-slint-compiler
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,7 +64,10 @@ cargo test --manifest-path tests/Cargo.toml -p test-driver-interpreter --
 
 You can add an argument to test only for particular tests.
 
-If the last component in the file includes a `bool` property named `test`, the test will verify that its value is `true`.
+If the last component in the file includes a public `bool` property named `test` (declared
+`out` or `in-out`), the test will verify that its value is `true`. A `private` (the default)
+or `in` property is invisible to the driver, so the test passes vacuously without actually
+checking anything.
 
 example:
 


### PR DESCRIPTION
## Summary
- Node.js build instructions were inconsistent across three places: `docs/building.md` said `npm install` even though the repo is a pnpm workspace, and `AGENTS.md`'s `pnpm install` alone doesn't build the native module (that's the separate `build` script in `api/node/package.json`). Both now match `api/node/README.md`'s `pnpm install && pnpm build`.
- `docs/development/type-system.md`'s test commands targeted the `slint-compiler` CLI crate (`tools/compiler`) instead of `i-slint-compiler`, where `langtype.rs`/`lookup.rs`/`typeregister.rs` actually live — the commands compiled but ran none of the intended tests.
- `docs/testing.md` and `AGENTS.md` disagreed on the required visibility of a test's `test` property (one said `out`, the other's example used `in-out`). Both work, since the interpreter driver only sees public properties (`tests/driver/interpreter/interpreter.rs`); both docs now say so explicitly and warn that a `private`/`in` property passes vacuously.

## Test plan
- [x] Confirmed `internal/compiler/Cargo.toml` crate name is `i-slint-compiler`.
- [x] Confirmed `api/node/package.json` has a separate `build` script (napi build) not run by `pnpm install`.
- [x] Prose-only changes — no code affected.

https://claude.ai/code/session_01TVXqXMjRWrBgrxTBcLTQFc