### PR TITLE
skia: reject sRGB render targets in SkiaWGPURenderer::render_to_texture

### DIFF
--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -63,10 +63,27 @@ impl SkiaWGPURenderer {
 
     /// Render the scene to the given texture.
     ///
-    /// The texture must have been created with `RENDER_ATTACHMENT` usage and have a supported
-    /// format. Supported formats depend on the GPU backend: `Rgba8Unorm` and `Rgba8UnormSrgb`
-    /// are supported on all backends; `Bgra8Unorm` is additionally supported on Metal and Vulkan.
+    /// The texture must have been created with `RENDER_ATTACHMENT` usage and have a supported,
+    /// **non-sRGB** format: `Rgba8Unorm` on all backends, and `Bgra8Unorm` additionally on Metal
+    /// and Vulkan.
+    ///
+    /// sRGB texture formats (e.g. `Rgba8UnormSrgb`) are **rejected**: Slint's colors are already
+    /// display-ready sRGB, so an sRGB target would double-encode them and wash colors out. To get
+    /// the result in a texture sampled *as* sRGB, use a non-sRGB base format with its sRGB variant
+    /// in `view_formats` and sample through an sRGB view. The returned error spells this out.
     pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
+        let format = texture.format();
+        if format.is_srgb() {
+            return Err(PlatformError::from(format!(
+                "SkiaWGPURenderer::render_to_texture: sRGB texture format {format:?} is not \
+                 supported as a render target. Slint renders display-ready sRGB colors, so an \
+                 sRGB target applies an extra sRGB encode and washes out colors. Use the \
+                 non-sRGB format {:?} instead; to sample the result as sRGB, add {format:?} to \
+                 the texture's `view_formats` and sample through an sRGB texture view.",
+                format.remove_srgb_suffix(),
+            )));
+        }
+
         self.renderer.invoke_rendering_notifier_setup(&self.surface)?;
 
         let gr_context = &mut self.surface.gr_context.borrow_mut();


### PR DESCRIPTION
Fixes #12458.

`SkiaWGPURenderer::render_to_texture()` rendered washed-out colors when the caller's target
texture had an sRGB pixel format (e.g. `Rgba8UnormSrgb`): Slint writes display-ready sRGB
byte values, but an sRGB render target applies a second, hardware sRGB encode on store, so
colors are encoded twice. The doc comment even listed `Rgba8UnormSrgb` as supported.

The **windowed** WGPU-Skia path already sidesteps this by filtering the swapchain to
non-sRGB formats (`WGPUSurface::new_with_surface`, `wgpu_29_surface.rs:60-69`); the offscreen
`render_to_texture` path did not carry that invariant. This change makes the offscreen path
reject sRGB target formats up front (backend-agnostically, before any GPU work) with an
actionable error that names the non-sRGB format to use and points at the
`view_formats` + sRGB-sampling-view pattern for callers who need to sample the result as
sRGB. The doc comment is corrected to match.

Rejecting (rather than color-managing the sRGB target) is deliberate: on Metal,
`skia-safe`'s `wrap_backend_render_target` cannot produce correct output for an sRGB
`MTLPixelFormat` — `SRGBA8888` always applies the extra encode (an explicit
`ColorSpace::new_srgb()` has no effect) and `RGBA8888` is rejected by Skia against an sRGB
backing format. Raw-byte measurements are in #12458.

### Testing

- Verified on **macOS / Metal** with a headless offscreen readback harness
  (`copy_texture_to_buffer`): `Rgba8Unorm` and `Bgra8Unorm` render the literal color bytes;
  `Rgba8UnormSrgb` previously read back the sRGB-encoded (too-bright) value and now returns
  the descriptive error instead. The `bevy-hosts-slint-gpu` example uses `Rgba8Unorm` and is
  unaffected.
- **Not verified on Vulkan / DX12** (cfg-gated off on macOS). The guard is backend-agnostic
  and consistent with the windowed path's non-sRGB filter on all backends; a maintainer with
  Linux/Windows hardware may want to confirm the symptom and the guard there.

<!--
- [x] Modifies visible behavior → the `render_to_texture` doc comment is updated accordingly.
- [~] Auto-tested: validated with a local headless GPU harness; not added to CI since the
      WGPU-Skia path needs a real GPU. Happy to contribute the harness as an example if wanted.
- [x] Fixes an existing issue (`Fixes #12458`).
- [x] Noteworthy → `ChangeLog:` line in the commit.
-->
