### PR TITLE
android: fix caret/selection handle spuriously reported as invisible

### DIFF
--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -409,7 +409,13 @@ impl JavaHelper {
                 r.contains(i_slint_core::lengths::logical_point_from_api(data.cursor_rect_origin))
             });
             let anchor_visible = data.clip_rect.map_or(true, |r| {
-                r.contains(i_slint_core::lengths::logical_point_from_api(data.anchor_point))
+                // anchor_point is `origin + cursor_size` for handle placement; check the
+                // anchor cursor's origin so we don't spuriously fail on the clip rect's edge.
+                let anchor_origin =
+                    i_slint_core::lengths::logical_point_from_api(data.anchor_point)
+                        - i_slint_core::lengths::logical_size_from_api(data.cursor_rect_size)
+                            .to_vector();
+                r.contains(anchor_origin)
             });
 
             // Add 2*cur_size.width to the y position to be a bit under the cursor


### PR DESCRIPTION
`InputMethodProperties::anchor_point` is stored as `anchor_cursor.origin + cursor_rect_size` — the shift positions the drawn handle at the bottom of the cursor line. `anchor_visible` was checking that shifted point against the containing item's `clip_rect`, and when the cursor sits at the bottom of the clip area (any TextInput inside a fixed-height container like a LineEdit), the shifted point lands exactly on the exclusive bottom edge: `Rect::contains` returns false, and `anchor_x` gets the `-1` sentinel.

With no selection, `set_imm_data` on the Java side then passes `-1` as `left_x` for the single-cursor handle, and the popup ends up positioned at `x = -1 - popup_width/2`, i.e. off the left edge of the screen. With a selection, the same shift makes the anchor-end selection handle vanish.

Undo the shift for the visibility check — the actual cursor rect is what should be tested against the clip, and its size is the same as the cursor's.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
