### PR TITLE
docs: remove stale top-level content and refresh repository overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Rust (`rs/slint/`, `rs/macros/` for `slint!`, `rs/build/`), C++ (`cpp/`, CMake),
 
 ### Tools (`tools/`)
 
-`lsp/` (LSP server), `compiler/` (CLI), `viewer/` (hot-reload `.slint` viewer), `slintpad/` (web playground), `figma_import/`, `tr-extractor/` (i18n), `updater/` (version migration).
+`lsp/` (LSP server), `compiler/` (CLI), `viewer/` (hot-reload `.slint` viewer), `slintpad/` (web playground), `figma_import/` (Figma-to-Slint conversion), `figma-inspector/` (Figma plugin: shows Slint markup for a selected design element), `tr-extractor/` (i18n).
 
 ### Editor Support (`editors/`)
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,4 +1,4 @@
-<!-- cSpell: ignore xkbcommon fontconfig vcpkg DCMAKE RUSTDOCFLAGS cppdocs pyslint TYPESENSE winget xcbcommon -->
+<!-- cSpell: ignore xkbcommon fontconfig vcpkg DCMAKE RUSTDOCFLAGS cppdocs pyslint winget -->
 # Slint Build Guide
 
 This page explains how to build and test Slint.
@@ -23,14 +23,16 @@ Once this is done, you should have the `rustc` compiler and the `cargo` build sy
 
 <center>
 
-| Platform                          | Binaries                                           |
-| --------------------------------- | -------------------------------------------------- |
-| Windows                           | `x86_64-pc-windows-msvc`                           |
-| Linux Ubuntu 16+<br />CentOS 7, 8 | `x86_64-unknown-linux-gnu`                         |
-| macOS                             | `x86_64-apple-darwin`                              |
-| Android                           | `aarch64-linux-android`<br/>`x86_64-linux-android` |
-| iOS                               | `aarch64-apple-ios`<br/>`x86_64-apple-ios`         |
-| WebAssembly                       | `wasm32-unknown-emscripten`                        |
+| Platform                          | Binaries                                                     |
+| --------------------------------- | -------------------------------------------------------------|
+| Windows                           | `x86_64-pc-windows-msvc`                                      |
+| Linux Ubuntu 16+<br />CentOS 7, 8 | `x86_64-unknown-linux-gnu`<br/>`aarch64-unknown-linux-gnu`     |
+| macOS                             | `x86_64-apple-darwin`<br/>`aarch64-apple-darwin`               |
+| Android                           | `aarch64-linux-android`<br/>`x86_64-linux-android`             |
+| iOS                               | `aarch64-apple-ios`<br/>`x86_64-apple-ios`                     |
+| WebAssembly                       | `wasm32-unknown-emscripten`                                    |
+
+See the [rust-skia binary targets list](https://github.com/rust-skia/rust-skia#platform-support-build-targets-and-prebuilt-binaries) for the authoritative, up-to-date list.
 
 </center>
 
@@ -46,7 +48,7 @@ For Linux a few additional packages beyond the usual build essentials are needed
 - (optional) GStreamer libraries `libgstreamer1.0-dev` `libgstreamer-plugins-base1.0-dev` `gstreamer1.0-plugins-base` `gstreamer1.0-plugins-good` `gstreamer1.0-plugins-bad` `gstreamer1.0-plugins-ugly` `gstreamer1.0-libav` `libgstrtspserver-1.0-dev` `libges-1.0-dev`
 - openssl (`libssl-dev` on debian based distributions)
 
-`xcb` and `xcbcommon` aren't needed if you are only using `backend-winit-wayland` without `backend-winit-x11`.
+`xcb` and `xkbcommon` aren't needed if you are only using `backend-winit-wayland` without `backend-winit-x11`.
 
 ### macOS
 
@@ -289,87 +291,3 @@ Run the following commands from the `/docs/nodejs` sub-folder to generate the do
 pnpm install
 pnpm build
 ```
-
-
-### Building search database
-
-We use Typesense for document search.
-
-#### Infrastructure
-
-* Typesense Server: The Typesense Server will hold the search index.
-* Accessibility: The Typesense server must be accessible from the search bar in documentation site.
-* Docker: Docker is needed to run the Typesense Docsearch Scraper.
-* Typesense Docsearch Scraper: This tool will be used to index the documentation website.
-
-#### Pre-requisites
-
-* Install docker (<https://docs.docker.com/engine/install/>)
-
-* Install jq
-
-```sh
-pip3 install jq
-```
-
-#### Testing Locally
-
-* Install and start Typesense server (<https://typesense.org/docs/guide/install-typesense.html#option-2-local-machine-self-hosting>)
-  * Note down the API key, the default port, and the data directory.
-
-* Verify that the server is running
-  * Replace the port below with the default port
-  * It should return {"ok":true} if the server is running correctly.
-
-```sh
-curl http://localhost:8108/health
-```
-
-#### Testing on Typesense Cloud
-
-* Create an account as per instructions (<https://typesense.org/docs/guide/install-typesense.html#option-1-typesense-cloud>)
-  * Note down the API key and the hostname.
-
-#### Creating search index
-
-A helper script is located under `search` sub-folder that will (optionally) build the docs (currently only Slint docs), scrape the documents, and upload the search index to Typesense server.
-
-The script accepts the following arguments
-
--a : API key to authenticate with Typesense Server (default: `xyz`)
-
--b : Build Slint docs (for testing locally set this flag ) (default: `false`)
-
--c : Location of config file (default: `docs/search/scraper-config.json`)
-
--d : Location of index.html of docs (default: `target/slintdocs/html`)
-
--i : Name of the search index (default: `local`)
-
--p : Port to access Typesense server (default: `8108`)
-
--r : Remote Server when using Typesense Cloud
-
--u : URL on which the docs will be served (default: `http://localhost:8000`)
-
-Example when running locally
-
-```sh
-docs/search/docsearch-scraper.sh -b
-```
-
-Example when running on Typesense Cloud, where `$cluster_name` is the name of the cluster on Typesense Cloud
-
-```sh
-docs/search/docsearch-scraper.sh -a API_KEY -b -r TYPESENSE_CLOUD_HOST_NAME
-```
-
-#### Testing search functionality
-
-Run http server
-
-```sh
-python3 -m http.server -d target/slintdocs/html
-```
-
-Open browser (<http://localhost:8000>) and use the search bar to search for content

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,54 +22,45 @@ mise generate git-pre-commit --write --task=ci:autofix:fix
 
 ## Repository structures
 
+For the crate/directory map of `internal/`, `api/`, `tools/`, and `editors/`, see the
+Architecture section of [AGENTS.md](../AGENTS.md) — kept there as the single source of truth
+so this file doesn't drift out of sync with it. `internal/compiler/tests/` holds the syntax
+tests, which test that the compiler reports the right error for invalid input.
+
+This section covers the rest of the repository layout that AGENTS.md doesn't:
+
 ### `helper_crates`
 
 A set of crates that are somehow not strictly related to Slint, and that could be moved to
 their own repository and have their own version release at some point.
 
-### `internal`
-
-`internal` contains code that isn't meant to be used directly by a user of Slint.
-
-#### `compiler`
-
-The main library for the compiler for .slint.
-
-Nothing in there should depend on the runtime crates.
-
-There is a **`test`** subdirectory that contains the syntax tests.
-These tests allow you to test the proper error conditions.
-
-#### Runtime libraries
-
-The library crates that are used at runtime.
-
-* **`core`** is the main library. It's meant to be used for all front-ends. Ideally it should
-  be kept as small as possible. **`core-macros`** contains some procedural macro used by core library.
-* **`backends`** contains the different backends for the different platforms (winit, qt, linuxkms, android-activity, etc.), separated from
-  core library.
-* **`interpreter`** is the library used by the more dynamic languages backend to compile and
-  interpret .slint files. It links both against core library and the compiler lib
-
-### `tools`
-
-* **`compiler`** is the tool to generate the target language (e.g. c++) from the .slint files for
-  frontend that have a compilation step and generated code.
-* **`viewer`** is a tool that allow to open and view a .slint file.
-
-### `api`
-
-Here one can find the frontend for different languages.
-
 ### `tests`
 
-The integration test that are testing a bunch of .slint with different front-ends
+The integration tests that exercise a set of `.slint` files across the different front-ends
+(Rust, C++, interpreter, Node.js, Python). See [testing.md](./testing.md). This is its own
+Cargo workspace, as are `examples/`, `demos/`, and `ui-libraries/material/` (see
+[building.md](./building.md#workspace-layout)).
 
-See [testing.md](./testing.md)
+### `examples` and `demos`
 
-### `examples`
+Small, manually-run examples (`examples/`) and full demo applications (`demos/`), showing how
+to use the Slint markup language and interact with a UI from each supported host language.
 
-Some manual tests
+### `ui-libraries`
+
+Widget libraries shipped separately from the compiler's built-in widgets, currently
+`material` (a Material Design implementation and its gallery).
+
+### `xtask`
+
+Repository maintenance tasks run via `cargo xtask <task>`: license-header checks, REUSE
+compliance, generating the cbindgen headers the C++ docs need, and Node package prep.
+Run `cargo xtask --help` for the full list.
+
+### `ai-plugins`
+
+The Slint skill and marketplace manifests shipped to AI coding assistants (Claude Code,
+Cursor); see [ai-plugins/skills/slint/SKILL.md](../ai-plugins/skills/slint/SKILL.md).
 
 ## Documentation
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -3,15 +3,30 @@
 
 ```
 docs/
-├── astro/          # The Astro project that builds the Slint language docs
-├── README.md       # This file
-├── building.md     # How to build Slint
-├── development.md  # How to develop Slint
-├── embedded-tutorials.md       # Embedded tutorials template
-├── ios.md          # How to build slint-viewer for iOS / TestFlight
-├── install_qt.md   # How to install Qt
-├── nightly-release-notes.md    # Release note template
-├── release-artifacts.md
-├── platform-integrations.md    # Platform integrations template
-└── release-notes.md            # Release note template
+├── astro/                    # The Astro project that builds the Slint language (DSL) docs
+├── building.md               # How to build Slint
+├── development.md            # How to develop Slint
+├── development/               # Deep dives into specific subsystems (compiler, renderers, layout, ...)
+├── testing.md                 # The testing infrastructure
+├── internal/                  # Contributor process docs (triage, release, writing style guide)
+├── common/                    # Shared Astro components/config for the per-language doc sites
+├── cpp/                       # The C++ API doc site (Doxygen -> Markdown -> Astro/Starlight)
+├── nodejs/                    # The Node.js API doc site
+├── python/                    # The Python API doc site
+├── safety/                    # The safety/certification doc site
+├── site/                      # The docs.slint.dev landing page
+├── slint-doc-generator/       # Rust tool that extracts DSL doc comments for the astro site
+├── embedded-tutorials.md      # Embedded tutorials template
+├── ios.md                     # How to build slint-viewer for iOS / TestFlight
+├── install_qt.md              # How to install Qt
+├── torizon.md                 # Deploying to Torizon
+├── nightly-release-notes.md   # Release note template
+├── release-notes.md           # Release note template
+└── release-artifacts.md       # Release artifact listing
 ```
+
+Start with [building.md](building.md) to get building, and [development.md](development.md)
+for the repository structure and contribution workflow. [testing.md](testing.md) documents
+the test drivers, and [development/](development/) has one deep-dive file per subsystem
+(compiler internals, layout, rendering, the item tree, and more) for agents and contributors
+working in that area.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -146,8 +146,12 @@ including how to rebuild `slint-python` after making changes.
 
 ## Screenshot tests
 
-This is used to test renderer backends. At the moment it supports the `SoftwareRenderer`. Each `.slint` file in `tests/screenshots/cases` will be loaded
-rendered and the results will be compared to the reference images in `tests/screenshots/references`.
+This is used to test renderer backends. It supports the `SoftwareRenderer` (with and without
+embedded assets) and the Skia renderer, selected via the `software`, `software-embed-assets`,
+and `skia` Cargo features (all enabled by default). Each `.slint` file in
+`tests/screenshots/cases` will be loaded, rendered with each enabled renderer, and the results
+will be compared to the reference images in the matching `tests/screenshots/references/<renderer>`
+sub-directory.
 
 To generate references images for all test files in `tests/screenshots/cases` run:
 


### PR DESCRIPTION
## Summary
- `docs/building.md`: drops the "Building search database" (Typesense) section — `docs/search/` and the Sphinx-era `target/slintdocs/html` output path it describes don't exist anywhere in the tree anymore. Fixes the Skia prebuilt-binaries table, which was missing `aarch64-apple-darwin` and `aarch64-unknown-linux-gnu` (confirmed against rust-skia's own supported-targets list), and links to that list so the table doesn't go stale again. Fixes `xcbcommon` → `xkbcommon` (a typo baked into the cSpell ignore list).
- `docs/readme.md`: regenerates the `docs/` directory index — it listed a `platform-integrations.md` that doesn't exist and omitted about half the actual contents (`development/`, `internal/`, `testing.md`, `torizon.md`, and the per-language Astro doc sites).
- `docs/testing.md`: the screenshot-test section claimed software-renderer-only; it's had Skia and embed-assets variants for a while (`tests/screenshots/Cargo.toml` default features).
- `docs/development.md`: the repository-structure section referenced a `test` subdirectory (actually `internal/compiler/tests/`) and a `tools/` list missing `lsp`, `slintpad`, `figma_import`, and `tr-extractor`. Rather than re-list `internal/`/`api/`/`tools/`/`editors/` a second time and have it drift again, it now points at AGENTS.md's Architecture section as the canonical map, and fills in what that section doesn't cover (`helper_crates`, `tests/`, `examples/`, `demos/`, `ui-libraries/`, `xtask/`, `ai-plugins/`).
- `AGENTS.md`: while making it the canonical map, found its own Tools list referenced `tools/updater/`, which was removed in #11859, and was missing `tools/figma-inspector/`. Fixed both.

## Test plan
- [x] Grepped the whole repo for `docsearch-scraper`/`Typesense` — no other references, confirms the section is fully dead.
- [x] Verified the Skia target list against rust-skia's own "Platform Support, Build Targets, and Prebuilt Binaries" section.
- [x] Confirmed `tests/screenshots/Cargo.toml`'s `skia`/`software`/`software-embed-assets` feature names and default-on status.
- [x] Confirmed `tools/updater` was removed via `git log -- tools/updater` (#11859) and that `tools/figma-inspector` exists with its own README.
- [x] Confirmed all new/changed relative links in `docs/readme.md` and `docs/development.md` resolve to existing files.
- [x] Prose-only changes — no code affected.

https://claude.ai/code/session_01TVXqXMjRWrBgrxTBcLTQFc