### PR TITLE
CI: fix material gallery android build

### DIFF
--- a/.github/workflows/material_gallery.yaml
+++ b/.github/workflows/material_gallery.yaml
@@ -17,6 +17,8 @@ jobs:
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: s
       CARGO_INCREMENTAL: false
+      # xbuild outputs to the workspace's target dir; use the shared repository one
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
       CARGO_APK_RELEASE_KEYSTORE: /home/runner/.android/release.keystore
       CARGO_APK_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since 873ff599498e79ad8d8c4444bf21e6e00e258c9f, ui-libraries/material is its own workspace, so xbuild wrote the apk/aab to its target directory instead of the repository one where the workflow expects them. Set CARGO_TARGET_DIR to restore the old location.
