### PR TITLE
Make sure a ScrollView can always be flicked with the touch events

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
@@ -51,7 +51,7 @@ Used to render the frame as disabled or enabled, but doesn't change behavior of 
 ### mouse-drag-pan-enabled
 <SlintProperty propName="mouse-drag-pan-enabled" typeName="bool" defaultValue="false" propertyVisibility="in">
 When true, the view can be scrolled by dragging with the mouse.
-Panning with a touch screen and scrolling with the mouse wheel work regardless of this property.
+Panning with a touch screen and scrolling with the mouse wheel works regardless of this property.
 </SlintProperty>
 
 ### has-focus

--- a/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
@@ -49,8 +49,9 @@ Used to render the frame as disabled or enabled, but doesn't change behavior of 
 </SlintProperty>
 
 ### mouse-drag-pan-enabled
-<SlintProperty propName="mouse-drag-pan-enabled" typeName="bool" defaultValue="true for Material style, false for all others" propertyVisibility="in">
+<SlintProperty propName="mouse-drag-pan-enabled" typeName="bool" defaultValue="false" propertyVisibility="in">
 When true, the view can be scrolled by dragging with the mouse.
+Panning with a touch screen and scrolling with the mouse wheel work regardless of this property.
 </SlintProperty>
 
 ### has-focus

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -997,6 +997,7 @@ component KeyBinding {
 /// interacting with `TouchArea` elements:
 ///
 /// 1. If the `Flickable`'s `interactive` property is `false`, all events are forwarded to elements underneath.
+///    If `mouse-drag-pan-enabled` is `false`, only mouse events are forwarded this way, while touch events keep panning.
 /// 2. If a press event is received where the event's coordinates interact with a `TouchArea`, the event is stored
 ///    and any subsequent move and release events are handled as follows:
 ///    1. If 100ms elapse without any events, the stored press event is delivered to the `TouchArea`.
@@ -1018,7 +1019,7 @@ component KeyBinding {
 /// ## Wheel/Scroll Event Interaction
 ///
 /// The `Flickable` also supports scrolling with the mouse wheel and touchpad scroll gestures.
-/// It will scroll regardless of the `interactive` property.
+/// It will scroll regardless of the `interactive` and `mouse-drag-pan-enabled` properties.
 /// If the `Flickable` can scroll in the event's direction, the event will be intercepted.
 /// If the Flickable can't scroll in the direction of the event, the event will be forwarded to the parent.
 /// \group:gestures
@@ -1028,8 +1029,12 @@ export component Flickable inherits Empty {
     ///     interactive: false;
     /// }
     /// ```
-    /// When true, the viewport can be scrolled by clicking on it and dragging it with the cursor.
+    /// When false, the viewport can't be panned by the user, neither by dragging with the mouse
+    /// nor with touch.
     in property <bool> interactive: true;
+    /// When true, the viewport can be scrolled by clicking on it and dragging it with the cursor.
+    /// Panning with a touch screen is only affected by `interactive`.
+    in property <bool> mouse-drag-pan-enabled: true;
     /// The total width of the scrollable element.
     in property <length> viewport-width;
     /// The total height of the scrollable element.

--- a/internal/compiler/widgets/cosmic/scrollview.slint
+++ b/internal/compiler/widgets/cosmic/scrollview.slint
@@ -104,7 +104,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> mouse-drag-pan-enabled <=> flickable.interactive;
+    in property <bool> mouse-drag-pan-enabled <=> flickable.mouse-drag-pan-enabled;
 
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;
@@ -119,7 +119,7 @@ export component ScrollView {
     preferred-width: 100%;
 
     flickable := Flickable {
-        interactive: false;
+        mouse-drag-pan-enabled: false;
         viewport-y <=> vertical-bar.value;
         viewport-x <=> horizontal-bar.value;
         width: 100%;

--- a/internal/compiler/widgets/cupertino/scrollview.slint
+++ b/internal/compiler/widgets/cupertino/scrollview.slint
@@ -112,7 +112,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> mouse-drag-pan-enabled <=> flickable.interactive;
+    in property <bool> mouse-drag-pan-enabled <=> flickable.mouse-drag-pan-enabled;
 
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;
@@ -129,7 +129,7 @@ export component ScrollView {
     flickable := Flickable {
         x: 2px;
         y: 2px;
-        interactive: false;
+        mouse-drag-pan-enabled: false;
         viewport-y <=> vertical-bar.value;
         viewport-x <=> horizontal-bar.value;
         width: parent.width - 4px;

--- a/internal/compiler/widgets/fluent/scrollview.slint
+++ b/internal/compiler/widgets/fluent/scrollview.slint
@@ -157,7 +157,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> mouse-drag-pan-enabled <=> flickable.interactive;
+    in property <bool> mouse-drag-pan-enabled <=> flickable.mouse-drag-pan-enabled;
 
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;
@@ -172,7 +172,7 @@ export component ScrollView {
     preferred-width: 100%;
 
     flickable := Flickable {
-        interactive: false;
+        mouse-drag-pan-enabled: false;
         viewport-y <=> vertical-bar.value;
         viewport-x <=> horizontal-bar.value;
         width: parent.width;

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -116,7 +116,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> mouse-drag-pan-enabled <=> flickable.interactive;
+    in property <bool> mouse-drag-pan-enabled <=> flickable.mouse-drag-pan-enabled;
 
     callback scrolled <=> flickable.flicked;
 

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -130,6 +130,7 @@ export component ScrollView {
     flickable := Flickable {
         x: 0;
         y: 0;
+        mouse-drag-pan-enabled: false;
         viewport-y <=> vertical-bar.value;
         viewport-x <=> horizontal-bar.value;
         width: parent.width - vertical-bar.width - 4px;

--- a/internal/compiler/widgets/qt/internal-scrollview.slint
+++ b/internal/compiler/widgets/qt/internal-scrollview.slint
@@ -17,7 +17,7 @@ export component InternalScrollView {
     in property <bool> enabled <=> native.enabled;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> native.vertical-scrollbar-policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> native.horizontal-scrollbar-policy;
-    in property <bool> mouse-drag-pan-enabled <=> fli.interactive;
+    in property <bool> mouse-drag-pan-enabled <=> fli.mouse-drag-pan-enabled;
 
     // Used by the StandardTableView
     out property <length> native-padding-left: native.native-padding-left;
@@ -50,7 +50,7 @@ export component InternalScrollView {
         height: root.height - self.y - native.native-padding-bottom;
 
         @children
-        interactive: false;
+        mouse-drag-pan-enabled: false;
         viewport-y <=> native.vertical-value;
         viewport-x <=> native.horizontal-value;
     }

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -120,6 +120,12 @@ impl MouseEvent {
         }
     }
 
+    /// Whether the event originates from a touch screen rather than a mouse.
+    pub fn is_from_touch(&self) -> bool {
+        // touch events carry the finger id + 1, events from a mouse carry 0
+        self.touch_finger_id() != 0
+    }
+
     /// The position of the cursor for this event, if any
     pub fn position(&self) -> Option<LogicalPoint> {
         match self {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -65,6 +65,7 @@ pub struct Flickable {
     pub viewport_height: Property<LogicalLength>,
 
     pub interactive: Property<bool>,
+    pub mouse_drag_pan_enabled: Property<bool>,
 
     pub flicked: Callback<VoidArg>,
 
@@ -152,7 +153,7 @@ impl Item for Flickable {
                 return InputEventFilterResult::Intercept;
             }
         }
-        if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {
+        if self.rejects_pan_event(event) {
             return InputEventFilterResult::ForwardAndIgnore;
         }
         self.data.handle_mouse_filter(self, event, window_adapter, self_rc)
@@ -165,7 +166,7 @@ impl Item for Flickable {
         self_rc: &ItemRc,
         _: &mut super::MouseCursor,
     ) -> InputEventResult {
-        if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {
+        if self.rejects_pan_event(event) {
             return InputEventResult::EventIgnored;
         }
         if let Some(pos) = event.position() {
@@ -244,6 +245,22 @@ impl ItemConsts for Flickable {
 }
 
 impl Flickable {
+    /// Whether the event must not pan this Flickable because `interactive` or
+    /// `mouse-drag-pan-enabled` disables it.
+    fn rejects_pan_event(self: Pin<&Self>, event: &MouseEvent) -> bool {
+        match event {
+            MouseEvent::Wheel { .. } => false,
+            MouseEvent::Pressed { .. } | MouseEvent::Moved { .. } | MouseEvent::Released { .. } => {
+                !self.interactive() || (!event.is_from_touch() && !self.mouse_drag_pan_enabled())
+            }
+            MouseEvent::Exit
+            | MouseEvent::DragMove { .. }
+            | MouseEvent::Drop { .. }
+            | MouseEvent::PinchGesture { .. }
+            | MouseEvent::RotationGesture { .. } => !self.interactive(),
+        }
+    }
+
     fn choose_min_move(
         current_view_start: Coord, // vx or vy
         view_len: Coord,           // w or h

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -153,7 +153,7 @@ impl Item for Flickable {
                 return InputEventFilterResult::Intercept;
             }
         }
-        if self.rejects_pan_event(event) {
+        if !self.accepts_pan_event(event) {
             return InputEventFilterResult::ForwardAndIgnore;
         }
         self.data.handle_mouse_filter(self, event, window_adapter, self_rc)
@@ -166,7 +166,7 @@ impl Item for Flickable {
         self_rc: &ItemRc,
         _: &mut super::MouseCursor,
     ) -> InputEventResult {
-        if self.rejects_pan_event(event) {
+        if !self.accepts_pan_event(event) {
             return InputEventResult::EventIgnored;
         }
         if let Some(pos) = event.position() {
@@ -245,19 +245,19 @@ impl ItemConsts for Flickable {
 }
 
 impl Flickable {
-    /// Whether the event must not pan this Flickable because `interactive` or
-    /// `mouse-drag-pan-enabled` disables it.
-    fn rejects_pan_event(self: Pin<&Self>, event: &MouseEvent) -> bool {
+    /// Whether the event may pan this Flickable, given that `interactive` and
+    /// `mouse-drag-pan-enabled` can disable it.
+    fn accepts_pan_event(self: Pin<&Self>, event: &MouseEvent) -> bool {
         match event {
-            MouseEvent::Wheel { .. } => false,
+            MouseEvent::Wheel { .. } => true,
             MouseEvent::Pressed { .. } | MouseEvent::Moved { .. } | MouseEvent::Released { .. } => {
-                !self.interactive() || (!event.is_from_touch() && !self.mouse_drag_pan_enabled())
+                self.interactive() && (event.is_from_touch() || self.mouse_drag_pan_enabled())
             }
             MouseEvent::Exit
             | MouseEvent::DragMove { .. }
             | MouseEvent::Drop { .. }
             | MouseEvent::PinchGesture { .. }
-            | MouseEvent::RotationGesture { .. } => !self.interactive(),
+            | MouseEvent::RotationGesture { .. } => self.interactive(),
         }
     }
 

--- a/tests/cases/elements/flickable_touch_pan.slint
+++ b/tests/cases/elements/flickable_touch_pan.slint
@@ -1,0 +1,94 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Panning with a touch screen or the mouse wheel works even when
+// `mouse-drag-pan-enabled` is false, while `interactive: false` disables
+// both mouse and touch panning.
+
+export component TestCase inherits Window {
+    width: 500phx;
+    height: 500phx;
+
+    f := Flickable {
+        viewport-width: 2100phx;
+        viewport-height: 2100phx;
+        mouse-drag-pan-enabled: false;
+
+        flicked => {
+            root.flicked-count += 1;
+        }
+    }
+
+    in-out property <bool> interactive <=> f.interactive;
+    in-out property <length> viewport-x <=> f.viewport-x;
+    in-out property <length> viewport-y <=> f.viewport-y;
+    in-out property <int> flicked-count;
+}
+
+/*
+
+```rust
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+use slint_testing::{LogicalPoint, TouchPhase, WindowInner};
+let instance = TestCase::new().unwrap();
+
+// Dragging with the mouse doesn't pan
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(300.0, 100.0), button: PointerEventButton::Left });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(300.0, 100.0) });
+slint_testing::mock_elapsed_time(16);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(200.0, 50.0) });
+slint_testing::mock_elapsed_time(16);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(200.0, 50.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(1000);
+assert_eq!(instance.get_viewport_x(), 0.);
+assert_eq!(instance.get_viewport_y(), 0.);
+assert_eq!(instance.get_flicked_count(), 0);
+
+// Scrolling with the mouse wheel pans
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(300.0, 100.0), delta_x: -30.0, delta_y: -50.0 });
+assert_eq!(instance.get_viewport_x(), -30.);
+assert_eq!(instance.get_viewport_y(), -50.);
+assert_eq!(instance.get_flicked_count(), 1);
+instance.set_viewport_x(0.);
+instance.set_viewport_y(0.);
+instance.set_flicked_count(0);
+
+// Dragging with a finger pans
+let window = instance.window();
+let inner = WindowInner::from_pub(&window);
+inner.process_touch_input(7, LogicalPoint::new(300.0, 100.0), TouchPhase::Started);
+inner.process_touch_input(7, LogicalPoint::new(300.0, 100.0), TouchPhase::Moved);
+assert_eq!(instance.get_viewport_x(), 0.);
+assert_eq!(instance.get_viewport_y(), 0.);
+inner.process_touch_input(7, LogicalPoint::new(200.0, 50.0), TouchPhase::Moved);
+assert_eq!(instance.get_viewport_x(), -100.);
+assert_eq!(instance.get_viewport_y(), -50.);
+assert!(instance.get_flicked_count() > 0);
+// Release long after the last move so no fling animation starts
+slint_testing::mock_elapsed_time(1000);
+inner.process_touch_input(7, LogicalPoint::new(200.0, 50.0), TouchPhase::Ended);
+slint_testing::mock_elapsed_time(1000);
+assert_eq!(instance.get_viewport_x(), -100.);
+assert_eq!(instance.get_viewport_y(), -50.);
+instance.set_viewport_x(0.);
+instance.set_viewport_y(0.);
+instance.set_flicked_count(0);
+
+// interactive: false disables touch panning too
+instance.set_interactive(false);
+inner.process_touch_input(8, LogicalPoint::new(300.0, 100.0), TouchPhase::Started);
+inner.process_touch_input(8, LogicalPoint::new(300.0, 100.0), TouchPhase::Moved);
+inner.process_touch_input(8, LogicalPoint::new(200.0, 50.0), TouchPhase::Moved);
+inner.process_touch_input(8, LogicalPoint::new(200.0, 50.0), TouchPhase::Ended);
+slint_testing::mock_elapsed_time(1000);
+assert_eq!(instance.get_viewport_x(), 0.);
+assert_eq!(instance.get_viewport_y(), 0.);
+assert_eq!(instance.get_flicked_count(), 0);
+
+// ... but wheel scrolling still works
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(300.0, 100.0), delta_x: -30.0, delta_y: -50.0 });
+assert_eq!(instance.get_viewport_x(), -30.);
+assert_eq!(instance.get_viewport_y(), -50.);
+```
+
+*/

--- a/tests/cases/widgets/scrollview.slint
+++ b/tests/cases/widgets/scrollview.slint
@@ -78,5 +78,38 @@ assert!(instance.get_viewport_y() != -200.0);
 *scrolled_emitted.borrow_mut() = false;
 ```
 
+```rust
+// Panning the content: touch pans, mouse dragging doesn't (mouse-drag-pan-enabled defaults to false)
+use slint::{LogicalPosition, platform::{WindowEvent, PointerEventButton}};
+use slint_testing::{LogicalPoint, TouchPhase, WindowInner};
+
+let instance = TestCase::new().unwrap();
+
+// Drag the content with the mouse
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(50.0, 50.0), button: PointerEventButton::Left });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 50.0) });
+slint_testing::mock_elapsed_time(16);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(20.0, 30.0) });
+slint_testing::mock_elapsed_time(16);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(20.0, 30.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(1000);
+assert_eq!(instance.get_viewport_x(), 0.);
+assert_eq!(instance.get_viewport_y(), 0.);
+
+// Drag the content with a finger
+let window = instance.window();
+let inner = WindowInner::from_pub(&window);
+inner.process_touch_input(3, LogicalPoint::new(50.0, 50.0), TouchPhase::Started);
+inner.process_touch_input(3, LogicalPoint::new(50.0, 50.0), TouchPhase::Moved);
+inner.process_touch_input(3, LogicalPoint::new(20.0, 30.0), TouchPhase::Moved);
+assert_eq!(instance.get_viewport_x(), -30.);
+assert_eq!(instance.get_viewport_y(), -20.);
+// Release long after the last move so no fling animation starts
+slint_testing::mock_elapsed_time(1000);
+inner.process_touch_input(3, LogicalPoint::new(20.0, 30.0), TouchPhase::Ended);
+slint_testing::mock_elapsed_time(1000);
+assert_eq!(instance.get_viewport_x(), -30.);
+assert_eq!(instance.get_viewport_y(), -20.);
+```
 
 */


### PR DESCRIPTION
ScrollView by default can only be scrolled with the scrollbar.
When the user is using a mouse, this is the correct behavior.
But with a finger (touch events), we should pan with the finger.

Fixes: https://github.com/slint-ui/slint/issues/4352