### PR TITLE
docs: fix systemic site bugs and high-severity correctness errors

### DIFF
--- a/docs/astro/src/content/docs/guide/backends-and-renderers/backend_linuxkms.md
+++ b/docs/astro/src/content/docs/guide/backends-and-renderers/backend_linuxkms.md
@@ -25,7 +25,7 @@ For compilation, pkg-config is used to determine the location of the following r
 | `libudev`               | `libudev-dev`                        |
 | `libseat`               | `libseat-dev`                        |
 
-:::note{Note}
+:::note[Note]
 If you don't have `libseat` available on your target system, then instead of selecting `backend-linuxkms`, select
 `backend-linuxkms-noseat`. This variant of the LinuxKMS backend eliminates the need to have libseat installed, but
 in exchange requires running the application as a user that's privileged to access all input and DRM/KMS device
@@ -44,12 +44,12 @@ The LinuxKMS backend supports different renderers. They can be explicitly select
 | Skia           | OpenGL ES 2.0, Vulkan  | `linuxkms-skia-opengl`, `linuxkms-skia-vulkan`, or `linuxkms-skia-software` |
 | Software       | None                   | `linuxkms-software`                                                         |
 
-:::note{Note}
+:::note[Note]
 This backend is still experimental. The backend has not undergone a great variety of testing on different devices
 and there are [known issues](https://github.com/slint-ui/slint/labels/a%3Abackend-linuxkms).
 :::
 
-:::note{Note}
+:::note[Note]
 A mouse is supported as input device, but rendering of the mouse cursor only works with the Skia and FemtoVG renderers,
 not with the Slint software renderer.
 :::

--- a/docs/astro/src/content/docs/guide/development/custom-controls.mdx
+++ b/docs/astro/src/content/docs/guide/development/custom-controls.mdx
@@ -520,7 +520,7 @@ import slint
 
 class App(slint.loader.recipe.Recipe):
     @slint.callback(global_name="Logic")
-    def to_upper_case(&self, value: str) -> str:
+    def to_upper_case(self, value: str) -> str:
         return value.upper()
 
 # ...

--- a/docs/astro/src/content/docs/guide/development/translations.mdx
+++ b/docs/astro/src/content/docs/guide/development/translations.mdx
@@ -96,7 +96,7 @@ Pass the `--no-default-translation-context` flag to `slint-tr-extractor` if you 
 
 <Tabs syncKey="dev-language">
 <TabItem label="Rust" icon="seti:rust">
-With <LangRefLink lang="rust-slint-build" relpath="struct.compilerconfiguration#method.set_default_translation_context">`slint_build::CompilerConfiguration::set_default_translation_context(slint_build::DefaultTranslationContext::None)`</LangRefLink>
+With <LangRefLink lang="rust-slint-build" relpath="struct.compilerconfiguration#method.with_default_translation_context">`slint_build::CompilerConfiguration::with_default_translation_context(slint_build::DefaultTranslationContext::None)`</LangRefLink>
 when using a build script.
 With <LangRefLink lang="rust-slint-interpreter" relpath="struct.compiler#method.set_default_translation_context">`slint_interpreter::Compiler::set_default_translation_context(slint_interpreter::DefaultTranslationContext::None)`</LangRefLink>
 when using the `slint-interpreter` crate.

--- a/docs/astro/src/content/docs/guide/experimental/overview.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/overview.mdx
@@ -50,7 +50,7 @@ How you enable them depends on the language and tool you use.
 ## Tools
 
 The `SLINT_ENABLE_EXPERIMENTAL_FEATURES` variable also enables experimental features in `slint-viewer`.
-`slint-lsp` always has experimental features enabled.
+`slint-lsp` enables experimental features when started with `SLINT_ENABLE_EXPERIMENTAL_FEATURES=1`, or when the editor sets the `experimental` workspace option.
 
 ## SlintPad
 

--- a/docs/astro/src/content/docs/guide/language/coding/file.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/file.mdx
@@ -77,7 +77,7 @@ export component MyApp inherits Window {
 }
 ```
 
-:::note{Note}
+:::note[Note]
 Names have to be valid [identifiers](#identifiers).
 :::
 
@@ -105,7 +105,7 @@ Single line comments are denoted by `//` and are terminated by a new line.
 
 ### Multi Line Comments
 
-Multi line comments are denoted by `/*` and `*/` and are terminated by a new line.
+Multi line comments are denoted by `/*` and `*/`, and can span multiple lines.
 
 ```slint
 /*

--- a/docs/astro/src/content/docs/guide/language/coding/globals.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/globals.mdx
@@ -99,7 +99,7 @@ class App(slint.loader.app.App):
     def magic_operation(self, value: int) -> int:
         return value * 2
 
-app = new App()
+app = App()
 app.Logic.the_value = 42
 
 # ...

--- a/docs/astro/src/content/docs/guide/language/coding/positioning-and-layouts.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/positioning-and-layouts.mdx
@@ -415,9 +415,8 @@ export component Example inherits Window {
 The GridLayout lays the element in a grid.
 Each element gains the properties `row`, `col`, `rowspan`, and `colspan`.
 You can either use a `Row` sub-element, or set the `row` property explicitly.
-These properties must be statically known at compile time, so it's impossible
-to use arithmetic or depend on properties. As of now, the use of `for` or `if`
-isn't allowed in a grid layout.
+These properties can be changed at runtime, and `for` and `if` are supported
+in a grid layout.
 
 This example use the `Row` element
 

--- a/docs/astro/src/content/docs/guide/platforms/embedded.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/embedded.mdx
@@ -85,7 +85,7 @@ services:
       - "c 226:* rmw"
 ```
 
-:::Note{}
+:::note[Note]
 Change the `image` to match your hardware platform:
 
 | Platform      | Image                                                    |

--- a/docs/astro/src/content/docs/guide/platforms/mobile/general.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/mobile/general.mdx
@@ -97,7 +97,7 @@ is detected. This might also change at runtime, for example if the user attaches
 keyboard is visible (in this case, the operating system might hide the virtual keyboard by itself). In any case, if there
 is a non-floating virtual keyboard visible, Slint exposes this to the application.
 
-You can detect if the keyboard is shown by checking whether `virtual-keyboard-width * virtual-keyboard-height` is
+You can detect if the keyboard is shown by checking whether `virtual-keyboard-size.width * virtual-keyboard-size.height` is
 greater than 0.
 
 Some virtual keyboards are translucent, which means that the area below the keyboard can be visible to some extend. So,

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -265,7 +265,7 @@ It defines coordinates (x,y) relative to the enclosing Window or PopupWindow, bu
 ## Miscellaneous
 
 ### cache-rendering-hint
-<SlintProperty typeName="bool" propName="cache-rendering-hint" default="false" >
+<SlintProperty typeName="bool" propName="cache-rendering-hint" defaultValue="false" >
 When set to `true`, this provides a hint to the renderer to cache the contents of the element
 and all the children into an intermediate cached layer. For complex sub-trees that rarely
 change this may speed up the rendering, at the expense of increased memory consumption.
@@ -358,39 +358,39 @@ The role of the element. This property is mandatory to be able to use any other 
 </SlintProperty>
 
 ### accessible-checkable
-<SlintProperty typeName="bool" propName="accessible-checkable" default="false">
+<SlintProperty typeName="bool" propName="accessible-checkable" defaultValue="false">
 Whether the element is can be checked or not.
 </SlintProperty>
 
 ### accessible-checked
-<SlintProperty typeName="bool" propName="accessible-checked" default="false">
+<SlintProperty typeName="bool" propName="accessible-checked" defaultValue="false">
 Whether the element is checked or not. This maps to the "checked" state of checkboxes, radio buttons, and other widgets.
 </SlintProperty>
 
 ### accessible-description
-<SlintProperty typeName="string" propName="accessible-description" default='""'>
+<SlintProperty typeName="string" propName="accessible-description" defaultValue='""'>
 The description for the current element.
 </SlintProperty>
 
 ### accessible-enabled
-<SlintProperty typeName="bool" propName="accessible-enabled" default="true">
+<SlintProperty typeName="bool" propName="accessible-enabled" defaultValue="true">
 Whether the element is enabled or not. This maps to the "enabled" state of most widgets. (default value: `true`)
 </SlintProperty>
 
 ### accessible-expandable
-<SlintProperty typeName="bool" propName="accessible-expandable" default="false">
+<SlintProperty typeName="bool" propName="accessible-expandable" defaultValue="false">
 Whether the element can be expanded or not. For example, a `ComboBox` widget should set this to true,
 as its selection can be changed via an expandable popup.
 </SlintProperty>
 
 ### accessible-expanded
-<SlintProperty typeName="bool" propName="accessible-expanded" default="false">
+<SlintProperty typeName="bool" propName="accessible-expanded" defaultValue="false">
 Whether the element is expanded or not. Applies to combo boxes, menu items,
 tree view items and other widgets.
 </SlintProperty>
 
 ### accessible-id
-<SlintProperty typeName="string" propName="accessible-id" default='""'>
+<SlintProperty typeName="string" propName="accessible-id" defaultValue='""'>
 A unique identifier for the element, used to identify widgets for automation and testing purposes.
 This property can be set to any string value and is particularly useful when writing automated tests or
 when using accessibility tools to uniquely identify specific widgets in your application.
@@ -407,7 +407,7 @@ for i in 5: Rectangle {
 </SlintProperty>
 
 ### accessible-label
-<SlintProperty typeName="string" propName="accessible-label" default='""'>
+<SlintProperty typeName="string" propName="accessible-label" defaultValue='""'>
 The label for an interactive element. (default value: empty for most elements, or the value of the `text` property for Text elements)
 </SlintProperty>
 
@@ -417,40 +417,40 @@ The orientation of the element when it makes sense, such as a `Slider` or a `Scr
 technologies can use this to inform the user whether the widget is laid out horizontally or vertically.
 </SlintProperty>
 
-### accessible-live
-<SlintProperty typeName="enum" enumName="AccessibleLive">
+### accessible-live-region
+<SlintProperty typeName="enum" propName="accessible-live-region" enumName="AccessibleLiveness">
 Marks the element as a live region whose textual content should be announced by assistive
 technologies when it changes. Use `polite` for non-urgent updates and `assertive` for updates that
 should interrupt the user. The default `off` disables live announcements.
 </SlintProperty>
 
 ### accessible-value-maximum
-<SlintProperty typeName="float" propName="accessible-value-maximum" default="0">
+<SlintProperty typeName="float" propName="accessible-value-maximum" defaultValue="0">
 The maximum value of the item. This is used for example by spin boxes.
 </SlintProperty>
 
 ### accessible-value-minimum
-<SlintProperty typeName="float" propName="accessible-value-minimum" default="0">
+<SlintProperty typeName="float" propName="accessible-value-minimum" defaultValue="0">
 The minimum value of the item.
 </SlintProperty>
 
 ### accessible-value-step
-<SlintProperty typeName="float" propName="accessible-value-step" default="0">
+<SlintProperty typeName="float" propName="accessible-value-step" defaultValue="0">
 The smallest increment or decrement by which the current value can change. This corresponds to the step by which a handle on a slider can be dragged.
 </SlintProperty>
 
 ### accessible-value
-<SlintProperty typeName="string" propName="accessible-value" default='""'>
+<SlintProperty typeName="string" propName="accessible-value" defaultValue='""'>
 The current value of the item.
 </SlintProperty>
 
 ### accessible-placeholder-text
-<SlintProperty typeName="string" propName="accessible-placeholder-text" default='""'>
+<SlintProperty typeName="string" propName="accessible-placeholder-text" defaultValue='""'>
 A placeholder text to use when the item's value is empty. Applies to text elements.
 </SlintProperty>
 
 ### accessible-read-only
-<SlintProperty typeName="bool" propName="accessible-read-only" default="false">
+<SlintProperty typeName="bool" propName="accessible-read-only" defaultValue="false">
 Whether the element's content can be edited. This maps to the "read-only" state of line edit and text edit widgets.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/global-functions/math.mdx
+++ b/docs/astro/src/content/docs/reference/global-functions/math.mdx
@@ -81,7 +81,7 @@ Return the log of the first value with a base of the second value
 
 ### ln(float) -> float
 
-Return the natural log of the value. Same as log(e, x)
+Return the natural log of the value. Same as `log(x, e)`
 
 ### min(T, T) -> T
 ### max(T, T) -> T
@@ -109,9 +109,9 @@ Square root
 
 Return the value of the first value raised to the second
 
-### exp(float, float) -> float
+### exp(float) -> float
 
-Return the value of the e raised to the x
+Return the value of e raised to the given value
 
 ## Trigonometric Functions
 ### acos(float) -> angle

--- a/docs/astro/src/content/docs/reference/layouts/overview.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/overview.mdx
@@ -11,7 +11,7 @@ import SlintProperty from '@slint/common-files/src/components/SlintProperty.astr
 These properties are valid on all visible items and can be used to specify constraints when used in layouts:
 
 ### col, row
-<SlintProperty propName="col, row" typeName="int" default="0">
+<SlintProperty propName="col, row" typeName="int" defaultValue="0">
 See <Link type="GridLayout" />.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinner.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinner.mdx
@@ -27,12 +27,12 @@ The `Spinner` informs the user about the status of an on-going operation, such a
 ## Properties
 
 ## indeterminate
-<SlintProperty typeName="bool" propName="indeterminate" default="false" >
+<SlintProperty typeName="bool" propName="indeterminate" defaultValue="false" >
 Set to true if the progress of the operation cannot be determined by value.
 </SlintProperty>
 
 ## progress
-<SlintProperty typeName="float" propName="progress" default="0" >
+<SlintProperty typeName="float" propName="progress" defaultValue="0" >
 Percentage of completion, as value between 0 and 1. Values less than 0 or greater than 1 are capped.
 
 ```slint "progress: 0.5;"

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/standardbutton.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/standardbutton.mdx
@@ -25,17 +25,17 @@ it can used one of the pre-defined `kind` and the text and icon will depend on t
 ## Properties
 
 ### enabled
-<SlintProperty typeName="bool" propName="enabled" default="true" >
+<SlintProperty typeName="bool" propName="enabled" defaultValue="true" >
 Defaults to true. When false, the button can't be pressed
 </SlintProperty>
 
 ### has-focus
-<SlintProperty typeName="bool" propName="has-focus" default="false" propertyVisibility="out">
+<SlintProperty typeName="bool" propName="has-focus" propertyVisibility="out">
 Set to true when the button currently has the focus
 </SlintProperty>
 
 ### kind
-<SlintProperty typeName="enum" propName="kind" default="ok" enumName="StandardButtonKind" >
+<SlintProperty typeName="enum" propName="kind" defaultValue="ok" enumName="StandardButtonKind" >
 The kind of button, one of `ok` `cancel`, `apply`, `close`, `reset`, `help`, `yes`, `no,` `abort`, `retry` or `ignore`
 
 ```slint "kind: ok;"
@@ -51,7 +51,7 @@ If set to true the button is displayed with the primary accent color.
 </SlintProperty>
 
 ### pressed
-<SlintProperty typeName="bool" propName="pressed" default="false" propertyVisibility="out">
+<SlintProperty typeName="bool" propName="pressed" propertyVisibility="out">
 Set to true when the button is pressed.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/switch.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/switch.mdx
@@ -25,7 +25,7 @@ A `Switch` is a representation of a physical switch that allows users to turn th
 ## Properties
 
 ### checked
-<SlintProperty typeName="bool" propName="checked" default="false" propertyVisibility="in-out">
+<SlintProperty typeName="bool" propName="checked" defaultValue="false" propertyVisibility="in-out">
 Whether the switch is checked or not.
 
 ```slint "checked: true;"
@@ -37,12 +37,12 @@ Switch {
 </SlintProperty>
 
 ### enabled
-<SlintProperty typeName="bool" propName="enabled" default="true" >
+<SlintProperty typeName="bool" propName="enabled" defaultValue="true" >
 When false, the switch can't be pressed
 </SlintProperty>
 
 ### has-focus
-<SlintProperty typeName="bool" propName="has-focus" default="false" propertyVisibility="out">
+<SlintProperty typeName="bool" propName="has-focus" propertyVisibility="out">
 Set to true when the switch has keyboard focus
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
@@ -36,7 +36,7 @@ are bigger than the size of the visible area.
 If the ScrollView contains a layout, the default value for the `viewport-width` and
 `viewport-height` is the minimum size of that layout.
 
-:::note{Note}
+:::note[Note]
 A ScrollView will always instantiate all of its children, so its performance may degrade with large number of children, even if they are not visible.
 If you want to display a long list of items, use a <Link type="ListView"/> instead, which only instantiates visible children.
 :::

--- a/docs/astro/src/content/docs/reference/std-widgets/views/standardlistview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/standardlistview.mdx
@@ -33,12 +33,12 @@ Like ListView, but with a default delegate, and a `model` property.
 Same as <Link type="ListView" />, and in addition:
 
 ### current-item
-<SlintProperty typeName="int" propName="current-item" default="-1" propertyVisibility="in-out">
+<SlintProperty typeName="int" propName="current-item" defaultValue="-1" propertyVisibility="in-out">
 The index of the currently active item. -1 mean none is selected, which is the default
 </SlintProperty>
 
 ### model
-<SlintProperty typeName="struct" structName="StandardListViewItem" propName="model" default="[]">
+<SlintProperty typeName="struct" structName="StandardListViewItem" propName="model" defaultValue="[]">
 The model.
 
 ```slint 'model: [{ text: "Blue" }, { text: "Red" }, { text: "Green" }];'

--- a/docs/astro/src/content/docs/reference/std-widgets/views/standardtableview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/standardtableview.mdx
@@ -9,7 +9,7 @@ import Link from '@slint/common-files/src/components/Link.astro';
 
 The `StandardTableView` represents a table of data with columns and rows. Cells
 are organized in a model where each row is a model of
-<SlintProperty typeName="struct" structName="StandardListViewItem" propName="model" default="[]" >
+<SlintProperty typeName="struct" structName="StandardListViewItem" propName="model" defaultValue="[]" >
 The model of items in each row.
 </SlintProperty>
 
@@ -55,7 +55,7 @@ Indicates the sorted column, or `-1` when no column is sorted.
 </SlintProperty>
 
 ### columns
-<SlintProperty typeName="[struct]" structName="TableColumn" propName="columns" default="[]" propertyVisibility="in-out">
+<SlintProperty typeName="[struct]" structName="TableColumn" propName="columns" defaultValue="[]" propertyVisibility="in-out">
 Defines the model of the table columns.
 
 ```slint 'columns: [{ title: "Header 1" }, { title: "Header 2" }];'
@@ -67,7 +67,7 @@ StandardTableView {
 </SlintProperty>
 
 ### rows
-<SlintProperty typeName="[[struct]]" structName="StandardListViewItem" propName="rows" default="[]" propertyVisibility="in-out">
+<SlintProperty typeName="[[struct]]" structName="StandardListViewItem" propName="rows" defaultValue="[]" propertyVisibility="in-out">
 Defines the model of table rows.
 
 ```slint 'rows: [{ text: "Item 1" }, { text: "Item 2" }];'
@@ -79,7 +79,7 @@ StandardTableView {
 </SlintProperty>
 
 ### current-row
-<SlintProperty typeName="int" propName="current-row" default="-1" propertyVisibility="in-out">
+<SlintProperty typeName="int" propName="current-row" defaultValue="-1" propertyVisibility="in-out">
 The index of the currently active row. -1 mean none is selected, which is the default.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/views/tabwidget.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/tabwidget.mdx
@@ -32,7 +32,7 @@ a time.
 ## Properties
 
 ### current-index
-<SlintProperty typeName="int" propName="current-index" default="0">
+<SlintProperty typeName="int" propName="current-index" defaultValue="0">
 The index of the currently visible tab.
 
 ```slint "current-index: 1;"

--- a/docs/astro/src/content/docs/tutorial/getting_started.mdx
+++ b/docs/astro/src/content/docs/tutorial/getting_started.mdx
@@ -83,7 +83,7 @@ Replace the contents of `ui/app-window.slint` with the following:
 
 import appWindow from '/src/content/code/app-window.slint?raw'
 
-<Code code={extractLines(appWindow, 6, 11)} lang="slint" title="app-window.slint" />
+<Code code={extractLines(appWindow, 7, 12)} lang="slint" title="app-window.slint" />
 
 Configure with CMake:
 

--- a/docs/cpp/scripts/lib/slug.ts
+++ b/docs/cpp/scripts/lib/slug.ts
@@ -79,7 +79,7 @@ export function disambiguateAnchor(base: string, occurrence: number): string {
 
 /**
  * A relative URL from one page slug to another (both relative to the docs root,
- * e.g. `api/namespaces/slint`). Relative links resolve correctly whether the
+ * e.g. `api/slint`). Relative links resolve correctly whether the
  * site is served at `/` or under a base like `/master/docs/cpp/`, unlike
  * root-absolute links which Astro does not rewrite with the base. Pages use
  * `trailingSlash: "always"`, so each slug is served as its own directory.

--- a/docs/cpp/src/content/docs/generated-code.mdx
+++ b/docs/cpp/src/content/docs/generated-code.mdx
@@ -73,7 +73,7 @@ This generates a header with the following contents (edited for documentation pu
 class SampleComponent {
 public:
     /// Constructor function
-    inline auto create () -> slint::ComponentHandle<MainWindow>;
+    static inline auto create () -> slint::ComponentHandle<SampleComponent>;
     /// Destructor
     inline ~SampleComponent ();
 

--- a/docs/cpp/src/content/docs/index.mdx
+++ b/docs/cpp/src/content/docs/index.mdx
@@ -19,7 +19,7 @@ built into your application. This gives the smallest memory footprint and the
 best performance. The CMake integration (`slint_target_sources`) makes the
 translation automatic; the generated code exposes an API to get and set
 properties, populate data models and handle callbacks. It uses types from the
-[`slint`](api/namespaces/slint/) namespace, such as `slint::SharedString` and
+[`slint`](api/slint/) namespace, such as `slint::SharedString` and
 `slint::Color`.
 
 **Interpreted at run-time.** Load `.slint` files dynamically at run-time. This

--- a/docs/cpp/src/content/docs/mcu/esp-idf.mdx
+++ b/docs/cpp/src/content/docs/mcu/esp-idf.mdx
@@ -131,4 +131,4 @@ If you run into compile or run-time issues, see the [Troubleshooting](troublesho
 
  - For more details about the Slint language, check out the <SlintRef href="" label="Slint Language Documentation" code={false} />.
  - Learn about the [Type Mappings](../../types/) between Slint and C++.
- - Study the [C++ API Reference](../../api/namespaces/slint/).
+ - Study the [C++ API Reference](../../api/slint/).

--- a/docs/cpp/src/content/docs/mcu/generic.mdx
+++ b/docs/cpp/src/content/docs/mcu/generic.mdx
@@ -49,7 +49,7 @@ cmake -DRust_CARGO_TARGET=thumbv7em-none-eabihf -DSLINT_FEATURE_FREESTANDING=ON
 ## Next Steps
 
  - Check out the [Getting Started](../../getting-started/) instructions for a generic "Hello World" with C++.
- - Study the [C++ API Reference](../../api/namespaces/slint/), in particular the `slint::platform` namespace for
+ - Study the [C++ API Reference](../../api/slint/), in particular the `slint::platform` namespace for
    writing a Slint platform integration to handle touch input and render pixel, which you
    need to forward to your MCU's display driver.
  - For more details about the Slint language, check out the <SlintRef href="" label="Slint Language Documentation" code={false} />.

--- a/docs/cpp/src/content/docs/mcu/stm32.mdx
+++ b/docs/cpp/src/content/docs/mcu/stm32.mdx
@@ -45,4 +45,4 @@ To get started, select a download from the following table. If your board is not
 
  - For more details about the Slint language, check out the <SlintRef href="" label="Slint Language Documentation" code={false} />.
  - Learn about the [Type Mappings](../../types/) between Slint and C++.
- - Study the [C++ API Reference](../../api/namespaces/slint/).
+ - Study the [C++ API Reference](../../api/slint/).

--- a/docs/cpp/src/content/docs/overview.mdx
+++ b/docs/cpp/src/content/docs/overview.mdx
@@ -29,7 +29,7 @@ handling callbacks to react to events triggered by the user.
 The provided CMake integration makes it easy to compile your Slint sources:
 The [`slint_target_sources` CMake command](../cmake-reference/slint-target-sources/) makes the translation automatic. The
 [generated code](../generated-code/) has an API to set and get property values,
-etc. This API uses types from the [`slint`](../api/namespaces/slint/) namespace, for
+etc. This API uses types from the [`slint`](../api/slint/) namespace, for
 example `slint::SharedString` or `slint::Color`.
 
 ## Run-Time Interpreted `.slint` Designs
@@ -40,7 +40,7 @@ more memory, however it provides more flexibility in your application design.
 
 The entry point to loading a `.slint` file is the
 `slint::interpreter::ComponentCompiler` class in the
-[`slint::interpreter`](../api/namespaces/slint-interpreter/) namespace.
+[`slint::interpreter`](../api/slint/interpreter/) namespace.
 
 With the help of `slint::interpreter::ComponentCompiler` you create
 a `slint::interpreter::ComponentDefinition`, which provides

--- a/docs/nodejs/src/content/docs/index.md
+++ b/docs/nodejs/src/content/docs/index.md
@@ -431,7 +431,7 @@ import * as slint from "slint-ui";
 let ui = slint.loadFile(new URL("ui/my-component.slint", import.meta.url));
 let component = new ui.MyComponent();
 
-component.Logic.to_upper_case = (str) => {
+component.Logic.to_uppercase = (str) => {
     return str.toUpperCase();
 };
 ```

--- a/docs/safety/src/content/docs/development-phases.md
+++ b/docs/safety/src/content/docs/development-phases.md
@@ -4,9 +4,9 @@ description: Development phases for Slint SC.
 
 ---
 
-# Development Phases (ISO 26262-4)
+## Development Phases (ISO 26262-4)
 
-# Phase 1: Ticket Approval
+## Phase 1: Ticket Approval
 
 A ticket, also known as a Github Issue, should describe the work necessary to be done. The ticket should also contain the motivation for the change, and a proposed solution.
 
@@ -14,7 +14,7 @@ The ticket should detail the impact of the change on the safety of the system.
 
 Once the ticket has been scoped and approved, Code Development may begin.
 
-# Phase 2: Code Development
+## Phase 2: Code Development
 
 During this phase, the developer will implement the changes described in the ticket.
 
@@ -24,7 +24,7 @@ After work has reached the point where it should be reviewed by others, the deve
 
 After each PR is created, or after each new commit is pushed to that branch, the CI/CD pipeline will run, and the developer can see the results of the Regression Tests.
 
-# Phase 3: Code Review
+## Phase 3: Code Review
 
 The master branch is protected, only admins are able to push directly to the `master` branch.
 
@@ -37,7 +37,7 @@ Reviewers can leave comments on the PR. Some comments are just nitpicks but some
 Once approved, the author of the PR can merge the PR if he has the rights to do so.
 For external contributions, the reviewer must merge the PR.
 
-# Phase 4: Testing
+## Phase 4: Testing
 
 We have a set of tests that are executed as part of this phase.
 These tests can be run locally using the "cargo test" command.

--- a/docs/safety/src/content/docs/development-process.md
+++ b/docs/safety/src/content/docs/development-process.md
@@ -4,17 +4,17 @@ description: Tools, processes, and infrastructure used for Slint SC development.
 ---
 
 
-# The Development Process (ISO 26262-8 11.4.8)
+## The Development Process (ISO 26262-8 11.4.8)
 
 This section describes the tools we use and the processes we follow to develop Slint SC, aiming to fulfill the supporting process requirements of ISO 26262 Part 8 (Sections 6-12)
 
-## Organization members
+### Organization members
 
 The administrators of the slint-ui Github organization are the founders of SixtyFPS GmbH.
 All employees of SixtyFPS GmbH are members of the organization.
 External contributors may also be invited to become members of the Github organization.
 
-## Language and Compiler
+### Language and Compiler
 
 The `slint-compiler` translates `.slint` files into Rust code. Slint SC is itself written in Rust and is built using Ferrocene version 26.02.0.
 
@@ -23,7 +23,7 @@ The `slint-compiler` translates `.slint` files into Rust code. Slint SC is itsel
 * **Tool Confidence Level (TCL):** The combination of TI2 and TD2/TD3 results in a Tool Confidence Level of TCL2 or TCL3.
 * **Qualification Strategy:** As a high-impact tool, Ferrocene is already ASIL D qualified for safety-critical deployment. The `slint-compiler` is not yet qualified and must be qualified before being used in a safety-critical project.
 
-## Configuration Management (ISO 26262-8 7.x)
+### Configuration Management (ISO 26262-8 7.x)
 
 Slint SC utilizes a structured configuration management process to ensure artifacts are reproducible and traceable.
 
@@ -31,7 +31,7 @@ Slint SC utilizes a structured configuration management process to ensure artifa
 * **Baselining:** Releases are tagged in git as `release/MajorVersion.MinorVersion`.
 * **Nightly Builds:** Automated nightly builds generate documentation, examples, and release artifacts to provide continuous visibility into the master branch's stability.
 
-## Change Management (ISO 26262-8 8.x)
+### Change Management (ISO 26262-8 8.x)
 
 Modifications to the Slint SC codebase are managed to preserve the safety and integrity of the system.
 
@@ -40,7 +40,7 @@ Modifications to the Slint SC codebase are managed to preserve the safety and in
 * **Code Reviews:** While administrators have push access, all safety-impacting changes must go through a formal Pull Request (PR) process. PRs enforce peer review, providing an opportunity to challenge the impact analysis and verify the implementation before merging.
 * **Traceability:** Every functional change merged into the codebase must be traceable back to an established issue or requirement, ensuring comprehensive oversight.
 
-## CI System and Infrastructure
+### CI System and Infrastructure
 
 Continuous Integration (CI) is achieved through GitHub Actions, a platform provided by GitHub that is used to automate building, testing, and deployment of software. Here are some definitions of terms:
 
@@ -57,11 +57,11 @@ For Slint, [Actions](https://github.com/slint-ui/slint/actions) are triggered fo
 * **Tool Impact (TI1):** The CI system schedules and runs tests but does not generate the final executable code itself. Failures during CI block merging the PR.
 * **Qualification Strategy:** Verification of the CI pipeline is achieved through increased confidence from use.
 
-## Software Component Qualification (ISO 26262-8 12.x)
+### Software Component Qualification (ISO 26262-8 12.x)
 
 To ensure that software tools used in the development of Slint SC do not introduce or fail to detect errors, tools are assessed based on their Tool Impact (TI) and Tool Error Detection (TD) to determine their Tool Confidence Level (TCL).
 
-### Dependencies
+#### Dependencies
 
 Because Slint SC is intended for embedded systems, there are very few internal dependencies, and exactly **zero external dependencies** for the core runtime portion of Slint SC.
 
@@ -71,17 +71,17 @@ For build-time tooling and optional features (e.g., image decoding), external li
 
 * **Qualification Strategy:** Any necessary external Software of Unknown Provenance (SOUP) must undergo rigorous evaluation, including static analysis, functional testing, and security auditing, to justify its suitability for reuse in a safety-related context before integration.
 
-## Distributed Development (ISO 26262-8 5.x)
+### Distributed Development (ISO 26262-8 5.x)
 
 Employees of SixtyFPS GmbH are located in different countries, and some work remotely. This is not a problem, as we have all the necessary infrastructure in place to support this.
 
 (TODO: Add more details about how distributed development is supported)
 
-## Release Schedule
+### Release Schedule
 
 (TODO: add release schedule)
 
-## Verification (ISO 26262-8 9.4.x)
+### Verification (ISO 26262-8 9.4.x)
 
 A comprehensive verification strategy is employed to confirm that Slint SC meets its safety requirements. The CI pipeline enforces automated test execution, including:
 * **Interpreter and API Tests:** Ensuring the core APIs behave as expected.
@@ -90,6 +90,6 @@ A comprehensive verification strategy is employed to confirm that Slint SC meets
 
 *Note: Specific test coverage metrics (e.g., MC/DC, statement coverage) and static analysis results are required for formal safety certification and are collected during the release baselining process.*
 
-## Hardware Qualification (ISO 26262-8 13.x)
+### Hardware Qualification (ISO 26262-8 13.x)
 
 *Note: Section 13 is Out of Scope.* Slint SC is a purely software-based UI toolkit. Qualification of the underlying hardware elements (e.g., MCU/MPU, memory, display controllers) operating the safety-critical UI is the responsibility of the system integrator.

--- a/docs/safety/src/content/docs/using-slint-sc.md
+++ b/docs/safety/src/content/docs/using-slint-sc.md
@@ -3,7 +3,7 @@ title: Using Slint SC
 description: Components included in Slint SC and use cases.
 ---
 
-# Slint SC Software Units (ISO 26262:6 7.4.4)
+## Slint SC Software Units (ISO 26262:6 7.4.4)
 
 This is what is included in Slint SC:
 
@@ -16,7 +16,7 @@ Each of these things can have a **Usage** and a **Constraints** section.
 
 Each feature of the language or a library can map to a Requirement ID, and have 1 or more code test-examples.
 
-## Slint SC Architecture Design (ISO 26262:6 7.4)
+### Slint SC Architecture Design (ISO 26262:6 7.4)
 
 During the development of the software architectural design, the following should be considered:
 
@@ -29,7 +29,7 @@ During the development of the software architectural design, the following shoul
 5. Testability of the software
 6. Maintainability of the software architectural design
 
-### Static Design
+#### Static Design
 
 The software architectural design should have a static design part which
 addresses:
@@ -83,7 +83,7 @@ flowchart TD
     SlintCore --> |Interfaces with| Renderer
 ```
 
-### Dynamic Design
+#### Dynamic Design
 
 In addition, the software architectural design should have a dynamic design part which addresses:
 
@@ -116,7 +116,7 @@ sequenceDiagram
     end
 ```
 
-### Safety Analysis Report (ISO 26262:6 7.4.10)
+#### Safety Analysis Report (ISO 26262:6 7.4.10)
 
 Safety-oriented analysis shall be carried out at the software architectural level in accordance with ISO 26262-9:2018, Clause 8, in order to:
 
@@ -125,9 +125,9 @@ Safety-oriented analysis shall be carried out at the software architectural leve
 
 (TODO: Insert Safety Analysis Report here)
 
-# Use Cases (ISO 26262:8 11.4.5.1)
+## Use Cases (ISO 26262:8 11.4.5.1)
 
-## Using Slint SC in a project
+### Using Slint SC in a project
 
 * **ID** : UC_ADD_SLINT_SC_TO_PROJECT
 * **Input** : Cargo.toml file in the root of a rust project file tree
@@ -139,7 +139,7 @@ To add it to a project, one simply adds Slint SC as a dependency in `Cargo.toml`
 
 (TODO - show example)
 
-## Compiling a .slint file into Rust
+### Compiling a .slint file into Rust
 
 * **ID** : UC_COMPILE_SLINT_FILE
 * **Input** : a .slint file
@@ -160,7 +160,7 @@ fn main() {
 }
 ```
 
-# Constraints
+## Constraints
 
 The standard essentially views a **Requirement** as what the system *must do* (or a property it must have), whereas a **Constraint** is a boundary condition that *limits the solution space*.
 
@@ -173,7 +173,7 @@ when an unsafe feature is found.
 
 Individual Constraints can have a section each here, with a descriptive ID that begins with CON_, and a Rationale, Impact, and Mitigation.
 
-## CON_NO_GLOBAL_ALLOCATOR
+### CON_NO_GLOBAL_ALLOCATOR
 
 The Slint SC Compiler should not generate or allow code that uses a global allocator.
 
@@ -183,7 +183,7 @@ The Slint SC Compiler should not generate or allow code that uses a global alloc
 
 **Mitigation**: The generated code should not use a global allocator. Instead, it should use a custom allocator that is specific to the generated code.
 
-## CON_NO_DYNAMIC_MEMORY_ALLOCATION
+### CON_NO_DYNAMIC_MEMORY_ALLOCATION
 
 The Slint SC Compiler should not generate or allow code that uses dynamic memory allocation.
 
@@ -193,7 +193,7 @@ The Slint SC Compiler should not generate or allow code that uses dynamic memory
 
 **Mitigation**: The generated code should not use dynamic memory allocation. Instead, it should use a custom allocator that is specific to the generated code.
 
-## CON_NO_UNBOUNDED_RECURSION
+### CON_NO_UNBOUNDED_RECURSION
 
 The Slint SC Compiler should not generate or allow unbounded recursion.
 
@@ -203,7 +203,7 @@ The Slint SC Compiler should not generate or allow unbounded recursion.
 
 **Mitigation**: The generated code should not use unbounded recursion. Instead, it should use a custom allocator that is specific to the generated code.
 
-## CON_NO_UNSAFE_CODE
+### CON_NO_UNSAFE_CODE
 
 The Slint SC Compiler should not generate or allow unsafe code.
 


### PR DESCRIPTION
Part of a review of the published documentation site (`docs/astro`, `docs/cpp`, `docs/nodejs`, `docs/safety`) for completeness, correctness, and cohesion. This is the first batch: systemic bugs (one fix pattern, many files) and high-severity correctness errors (docs that produce non-compiling code or 404s). Every concrete claim was verified against the code at current master.

## Systemic

- **`SlintProperty`: `default=` was silently ignored.** The component only accepts `defaultValue`, so `default="…"` dropped the value entirely (fell back to the type's generic default). Renamed across `reference/common.mdx`, `reference/layouts/overview.mdx`, and the std-widgets pages. For `out` properties the attribute is *dropped* rather than renamed — the component rejects a default on an output.
- **C++ docs: six broken `api/namespaces/…` links → 404.** The API generator emits `api/slint/…` (see `docs/cpp/scripts/lib/slug.ts`); fixed the links (interpreter → `api/slint/interpreter/`) and the stale docstring in `slug.ts` that seeded them.
- **Normalized Starlight asides** from `:::note{Note}` / `:::Note{}` (which render as literal text) to `:::note[Note]`.
- **Safety docs: demoted body headings one level** so the frontmatter `title` is the only H1 (was producing duplicate H1s and empty on-page ToCs).

## Correctness

- `reference/common.mdx`: `accessible-live` → `accessible-live-region` / `AccessibleLiveness` (the documented name/enum did not exist; also added the missing required `propName`).
- `reference/global-functions/math.mdx`: `exp(float, float)` → `exp(float)` (the builtin is single-arg); `ln` "Same as `log(e, x)`" → "`log(x, e)`".
- `guide/language/coding/positioning-and-layouts.mdx`: `GridLayout` `row`/`col`/`rowspan`/`colspan` are runtime-settable and `for`/`if` are supported (since 1.15) — the page claimed the opposite. (Relates to #7418.)
- `guide/language/coding/file.mdx`: multi-line comments end at `*/`, not at a newline.
- Invalid language snippets: Python `new App()` → `App()` and `def f(&self, …)` → `def f(self, …)`; C++ tutorial snippet range fixed to include the component's closing brace.
- `guide/development/translations.mdx`: build API is `with_default_translation_context` (not `set_…`), with the matching rustdoc anchor.
- `guide/experimental/overview.mdx`: `slint-lsp` enables experimental features via `SLINT_ENABLE_EXPERIMENTAL_FEATURES` or the `experimental` workspace option — not always.
- `guide/platforms/mobile/general.mdx`: `virtual-keyboard-size.width/.height` (the property is a `Size`), not `virtual-keyboard-width`/`-height`.
- `docs/cpp/.../generated-code.mdx`: `create()` returns `ComponentHandle<SampleComponent>` and is `static`.
- `docs/nodejs/.../index.md`: the JS callback handler name now matches the `.slint` declaration (`to_uppercase`).

Verified statically (MDX tag balance, generated-enum resolution, no `out` property carrying a `defaultValue`); relying on the docs CI build for the full end-to-end check.