### PR TITLE
docs: fix code drift in the development/ deep-dive docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,5 +187,5 @@ Load the relevant file under `docs/development/` when working in the listed area
 - `text-layout.md` — `internal/core/textlayout/`, text rendering: shaping, line breaking, styled text.
 - `window-backend-integration.md` — `internal/core/window.rs`, `internal/backends/`: WindowAdapter, Platform, WindowEvent, popups.
 - `lsp-architecture.md` — `tools/lsp/`, IDE tooling: completion, hover, semantic tokens, live preview.
-- `mcp-server.md` — `internal/backends/testing/mcp_server.rs`, `introspection.rs`: shared introspection layer, handle/arena, HTTP transport, adding tools.
+- `mcp-server.md` — `internal/backends/testing/mcp_server.rs`, `introspection/`: shared introspection layer, handle/arena, HTTP transport, adding tools.
 - `ffi-language-bindings.md` — `api/`, internal FFI: cbindgen, FFI patterns, adding cross-language APIs.

--- a/docs/development/animation-internals.md
+++ b/docs/development/animation-internals.md
@@ -16,9 +16,9 @@ The animation driver (`internal/core/animations.rs`) manages a global instant th
 
 ```
 AnimationDriver
-├── global_instant: Property<Instant>  // Current animation time
-├── active_animations: bool            // Whether animations are running
-└── update_animations(new_tick)        // Called per frame by the backend
+├── global_instant: Pin<Box<Property<Instant>>>  // Current animation time
+├── active_animations: Cell<bool>                // Whether animations are running
+└── update_animations(new_tick)                  // Called per frame by the backend
 ```
 
 **Key components:**
@@ -29,11 +29,13 @@ AnimationDriver
 | `current_tick()` | `internal/core/animations.rs` | Get current animation time (registers dependency) |
 | `animation_tick()` | `internal/core/animations.rs` | Same, but signals a frame is needed |
 | `update_timers_and_animations()` | `internal/core/platform.rs` | Called by platform each frame |
-| `EasingCurve` | `internal/core/items.rs` | Enum of easing curve types |
+| `EasingCurve` | `internal/core/animations.rs` | Enum of easing curve types |
 
 ## Easing Curve Implementation
 
-Easing curves are defined in the `EasingCurve` enum in `internal/core/items.rs`. The interpolation logic is in `internal/core/animations.rs`.
+Easing curves are defined in the `EasingCurve` enum in `internal/core/animations.rs`, which
+also holds the interpolation logic. (The compiler has its own copy of the enum for constant
+folding at compile time, in `internal/compiler/expression_tree.rs`.)
 
 For `cubic-bezier(a, b, c, d)`, Slint uses a binary search algorithm to find the t parameter for a given x value, then evaluates the y component of the bezier curve.
 
@@ -88,23 +90,23 @@ if window.has_active_animations() {
 For deterministic testing without real-time waits:
 
 ```rust
-use slint_testing::mock_elapsed_time;
+use i_slint_backend_testing::mock_elapsed_time;
+use core::time::Duration;
 
 // Advance animation time by 100ms
-mock_elapsed_time(100);
+mock_elapsed_time(Duration::from_millis(100));
 
 // Complete a 300ms animation
-mock_elapsed_time(300);
+mock_elapsed_time(Duration::from_millis(300));
 ```
 
-This is implemented in `internal/core/tests/` and used throughout the test suite.
+This is implemented in `internal/backends/testing/` and used throughout the test suite.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `internal/core/animations.rs` | Animation driver, timing, interpolation |
-| `internal/core/items.rs` | `EasingCurve` enum definition |
+| `internal/core/animations.rs` | Animation driver, timing, interpolation, `EasingCurve` enum |
 | `internal/core/timers.rs` | Timer integration with animation system |
 | `internal/core/platform.rs` | `update_timers_and_animations()` entry point |
 
@@ -112,7 +114,8 @@ This is implemented in `internal/core/tests/` and used throughout the test suite
 
 ### Adding a New Easing Curve
 
-1. Add variant to `EasingCurve` enum in `internal/core/items.rs`
+1. Add a variant to the `EasingCurve` enum in `internal/core/animations.rs` (and its
+   compiler-side copy in `internal/compiler/expression_tree.rs`)
 2. Handle interpolation in `internal/core/animations.rs`
 3. Add parsing support in `internal/compiler/` if new syntax needed
 4. Add tests in `tests/cases/`

--- a/docs/development/animation-internals.md
+++ b/docs/development/animation-internals.md
@@ -1,3 +1,4 @@
+<!-- cSpell: ignore millis -->
 # Animation System Internals
 
 > Note for AI coding assistants (agents):

--- a/docs/development/compiler-internals.md
+++ b/docs/development/compiler-internals.md
@@ -94,7 +94,7 @@ The interpreter (`internal/interpreter/`) compiles `.slint` at runtime and uses 
 | `Element` | `compiler/object_tree.rs` | An element within a component |
 | `Expression` | `compiler/expression_tree.rs` | Compiled expressions |
 | `Type` | `compiler/langtype.rs` | Type system representation |
-| `CompilationUnit` | `compiler/llr/mod.rs` | LLR output ready for code generation |
+| `CompilationUnit` | `compiler/llr/item_tree.rs` | LLR output ready for code generation |
 
 ## Common Modification Patterns
 

--- a/docs/development/custom-renderer.md
+++ b/docs/development/custom-renderer.md
@@ -113,8 +113,8 @@ The software renderer builds a scene graph then rasterizes:
 pub struct SoftwareRenderer { ... }
 
 impl SoftwareRenderer {
-    pub fn render(&self, buffer: &mut [impl TargetPixel], pixel_stride: usize);
-    pub fn render_by_line(&self, line_callback: impl FnMut(&mut [impl TargetPixel]));
+    pub fn render(&self, buffer: &mut [impl TargetPixel], pixel_stride: usize) -> PhysicalRegion;
+    pub fn render_by_line(&self, line_buffer: impl LineBufferProvider) -> PhysicalRegion;
 }
 ```
 
@@ -174,15 +174,29 @@ renderer-software = ["i-slint-backend-selector/renderer-software"]
 
 ### Backend Selector
 
-The selector (`internal/backends/selector/lib.rs`) chooses renderer at runtime:
+`create_backend()` (`internal/backends/selector/lib.rs`) chooses the event-loop backend
+(winit/Qt/linuxkms/testing/headless) at runtime:
 
-1. Check `SLINT_BACKEND` environment variable (e.g., `winit-skia`, `winit-femtovg`)
-2. Fall back to compile-time feature priority
+1. Parse the `SLINT_BACKEND` environment variable with `parse_backend_env_var()`, which
+   splits it into an event-loop name and a renderer name (e.g. `winit-skia` → `("winit",
+   "skia")`).
+2. Dispatch to the matching event-loop backend's constructor, passing the renderer name
+   along (e.g. `i_slint_backend_winit::Backend::new_with_renderer_by_name`).
+3. If no backend/renderer was requested (or the requested one isn't compiled in), fall
+   back to `create_default_backend()`'s compile-time feature priority.
+
+The renderer name itself is resolved *inside* each event-loop backend, not in the
+selector. For winit, that's `create_renderer()` in `internal/backends/winit/lib.rs`, which
+matches on the renderer name (`"skia"`, `"software"`, `"gl"`/`"femtovg"`, ...) against the
+renderers compiled in via Cargo features.
 
 To add a new renderer:
-1. Add feature flag to `internal/backends/selector/Cargo.toml`
-2. Update `try_create_renderer()` in `internal/backends/selector/lib.rs`
-3. Wire up in the appropriate backend (e.g., `internal/backends/winit/`)
+1. Add a feature flag to the relevant backend's `Cargo.toml` (e.g.
+   `internal/backends/winit/Cargo.toml`) and to `api/rs/slint/Cargo.toml`.
+2. Add a match arm for its name in that backend's renderer-dispatch function (e.g.
+   `create_renderer()` in `internal/backends/winit/lib.rs`).
+3. Implement `WinitCompatibleRenderer` (or the equivalent trait for other backends) for
+   the new renderer.
 
 ### Runtime Selection
 
@@ -257,14 +271,19 @@ internal/renderers/
 │   ├── lib.rs           # FemtoVGRenderer, GraphicsBackend trait
 │   ├── itemrenderer.rs  # GLItemRenderer (ItemRenderer impl)
 │   ├── opengl.rs        # OpenGL backend
-│   └── wgpu.rs          # WebGPU backend
+│   ├── wgpu.rs          # WebGPU backend
+│   ├── font_cache.rs
+│   └── images.rs
 ├── skia/
 │   ├── lib.rs           # SkiaRenderer, Surface trait
 │   ├── itemrenderer.rs  # SkiaItemRenderer (ItemRenderer impl)
 │   ├── opengl_surface.rs
 │   ├── metal_surface.rs
 │   ├── vulkan_surface.rs
-│   └── software_surface.rs
+│   ├── d3d_surface.rs
+│   ├── software_surface.rs
+│   ├── wgpu_28_surface.rs / wgpu_29_surface.rs
+│   └── wgpu_renderer.rs
 └── software/
     ├── lib.rs           # SoftwareRenderer, scene building
     ├── scene.rs         # Scene graph structures

--- a/docs/development/ffi-language-bindings.md
+++ b/docs/development/ffi-language-bindings.md
@@ -113,14 +113,14 @@ The `cbindgen.rs` file (900+ lines) generates C++ headers:
 
 ```rust
 // api/cpp/cbindgen.rs
-fn gen_enums(include_dir: &Path) {
+fn enums(include_dir: &Path) {
     // Generates slint_enums.h and slint_enums_internal.h
-    i_slint_common::for_each_enums!(gen_enum_descriptors);
+    i_slint_common::for_each_enums!(print_enums);
 }
 
-fn gen_structs(include_dir: &Path) {
+fn builtin_structs(include_dir: &Path) {
     // Generates slint_builtin_structs.h
-    i_slint_common::for_each_builtin_structs!(gen_struct_descriptors);
+    i_slint_common::for_each_builtin_structs!(print_structs);
 }
 
 // Type renaming for C++
@@ -177,7 +177,7 @@ api/node/
 │   ├── lib.rs              # Module entry point
 │   ├── types/              # Type wrappers
 │   │   ├── brush.rs
-│   │   ├── image.rs
+│   │   ├── image_data.rs
 │   │   └── ...
 │   └── interpreter/        # Interpreter bindings
 │       ├── component_compiler.rs
@@ -195,8 +195,9 @@ use napi::{Env, JsFunction};
 extern crate napi_derive;
 
 #[napi]
-pub fn mock_elapsed_time(ms: f64) {
-    i_slint_core::tests::slint_mock_elapsed_time(ms as _);
+pub fn mock_elapsed_time(_ms: f64) {
+    #[cfg(feature = "testing")]
+    i_slint_backend_testing::mock_elapsed_time(_ms as u64);
 }
 
 #[napi]
@@ -430,13 +431,14 @@ fn make_c_function_binding(
 }
 ```
 
-### Window FFI (`internal/core/window.rs`)
+### Window FFI (`internal/core/window.rs`, plus `slint_windowrc_init` in `api/cpp/lib.rs`)
 
 ```rust
 pub mod ffi {
     #[repr(C)]
     pub struct WindowAdapterRcOpaque(*const c_void, *const c_void);
 
+    // Defined in api/cpp/lib.rs, not window.rs's ffi module
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) { ... }
 
@@ -450,7 +452,7 @@ pub mod ffi {
     ) { ... }
 
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_show(handle: &WindowAdapterRcOpaque) { ... }
+    pub unsafe extern "C" fn slint_windowrc_show(handle: *const WindowAdapterRcOpaque) { ... }
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_hide(handle: &WindowAdapterRcOpaque) { ... }

--- a/docs/development/input-event-system.md
+++ b/docs/development/input-event-system.md
@@ -19,7 +19,7 @@ Slint's input system handles mouse, touch, keyboard events and focus management.
 
 | File | Purpose |
 |------|---------|
-| `internal/core/input.rs` | MouseEvent, KeyEvent, event processing |
+| `internal/core/input.rs` | MouseEvent, event processing (re-exports `KeyEvent`/`KeyboardModifiers` from `internal/common/builtin_structs.rs`) |
 | `internal/core/item_focus.rs` | Focus chain navigation |
 | `internal/core/window.rs` | Window-level event dispatch |
 | `internal/core/items.rs` | Item event handlers (input_event, etc.) |
@@ -35,7 +35,7 @@ pub enum MouseEvent {
         position: LogicalPoint,
         button: PointerEventButton,
         click_count: u8,
-        is_touch: bool,
+        touch_finger_id: i32,  // Set for touch input, 0 for mouse
     },
 
     /// Mouse/finger released
@@ -43,20 +43,26 @@ pub enum MouseEvent {
         position: LogicalPoint,
         button: PointerEventButton,
         click_count: u8,
-        is_touch: bool,
+        touch_finger_id: i32,
     },
 
     /// Pointer moved
-    Moved { position: LogicalPoint, is_touch: bool },
+    Moved { position: LogicalPoint, touch_finger_id: i32 },
 
-    /// Mouse wheel
-    Wheel { position: LogicalPoint, delta_x: Coord, delta_y: Coord },
+    /// Mouse wheel or touchpad scroll
+    Wheel { position: LogicalPoint, delta_x: Coord, delta_y: Coord, phase: TouchPhase },
 
     /// Drag operation in progress over item
-    DragMove(DropEvent),
+    DragMove { event: DropEvent, allowed: AllowedDragActions },
 
     /// Drop occurred on item
-    Drop(DropEvent),
+    Drop { event: DropEvent, allowed: AllowedDragActions },
+
+    /// A platform-recognized pinch gesture (macOS/iOS trackpad, Qt)
+    PinchGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
+
+    /// A platform-recognized rotation gesture (macOS/iOS trackpad, Qt)
+    RotationGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
 
     /// Mouse exited the item
     Exit,
@@ -97,7 +103,7 @@ pub struct MouseInputState {
     grabbed: bool,
 
     /// Active drag-drop data
-    pub(crate) drag_data: Option<DropEvent>,
+    pub(crate) drag_data: Option<DragData>,
 
     /// Delayed event (for Flickable touch handling)
     delayed: Option<(Timer, MouseEvent)>,
@@ -248,11 +254,7 @@ Only `DragArea` items can start drags:
 // DragArea returns StartDrag from input_event
 InputEventResult::StartDrag => {
     mouse_input_state.grabbed = false;
-    mouse_input_state.drag_data = Some(DropEvent {
-        mime_type: drag_area.mime_type(),
-        data: drag_area.data(),
-        position: Default::default(),
-    });
+    mouse_input_state.drag_data = Some(DragData { ... });
 }
 ```
 
@@ -261,7 +263,7 @@ InputEventResult::StartDrag => {
 Items receive `DragMove` events:
 
 ```rust
-MouseEvent::DragMove(DropEvent { mime_type, data, position })
+MouseEvent::DragMove { event: DropEvent { mime_type, data, position }, allowed }
 ```
 
 Items return `EventAccepted` to indicate they can receive the drop.
@@ -271,7 +273,7 @@ Items return `EventAccepted` to indicate they can receive the drop.
 When mouse is released during drag:
 
 ```rust
-MouseEvent::Drop(DropEvent { mime_type, data, position })
+MouseEvent::Drop { event: DropEvent { mime_type, data, position }, allowed }
 ```
 
 ## Keyboard Events
@@ -388,13 +390,18 @@ pub fn set_focus_item(
 ### FocusReason
 
 ```rust
+#[non_exhaustive]
 pub enum FocusReason {
-    /// Focus changed via click
-    PointerAction,
-    /// Focus changed via Tab key
+    /// A built-in function invocation caused the event (`.focus()`, `.clear-focus()`)
+    Programmatic,
+    /// Keyboard navigation caused the event (tabbing)
     TabNavigation,
-    /// Focus changed via code (forward-focus, etc.)
-    Other,
+    /// A mouse click caused the event
+    PointerClick,
+    /// A popup caused the event
+    PopupActivation,
+    /// The window manager changed the active window and caused the event
+    WindowActivation,
 }
 ```
 

--- a/docs/development/lsp-architecture.md
+++ b/docs/development/lsp-architecture.md
@@ -329,17 +329,19 @@ See `tools/lsp/common/rename_component.rs` for the rename flow and
 
 ```rust
 pub struct PreviewState {
-    pub ui: Option<PreviewUi>,
+    pub app_window: Option<ui::AppWindow>,
+    pub api: slint::Weak<ui::Api<'static>>,
     handle: Rc<RefCell<Option<ComponentInstance>>>,
     document_cache: Rc<RefCell<Option<Rc<DocumentCache>>>>,
     selected: Option<ElementSelection>,
 
     source_code: SourceCodeCache,
-    config: PreviewConfig,
+    pub config: PreviewConfig,
     current_previewed_component: Option<PreviewComponent>,
     loading_state: PreviewFutureState,
 
     pub to_lsp: RefCell<Option<Rc<dyn PreviewToLsp>>>,
+    // ... plus undo/redo, live-data, and dependency-tracking fields
 }
 ```
 
@@ -360,21 +362,34 @@ pub struct PreviewState {
 
 ### LSP ↔ Preview Communication
 
+Both enums are defined in the `i-slint-live-preview` crate
+(`internal/live-preview/protocol/`), not in `tools/lsp/` itself.
+
 ```rust
-// LSP to Preview
+// LSP to Preview (internal/live-preview/protocol/lsp_to_preview.rs)
 pub enum LspToPreviewMessage {
-    SetContents { url: VersionedUrl, contents: String },
+    InvalidateContents { url: Url },
+    ForgetFile { url: Url },
+    SetContents { url: VersionedUrl, contents: Vec<u8> },
     SetConfiguration { config: PreviewConfig },
     ShowPreview(PreviewComponent),
-    HighlightFromEditor { url: Url, offset: TextSize },
+    HighlightFromEditor { url: Option<Url>, offset: u32 },
+    // ... plus remote-preview WebSocket state messages
 }
 
-// Preview to LSP
+// Preview to LSP (internal/live-preview/protocol/preview_to_lsp.rs)
 pub enum PreviewToLspMessage {
-    RequestState { paths: Vec<String> },
-    UpdateElement { ... },
-    SendWorkspaceEdit { ... },
-    ShowDocument { ... },
+    Diagnostics { uri: Url, version: SourceFileVersion, diagnostics: Vec<Diagnostic> },
+    ShowDocument { file: Url, selection: Range, take_focus: bool },
+    PreviewTypeChanged { target: PreviewTarget },
+    RequestState { files: Vec<Url> },
+    SendWorkspaceEdit { label: Option<String>, edit: WorkspaceEdit },
+    SendShowMessage { message: ShowMessageParams },
+    TelemetryEvent(Map<String, Value>),
+    DebugMessage { location: Option<(PathBuf, usize, usize)>, message: String },
+    ConnectRemote { addresses: Vec<String>, port: u16 },
+    DisconnectRemote,
+    Pong,
 }
 ```
 
@@ -473,12 +488,17 @@ with_lookup_ctx(document_cache, node, Some(offset), |ctx| {
 
 ### Finding Element at Position
 
+`element_at_position` is a method on `DocumentCache`
+(`tools/lsp/common/document_cache.rs`), not a free function:
+
 ```rust
-fn element_at_position(
-    document_cache: &DocumentCache,
-    uri: &Url,
-    position: &Position,
-) -> Option<ElementRc>;
+impl DocumentCache {
+    pub fn element_at_position(
+        &self,
+        uri: &Url,
+        position: &Position,
+    ) -> Option<ElementRcNode>;
+}
 ```
 
 ### Publishing Diagnostics

--- a/docs/development/mcp-server.md
+++ b/docs/development/mcp-server.md
@@ -1,3 +1,4 @@
+<!-- cSpell: ignore slotmap -->
 # Embedded MCP Server
 
 The testing backend includes an embedded [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that allows MCP-compatible clients (e.g. Claude Code) to inspect and interact with a running Slint application over HTTP. This document covers the architecture and internals for developers working on `internal/backends/testing/`.

--- a/docs/development/mcp-server.md
+++ b/docs/development/mcp-server.md
@@ -10,7 +10,7 @@ The MCP server shares a common introspection layer with the system-testing (prot
 ┌─────────────────────────────────────────────┐
 │         Slint Application (event loop)      │
 ├──────────────────┬──────────────────────────┤
-│                  │  introspection.rs         │
+│                  │  introspection/           │
 │                  │  IntrospectionState       │
 │                  │  (window/element arenas)  │
 │       ┌──────────┴──────────┐               │
@@ -36,7 +36,7 @@ See the [README](../../internal/backends/testing/README.md#enabling-the-mcp-serv
 
 ## Initialization Flow
 
-Initialization is triggered from the backend selector (`internal/backends/selector/api.rs`) after the platform is successfully created:
+Initialization is triggered from `init_testing_backends()` in the backend selector (`internal/backends/selector/lib.rs`) after the platform is successfully created:
 
 1. `mcp_server::init()` checks `SLINT_MCP_PORT`. If absent, returns early.
 2. Calls `introspection::ensure_window_tracking()` to install a window-shown hook that registers windows with the shared `IntrospectionState`.
@@ -44,19 +44,21 @@ Initialization is triggered from the backend selector (`internal/backends/select
 
 The lazy start via `OnceCell` ensures the server only binds the port once the application has an event loop running and a window to inspect.
 
-## Shared Introspection Layer (`introspection.rs`)
+## Shared Introspection Layer (`introspection/`)
 
 ### IntrospectionState
 
-The central data structure, stored as a thread-local `Rc<IntrospectionState>`:
+The central data structure, stored as a thread-local `Rc<IntrospectionState>`. `windows` and
+`element_handles` are keyed by a `slotmap`-based `ArenaIndex` (a generational key type
+defined via `slotmap::new_key_type!`), not the `generational_arena` crate:
 
-- **`windows`** — `Arena<TrackedWindow>`: tracks live windows via weak references to their `WindowAdapter`.
-- **`element_handles`** — `Arena<ElementHandle>`: maps arena indices to `ElementHandle` instances.
-- **`element_handle_order`** — `VecDeque<Index>`: tracks insertion order for FIFO eviction.
+- **`windows`** — `RefCell<SlotMap<ArenaIndex, TrackedWindow>>`: tracks live windows via weak references to their `WindowAdapter`.
+- **`element_handles`** — `RefCell<SlotMap<ArenaIndex, ElementHandle>>`: maps arena indices to `ElementHandle` instances.
+- **`element_handle_order`** — `RefCell<VecDeque<ArenaIndex>>`: tracks insertion order for FIFO eviction.
 
 ### Handle System
 
-Both transports use `generational_arena::Index` internally. The proto `Handle` type (`{index, generation}`) is the wire format — `index_to_handle()` and `handle_to_index()` convert between them.
+Both transports use `ArenaIndex` (a `slotmap` key) internally. The proto `Handle` type (`{index, generation}`) is the wire format — `index_to_handle()` and `handle_to_index()` convert between them.
 
 Handles are generational: if an element is evicted and its arena slot reused, stale handles are detected because the generation won't match.
 
@@ -120,14 +122,15 @@ The MCP transport uses the `serde_json`-based serialization, while the system-te
 1. Add request and response message types to `slint_systest.proto`. The build pipeline will auto-generate the JSON schema for the MCP tool's `inputSchema`.
 2. Add a `ToolDef` entry to the `TOOLS` table in `mcp_server.rs` with name, description, proto request type, and optional fields.
 3. Add a match arm in `handle_tool_call()`.
-4. If the tool needs new introspection capabilities, add methods to `IntrospectionState` in `introspection.rs` so both transports can use them.
+4. If the tool needs new introspection capabilities, add methods to `IntrospectionState` in `introspection/mod.rs` so both transports can use them.
 5. Update the `instructions` string in the `initialize` response if the new tool changes the recommended workflow.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `internal/backends/testing/introspection.rs` | Shared `IntrospectionState`, arena management, window/element operations |
+| `internal/backends/testing/introspection/mod.rs` | Shared `IntrospectionState`, arena management, window/element operations |
+| `internal/backends/testing/introspection/proto.rs` | Conversions between internal state and protobuf-derived types |
 | `internal/backends/testing/mcp_server.rs` | HTTP server, JSON-RPC dispatch, MCP tool definitions |
 | `internal/backends/testing/systest.rs` | System-testing TCP/protobuf transport (shares introspection layer) |
 | `internal/backends/testing/slint_systest.proto` | Protobuf definitions (source of truth for data types) |

--- a/docs/development/model-repeater-system.md
+++ b/docs/development/model-repeater-system.md
@@ -20,7 +20,8 @@ The Model system provides data for repeated elements in Slint's `for` expression
 
 | File | Purpose |
 |------|---------|
-| `internal/core/model.rs` | Model trait, VecModel, ModelRc, Repeater |
+| `internal/core/model.rs` | Model trait, VecModel, ModelRc |
+| `internal/core/model/repeater.rs` | Repeater, RepeaterTracker, RepeaterInner, Conditional |
 | `internal/core/model/adapters.rs` | MapModel, FilterModel, SortModel, ReverseModel |
 | `internal/core/model/model_peer.rs` | Change notification system |
 
@@ -262,7 +263,9 @@ let result = VecModel::from(vec![5, 2, 8, 1, 9])
 
 ## Repeater
 
-The `Repeater<C>` manages instantiation of item trees based on model data.
+The `Repeater<C>` manages instantiation of item trees based on model data. It (along with
+`RepeaterTracker`, `RepeaterInner`, and `Conditional`) is defined in
+`internal/core/model/repeater.rs`, not `model.rs`.
 
 ### Structure
 
@@ -271,18 +274,27 @@ pub struct Repeater<C: RepeatedItemTree>(
     ModelChangeListenerContainer<RepeaterTracker<C>>
 );
 
-struct RepeaterTracker<T: RepeatedItemTree> {
+pub struct RepeaterTracker<T: RepeatedItemTree> {
     inner: RefCell<RepeaterInner<T>>,
     model: Property<ModelRc<T::Data>>,
     is_dirty: Property<bool>,
+    /// Marked dirty when instances are added/removed, separately from `is_dirty`.
+    instance_generation: Property<()>,
     listview_geometry_tracker: PropertyTracker,
 }
 
 struct RepeaterInner<C: RepeatedItemTree> {
     instances: Vec<(RepeatedInstanceState, Option<ItemTreeRc<C>>)>,
+    /// ListView-specific layout state (offset, cached heights, scroll position).
+    layout_state: RepeaterLayoutState,
+}
+
+/// Persistent layout state for a ListView repeater.
+pub struct RepeaterLayoutState {
     offset: usize,              // For ListView virtualization
-    cached_item_height: LogicalLength,
-    // ...
+    cached_item_height: Coord,
+    previous_viewport_y: Coord,
+    anchor_y: Coord,
 }
 ```
 

--- a/docs/development/text-layout.md
+++ b/docs/development/text-layout.md
@@ -27,7 +27,8 @@ Slint's text layout system handles the complex process of converting text string
 | `internal/core/textlayout/fragments.rs` | TextFragment, fragment iteration |
 | `internal/core/textlayout/glyphclusters.rs` | Glyph cluster grouping |
 | `internal/core/textlayout/linebreak_unicode.rs` | Unicode line break algorithm |
-| `internal/core/styled_text.rs` | Markdown/HTML parsing |
+| `internal/core/styled_text.rs` | Public `StyledText` API, FFI |
+| `internal/common/styled_text.rs` | Markdown/HTML parsing, `Style`/`FormattedSpan`/`StyledTextParagraph` |
 
 ## Text Layout Pipeline
 
@@ -364,6 +365,11 @@ pub fn byte_offset_for_position(
 
 ## Styled Text
 
+`Style`, `FormattedSpan`, and `StyledTextParagraph` are defined in
+`internal/common/styled_text.rs` (crate `i-slint-common`, behind the `markdown` feature),
+not `internal/core/styled_text.rs` — the core file only re-exports `StyledTextParagraph`
+and adds the public `StyledText` API and FFI.
+
 ### Style Types
 
 ```rust
@@ -374,7 +380,7 @@ pub enum Style {
     Code,           // `code`
     Link,           // [text](url)
     Underline,      // <u>underline</u>
-    Color(Color),   // <span style="color:...">
+    Color(u32),     // <span style="color:...">, ARGB-encoded
 }
 ```
 
@@ -397,12 +403,15 @@ pub struct FormattedSpan {
 
 ```rust
 pub struct StyledText {
-    pub paragraphs: SharedVector<StyledTextParagraph>,
+    pub(crate) paragraphs: SharedVector<StyledTextParagraph>,
 }
 
 impl StyledText {
-    /// Parse markdown string
-    pub fn parse(string: &str) -> Result<Self, StyledTextError>;
+    /// Create styled text from plain text without markdown parsing.
+    pub fn from_plain_text(text: &str) -> Self;
+
+    /// Parse markdown into styled text.
+    pub fn from_markdown(markdown: &str) -> Result<Self, StyledTextFromMarkdownError>;
 }
 ```
 

--- a/docs/development/window-backend-integration.md
+++ b/docs/development/window-backend-integration.md
@@ -22,7 +22,7 @@ Slint's window system provides an abstraction layer between the UI framework and
 |------|---------|
 | `internal/core/window.rs` | WindowInner, WindowAdapter trait |
 | `internal/core/platform.rs` | Platform trait, WindowEvent enum |
-| `internal/core/window/popup.rs` | Popup placement and management |
+| `internal/core/window/popup.rs` | Popup placement (`Placement`, `place_popup`) — `PopupWindow` itself is in `window.rs` |
 | `internal/backends/winit/` | Winit-based cross-platform backend |
 | `internal/backends/qt/` | Qt integration backend |
 | `internal/backends/linuxkms/` | Direct Linux KMS rendering |
@@ -135,20 +135,19 @@ pub trait Platform {
     /// Run the event loop (blocking)
     fn run_event_loop(&self) -> Result<(), PlatformError>;
 
-    /// Run event loop for specified duration
-    fn run_event_loop_until_quit(
+    /// Process pending events and wait for new ones up to `timeout`
+    /// (the actual per-iteration entry point; `run_event_loop()` is built on top of it)
+    fn process_events(
         &self,
         timeout: Option<Duration>,
-    ) -> Result<EventLoopQuitBehavior, PlatformError>;
+    ) -> Result<core::ops::ControlFlow<()>, PlatformError>;
 
-    /// Exit the event loop
-    fn quit_event_loop(&self) -> Result<(), PlatformError>;
-
-    /// Get event loop proxy for cross-thread communication
-    fn event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>>;
+    /// Get event loop proxy for cross-thread communication (its `quit_event_loop()`
+    /// exits the loop; there is no `quit_event_loop` directly on `Platform`)
+    fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>>;
 
     /// Get clipboard contents
-    fn clipboard_text(&self, clipboard: Clipboard) -> Option<SharedString>;
+    fn clipboard_text(&self, clipboard: Clipboard) -> Option<String>;
 
     /// Set clipboard contents
     fn set_clipboard_text(&self, text: &str, clipboard: Clipboard);
@@ -272,6 +271,10 @@ impl PropertyDirtyHandler for WindowPropertiesTracker {
 ## Popup Management
 
 ### PopupWindow Structure
+
+`PopupWindow` and `PopupWindowLocation` are defined in `internal/core/window.rs`;
+`PopupClosePolicy` is defined in `internal/common/enums.rs` and re-exported via
+`crate::items::PopupClosePolicy`.
 
 ```rust
 pub struct PopupWindow {


### PR DESCRIPTION
## Summary

Each file under `docs/development/` documents an internal subsystem for agents and contributors working in that area. Several had drifted from the code since they were written. All fixes below were verified against current `master` (file:line references in the commit message).

- **input-event-system.md**: `MouseEvent` had an `is_touch: bool` field that doesn't exist (it's `touch_finger_id: i32`); `DragMove`/`Drop` were shown as tuple variants instead of struct variants with an `allowed` field; `Wheel` was missing its `phase` field, and `PinchGesture`/`RotationGesture` were missing entirely; `FocusReason`'s variants didn't match reality; `MouseInputState.drag_data` is `Option<DragData>`, not `Option<DropEvent>`.
- **custom-renderer.md**: the documented extension point `try_create_renderer()` doesn't exist anywhere in the codebase — renderer selection actually happens in each event-loop backend's own dispatch function (`create_renderer()` in `internal/backends/winit/lib.rs` for winit). Also fixed `SoftwareRenderer`'s method signatures and the renderer directory listings (missing `d3d_surface.rs`, wgpu surfaces, etc.).
- **animation-internals.md**: `EasingCurve` is defined in `animations.rs`, not `items.rs`; the mock-time example used a nonexistent `slint_testing` crate and integer milliseconds instead of `i_slint_backend_testing::mock_elapsed_time(Duration)`.
- **window-backend-integration.md**: the `Platform` trait doesn't have `run_event_loop_until_quit`/`quit_event_loop`/`event_loop_proxy` — the real per-iteration entry point is `process_events()`, `quit_event_loop()` is on `EventLoopProxy`, and `clipboard_text()` returns `Option<String>`. Also fixed where `PopupWindow`/`PopupClosePolicy` are actually defined.
- **text-layout.md**: the styled-text types (`Style`, `FormattedSpan`, `StyledTextParagraph`) live in `internal/common/styled_text.rs` behind the `markdown` feature, not `internal/core/styled_text.rs`; documented a `StyledText::parse()` that doesn't exist (it's `from_markdown()`/`from_plain_text()`).
- **mcp-server.md**: `introspection.rs` is now the `introspection/` module directory; the arena is backed by `slotmap`, not `generational_arena`. Also fixed where `mcp_server::init()` is actually called from.
- **model-repeater-system.md**: `Repeater`/`RepeaterTracker`/`RepeaterInner`/`Conditional` live in `model/repeater.rs`, not `model.rs`; `RepeaterInner`'s `offset`/`cached_item_height` moved into a separate `RepeaterLayoutState`.
- **lsp-architecture.md**: `PreviewToLspMessage`'s variant list was stale (invented an `UpdateElement` variant, wrong `RequestState` field); `PreviewState.ui` doesn't exist anymore (now `app_window`/`api`); `element_at_position` is a `DocumentCache` method, not a free function.
- **compiler-internals.md** / **ffi-language-bindings.md**: minor path/name fixes (`CompilationUnit`'s actual file, `slint_windowrc_init`'s real location, cbindgen helper function names, node's `image_data.rs`).
- **AGENTS.md**: fixed its own `introspection.rs` reference in the deep-dive index to match the mcp-server.md fix above.

## Test plan
- [x] Every changed symbol/path/signature was grepped against current `master` before editing (struct/enum definitions, trait methods, file locations) — see the commit message for the specific evidence per file.
- [x] Swept all ten touched files afterward for leftover stale terms (`is_touch`, `try_create_renderer`, `generational_arena`, old `introspection.rs` path, etc.) — none remain.
- [x] Prose-only changes — no code affected.

https://claude.ai/code/session_01TVXqXMjRWrBgrxTBcLTQFc