### PR TITLE
docs: fill remaining gaps in test driver docs and contributor pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ cargo test --manifest-path tests/Cargo.toml -p test-driver-interpreter   # Faste
 cargo test --manifest-path tests/Cargo.toml -p test-driver-rust          # Rust API (slow to compile without SLINT_TEST_FILTER)
 cargo test --manifest-path tests/Cargo.toml -p test-driver-cpp           # C++ (build slint-cpp first for the dynamic library)
 cargo test --manifest-path tests/Cargo.toml -p test-driver-nodejs        # Node.js
+cargo test --manifest-path tests/Cargo.toml -p test-driver-python        # Python
 cargo test --manifest-path tests/Cargo.toml -p doctests                  # Documentation snippets
 ```
 
@@ -155,6 +156,10 @@ When this principle applies: any time you design syntax for a new visual or layo
 
 - The default git branch is `master`.
 - Prefer linear history — rebase or squash on merge.
+- During review, prefer adding small follow-up commits over amending, so the reviewer can
+  track how feedback was incorporated; squash them once the review is complete. See
+  [`docs/development.md`](docs/development.md#commit-history--code-reviews) for the full
+  fixup-then-squash workflow, and for `mise`-based environment setup.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,15 @@
-
 # Contributing
 
 We warmly welcome contributions to the project. Let's discuss ideas or questions
 in [Github discussions](https://github.com/slint-ui/slint/discussions) or on our [public chat](https://chat.slint.dev).
 Please feel welcome to open GitHub issues or pull requests.
-Use 👍 reaction on issue that you consider important.
+Use 👍 reaction on issues that you consider important.
 
 Issues which we think are suitable for new contributors are tagged with
 https://github.com/slint-ui/slint/labels/good%20first%20issue.
+
+If you use an AI coding assistant, it reads [AGENTS.md](AGENTS.md) for build commands and
+architecture notes specific to this repository.
 
 ## Internal documentation
 
@@ -15,6 +17,7 @@ https://github.com/slint-ui/slint/labels/good%20first%20issue.
  - [Building Slint from sources in this repository](docs/building.md)
  - [Testing](docs/testing.md)
  - [GitHub issues triage and labels](docs/internal/triage.md)
+ - [Writing style guide](docs/internal/writing-style-guide.md) for commit messages, code comments, and documentation
 
 ## License
 

--- a/ai-plugins/skills/slint/reference/debugging-and-mcp.md
+++ b/ai-plugins/skills/slint/reference/debugging-and-mcp.md
@@ -47,7 +47,9 @@ slint-viewer --screenshot out.png --load-data props.json ui/main.slint
   `SLINT_SCALE_FACTOR` apply.
 - `Error: take_snapshot() called on window with invalid size` means the
   component's preferred size is zero — give the root explicit
-  `width`/`height`. (For compile checking alone, use `--check` instead.)
+  `width`/`height`, or pass `--size WIDTHxHEIGHT` (e.g. `--size 360x800`)
+  `(1.18+)` to force a size without editing the `.slint` file. (For compile
+  checking alone, use `--check` instead.)
 - `--load-data file.json` sets the root component's properties *and* `global`
   singletons — dot-qualify (`{"Theme.dark": true}`) or nest
   (`{"AppData": {"rows": [...]}}`). It runs no host-language logic, so for

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Slint tests
 
-This documents describe the testing infrastructure of Slint
+This document describes the testing infrastructure of Slint.
 
 ## Workspace layout
 
@@ -12,12 +12,12 @@ this for you, so prefer it when it covers your driver (see the Rust driver secti
 
 ## Syntax tests
 
-The syntax tests are testing that the compiler show the right error messages in case of error.
+The syntax tests check that the compiler shows the right error messages in case of error.
 
 The syntax tests are located in [internal/compiler/tests/syntax/](../internal/compiler/tests/syntax/) and it's driven by the
 [`syntax_tests.rs`](../internal/compiler/tests/syntax_tests.rs) file. More info in the comments of that file.
 
-In summary, each .slint files have comments with `> <error` like so:
+In summary, each .slint file has comments with `> <error` like so:
 
 ```ignore
 foo bar
@@ -43,15 +43,19 @@ This will change the comments to add the error of the expected messages
 
 ## Driver tests
 
-These tests make sure that feature in .slint behave as expected.
-All the .slint files in the sub directories are going to be test by the drivers with the different
+These tests make sure that features in .slint behave as expected.
+All the .slint files in the sub directories will be tested by the drivers with the different
 language frontends.
 
 The `.slint` code contains a comment with some block of code which is extracted by the relevant driver.
 
+`tests/run_tests.sh <rust|cpp|interpreter|python|nodejs> [<filter>]` is the convenient entry
+point for all five drivers below and passes `--manifest-path tests/Cargo.toml` for you; the
+`cargo test -p test-driver-*` commands shown per driver are the equivalent direct invocations.
+
 ### Interpreter test
 
-The interpreter test is the faster test to compile and run. It test the compiler and the eval feature
+The interpreter test is the faster test to compile and run. It tests the compiler and the eval feature
 as run by the viewer or such. It can be run like so:
 
 ```
@@ -107,7 +111,11 @@ Each program is compiled separately. And then run.
 
 Some macro like `assert_eq` are defined to look similar to the rust equivalent.
 
+It requires the Slint C++ library to be built first (see
+[building.md](./building.md#c-tests)):
+
 ```
+cargo build --lib -p slint-cpp
 cargo test --manifest-path tests/Cargo.toml -p test-driver-cpp --
 ```
 
@@ -122,6 +130,19 @@ Each test is run in a different node process.
 ```
 cargo test --manifest-path tests/Cargo.toml -p test-driver-nodejs
 ```
+
+### Python driver
+
+This is used to test the Python API. It compiles each `.slint` file with `OutputFormat::Python`,
+then runs the generated `.py` file as a subprocess via `uv run`, which loads the `slint` Python
+module and re-compiles the source using `slint-interpreter`.
+
+```
+cargo test -p test-driver-python
+```
+
+See [docs/development/python-tests.md](development/python-tests.md) for the full picture,
+including how to rebuild `slint-python` after making changes.
 
 ## Screenshot tests
 
@@ -156,5 +177,5 @@ and [docs/development/mcp-server.md](development/mcp-server.md) for architecture
 cargo test --manifest-path tests/Cargo.toml -p doctests
 ```
 
-The doctests extracts the ```` ```slint ````  from the files in the docs folder and make  sure that
-the snippets can be build without errors
+The doctests extract the ```` ```slint ```` snippets from the files in the docs folder and make sure
+they can be built without errors.


### PR DESCRIPTION
## Summary
- `docs/testing.md`: adds a Python driver section — `test-driver-python` is fully supported via `tests/run_tests.sh` and has its own deep-dive doc (`docs/development/python-tests.md`), but was undocumented in the main testing guide. Also mentions `run_tests.sh` up front as the common entry point for all five drivers, links the C++ driver section to `building.md`'s `slint-cpp` prerequisite, and does a light grammar sweep.
- `AGENTS.md`: adds `test-driver-python` to the driver command list; points to `docs/development.md` for the fixup-then-squash review workflow and `mise`-based environment setup, neither of which AGENTS.md covered.
- `CONTRIBUTING.md`: adds a pointer to `AGENTS.md` (for AI-assisted contributions) and to the writing style guide, which AGENTS.md already makes mandatory but which was never linked for human contributors; fixes "issue" → "issues" and a stray leading blank line.
- `ai-plugins/skills/slint/reference/debugging-and-mcp.md`: documents the `slint-viewer --size WIDTHxHEIGHT` flag `(1.18+)` as an alternative fix for the "invalid size" screenshot error, alongside the existing width/height guidance.

This is the last of five PRs from a broader documentation review (see #12432, #12433, #12434, #12435 for the earlier ones); it covers what was left after fixing broken commands, contradictions, stale content, and deep-dive code drift.

## Test plan
- [x] Confirmed `test-driver-python` and `tests/run_tests.sh`'s `python` support exist and match the description given.
- [x] Confirmed the `docs/development.md#commit-history--code-reviews` anchor matches GitHub's heading-slug algorithm for that section title.
- [x] Confirmed `--size` is unreleased (absent from CHANGELOG.md) via `tools/viewer/main.rs`, so the `(1.18+)` tag is correct.
- [x] Prose-only changes — no code affected.

https://claude.ai/code/session_01TVXqXMjRWrBgrxTBcLTQFc