### PR TITLE
window(core): clear focus when focused item becomes invisible

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1749,6 +1749,7 @@ export component Clip {
     in property <length> border-bottom-right-radius;
     in property <length> border-width;
     in property <bool> clip;
+    in property <bool> is-visibility-clip;
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -93,19 +93,26 @@ fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -
         id: format_smolstr!("{}-visibility", child.borrow().id),
         base_type: ElementType::Native(native_clip.clone()),
         enclosing_component: child.borrow().enclosing_component.clone(),
-        bindings: std::iter::once((
-            SmolStr::new_static("clip"),
-            RefCell::new(
-                Expression::UnaryOp {
-                    sub: Box::new(Expression::PropertyReference(NamedReference::new(
-                        child,
-                        SmolStr::new_static("visible"),
-                    ))),
-                    op: '!',
-                }
-                .into(),
+        bindings: [
+            (
+                SmolStr::new_static("clip"),
+                RefCell::new(
+                    Expression::UnaryOp {
+                        sub: Box::new(Expression::PropertyReference(NamedReference::new(
+                            child,
+                            SmolStr::new_static("visible"),
+                        ))),
+                        op: '!',
+                    }
+                    .into(),
+                ),
             ),
-        ))
+            (
+                SmolStr::new_static("is-visibility-clip"),
+                RefCell::new(Expression::BoolLiteral(true).into()),
+            ),
+        ]
+        .into_iter()
         .collect(),
         grid_layout_cell: child_grid_layout_cell,
         ..Default::default()

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -407,6 +407,20 @@ impl ItemRc {
             && clip.min.y <= geometry.max.y
     }
 
+    pub(crate) fn visibility_clips(&self) -> Vec<VWeakMapped<ItemTreeVTable, crate::items::Clip>> {
+        let mut visibility_clips = Vec::new();
+        let mut current = Some(self.clone());
+        while let Some(item) = current {
+            if let Some(clip) = item.downcast::<crate::items::Clip>() {
+                if clip.as_pin_ref().is_visibility_clip() {
+                    visibility_clips.push(VRcMapped::downgrade(&clip));
+                }
+            }
+            current = item.parent_item(ParentItemTraversalMode::StopAtPopups);
+        }
+        visibility_clips
+    }
+
     /// Returns true if this item is visible or only clipped away by a `Flickable`.
     pub(crate) fn is_visible_or_clipped_by_flickable(&self) -> bool {
         if self.is_visible() {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -729,6 +729,7 @@ pub struct Clip {
     pub border_width: Property<LogicalLength>,
     pub cached_rendering_data: CachedRenderingData,
     pub clip: Property<bool>,
+    pub is_visibility_clip: Property<bool>,
 }
 
 impl Item for Clip {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -21,7 +21,7 @@ use crate::item_tree::{
 use crate::items::{InputType, ItemRef, MenuEntry, MouseCursor, PopupClosePolicy};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalVector, SizeLengths};
 use crate::menus::MenuVTable;
-use crate::properties::{Property, PropertyTracker};
+use crate::properties::{ChangeTracker, Property, PropertyTracker};
 use crate::renderer::Renderer;
 use crate::{Callback, Coord, SharedString, SharedVector};
 use alloc::boxed::Box;
@@ -575,6 +575,7 @@ pub struct WindowInner {
 
     /// ItemRC that currently have the focus (possibly an instance of TextInput)
     pub focus_item: RefCell<crate::item_tree::ItemWeak>,
+    focus_item_visibility_tracker: ChangeTracker,
     /// The last text that was sent to the input method
     pub(crate) last_ime_text: RefCell<SharedString>,
     /// Don't let ComponentContainers's instantiation change the focus.
@@ -652,6 +653,7 @@ impl WindowInner {
                 ),
             }),
             focus_item: Default::default(),
+            focus_item_visibility_tracker: Default::default(),
             last_ime_text: Default::default(),
             cursor_blinker: Default::default(),
             active_popups: Default::default(),
@@ -670,6 +672,7 @@ impl WindowInner {
     /// done with that component.
     pub fn set_component(&self, component: &ItemTreeRc) {
         self.close_all_popups();
+        self.focus_item_visibility_tracker.clear();
         self.focus_item.replace(Default::default());
         self.mouse_input_state.replace(Default::default());
         self.touch_state.replace(Default::default());
@@ -1383,6 +1386,7 @@ impl WindowInner {
     ///
     /// This sends the event which must be either FocusOut or WindowLostFocus for popups
     fn take_focus_item(&self, event: &FocusEvent) -> Option<ItemRc> {
+        self.focus_item_visibility_tracker.clear();
         let focus_item = self.focus_item.take();
         assert!(matches!(event, FocusEvent::FocusOut(_)));
 
@@ -1409,6 +1413,7 @@ impl WindowInner {
         match item {
             Some(item) => {
                 *self.focus_item.borrow_mut() = item.downgrade();
+                self.track_focus_item_visibility(item);
                 let result = item.borrow().as_ref().focus_event(
                     &FocusEvent::FocusIn(reason),
                     &self.window_adapter(),
@@ -1422,10 +1427,35 @@ impl WindowInner {
                 result
             }
             None => {
+                self.focus_item_visibility_tracker.clear();
                 *self.focus_item.borrow_mut() = Default::default();
                 crate::input::FocusEventResult::FocusAccepted // We were removing the focus, treat that as OK
             }
         }
+    }
+
+    fn track_focus_item_visibility(&self, item: &ItemRc) {
+        let visibility_clips = item.visibility_clips();
+        self.focus_item_visibility_tracker.init(
+            (item.downgrade(), self.window_adapter_weak.clone(), visibility_clips),
+            |(_, _, visibility_clips)| {
+                visibility_clips
+                    .iter()
+                    .all(|clip| clip.upgrade().is_some_and(|clip| !clip.as_pin_ref().clip()))
+            },
+            |(item, window_adapter, _), visible| {
+                if *visible {
+                    return;
+                }
+                let Some(item) = item.upgrade() else { return };
+                let Some(window_adapter) = window_adapter.upgrade() else { return };
+                WindowInner::from_pub(window_adapter.window()).set_focus_item(
+                    &item,
+                    false,
+                    FocusReason::Programmatic,
+                );
+            },
+        );
     }
 
     fn move_focus(

--- a/tests/cases/focus/text-input-focused-hide.slint
+++ b/tests/cases/focus/text-input-focused-hide.slint
@@ -1,0 +1,55 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { LineEdit } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    in-out property<bool> input-visible: true;
+
+    callback focus-and-hide-input();
+    focus-and-hide-input => {
+        input.focus();
+        hide-timer.start();
+    }
+
+    callback show-and-focus-input();
+    show-and-focus-input => {
+        input-visible = true;
+        input.focus();
+    }
+
+    hide-timer := Timer {
+        interval: 1ms;
+        triggered => {
+            input-visible = false;
+        }
+    }
+
+    input := LineEdit {
+        visible: root.input-visible;
+    }
+
+    out property<bool> item-focused: input.has-focus;
+    out property<bool> text-input-focused: TextInputInterface.text-input-focused;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_item_focused());
+assert!(!instance.get_text_input_focused());
+
+instance.invoke_focus_and_hide_input();
+assert!(instance.get_item_focused());
+assert!(instance.get_text_input_focused());
+
+slint_testing::mock_elapsed_time(10);
+
+assert!(!instance.get_item_focused());
+assert!(!instance.get_text_input_focused());
+
+instance.invoke_show_and_focus_input();
+assert!(instance.get_item_focused());
+assert!(instance.get_text_input_focused());
+```
+*/

--- a/tests/cases/focus/text-input-focused-parent-hide.slint
+++ b/tests/cases/focus/text-input-focused-parent-hide.slint
@@ -1,0 +1,47 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { LineEdit } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    in-out property<bool> input-parent-visible: true;
+
+    callback focus-and-hide-input-parent();
+    focus-and-hide-input-parent => {
+        input.focus();
+        hide-timer.start();
+    }
+
+    hide-timer := Timer {
+        interval: 1ms;
+        triggered => {
+            input-parent-visible = false;
+        }
+    }
+
+    Rectangle {
+        visible: root.input-parent-visible;
+
+        input := LineEdit {}
+    }
+
+    out property<bool> item-focused: input.has-focus;
+    out property<bool> text-input-focused: TextInputInterface.text-input-focused;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_item_focused());
+assert!(!instance.get_text_input_focused());
+
+instance.invoke_focus_and_hide_input_parent();
+assert!(instance.get_item_focused());
+assert!(instance.get_text_input_focused());
+
+slint_testing::mock_elapsed_time(10);
+
+assert!(!instance.get_item_focused());
+assert!(!instance.get_text_input_focused());
+```
+*/


### PR DESCRIPTION
When a focused item becomes invisible, the window keeps it as the focused item.

Slint lowers `visible` to an internal `Clip`. Mark these compiler-generated clips and collect weak references to them when focus is assigned, stopping at popup boundaries. If one hides the focused item, clear focus through `FocusOut`. Later visibility checks only read the cached clips, without evaluating geometry or layout bindings.

Add regression tests for hiding a focused item directly and through its parent.

Fixes #11079