### PR TITLE
rust codegen: don't monomorphize the binding machinery per component

### DIFF
--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -13,31 +13,15 @@ use re_exports::*;
 // Helper functions called from generated code to reduce code bloat from
 // extra copies of the original functions for each call site due to
 // the impl Fn() they are taking.
+//
+// The functions generic over `StrongItemTreeRef` serve global components;
+// regular components use the `*_erased` functions from `re_exports`, which
+// are not monomorphized per component.
 
 pub trait StrongItemTreeRef: Sized {
     type Weak: Clone + 'static;
     fn to_weak(&self) -> Self::Weak;
     fn from_weak(weak: &Self::Weak) -> Option<Self>;
-}
-
-impl<C: 'static> StrongItemTreeRef for VRc<ItemTreeVTable, C> {
-    type Weak = VWeak<ItemTreeVTable, C>;
-    fn to_weak(&self) -> Self::Weak {
-        VRc::downgrade(self)
-    }
-    fn from_weak(weak: &Self::Weak) -> Option<Self> {
-        weak.upgrade()
-    }
-}
-
-impl<C: 'static> StrongItemTreeRef for VRcMapped<ItemTreeVTable, C> {
-    type Weak = VWeakMapped<ItemTreeVTable, C>;
-    fn to_weak(&self) -> Self::Weak {
-        VRcMapped::downgrade(self)
-    }
-    fn from_weak(weak: &Self::Weak) -> Option<Self> {
-        weak.upgrade()
-    }
 }
 
 impl<C: 'static> StrongItemTreeRef for Pin<Rc<C>> {
@@ -206,7 +190,9 @@ pub mod re_exports {
     pub use i_slint_core::model::*;
     pub use i_slint_core::open_url;
     pub use i_slint_core::properties::{
-        ChangeTracker, Property, PropertyTracker, StateInfo, set_state_binding,
+        ChangeTracker, Property, PropertyTracker, StateInfo, change_tracker_init_erased,
+        set_animated_property_binding_erased, set_callback_handler_erased,
+        set_property_binding_erased, set_property_state_binding_erased, set_state_binding,
     };
     pub use i_slint_core::slice::Slice;
     pub use i_slint_core::string::shared_string_from_number;

--- a/cspell.json
+++ b/cspell.json
@@ -24,6 +24,8 @@
         "minx",
         "miny",
         "miri",
+        "monomorphized",
+        "monomorphizing",
         "peekable",
         "Realloc",
         "refcell",

--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this crate will be documented in this file.
 
  - Replaced the `static_vtable` function with `STATIC_VTABLE` associated
    const.
+ - Added `ErasedWeakFn`, a weak reference to a mapped object bundled with a
+   function taking that object and an `&Arg`, neither generic over the mapped
+   type, created with `VRcMapped::downgrade_erased_fn`.
 
 ## [0.4.0]
 

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -427,6 +427,44 @@ impl<VTable: VTableMetaDropInPlace + 'static, MappedType: ?Sized> VRcMapped<VTab
     }
 }
 
+impl<VTable: VTableMetaDropInPlace + 'static, MappedType> VRcMapped<VTable, MappedType> {
+    /// A [`Dyn`] weak reference to the mapped object, keeping only a raw pointer to it.
+    /// Private: it is only ever paired with a matching function inside [`ErasedWeakFn`],
+    /// so the pointer is never handed to a function expecting a different type.
+    fn downgrade_dyn(this: &Self) -> VWeakMapped<VTable, Dyn> {
+        VWeakMapped {
+            parent_weak: VRc::downgrade(&this.parent_strong),
+            // Cast through raw pointers so the pointer keeps its provenance over all of
+            // `MappedType`, without forming an intermediate reference.
+            object: this.object as *const Dyn,
+        }
+    }
+
+    /// Bundle a weak reference to this object with `f`, so that `f` can later be run on the
+    /// object (while it is still alive) through the returned [`ErasedWeakFn`], without that
+    /// handle being generic over `MappedType`. Pass `Arg = ()` for a function that takes no
+    /// meaningful argument.
+    pub fn downgrade_erased_fn<Arg: ?Sized, Ret>(
+        this: &Self,
+        f: fn(core::pin::Pin<&MappedType>, &Arg) -> Ret,
+    ) -> ErasedWeakFn<VTable, Ret, Arg> {
+        ErasedWeakFn {
+            weak: Self::downgrade_dyn(this),
+            // SAFETY: `weak` yields a pointer to this `MappedType`, and `Pin<&MappedType>`
+            // (repr(transparent) over `&MappedType`, a thin pointer for the sized
+            // `MappedType`) is ABI-compatible with `*const ()` as a function parameter; the
+            // `&Arg` parameter is unchanged. So calling the transmuted pointer with that
+            // pointer is defined.
+            call: unsafe {
+                core::mem::transmute::<
+                    fn(core::pin::Pin<&MappedType>, &Arg) -> Ret,
+                    fn(*const (), &Arg) -> Ret,
+                >(f)
+            },
+        }
+    }
+}
+
 impl<VTable: VTableMetaDropInPlace + 'static, MappedType: ?Sized> Deref
     for VRcMapped<VTable, MappedType>
 {
@@ -461,6 +499,31 @@ impl<VTable: VTableMetaDropInPlace + 'static, MappedType: ?Sized> Clone
 {
     fn clone(&self) -> Self {
         Self { parent_weak: self.parent_weak.clone(), object: self.object }
+    }
+}
+
+/// Runs a stored function on a mapped object as long as that object is still alive.
+///
+/// Create one from a [`VRcMapped`] and a function with [`VRcMapped::downgrade_erased_fn`],
+/// then call [`Self::upgrade_and_call`] whenever you want to run the function on the object,
+/// passing the argument it expects (`&()` if it takes none). Once every strong reference to
+/// the object is gone, `upgrade_and_call` returns `None` and the function is not run.
+///
+/// The type is only parameterized by the argument and return types, not by the type of the
+/// mapped object, so code that stores an `ErasedWeakFn` is compiled once no matter how many
+/// mapped types it is used with.
+pub struct ErasedWeakFn<VTable: VTableMetaDropInPlace + 'static, Ret, Arg: ?Sized = ()> {
+    weak: VWeakMapped<VTable, Dyn>,
+    call: fn(*const (), &Arg) -> Ret,
+}
+
+impl<VTable: VTableMetaDropInPlace + 'static, Ret, Arg: ?Sized> ErasedWeakFn<VTable, Ret, Arg> {
+    /// Run the stored function on the object with `arg`, or return `None` if the object has
+    /// been dropped.
+    pub fn upgrade_and_call(&self, arg: &Arg) -> Option<Ret> {
+        let strong = self.weak.upgrade()?;
+        // `strong` keeps the object alive and pinned for the duration of the call.
+        Some((self.call)(strong.object as *const (), arg))
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -900,10 +900,28 @@ fn handle_property_init(
     let rust_property = access_member(prop, ctx).unwrap();
     let prop_type = ctx.property_ty(prop);
 
-    let init_self_pin_ref = if ctx.current_global().is_some() {
-        quote!(let _self = self_rc.as_ref();)
-    } else {
-        quote!(let _self = self_rc.as_pin_ref();)
+    // Components use the type-erased helpers, so the binding machinery is
+    // instantiated once per property type instead of per (property type,
+    // component). Globals are behind a plain Rc without a type-erased weak
+    // form and keep the helpers that are generic over the component.
+    let erased = ctx.current_global().is_none();
+    // A closure evaluating `body` on the component, in the form expected by
+    // the selected helper. Optionally takes extra arguments.
+    let self_closure = |args: TokenStream, body: TokenStream| {
+        if erased {
+            quote!(move |_self #args| #body)
+        } else {
+            quote!(move |self_rc #args| { let _self = self_rc.as_ref(); #body })
+        }
+    };
+    let helper = |name: &str| {
+        if erased {
+            let name = format_ident!("{name}_erased");
+            quote!(sp::#name)
+        } else {
+            let name = format_ident!("{name}");
+            quote!(slint::private_unstable_api::#name)
+        }
     };
 
     if let Type::Callback(callback) = &prop_type {
@@ -912,14 +930,11 @@ fn handle_property_init(
         let tokens_for_expression =
             compile_expression(&binding_expression.expression.borrow(), &ctx2);
         let as_ = if matches!(callback.return_type, Type::Void) { quote!(;) } else { quote!(as _) };
+        let set_callback_handler = helper("set_callback_handler");
+        let handler = self_closure(quote!(, args), quote!({ (#tokens_for_expression) #as_ }));
         init.push(quote!({
             #[allow(unreachable_code, unused)]
-            slint::private_unstable_api::set_callback_handler(#rust_property, &self_rc, {
-                move |self_rc, args| {
-                    #init_self_pin_ref
-                    (#tokens_for_expression) #as_
-                }
-            });
+            #set_callback_handler(#rust_property, &self_rc, { #handler });
         }));
     } else {
         let tokens_for_expression =
@@ -927,62 +942,61 @@ fn handle_property_init(
 
         let tokens_for_expression = set_primitive_property_value(prop_type, tokens_for_expression);
 
+        // Cast to the property type unless the Rust code is the never type, as with return
+        // statements inside a block the type of the return expression is `()` instead of `!`.
+        let maybe_cast = if binding_expression.expression.borrow().ty(ctx) == Type::Invalid {
+            None
+        } else {
+            Some(quote!(as _))
+        };
+        // The erased helpers take functions with an extra unused `&()` argument, so that
+        // erasing them does not change their arity. The global (non-erased) helpers don't.
+        let unit_arg = if erased { quote!(, _: &()) } else { quote!() };
         init.push(match binding_expression.kind {
             llr::BindingKind::Constant => {
                 let t = rust_property_type(prop_type).unwrap_or(quote!(_));
                 quote! { #rust_property.set({ (#tokens_for_expression) as #t }); }
             }
             llr::BindingKind::State => {
-                let maybe_cast = if binding_expression.expression.borrow().ty(ctx) == Type::Invalid {
-                    None
-                } else {
-                    Some(quote!(as _))
-                };
-                let binding_tokens = quote!(move |self_rc| {
-                    #init_self_pin_ref
-                    (#tokens_for_expression) #maybe_cast
-                });
+                let binding_tokens =
+                    self_closure(unit_arg.clone(), quote!((#tokens_for_expression) #maybe_cast));
+                let set_property_state_binding = helper("set_property_state_binding");
                 quote! { {
-                    slint::private_unstable_api::set_property_state_binding(#rust_property, &self_rc, #binding_tokens);
+                    #set_property_state_binding(#rust_property, &self_rc, #binding_tokens);
                 } }
             }
             llr::BindingKind::Normal => {
-                let maybe_cast = if binding_expression.expression.borrow().ty(ctx) == Type::Invalid {
-                    None
-                } else {
-                    Some(quote!(as _))
-                };
-                let binding_tokens = quote!(move |self_rc| {
-                    #init_self_pin_ref
-                    (#tokens_for_expression) #maybe_cast
-                });
+                let binding_tokens =
+                    self_closure(unit_arg.clone(), quote!((#tokens_for_expression) #maybe_cast));
                 match &binding_expression.animation {
                     Some(llr::Animation::Static(anim)) => {
                         let anim = compile_expression(anim, ctx);
+                        let set_animated_property_binding = helper("set_animated_property_binding");
+                        let details = self_closure(unit_arg.clone(), quote!((#anim, None)));
                         quote! { {
-                            #init_self_pin_ref
-                            slint::private_unstable_api::set_animated_property_binding(
-                                #rust_property, &self_rc, #binding_tokens, move |self_rc| {
-                                    #init_self_pin_ref
-                                    (#anim, None)
-                                });
+                            #set_animated_property_binding(
+                                #rust_property, &self_rc, #binding_tokens, #details);
                         } }
                     }
                     Some(llr::Animation::Transition(animation)) => {
                         let animation = compile_expression(animation, ctx);
-                        quote! {
-                            slint::private_unstable_api::set_animated_property_binding(
-                                #rust_property, &self_rc, #binding_tokens, move |self_rc| {
-                                    #init_self_pin_ref
-                                    let (animation, change_time) = #animation;
-                                    (animation, Some(change_time))
-                                }
-                            );
-                        }
+                        let set_animated_property_binding = helper("set_animated_property_binding");
+                        let details = self_closure(
+                            unit_arg.clone(),
+                            quote!({
+                                let (animation, change_time) = #animation;
+                                (animation, Some(change_time))
+                            }),
+                        );
+                        quote! { {
+                            #set_animated_property_binding(
+                                #rust_property, &self_rc, #binding_tokens, #details);
+                        } }
                     }
                     None => {
+                        let set_property_binding = helper("set_property_binding");
                         quote! { {
-                            slint::private_unstable_api::set_property_binding(#rust_property, &self_rc, #binding_tokens);
+                            #set_property_binding(#rust_property, &self_rc, #binding_tokens);
                         } }
                     }
                 }
@@ -1673,20 +1687,12 @@ fn generate_sub_component(
         let prop = compile_expression(&Expression::PropertyReference(p.clone()), &ctx);
         let change_tracker = format_ident!("change_tracker{idx}");
         quote! {
-            let self_weak = sp::VRcMapped::downgrade(&self_rc);
             #[allow(dead_code, unused)]
-            _self.#change_tracker.init(
-                self_weak,
-                move |self_weak| {
-                    let self_rc = self_weak.upgrade().unwrap();
-                    let _self = self_rc.as_pin_ref();
-                    #prop
-                },
-                move |self_weak, _| {
-                    let self_rc = self_weak.upgrade().unwrap();
-                    let _self = self_rc.as_pin_ref();
-                    #code;
-                }
+            sp::change_tracker_init_erased(
+                &_self.#change_tracker,
+                &self_rc,
+                move |_self, _: &()| #prop,
+                move |_self, _| { #code; }
             );
         }
     }));

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1147,8 +1147,10 @@ fn properties_simple_test() {
 }
 
 mod change_tracker;
+mod erased_bindings;
 mod two_way_binding;
 pub use change_tracker::*;
+pub use erased_bindings::*;
 mod properties_animations;
 pub use properties_animations::*;
 

--- a/internal/core/properties/erased_bindings.rs
+++ b/internal/core/properties/erased_bindings.rs
@@ -1,0 +1,177 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Install property bindings and callback handlers on a component without
+//! monomorphizing the machinery per component type.
+//!
+//! The generated code of every component would otherwise instantiate its own
+//! copy of the binding holder machinery for each property type it uses. The
+//! functions here keep the component behind an [`ErasedWeakFn`], which pairs a
+//! type-erased weak reference with the binding function so that everything past
+//! the `#[inline]` shims is monomorphized per property type only, not per
+//! component. The erasure and its safety live in the `vtable` crate; this module
+//! is entirely safe.
+//!
+//! The binding functions all take an extra `&Arg` (`&()` for those without a
+//! meaningful argument), so that erasing them never changes the function's arity.
+
+use super::Property;
+use crate::callbacks::Callback;
+use core::pin::Pin;
+use vtable::{ErasedWeakFn, VRcMapped, VTableMetaDropInPlace};
+
+/// Sets the binding of `property` to evaluate `binding` on the component
+/// `self_rc`, or to produce the default value once the component is gone.
+#[inline]
+pub fn set_property_binding_erased<
+    T: Clone + Default + 'static,
+    VT: VTableMetaDropInPlace + 'static,
+    X,
+>(
+    property: Pin<&Property<T>>,
+    self_rc: &VRcMapped<VT, X>,
+    binding: fn(Pin<&X>, &()) -> T,
+) {
+    set_property_binding_impl(property, VRcMapped::downgrade_erased_fn(self_rc, binding))
+}
+
+fn set_property_binding_impl<T: Clone + Default + 'static, VT: VTableMetaDropInPlace + 'static>(
+    property: Pin<&Property<T>>,
+    binding: ErasedWeakFn<VT, T>,
+) {
+    property.set_binding(move || binding.upgrade_and_call(&()).unwrap_or_default())
+}
+
+/// Like [`set_property_binding_erased`], for an animated binding.
+/// The component must outlive the binding.
+#[inline]
+pub fn set_animated_property_binding_erased<
+    T: Clone + super::InterpolatedPropertyValue + 'static,
+    VT: VTableMetaDropInPlace + 'static,
+    X,
+>(
+    property: Pin<&Property<T>>,
+    self_rc: &VRcMapped<VT, X>,
+    binding: fn(Pin<&X>, &()) -> T,
+    compute_animation_details: fn(
+        Pin<&X>,
+        &(),
+    ) -> (
+        crate::items::PropertyAnimation,
+        Option<crate::animations::Instant>,
+    ),
+) {
+    set_animated_property_binding_impl(
+        property,
+        VRcMapped::downgrade_erased_fn(self_rc, binding),
+        VRcMapped::downgrade_erased_fn(self_rc, compute_animation_details),
+    )
+}
+
+fn set_animated_property_binding_impl<
+    T: Clone + super::InterpolatedPropertyValue + 'static,
+    VT: VTableMetaDropInPlace + 'static,
+>(
+    property: Pin<&Property<T>>,
+    binding: ErasedWeakFn<VT, T>,
+    compute_animation_details: ErasedWeakFn<
+        VT,
+        (crate::items::PropertyAnimation, Option<crate::animations::Instant>),
+    >,
+) {
+    property.set_animated_binding(
+        move || binding.upgrade_and_call(&()).expect("binding evaluated on dropped component"),
+        move || {
+            compute_animation_details
+                .upgrade_and_call(&())
+                .expect("binding evaluated on dropped component")
+        },
+    )
+}
+
+/// Like [`set_property_binding_erased`], for a state binding.
+/// The component must outlive the binding.
+#[inline]
+pub fn set_property_state_binding_erased<VT: VTableMetaDropInPlace + 'static, X>(
+    property: Pin<&Property<super::StateInfo>>,
+    self_rc: &VRcMapped<VT, X>,
+    binding: fn(Pin<&X>, &()) -> i32,
+) {
+    set_property_state_binding_impl(property, VRcMapped::downgrade_erased_fn(self_rc, binding))
+}
+
+fn set_property_state_binding_impl<VT: VTableMetaDropInPlace + 'static>(
+    property: Pin<&Property<super::StateInfo>>,
+    binding: ErasedWeakFn<VT, i32>,
+) {
+    super::set_state_binding(property, move || {
+        binding.upgrade_and_call(&()).expect("binding evaluated on dropped component")
+    })
+}
+
+/// Initialize `change_tracker` to evaluate `eval` on the component `self_rc`
+/// and call `notify` when the result changes. The component must outlive the
+/// change tracker.
+#[inline]
+pub fn change_tracker_init_erased<
+    T: Default + PartialEq + 'static,
+    VT: VTableMetaDropInPlace + 'static,
+    X,
+>(
+    change_tracker: &super::ChangeTracker,
+    self_rc: &VRcMapped<VT, X>,
+    eval: fn(Pin<&X>, &()) -> T,
+    notify: fn(Pin<&X>, &T),
+) {
+    change_tracker_init_impl(
+        change_tracker,
+        VRcMapped::downgrade_erased_fn(self_rc, eval),
+        VRcMapped::downgrade_erased_fn(self_rc, notify),
+    )
+}
+
+fn change_tracker_init_impl<
+    T: Default + PartialEq + 'static,
+    VT: VTableMetaDropInPlace + 'static,
+>(
+    change_tracker: &super::ChangeTracker,
+    eval: ErasedWeakFn<VT, T>,
+    notify: ErasedWeakFn<VT, (), T>,
+) {
+    change_tracker.init(
+        (eval, notify),
+        |(eval, _)| eval.upgrade_and_call(&()).expect("change tracker on dropped component"),
+        |(_, notify), value| {
+            notify.upgrade_and_call(value).expect("change tracker on dropped component");
+        },
+    )
+}
+
+/// Sets the handler of `callback` to evaluate `handler` on the component
+/// `self_rc`. The component must outlive the callback handler.
+#[inline]
+pub fn set_callback_handler_erased<
+    Arg: ?Sized + 'static,
+    Ret: Default + 'static,
+    VT: VTableMetaDropInPlace + 'static,
+    X,
+>(
+    callback: Pin<&Callback<Arg, Ret>>,
+    self_rc: &VRcMapped<VT, X>,
+    handler: fn(Pin<&X>, &Arg) -> Ret,
+) {
+    set_callback_handler_impl(callback, VRcMapped::downgrade_erased_fn(self_rc, handler))
+}
+
+fn set_callback_handler_impl<
+    Arg: ?Sized + 'static,
+    Ret: Default + 'static,
+    VT: VTableMetaDropInPlace + 'static,
+>(
+    callback: Pin<&Callback<Arg, Ret>>,
+    handler: ErasedWeakFn<VT, Ret, Arg>,
+) {
+    callback.set_handler(move |arg| {
+        handler.upgrade_and_call(arg).expect("callback invoked on a dropped component")
+    })
+}


### PR DESCRIPTION
Installing a property binding, callback, animated or state binding, or change tracker went through helpers that are generic over the component type, so every component instantiated its own copy of the binding machinery for every property type it uses. With thousands of components in a large UI, these instantiations are a big part of the compiled code and of the compiler's time and memory for a release build.

Erase the component type at the installation boundary instead: the component is kept behind a new type-erased VWeakMappedErased and the binding function pointer is transmuted to take the erased pointer. The machinery is then instantiated once per property type. No runtime cost: same capture sizes, the pairing is checked at compile time, and evaluation does the same work as before. All unsafe is confined to one documented module; the generated code contains none. Globals keep the generic path (Rc has no erased weak form, and there are few global types).

|                       | binary                   | stripped binary          | UI crate rebuild (CPU time) |
 |-----------------------|--------------------------|--------------------------|-----------------------------|
| examples/gallery      | 30.25 → 29.53 MB (−2.4%) | 24.69 → 24.52 MB (−0.7%) | 57.3 s → 52.5 s (−8%)       |
| demos/home-automation | 27.84 → 27.55 MB (−1.0%) | 23.02 → 22.96 MB (−0.3%) | unchanged (within noise)    |
