### PR TITLE
Refactor two-way struct member bindings

### DIFF
--- a/api/cpp/include/private/slint_properties.h
+++ b/api/cpp/include/private/slint_properties.h
@@ -415,6 +415,10 @@ struct Property
                     // classes: install the projections (which also marks the
                     // commons' dependents dirty).
                     auto *self = reinterpret_cast<StructMemberBindings *>(user_data);
+                    // drop stale dependency registrations in case the holder
+                    // was evaluated while installed elsewhere (mirrors the
+                    // Rust StructMemberBindings::intercept_set_binding)
+                    cbindgen_private::slint_property_reset_binding_dependencies(new_binding);
                     if (auto *old = std::exchange(self->slot->holder, new_binding)) {
                         self->slot->dispose(old);
                     }

--- a/api/cpp/include/private/slint_properties.h
+++ b/api/cpp/include/private/slint_properties.h
@@ -281,53 +281,48 @@ struct Property
     /// bindings onto its *fields*. Mirrors the Rust `StructMemberBindings`
     /// (see internal/core/properties/two_way_binding.rs): each mapped field
     /// is synchronized with a shared narrow common property of the field's
-    /// type; the struct's own value-producing binding lives in the
-    /// `DriverSlot` and both produces the unmapped fields and drives the
+    /// type; the struct's own value-producing binding lives on the slot
+    /// property and both produces the unmapped fields and drives the
     /// commons via projections.
     struct StructMemberBindings
     {
-        struct DriverSlot
+        /// The struct property's own value-producing binding ("real
+        /// binding") is installed on this dedicated property, shared with
+        /// the driver projections of the mapped fields' commons: its dirty
+        /// flag memoizes the evaluation (the binding runs at most once per
+        /// change of its inputs, no matter how many commons and wrappers
+        /// read it) and the dependency graph (commons/wrapper -> slot
+        /// property -> the binding's inputs) replaces manual dirty
+        /// forwarding.
+        std::shared_ptr<Property<T>> slot;
+
+        explicit StructMemberBindings(const T &seed) : slot(std::make_shared<Property<T>>(seed))
         {
-            /// The struct property's own value-producing binding is
-            /// installed on this dedicated property: its dirty flag
-            /// memoizes the evaluation (the binding runs at most once per
-            /// change of its inputs, no matter how many commons and
-            /// wrappers read it) and the dependency graph (commons/wrapper
-            /// -> slot property -> the binding's inputs) replaces manual
-            /// dirty forwarding.
-            Property<T> property;
+        }
 
-            explicit DriverSlot(const T &seed) : property(seed) { }
-
-            bool has_holder() const
-            {
-                return (reinterpret_cast<uintptr_t>(property.inner._0) & 0b10) != 0;
-            }
-            /// Drop the real binding, if any. Panics ("Recursion detected")
-            /// when the real binding is currently executing (a binding
-            /// writing back to its own struct property).
-            void clear()
-            {
-                cbindgen_private::slint_property_remove_binding(&property.inner);
-            }
-            /// Install `holder` (an owned Rust `BindingHolder`) as the slot
-            /// property's binding, dropping the previous one.
-            void install(void *holder)
-            {
-                clear();
-                cbindgen_private::slint_property_set_binding_internal(&property.inner, holder);
-                // A stolen (second-hand) holder may have been evaluated in
-                // its old home with a clean dirty flag and wiped dependency
-                // registrations; without this it would never re-evaluate
-                // here.
-                cbindgen_private::slint_property_mark_binding_and_dependencies_dirty(
-                        &property.inner);
-            }
-        };
-
-        std::shared_ptr<DriverSlot> slot;
-
-        explicit StructMemberBindings(const T &seed) : slot(std::make_shared<DriverSlot>(seed)) { }
+        static bool slot_has_binding(const Property<T> &slot_property)
+        {
+            return (reinterpret_cast<uintptr_t>(slot_property.inner._0) & 0b10) != 0;
+        }
+        /// Drop the real binding, if any. Panics ("Recursion detected")
+        /// when the real binding is currently executing (a binding
+        /// writing back to its own struct property).
+        void clear_driver_binding() const
+        {
+            cbindgen_private::slint_property_remove_binding(&slot->inner);
+        }
+        /// Install `holder` (an owned Rust `BindingHolder`) as the slot
+        /// property's binding, dropping the previous one.
+        void install_driver_binding(void *holder) const
+        {
+            clear_driver_binding();
+            cbindgen_private::slint_property_set_binding_internal(&slot->inner, holder);
+            // A stolen (second-hand) holder may have been evaluated in
+            // its old home with a clean dirty flag and wiped dependency
+            // registrations; without this it would never re-evaluate
+            // here.
+            cbindgen_private::slint_property_mark_binding_and_dependencies_dirty(&slot->inner);
+        }
 
         struct Mapping
         {
@@ -340,7 +335,7 @@ struct Property
             std::function<void(const T &)> push_to_common;
             /// Installs a driver projection for this mapping's field onto
             /// the common.
-            std::function<void(const std::shared_ptr<DriverSlot> &)> install_projection;
+            std::function<void(const std::shared_ptr<Property<T>> &)> install_projection;
             /// The narrow common property (a shared_ptr<Property<T2>>),
             /// type-erased for the field-keyed reuse lookup.
             std::shared_ptr<void> common;
@@ -358,7 +353,7 @@ struct Property
         }
         auto *wrapper = new StructMemberBindings(prop->value);
         if (void *old = cbindgen_private::slint_property_detach_binding(&prop->inner)) {
-            wrapper->slot->install(old);
+            wrapper->install_driver_binding(old);
         }
         cbindgen_private::slint_property_set_binding_with_kind(
                 &prop->inner,
@@ -368,8 +363,8 @@ struct Property
                     // Only read the slot property while it carries the real
                     // binding: when binding-less its stored value is stale
                     // and would clobber the struct's own stored value.
-                    if (self->slot->has_holder()) {
-                        v = self->slot->property.get();
+                    if (StructMemberBindings::slot_has_binding(*self->slot)) {
+                        v = self->slot->get();
                     }
                     for (auto &mapping : self->mappings) {
                         mapping.apply_from_common(v);
@@ -384,7 +379,7 @@ struct Property
                     // property) and pushes the mapped fields into their
                     // classes; the unmapped fields are stored by set().
                     auto *self = reinterpret_cast<StructMemberBindings *>(user_data);
-                    self->slot->clear();
+                    self->clear_driver_binding();
                     const T &v = *reinterpret_cast<const T *>(value);
                     for (auto &mapping : self->mappings) {
                         mapping.push_to_common(v);
@@ -400,7 +395,7 @@ struct Property
                     // was evaluated while installed elsewhere (mirrors the
                     // Rust StructMemberBindings::intercept_set_binding)
                     cbindgen_private::slint_property_reset_binding_dependencies(new_binding);
-                    self->slot->install(new_binding);
+                    self->install_driver_binding(new_binding);
                     for (auto &mapping : self->mappings) {
                         mapping.install_projection(self->slot);
                     }
@@ -439,21 +434,20 @@ struct Property
             std::string(field_key),
             [common, set_field](T &value) { set_field(value, common->get()); },
             [common, get_field](const T &value) { common->set(get_field(value)); },
-            [common, get_field](const std::shared_ptr<typename StructMemberBindings::DriverSlot>
-                                        &slot) {
+            [common, get_field](const std::shared_ptr<Property<T>> &slot) {
                 // The driver projection: evaluates the struct's binding and
                 // extracts the mapped field, so the binding drives the class
                 // (last installed binding on the common wins).
                 struct Projection
                 {
-                    std::shared_ptr<typename StructMemberBindings::DriverSlot> slot;
+                    std::shared_ptr<Property<T>> slot;
                     GetField get_field;
                 };
                 cbindgen_private::slint_property_set_binding(
                         &common->inner,
                         [](void *user_data, void *value) {
                             auto *self = reinterpret_cast<Projection *>(user_data);
-                            if (!self->slot->has_holder()) {
+                            if (!StructMemberBindings::slot_has_binding(*self->slot)) {
                                 // the driver was dropped: keep the common's
                                 // current value (a C++ binding cannot remove
                                 // itself; the projection stays installed but
@@ -464,7 +458,7 @@ struct Property
                             // projection as its dependent and memoizes the
                             // real binding behind its dirty flag
                             *reinterpret_cast<T2 *>(value) =
-                                    self->get_field(self->slot->property.get());
+                                    self->get_field(self->slot->get());
                         },
                         new Projection { slot, get_field },
                         [](void *user_data) { delete reinterpret_cast<Projection *>(user_data); },
@@ -473,7 +467,7 @@ struct Property
             common,
         };
         // A pre-existing binding must also drive this field's class.
-        if (wrapper->slot->has_holder()) {
+        if (StructMemberBindings::slot_has_binding(*wrapper->slot)) {
             mapping.install_projection(wrapper->slot);
         }
         bool replaced = false;

--- a/api/cpp/include/private/slint_properties.h
+++ b/api/cpp/include/private/slint_properties.h
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #pragma once
-#include <string_view>
+#include <functional>
 #include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace slint::cbindgen_private {
 struct PropertyAnimation;
@@ -19,6 +23,16 @@ struct ChangeTracker
 namespace slint::private_api {
 
 using cbindgen_private::StateInfo;
+
+/// `kind` tags for `slint_property_set_binding_with_kind` /
+/// `slint_property_binding_kind_user_data`, identifying the C++ object
+/// behind a binding's `user_data` so it can be recovered safely later.
+/// A `Property<T>::TwoWayBinding` (holds the two-way class' shared common
+/// property).
+constexpr uint8_t cpp_two_way_binding_kind = 1;
+/// A `Property<T>::StructMemberBindings` (the wrapper binding of a struct
+/// property whose fields participate in two-way binding classes).
+constexpr uint8_t cpp_struct_member_bindings_kind = 2;
 
 inline void slint_property_set_animated_binding_helper(
         const cbindgen_private::PropertyHandleOpaque *handle, void (*binding)(void *, int *),
@@ -142,14 +156,14 @@ struct Property
             std::swap(handle, const_cast<Property<T> *>(p2)->inner);
         }
         auto common_property = std::make_shared<Property<T>>(handle, std::move(value));
-        cbindgen_private::slint_property_set_binding(
+        cbindgen_private::slint_property_set_binding_with_kind(
                 &p1->inner, TwoWayBinding::call_fn, new TwoWayBinding { common_property },
                 TwoWayBinding::del_fn, TwoWayBinding::intercept_fn,
-                TwoWayBinding::intercept_binding_fn);
-        cbindgen_private::slint_property_set_binding(
+                TwoWayBinding::intercept_binding_fn, cpp_two_way_binding_kind);
+        cbindgen_private::slint_property_set_binding_with_kind(
                 &p2->inner, TwoWayBinding::call_fn, new TwoWayBinding { common_property },
                 TwoWayBinding::del_fn, TwoWayBinding::intercept_fn,
-                TwoWayBinding::intercept_binding_fn);
+                TwoWayBinding::intercept_binding_fn, cpp_two_way_binding_kind);
     }
 
     template<typename T2, typename M1, typename M2>
@@ -218,10 +232,10 @@ struct Property
             return true;
         };
 
-        cbindgen_private::slint_property_set_binding(
+        cbindgen_private::slint_property_set_binding_with_kind(
                 &prop1->inner, TwoWayBinding::call_fn, new TwoWayBinding { common_property },
                 TwoWayBinding::del_fn, TwoWayBinding::intercept_fn,
-                TwoWayBinding::intercept_binding_fn);
+                TwoWayBinding::intercept_binding_fn, cpp_two_way_binding_kind);
 
         cbindgen_private::slint_property_set_binding(
                 &prop2->inner, call_fn, new TwoWayBindingWithMap { common_property, map1, map2 },
@@ -255,9 +269,350 @@ struct Property
                     return true;
                 },
                 [](void *, void *) -> bool {
-                    // Cannot rebind a property already two-way bound to a model.
-                    std::abort();
+                    // A new binding replaces the model binding (this happens
+                    // when a driver projection is installed on a two-way
+                    // class' common property that is bound to a model row;
+                    // same behavior as the Rust TwoWayBindingModel).
+                    return false;
                 });
+    }
+
+    /// The binding wrapper installed on a struct property that has two-way
+    /// bindings onto its *fields*. Mirrors the Rust `StructMemberBindings`
+    /// (see internal/core/properties/two_way_binding.rs): each mapped field
+    /// is synchronized with a shared narrow common property of the field's
+    /// type; the struct's own value-producing binding lives in the
+    /// `DriverSlot` and both produces the unmapped fields and drives the
+    /// commons via projections.
+    struct StructMemberBindings
+    {
+        struct DriverSlot
+        {
+            /// The struct property's own binding (an owned Rust
+            /// `BindingHolder`), if any.
+            void *holder = nullptr;
+            /// Seed value for evaluating the binding outside of the struct
+            /// property's own storage.
+            T cache {};
+            /// Number of nested `evaluate_holder` frames; while non-zero,
+            /// holders are parked in `pending_drops` instead of deleted (a
+            /// projection evaluates the binding without the struct
+            /// property's lock, so a write-back could otherwise free the
+            /// binding while it is executing).
+            int evaluation_depth = 0;
+            std::vector<void *> pending_drops;
+
+            void dispose(void *binding)
+            {
+                if (evaluation_depth > 0) {
+                    pending_drops.push_back(binding);
+                } else {
+                    cbindgen_private::slint_property_delete_binding(binding);
+                }
+            }
+            void clear()
+            {
+                if (auto *binding = std::exchange(holder, static_cast<void *>(nullptr))) {
+                    dispose(binding);
+                }
+            }
+            /// Evaluate the current holder into `value`, keeping it alive
+            /// until the evaluation returns even if it is cleared or
+            /// replaced while executing. Returns false when the slot is
+            /// empty.
+            bool evaluate_holder(T *value)
+            {
+                auto *binding = holder;
+                if (!binding) {
+                    return false;
+                }
+                evaluation_depth++;
+                cbindgen_private::slint_property_evaluate_binding(binding, value);
+                if (--evaluation_depth == 0) {
+                    while (!pending_drops.empty()) {
+                        auto *pending = pending_drops.back();
+                        pending_drops.pop_back();
+                        cbindgen_private::slint_property_delete_binding(pending);
+                    }
+                }
+                return true;
+            }
+            ~DriverSlot()
+            {
+                clear();
+                while (!pending_drops.empty()) {
+                    auto *pending = pending_drops.back();
+                    pending_drops.pop_back();
+                    cbindgen_private::slint_property_delete_binding(pending);
+                }
+            }
+        };
+
+        std::shared_ptr<DriverSlot> slot = std::make_shared<DriverSlot>();
+
+        struct Mapping
+        {
+            /// Field path within the struct (e.g. "field" or "outer.inner"),
+            /// used to find and replace the mapping on re-links.
+            std::string key;
+            /// `value.<key> = common.get()`
+            std::function<void(T &)> apply_from_common;
+            /// `common.set(get_field(value))`
+            std::function<void(const T &)> push_to_common;
+            /// Installs a driver projection for this mapping's field onto
+            /// the common.
+            std::function<void(const std::shared_ptr<DriverSlot> &)> install_projection;
+            /// The narrow common property (a shared_ptr<Property<T2>>),
+            /// type-erased for the field-keyed reuse lookup.
+            std::shared_ptr<void> common;
+        };
+        std::vector<Mapping> mappings;
+    };
+
+    /// Make sure the property wears a `StructMemberBindings` wrapper, moving
+    /// a pre-existing binding into the wrapper's driver slot.
+    static StructMemberBindings *ensure_struct_member_bindings(const Property<T> *prop)
+    {
+        if (void *user_data = cbindgen_private::slint_property_binding_kind_user_data(
+                    &prop->inner, cpp_struct_member_bindings_kind)) {
+            return reinterpret_cast<StructMemberBindings *>(user_data);
+        }
+        auto *wrapper = new StructMemberBindings();
+        wrapper->slot->cache = prop->value;
+        if (void *old = cbindgen_private::slint_property_detach_binding(&prop->inner)) {
+            wrapper->slot->holder = old;
+        }
+        cbindgen_private::slint_property_set_binding_with_kind(
+                &prop->inner,
+                [](void *user_data, void *value) {
+                    auto *self = reinterpret_cast<StructMemberBindings *>(user_data);
+                    T &v = *reinterpret_cast<T *>(value);
+                    if (self->slot->evaluate_holder(&v)) {
+                        self->slot->cache = v;
+                    }
+                    for (auto &mapping : self->mappings) {
+                        mapping.apply_from_common(v);
+                    }
+                },
+                wrapper,
+                [](void *user_data) {
+                    delete reinterpret_cast<StructMemberBindings *>(user_data);
+                },
+                [](void *user_data, const void *value) -> bool {
+                    // Setting a value drops the binding (as on an unwrapped
+                    // property) and pushes the mapped fields into their
+                    // classes; the unmapped fields are stored by set().
+                    auto *self = reinterpret_cast<StructMemberBindings *>(user_data);
+                    self->slot->clear();
+                    const T &v = *reinterpret_cast<const T *>(value);
+                    for (auto &mapping : self->mappings) {
+                        mapping.push_to_common(v);
+                    }
+                    return true;
+                },
+                [](void *user_data, void *new_binding) -> bool {
+                    // A new binding becomes the driver of the mapped fields'
+                    // classes: install the projections (which also marks the
+                    // commons' dependents dirty).
+                    auto *self = reinterpret_cast<StructMemberBindings *>(user_data);
+                    if (auto *old = std::exchange(self->slot->holder, new_binding)) {
+                        self->slot->dispose(old);
+                    }
+                    for (auto &mapping : self->mappings) {
+                        mapping.install_projection(self->slot);
+                    }
+                    return true;
+                },
+                cpp_struct_member_bindings_kind);
+        return wrapper;
+    }
+
+    /// The (type-erased) narrow common property the given field of this
+    /// struct property is synchronized with, if any.
+    static std::shared_ptr<void> struct_member_common(const Property<T> *prop,
+                                                      std::string_view field_key)
+    {
+        if (void *user_data = cbindgen_private::slint_property_binding_kind_user_data(
+                    &prop->inner, cpp_struct_member_bindings_kind)) {
+            auto *wrapper = reinterpret_cast<StructMemberBindings *>(user_data);
+            for (auto &mapping : wrapper->mappings) {
+                if (mapping.key == field_key) {
+                    return mapping.common;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    /// Add (or replace, keyed by `field_key`) a mapping synchronizing
+    /// `field_key` of this struct property with `common`.
+    template<typename T2, typename GetField, typename SetField>
+    static void add_struct_member_mapping(const Property<T> *prop, std::string_view field_key,
+                                          std::shared_ptr<Property<T2>> common, GetField get_field,
+                                          SetField set_field)
+    {
+        auto *wrapper = ensure_struct_member_bindings(prop);
+        typename StructMemberBindings::Mapping mapping {
+            std::string(field_key),
+            [common, set_field](T &value) { set_field(value, common->get()); },
+            [common, get_field](const T &value) { common->set(get_field(value)); },
+            [common, get_field](const std::shared_ptr<typename StructMemberBindings::DriverSlot>
+                                        &slot) {
+                // The driver projection: evaluates the struct's binding and
+                // extracts the mapped field, so the binding drives the class
+                // (last installed binding on the common wins).
+                struct Projection
+                {
+                    std::shared_ptr<typename StructMemberBindings::DriverSlot> slot;
+                    GetField get_field;
+                };
+                cbindgen_private::slint_property_set_binding(
+                        &common->inner,
+                        [](void *user_data, void *value) {
+                            auto *self = reinterpret_cast<Projection *>(user_data);
+                            T struct_value = self->slot->cache;
+                            if (!self->slot->evaluate_holder(&struct_value)) {
+                                // the driver was dropped: keep the common's
+                                // current value
+                                return;
+                            }
+                            *reinterpret_cast<T2 *>(value) = self->get_field(struct_value);
+                            self->slot->cache = std::move(struct_value);
+                        },
+                        new Projection { slot, get_field },
+                        [](void *user_data) { delete reinterpret_cast<Projection *>(user_data); },
+                        nullptr, nullptr);
+            },
+            common,
+        };
+        // A pre-existing binding must also drive this field's class.
+        if (wrapper->slot->holder) {
+            mapping.install_projection(wrapper->slot);
+        }
+        bool replaced = false;
+        for (auto &existing : wrapper->mappings) {
+            if (existing.key == mapping.key) {
+                existing = std::move(mapping);
+                replaced = true;
+                break;
+            }
+        }
+        if (!replaced) {
+            wrapper->mappings.push_back(std::move(mapping));
+        }
+        // The wrapper must re-evaluate to pick up the new mapping's common
+        // (and register the dependency on it).
+        cbindgen_private::slint_property_mark_binding_and_dependencies_dirty(&prop->inner);
+    }
+
+    /// Link `field_key` of the struct property `struct_prop` two-way with
+    /// the property `member_prop`, such that they always have the same
+    /// value. This is the runtime counterpart of `member <=> strct.field`;
+    /// `struct_prop` is the right-hand side and its current field value
+    /// wins. Mirrors the Rust `Property::link_two_way_to_member`.
+    template<typename T2, typename GetField, typename SetField>
+    static void link_two_way_to_member(const Property<T> *struct_prop,
+                                       const Property<T2> *member_prop, std::string_view field_key,
+                                       GetField get_field, SetField set_field)
+    {
+        std::shared_ptr<Property<T2>> common;
+        bool member_was_linked = false;
+        if (void *user_data = cbindgen_private::slint_property_binding_kind_user_data(
+                    &member_prop->inner, cpp_two_way_binding_kind)) {
+            common = reinterpret_cast<typename Property<T2>::TwoWayBinding *>(user_data)
+                             ->common_property;
+            member_was_linked = true;
+        }
+        if (auto struct_common_erased = struct_member_common(struct_prop, field_key)) {
+            auto struct_common = std::static_pointer_cast<Property<T2>>(struct_common_erased);
+            if (common && common != struct_common) {
+                // both sides are already in (distinct) classes: unify them
+                Property<T2>::link_two_way(common.get(), struct_common.get());
+            }
+            common = struct_common;
+        }
+        if (!common) {
+            // seed a new class with the struct's genuine field value (the
+            // right-hand side of `<=>` wins)
+            common = std::make_shared<Property<T2>>(get_field(struct_prop->get()));
+        } else if ((reinterpret_cast<uintptr_t>(common->inner._0) & 0b10) == 0) {
+            // push the struct's field value into a reused class, unless the
+            // class is driven by a binding (the binding stays authoritative)
+            common->set(get_field(struct_prop->get()));
+        }
+
+        add_struct_member_mapping(struct_prop, field_key, common, get_field, set_field);
+
+        if (!member_was_linked) {
+            // a pre-existing regular binding on the member is dropped by
+            // set_binding (the struct's value wins; bindings install after
+            // the links in generated code)
+            cbindgen_private::slint_property_set_binding_with_kind(
+                    &member_prop->inner, Property<T2>::TwoWayBinding::call_fn,
+                    new typename Property<T2>::TwoWayBinding { common },
+                    Property<T2>::TwoWayBinding::del_fn, Property<T2>::TwoWayBinding::intercept_fn,
+                    Property<T2>::TwoWayBinding::intercept_binding_fn, cpp_two_way_binding_kind);
+        }
+    }
+
+    /// Link `field_key_a` of the struct property `prop_a` two-way with
+    /// `field_key_b` of the struct property `prop_b` (both fields have the
+    /// same type `T2`). This is the runtime counterpart of a whole-struct
+    /// `<=>` that the compiler decomposed into per-field links; `prop_b` is
+    /// the right-hand side and its current field value wins.
+    template<typename T2, typename TB, typename GetFieldA, typename SetFieldA, typename GetFieldB,
+             typename SetFieldB>
+    static void link_two_way_members(const Property<T> *prop_a, std::string_view field_key_a,
+                                     GetFieldA get_field_a, SetFieldA set_field_a,
+                                     const Property<TB> *prop_b, std::string_view field_key_b,
+                                     GetFieldB get_field_b, SetFieldB set_field_b)
+    {
+        auto common_a = std::static_pointer_cast<Property<T2>>(
+                Property<T>::struct_member_common(prop_a, field_key_a));
+        auto common_b = std::static_pointer_cast<Property<T2>>(
+                Property<TB>::struct_member_common(prop_b, field_key_b));
+        std::shared_ptr<Property<T2>> common;
+        if (common_a && common_b) {
+            if (common_a != common_b) {
+                Property<T2>::link_two_way(common_a.get(), common_b.get());
+            }
+            common = common_b;
+        } else if (common_a) {
+            common = common_a;
+        } else if (common_b) {
+            common = common_b;
+        }
+        if (!common) {
+            common = std::make_shared<Property<T2>>(get_field_b(prop_b->get()));
+        } else if ((reinterpret_cast<uintptr_t>(common->inner._0) & 0b10) == 0) {
+            common->set(get_field_b(prop_b->get()));
+        }
+        // prop_b's mapping is installed last, so a binding on prop_b wins
+        // the driver election over one on prop_a.
+        Property<T>::add_struct_member_mapping(prop_a, field_key_a, common, get_field_a,
+                                               set_field_a);
+        Property<TB>::add_struct_member_mapping(prop_b, field_key_b, common, get_field_b,
+                                                set_field_b);
+    }
+
+    /// Link `field_key` of the struct property `struct_prop` two-way with a
+    /// value stored in a model row. This is the runtime counterpart of a
+    /// whole-row `strct <=> model-data` that the compiler decomposed into
+    /// per-field links; the model is authoritative (the row binding is
+    /// installed on the class' common property and drives it).
+    template<typename T2, typename GetField, typename SetField, typename Getter, typename Setter>
+    static void link_two_way_member_to_model_data(const Property<T> *struct_prop,
+                                                  std::string_view field_key, GetField get_field,
+                                                  SetField set_field, Getter getter, Setter setter)
+    {
+        auto common = std::static_pointer_cast<Property<T2>>(
+                struct_member_common(struct_prop, field_key));
+        if (!common) {
+            common = std::make_shared<Property<T2>>(get_field(struct_prop->get()));
+        }
+        add_struct_member_mapping(struct_prop, field_key, common, get_field, set_field);
+        Property<T2>::link_two_way_to_model_data(common.get(), std::move(getter),
+                                                 std::move(setter));
     }
 
     /// Internal (private) constructor used by link_two_way

--- a/api/cpp/include/private/slint_properties.h
+++ b/api/cpp/include/private/slint_properties.h
@@ -288,67 +288,46 @@ struct Property
     {
         struct DriverSlot
         {
-            /// The struct property's own binding (an owned Rust
-            /// `BindingHolder`), if any.
-            void *holder = nullptr;
-            /// Seed value for evaluating the binding outside of the struct
-            /// property's own storage.
-            T cache {};
-            /// Number of nested `evaluate_holder` frames; while non-zero,
-            /// holders are parked in `pending_drops` instead of deleted (a
-            /// projection evaluates the binding without the struct
-            /// property's lock, so a write-back could otherwise free the
-            /// binding while it is executing).
-            int evaluation_depth = 0;
-            std::vector<void *> pending_drops;
+            /// The struct property's own value-producing binding is
+            /// installed on this dedicated property: its dirty flag
+            /// memoizes the evaluation (the binding runs at most once per
+            /// change of its inputs, no matter how many commons and
+            /// wrappers read it) and the dependency graph (commons/wrapper
+            /// -> slot property -> the binding's inputs) replaces manual
+            /// dirty forwarding.
+            Property<T> property;
 
-            void dispose(void *binding)
+            explicit DriverSlot(const T &seed) : property(seed) { }
+
+            bool has_holder() const
             {
-                if (evaluation_depth > 0) {
-                    pending_drops.push_back(binding);
-                } else {
-                    cbindgen_private::slint_property_delete_binding(binding);
-                }
+                return (reinterpret_cast<uintptr_t>(property.inner._0) & 0b10) != 0;
             }
+            /// Drop the real binding, if any. Panics ("Recursion detected")
+            /// when the real binding is currently executing (a binding
+            /// writing back to its own struct property).
             void clear()
             {
-                if (auto *binding = std::exchange(holder, static_cast<void *>(nullptr))) {
-                    dispose(binding);
-                }
+                cbindgen_private::slint_property_remove_binding(&property.inner);
             }
-            /// Evaluate the current holder into `value`, keeping it alive
-            /// until the evaluation returns even if it is cleared or
-            /// replaced while executing. Returns false when the slot is
-            /// empty.
-            bool evaluate_holder(T *value)
-            {
-                auto *binding = holder;
-                if (!binding) {
-                    return false;
-                }
-                evaluation_depth++;
-                cbindgen_private::slint_property_evaluate_binding(binding, value);
-                if (--evaluation_depth == 0) {
-                    while (!pending_drops.empty()) {
-                        auto *pending = pending_drops.back();
-                        pending_drops.pop_back();
-                        cbindgen_private::slint_property_delete_binding(pending);
-                    }
-                }
-                return true;
-            }
-            ~DriverSlot()
+            /// Install `holder` (an owned Rust `BindingHolder`) as the slot
+            /// property's binding, dropping the previous one.
+            void install(void *holder)
             {
                 clear();
-                while (!pending_drops.empty()) {
-                    auto *pending = pending_drops.back();
-                    pending_drops.pop_back();
-                    cbindgen_private::slint_property_delete_binding(pending);
-                }
+                cbindgen_private::slint_property_set_binding_internal(&property.inner, holder);
+                // A stolen (second-hand) holder may have been evaluated in
+                // its old home with a clean dirty flag and wiped dependency
+                // registrations; without this it would never re-evaluate
+                // here.
+                cbindgen_private::slint_property_mark_binding_and_dependencies_dirty(
+                        &property.inner);
             }
         };
 
-        std::shared_ptr<DriverSlot> slot = std::make_shared<DriverSlot>();
+        std::shared_ptr<DriverSlot> slot;
+
+        explicit StructMemberBindings(const T &seed) : slot(std::make_shared<DriverSlot>(seed)) { }
 
         struct Mapping
         {
@@ -377,18 +356,20 @@ struct Property
                     &prop->inner, cpp_struct_member_bindings_kind)) {
             return reinterpret_cast<StructMemberBindings *>(user_data);
         }
-        auto *wrapper = new StructMemberBindings();
-        wrapper->slot->cache = prop->value;
+        auto *wrapper = new StructMemberBindings(prop->value);
         if (void *old = cbindgen_private::slint_property_detach_binding(&prop->inner)) {
-            wrapper->slot->holder = old;
+            wrapper->slot->install(old);
         }
         cbindgen_private::slint_property_set_binding_with_kind(
                 &prop->inner,
                 [](void *user_data, void *value) {
                     auto *self = reinterpret_cast<StructMemberBindings *>(user_data);
                     T &v = *reinterpret_cast<T *>(value);
-                    if (self->slot->evaluate_holder(&v)) {
-                        self->slot->cache = v;
+                    // Only read the slot property while it carries the real
+                    // binding: when binding-less its stored value is stale
+                    // and would clobber the struct's own stored value.
+                    if (self->slot->has_holder()) {
+                        v = self->slot->property.get();
                     }
                     for (auto &mapping : self->mappings) {
                         mapping.apply_from_common(v);
@@ -419,9 +400,7 @@ struct Property
                     // was evaluated while installed elsewhere (mirrors the
                     // Rust StructMemberBindings::intercept_set_binding)
                     cbindgen_private::slint_property_reset_binding_dependencies(new_binding);
-                    if (auto *old = std::exchange(self->slot->holder, new_binding)) {
-                        self->slot->dispose(old);
-                    }
+                    self->slot->install(new_binding);
                     for (auto &mapping : self->mappings) {
                         mapping.install_projection(self->slot);
                     }
@@ -474,14 +453,18 @@ struct Property
                         &common->inner,
                         [](void *user_data, void *value) {
                             auto *self = reinterpret_cast<Projection *>(user_data);
-                            T struct_value = self->slot->cache;
-                            if (!self->slot->evaluate_holder(&struct_value)) {
+                            if (!self->slot->has_holder()) {
                                 // the driver was dropped: keep the common's
-                                // current value
+                                // current value (a C++ binding cannot remove
+                                // itself; the projection stays installed but
+                                // inert and is replaced on the next install)
                                 return;
                             }
-                            *reinterpret_cast<T2 *>(value) = self->get_field(struct_value);
-                            self->slot->cache = std::move(struct_value);
+                            // reading the slot property registers this
+                            // projection as its dependent and memoizes the
+                            // real binding behind its dirty flag
+                            *reinterpret_cast<T2 *>(value) =
+                                    self->get_field(self->slot->property.get());
                         },
                         new Projection { slot, get_field },
                         [](void *user_data) { delete reinterpret_cast<Projection *>(user_data); },
@@ -490,7 +473,7 @@ struct Property
             common,
         };
         // A pre-existing binding must also drive this field's class.
-        if (wrapper->slot->holder) {
+        if (wrapper->slot->has_holder()) {
             mapping.install_projection(wrapper->slot);
         }
         bool replaced = false;

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -530,12 +530,12 @@ public:
     LogicalPosition absolute_position() const
     {
         if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            cbindgen_private::LogicalRect rect =
-                    item->item_tree.vtable()->item_geometry(item->item_tree.borrow(), item->index);
+            // `slint_item_absolute_position` already returns the element's own absolute
+            // position (it maps the element's geometry origin through the ancestor transforms).
             cbindgen_private::LogicalPoint abs =
                     slint::cbindgen_private::slint_item_absolute_position(&item->item_tree,
                                                                           item->index);
-            return LogicalPosition({ abs.x + rect.x, abs.y + rect.y });
+            return LogicalPosition({ abs.x, abs.y });
         }
         return LogicalPosition({ 0, 0 });
     }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1909,7 +1909,8 @@ impl BindingExpression {
     }
 
     /// Merge the other into this one. Normally, &self is kept intact (has priority)
-    /// unless the expression is invalid, in which case the other one is taken.
+    /// unless the expression is invalid or a synthetic debug hook, in which case the
+    /// other one is taken.
     ///
     /// Also the animation is taken if the other don't have one, and the two ways binding
     /// are taken into account.
@@ -1921,18 +1922,46 @@ impl BindingExpression {
         }
         let has_binding = self.has_binding();
         self.two_way_bindings.extend_from_slice(&other.two_way_bindings);
-        if !has_binding {
-            self.priority = other.priority;
-            self.expression = other.expression.clone();
-            true
-        } else {
-            false
+        if has_binding {
+            return false;
         }
+        // A synthetic debug hook is equivalent to "no binding", but the hook wrapper (and
+        // its id) must survive the merge so the property stays live-editable on this
+        // element: upgrade the hook in place with the other side's real expression.
+        if let Expression::DebugHook { expression, synthetic, .. } = &mut self.expression {
+            debug_assert!(*synthetic, "has_binding() returned false for a non-synthetic hook");
+            if !matches!(other.expression, Expression::Invalid)
+                && !other.expression.is_synthetic_debug_hook()
+            {
+                *expression = Box::new(other.expression.clone());
+                *synthetic = false;
+                self.priority = other.priority;
+                return true;
+            }
+            if self.two_way_bindings.is_empty() {
+                // Nothing real to adopt from the other side: keep the synthetic placeholder.
+                return false;
+            }
+            // Two-way bindings now drive this property. The synthetic default must not
+            // become the two-way's initial value, so the hook is dropped (the property is
+            // then edited through the two-way target instead).
+            self.expression = Expression::Invalid;
+            self.priority = other.priority;
+            return true;
+        }
+        self.priority = other.priority;
+        self.expression = other.expression.clone();
+        true
     }
 
     /// returns false if there is no expression or two way binding
+    ///
+    /// A synthetic debug hook (a materialized placeholder for an unbound property) counts
+    /// as "no expression".
     pub fn has_binding(&self) -> bool {
-        !matches!(self.expression, Expression::Invalid) || !self.two_way_bindings.is_empty()
+        (!matches!(self.expression, Expression::Invalid)
+            && !self.expression.is_synthetic_debug_hook())
+            || !self.two_way_bindings.is_empty()
     }
 }
 

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1789,19 +1789,26 @@ pub enum TwoWayBinding {
         /// If property is a struct, this is the fields.
         /// So if you have `foo <=> element.property.baz.xyz`, then `field_access` is `vec!["baz", "xyz"]`
         field_access: Vec<SmolStr>,
+        /// Field path applied to the property *holding* this two-way
+        /// binding. Non-empty only for links the compiler decomposed
+        /// because their two-way class contains both whole-struct and
+        /// struct-field links (see the `decompose_two_way_links` pass).
+        field_access1: Vec<SmolStr>,
     },
     ModelData {
         /// The model being linked
         repeated_element: ElementWeak,
         /// same as `Self::Property::field_access`
         field_access: Vec<SmolStr>,
+        /// same as `Self::Property::field_access1`
+        field_access1: Vec<SmolStr>,
     },
 }
 impl TwoWayBinding {
     pub fn ty(&self) -> Type {
         let (mut ty, field_access) = match self {
-            Self::Property { property, field_access } => (property.ty(), field_access),
-            Self::ModelData { repeated_element, field_access } => {
+            Self::Property { property, field_access, .. } => (property.ty(), field_access),
+            Self::ModelData { repeated_element, field_access, .. } => {
                 let ty =
                     Expression::RepeaterModelReference { element: repeated_element.clone() }.ty();
                 (ty, field_access)
@@ -1834,7 +1841,7 @@ impl TwoWayBinding {
 
 impl From<NamedReference> for TwoWayBinding {
     fn from(nr: NamedReference) -> Self {
-        Self::Property { property: nr, field_access: Vec::new() }
+        Self::Property { property: nr, field_access: Vec::new(), field_access1: Vec::new() }
     }
 }
 

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -907,6 +907,9 @@ pub enum Expression {
     DebugHook {
         expression: Box<Expression>,
         id: SmolStr,
+        /// True if this hook was materialized for a property that had no binding in the source.
+        /// Passes should treat a synthetic hook as "no binding" — the same as `Expression::Invalid`.
+        synthetic: bool,
     },
 
     EmptyComponentFactory,
@@ -1750,6 +1753,12 @@ impl Expression {
             _ => self,
         }
     }
+
+    /// Returns true if this is a synthetic debug hook — i.e. a hook materialized for a property
+    /// that had no binding in the source. Passes should treat this like `Expression::Invalid`.
+    pub fn is_synthetic_debug_hook(&self) -> bool {
+        matches!(self, Expression::DebugHook { synthetic: true, .. })
+    }
 }
 
 fn model_inner_type(model: &Expression) -> Type {
@@ -2210,9 +2219,12 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
             write!(f, ")")
         }
         Expression::EmptyComponentFactory => write!(f, "<empty-component-factory>"),
-        Expression::DebugHook { expression, id } => {
+        Expression::DebugHook { expression, id, synthetic } => {
             write!(f, "debug-hook(")?;
             pretty_print(f, expression)?;
+            if *synthetic {
+                write!(f, " SYNTHETIC")?;
+            }
             write!(f, "\"{id}\")")
         }
     }

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -115,7 +115,7 @@ pub fn generate(
             )); // Perhaps byte code in the future?
         }
         OutputFormat::Llr => {
-            let root = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+            let root = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, false);
             let mut output = String::new();
             crate::llr::pretty_print::pretty_print(&root, &mut output).unwrap();
             write!(destination, "{output}")?;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -635,13 +635,17 @@ fn lower_field_access_chain(
 }
 
 /// Emit a `link_two_way_to_model_data` call wiring `p1` to a row of the
-/// model described by `info`, optionally through a struct `field_access`.
+/// model described by `info`, optionally through a struct `field_access` —
+/// or, for a compiler-decomposed cell link (`twb.field_access1` non-empty),
+/// a `link_two_way_member_to_model_data` call wiring the field of `p1` at
+/// `field_access1` to the row field at `field_access`.
 fn generate_model_two_way_binding(
     ctx: &EvaluationContext,
     info: &llr::ResolvedModelTwoWayBinding,
     p1: &str,
-    field_access: &[SmolStr],
+    twb: &llr::TwoWayBinding,
 ) -> String {
+    let field_access = &twb.field_access;
     let body_sc = &ctx.compilation_unit.sub_components[info.body_sub_component];
     let data_prop_name = field_name(&body_sc.properties[info.data_prop].name);
     let index_prop_name = field_name(&body_sc.properties[info.index_prop].name);
@@ -676,15 +680,16 @@ fn generate_model_two_way_binding(
     // Capture a weak pointer instead of a raw `self` so the getter and
     // setter stay safe when the repeater instance is destroyed while a
     // forwarded binding on a shared common property still references it.
-    format!(
-        "slint::private_api::Property<{cpp_ty}>::link_two_way_to_model_data(&{p1}, \
-         [weak = self->self_weak]() -> std::optional<{cpp_ty}> {{ \
+    let getter = format!(
+        "[weak = self->self_weak]() -> std::optional<{cpp_ty}> {{ \
             auto rc = weak.lock(); \
             if (!rc) return std::nullopt; \
             auto self = reinterpret_cast<const {self_type}*>((*rc).borrow().instance); \
             {body_setup}return {getter_expr}; \
-         }}, \
-         [weak = self->self_weak](const {cpp_ty} &value) {{ \
+         }}"
+    );
+    let setter = format!(
+        "[weak = self->self_weak](const {cpp_ty} &value) {{ \
             auto rc = weak.lock(); \
             if (!rc) return; \
             auto self = reinterpret_cast<const {self_type}*>((*rc).borrow().instance); \
@@ -695,8 +700,24 @@ fn generate_model_two_way_binding(
                 (*parent_opt)->repeater_{repeater_index}.model_set_row_data(\
                     static_cast<size_t>({body}->{index_prop_name}.get()), data); \
             }} \
-         }});"
-    )
+         }}"
+    );
+
+    if twb.field_access1.is_empty() {
+        format!(
+            "slint::private_api::Property<{cpp_ty}>::link_two_way_to_model_data(&{p1}, {getter}, {setter});"
+        )
+    } else {
+        let prop1_ty = ctx.relative_property_ty(&twb.prop1, 0);
+        let struct_cpp_ty = prop1_ty.cpp_type().unwrap();
+        let (access1, _) = lower_field_access_chain("x".into(), prop1_ty, &twb.field_access1);
+        let field_key1 = twb.field_access1.join(".");
+        format!(
+            "slint::private_api::Property<{struct_cpp_ty}>::link_two_way_member_to_model_data<{cpp_ty}>(&{p1}, \"{field_key1}\", \
+             [](const auto &x){{ return {access1}; }}, [](auto &x, const auto &v){{ {access1} = v; }}, \
+             {getter}, {setter});"
+        )
+    }
 }
 
 fn handle_property_init(
@@ -794,7 +815,7 @@ pub fn generate(
         embed_resource(er, resource_id, &mut file.resources);
     }
 
-    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, false);
+    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, true);
 
     #[cfg(feature = "bundle-translations")]
     if let Some(translations) = &llr.translations {
@@ -2357,23 +2378,56 @@ fn generate_sub_component(
     for twb in &component.two_way_bindings {
         let p1 = access_local_member(&twb.prop1, &ctx);
         if let Some(info) = twb.resolve_model(&ctx) {
-            init.push(generate_model_two_way_binding(&ctx, &info, &p1, &twb.field_access));
-        } else if twb.field_access.is_empty() {
-            let ty = ctx.relative_property_ty(&twb.prop1, 0).cpp_type().unwrap();
-            init.push(
-                access_member(&twb.prop2, &ctx).then(|p2| {
-                    format!("slint::private_api::Property<{ty}>::link_two_way(&{p1}, &{p2})",)
-                }) + ";",
-            );
+            init.push(generate_model_two_way_binding(&ctx, &info, &p1, twb));
         } else {
-            let prop2_ty = ctx.property_ty(&twb.prop2);
-            let cpp_ty = prop2_ty.cpp_type().unwrap();
-            let (access, _) = lower_field_access_chain("x".into(), prop2_ty, &twb.field_access);
-            init.push(
-                access_member(&twb.prop2, &ctx).then(|p2|
-                    format!("slint::private_api::Property<{cpp_ty}>::link_two_way_with_map(&{p2}, &{p1}, [](const auto &x){{ return {access}; }}, [](auto &x, const auto &v){{ {access} = v; }})")
-                ) + ";",
-            );
+            match (twb.field_access.is_empty(), twb.field_access1.is_empty()) {
+                (true, true) => {
+                    let ty = ctx.relative_property_ty(&twb.prop1, 0).cpp_type().unwrap();
+                    init.push(
+                        access_member(&twb.prop2, &ctx).then(|p2| {
+                            format!(
+                                "slint::private_api::Property<{ty}>::link_two_way(&{p1}, &{p2})",
+                            )
+                        }) + ";",
+                    );
+                }
+                (false, true) => {
+                    // `prop1 <=> prop2.field_access`: prop2 is the struct
+                    let prop2_ty = ctx.property_ty(&twb.prop2);
+                    let cpp_ty = prop2_ty.cpp_type().unwrap();
+                    let (access, _) =
+                        lower_field_access_chain("x".into(), prop2_ty, &twb.field_access);
+                    let field_key = twb.field_access.join(".");
+                    init.push(
+                        access_member(&twb.prop2, &ctx).then(|p2|
+                            format!("slint::private_api::Property<{cpp_ty}>::link_two_way_to_member(&{p2}, &{p1}, \"{field_key}\", [](const auto &x){{ return {access}; }}, [](auto &x, const auto &v){{ {access} = v; }})")
+                        ) + ";",
+                    );
+                }
+                (false, false) => {
+                    // a compiler-decomposed cell link:
+                    // `prop1.field_access1 <=> prop2.field_access`
+                    let prop1_ty = ctx.relative_property_ty(&twb.prop1, 0);
+                    let prop2_ty = ctx.property_ty(&twb.prop2);
+                    let ty_a = prop1_ty.cpp_type().unwrap();
+                    let ty_b = prop2_ty.cpp_type().unwrap();
+                    let (access1, cell_ty) =
+                        lower_field_access_chain("x".into(), prop1_ty, &twb.field_access1);
+                    let (access2, _) =
+                        lower_field_access_chain("x".into(), prop2_ty, &twb.field_access);
+                    let cell_cpp_ty = cell_ty.cpp_type().unwrap();
+                    let field_key1 = twb.field_access1.join(".");
+                    let field_key2 = twb.field_access.join(".");
+                    init.push(
+                        access_member(&twb.prop2, &ctx).then(|p2|
+                            format!("slint::private_api::Property<{ty_a}>::link_two_way_members<{cell_cpp_ty}, {ty_b}>(&{p1}, \"{field_key1}\", [](const auto &x){{ return {access1}; }}, [](auto &x, const auto &v){{ {access1} = v; }}, &{p2}, \"{field_key2}\", [](const auto &x){{ return {access2}; }}, [](auto &x, const auto &v){{ {access2} = v; }})")
+                        ) + ";",
+                    );
+                }
+                (true, false) => {
+                    unreachable!("decomposed two-way links always have a path on both sides")
+                }
+            }
         }
     }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -794,7 +794,7 @@ pub fn generate(
         embed_resource(er, resource_id, &mut file.resources);
     }
 
-    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, false);
 
     #[cfg(feature = "bundle-translations")]
     if let Some(translations) = &llr.translations {

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -21,7 +21,7 @@ pub fn generate(
 
     generate_value_conversions(&mut file, &doc.used_types.borrow().structs_and_enums);
 
-    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, false);
 
     let main_file = doc
         .node

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -21,7 +21,7 @@ pub fn generate(
 
     generate_value_conversions(&mut file, &doc.used_types.borrow().structs_and_enums);
 
-    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, false);
+    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, true);
 
     let main_file = doc
         .node

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -390,7 +390,7 @@ pub fn generate_py_module(
         }
     }
 
-    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, false);
 
     let globals = llr.globals.iter().filter(|glob| glob.exported && glob.must_generate());
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -4309,7 +4309,7 @@ fn compile_builtin_function_call(
             if let [Expression::PropertyReference(pr)] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 quote!(
-                    sp::logical_position_to_api((*#item_rc).map_to_window(::core::default::Default::default()))
+                    sp::logical_position_to_api((*#item_rc).map_to_window((*#item_rc).geometry().origin))
                 )
             } else {
                 panic!("internal error: invalid args to MapPointToWindow {arguments:?}")

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1504,7 +1504,7 @@ fn generate_sub_component(
                             set_primitive_property_value(&ty, quote!(s #access .clone()));
                         let to_struct_value =
                             primitive_value_from_property_value(&ty, quote!((*v).clone()));
-                        quote!(sp::Property::link_two_way_to_member(#p2, #p1, #field_key, |s| #to_property_value, |s, v| s #access = #to_struct_value))
+                        quote!(sp::Property::link_two_way_to_member(#p2, #p1, #field_key, |s| #to_property_value, |s, v| s #access = #to_struct_value, false))
                     }
                     (false, false) => {
                         // a compiler-decomposed cell link:

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -811,26 +811,17 @@ fn generate_model_two_way_binding(
 
     // The leaf field type may differ from the property type (e.g. struct
     // field `f32` vs property `LogicalLength`); apply the usual conversions.
-    // Cell links (`field_access1` non-empty) connect two struct fields of
-    // the same type, so no conversion applies there.
+    // Cell links (`field_access1` non-empty) use the property representation
+    // for their shared common too, so the same conversions apply.
     let (access_model, getter_value) = if field_access.is_empty() {
         (quote!(let data = value.clone();), quote!(#data_f.apply_pin(x.as_pin_ref()).get()))
     } else {
         let (access, ty) = lower_field_access_chain(info.data_prop_ty, field_access);
-        let (to_struct_value, to_property_value) = if twb.field_access1.is_empty() {
-            (
-                primitive_value_from_property_value(&ty, quote!(value.clone())),
-                set_primitive_property_value(
-                    &ty,
-                    quote!(#data_f.apply_pin(x.as_pin_ref()).get() #access .clone()),
-                ),
-            )
-        } else {
-            (
-                quote!(value.clone()),
-                quote!(#data_f.apply_pin(x.as_pin_ref()).get() #access .clone()),
-            )
-        };
+        let to_struct_value = primitive_value_from_property_value(&ty, quote!(value.clone()));
+        let to_property_value = set_primitive_property_value(
+            &ty,
+            quote!(#data_f.apply_pin(x.as_pin_ref()).get() #access .clone()),
+        );
         (
             quote! {
                 let mut data = #data_f.apply_pin(x.as_pin_ref()).get();
@@ -855,11 +846,13 @@ fn generate_model_two_way_binding(
         quote! { sp::Property::link_two_way_to_model_data(#p1, #item_tree_weak, #getter, #setter) }
     } else {
         let prop1_ref = llr::MemberReference::from(twb.prop1.clone());
-        let (access1, _) =
+        let (access1, ty1) =
             lower_field_access_chain(ctx.property_ty(&prop1_ref), &twb.field_access1);
         let field_key1 = twb.field_access1.join(".");
+        let get1 = set_primitive_property_value(&ty1, quote!(s #access1 .clone()));
+        let set1 = primitive_value_from_property_value(&ty1, quote!((*v).clone()));
         quote! { sp::Property::link_two_way_member_to_model_data(#p1, #field_key1,
-            |s| s #access1 .clone(), |s, v| s #access1 = (*v).clone(),
+            |s| #get1, |s, v| s #access1 = #set1,
             #item_tree_weak, #getter, #setter
         )}
     }
@@ -1515,22 +1508,30 @@ fn generate_sub_component(
                     }
                     (false, false) => {
                         // a compiler-decomposed cell link:
-                        // `prop1.field_access1 <=> prop2.field_access`
-                        // (both cells have the same type, no conversions)
+                        // `prop1.field_access1 <=> prop2.field_access`.
+                        // Both cells have the same type; the shared common
+                        // uses the *property* representation of that type
+                        // (e.g. LogicalLength for a `length` field stored as
+                        // Coord), so it is the same `Property<T2>` type a
+                        // member link to the same field would create.
                         let prop1_ref = llr::MemberReference::from(twb.prop1.clone());
-                        let (access1, _) = lower_field_access_chain(
+                        let (access1, ty1) = lower_field_access_chain(
                             ctx.property_ty(&prop1_ref),
                             &twb.field_access1,
                         );
-                        let (access2, _) = lower_field_access_chain(
+                        let (access2, ty2) = lower_field_access_chain(
                             ctx.property_ty(&twb.prop2),
                             &twb.field_access,
                         );
                         let field_key1 = twb.field_access1.join(".");
                         let field_key2 = twb.field_access.join(".");
+                        let get1 = set_primitive_property_value(&ty1, quote!(s #access1 .clone()));
+                        let set1 = primitive_value_from_property_value(&ty1, quote!((*v).clone()));
+                        let get2 = set_primitive_property_value(&ty2, quote!(s #access2 .clone()));
+                        let set2 = primitive_value_from_property_value(&ty2, quote!((*v).clone()));
                         quote!(sp::Property::link_two_way_members(
-                            #p1, #field_key1, |s| s #access1 .clone(), |s, v| s #access1 = (*v).clone(),
-                            #p2, #field_key2, |s| s #access2 .clone(), |s, v| s #access2 = (*v).clone()
+                            #p1, #field_key1, |s| #get1, |s, v| s #access1 = #set1,
+                            #p2, #field_key2, |s| #get2, |s, v| s #access2 = #set2
                         ))
                     }
                     (true, false) => {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -205,7 +205,7 @@ pub fn generate(
     let (structs_and_enums_ids, inner_module) =
         generate_types(&doc.used_types.borrow().structs_and_enums);
 
-    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, true);
 
     if llr.public_components.is_empty() {
         return Ok(Default::default());
@@ -776,13 +776,17 @@ fn lower_field_access_chain(root_ty: &Type, field_access: &[SmolStr]) -> (TokenS
 }
 
 /// Emit a `link_two_way_to_model_data` call wiring `p1` to a row of the
-/// model described by `info`, optionally through a struct `field_access`.
+/// model described by `info`, optionally through a struct `field_access` —
+/// or, for a compiler-decomposed cell link (`twb.field_access1` non-empty),
+/// a `link_two_way_member_to_model_data` call wiring the field of `p1` at
+/// `field_access1` to the row field at `field_access`.
 fn generate_model_two_way_binding(
     ctx: &EvaluationContext,
     info: &llr::ResolvedModelTwoWayBinding,
     p1: &TokenStream,
-    field_access: &[SmolStr],
+    twb: &llr::TwoWayBinding,
 ) -> TokenStream {
+    let field_access = &twb.field_access;
     let body_sc = &ctx.compilation_unit.sub_components[info.body_sub_component];
     let parent_sc = &ctx.compilation_unit.sub_components[info.parent_sub_component];
     let body_id = self::inner_component_id(body_sc);
@@ -807,15 +811,26 @@ fn generate_model_two_way_binding(
 
     // The leaf field type may differ from the property type (e.g. struct
     // field `f32` vs property `LogicalLength`); apply the usual conversions.
+    // Cell links (`field_access1` non-empty) connect two struct fields of
+    // the same type, so no conversion applies there.
     let (access_model, getter_value) = if field_access.is_empty() {
         (quote!(let data = value.clone();), quote!(#data_f.apply_pin(x.as_pin_ref()).get()))
     } else {
         let (access, ty) = lower_field_access_chain(info.data_prop_ty, field_access);
-        let to_struct_value = primitive_value_from_property_value(&ty, quote!(value.clone()));
-        let to_property_value = set_primitive_property_value(
-            &ty,
-            quote!(#data_f.apply_pin(x.as_pin_ref()).get() #access .clone()),
-        );
+        let (to_struct_value, to_property_value) = if twb.field_access1.is_empty() {
+            (
+                primitive_value_from_property_value(&ty, quote!(value.clone())),
+                set_primitive_property_value(
+                    &ty,
+                    quote!(#data_f.apply_pin(x.as_pin_ref()).get() #access .clone()),
+                ),
+            )
+        } else {
+            (
+                quote!(value.clone()),
+                quote!(#data_f.apply_pin(x.as_pin_ref()).get() #access .clone()),
+            )
+        };
         (
             quote! {
                 let mut data = #data_f.apply_pin(x.as_pin_ref()).get();
@@ -825,18 +840,29 @@ fn generate_model_two_way_binding(
         )
     };
 
-    quote! { sp::Property::link_two_way_to_model_data(#p1, #item_tree_weak,
-        |item_tree_weak| item_tree_weak.upgrade().map(|x| #getter_value),
-        |item_tree_weak, value| {
-            if let Some(x) = item_tree_weak.upgrade() {
-                if let Some(parent) = x.parent.upgrade() {
-                    let index = #index_f.apply_pin(x.as_pin_ref()).get();
-                    #access_model
-                    #repeater.apply_pin(parent.as_pin_ref()).model_set_row_data(index as usize, data);
-                }
+    let getter = quote!(|item_tree_weak| item_tree_weak.upgrade().map(|x| #getter_value));
+    let setter = quote!(|item_tree_weak, value| {
+        if let Some(x) = item_tree_weak.upgrade() {
+            if let Some(parent) = x.parent.upgrade() {
+                let index = #index_f.apply_pin(x.as_pin_ref()).get();
+                #access_model
+                #repeater.apply_pin(parent.as_pin_ref()).model_set_row_data(index as usize, data);
             }
         }
-    )}
+    });
+
+    if twb.field_access1.is_empty() {
+        quote! { sp::Property::link_two_way_to_model_data(#p1, #item_tree_weak, #getter, #setter) }
+    } else {
+        let prop1_ref = llr::MemberReference::from(twb.prop1.clone());
+        let (access1, _) =
+            lower_field_access_chain(ctx.property_ty(&prop1_ref), &twb.field_access1);
+        let field_key1 = twb.field_access1.join(".");
+        quote! { sp::Property::link_two_way_member_to_model_data(#p1, #field_key1,
+            |s| s #access1 .clone(), |s, v| s #access1 = (*v).clone(),
+            #item_tree_weak, #getter, #setter
+        )}
+    }
 }
 
 fn handle_property_init(
@@ -1468,20 +1494,48 @@ fn generate_sub_component(
     for twb in &component.two_way_bindings {
         let p1 = access_local_member(&twb.prop1, &ctx);
         let r = if let Some(info) = twb.resolve_model(&ctx) {
-            generate_model_two_way_binding(&ctx, &info, &p1, &twb.field_access)
+            generate_model_two_way_binding(&ctx, &info, &p1, twb)
         } else {
             let p2 = access_member(&twb.prop2, &ctx);
             p2.then(|p2| {
-                if twb.field_access.is_empty() {
-                    quote!(sp::Property::link_two_way(#p1, #p2))
-                } else {
-                    let (access, ty) =
-                        lower_field_access_chain(ctx.property_ty(&twb.prop2), &twb.field_access);
-                    let to_property_value =
-                        set_primitive_property_value(&ty, quote!(s #access .clone()));
-                    let to_struct_value =
-                        primitive_value_from_property_value(&ty, quote!((*v).clone()));
-                    quote!(sp::Property::link_two_way_with_map(#p2, #p1, |s| #to_property_value, |s, v| s #access = #to_struct_value))
+                match (twb.field_access.is_empty(), twb.field_access1.is_empty()) {
+                    (true, true) => quote!(sp::Property::link_two_way(#p1, #p2)),
+                    (false, true) => {
+                        // `prop1 <=> prop2.field_access`: prop2 is the struct
+                        let (access, ty) = lower_field_access_chain(
+                            ctx.property_ty(&twb.prop2),
+                            &twb.field_access,
+                        );
+                        let field_key = twb.field_access.join(".");
+                        let to_property_value =
+                            set_primitive_property_value(&ty, quote!(s #access .clone()));
+                        let to_struct_value =
+                            primitive_value_from_property_value(&ty, quote!((*v).clone()));
+                        quote!(sp::Property::link_two_way_to_member(#p2, #p1, #field_key, |s| #to_property_value, |s, v| s #access = #to_struct_value))
+                    }
+                    (false, false) => {
+                        // a compiler-decomposed cell link:
+                        // `prop1.field_access1 <=> prop2.field_access`
+                        // (both cells have the same type, no conversions)
+                        let prop1_ref = llr::MemberReference::from(twb.prop1.clone());
+                        let (access1, _) = lower_field_access_chain(
+                            ctx.property_ty(&prop1_ref),
+                            &twb.field_access1,
+                        );
+                        let (access2, _) = lower_field_access_chain(
+                            ctx.property_ty(&twb.prop2),
+                            &twb.field_access,
+                        );
+                        let field_key1 = twb.field_access1.join(".");
+                        let field_key2 = twb.field_access.join(".");
+                        quote!(sp::Property::link_two_way_members(
+                            #p1, #field_key1, |s| s #access1 .clone(), |s, v| s #access1 = (*v).clone(),
+                            #p2, #field_key2, |s| s #access2 .clone(), |s, v| s #access2 = (*v).clone()
+                        ))
+                    }
+                    (true, false) => {
+                        unreachable!("decomposed two-way links always have a path on both sides")
+                    }
                 }
             })
         };

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -22,7 +22,7 @@ pub fn generate(
     let type_value_conversions =
         generate_value_conversions(&doc.used_types.borrow().structs_and_enums);
 
-    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config, true);
 
     if llr.public_components.is_empty() {
         return Ok(Default::default());

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -187,6 +187,14 @@ pub struct CompilerConfiguration {
     /// Generate debug hooks to inspect/override properties.
     pub debug_hooks: Option<std::hash::RandomState>,
 
+    /// Decompose whole-struct two-way links whose class also contains
+    /// struct-field links into per-field links, on the object tree (see the
+    /// `decompose_two_way_links` pass). Enabled for backends whose runtime
+    /// uses the narrow-common two-way machinery for struct members
+    /// (currently the interpreter; the Rust generator does the equivalent
+    /// decomposition when lowering to the LLR).
+    pub decompose_struct_two_way_links: bool,
+
     pub components_to_generate: ComponentSelection,
 
     /// The name of the library when compiling as a library.
@@ -240,6 +248,8 @@ impl CompilerConfiguration {
             Err(_) => output_format == OutputFormat::Interpreter,
         };
 
+        let decompose_struct_two_way_links = output_format == OutputFormat::Interpreter;
+
         let const_scale_factor = std::env::var("SLINT_SCALE_FACTOR")
             .ok()
             .and_then(|x| x.parse::<f32>().ok())
@@ -281,6 +291,7 @@ impl CompilerConfiguration {
             error_on_binding_loop_with_window_layout: false,
             debug_info,
             debug_hooks: None,
+            decompose_struct_two_way_links,
             components_to_generate: ComponentSelection::ExportedWindows,
             #[cfg(all(feature = "software-renderer", feature = "sdf-fonts"))]
             use_sdf_fonts: false,

--- a/internal/compiler/llr.rs
+++ b/internal/compiler/llr.rs
@@ -12,6 +12,7 @@ pub mod lower_expression;
 pub mod lower_layout_expression;
 pub mod lower_to_item_tree;
 pub mod pretty_print;
+pub mod two_way_cuts;
 
 /// The optimization passes over the LLR
 pub mod optim_passes {

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -243,6 +243,10 @@ pub struct TwoWayBinding {
     pub is_model: Option<PropertyIdx>,
     /// Field path applied to `prop2`, when `prop2` is a struct.
     pub field_access: Vec<SmolStr>,
+    /// Field path applied to `prop1`. Non-empty only for links the compiler
+    /// decomposed because their two-way class contains both whole-struct
+    /// and struct-field links (see [`crate::llr::two_way_cuts`]).
+    pub field_access1: Vec<SmolStr>,
 }
 
 /// Resolved view of a model two-way binding, used by code generators to

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -18,8 +18,12 @@ use typed_index_collections::TiVec;
 pub fn lower_to_item_tree(
     document: &crate::object_tree::Document,
     compiler_config: &CompilerConfiguration,
+    decompose_struct_two_way_links: bool,
 ) -> CompilationUnit {
     let mut state = LoweringState::default();
+    if decompose_struct_two_way_links {
+        state.member_cuts = Some(super::two_way_cuts::MemberCuts::analyze(document));
+    }
 
     #[cfg(feature = "bundle-translations")]
     {
@@ -198,6 +202,10 @@ pub struct LoweringState {
     global_properties: HashMap<NamedReference, MemberReference>,
     sub_components: TiVec<SubComponentIdx, LoweredSubComponent>,
     sub_component_mapping: HashMap<ByAddress<Rc<Component>>, SubComponentIdx>,
+    /// `Some` when whole-struct two-way links whose class also contains
+    /// struct-field links are decomposed into per-field links (only done
+    /// for backends whose runtime supports the decomposed form).
+    member_cuts: Option<super::two_way_cuts::MemberCuts>,
     #[cfg(feature = "bundle-translations")]
     pub translation_builder: Option<crate::translations::TranslationsBuilder>,
 }
@@ -481,29 +489,78 @@ fn lower_sub_component(
         }
 
         for tw in &binding.two_way_bindings {
-            sub_component.two_way_bindings.push(match tw {
+            match tw {
                 crate::expression_tree::TwoWayBinding::Property { property, field_access } => {
-                    TwoWayBinding {
-                        prop1: prop.local(),
-                        prop2: ctx.map_property_reference(property),
-                        field_access: field_access.clone(),
-                        is_model: None,
+                    let prop2 = ctx.map_property_reference(property);
+                    // Decompose the link into per-field cell links when its
+                    // two-way class mixes whole-struct and struct-field
+                    // links (see `two_way_cuts`).
+                    let cells = ctx
+                        .state
+                        .member_cuts
+                        .as_ref()
+                        .and_then(|cuts| cuts.decomposed_cells(&nr));
+                    match cells {
+                        None => sub_component.two_way_bindings.push(TwoWayBinding {
+                            prop1: prop.local(),
+                            prop2,
+                            field_access: field_access.clone(),
+                            field_access1: Vec::new(),
+                            is_model: None,
+                        }),
+                        Some(cells) => {
+                            for cell in cells {
+                                let mut cell_field_access = field_access.clone();
+                                cell_field_access.extend(cell.iter().cloned());
+                                sub_component.two_way_bindings.push(TwoWayBinding {
+                                    prop1: prop.local(),
+                                    prop2: prop2.clone(),
+                                    field_access: cell_field_access,
+                                    field_access1: cell,
+                                    is_model: None,
+                                });
+                            }
+                        }
                     }
                 }
                 crate::expression_tree::TwoWayBinding::ModelData {
                     repeated_element,
                     field_access,
-                } => TwoWayBinding {
-                    prop1: prop.local(),
-                    prop2: super::lower_expression::repeater_special_property(
+                } => {
+                    let prop2 = super::lower_expression::repeater_special_property(
                         repeated_element,
                         component,
                         PropertyIdx::REPEATER_DATA,
-                    ),
-                    field_access: field_access.clone(),
-                    is_model: Some(PropertyIdx::REPEATER_INDEX),
-                },
-            });
+                    );
+                    let cells = ctx
+                        .state
+                        .member_cuts
+                        .as_ref()
+                        .and_then(|cuts| cuts.decomposed_cells(&nr));
+                    match cells {
+                        None => sub_component.two_way_bindings.push(TwoWayBinding {
+                            prop1: prop.local(),
+                            prop2,
+                            field_access: field_access.clone(),
+                            field_access1: Vec::new(),
+                            is_model: Some(PropertyIdx::REPEATER_INDEX),
+                        }),
+                        Some(cells) => {
+                            for cell in cells {
+                                let mut cell_field_access = field_access.clone();
+                                cell_field_access.extend(cell.iter().cloned());
+                                sub_component.two_way_bindings.push(TwoWayBinding {
+                                    prop1: prop.local(),
+                                    prop2: prop2.clone(),
+                                    field_access: cell_field_access,
+                                    field_access1: cell,
+                                    is_model: Some(PropertyIdx::REPEATER_INDEX),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
         }
         if !matches!(binding.expression, tree_Expression::Invalid) {
             let expression =

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -490,8 +490,24 @@ fn lower_sub_component(
 
         for tw in &binding.two_way_bindings {
             match tw {
-                crate::expression_tree::TwoWayBinding::Property { property, field_access } => {
+                crate::expression_tree::TwoWayBinding::Property {
+                    property,
+                    field_access,
+                    field_access1,
+                } => {
                     let prop2 = ctx.map_property_reference(property);
+                    if !field_access1.is_empty() {
+                        // already decomposed by the decompose_two_way_links
+                        // pass on the object tree
+                        sub_component.two_way_bindings.push(TwoWayBinding {
+                            prop1: prop.local(),
+                            prop2,
+                            field_access: field_access.clone(),
+                            field_access1: field_access1.clone(),
+                            is_model: None,
+                        });
+                        continue;
+                    }
                     // Decompose the link into per-field cell links when its
                     // two-way class mixes whole-struct and struct-field
                     // links (see `two_way_cuts`).
@@ -526,12 +542,25 @@ fn lower_sub_component(
                 crate::expression_tree::TwoWayBinding::ModelData {
                     repeated_element,
                     field_access,
+                    field_access1,
                 } => {
                     let prop2 = super::lower_expression::repeater_special_property(
                         repeated_element,
                         component,
                         PropertyIdx::REPEATER_DATA,
                     );
+                    if !field_access1.is_empty() {
+                        // already decomposed by the decompose_two_way_links
+                        // pass on the object tree
+                        sub_component.two_way_bindings.push(TwoWayBinding {
+                            prop1: prop.local(),
+                            prop2,
+                            field_access: field_access.clone(),
+                            field_access1: field_access1.clone(),
+                            is_model: Some(PropertyIdx::REPEATER_INDEX),
+                        });
+                        continue;
+                    }
                     let cells = ctx
                         .state
                         .member_cuts

--- a/internal/compiler/llr/two_way_cuts.rs
+++ b/internal/compiler/llr/two_way_cuts.rs
@@ -1,0 +1,171 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Analysis of two-way binding classes that span both whole struct
+//! properties and struct *fields*.
+//!
+//! At runtime, a struct property whose fields participate in two-way binding
+//! classes wears a `StructMemberBindings` wrapper binding, while a property
+//! linked as a whole carries a plain `TwoWayBinding`. The two cannot coexist
+//! on one property, so every link that would install a plain two-way binding
+//! on a property that also needs the wrapper is decomposed into per-field
+//! ("cell") links at compile time. Classes without any member link keep the
+//! plain `link_two_way` — zero overhead in the common case.
+//!
+//! The analysis is a fixpoint over all two-way links of the program: a link
+//! `a <=> b.path` makes `a` (as a whole) and the field of `b` at `path` the
+//! same value forever, so a cell boundary ("cut") required on one side is
+//! required, suitably translated, on the other side as well. This also
+//! splits prefix-overlapping member links (`x <=> s.a` and `y <=> s.a.b`)
+//! into disjoint cells.
+//!
+//! Model-row two-way bindings (`TwoWayBinding::ModelData`) are not
+//! decomposed: they install a binding directly on the left-hand side
+//! property and do not participate in the wrapper machinery. Mixing a
+//! model-row link and a struct member link on one property is not supported
+//! (it was not supported by the previous wide-common machinery either).
+
+use crate::langtype::{ElementType, Type};
+use crate::namedreference::NamedReference;
+use crate::object_tree::Document;
+use smol_str::SmolStr;
+use std::collections::{HashMap, HashSet};
+
+/// Resolve a property reference on a component-instance element to the
+/// declaring component's root element, so that references to the same
+/// runtime property from inside and outside a component definition compare
+/// equal.
+pub fn canonical_property(reference: &NamedReference) -> NamedReference {
+    let mut element = reference.element();
+    loop {
+        let base = {
+            let borrowed = element.borrow();
+            if borrowed.property_declarations.contains_key(reference.name()) {
+                break;
+            }
+            match &borrowed.base_type {
+                ElementType::Component(component) => component.root_element.clone(),
+                _ => break,
+            }
+        };
+        element = base;
+    }
+    NamedReference::new(&element, reference.name().clone())
+}
+
+/// The set of field paths ("cuts") at which struct properties participate
+/// in two-way binding classes. See the module documentation.
+pub struct MemberCuts {
+    cuts: HashMap<NamedReference, HashSet<Vec<SmolStr>>>,
+}
+
+impl MemberCuts {
+    pub fn analyze(document: &Document) -> Self {
+        // (prop1, prop2, path2): `prop1 <=> prop2.path2` — the left-hand
+        // side of a two-way binding is always a whole property.
+        let mut links: Vec<(NamedReference, NamedReference, Vec<SmolStr>)> = Vec::new();
+        document.visit_all_used_components(|component| {
+            crate::object_tree::recurse_elem_including_sub_components(
+                component,
+                &(),
+                &mut |element, _| {
+                    for (name, binding) in &element.borrow().bindings {
+                        for twb in &binding.borrow().two_way_bindings {
+                            if let crate::expression_tree::TwoWayBinding::Property {
+                                property,
+                                field_access,
+                            } = twb
+                            {
+                                let prop1 = canonical_property(&NamedReference::new(
+                                    element,
+                                    name.clone(),
+                                ));
+                                let prop2 = canonical_property(property);
+                                links.push((prop1, prop2, field_access.clone()));
+                            }
+                        }
+                    }
+                },
+            )
+        });
+
+        let mut cuts: HashMap<NamedReference, HashSet<Vec<SmolStr>>> = HashMap::new();
+        for (_, prop2, path2) in &links {
+            if !path2.is_empty() {
+                cuts.entry(prop2.clone()).or_default().insert(path2.clone());
+            }
+        }
+
+        // Propagate the cuts through the links until a fixpoint is reached.
+        // This terminates: only valid (finitely many) field paths of each
+        // property's type are ever inserted, and the sets grow monotonically.
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (prop1, prop2, path2) in &links {
+                // A cut anywhere in prop1 lies at path2 + cut in prop2.
+                let prop1_cuts: Vec<Vec<SmolStr>> =
+                    cuts.get(prop1).map(|c| c.iter().cloned().collect()).unwrap_or_default();
+                for cut in prop1_cuts {
+                    let mut translated = path2.clone();
+                    translated.extend(cut);
+                    changed |= cuts.entry(prop2.clone()).or_default().insert(translated);
+                }
+                // A cut strictly below path2 in prop2 lies at the
+                // corresponding sub-path in prop1. (Cuts at or above path2
+                // do not constrain prop1.)
+                let deeper: Vec<Vec<SmolStr>> = cuts
+                    .get(prop2)
+                    .map(|c| {
+                        c.iter()
+                            .filter(|cut| cut.len() > path2.len() && cut.starts_with(path2))
+                            .map(|cut| cut[path2.len()..].to_vec())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                for sub_path in deeper {
+                    changed |= cuts.entry(prop1.clone()).or_default().insert(sub_path);
+                }
+            }
+        }
+        Self { cuts }
+    }
+
+    /// If the two-way link held by `prop1` must be decomposed, return the
+    /// cell partition of `prop1`'s type: the (non-empty, disjoint, covering)
+    /// field paths whose links replace the original one. `None` means the
+    /// link is kept as-is.
+    pub fn decomposed_cells(&self, prop1: &NamedReference) -> Option<Vec<Vec<SmolStr>>> {
+        let canonical = canonical_property(prop1);
+        let cuts = self.cuts.get(&canonical).filter(|c| !c.is_empty())?;
+        let mut cells = Vec::new();
+        cover(&canonical.ty(), cuts, &mut Vec::new(), &mut cells);
+        if cells.len() == 1 && cells[0].is_empty() { None } else { Some(cells) }
+    }
+}
+
+/// Compute the partition of `ty`'s field tree induced by `cuts`: recurse
+/// into every field as long as a cut lies strictly below the current path.
+fn cover(
+    ty: &Type,
+    cuts: &HashSet<Vec<SmolStr>>,
+    prefix: &mut Vec<SmolStr>,
+    out: &mut Vec<Vec<SmolStr>>,
+) {
+    let has_deeper_cut = cuts.iter().any(|cut| cut.len() > prefix.len() && cut.starts_with(prefix));
+    if !has_deeper_cut {
+        out.push(prefix.clone());
+        return;
+    }
+    let Type::Struct(s) = ty else {
+        // cuts always originate from field accesses on struct types
+        debug_assert!(false, "two-way binding cut below a non-struct type");
+        out.push(prefix.clone());
+        return;
+    };
+    for (field_name, field_type) in &s.fields {
+        prefix.push(field_name.clone());
+        cover(field_type, cuts, prefix, out);
+        prefix.pop();
+    }
+}

--- a/internal/compiler/llr/two_way_cuts.rs
+++ b/internal/compiler/llr/two_way_cuts.rs
@@ -61,9 +61,12 @@ pub struct MemberCuts {
 
 impl MemberCuts {
     pub fn analyze(document: &Document) -> Self {
-        // (prop1, prop2, path2): `prop1 <=> prop2.path2` — the left-hand
-        // side of a two-way binding is always a whole property.
-        let mut links: Vec<(NamedReference, NamedReference, Vec<SmolStr>)> = Vec::new();
+        // (prop1, path1, prop2, path2): `prop1.path1 <=> prop2.path2`.
+        // In source, the left-hand side of a two-way binding is always a
+        // whole property (`path1` empty); non-empty `path1` only occurs
+        // when the tree was already decomposed.
+        type Link = (NamedReference, Vec<SmolStr>, NamedReference, Vec<SmolStr>);
+        let mut links: Vec<Link> = Vec::new();
         document.visit_all_used_components(|component| {
             crate::object_tree::recurse_elem_including_sub_components(
                 component,
@@ -74,6 +77,7 @@ impl MemberCuts {
                             if let crate::expression_tree::TwoWayBinding::Property {
                                 property,
                                 field_access,
+                                field_access1,
                             } = twb
                             {
                                 let prop1 = canonical_property(&NamedReference::new(
@@ -81,7 +85,12 @@ impl MemberCuts {
                                     name.clone(),
                                 ));
                                 let prop2 = canonical_property(property);
-                                links.push((prop1, prop2, field_access.clone()));
+                                links.push((
+                                    prop1,
+                                    field_access1.clone(),
+                                    prop2,
+                                    field_access.clone(),
+                                ));
                             }
                         }
                     }
@@ -90,42 +99,53 @@ impl MemberCuts {
         });
 
         let mut cuts: HashMap<NamedReference, HashSet<Vec<SmolStr>>> = HashMap::new();
-        for (_, prop2, path2) in &links {
+        for (prop1, path1, prop2, path2) in &links {
             if !path2.is_empty() {
                 cuts.entry(prop2.clone()).or_default().insert(path2.clone());
             }
+            if !path1.is_empty() {
+                cuts.entry(prop1.clone()).or_default().insert(path1.clone());
+            }
         }
 
-        // Propagate the cuts through the links until a fixpoint is reached.
-        // This terminates: only valid (finitely many) field paths of each
-        // property's type are ever inserted, and the sets grow monotonically.
+        // Propagate the cuts through the links until a fixpoint is reached:
+        // a link makes the field of prop1 at path1 and the field of prop2
+        // at path2 the same value, so a cut strictly below one link anchor
+        // lies at the corresponding sub-path below the other. This
+        // terminates: only valid (finitely many) field paths of each
+        // property's type are ever inserted, and the sets grow
+        // monotonically.
+        let propagate = |cuts: &mut HashMap<NamedReference, HashSet<Vec<SmolStr>>>,
+                         from: &NamedReference,
+                         from_path: &[SmolStr],
+                         to: &NamedReference,
+                         to_path: &[SmolStr]|
+         -> bool {
+            let deeper: Vec<Vec<SmolStr>> = cuts
+                .get(from)
+                .map(|c| {
+                    c.iter()
+                        .filter(|cut| cut.len() > from_path.len() && cut.starts_with(from_path))
+                        .map(|cut| {
+                            let mut translated = to_path.to_vec();
+                            translated.extend(cut[from_path.len()..].iter().cloned());
+                            translated
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let mut changed = false;
+            for translated in deeper {
+                changed |= cuts.entry(to.clone()).or_default().insert(translated);
+            }
+            changed
+        };
         let mut changed = true;
         while changed {
             changed = false;
-            for (prop1, prop2, path2) in &links {
-                // A cut anywhere in prop1 lies at path2 + cut in prop2.
-                let prop1_cuts: Vec<Vec<SmolStr>> =
-                    cuts.get(prop1).map(|c| c.iter().cloned().collect()).unwrap_or_default();
-                for cut in prop1_cuts {
-                    let mut translated = path2.clone();
-                    translated.extend(cut);
-                    changed |= cuts.entry(prop2.clone()).or_default().insert(translated);
-                }
-                // A cut strictly below path2 in prop2 lies at the
-                // corresponding sub-path in prop1. (Cuts at or above path2
-                // do not constrain prop1.)
-                let deeper: Vec<Vec<SmolStr>> = cuts
-                    .get(prop2)
-                    .map(|c| {
-                        c.iter()
-                            .filter(|cut| cut.len() > path2.len() && cut.starts_with(path2))
-                            .map(|cut| cut[path2.len()..].to_vec())
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                for sub_path in deeper {
-                    changed |= cuts.entry(prop1.clone()).or_default().insert(sub_path);
-                }
+            for (prop1, path1, prop2, path2) in &links {
+                changed |= propagate(&mut cuts, prop1, path1, prop2, path2);
+                changed |= propagate(&mut cuts, prop2, path2, prop1, path1);
             }
         }
         Self { cuts }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2299,9 +2299,13 @@ impl Element {
     ///
     /// If `need_explicit` is true, then only consider binding set in the code, not the ones set
     /// by the compiler later.
+    ///
+    /// Synthetic debug hooks (materialized for unbound properties) are never considered set.
     pub fn is_binding_set(self: &Element, property_name: &str, need_explicit: bool) -> bool {
         if self.bindings.get(property_name).is_some_and(|b| {
-            b.borrow().has_binding() && (!need_explicit || b.borrow().priority > 0)
+            b.borrow().has_binding()
+                && !b.borrow().expression.is_synthetic_debug_hook()
+                && (!need_explicit || b.borrow().priority > 0)
         }) {
             true
         } else if let ElementType::Component(base) = &self.base_type {
@@ -2312,8 +2316,12 @@ impl Element {
     }
 
     /// Returns true if the property is set by a binding or an assignment expression
+    ///
+    /// Synthetic debug hooks (materialized for unbound properties) are not considered set.
     pub fn is_property_set(self: &Element, property_name: &str) -> bool {
-        self.bindings.contains_key(property_name)
+        self.bindings
+            .get(property_name)
+            .is_some_and(|b| !b.borrow().expression.is_synthetic_debug_hook())
             || self
                 .property_analysis
                 .borrow()
@@ -2323,9 +2331,13 @@ impl Element {
     }
 
     /// Set the property `property_name` of this Element only if it was not set.
-    /// the `expression_fn` will only be called if it isn't set
+    /// the `expression_fn` will only be called if it isn't set.
     ///
-    /// returns true if the binding was changed
+    /// If a synthetic debug hook exists for this property, the hook's inner expression is
+    /// replaced with the new value (keeping the wrapper and id) and the hook is marked
+    /// non-synthetic — so the property becomes live-editable at its real computed value.
+    ///
+    /// Returns true if the binding was changed.
     pub fn set_binding_if_not_set(
         &mut self,
         property_name: SmolStr,
@@ -2342,9 +2354,20 @@ impl Element {
                 vacant_entry.insert(binding.into());
             }
             Entry::Occupied(mut existing_entry) => {
-                let mut binding: BindingExpression = expression_fn().into();
-                binding.priority = i32::MAX;
-                existing_entry.get_mut().get_mut().merge_with(&binding);
+                let inner = existing_entry.get_mut().get_mut();
+                // If a synthetic debug hook occupies the slot, replace its inner expression
+                // with the new value and mark it as non-synthetic.
+                if let expression_tree::Expression::DebugHook { expression, synthetic, .. } =
+                    &mut inner.expression
+                {
+                    *expression = Box::new(expression_fn());
+                    *synthetic = false;
+                    inner.priority = i32::MAX;
+                } else {
+                    let mut binding: BindingExpression = expression_fn().into();
+                    binding.priority = i32::MAX;
+                    inner.merge_with(&binding);
+                }
             }
         };
         true

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2300,12 +2300,11 @@ impl Element {
     /// If `need_explicit` is true, then only consider binding set in the code, not the ones set
     /// by the compiler later.
     ///
-    /// Synthetic debug hooks (materialized for unbound properties) are never considered set.
+    /// Synthetic debug hooks (materialized for unbound properties) are never considered set
+    /// (`has_binding` treats them as "no expression").
     pub fn is_binding_set(self: &Element, property_name: &str, need_explicit: bool) -> bool {
         if self.bindings.get(property_name).is_some_and(|b| {
-            b.borrow().has_binding()
-                && !b.borrow().expression.is_synthetic_debug_hook()
-                && (!need_explicit || b.borrow().priority > 0)
+            b.borrow().has_binding() && (!need_explicit || b.borrow().priority > 0)
         }) {
             true
         } else if let ElementType::Component(base) = &self.base_type {
@@ -2328,6 +2327,30 @@ impl Element {
                 .get(property_name)
                 .is_some_and(|a| a.is_set || a.is_linked)
             || matches!(&self.base_type, ElementType::Component(base) if base.root_element.borrow().is_property_set(property_name))
+    }
+
+    /// The binding for `property_name`, if one exists and is not a synthetic debug hook.
+    ///
+    /// This is the hook-aware replacement for `self.bindings.get(..)`: a synthetic debug hook
+    /// is a materialized placeholder for an *unbound* property and must read as "no binding".
+    /// Use this instead of the raw map whenever the question is "did anything bind this
+    /// property" or "what is this property's binding".
+    pub fn binding(&self, property_name: &str) -> Option<&RefCell<BindingExpression>> {
+        self.bindings
+            .get(property_name)
+            .filter(|binding| !binding.borrow().expression.is_synthetic_debug_hook())
+    }
+
+    /// Iterate over the bindings that are not synthetic debug hooks.
+    ///
+    /// The hook-aware replacement for iterating `self.bindings` directly when enumerating the
+    /// properties that are actually set on this element.
+    pub fn real_bindings(
+        &self,
+    ) -> impl Iterator<Item = (&SmolStr, &RefCell<BindingExpression>)> {
+        self.bindings
+            .iter()
+            .filter(|(_, binding)| !binding.borrow().expression.is_synthetic_debug_hook())
     }
 
     /// Set the property `property_name` of this Element only if it was not set.

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2373,6 +2373,46 @@ impl Element {
         true
     }
 
+    /// Unconditionally set the property `property_name` to `new_binding`, but handle a synthetic
+    /// debug hook that already occupies the slot specially: instead of replacing it, upgrade it
+    /// in-place (replace its inner expression, clear `synthetic`, keep the wrapper+id so the
+    /// property stays live-editable).
+    ///
+    /// Returns the old `BindingExpression` if a *real* (non-synthetic) binding was displaced so
+    /// the caller can report a conflict.  Returns `None` if the slot was empty or held only a
+    /// synthetic hook (no conflict).
+    ///
+    /// This is intended for passes like `lower_layout` that must force-set a property and need to
+    /// distinguish a genuine conflict from a synthetic placeholder.
+    pub fn set_binding_overwriting(
+        &mut self,
+        property_name: SmolStr,
+        new_binding: BindingExpression,
+    ) -> Option<BindingExpression> {
+        match self.bindings.entry(property_name) {
+            Entry::Vacant(v) => {
+                v.insert(RefCell::new(new_binding));
+                None
+            }
+            Entry::Occupied(mut e) => {
+                let existing = e.get_mut().get_mut();
+                if let expression_tree::Expression::DebugHook { expression, synthetic, .. } =
+                    &mut existing.expression
+                {
+                    if *synthetic {
+                        // Upgrade the synthetic placeholder in-place.
+                        *expression = Box::new(new_binding.expression);
+                        *synthetic = false;
+                        existing.priority = i32::MAX;
+                        return None;
+                    }
+                }
+                // Real (non-synthetic) binding exists: replace it and report the conflict.
+                Some(std::mem::replace(e.get_mut().get_mut(), new_binding))
+            }
+        }
+    }
+
     pub fn sub_component(&self) -> Option<&Rc<Component>> {
         if self.repeated.is_some() {
             None

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -28,6 +28,7 @@ mod focus_handling;
 pub mod generate_item_indices;
 pub mod infer_aliases_types;
 mod inject_debug_hooks;
+pub use inject_debug_hooks::property_id;
 mod inlining;
 mod key_bindings;
 mod lower_absolute_coordinates;

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -196,6 +196,11 @@ pub async fn run_passes(
     for root_component in doc.exported_roots() {
         lower_layout::check_window_layout(&root_component);
     }
+    if let Some(random_state) = &type_loader.compiler_config.debug_hooks {
+        for root_component in doc.exported_roots() {
+            inject_debug_hooks::inject_debug_hooks(&root_component, random_state);
+        }
+    }
     collect_globals::collect_globals(doc, diag);
 
     if type_loader.compiler_config.inline_all_elements {
@@ -327,7 +332,6 @@ pub fn run_import_passes(
     type_loader: &crate::typeloader::TypeLoader,
     diag: &mut crate::diagnostics::BuildDiagnostics,
 ) {
-    inject_debug_hooks::inject_debug_hooks(doc, type_loader);
     infer_aliases_types::resolve_aliases(doc, diag);
     resolving::resolve_expressions(doc, type_loader, diag);
     purity_check::purity_check(doc, diag);

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -113,6 +113,14 @@ pub async fn run_passes(
     let raw_type_loader =
         keep_raw.then(|| crate::typeloader::snapshot_with_extra_doc(type_loader, doc).unwrap());
 
+    // Inject debug hooks early — before any lowering or inlining — so source element identity
+    // is preserved and hooks can be attributed to the correct source location.
+    if let Some(random_state) = &type_loader.compiler_config.debug_hooks {
+        for root_component in doc.exported_roots() {
+            inject_debug_hooks::inject_debug_hooks(&root_component, random_state);
+        }
+    }
+
     collect_libraries::collect_libraries(doc);
     collect_subcomponents::collect_subcomponents(doc);
     lower_tooltips::lower_tooltips(doc, type_loader, diag).await;
@@ -149,11 +157,6 @@ pub async fn run_passes(
         focus_handling::call_focus_on_init(popup_menu_impl);
     }
 
-    if type_loader.compiler_config.debug_hooks.is_some() {
-        for root_component in doc.exported_roots() {
-            inject_debug_hooks::inject_reserved_properties(&root_component);
-        }
-    }
     doc.visit_all_used_components(|component| {
         border_radius::handle_border_radius(component, diag);
         check_drag_area::check_drag_area(component, diag);
@@ -200,11 +203,6 @@ pub async fn run_passes(
     });
     for root_component in doc.exported_roots() {
         lower_layout::check_window_layout(&root_component);
-    }
-    if let Some(random_state) = &type_loader.compiler_config.debug_hooks {
-        for root_component in doc.exported_roots() {
-            inject_debug_hooks::inject_debug_hooks(&root_component, random_state);
-        }
     }
     collect_globals::collect_globals(doc, diag);
 

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -149,6 +149,11 @@ pub async fn run_passes(
         focus_handling::call_focus_on_init(popup_menu_impl);
     }
 
+    if type_loader.compiler_config.debug_hooks.is_some() {
+        for root_component in doc.exported_roots() {
+            inject_debug_hooks::inject_reserved_properties(&root_component);
+        }
+    }
     doc.visit_all_used_components(|component| {
         border_radius::handle_border_radius(component, diag);
         check_drag_area::check_drag_area(component, diag);

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -206,7 +206,13 @@ pub async fn run_passes(
     }
     collect_globals::collect_globals(doc, diag);
 
-    if type_loader.compiler_config.inline_all_elements {
+    // Debug hooks rely on full inlining: the synthetic hooks injected on component-instance
+    // elements are only upgraded with the component's real default bindings when the component
+    // is inlined (see `BindingExpression::merge_with`). Without inlining they would shadow the
+    // definition's defaults at runtime. This overrides a `SLINT_INLINING=false` env override.
+    if type_loader.compiler_config.inline_all_elements
+        || type_loader.compiler_config.debug_hooks.is_some()
+    {
         inlining::inline(doc, inlining::InlineSelection::InlineAllComponents, diag);
         doc.used_types.borrow_mut().sub_components.clear();
     }
@@ -224,7 +230,11 @@ pub async fn run_passes(
         // item tree ends up with a hierarchy where certain items have children that aren't child elements
         // but siblings or sibling children. We need a new data structure to perform a correct element tree
         // traversal.
-        if !type_loader.compiler_config.debug_info {
+        // Also keep the rectangles when debug hooks are enabled: their (synthetic) hooks are
+        // what makes the elements live-editable, and removing the element would drop them.
+        if !type_loader.compiler_config.debug_info
+            && type_loader.compiler_config.debug_hooks.is_none()
+        {
             optimize_useless_rectangles::optimize_useless_rectangles(component);
         }
         move_declarations::move_declarations(component);
@@ -245,6 +255,18 @@ pub async fn run_passes(
     });
 
     remove_unused_properties::remove_unused_properties(doc);
+
+    // With debug hooks enabled, every synthetic hook must by now either have been upgraded
+    // (by a pass computing the property's value or by inlining merging the definition's
+    // default) or sit on a property that exists at runtime. An orphan would abort the
+    // interpreter at instantiation ("unknown property ..."); catch it here with a source
+    // location instead.
+    if type_loader.compiler_config.debug_hooks.is_some() && !diag.has_errors() {
+        doc.visit_all_used_components(|component| {
+            inject_debug_hooks::validate_no_orphan_synthetic_hooks(component);
+        });
+    }
+
     // collect globals once more: After optimizations we might have less globals
     collect_globals::collect_globals(doc, diag);
     collect_structs_and_enums::collect_structs_and_enums(doc);

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -51,6 +51,7 @@ pub mod materialize_fake_properties;
 pub mod move_declarations;
 mod optimize_useless_rectangles;
 mod purity_check;
+mod decompose_two_way_links;
 mod remove_aliases;
 mod remove_return;
 mod remove_unused_properties;
@@ -242,6 +243,10 @@ pub async fn run_passes(
 
     remove_aliases::remove_aliases(doc, diag);
     remove_return::remove_return(doc);
+
+    if type_loader.compiler_config.decompose_struct_two_way_links && !diag.has_errors() {
+        decompose_two_way_links::decompose_two_way_links(doc);
+    }
 
     doc.visit_all_used_components(|component| {
         if !diag.has_errors() {

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -727,9 +727,10 @@ fn recurse_expression(
             }
             BuiltinFunction::ItemAbsolutePosition => {
                 if let Some(Expression::ElementReference(item)) = arguments.first() {
+                    // The result depends on the element's own geometry origin as well as every
+                    // ancestor's (map_to_window walks the whole ancestor chain).
                     let mut item = item.upgrade().unwrap();
-                    while let Some(parent) = find_parent_element(&item) {
-                        item = parent;
+                    loop {
                         vis(
                             &NamedReference::new(&item, SmolStr::new_static("x")).into(),
                             ReadType::NativeRead,
@@ -738,6 +739,8 @@ fn recurse_expression(
                             &NamedReference::new(&item, SmolStr::new_static("y")).into(),
                             ReadType::NativeRead,
                         );
+                        let Some(parent) = find_parent_element(&item) else { break };
+                        item = parent;
                     }
                 }
             }

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -1018,8 +1018,8 @@ fn check_window_properties(doc: &Document, global_analysis: &mut GlobalAnalysis)
                             .get(DEFAULT_FONT_SIZE)
                             .is_some_and(|a| a.is_set)
                     {
-                        let value = elem.borrow().bindings.get(DEFAULT_FONT_SIZE).and_then(|e| {
-                            match &e.borrow().expression {
+                        let value = elem.borrow().binding(DEFAULT_FONT_SIZE).and_then(|e| {
+                            match e.borrow().expression.ignore_debug_hooks() {
                                 Expression::NumberLiteral(v, crate::expression_tree::Unit::Px) => {
                                     Some(*v as f32)
                                 }

--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -93,7 +93,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
         for optional_binding in super::border_radius::BORDER_RADIUS_PROPERTIES.iter() {
             copy_optional_binding(parent_elem, optional_binding, &clip);
         }
-    } else if parent_elem.borrow().bindings.contains_key("border-radius") {
+    } else if parent_elem.borrow().binding("border-radius").is_some() {
         for prop in super::border_radius::BORDER_RADIUS_PROPERTIES.iter() {
             clip.borrow_mut().bindings.insert(
                 SmolStr::new(prop),
@@ -121,7 +121,7 @@ fn copy_optional_binding(
     optional_binding: &'static str,
     clip: &ElementRc,
 ) {
-    if parent_elem.borrow().bindings.contains_key(optional_binding) {
+    if parent_elem.borrow().binding(optional_binding).is_some() {
         clip.borrow_mut().bindings.insert(
             optional_binding.into(),
             RefCell::new(

--- a/internal/compiler/passes/decompose_two_way_links.rs
+++ b/internal/compiler/passes/decompose_two_way_links.rs
@@ -1,0 +1,92 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Decompose whole-struct two-way links whose class also contains
+//! struct-field links into per-field ("cell") links.
+//!
+//! At runtime, a struct property whose fields participate in two-way
+//! binding classes wears a `StructMemberBindings` wrapper binding, while a
+//! property linked as a whole carries a plain `TwoWayBinding`; the two
+//! cannot coexist on one property. See [`crate::llr::two_way_cuts`] for the
+//! analysis. This pass performs the equivalent rewrite on the object tree
+//! for backends that do not lower through the LLR (the interpreter); it is
+//! enabled by `CompilerConfiguration::decompose_struct_two_way_links`.
+
+use crate::expression_tree::TwoWayBinding;
+use crate::llr::two_way_cuts::{MemberCuts, canonical_property};
+use crate::namedreference::NamedReference;
+use crate::object_tree::{Document, recurse_elem_including_sub_components};
+
+/// Whether the interpreter stores this property as a `Property<Value>`:
+/// user-declared properties of struct type are; native item properties and
+/// builtin-global properties are natively typed and keep the wide-common
+/// machinery.
+fn is_declared_property(reference: &NamedReference) -> bool {
+    let canonical = canonical_property(reference);
+    let element = canonical.element();
+    let is_declared = element.borrow().property_declarations.contains_key(canonical.name());
+    is_declared
+}
+
+pub fn decompose_two_way_links(doc: &Document) {
+    let cuts = MemberCuts::analyze(doc);
+
+    doc.visit_all_used_components(|component| {
+        recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
+            for (name, binding) in &elem.borrow().bindings {
+                if binding.borrow().two_way_bindings.is_empty() {
+                    continue;
+                }
+                let prop1 = NamedReference::new(elem, name.clone());
+                let Some(cells) = cuts.decomposed_cells(&prop1) else { continue };
+                if !is_declared_property(&prop1) {
+                    // natively stored struct property: keep the wide-common
+                    // machinery (pre-existing behavior)
+                    continue;
+                }
+                let two_way_bindings = &mut binding.borrow_mut().two_way_bindings;
+                *two_way_bindings = two_way_bindings
+                    .drain(..)
+                    .flat_map(|twb| -> Vec<TwoWayBinding> {
+                        match twb {
+                            TwoWayBinding::Property { property, field_access, field_access1 }
+                                if field_access1.is_empty()
+                                    && is_declared_property(&property) =>
+                            {
+                                cells
+                                    .iter()
+                                    .map(|cell| {
+                                        let mut cell_field_access = field_access.clone();
+                                        cell_field_access.extend(cell.iter().cloned());
+                                        TwoWayBinding::Property {
+                                            property: property.clone(),
+                                            field_access: cell_field_access,
+                                            field_access1: cell.clone(),
+                                        }
+                                    })
+                                    .collect()
+                            }
+                            TwoWayBinding::ModelData {
+                                repeated_element,
+                                field_access,
+                                field_access1,
+                            } if field_access1.is_empty() => cells
+                                .iter()
+                                .map(|cell| {
+                                    let mut cell_field_access = field_access.clone();
+                                    cell_field_access.extend(cell.iter().cloned());
+                                    TwoWayBinding::ModelData {
+                                        repeated_element: repeated_element.clone(),
+                                        field_access: cell_field_access,
+                                        field_access1: cell.clone(),
+                                    }
+                                })
+                                .collect(),
+                            other => vec![other],
+                        }
+                    })
+                    .collect();
+            }
+        })
+    });
+}

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -170,7 +170,7 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         .children
         .iter()
         .filter(|c| {
-            !c.borrow().bindings.contains_key("x") && !c.borrow().bindings.contains_key("y")
+            !c.borrow().is_binding_set("x", false) && !c.borrow().is_binding_set("y", false)
         })
         .filter_map(|c| {
             gen_layout_info_prop(c, diag);

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -9,7 +9,6 @@
     This pass must be run after lower_layout
 */
 
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::diagnostics::{BuildDiagnostics, DiagnosticLevel, Spanned};
@@ -483,7 +482,8 @@ fn make_default_aspect_ratio_preserving_binding(
         op: '*',
     };
 
-    elem.borrow_mut().bindings.insert(missing_size_property, RefCell::new(binding.into()));
+    let binding_expr = binding;
+    elem.borrow_mut().set_binding_if_not_set(missing_size_property, || binding_expr);
 }
 
 fn maybe_center_in_parent(

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -356,7 +356,8 @@ fn fix_percent_size(
     if binding.borrow().ty() != Type::Percent {
         let Some(parent) = parent.as_ref() else { return false };
         // Pattern match to check it was already parent.<property>
-        return matches!(&binding.borrow().expression, Expression::PropertyReference(nr) if *nr.name() == property && Rc::ptr_eq(&nr.element(), parent));
+        // (through a possible debug hook wrapper)
+        return matches!(binding.borrow().expression.ignore_debug_hooks(), Expression::PropertyReference(nr) if *nr.name() == property && Rc::ptr_eq(&nr.element(), parent));
     }
     let mut b = binding.borrow_mut();
     if let Some(mut parent) = parent.clone() {
@@ -368,8 +369,8 @@ fn fix_percent_size(
             parent.borrow().lookup_property(property).property_type,
             Type::LogicalLength
         );
-        let fill =
-            matches!(b.expression, Expression::NumberLiteral(x, _) if (x - 100.).abs() < 0.001);
+        let fill = matches!(b.expression.ignore_debug_hooks(),
+            Expression::NumberLiteral(x, _) if (x - 100.).abs() < 0.001);
         b.expression = Expression::BinaryExpression {
             lhs: Box::new(std::mem::take(&mut b.expression).maybe_convert_to(
                 Type::Float32,
@@ -515,6 +516,10 @@ fn adjust_image_clip_rect(elem: &ElementRc, builtin: &Rc<BuiltinElement>) {
     debug_assert_eq!(builtin.native_class.class_name, "ClippedImage");
 
     if builtin.native_class.properties.keys().any(|p| {
+        // Deliberately count synthetic debug hooks here (raw map access): they also count as
+        // "used" in resolve_native_classes, so the ClippedImage native class gets selected —
+        // and a ClippedImage without the synthesized clip defaults renders/measures as a
+        // zero-size clip. This condition must match the class-selection semantics.
         elem.borrow().bindings.contains_key(p)
             || elem.borrow().property_analysis.borrow().get(p).is_some_and(|a| a.is_used())
     }) {

--- a/internal/compiler/passes/deprecated_rotation_origin.rs
+++ b/internal/compiler/passes/deprecated_rotation_origin.rs
@@ -7,7 +7,6 @@ use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::Expression;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, ElementRc};
-use core::cell::RefCell;
 use smol_str::SmolStr;
 
 pub fn handle_rotation_origin(component: &Component, diag: &mut BuildDiagnostics) {
@@ -66,16 +65,15 @@ pub fn handle_rotation_origin(component: &Component, diag: &mut BuildDiagnostics
                     .collect(),
             };
 
-            match elem.borrow_mut().bindings.entry(transform_origin.0.into()) {
-                std::collections::btree_map::Entry::Occupied(occupied_entry) => {
-                    diag.push_error(
-                        "Can't specify transform-origin if rotation-origin-x or rotation-origin-y is used on this element".into(),
-                        &occupied_entry.get().borrow().span
-                    );
-                }
-                std::collections::btree_map::Entry::Vacant(vacant_entry) => {
-                    vacant_entry.insert(RefCell::new(expr.into()));
-                }
+            // set_binding_overwriting upgrades a synthetic debug hook placeholder in place
+            // and only reports a real (user-written) binding as a conflict.
+            if let Some(old_binding) =
+                elem.borrow_mut().set_binding_overwriting(transform_origin.0.into(), expr.into())
+            {
+                diag.push_error(
+                    "Can't specify transform-origin if rotation-origin-x or rotation-origin-y is used on this element".into(),
+                    &old_binding,
+                );
             }
         },
     );

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -146,11 +146,11 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
         })
     };
 
-    if !flickable_elem.borrow().bindings.contains_key("height") {
+    if !flickable_elem.borrow().is_binding_set("height", false) {
         forward_minmax_of("max-height", MinMaxOp::Min);
         forward_minmax_of("preferred-height", MinMaxOp::Min);
     }
-    if !flickable_elem.borrow().bindings.contains_key("width") {
+    if !flickable_elem.borrow().is_binding_set("width", false) {
         forward_minmax_of("max-width", MinMaxOp::Min);
         forward_minmax_of("preferred-width", MinMaxOp::Min);
     }
@@ -212,8 +212,10 @@ fn set_binding_if_not_explicit(
     expression: impl FnOnce() -> Option<Expression>,
 ) {
     // we can't use `set_binding_if_not_set` directly because `expression()` may borrow `elem`
-    if elem.borrow().bindings.get(property).is_none_or(|b| !b.borrow().has_binding())
-        && let Some(e) = expression()
+    // A synthetic debug hook is treated the same as "no binding" here.
+    if elem.borrow().bindings.get(property).is_none_or(|b| {
+        !b.borrow().has_binding() || b.borrow().expression.is_synthetic_debug_hook()
+    }) && let Some(e) = expression()
     {
         elem.borrow_mut().set_binding_if_not_set(property.into(), || e);
     }

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -212,10 +212,9 @@ fn set_binding_if_not_explicit(
     expression: impl FnOnce() -> Option<Expression>,
 ) {
     // we can't use `set_binding_if_not_set` directly because `expression()` may borrow `elem`
-    // A synthetic debug hook is treated the same as "no binding" here.
-    if elem.borrow().bindings.get(property).is_none_or(|b| {
-        !b.borrow().has_binding() || b.borrow().expression.is_synthetic_debug_hook()
-    }) && let Some(e) = expression()
+    // (`has_binding` treats a synthetic debug hook as "no binding")
+    if elem.borrow().bindings.get(property).is_none_or(|b| !b.borrow().has_binding())
+        && let Some(e) = expression()
     {
         elem.borrow_mut().set_binding_if_not_set(property.into(), || e);
     }

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -17,7 +17,7 @@ pub fn inject_debug_hooks(doc: &object_tree::Document, type_loader: &typeloader:
     });
 }
 
-fn property_id(element_id: u64, name: &smol_str::SmolStr) -> smol_str::SmolStr {
+pub fn property_id(element_id: u64, name: &smol_str::SmolStr) -> smol_str::SmolStr {
     smol_str::format_smolstr!("?{element_id}-{name}")
 }
 

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -155,6 +155,35 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
     }
 }
 
+pub fn inject_reserved_properties(component: &std::rc::Rc<object_tree::Component>) {
+    object_tree::recurse_elem(&component.root_element, &(), &mut |elem_rc, &()| {
+        let elem = elem_rc.borrow();
+        if elem.repeated.is_some() {
+            inject_reserved_properties(elem.base_type.as_component());
+            return;
+        }
+        if elem.is_component_placeholder || elem.sub_component().is_some() || elem.debug.is_empty()
+        {
+            return;
+        }
+        drop(elem);
+
+        for property_name in crate::typeregister::RESERVED_TRANSFORM_PROPERTIES
+            .iter()
+            .map(|(prop_name, _)| *prop_name)
+        {
+            if let Some(default_expr) =
+                super::lower_property_to_element::transform_property_default_value(
+                    elem_rc,
+                    property_name,
+                )
+            {
+                elem_rc.borrow_mut().set_binding_if_not_set(property_name.into(), || default_expr);
+            }
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -41,6 +41,21 @@ fn calculate_element_hash(
 }
 
 fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
+    let e = element.borrow();
+    // Inject debug hook into the repeaters generated component, instead of its remaining
+    // pseudo-element
+    if e.repeated.is_some() {
+        inject_debug_hooks(e.base_type.as_component(), random_state);
+        return;
+    }
+    // Skip injecting debug hooks for these cases:
+    // * @children placeholder (generator skips these too)
+    // * non-inlined sub-component instances (base_type = Component)
+    if e.is_component_placeholder || e.sub_component().is_some() {
+        return;
+    }
+    drop(e);
+
     // Step 1: compute and store the element hash on EVERY debug entry.
     // This pass now runs after required-inlining, so an element may carry several debug
     // entries (one per merged source element). The LSP looks up the hash on the entry that

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -28,8 +28,10 @@ pub fn inject_debug_hooks(
     component: &std::rc::Rc<object_tree::Component>,
     random_state: &std::hash::RandomState,
 ) {
-    object_tree::recurse_elem(&component.root_element, &(), &mut |elem, &()| {
-        process_element(elem, random_state);
+    let root = component.root_element.clone();
+    object_tree::recurse_elem(&root, &(), &mut |elem, &()| {
+        let is_root = std::rc::Rc::ptr_eq(elem, &root);
+        process_element(elem, random_state, is_root);
     });
 }
 
@@ -58,7 +60,7 @@ fn calculate_element_hash(
     hasher.finish()
 }
 
-fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
+fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, is_root: bool) {
     let e = element.borrow();
     // Before repeater_component::process_repeater_components runs, a repeated element still
     // holds its content as children — recurse_elem will visit them naturally.
@@ -152,8 +154,33 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
             .collect()
     };
 
+    // Reserved geometry properties (x, y, width, height) — these are not in property_list()
+    // because they are injected globally by the type system, not per builtin element.
+    // We exclude "z" to avoid spurious property materialization in materialize_fake_properties.
+    // We skip the component root element because its geometry is either runtime-managed (Window)
+    // or set after inlining into a parent component — either way, no compiler pass will upgrade
+    // a synthetic hook, which would leave root geometry frozen at 0px.
+    let geometry_candidates: Vec<(smol_str::SmolStr, Expression)> = if is_root {
+        vec![]
+    } else {
+        let elem = element.borrow();
+        crate::typeregister::RESERVED_GEOMETRY_PROPERTIES
+            .iter()
+            .filter(|(name, _)| *name != "z")
+            .filter_map(|(prop_name, ty)| {
+                if elem.bindings.contains_key(*prop_name) {
+                    return None;
+                }
+                let default = Expression::default_value_for_type(ty);
+                if matches!(default, Expression::Invalid) {
+                    return None;
+                }
+                Some((smol_str::SmolStr::new_static(prop_name), default))
+            })
+            .collect()
+    };
+
     // Also include reserved transform-property defaults.
-    // TODO: Add any other reserved properties here when debug hooks on them are needed
     let transform_candidates: Vec<(smol_str::SmolStr, Expression)> = {
         let elem = element.borrow();
         if elem.debug.is_empty() {
@@ -185,6 +212,19 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
         use std::collections::btree_map::Entry;
         if let Entry::Vacant(entry) = element.borrow_mut().bindings.entry(name) {
             entry.insert(binding_expressions.into());
+        }
+    }
+
+    // Insert synthetic hooks for reserved geometry properties (x, y, width, height).
+    for (name, default_expr) in geometry_candidates {
+        let id = property_id(element_hash, &name);
+        let mut binding_expressions: crate::expression_tree::BindingExpression =
+            Expression::DebugHook { expression: Box::new(default_expr), id, synthetic: true }
+                .into();
+        binding_expressions.priority = 0;
+        use std::collections::btree_map::Entry;
+        if let Entry::Vacant(v) = element.borrow_mut().bindings.entry(name) {
+            v.insert(binding_expressions.into());
         }
     }
 

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -2,6 +2,24 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 //! Hooks properties for live inspection.
+//!
+//! This pass runs once, early in compilation — right after the import passes but before any
+//! lowering or inlining. At that point every element has exactly one debug entry and
+//! source-identity is intact.
+//!
+//! For each element the pass does two things:
+//!
+//! 1. **Wrap existing bindings** in a non-synthetic `Expression::DebugHook` so the editor can
+//!    read and override the live value.
+//!
+//! 2. **Materialize synthetic hooks** for every *unbound* settable property, wrapping the
+//!    type default.  These are marked `synthetic: true` (and inserted with `priority = 0`).
+//!    The compiler's central helpers (`is_binding_set`, `set_binding_if_not_set`, …) in
+//!    `object_tree.rs` treat synthetic hooks as "no binding", so later passes see exactly the
+//!    same binding landscape as they did before the hooks were injected.  When a later pass
+//!    sets a default on a property that carries a synthetic hook, `set_binding_if_not_set`
+//!    replaces the hook's inner expression in place (keeping the wrapper and id) and clears
+//!    the `synthetic` flag — so the hook ends up wrapping the real compiler-computed value.
 
 use crate::expression_tree::Expression;
 use crate::object_tree::{self, ElementRc, PropertyVisibility};
@@ -21,10 +39,10 @@ pub fn property_id(element_id: u64, name: &smol_str::SmolStr) -> smol_str::SmolS
 
 fn calculate_element_hash(
     elem: &object_tree::Element,
-    index: usize,
     random_state: &std::hash::RandomState,
 ) -> u64 {
-    let node = &elem.debug[index].node;
+    // At early-injection time (before any inlining) every element has exactly one debug entry.
+    let node = &elem.debug[0].node;
 
     let elem_path = node.source_file.path();
     let elem_offset = node
@@ -42,42 +60,31 @@ fn calculate_element_hash(
 
 fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
     let e = element.borrow();
-    // Inject debug hook into the repeaters generated component, instead of its remaining
-    // pseudo-element
-    if e.repeated.is_some() {
-        inject_debug_hooks(e.base_type.as_component(), random_state);
-        return;
-    }
-    // Skip injecting debug hooks for these cases:
+    // Before repeater_component::process_repeater_components runs, a repeated element still
+    // holds its content as children — recurse_elem will visit them naturally.
+    // Skip:
     // * @children placeholder (generator skips these too)
     // * non-inlined sub-component instances (base_type = Component)
     if e.is_component_placeholder || e.sub_component().is_some() {
         return;
     }
+    if e.debug.is_empty() {
+        return;
+    }
     drop(e);
 
-    // Step 1: compute and store the element hash on EVERY debug entry.
-    // This pass now runs after required-inlining, so an element may carry several debug
-    // entries (one per merged source element). The LSP looks up the hash on the entry that
-    // matches the selected source location, so each entry needs its own hash. (The old
-    // early-pass invariant `debug.len() == 1` no longer holds.)
+    // Step 1: compute and store the element hash.
+    // At early-injection time debug.len() == 1, so a single hash suffices.
     let element_hash = {
         let mut elem = element.borrow_mut();
-        if elem.debug.is_empty() {
-            return;
+        if elem.debug[0].element_hash == 0 {
+            let hash = calculate_element_hash(&elem, random_state);
+            elem.debug[0].element_hash = hash;
         }
-        for i in 0..elem.debug.len() {
-            if elem.debug[i].element_hash == 0 {
-                let hash = calculate_element_hash(&elem, i, random_state);
-                elem.debug[i].element_hash = hash;
-            }
-        }
-        // Bindings live on this (outermost, editor-selectable) element; a selection resolves to
-        // its primary debug entry, so the first entry's hash is the one used to build ids.
         elem.debug[0].element_hash
     };
 
-    // Step 2: Wrap existing bindings.
+    // Step 2: Wrap existing real bindings in a non-synthetic DebugHook.
     {
         let elem = element.borrow();
         elem.bindings.iter().for_each(|(name, be)| {
@@ -92,14 +99,15 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
                     Expression::DebugHook {
                         expression: Box::new(expr),
                         id: property_id(element_hash, name),
+                        synthetic: false,
                     }
                 }
             };
         });
     }
 
-    // Step 3: Materialize hooked defaults for unbound settable properties.
-    // Collect candidates first (releases the borrow), then insert.
+    // Step 3: Materialize synthetic hooks for unbound settable properties.
+    // Collect candidates first to release the borrow, then insert.
     let candidates: Vec<(smol_str::SmolStr, crate::langtype::Type)> = {
         let elem = element.borrow();
 
@@ -128,9 +136,9 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
                 match lookup.property_visibility {
                     PropertyVisibility::Public
                     | PropertyVisibility::InOut
-                    | PropertyVisibility::Input => {}
-                    PropertyVisibility::Private
-                    | PropertyVisibility::Output
+                    | PropertyVisibility::Input
+                    | PropertyVisibility::Private => {}
+                    PropertyVisibility::Output
                     | PropertyVisibility::Constexpr
                     | PropertyVisibility::Protected
                     | PropertyVisibility::Fake => return None,
@@ -144,44 +152,54 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
             .collect()
     };
 
-    // Now insert the hooked defaults.
+    // Also include reserved transform-property defaults.
+    // TODO: Add any other reserved properties here when debug hooks on them are needed
+    let transform_candidates: Vec<(smol_str::SmolStr, Expression)> = {
+        let elem = element.borrow();
+        if elem.debug.is_empty() {
+            vec![]
+        } else {
+            crate::typeregister::RESERVED_TRANSFORM_PROPERTIES
+                .iter()
+                .filter_map(|(prop_name, _)| {
+                    if elem.bindings.contains_key(*prop_name) {
+                        return None;
+                    }
+                    let default_expr =
+                        super::lower_property_to_element::transform_property_default_value(
+                            element, prop_name,
+                        )?;
+                    Some((smol_str::SmolStr::new_static(prop_name), default_expr))
+                })
+                .collect()
+        }
+    };
+
+    // Insert synthetic hooks for all unbound properties.
     for (name, ty) in candidates {
         let default = Expression::default_value_for_type(&ty);
         let id = property_id(element_hash, &name);
-        element.borrow_mut().set_binding_if_not_set(name, || Expression::DebugHook {
-            expression: Box::new(default),
-            id,
-        });
+        let mut binding_expressions: crate::expression_tree::BindingExpression =
+            Expression::DebugHook { expression: Box::new(default), id, synthetic: true }.into();
+        binding_expressions.priority = 0;
+        use std::collections::btree_map::Entry;
+        if let Entry::Vacant(entry) = element.borrow_mut().bindings.entry(name) {
+            entry.insert(binding_expressions.into());
+        }
     }
-}
 
-pub fn inject_reserved_properties(component: &std::rc::Rc<object_tree::Component>) {
-    object_tree::recurse_elem(&component.root_element, &(), &mut |elem_rc, &()| {
-        let elem = elem_rc.borrow();
-        if elem.repeated.is_some() {
-            inject_reserved_properties(elem.base_type.as_component());
-            return;
+    // Insert synthetic hooks for the transform properties.
+    for (name, default_expr) in transform_candidates {
+        let id = property_id(element_hash, &name);
+        let mut binding_expressions: crate::expression_tree::BindingExpression =
+            Expression::DebugHook { expression: Box::new(default_expr), id, synthetic: true }
+                .into();
+        binding_expressions.priority = 0;
+        use std::collections::btree_map::Entry;
+        if let Entry::Vacant(v) = element.borrow_mut().bindings.entry(name) {
+            v.insert(binding_expressions.into());
         }
-        if elem.is_component_placeholder || elem.sub_component().is_some() || elem.debug.is_empty()
-        {
-            return;
-        }
-        drop(elem);
-
-        for property_name in crate::typeregister::RESERVED_TRANSFORM_PROPERTIES
-            .iter()
-            .map(|(prop_name, _)| *prop_name)
-        {
-            if let Some(default_expr) =
-                super::lower_property_to_element::transform_property_default_value(
-                    elem_rc,
-                    property_name,
-                )
-            {
-                elem_rc.borrow_mut().set_binding_if_not_set(property_name.into(), || default_expr);
-            }
-        }
-    });
+    }
 }
 
 #[cfg(test)]
@@ -206,15 +224,20 @@ mod tests {
         doc
     }
 
-    fn component(doc: &crate::object_tree::Document, id: &str) -> Rc<Component> {
+    fn component<'a>(doc: &'a crate::object_tree::Document, id: &str) -> Rc<Component> {
         doc.inner_components.iter().find(|c| c.id == id).expect("component").clone()
     }
 
     fn child(root: &ElementRc, id: &str) -> ElementRc {
-        // The unique-id pass suffixes ids (`txt` -> `txt-2`), so match name or `name-N`.
+        // The unique-id pass suffixes ids with a number (`txt` -> `txt-2`).
+        // Only match that numeric suffix — don't match `txt-Transform-2` for `txt`.
         fn rec(e: &ElementRc, id: &str) -> Option<ElementRc> {
             let this_id = e.borrow().id.clone();
-            if this_id == id || this_id.starts_with(&format!("{id}-")) {
+            let matches = this_id == id
+                || this_id
+                    .strip_prefix(&format!("{id}-"))
+                    .is_some_and(|suffix| suffix.chars().all(|c| c.is_ascii_digit()));
+            if matches {
                 return Some(e.clone());
             }
             let children = e.borrow().children.clone();
@@ -231,6 +254,13 @@ mod tests {
             Expression::DebugHook { expression, .. } => Some(*expression),
             _ => None,
         }
+    }
+
+    /// Whether the binding is a synthetic debug hook.
+    fn is_synthetic(elem: &ElementRc, name: &str) -> bool {
+        let e = elem.borrow();
+        let Some(be) = e.bindings.get(name) else { return false };
+        matches!(be.borrow().expression, Expression::DebugHook { synthetic: true, .. })
     }
 
     #[test]
@@ -252,22 +282,28 @@ mod tests {
         let txt = child(&foo.root_element, "txt");
         let rect = child(&foo.root_element, "rect");
 
-        // Unbound `text` is now hooked, wrapping the empty-string type default.
+        // Unbound `text` is now hooked (synthetic), wrapping the empty-string type default.
         let text_inner = hooked(&txt, "text").expect("txt.text should be a DebugHook");
+        assert!(is_synthetic(&txt, "text"), "txt.text hook should be synthetic (unbound property)");
         assert!(
             matches!(super::super::ignore_debug_hooks(&text_inner), Expression::StringLiteral(s) if s.is_empty()),
             "txt.text default should be the empty-string sentinel, got {text_inner:?}"
         );
 
-        // Unbound `font-size` is hooked wrapping the 0 sentinel — keeps runtime Window inheritance.
+        // Unbound `font-size` is hooked (synthetic), wrapping the 0 sentinel.
         let fs_inner = hooked(&txt, "font-size").expect("txt.font-size should be a DebugHook");
+        assert!(is_synthetic(&txt, "font-size"), "txt.font-size hook should be synthetic");
         assert!(
             matches!(super::super::ignore_debug_hooks(&fs_inner), Expression::NumberLiteral(v, _) if *v == 0.),
             "txt.font-size default should be the 0 sentinel, got {fs_inner:?}"
         );
 
-        // An explicitly-set property is *wrapped* (its value preserved), not replaced.
+        // An explicitly-set property is *wrapped* (non-synthetic, value preserved).
         let bg_inner = hooked(&rect, "background").expect("rect.background should be a DebugHook");
+        assert!(
+            !is_synthetic(&rect, "background"),
+            "rect.background should be non-synthetic (was explicitly set)"
+        );
         assert!(
             !matches!(super::super::ignore_debug_hooks(&bg_inner), Expression::Invalid),
             "rect.background should wrap its real value"
@@ -275,5 +311,40 @@ mod tests {
 
         // Top-level elements carry a non-zero element_hash (used to build the hook ids).
         assert_ne!(txt.borrow().debug.first().unwrap().element_hash, 0);
+    }
+
+    /// Regression: geometry defaults (width/height) must still be computed even when
+    /// debug hooks are active and inject synthetic hooks for unbound geometry properties.
+    #[test]
+    fn geometry_defaults_still_set_with_debug_hooks() {
+        let doc = compile(
+            r#"
+            export component Foo inherits Window {
+                img := Image { source: @image-url("nonexistent.png"); }
+            }
+            "#,
+        );
+        let foo = component(&doc, "Foo");
+        let img = child(&foo.root_element, "img");
+
+        for property in ["x", "y", "width", "height"] {
+            // The default_geometry pass must have set width and height on the image.
+            // If synthetic hooks were treated as real bindings, default_geometry would
+            // skip the image, leaving it with no layout binding.  The resulting hook
+            // must therefore be non-synthetic (upgraded from the compiler-computed default).
+            let element = img.borrow();
+            let binding_expression = element
+                .bindings
+                .get(property)
+                .unwrap_or_else(|| panic!("img.{property} must be bound after default_geometry"));
+            // A synthetic hook would mean default_geometry never ran.
+            let expression = &binding_expression.borrow().expression;
+            // There must be a debug hook, but it must not be synthetic, as the pass injects a "real"
+            // binding
+            assert!(
+                matches!(expression, Expression::DebugHook { synthetic: false, .. }),
+                "img.width should not be synthetic after default_geometry, got {expression:?}"
+            );
+        }
     }
 }

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -44,6 +44,45 @@ pub fn property_id(element_id: u64, name: &smol_str::SmolStr) -> smol_str::SmolS
     smol_str::format_smolstr!("?{element_id}-{name}")
 }
 
+/// Guard rail, run near the end of the passes when debug hooks are enabled: every synthetic
+/// hook that survived must sit on a property that actually exists at runtime (native,
+/// declared, or materialized). An orphan would make the interpreter abort at instantiation
+/// with "unknown property ..." — catch it at compile time with a source location instead.
+///
+/// A property still needing materialization at this point (`should_materialize` returns
+/// `Some`) is exactly such an orphan.
+pub fn validate_no_orphan_synthetic_hooks(component: &std::rc::Rc<object_tree::Component>) {
+    if !cfg!(debug_assertions) {
+        return;
+    }
+    object_tree::recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, &()| {
+        let elem = elem.borrow();
+        for (name, binding_expression) in elem.bindings.iter() {
+            if !binding_expression.borrow().expression.is_synthetic_debug_hook() {
+                continue;
+            }
+            if super::materialize_fake_properties::should_materialize(
+                &elem.property_declarations,
+                &elem.base_type,
+                name,
+            )
+            .is_some()
+            {
+                panic!(
+                    "Orphan synthetic debug hook: property '{name}' on element '{}' ({}) does \
+                     not exist at runtime — a pass inserted or kept a synthetic hook for a \
+                     property that is neither native, declared, nor materialized",
+                    elem.id,
+                    elem.debug
+                        .first()
+                        .map(|d| format!("{:?}", d.node.source_file.path()))
+                        .unwrap_or_default(),
+                );
+            }
+        }
+    });
+}
+
 fn calculate_element_hash(
     elem: &object_tree::Element,
     random_state: &std::hash::RandomState,
@@ -69,10 +108,17 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, i
     let e = element.borrow();
     // Before repeater_component::process_repeater_components runs, a repeated element still
     // holds its content as children — recurse_elem will visit them naturally.
-    // Skip:
-    // * @children placeholder (generator skips these too)
-    // * non-inlined sub-component instances (base_type = Component)
-    if e.is_component_placeholder || e.sub_component().is_some() {
+    //
+    // Component-instance elements (base_type = Component, e.g. `sub := Sub { ... }`) are
+    // processed like any other element: their explicit instance bindings are wrapped and
+    // their unbound properties get synthetic hooks. The definition's own defaults are NOT
+    // consulted here — when the component is inlined, `BindingExpression::merge_with`
+    // upgrades a synthetic hook in place with the definition's real binding, so the
+    // property stays live-editable per instance (under the instance element's hook id)
+    // at its correct default value.
+    //
+    // Skip only the @children placeholder (the generator skips these too).
+    if e.is_component_placeholder {
         return;
     }
     if e.debug.is_empty() {
@@ -95,6 +141,12 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, i
     {
         let elem = element.borrow();
         elem.bindings.iter().for_each(|(name, be)| {
+            // Only hook properties — callback handlers and functions also live in
+            // `bindings`, but hook ids are a property-only namespace and overriding a code
+            // block with a value makes no sense.
+            if !elem.lookup_property(name).property_type.is_property_type() {
+                return;
+            }
             let expr = std::mem::take(&mut be.borrow_mut().expression);
             be.borrow_mut().expression = {
                 let stripped = super::ignore_debug_hooks(&expr);
@@ -163,10 +215,10 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, i
     // property-to-element lowerings, and their geometry is managed specially (runtime-managed
     // for windows, set after inlining otherwise) — treat them all like the component root below.
     // A `PopupWindow` is still an ordinary child element at this point, but the lower_popups
-    // pass later turns it into the root of its own component.
+    // pass later turns it into the root of its own component. `builtin_type()` walks through
+    // component bases, so instances of `component MyPopup inherits PopupWindow` are covered.
     let becomes_root = is_root
-        || matches!(&element.borrow().base_type,
-            crate::langtype::ElementType::Builtin(b) if b.name == "PopupWindow");
+        || element.borrow().builtin_type().is_some_and(|b| b.name == "PopupWindow");
 
     // Reserved geometry properties (x, y, width, height) — these are not in property_list()
     // because they are injected globally by the type system, not per builtin element.
@@ -389,6 +441,154 @@ mod tests {
         assert_ne!(txt.borrow().debug.first().unwrap().element_hash, 0);
     }
 
+    /// Component-instance elements are hooked too. The synthetic hooks injected on the
+    /// instance for the component's unbound properties must be upgraded with the definition's
+    /// real default bindings when the component is inlined (`merge_with`) — NOT clobber them.
+    /// Regression: repeated instances used to lose `tint: blue` / `background: tint` and
+    /// render transparent.
+    #[test]
+    fn instance_defaults_upgraded_into_hooks() {
+        let doc = compile(
+            r#"
+            component Item inherits Rectangle {
+                in property <color> tint: blue;
+                background: tint;
+            }
+            export component Win inherits Window {
+                width: 100px; height: 100px;
+                plain := Item { }
+                for _idx in 2: Item { }
+            }
+            "#,
+        );
+        let win = component(&doc, "Win");
+
+        let assert_background_preserved = |element: &ElementRc, what: &str| {
+            let borrowed = element.borrow();
+            let binding_expression = borrowed
+                .bindings
+                .get("background")
+                .unwrap_or_else(|| panic!("{what}: background must be bound"));
+            let expression = binding_expression.borrow().expression.clone();
+            let Expression::DebugHook { expression: inner, id, synthetic } = expression else {
+                panic!("{what}: background must be a DebugHook, got {expression:?}");
+            };
+            assert!(!synthetic, "{what}: hook must be upgraded with the definition's binding");
+            // The definition's `background: tint` must survive as the hook's inner expression
+            // (a reference to the — possibly moved/renamed — tint property, not the
+            // transparent type default).
+            let mut references_tint = false;
+            inner.visit_recursive(&mut |expression| {
+                if let Expression::PropertyReference(named_reference) = expression
+                    && named_reference.name().ends_with("tint")
+                {
+                    references_tint = true;
+                }
+            });
+            assert!(references_tint, "{what}: background must still reference tint, got {inner:?}");
+            // The hook id must belong to one of the merged source elements (the instance
+            // element's hash — hooks were injected before inlining).
+            assert!(
+                borrowed
+                    .debug
+                    .iter()
+                    .any(|d| property_id(d.element_hash, &smol_str::SmolStr::new_static("background")) == id),
+                "{what}: hook id {id} must match a merged element hash"
+            );
+        };
+
+        // Non-repeated instance: `plain` is the merged element after inlining.
+        let plain = child(&win.root_element, "plain");
+        assert_background_preserved(&plain, "plain instance");
+
+        // Repeated instance: the repeated element's base is the generated repeater component;
+        // the merged instance element is inside it.
+        let repeated = win
+            .root_element
+            .borrow()
+            .children
+            .iter()
+            .find(|c| c.borrow().repeated.is_some())
+            .expect("repeated element")
+            .clone();
+        let repeated_base = repeated.borrow().base_type.as_component().clone();
+        let mut found = None;
+        object_tree::recurse_elem(&repeated_base.root_element, &(), &mut |elem, &()| {
+            if elem.borrow().bindings.contains_key("background") {
+                found = Some(elem.clone());
+            }
+        });
+        let repeated_item = found.expect("repeated Item element with background binding");
+        assert_background_preserved(&repeated_item, "repeated instance");
+    }
+
+    /// Direct unit tests for the synthetic-hook rules in `BindingExpression::merge_with`
+    /// (used by inlining to merge a definition's bindings into an instance element).
+    #[test]
+    fn merge_with_synthetic_hook_rules() {
+        use crate::expression_tree::BindingExpression;
+
+        let synthetic_hook = || -> BindingExpression {
+            Expression::DebugHook {
+                expression: Box::new(Expression::NumberLiteral(0., Default::default())),
+                id: "?42-prop".into(),
+                synthetic: true,
+            }
+            .into()
+        };
+        let real_binding = |value: f64| -> BindingExpression {
+            let mut binding: BindingExpression =
+                Expression::NumberLiteral(value, Default::default()).into();
+            binding.priority = 3;
+            binding
+        };
+
+        // Synthetic hook + real binding: upgraded in place, wrapper and id survive.
+        let mut binding = synthetic_hook();
+        assert!(binding.merge_with(&real_binding(7.)), "the other expression must be taken");
+        match &binding.expression {
+            Expression::DebugHook { expression, id, synthetic } => {
+                assert!(!synthetic, "upgraded hook must no longer be synthetic");
+                assert_eq!(id, "?42-prop", "the hook id must survive the merge");
+                assert!(
+                    matches!(**expression, Expression::NumberLiteral(v, _) if v == 7.),
+                    "the definition's expression must be taken"
+                );
+            }
+            other => panic!("expected an upgraded DebugHook, got {other:?}"),
+        }
+        assert_eq!(binding.priority, 3, "the other side's priority must be taken");
+
+        // Synthetic hook + synthetic hook: unchanged, still synthetic ("no binding").
+        let mut binding = synthetic_hook();
+        assert!(!binding.merge_with(&synthetic_hook()));
+        assert!(binding.expression.is_synthetic_debug_hook());
+
+        // Synthetic hook + two-way-only binding: the hook is dropped — its default must not
+        // become the two-way's initial value.
+        let mut binding = synthetic_hook();
+        let mut two_way: BindingExpression = Expression::Invalid.into();
+        two_way.two_way_bindings.push(crate::expression_tree::TwoWayBinding::ModelData {
+            repeated_element: std::rc::Weak::default(),
+            field_access: Default::default(),
+        });
+        assert!(binding.merge_with(&two_way));
+        assert!(matches!(binding.expression, Expression::Invalid));
+        assert_eq!(binding.two_way_bindings.len(), 1);
+
+        // Real (non-synthetic hook) binding keeps priority over anything.
+        let mut binding: BindingExpression = Expression::DebugHook {
+            expression: Box::new(Expression::NumberLiteral(1., Default::default())),
+            id: "?42-prop".into(),
+            synthetic: false,
+        }
+        .into();
+        assert!(!binding.merge_with(&real_binding(9.)));
+        assert!(
+            matches!(binding.expression.ignore_debug_hooks(), Expression::NumberLiteral(v, _) if *v == 1.)
+        );
+    }
+
     /// The injected `transform-rotation` hook must cause the Transform wrapper element to be
     /// reified so the property actually exists at runtime, and the hook (carrying the source
     /// element's hash id) must survive as a non-synthetic binding. A binding left on a property
@@ -480,3 +680,4 @@ mod tests {
         }
     }
 }
+

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -3,17 +3,15 @@
 
 //! Hooks properties for live inspection.
 
-use crate::{expression_tree, object_tree, typeloader};
+use crate::expression_tree::Expression;
+use crate::object_tree::{self, ElementRc, PropertyVisibility};
 
-pub fn inject_debug_hooks(doc: &object_tree::Document, type_loader: &typeloader::TypeLoader) {
-    let Some(random_state) = &type_loader.compiler_config.debug_hooks else {
-        return;
-    };
-
-    doc.visit_all_used_components(|component| {
-        object_tree::recurse_elem_including_sub_components(component, &(), &mut |e, &()| {
-            process_element(e, random_state);
-        })
+pub fn inject_debug_hooks(
+    component: &std::rc::Rc<object_tree::Component>,
+    random_state: &std::hash::RandomState,
+) {
+    object_tree::recurse_elem(&component.root_element, &(), &mut |elem, &()| {
+        process_element(elem, random_state);
     });
 }
 
@@ -23,9 +21,10 @@ pub fn property_id(element_id: u64, name: &smol_str::SmolStr) -> smol_str::SmolS
 
 fn calculate_element_hash(
     elem: &object_tree::Element,
+    index: usize,
     random_state: &std::hash::RandomState,
 ) -> u64 {
-    let node = &elem.debug.first().expect("There was one element a moment ago").node;
+    let node = &elem.debug[index].node;
 
     let elem_path = node.source_file.path();
     let elem_offset = node
@@ -41,32 +40,196 @@ fn calculate_element_hash(
     hasher.finish()
 }
 
-fn process_element(element: &object_tree::ElementRc, random_state: &std::hash::RandomState) {
-    let mut elem = element.borrow_mut();
-    // We did not merge Elements yet and we have debug info!
-    assert_eq!(elem.debug.len(), 1);
+fn process_element(element: &ElementRc, random_state: &std::hash::RandomState) {
+    // Step 1: compute and store the element hash on EVERY debug entry.
+    // This pass now runs after required-inlining, so an element may carry several debug
+    // entries (one per merged source element). The LSP looks up the hash on the entry that
+    // matches the selected source location, so each entry needs its own hash. (The old
+    // early-pass invariant `debug.len() == 1` no longer holds.)
+    let element_hash = {
+        let mut elem = element.borrow_mut();
+        if elem.debug.is_empty() {
+            return;
+        }
+        for i in 0..elem.debug.len() {
+            if elem.debug[i].element_hash == 0 {
+                let hash = calculate_element_hash(&elem, i, random_state);
+                elem.debug[i].element_hash = hash;
+            }
+        }
+        // Bindings live on this (outermost, editor-selectable) element; a selection resolves to
+        // its primary debug entry, so the first entry's hash is the one used to build ids.
+        elem.debug[0].element_hash
+    };
 
-    // Ignore nodes previously set up
-    if elem.debug.first().expect("There was one element a moment ago").element_hash != 0 {
-        return;
+    // Step 2: Wrap existing bindings.
+    {
+        let elem = element.borrow();
+        elem.bindings.iter().for_each(|(name, be)| {
+            let expr = std::mem::take(&mut be.borrow_mut().expression);
+            be.borrow_mut().expression = {
+                let stripped = super::ignore_debug_hooks(&expr);
+                if matches!(stripped, Expression::Invalid)
+                    || matches!(expr, Expression::DebugHook { .. })
+                {
+                    expr
+                } else {
+                    Expression::DebugHook {
+                        expression: Box::new(expr),
+                        id: property_id(element_hash, name),
+                    }
+                }
+            };
+        });
     }
 
-    let element_hash = calculate_element_hash(&elem, random_state);
+    // Step 3: Materialize hooked defaults for unbound settable properties.
+    // Collect candidates first (releases the borrow), then insert.
+    let candidates: Vec<(smol_str::SmolStr, crate::langtype::Type)> = {
+        let elem = element.borrow();
 
-    elem.bindings.iter().for_each(|(name, be)| {
-        let expr = std::mem::take(&mut be.borrow_mut().expression);
-        be.borrow_mut().expression = {
-            let stripped = super::ignore_debug_hooks(&expr);
-            if matches!(stripped, expression_tree::Expression::Invalid) {
-                stripped.clone()
-            } else {
-                expression_tree::Expression::DebugHook {
-                    expression: Box::new(expr),
-                    id: property_id(element_hash, name),
+        // Properties from the base type.
+        let base_props = elem.base_type.property_list();
+
+        // Properties from own declarations.
+        let own_props: Vec<(smol_str::SmolStr, crate::langtype::Type)> = elem
+            .property_declarations
+            .iter()
+            .map(|(name, decl)| (name.clone(), decl.property_type.clone()))
+            .collect();
+
+        base_props
+            .into_iter()
+            .chain(own_props)
+            .filter(|(name, _)| !elem.bindings.contains_key(name.as_str()))
+            .filter_map(|(name, _ty)| {
+                let name_str = name.clone();
+                let lookup = elem.lookup_property(&name_str);
+                // Skip functions/callbacks exposed as builtin functions.
+                if lookup.builtin_function.is_some() {
+                    return None;
                 }
-            }
-        };
-    });
+                // Only settable visibilities.
+                match lookup.property_visibility {
+                    PropertyVisibility::Public
+                    | PropertyVisibility::InOut
+                    | PropertyVisibility::Input => {}
+                    PropertyVisibility::Private
+                    | PropertyVisibility::Output
+                    | PropertyVisibility::Constexpr
+                    | PropertyVisibility::Protected
+                    | PropertyVisibility::Fake => return None,
+                }
+                let default = Expression::default_value_for_type(&lookup.property_type);
+                if matches!(default, Expression::Invalid) {
+                    return None;
+                }
+                Some((name, lookup.property_type))
+            })
+            .collect()
+    };
 
-    elem.debug.first_mut().expect("There was one element a moment ago").element_hash = element_hash;
+    // Now insert the hooked defaults.
+    for (name, ty) in candidates {
+        let default = Expression::default_value_for_type(&ty);
+        let id = property_id(element_hash, &name);
+        element.borrow_mut().set_binding_if_not_set(name, || Expression::DebugHook {
+            expression: Box::new(default),
+            id,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object_tree::Component;
+    use std::rc::Rc;
+
+    fn compile(source: &str) -> crate::object_tree::Document {
+        let mut config =
+            crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        config.style = Some("fluent".into());
+        config.debug_hooks = Some(std::hash::RandomState::new());
+        let mut diags = crate::diagnostics::BuildDiagnostics::default();
+        let doc_node = crate::parser::parse(
+            source.into(),
+            Some(std::path::Path::new("test.slint")),
+            &mut diags,
+        );
+        let (doc, diag, _) = spin_on::spin_on(crate::compile_syntax_node(doc_node, diags, config));
+        assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
+        doc
+    }
+
+    fn component(doc: &crate::object_tree::Document, id: &str) -> Rc<Component> {
+        doc.inner_components.iter().find(|c| c.id == id).expect("component").clone()
+    }
+
+    fn child(root: &ElementRc, id: &str) -> ElementRc {
+        // The unique-id pass suffixes ids (`txt` -> `txt-2`), so match name or `name-N`.
+        fn rec(e: &ElementRc, id: &str) -> Option<ElementRc> {
+            let this_id = e.borrow().id.clone();
+            if this_id == id || this_id.starts_with(&format!("{id}-")) {
+                return Some(e.clone());
+            }
+            let children = e.borrow().children.clone();
+            children.iter().find_map(|c| rec(c, id))
+        }
+        rec(root, id).unwrap_or_else(|| panic!("element {id} not found"))
+    }
+
+    /// The inner expression of a property's DebugHook, or None if the binding is not a hook.
+    fn hooked(elem: &ElementRc, name: &str) -> Option<Expression> {
+        let e = elem.borrow();
+        let be = e.bindings.get(name)?;
+        match be.borrow().expression.clone() {
+            Expression::DebugHook { expression, .. } => Some(*expression),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn injects_and_wraps_top_level_only() {
+        let doc = compile(
+            r#"
+            component Sub inherits Rectangle {
+                inner-text := Text { }
+            }
+            export component Foo inherits Window {
+                txt := Text { }
+                rect := Rectangle { background: red; }
+                sub := Sub { }
+            }
+            "#,
+        );
+
+        let foo = component(&doc, "Foo");
+        let txt = child(&foo.root_element, "txt");
+        let rect = child(&foo.root_element, "rect");
+
+        // Unbound `text` is now hooked, wrapping the empty-string type default.
+        let text_inner = hooked(&txt, "text").expect("txt.text should be a DebugHook");
+        assert!(
+            matches!(super::super::ignore_debug_hooks(&text_inner), Expression::StringLiteral(s) if s.is_empty()),
+            "txt.text default should be the empty-string sentinel, got {text_inner:?}"
+        );
+
+        // Unbound `font-size` is hooked wrapping the 0 sentinel — keeps runtime Window inheritance.
+        let fs_inner = hooked(&txt, "font-size").expect("txt.font-size should be a DebugHook");
+        assert!(
+            matches!(super::super::ignore_debug_hooks(&fs_inner), Expression::NumberLiteral(v, _) if *v == 0.),
+            "txt.font-size default should be the 0 sentinel, got {fs_inner:?}"
+        );
+
+        // An explicitly-set property is *wrapped* (its value preserved), not replaced.
+        let bg_inner = hooked(&rect, "background").expect("rect.background should be a DebugHook");
+        assert!(
+            !matches!(super::super::ignore_debug_hooks(&bg_inner), Expression::Invalid),
+            "rect.background should wrap its real value"
+        );
+
+        // Top-level elements carry a non-zero element_hash (used to build the hook ids).
+        assert_ne!(txt.borrow().debug.first().unwrap().element_hash, 0);
+    }
 }

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -20,6 +20,11 @@
 //!    sets a default on a property that carries a synthetic hook, `set_binding_if_not_set`
 //!    replaces the hook's inner expression in place (keeping the wrapper and id) and clears
 //!    the `synthetic` flag — so the hook ends up wrapping the real compiler-computed value.
+//!
+//! 3. **Inject a real `transform-rotation` binding** (a *non-synthetic* hook wrapping the 0deg
+//!    default) on elements that support it. Transform properties only exist at runtime when the
+//!    lowering reifies them onto a `Transform` wrapper element, which requires a visible binding
+//!    — see the comment on `transform_candidate` below.
 
 use crate::expression_tree::Expression;
 use crate::object_tree::{self, ElementRc, PropertyVisibility};
@@ -154,13 +159,24 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, i
             .collect()
     };
 
+    // Elements that are (or will become) the root of a component are never wrapped by the
+    // property-to-element lowerings, and their geometry is managed specially (runtime-managed
+    // for windows, set after inlining otherwise) — treat them all like the component root below.
+    // A `PopupWindow` is still an ordinary child element at this point, but the lower_popups
+    // pass later turns it into the root of its own component.
+    let becomes_root = is_root
+        || matches!(&element.borrow().base_type,
+            crate::langtype::ElementType::Builtin(b) if b.name == "PopupWindow");
+
     // Reserved geometry properties (x, y, width, height) — these are not in property_list()
     // because they are injected globally by the type system, not per builtin element.
     // We exclude "z" to avoid spurious property materialization in materialize_fake_properties.
-    // We skip the component root element because its geometry is either runtime-managed (Window)
-    // or set after inlining into a parent component — either way, no compiler pass will upgrade
-    // a synthetic hook, which would leave root geometry frozen at 0px.
-    let geometry_candidates: Vec<(smol_str::SmolStr, Expression)> = if is_root {
+    // We skip root elements because their geometry is either runtime-managed (Window) or set
+    // after inlining into a parent component — either way, no compiler pass will upgrade a
+    // synthetic hook, which would leave root geometry frozen at 0px.
+    // We also skip elements that don't actually have the property (non-item types like Timer
+    // report Type::Invalid for the reserved properties).
+    let geometry_candidates: Vec<(smol_str::SmolStr, Expression)> = if becomes_root {
         vec![]
     } else {
         let elem = element.borrow();
@@ -169,6 +185,10 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, i
             .filter(|(name, _)| *name != "z")
             .filter_map(|(prop_name, ty)| {
                 if elem.bindings.contains_key(*prop_name) {
+                    return None;
+                }
+                if elem.lookup_property(prop_name).property_type == crate::langtype::Type::Invalid
+                {
                     return None;
                 }
                 let default = Expression::default_value_for_type(ty);
@@ -180,25 +200,40 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, i
             .collect()
     };
 
-    // Also include reserved transform-property defaults.
-    let transform_candidates: Vec<(smol_str::SmolStr, Expression)> = {
+    // The reserved transform properties are unlike the geometry properties above: no item
+    // actually has them. They only exist at runtime when the lower_transform_properties pass
+    // finds a binding and reifies the property onto an injected `Transform` wrapper element.
+    // A synthetic hook is (by design) invisible to other passes, so it would never cause that
+    // wrapper to be created — the hook would remain as a binding to a property that never
+    // materializes, and the interpreter aborts on the unknown property.
+    //
+    // To keep every element rotatable in live-preview, inject `transform-rotation` as a
+    // *non-synthetic* hook wrapping its default — semantically "as if the user had written
+    // `transform-rotation: 0deg;`" — which the lowering then reifies like any real binding.
+    // Only `transform-rotation` gets this treatment: it is what the editor overrides live, and
+    // its default is context-free. The other transform properties have context-dependent
+    // defaults (e.g. `transform-scale-x` follows `transform-scale`, which passes running after
+    // this one may still bind) that are correctly computed at lowering time instead.
+    //
+    // Root elements (including future popup roots) are skipped — the lowering never wraps a
+    // root, so the transform properties are not applicable there — as are elements that don't
+    // support transforms at all (non-item types).
+    let transform_candidate: Option<(smol_str::SmolStr, Expression)> = {
         let elem = element.borrow();
-        if elem.debug.is_empty() {
-            vec![]
+        let property_name = smol_str::SmolStr::new_static("transform-rotation");
+        if becomes_root
+            || elem.bindings.contains_key(&property_name)
+            || elem.lookup_property(&property_name).property_type
+                == crate::langtype::Type::Invalid
+        {
+            None
         } else {
-            crate::typeregister::RESERVED_TRANSFORM_PROPERTIES
-                .iter()
-                .filter_map(|(prop_name, _)| {
-                    if elem.bindings.contains_key(*prop_name) {
-                        return None;
-                    }
-                    let default_expr =
-                        super::lower_property_to_element::transform_property_default_value(
-                            element, prop_name,
-                        )?;
-                    Some((smol_str::SmolStr::new_static(prop_name), default_expr))
-                })
-                .collect()
+            drop(elem);
+            super::lower_property_to_element::transform_property_default_value(
+                element,
+                &property_name,
+            )
+            .map(|default_expression| (property_name, default_expression))
         }
     };
 
@@ -228,11 +263,12 @@ fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, i
         }
     }
 
-    // Insert synthetic hooks for the transform properties.
-    for (name, default_expr) in transform_candidates {
+    // Insert the transform-rotation hook. Deliberately *non-synthetic*: later passes must see
+    // it as a real binding so the Transform wrapper element is created (see above).
+    if let Some((name, default_expr)) = transform_candidate {
         let id = property_id(element_hash, &name);
         let mut binding_expressions: crate::expression_tree::BindingExpression =
-            Expression::DebugHook { expression: Box::new(default_expr), id, synthetic: true }
+            Expression::DebugHook { expression: Box::new(default_expr), id, synthetic: false }
                 .into();
         binding_expressions.priority = 0;
         use std::collections::btree_map::Entry;
@@ -353,6 +389,49 @@ mod tests {
         assert_ne!(txt.borrow().debug.first().unwrap().element_hash, 0);
     }
 
+    /// The injected `transform-rotation` hook must cause the Transform wrapper element to be
+    /// reified so the property actually exists at runtime, and the hook (carrying the source
+    /// element's hash id) must survive as a non-synthetic binding. A binding left on a property
+    /// that is never materialized would abort the interpreter at instantiation time.
+    #[test]
+    fn transform_rotation_hook_is_reified() {
+        let doc = compile(
+            r#"
+            export component Foo inherits Window {
+                rect := Rectangle { }
+            }
+            "#,
+        );
+        let foo = component(&doc, "Foo");
+        let rect = child(&foo.root_element, "rect");
+        let rect_hash = rect.borrow().debug.first().unwrap().element_hash;
+        let rotation_hook_id =
+            property_id(rect_hash, &smol_str::SmolStr::new_static("transform-rotation"));
+
+        // A Transform wrapper element must have been injected for the rectangle.
+        let transform_element = child(&foo.root_element, "rect-Transform");
+
+        // The rotation hook ends up driving the Transform element (the two-way binding to the
+        // rectangle's materialized property is collapsed by the alias optimizations); it must
+        // be non-synthetic and wrap the 0 default.
+        let binding_holder = transform_element.borrow();
+        let binding_expression = binding_holder
+            .bindings
+            .get("transform-rotation")
+            .expect("the Transform element must bind transform-rotation");
+        match &binding_expression.borrow().expression {
+            Expression::DebugHook { id, synthetic, expression } => {
+                assert_eq!(id, &rotation_hook_id, "hook id must be derived from rect's hash");
+                assert!(!synthetic, "the injected rotation hook must be non-synthetic");
+                assert!(
+                    matches!(**expression, Expression::NumberLiteral(v, _) if v == 0.),
+                    "the rotation hook must wrap the 0deg default"
+                );
+            }
+            other => panic!("transform-rotation must be a DebugHook, got {other:?}"),
+        }
+    }
+
     /// Regression: geometry defaults (width/height) must still be computed even when
     /// debug hooks are active and inject synthetic hooks for unbound geometry properties.
     #[test]
@@ -366,24 +445,37 @@ mod tests {
         );
         let foo = component(&doc, "Foo");
         let img = child(&foo.root_element, "img");
+        let img_hash = img.borrow().debug.first().unwrap().element_hash;
+
+        // The geometry properties are materialized into declarations and the declarations
+        // (with their bindings) are moved to the root by move_declarations — so look the hook
+        // up by its id across the whole component instead of by name on the img element.
+        let find_hook_by_id = |wanted_id: &smol_str::SmolStr| -> Option<Expression> {
+            let mut found = None;
+            object_tree::recurse_elem(&foo.root_element, &(), &mut |elem, &()| {
+                for (_, binding_expression) in elem.borrow().bindings.iter() {
+                    if let Expression::DebugHook { id, .. } = &binding_expression.borrow().expression
+                        && id == wanted_id
+                    {
+                        found = Some(binding_expression.borrow().expression.clone());
+                    }
+                }
+            });
+            found
+        };
 
         for property in ["x", "y", "width", "height"] {
             // The default_geometry pass must have set width and height on the image.
             // If synthetic hooks were treated as real bindings, default_geometry would
             // skip the image, leaving it with no layout binding.  The resulting hook
-            // must therefore be non-synthetic (upgraded from the compiler-computed default).
-            let element = img.borrow();
-            let binding_expression = element
-                .bindings
-                .get(property)
-                .unwrap_or_else(|| panic!("img.{property} must be bound after default_geometry"));
-            // A synthetic hook would mean default_geometry never ran.
-            let expression = &binding_expression.borrow().expression;
-            // There must be a debug hook, but it must not be synthetic, as the pass injects a "real"
-            // binding
+            // must therefore be non-synthetic: either upgraded by default_geometry itself or
+            // by materialize_fake_properties' initialization.
+            let hook_id = property_id(img_hash, &smol_str::SmolStr::new_static(property));
+            let expression = find_hook_by_id(&hook_id)
+                .unwrap_or_else(|| panic!("a debug hook for img.{property} must survive"));
             assert!(
                 matches!(expression, Expression::DebugHook { synthetic: false, .. }),
-                "img.width should not be synthetic after default_geometry, got {expression:?}"
+                "img.{property} hook should not be synthetic after default_geometry, got {expression:?}"
             );
         }
     }

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -571,6 +571,7 @@ mod tests {
         two_way.two_way_bindings.push(crate::expression_tree::TwoWayBinding::ModelData {
             repeated_element: std::rc::Weak::default(),
             field_access: Default::default(),
+            field_access1: Default::default(),
         });
         assert!(binding.merge_with(&two_way));
         assert!(matches!(binding.expression, Expression::Invalid));

--- a/internal/compiler/passes/lower_absolute_coordinates.rs
+++ b/internal/compiler/passes/lower_absolute_coordinates.rs
@@ -1,16 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! This pass creates bindings to "absolute-y" and "absolute-y" properties
-//! that can be used to compute the window-absolute coordinates of elements.
+//! This pass creates bindings to the `absolute-position` property that can be used to compute
+//! the window-absolute coordinates of elements.
 
-use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::expression_tree::{BuiltinFunction, Expression};
-use crate::langtype::Type;
-use crate::namedreference::NamedReference;
 use crate::object_tree::Component;
 
 pub fn lower_absolute_coordinates(component: &Rc<Component>) {
@@ -22,56 +19,23 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
         }
     });
 
-    let Type::Struct(point_type) = BuiltinFunction::ItemAbsolutePosition.ty().return_type.clone()
-    else {
-        unreachable!()
-    };
-
     for nr in to_materialize {
         let elem = nr.element();
 
-        // Create a binding for the `absolute-position` property. The
-        // materialize properties pass is going to create the actual property later.
-
-        let parent_position_var = Box::new(Expression::ReadLocalVariable {
-            name: "parent_position".into(),
-            ty: point_type.clone().into(),
-        });
-
-        let binding = Expression::CodeBlock(vec![
-            Expression::StoreLocalVariable {
-                name: "parent_position".into(),
-                value: Expression::FunctionCall {
-                    function: BuiltinFunction::ItemAbsolutePosition.into(),
-                    arguments: vec![Expression::ElementReference(Rc::downgrade(&elem))],
-                    source_location: None,
-                }
-                .into(),
-            },
-            Expression::Struct {
-                ty: point_type.clone(),
-                values: IntoIterator::into_iter(["x", "y"])
-                    .map(|coord| {
-                        (
-                            coord.into(),
-                            Expression::BinaryExpression {
-                                lhs: Expression::StructFieldAccess {
-                                    base: parent_position_var.clone(),
-                                    name: coord.into(),
-                                }
-                                .into(),
-                                rhs: Expression::PropertyReference(NamedReference::new(
-                                    &elem,
-                                    SmolStr::new_static(coord),
-                                ))
-                                .into(),
-                                op: '+',
-                            },
-                        )
-                    })
-                    .collect(),
-            },
-        ]);
+        // `ItemAbsolutePosition` already returns the element's own absolute window position: it
+        // maps the element's geometry origin through the ancestor transforms at runtime. We do
+        // not add the element's `x`/`y` here — doing so would double-count the offset once a
+        // wrapper element (Opacity/Layer/Transform) is injected around the element (the wrapper
+        // takes over the element's geometry, so `map_to_window` already includes it), and it
+        // would also be wrong under a parent scale/rotation. Computing everything at runtime
+        // keeps it correct regardless of injected wrappers and cross-component inlining.
+        //
+        // The `materialize_fake_properties` pass creates the actual property later.
+        let binding = Expression::FunctionCall {
+            function: BuiltinFunction::ItemAbsolutePosition.into(),
+            arguments: vec![Expression::ElementReference(Rc::downgrade(&elem))],
+            source_location: None,
+        };
 
         elem.borrow_mut().bindings.insert(nr.name().clone(), RefCell::new(binding.into()));
     }

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1938,15 +1938,13 @@ fn insert_cache_prop_binding(
     layout_cache_prop: &NamedReference,
     diag: &mut BuildDiagnostics,
 ) {
-    let old = elem.borrow_mut().bindings.insert(
-        prop.into(),
-        BindingExpression::new_with_span(
-            expr,
-            layout_cache_prop.element().borrow().to_source_location(),
-        )
-        .into(),
+    let new_binding = BindingExpression::new_with_span(
+        expr,
+        layout_cache_prop.element().borrow().to_source_location(),
     );
-    if let Some(old) = old.map(RefCell::into_inner) {
+    // Use set_binding_overwriting so that a synthetic debug hook (an unbound geometry default)
+    // is upgraded in-place rather than being treated as a genuine conflicting binding.
+    if let Some(old) = elem.borrow_mut().set_binding_overwriting(prop.into(), new_binding) {
         diag.push_error(
             format!("The property '{prop}' cannot be set for elements placed in this layout, because the layout is already setting it"),
             &old,

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -657,7 +657,8 @@ fn lower_menu_items(
                 element.borrow_mut().enclosing_component = component_weak.clone();
                 element.borrow_mut().geometry_props = None;
 
-                if !in_menubar && let Some(binding) = element.borrow().bindings.get("shortcut") {
+                // binding() ignores synthetic debug hooks (placeholders for the unbound property)
+                if !in_menubar && let Some(binding) = element.borrow().binding("shortcut") {
                     diag.push_error(
                         "MenuItem shortcuts are currently only supported in the MenuBar".into(),
                         &*binding.borrow(),

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -26,13 +26,17 @@ pub(crate) fn lower_property_to_element(
     diag: &mut BuildDiagnostics,
 ) {
     for property_name in property_names.clone() {
+        // Only warn about real (non-synthetic) bindings on the root element.
+        // Synthetic debug hooks are placeholders that will be upgraded or stripped later.
         if let Some(b) = component.root_element.borrow().bindings.get(property_name) {
-            diag.push_warning(
-                format!(
-                    "The {property_name} property cannot be used on the root element, it will not be applied"
-                ),
-                &*b.borrow(),
-            );
+            if !b.borrow().expression.is_synthetic_debug_hook() {
+                diag.push_warning(
+                    format!(
+                        "The {property_name} property cannot be used on the root element, it will not be applied"
+                    ),
+                    &*b.borrow(),
+                );
+            }
         }
     }
 
@@ -50,7 +54,10 @@ pub(crate) fn lower_property_to_element(
         let has_property_binding = |e: &ElementRc| {
             property_names.clone().any(|property_name| {
                 e.borrow().base_type.lookup_property(property_name).property_type != Type::Invalid
-                    && (e.borrow().bindings.contains_key(property_name)
+                    // Ignore synthetic debug hooks — they are placeholders, not real user bindings.
+                    && (e.borrow().bindings.get(property_name).is_some_and(|b| {
+                        !b.borrow().expression.is_synthetic_debug_hook()
+                    })
                         || e.borrow()
                             .property_analysis
                             .borrow()

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -26,17 +26,15 @@ pub(crate) fn lower_property_to_element(
     diag: &mut BuildDiagnostics,
 ) {
     for property_name in property_names.clone() {
-        // Only warn about real (non-synthetic) bindings on the root element.
-        // Synthetic debug hooks are placeholders that will be upgraded or stripped later.
-        if let Some(b) = component.root_element.borrow().bindings.get(property_name) {
-            if !b.borrow().expression.is_synthetic_debug_hook() {
-                diag.push_warning(
-                    format!(
-                        "The {property_name} property cannot be used on the root element, it will not be applied"
-                    ),
-                    &*b.borrow(),
-                );
-            }
+        // binding() only returns real (non-synthetic) bindings — synthetic debug hooks are
+        // placeholders that will be upgraded or stripped later and must not warn.
+        if let Some(b) = component.root_element.borrow().binding(property_name) {
+            diag.push_warning(
+                format!(
+                    "The {property_name} property cannot be used on the root element, it will not be applied"
+                ),
+                &*b.borrow(),
+            );
         }
     }
 
@@ -54,10 +52,8 @@ pub(crate) fn lower_property_to_element(
         let has_property_binding = |e: &ElementRc| {
             property_names.clone().any(|property_name| {
                 e.borrow().base_type.lookup_property(property_name).property_type != Type::Invalid
-                    // Ignore synthetic debug hooks — they are placeholders, not real user bindings.
-                    && (e.borrow().bindings.get(property_name).is_some_and(|b| {
-                        !b.borrow().expression.is_synthetic_debug_hook()
-                    })
+                    // binding() ignores synthetic debug hooks — placeholders, not user bindings.
+                    && (e.borrow().binding(property_name).is_some()
                         || e.borrow()
                             .property_analysis
                             .borrow()
@@ -113,7 +109,9 @@ fn create_property_element(
                 NamedReference::new(child, property_name.clone()).into(),
             );
             if let Some(default_value_for_extra_properties) = default_value_for_extra_properties
-                && !child.borrow().bindings.contains_key(&property_name)
+                // binding() ignores synthetic debug hooks: an unbound property placeholder
+                // must not suppress the default value.
+                && child.borrow().binding(&property_name).is_none()
                 && let Some(e) = default_value_for_extra_properties(child, &property_name)
             {
                 bind.expression = e;

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -125,6 +125,44 @@ fn create_property_element(
     element.make_rc()
 }
 
+pub fn transform_property_default_value(
+    element: &ElementRc,
+    property_name: &str,
+) -> Option<Expression> {
+    let transform_origin = crate::typeregister::transform_origin_property();
+
+    let prop_div_2 = |prop: &str| Expression::BinaryExpression {
+        lhs: Expression::PropertyReference(NamedReference::new(element, prop.into())).into(),
+        op: '/',
+        rhs: Expression::NumberLiteral(2., Default::default()).into(),
+    };
+
+    match property_name {
+        "transform-origin" => Some(Expression::Struct {
+            ty: transform_origin.1.clone(),
+            values: [
+                (SmolStr::new_static("x"), prop_div_2("width")),
+                (SmolStr::new_static("y"), prop_div_2("height")),
+            ]
+            .into_iter()
+            .collect(),
+        }),
+        "transform-scale-x" | "transform-scale-y" => {
+            if element.borrow().is_binding_set("transform-scale", true) {
+                Some(Expression::PropertyReference(NamedReference::new(
+                    element,
+                    SmolStr::new_static("transform-scale"),
+                )))
+            } else {
+                Some(Expression::NumberLiteral(1., Default::default()))
+            }
+        }
+        "transform-scale" => None,
+        "transform-rotation" => Some(Expression::NumberLiteral(0., Default::default())),
+        _ => unreachable!(),
+    }
+}
+
 /// Wrapper around lower_property_to_element for the Transform element
 pub fn lower_transform_properties(
     component: &Rc<Component>,
@@ -137,38 +175,7 @@ pub fn lower_transform_properties(
         component,
         crate::typeregister::RESERVED_TRANSFORM_PROPERTIES.iter().map(|(prop_name, _)| *prop_name),
         std::iter::once(transform_origin.0),
-        Some(&|e, prop| {
-            let prop_div_2 = |prop: &str| Expression::BinaryExpression {
-                lhs: Expression::PropertyReference(NamedReference::new(e, prop.into())).into(),
-                op: '/',
-                rhs: Expression::NumberLiteral(2., Default::default()).into(),
-            };
-
-            match prop {
-                "transform-origin" => Some(Expression::Struct {
-                    ty: transform_origin.1.clone(),
-                    values: [
-                        (SmolStr::new_static("x"), prop_div_2("width")),
-                        (SmolStr::new_static("y"), prop_div_2("height")),
-                    ]
-                    .into_iter()
-                    .collect(),
-                }),
-                "transform-scale-x" | "transform-scale-y" => {
-                    if e.borrow().is_binding_set("transform-scale", true) {
-                        Some(Expression::PropertyReference(NamedReference::new(
-                            e,
-                            SmolStr::new_static("transform-scale"),
-                        )))
-                    } else {
-                        Some(Expression::NumberLiteral(1., Default::default()))
-                    }
-                }
-                "transform-scale" => None,
-                "transform-rotation" => Some(Expression::NumberLiteral(0., Default::default())),
-                _ => unreachable!(),
-            }
-        }),
+        Some(&|e, prop| transform_property_default_value(e, prop)),
         &SmolStr::new_static("Transform"),
         tr,
         diag,

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -88,7 +88,18 @@ fn lower_state_in_element(
             };
             match e.borrow_mut().bindings.entry(ne.name().clone()) {
                 std::collections::btree_map::Entry::Occupied(mut e) => {
-                    e.get_mut().get_mut().expression = new_expr
+                    let binding = e.get_mut().get_mut();
+                    // A synthetic debug hook may occupy an unbound property: upgrade it in
+                    // place (keep the wrapper and id, clear `synthetic`) so the property
+                    // stays live-editable. A non-synthetic hook already survives inside
+                    // `property_expr` (the else-branch), so it is replaced as before.
+                    match &mut binding.expression {
+                        Expression::DebugHook { expression, synthetic, .. } if *synthetic => {
+                            *expression = Box::new(new_expr);
+                            *synthetic = false;
+                        }
+                        expression => *expression = new_expr,
+                    }
                 }
                 std::collections::btree_map::Entry::Vacant(e) => {
                     let mut r = BindingExpression::from(new_expr);
@@ -203,7 +214,10 @@ fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProp
     let mut element_it = Some(element.clone());
     let mut in_base = false;
     while let Some(elem) = element_it {
-        if let Some(e) = elem.borrow().bindings.get(name) {
+        // binding() skips synthetic debug hooks: an unbound property's placeholder must not
+        // shadow a real default binding deeper in the base chain (it would become the state's
+        // else-branch and change the idle value).
+        if let Some(e) = elem.borrow().binding(name) {
             let e = e.borrow();
             if !e.two_way_bindings.is_empty() {
                 return ExpressionForProperty::TwoWayBinding;

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -291,17 +291,17 @@ fn set_geometry_prop(
     prop: &str,
     diag: &mut BuildDiagnostics,
 ) {
-    let old = content.borrow_mut().bindings.insert(
+    // set_binding_overwriting upgrades a synthetic debug hook placeholder in place and only
+    // reports a real (user-written) binding as a conflict.
+    let old = content.borrow_mut().set_binding_overwriting(
         prop.into(),
-        RefCell::new(
-            Expression::PropertyReference(NamedReference::new(
-                tab_widget,
-                format_smolstr!("content-{}", prop),
-            ))
-            .into(),
-        ),
+        Expression::PropertyReference(NamedReference::new(
+            tab_widget,
+            format_smolstr!("content-{}", prop),
+        ))
+        .into(),
     );
-    if let Some(old) = old.map(RefCell::into_inner) {
+    if let Some(old) = old {
         diag.push_error(
             format!("The property '{prop}' cannot be set for Tabs inside a TabWidget"),
             &old,

--- a/internal/compiler/passes/lower_tooltips.rs
+++ b/internal/compiler/passes/lower_tooltips.rs
@@ -116,8 +116,10 @@ fn bind_popup_effective_size_from_content(
     popup_window_rc: &ElementRc,
     tooltip_content_rc: &ElementRc,
 ) {
-    let content_has_width = tooltip_content_rc.borrow().bindings.contains_key(WIDTH);
-    let content_has_height = tooltip_content_rc.borrow().bindings.contains_key(HEIGHT);
+    // binding() ignores synthetic debug hooks — an unbound width/height must take the
+    // preferred-size path even when a hook placeholder occupies the slot.
+    let content_has_width = tooltip_content_rc.borrow().binding(WIDTH).is_some();
+    let content_has_height = tooltip_content_rc.borrow().binding(HEIGHT).is_some();
 
     if content_has_width {
         let explicit_width = NamedReference::new(tooltip_content_rc, SmolStr::new_static(WIDTH));
@@ -352,7 +354,7 @@ fn lower_tooltips_in_component(
         }
 
         let has_custom_content = !tooltip_candidate.borrow().children.is_empty();
-        let has_text_binding = tooltip_candidate.borrow().bindings.contains_key("text");
+        let has_text_binding = tooltip_candidate.borrow().binding("text").is_some();
         if has_custom_content && has_text_binding {
             diag.push_error(
                 "Tooltip cannot have both text and custom content".into(),

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -124,7 +124,7 @@ fn must_initialize(elem: &Element, prop: &str) -> bool {
 }
 
 /// Returns a type if the property needs to be materialized.
-fn should_materialize(
+pub(crate) fn should_materialize(
     property_declarations: &BTreeMap<SmolStr, PropertyDeclaration>,
     base_type: &ElementType,
     prop: &str,

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -83,11 +83,15 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
     }
 }
 
-// One must initialize if there is an actual expression for that binding
+// One must initialize if there is no real expression for that binding.
+// A synthetic debug hook (materialized default) counts as "not initialized".
 fn must_initialize(elem: &Element, prop: &str) -> bool {
     match elem.bindings.get(prop) {
         None => true,
-        Some(b) => matches!(b.borrow().expression, Expression::Invalid),
+        Some(b) => {
+            matches!(b.borrow().expression, Expression::Invalid)
+                || b.borrow().expression.is_synthetic_debug_hook()
+        }
     }
 }
 

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -40,6 +40,16 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
 
     recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
         for prop in elem.borrow().bindings.keys() {
+            // DebugHook bindings must not be materialized into property_declarations via this
+            // path: they are self-contained placeholders that must survive remove_unused_properties
+            // (which only removes declared properties).  If the property is genuinely referenced
+            // by a NamedReference, the first loop above will have already added it to
+            // `to_materialize`, and it will be handled correctly there.
+            if elem.borrow().bindings.get(prop).is_some_and(|b| {
+                matches!(b.borrow().expression, Expression::DebugHook { .. })
+            }) {
+                continue;
+            }
             let nr = NamedReference::new(elem, prop.clone());
             if let std::collections::hash_map::Entry::Vacant(e) = to_materialize.entry(nr) {
                 let elem = elem.borrow();
@@ -54,6 +64,17 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
 
     for (nr, ty) in to_materialize {
         let elem = nr.element();
+
+        // A DebugHook binding is a self-contained placeholder: don't materialize it into
+        // property_declarations.  If we did, move_declarations would pull it out of the inner
+        // element and into the root component, breaking the property's location.
+        // geometry_props NamedReferences (e.g. geometry_props.x → img.x) trigger this path;
+        // we skip them here so the DebugHook stays in-place on the inner element.
+        if elem.borrow().bindings.get(nr.name()).is_some_and(|b| {
+            matches!(b.borrow().expression, Expression::DebugHook { .. })
+        }) {
+            continue;
+        }
 
         elem.borrow_mut().property_declarations.insert(
             nr.name().clone(),

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -40,13 +40,14 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
 
     recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
         for prop in elem.borrow().bindings.keys() {
-            // DebugHook bindings must not be materialized into property_declarations via this
-            // path: they are self-contained placeholders that must survive remove_unused_properties
-            // (which only removes declared properties).  If the property is genuinely referenced
-            // by a NamedReference, the first loop above will have already added it to
-            // `to_materialize`, and it will be handled correctly there.
+            // Synthetic DebugHook bindings must not be materialized into property_declarations
+            // via this path: they are placeholders equivalent to "no binding", and a real
+            // binding for the same property would not have existed here. They are
+            // self-contained and must survive remove_unused_properties (which only removes
+            // declared properties). Non-synthetic hooks wrap a real binding and must behave
+            // exactly like one — including triggering materialization.
             if elem.borrow().bindings.get(prop).is_some_and(|b| {
-                matches!(b.borrow().expression, Expression::DebugHook { .. })
+                b.borrow().expression.is_synthetic_debug_hook()
             }) {
                 continue;
             }
@@ -65,17 +66,13 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
     for (nr, ty) in to_materialize {
         let elem = nr.element();
 
-        // A DebugHook binding is a self-contained placeholder: don't materialize it into
-        // property_declarations.  If we did, move_declarations would pull it out of the inner
-        // element and into the root component, breaking the property's location.
-        // geometry_props NamedReferences (e.g. geometry_props.x → img.x) trigger this path;
-        // we skip them here so the DebugHook stays in-place on the inner element.
-        if elem.borrow().bindings.get(nr.name()).is_some_and(|b| {
-            matches!(b.borrow().expression, Expression::DebugHook { .. })
-        }) {
-            continue;
-        }
-
+        // Note: a DebugHook binding must materialize like the binding it wraps would.
+        // A referenced property whose binding is a *synthetic* hook counts as uninitialized
+        // (see `must_initialize`), so `initialize` below upgrades the hook in place with the
+        // computed default — e.g. geometry_props references (geometry_props.x → img.x) reach
+        // this for unbound geometry, and the Transform element's two-way reference reaches it
+        // for the injected `transform-rotation`. Skipping hooked properties here instead would
+        // leave a binding on a property that never exists at runtime.
         elem.borrow_mut().property_declarations.insert(
             nr.name().clone(),
             PropertyDeclaration { property_type: ty, ..PropertyDeclaration::default() },
@@ -97,7 +94,17 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
                     e.insert(binding.into());
                 }
                 std::collections::btree_map::Entry::Occupied(mut e) => {
-                    e.get_mut().get_mut().expression = init_expr;
+                    // A synthetic debug hook may occupy the slot (must_initialize treats it as
+                    // uninitialized): upgrade it in place — keep the wrapper and id so the
+                    // property stays live-editable, wrap the computed default.
+                    if let Expression::DebugHook { expression, synthetic, .. } =
+                        &mut e.get_mut().get_mut().expression
+                    {
+                        *expression = Box::new(init_expr);
+                        *synthetic = false;
+                    } else {
+                        e.get_mut().get_mut().expression = init_expr;
+                    }
                 }
             }
         }

--- a/internal/compiler/passes/optimize_useless_rectangles.rs
+++ b/internal/compiler/passes/optimize_useless_rectangles.rs
@@ -63,7 +63,9 @@ fn can_optimize(elem: &ElementRc) -> bool {
 
     let analysis = e.property_analysis.borrow();
     for coord in ["x", "y"] {
-        if e.bindings.contains_key(coord) || analysis.get(coord).is_some_and(|a| a.is_set) {
+        // binding() / real_bindings() ignore synthetic debug hooks (placeholders for
+        // unbound properties), which must not prevent the optimization.
+        if e.binding(coord).is_some() || analysis.get(coord).is_some_and(|a| a.is_set) {
             return false;
         }
     }
@@ -72,7 +74,10 @@ fn can_optimize(elem: &ElementRc) -> bool {
     }
 
     // Check that no Rectangle property are set
-    !e.bindings.keys().chain(analysis.iter().filter(|(_, v)| v.is_set).map(|(k, _)| k)).any(|k| {
+    !e.real_bindings()
+        .map(|(k, _)| k)
+        .chain(analysis.iter().filter(|(_, v)| v.is_set).map(|(k, _)| k))
+        .any(|k| {
         !e.property_declarations.contains_key(k.as_str())
             && base_type.properties.contains_key(k.as_str())
     }) && e.accessibility_props.0.is_empty()

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -77,7 +77,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
     let mut process_element = |e: &ElementRc| {
         'bindings: for (name, binding) in &e.borrow().bindings {
             for twb in &binding.borrow().two_way_bindings {
-                if let TwoWayBinding::Property { property, field_access } = twb {
+                if let TwoWayBinding::Property { property, field_access, .. } = twb {
                     if !field_access.is_empty() {
                         // Don't optimize two way bindings to fields for now
                         continue;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2524,6 +2524,7 @@ pub fn resolve_two_way_binding(
                         Some(TwoWayBinding::ModelData {
                             repeated_element: element.clone(),
                             field_access: vec![],
+                            field_access1: vec![],
                         })
                     }
                     _ => None,
@@ -2534,8 +2535,9 @@ pub fn resolve_two_way_binding(
                 // lookup built it without type checks (the row type may not
                 // have been known yet). Emits per-field diagnostics and
                 // yields the leaf type as `expr_ty`.
-                let expr_ty = if let TwoWayBinding::ModelData { repeated_element, field_access } =
-                    &result
+                let expr_ty = if let TwoWayBinding::ModelData {
+                    repeated_element, field_access, ..
+                } = &result
                 {
                     let mut ty =
                         Expression::RepeaterModelReference { element: repeated_element.clone() }

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -604,18 +604,23 @@ impl Snapshotter {
                 .two_way_bindings
                 .iter()
                 .map(|twb| match twb {
-                    crate::expression_tree::TwoWayBinding::Property { property, field_access } => {
-                        crate::expression_tree::TwoWayBinding::Property {
-                            property: property.snapshot(self),
-                            field_access: field_access.clone(),
-                        }
-                    }
+                    crate::expression_tree::TwoWayBinding::Property {
+                        property,
+                        field_access,
+                        field_access1,
+                    } => crate::expression_tree::TwoWayBinding::Property {
+                        property: property.snapshot(self),
+                        field_access: field_access.clone(),
+                        field_access1: field_access1.clone(),
+                    },
                     crate::expression_tree::TwoWayBinding::ModelData {
                         repeated_element,
                         field_access,
+                        field_access1,
                     } => crate::expression_tree::TwoWayBinding::ModelData {
                         repeated_element: repeated_element.clone(),
                         field_access: field_access.clone(),
+                        field_access1: field_access1.clone(),
                     },
                 })
                 .collect(),

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2193,5 +2193,7 @@ pub unsafe extern "C" fn slint_item_absolute_position(
     self_index: u32,
 ) -> crate::lengths::LogicalPoint {
     let self_rc = ItemRc::new(self_component.clone(), self_index);
-    self_rc.map_to_window(Default::default())
+    // Map the item's own geometry origin through the ancestor transforms so the result is the
+    // item's absolute position, not its parent's.
+    self_rc.map_to_window(self_rc.geometry().origin)
 }

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -334,7 +334,8 @@ struct BindingVTable {
 ///
 /// # Safety
 ///
-/// IS_TWO_WAY_BINDING cannot be true if Self is not a TwoWayBinding
+/// IS_TWO_WAY_BINDING cannot be true if Self is not a TwoWayBinding.
+/// IS_STRUCT_MEMBER_BINDINGS cannot be true if Self is not a StructMemberBindings.
 unsafe trait BindingCallable<T> {
     /// This function is called by the property to evaluate the binding and produce a new value. The
     /// previous property value is provided in the value parameter.
@@ -362,6 +363,11 @@ unsafe trait BindingCallable<T> {
 
     /// Set to true if and only if Self is a TwoWayBinding<T>
     const IS_TWO_WAY_BINDING: bool = false;
+
+    /// Set to true if and only if Self is a StructMemberBindings<T>
+    /// (the wrapper binding installed on a struct property whose fields are
+    /// linked into two-way binding classes, see `two_way_binding.rs`)
+    const IS_STRUCT_MEMBER_BINDINGS: bool = false;
 }
 
 unsafe impl<T, F: Fn(&mut T) -> BindingResult> BindingCallable<T> for F {
@@ -449,6 +455,8 @@ struct BindingHolder<B = ()> {
     dirty: Cell<bool>,
     /// Specify that B is a `TwoWayBinding<T>`
     is_two_way_binding: bool,
+    /// Specify that B is a `StructMemberBindings<T>`
+    is_struct_member_bindings: bool,
     pinned: PhantomPinned,
     #[cfg(slint_debug_property)]
     pub debug_name: alloc::string::String,
@@ -538,6 +546,7 @@ fn alloc_binding_holder<T, B: BindingCallable<T> + 'static>(binding: B) -> *mut 
         vtable: <B as HasBindingVTable<T>>::VT,
         dirty: Cell::new(true), // starts dirty so it evaluates the property when used
         is_two_way_binding: B::IS_TWO_WAY_BINDING,
+        is_struct_member_bindings: B::IS_STRUCT_MEMBER_BINDINGS,
         pinned: PhantomPinned,
         #[cfg(slint_debug_property)]
         debug_name: Default::default(),
@@ -1245,6 +1254,7 @@ impl<const NEEDS_SET_DIRTY: bool> Default for PropertyTracker<NEEDS_SET_DIRTY, (
             vtable: VT,
             dirty: Cell::new(true), // starts dirty so it evaluates the property when used
             is_two_way_binding: false,
+            is_struct_member_bindings: false,
             pinned: PhantomPinned,
             binding: (),
             #[cfg(slint_debug_property)]
@@ -1370,6 +1380,7 @@ impl<const NEEDS_SET_DIRTY: bool, DirtyHandler: PropertyDirtyHandler>
             vtable: <DirtyHandler as HasBindingVTable>::VT,
             dirty: Cell::new(true), // starts dirty so it evaluates the property when used
             is_two_way_binding: false,
+            is_struct_member_bindings: false,
             pinned: PhantomPinned,
             binding: handler,
             #[cfg(slint_debug_property)]

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -457,6 +457,10 @@ struct BindingHolder<B = ()> {
     is_two_way_binding: bool,
     /// Specify that B is a `StructMemberBindings<T>`
     is_struct_member_bindings: bool,
+    /// Identifies C++-side two-way binding objects (see
+    /// `slint_property_set_binding_with_kind` in `ffi.rs`); 0 for everything
+    /// else.
+    cpp_binding_kind: u8,
     pinned: PhantomPinned,
     #[cfg(slint_debug_property)]
     pub debug_name: alloc::string::String,
@@ -547,6 +551,7 @@ fn alloc_binding_holder<T, B: BindingCallable<T> + 'static>(binding: B) -> *mut 
         dirty: Cell::new(true), // starts dirty so it evaluates the property when used
         is_two_way_binding: B::IS_TWO_WAY_BINDING,
         is_struct_member_bindings: B::IS_STRUCT_MEMBER_BINDINGS,
+        cpp_binding_kind: 0,
         pinned: PhantomPinned,
         #[cfg(slint_debug_property)]
         debug_name: Default::default(),
@@ -1255,6 +1260,7 @@ impl<const NEEDS_SET_DIRTY: bool> Default for PropertyTracker<NEEDS_SET_DIRTY, (
             dirty: Cell::new(true), // starts dirty so it evaluates the property when used
             is_two_way_binding: false,
             is_struct_member_bindings: false,
+            cpp_binding_kind: 0,
             pinned: PhantomPinned,
             binding: (),
             #[cfg(slint_debug_property)]
@@ -1381,6 +1387,7 @@ impl<const NEEDS_SET_DIRTY: bool, DirtyHandler: PropertyDirtyHandler>
             dirty: Cell::new(true), // starts dirty so it evaluates the property when used
             is_two_way_binding: false,
             is_struct_member_bindings: false,
+            cpp_binding_kind: 0,
             pinned: PhantomPinned,
             binding: handler,
             #[cfg(slint_debug_property)]

--- a/internal/core/properties/change_tracker.rs
+++ b/internal/core/properties/change_tracker.rs
@@ -178,6 +178,7 @@ impl ChangeTracker {
             vtable: <ChangeTrackerInner<T, EF, NF, Data> as HasBindingVTable>::VT,
             dirty: Cell::new(false),
             is_two_way_binding: false,
+            is_struct_member_bindings: false,
             pinned: PhantomPinned,
             binding: inner,
             #[cfg(slint_debug_property)]

--- a/internal/core/properties/change_tracker.rs
+++ b/internal/core/properties/change_tracker.rs
@@ -179,6 +179,7 @@ impl ChangeTracker {
             dirty: Cell::new(false),
             is_two_way_binding: false,
             is_struct_member_bindings: false,
+            cpp_binding_kind: 0,
             pinned: PhantomPinned,
             binding: inner,
             #[cfg(slint_debug_property)]

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -237,6 +237,18 @@ pub unsafe extern "C" fn slint_property_detach_binding(
     }
 }
 
+/// Drop the stale dependency registrations of a detached binding (a
+/// `BindingHolder` the caller owns) in case it was evaluated while
+/// installed elsewhere; they are re-created when the binding is next
+/// evaluated. Used by the C++ struct member wrapper when it takes
+/// ownership of a binding.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_property_reset_binding_dependencies(binding: *mut c_void) {
+    let binding = binding as *mut BindingHolder;
+    // Safety: the caller owns the holder and nothing is evaluating it
+    unsafe { *(*binding).dep_nodes.get() = Default::default() };
+}
+
 /// Mark the property's own binding dirty (so it re-evaluates on the next
 /// read) as well as the property's dependents. Used by the C++ struct
 /// member wrapper when a new field mapping is added to it.

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -55,6 +55,43 @@ pub unsafe extern "C" fn slint_property_set_changed(
     }
 }
 
+struct CFunctionBinding<T> {
+    binding_function: extern "C" fn(*mut c_void, *mut T),
+    user_data: *mut c_void,
+    drop_user_data: Option<extern "C" fn(*mut c_void)>,
+    intercept_set:
+        Option<extern "C" fn(user_data: *mut c_void, pointer_to_value: *const T) -> bool>,
+    intercept_set_binding:
+        Option<extern "C" fn(user_data: *mut c_void, new_binding: *mut c_void) -> bool>,
+}
+
+impl<T> Drop for CFunctionBinding<T> {
+    fn drop(&mut self) {
+        if let Some(x) = self.drop_user_data {
+            x(self.user_data)
+        }
+    }
+}
+
+unsafe impl<T> BindingCallable<T> for CFunctionBinding<T> {
+    fn evaluate(self: Pin<&Self>, value: &mut T) -> BindingResult {
+        (self.binding_function)(self.user_data, value as *mut T);
+        BindingResult::KeepBinding
+    }
+    fn intercept_set(self: Pin<&Self>, value: &T) -> bool {
+        match self.intercept_set {
+            None => false,
+            Some(intercept_set) => intercept_set(self.user_data, value as *const T),
+        }
+    }
+    unsafe fn intercept_set_binding(self: Pin<&Self>, new_binding: *mut BindingHolder) -> bool {
+        match self.intercept_set_binding {
+            None => false,
+            Some(intercept_set_b) => intercept_set_b(self.user_data, new_binding.cast()),
+        }
+    }
+}
+
 fn make_c_function_binding(
     binding: extern "C" fn(*mut c_void, *mut c_void),
     user_data: *mut c_void,
@@ -65,44 +102,7 @@ fn make_c_function_binding(
     intercept_set_binding: Option<
         extern "C" fn(user_data: *mut c_void, new_binding: *mut c_void) -> bool,
     >,
-) -> impl BindingCallable<c_void> {
-    struct CFunctionBinding<T> {
-        binding_function: extern "C" fn(*mut c_void, *mut T),
-        user_data: *mut c_void,
-        drop_user_data: Option<extern "C" fn(*mut c_void)>,
-        intercept_set:
-            Option<extern "C" fn(user_data: *mut c_void, pointer_to_value: *const T) -> bool>,
-        intercept_set_binding:
-            Option<extern "C" fn(user_data: *mut c_void, new_binding: *mut c_void) -> bool>,
-    }
-
-    impl<T> Drop for CFunctionBinding<T> {
-        fn drop(&mut self) {
-            if let Some(x) = self.drop_user_data {
-                x(self.user_data)
-            }
-        }
-    }
-
-    unsafe impl<T> BindingCallable<T> for CFunctionBinding<T> {
-        fn evaluate(self: Pin<&Self>, value: &mut T) -> BindingResult {
-            (self.binding_function)(self.user_data, value as *mut T);
-            BindingResult::KeepBinding
-        }
-        fn intercept_set(self: Pin<&Self>, value: &T) -> bool {
-            match self.intercept_set {
-                None => false,
-                Some(intercept_set) => intercept_set(self.user_data, value as *const T),
-            }
-        }
-        unsafe fn intercept_set_binding(self: Pin<&Self>, new_binding: *mut BindingHolder) -> bool {
-            match self.intercept_set_binding {
-                None => false,
-                Some(intercept_set_b) => intercept_set_b(self.user_data, new_binding.cast()),
-            }
-        }
-    }
-
+) -> CFunctionBinding<c_void> {
     CFunctionBinding {
         binding_function: binding,
         user_data,
@@ -152,6 +152,108 @@ pub unsafe extern "C" fn slint_property_set_binding_internal(
     binding: *mut c_void,
 ) {
     handle.0.set_binding_impl(binding.cast());
+}
+
+/// Same as [`slint_property_set_binding`], but additionally tags the created
+/// binding with a non-zero `kind` that identifies the C++-side object behind
+/// `user_data`, so that C++ code can later recover it with
+/// [`slint_property_binding_kind_user_data`]. Used for the C++ two-way
+/// binding objects (kind 1: `TwoWayBinding`, holding the class' common
+/// property; kind 2: `StructMemberBindings`, the struct member wrapper).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_property_set_binding_with_kind(
+    handle: &PropertyHandleOpaque,
+    binding: extern "C" fn(user_data: *mut c_void, pointer_to_value: *mut c_void),
+    user_data: *mut c_void,
+    drop_user_data: Option<extern "C" fn(*mut c_void)>,
+    intercept_set: Option<
+        extern "C" fn(user_data: *mut c_void, pointer_to_value: *const c_void) -> bool,
+    >,
+    intercept_set_binding: Option<
+        extern "C" fn(user_data: *mut c_void, new_binding: *mut c_void) -> bool,
+    >,
+    kind: u8,
+) {
+    let binding = make_c_function_binding(
+        binding,
+        user_data,
+        drop_user_data,
+        intercept_set,
+        intercept_set_binding,
+    );
+    let holder = alloc_binding_holder(binding);
+    // Safety: the holder was just allocated and is exclusively owned here
+    unsafe { (*holder).cpp_binding_kind = kind };
+    handle.0.set_binding_impl(holder);
+}
+
+/// If the property's current binding was created by
+/// [`slint_property_set_binding_with_kind`] with the given non-zero `kind`,
+/// return its `user_data`; a null pointer otherwise.
+///
+/// The caller may downcast the returned pointer to the C++ type associated
+/// with `kind` (and the property's value type): a given kind is only ever
+/// registered by the C++ code paths owning that type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_property_binding_kind_user_data(
+    handle: &PropertyHandleOpaque,
+    kind: u8,
+) -> *mut c_void {
+    let Some(holder) = PropertyHandle::pointer_to_binding(handle.0.handle.get()) else {
+        return core::ptr::null_mut();
+    };
+    // Safety: the handle points to a binding holder
+    unsafe {
+        if kind != 0 && (*holder).cpp_binding_kind == kind {
+            // Safety: a non-zero cpp_binding_kind is only set by
+            // slint_property_set_binding_with_kind, whose holders are always
+            // BindingHolder<CFunctionBinding<c_void>>
+            (*(holder as *const BindingHolder<CFunctionBinding<c_void>>)).binding.user_data
+        } else {
+            core::ptr::null_mut()
+        }
+    }
+}
+
+/// Detach the property's current binding and return it. The caller takes
+/// ownership of the returned binding (a `BindingHolder`, to be released
+/// with [`slint_property_delete_binding`] or re-installed with
+/// [`slint_property_set_binding_internal`]); the property keeps its
+/// dependents. Stale dependency registrations of the binding are dropped
+/// (they are re-created when the binding is next evaluated).
+///
+/// Returns null when the property has no binding.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_property_detach_binding(
+    handle: &PropertyHandleOpaque,
+) -> *mut c_void {
+    match handle.0.detach_binding() {
+        Some(holder) => {
+            // Safety: the holder is detached and exclusively owned
+            unsafe { *(*holder).dep_nodes.get() = Default::default() };
+            holder.cast()
+        }
+        None => core::ptr::null_mut(),
+    }
+}
+
+/// Mark the property's own binding dirty (so it re-evaluates on the next
+/// read) as well as the property's dependents. Used by the C++ struct
+/// member wrapper when a new field mapping is added to it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_property_mark_binding_and_dependencies_dirty(
+    handle: &PropertyHandleOpaque,
+) {
+    if let Some(holder) = PropertyHandle::pointer_to_binding(handle.0.handle.get()) {
+        // Safety: the handle points to a binding holder
+        unsafe { (*holder).dirty.set(true) };
+    }
+    if !handle.0.is_constant() {
+        handle.0.mark_dirty(
+            #[cfg(slint_debug_property)]
+            "",
+        );
+    }
 }
 
 /// Delete a binding. The pointer must be a pointer to a binding (so a BindingHolder)
@@ -569,6 +671,7 @@ pub unsafe extern "C" fn slint_change_tracker_init(
         dirty: Cell::new(false),
         is_two_way_binding: false,
         is_struct_member_bindings: false,
+        cpp_binding_kind: 0,
         pinned: PhantomPinned,
         binding: inner,
         #[cfg(slint_debug_property)]

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -249,6 +249,17 @@ pub unsafe extern "C" fn slint_property_reset_binding_dependencies(binding: *mut
     unsafe { *(*binding).dep_nodes.get() = Default::default() };
 }
 
+/// Remove (and drop) the property's current binding, if any, without
+/// interception. Asserts ("Recursion detected") that the binding is not
+/// currently being evaluated. Used by the C++ struct member wrapper to
+/// clear its driver slot property; do NOT emulate this with
+/// [`slint_property_detach_binding`] + [`slint_property_delete_binding`],
+/// which would skip the assertion and free an executing binding.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_property_remove_binding(handle: &PropertyHandleOpaque) {
+    handle.0.remove_binding();
+}
+
 /// Mark the property's own binding dirty (so it re-evaluates on the next
 /// read) as well as the property's dependents. Used by the C++ struct
 /// member wrapper when a new field mapping is added to it.

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -568,6 +568,7 @@ pub unsafe extern "C" fn slint_change_tracker_init(
         vtable: VT,
         dirty: Cell::new(false),
         is_two_way_binding: false,
+        is_struct_member_bindings: false,
         pinned: PhantomPinned,
         binding: inner,
         #[cfg(slint_debug_property)]

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -319,18 +319,28 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
 /// narrow common properties of the two-way classes its fields belong to.
 ///
 /// The struct's own value-producing binding ("real binding") is installed
-/// on a dedicated pinned [`Property<T>`]: its dirty flag memoizes the
-/// evaluation (the binding runs at most once per change of its inputs, no
-/// matter how many commons and wrappers read it) and the dependency graph
+/// on a dedicated [`Property<T>`]: its dirty flag memoizes the evaluation
+/// (the binding runs at most once per change of its inputs, no matter how
+/// many commons and wrappers read it) and the dependency graph
 /// (commons/wrapper → slot property → the binding's inputs) replaces
 /// manual dirty forwarding.
+///
+/// The slot is only ever handled through a `Pin<Rc<Self>>`; `property` is
+/// pinned structurally (it is never moved out, the slot has no `Drop`, and
+/// `Property<T>` makes the slot `!Unpin`).
 struct DriverSlot<T> {
-    property: Pin<Rc<Property<T>>>,
+    property: Property<T>,
 }
 
 impl<T: PartialEq + Clone + 'static> DriverSlot<T> {
     fn new(seed: T) -> Self {
-        Self { property: Rc::pin(Property::new(seed)) }
+        Self { property: Property::new(seed) }
+    }
+
+    /// Structural pin projection to the slot property.
+    fn property(self: Pin<&Self>) -> Pin<&Property<T>> {
+        // Safety: see the pinning notes on the type
+        unsafe { self.map_unchecked(|slot| &slot.property) }
     }
 
     /// Drop the real binding, if any. Panics ("Recursion detected") when
@@ -367,7 +377,7 @@ impl<T: PartialEq + Clone + 'static> DriverSlot<T> {
 /// property; the last installed binding on the common wins, like any other
 /// binding installed on a two-way class.
 struct DriverProjection<T, T2, GetField> {
-    slot: Rc<DriverSlot<T>>,
+    slot: Pin<Rc<DriverSlot<T>>>,
     get_field: GetField,
     marker: PhantomData<fn(T) -> T2>,
 }
@@ -389,7 +399,7 @@ unsafe impl<
         }
         // Reading the slot property registers this projection as its
         // dependent and memoizes the real binding behind its dirty flag.
-        *value = (self.get_field)(&self.slot.property.as_ref().get());
+        *value = (self.get_field)(&self.slot.as_ref().property().get());
         BindingResult::KeepBinding
     }
 }
@@ -408,7 +418,7 @@ struct StructMemberMapping<T> {
     push_to_common: Box<dyn Fn(&T)>,
     /// Installs a [`DriverProjection`] for this mapping's field onto the
     /// common, making the given slot's real binding drive the class.
-    install_projection: Box<dyn Fn(&Rc<DriverSlot<T>>)>,
+    install_projection: Box<dyn Fn(&Pin<Rc<DriverSlot<T>>>)>,
     /// The narrow common property (an `Rc<Property<T2>>`, semantically
     /// pinned), type-erased for the field-keyed reuse lookup.
     common: Rc<dyn core::any::Any>,
@@ -421,7 +431,7 @@ struct StructMemberMapping<T> {
 /// binding, if any, lives in the [`DriverSlot`] and both produces the
 /// unmapped fields and drives the commons via [`DriverProjection`]s.
 struct StructMemberBindings<T> {
-    slot: Rc<DriverSlot<T>>,
+    slot: Pin<Rc<DriverSlot<T>>>,
     mappings: RefCell<Vec<StructMemberMapping<T>>>,
 }
 
@@ -432,7 +442,7 @@ unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberB
         // when binding-less its stored value is stale and would clobber the
         // struct's own stored value (and register a spurious dependency).
         if self.slot.has_holder() {
-            *value = self.slot.property.as_ref().get();
+            *value = self.slot.as_ref().property().get();
         }
         for mapping in self.mappings.borrow().iter() {
             (mapping.apply_from_common)(value);
@@ -532,7 +542,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
         if self.with_struct_member_bindings(|_| ()).is_some() {
             return;
         }
-        let slot = Rc::new(DriverSlot::new(self.get_internal()));
+        let slot = Rc::pin(DriverSlot::new(self.get_internal()));
         if let Some(old) = self.handle.detach_binding() {
             debug_assert!(
                 unsafe { !(*old).is_two_way_binding },
@@ -583,7 +593,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                 }),
                 install_projection: Box::new({
                     let common = common.clone();
-                    move |slot: &Rc<DriverSlot<T>>| {
+                    move |slot: &Pin<Rc<DriverSlot<T>>>| {
                         // Safety: DriverProjection is a BindingCallable for T2
                         unsafe {
                             common.handle.set_binding(
@@ -1584,7 +1594,7 @@ mod struct_member_tests {
     #[test]
     #[should_panic(expected = "Recursion detected")]
     fn driver_slot_clear_of_executing_holder_panics_cleanly() {
-        let slot = Rc::new(DriverSlot::<i32>::new(0));
+        let slot = Rc::pin(DriverSlot::<i32>::new(0));
         let holder = alloc_binding_holder::<i32, _>({
             let slot = slot.clone();
             move |value: &mut i32| {
@@ -1594,7 +1604,7 @@ mod struct_member_tests {
             }
         });
         slot.install(holder);
-        let _ = slot.property.as_ref().get();
+        let _ = slot.as_ref().property().get();
     }
 
     /// The full-topology version of the scenario above: a struct binding

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -317,88 +317,45 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
 /// State shared between a [`StructMemberBindings`] wrapper installed on a
 /// struct property and the [`DriverProjection`] bindings it installs on the
 /// narrow common properties of the two-way classes its fields belong to.
+///
+/// The struct's own value-producing binding ("real binding") is installed
+/// on a dedicated pinned [`Property<T>`]: its dirty flag memoizes the
+/// evaluation (the binding runs at most once per change of its inputs, no
+/// matter how many commons and wrappers read it) and the dependency graph
+/// (commons/wrapper → slot property → the binding's inputs) replaces
+/// manual dirty forwarding.
 struct DriverSlot<T> {
-    /// The struct property's own value-producing binding ("real binding"),
-    /// if any. Owned by this slot; evaluated by the wrapper (to produce the
-    /// whole struct) and by the projections (to drive the commons).
-    holder: Cell<Option<*mut BindingHolder>>,
-    /// Seed value used to evaluate the real binding outside of the struct
-    /// property's own storage (projections have no access to the property).
-    cache: RefCell<T>,
-    /// Number of nested [`Self::evaluate_holder`] frames on the stack.
-    /// While non-zero, holders are not dropped but parked in
-    /// `pending_drops`: a projection evaluates the real binding *without*
-    /// holding the struct property's lock, so the binding may — via a
-    /// write-back to its own struct property — trigger `clear` while it is
-    /// still executing.
-    evaluation_depth: Cell<usize>,
-    /// Holders whose destruction was deferred by `evaluation_depth`.
-    pending_drops: RefCell<Vec<*mut BindingHolder>>,
+    property: Pin<Rc<Property<T>>>,
 }
 
-impl<T> DriverSlot<T> {
-    fn new(cache: T) -> Self {
-        Self {
-            holder: Cell::new(None),
-            cache: RefCell::new(cache),
-            evaluation_depth: Cell::new(0),
-            pending_drops: RefCell::new(Vec::new()),
-        }
+impl<T: PartialEq + Clone + 'static> DriverSlot<T> {
+    fn new(seed: T) -> Self {
+        Self { property: Rc::pin(Property::new(seed)) }
     }
 
-    /// Drop the real binding, if any (deferred while it is being
-    /// evaluated). Projections evaluate to a no-op and remove themselves
-    /// once the slot is empty.
+    /// Drop the real binding, if any. Panics ("Recursion detected") when
+    /// the real binding is currently executing — that only happens when a
+    /// binding writes back to its own struct property, a state in which
+    /// every full-topology route already panicked on a locked common or
+    /// struct handle before this design; the slot property merely fails
+    /// earlier, before any mutation.
     fn clear(&self) {
-        if let Some(holder) = self.holder.take() {
-            self.dispose(holder);
-        }
+        self.property.handle.remove_binding();
     }
 
-    /// Drop `holder`, deferring the destruction while an evaluation through
-    /// this slot is on the stack (the holder may be the one executing).
-    fn dispose(&self, holder: *mut BindingHolder) {
-        if self.evaluation_depth.get() > 0 {
-            self.pending_drops.borrow_mut().push(holder);
-        } else {
-            // Safety: the slot owns the holder and nothing is executing it
-            unsafe { ((*holder).vtable.drop)(holder) }
-        }
+    fn has_holder(&self) -> bool {
+        self.property.has_binding()
     }
 
-    /// Evaluate the slot's current holder into `value` (a pointer to the
-    /// holder's value type `T`), keeping the holder alive until the
-    /// evaluation returns even if it is cleared or replaced while executing.
-    ///
-    /// Returns `None` when the slot is empty.
-    fn evaluate_holder(&self, value: *mut c_void) -> Option<BindingResult> {
-        let holder = self.holder.get()?;
-        self.evaluation_depth.set(self.evaluation_depth.get() + 1);
-        scopeguard::defer! {
-            self.evaluation_depth.set(self.evaluation_depth.get() - 1);
-            if self.evaluation_depth.get() == 0 {
-                // pop-style drain: the borrow is not held across the drop
-                // call, whose Drop code could re-enter this slot
-                while let Some(holder) = self.pending_drops.borrow_mut().pop() {
-                    // Safety: parked by `dispose`, no longer executing
-                    unsafe { ((*holder).vtable.drop)(holder) }
-                }
-            }
-        }
-        // Safety: `holder` is a BindingHolder producing a `T`; it stays
-        // alive for the duration of this call thanks to the deferral above
-        Some(unsafe { ((*holder).vtable.evaluate)(holder, value) })
-    }
-}
-
-impl<T> Drop for DriverSlot<T> {
-    fn drop(&mut self) {
-        debug_assert_eq!(self.evaluation_depth.get(), 0);
+    /// Install `holder` as the slot property's binding, dropping the
+    /// previous one (bypassing the old binding's `intercept_set_binding`).
+    fn install(&self, holder: *mut BindingHolder) {
         self.clear();
-        while let Some(holder) = self.pending_drops.borrow_mut().pop() {
-            // Safety: parked by `dispose`, no longer executing
-            unsafe { ((*holder).vtable.drop)(holder) }
-        }
+        // A stolen (second-hand) holder may have been evaluated in its old
+        // home: its dirty flag is false and its dependency registrations
+        // were wiped, so without this it would never re-evaluate here.
+        unsafe { (*holder).dirty.set(true) };
+        self.property.handle.set_binding_impl(holder);
     }
 }
 
@@ -423,26 +380,17 @@ unsafe impl<
 > BindingCallable<T2> for DriverProjection<T, T2, GetField>
 {
     fn evaluate(self: Pin<&Self>, value: &mut T2) -> BindingResult {
-        let mut struct_value = self.slot.cache.borrow().clone();
-        let Some(result) =
-            self.slot.evaluate_holder((&mut struct_value as *mut T).cast::<c_void>())
-        else {
+        if !self.slot.has_holder() {
             // The driver was dropped (e.g. a value was set on the struct
             // property); keep the common's current value and clean up.
+            // Not reading the slot property also avoids registering a
+            // spurious dependency on it.
             return BindingResult::RemoveBinding;
-        };
-        *value = (self.get_field)(&struct_value);
-        self.slot.cache.replace(struct_value);
-        if result == BindingResult::RemoveBinding {
-            self.slot.clear();
         }
+        // Reading the slot property registers this projection as its
+        // dependent and memoizes the real binding behind its dirty flag.
+        *value = (self.get_field)(&self.slot.property.as_ref().get());
         BindingResult::KeepBinding
-    }
-
-    fn mark_dirty(self: Pin<&Self>) {
-        if let Some(real_binding) = self.slot.holder.get() {
-            unsafe { ((*real_binding).vtable.mark_dirty)(real_binding, false) }
-        }
     }
 }
 
@@ -480,13 +428,11 @@ struct StructMemberBindings<T> {
 // Safety: IS_STRUCT_MEMBER_BINDINGS is true and Self is StructMemberBindings
 unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberBindings<T> {
     fn evaluate(self: Pin<&Self>, value: &mut T) -> BindingResult {
-        // Dependencies register on the holder currently being evaluated
-        // (this wrapper's), as with any wrapped binding.
-        if let Some(result) = self.slot.evaluate_holder((value as *mut T).cast::<c_void>()) {
-            self.slot.cache.replace(value.clone());
-            if result == BindingResult::RemoveBinding {
-                self.slot.clear();
-            }
+        // Only read the slot property while it carries the real binding:
+        // when binding-less its stored value is stale and would clobber the
+        // struct's own stored value (and register a spurious dependency).
+        if self.slot.has_holder() {
+            *value = self.slot.property.as_ref().get();
         }
         for mapping in self.mappings.borrow().iter() {
             (mapping.apply_from_common)(value);
@@ -513,13 +459,11 @@ unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberB
                  the compiler should have decomposed this link"
             );
             // Drop stale dependency registrations in case this holder was
-            // evaluated while installed elsewhere; new registrations land on
-            // this wrapper's holder when it evaluates the binding.
+            // evaluated while installed elsewhere; new registrations land
+            // on the slot property when it evaluates the binding.
             *(*new_binding).dep_nodes.get() = Default::default();
         }
-        if let Some(old) = self.slot.holder.replace(Some(new_binding)) {
-            self.slot.dispose(old);
-        }
+        self.slot.install(new_binding);
         // The new binding must drive the classes of all mapped fields.
         // Installing the projections also marks the commons' dependents
         // dirty (including this wrapper and the struct's dependents),
@@ -528,12 +472,6 @@ unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberB
             (mapping.install_projection)(&self.slot);
         }
         true
-    }
-
-    fn mark_dirty(self: Pin<&Self>) {
-        if let Some(real_binding) = self.slot.holder.get() {
-            unsafe { ((*real_binding).vtable.mark_dirty)(real_binding, false) }
-        }
     }
 
     const IS_STRUCT_MEMBER_BINDINGS: bool = true;
@@ -603,9 +541,10 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
             );
             // Drop stale dependency registrations from evaluations that
             // happened while the binding was still installed directly; new
-            // registrations land on the wrapper when it evaluates the binding.
+            // registrations land on the slot property when it evaluates the
+            // binding.
             unsafe { *(*old).dep_nodes.get() = Default::default() };
-            slot.holder.set(Some(old));
+            slot.install(old);
         }
         // Safety: StructMemberBindings<T> is a BindingCallable for type T
         unsafe {
@@ -666,7 +605,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
             // A pre-existing real binding must also drive this field's class
             // (it may be a new class, or the class' driver may have been
             // dropped by the value push that preceded this call).
-            if wrapper.slot.holder.get().is_some() {
+            if wrapper.slot.has_holder() {
                 (mapping.install_projection)(&wrapper.slot);
             }
             let mut mappings = wrapper.mappings.borrow_mut();
@@ -1636,43 +1575,152 @@ mod struct_member_tests {
         assert_eq!(z_scalar.as_ref().get(), 11);
     }
 
-    /// A holder cleared or replaced while it is being evaluated (e.g. a
-    /// binding that writes back to its own struct property, evaluated from
-    /// a projection that does not hold the struct property's lock) must not
-    /// be dropped until the evaluation returns.
+    /// Clearing the slot while its holder is being evaluated (a binding
+    /// that writes back to its own struct property) is a clean "Recursion
+    /// detected" panic: the lock assertion fires before any drop, so a
+    /// use-after-free is impossible by construction. (Every full-topology
+    /// route to this state also panicked under the previous deferred-drop
+    /// design — on the locked common or struct handle instead.)
     #[test]
-    fn driver_slot_defers_drop_of_executing_holder() {
-        struct DropFlag(Rc<Cell<bool>>);
-        impl Drop for DropFlag {
-            fn drop(&mut self) {
-                self.0.set(true);
-            }
-        }
-
-        let dropped = Rc::new(Cell::new(false));
+    #[should_panic(expected = "Recursion detected")]
+    fn driver_slot_clear_of_executing_holder_panics_cleanly() {
         let slot = Rc::new(DriverSlot::<i32>::new(0));
         let holder = alloc_binding_holder::<i32, _>({
             let slot = slot.clone();
-            let flag = DropFlag(dropped.clone());
             move |value: &mut i32| {
-                // Clear the slot while this closure is executing: the drop
-                // of the holder (and with it this closure's environment)
-                // must be deferred until the evaluation returned.
                 slot.clear();
-                assert!(!flag.0.get(), "holder dropped while its evaluate() was still running");
                 *value = 42;
                 BindingResult::KeepBinding
             }
         });
-        slot.holder.set(Some(holder));
+        slot.install(holder);
+        let _ = slot.property.as_ref().get();
+    }
 
-        let mut out = 0i32;
-        let result = slot.evaluate_holder((&mut out as *mut i32).cast::<c_void>());
-        assert_eq!(result, Some(BindingResult::KeepBinding));
-        assert_eq!(out, 42);
-        // the deferred drop ran once the evaluation returned
-        assert!(dropped.get());
-        assert!(slot.holder.get().is_none());
+    /// The full-topology version of the scenario above: a struct binding
+    /// that writes back to its own struct property mid-evaluation fails
+    /// with a clean panic (instead of a use-after-free) when evaluated
+    /// through a projection. Modern .slint cannot express this (purity
+    /// checking rejects assignments in bindings); it is reachable from
+    /// legacy-syntax files, impure native callbacks, and property-setting
+    /// `Model::row_data` implementations.
+    #[test]
+    #[should_panic(expected = "Recursion detected")]
+    fn writeback_to_own_struct_property_panics_cleanly() {
+        let strct = Rc::pin(Property::<S1>::default());
+        let scalar = Rc::pin(Property::<String>::default());
+        link_s1(strct.as_ref(), scalar.as_ref());
+        let fired = Rc::new(Cell::new(false));
+        strct.as_ref().set_binding({
+            let strct = strct.clone();
+            let fired = fired.clone();
+            move || {
+                if !fired.replace(true) {
+                    strct.as_ref().set(S1 { s1: "written-back".into(), i1: 1 });
+                }
+                S1 { s1: "bound".into(), i1: 2 }
+            }
+        });
+        // Read through the projection: the struct's own lock is NOT held.
+        let _ = scalar.as_ref().get();
+    }
+
+    /// The real binding is memoized by the slot property: it runs at most
+    /// once per dirty cycle, no matter how many members and wrappers read
+    /// it. (Previously every projection and the wrapper each re-ran it —
+    /// N+1 evaluations for N linked fields.)
+    #[test]
+    fn real_binding_evaluates_once_per_dirty_cycle() {
+        let counter = Rc::pin(Property::new(1));
+        let index = Rc::pin(Property::new(10));
+        let strct = Rc::pin(Property::<S1>::default());
+        let string_member = Rc::pin(Property::<String>::default());
+        let int_member = Rc::pin(Property::<i32>::default());
+
+        link_s1(strct.as_ref(), string_member.as_ref());
+        Property::link_two_way_to_member(
+            strct.as_ref(),
+            int_member.as_ref(),
+            "i1",
+            |strct_value: &S1| strct_value.i1,
+            |strct_value: &mut S1, field_value: &i32| strct_value.i1 = *field_value,
+            false,
+        );
+
+        let evaluation_count = Rc::new(Cell::new(0usize));
+        strct.as_ref().set_binding({
+            let counter = counter.clone();
+            let index = index.clone();
+            let evaluation_count = evaluation_count.clone();
+            move || {
+                evaluation_count.set(evaluation_count.get() + 1);
+                S1 {
+                    s1: alloc::format!("v{}", counter.as_ref().get()),
+                    i1: index.as_ref().get(),
+                }
+            }
+        });
+
+        // Settle: reading every member and the struct itself runs the real
+        // binding exactly once.
+        assert_eq!(string_member.as_ref().get(), "v1");
+        assert_eq!(evaluation_count.get(), 1);
+        assert_eq!(int_member.as_ref().get(), 10);
+        assert_eq!(evaluation_count.get(), 1);
+        assert_eq!(strct.as_ref().get(), S1 { s1: "v1".into(), i1: 10 });
+        assert_eq!(evaluation_count.get(), 1);
+
+        // One dirty cycle: one evaluation, regardless of the read order.
+        counter.as_ref().set(2);
+        assert_eq!(string_member.as_ref().get(), "v2");
+        assert_eq!(int_member.as_ref().get(), 10);
+        assert_eq!(strct.as_ref().get(), S1 { s1: "v2".into(), i1: 10 });
+        assert_eq!(evaluation_count.get(), 2);
+
+        // Clean re-reads never re-run the binding.
+        let _ = string_member.as_ref().get();
+        let _ = int_member.as_ref().get();
+        let _ = strct.as_ref().get();
+        assert_eq!(evaluation_count.get(), 2);
+
+        // A change of an input feeding only ONE field still costs a single
+        // evaluation for the whole cycle.
+        index.as_ref().set(11);
+        assert_eq!(string_member.as_ref().get(), "v2");
+        assert_eq!(int_member.as_ref().get(), 11);
+        assert_eq!(strct.as_ref().get(), S1 { s1: "v2".into(), i1: 11 });
+        assert_eq!(evaluation_count.get(), 3);
+    }
+
+    /// Driver revival: a value set severs the driver (its projections
+    /// self-remove on the next read), and a later set_binding must
+    /// reinstall the projections and drive the class again.
+    #[test]
+    fn driver_revival_after_set() {
+        let source = Rc::pin(Property::new(String::from("first")));
+        let strct = Rc::pin(Property::<S1>::default());
+        let scalar = Rc::pin(Property::<String>::default());
+        link_s1(strct.as_ref(), scalar.as_ref());
+        strct.as_ref().set_binding({
+            let source = source.clone();
+            move || S1 { s1: source.as_ref().get(), i1: 1 }
+        });
+        assert_eq!(scalar.as_ref().get(), "first");
+
+        strct.as_ref().set(S1 { s1: "severed".into(), i1: 2 });
+        // the projection self-removes on this read
+        assert_eq!(scalar.as_ref().get(), "severed");
+
+        let source2 = Rc::pin(Property::new(String::from("revived")));
+        strct.as_ref().set_binding({
+            let source2 = source2.clone();
+            move || S1 { s1: source2.as_ref().get(), i1: 3 }
+        });
+        assert_eq!(scalar.as_ref().get(), "revived");
+        assert_eq!(strct.as_ref().get().i1, 3);
+        source2.as_ref().set("revived-b".into());
+        assert_eq!(scalar.as_ref().get(), "revived-b");
+        assert_eq!(strct.as_ref().get().s1, "revived-b");
     }
 
     /// Linking a member that is itself already part of a scalar two-way

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -325,21 +325,78 @@ struct DriverSlot<T> {
     /// Seed value used to evaluate the real binding outside of the struct
     /// property's own storage (projections have no access to the property).
     cache: RefCell<T>,
+    /// Number of nested [`Self::evaluate_holder`] frames on the stack.
+    /// While non-zero, holders are not dropped but parked in
+    /// `pending_drops`: a projection evaluates the real binding *without*
+    /// holding the struct property's lock, so the binding may — via a
+    /// write-back to its own struct property — trigger `clear` while it is
+    /// still executing.
+    evaluation_depth: Cell<usize>,
+    /// Holders whose destruction was deferred by `evaluation_depth`.
+    pending_drops: RefCell<Vec<*mut BindingHolder>>,
 }
 
 impl<T> DriverSlot<T> {
-    /// Drop the real binding, if any. Projections evaluate to a no-op and
-    /// remove themselves once the slot is empty.
+    fn new(cache: T) -> Self {
+        Self {
+            holder: Cell::new(None),
+            cache: RefCell::new(cache),
+            evaluation_depth: Cell::new(0),
+            pending_drops: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Drop the real binding, if any (deferred while it is being
+    /// evaluated). Projections evaluate to a no-op and remove themselves
+    /// once the slot is empty.
     fn clear(&self) {
         if let Some(holder) = self.holder.take() {
+            self.dispose(holder);
+        }
+    }
+
+    /// Drop `holder`, deferring the destruction while an evaluation through
+    /// this slot is on the stack (the holder may be the one executing).
+    fn dispose(&self, holder: *mut BindingHolder) {
+        if self.evaluation_depth.get() > 0 {
+            self.pending_drops.borrow_mut().push(holder);
+        } else {
+            // Safety: the slot owns the holder and nothing is executing it
             unsafe { ((*holder).vtable.drop)(holder) }
         }
+    }
+
+    /// Evaluate the slot's current holder into `value` (a pointer to the
+    /// holder's value type `T`), keeping the holder alive until the
+    /// evaluation returns even if it is cleared or replaced while executing.
+    ///
+    /// Returns `None` when the slot is empty.
+    fn evaluate_holder(&self, value: *mut c_void) -> Option<BindingResult> {
+        let holder = self.holder.get()?;
+        self.evaluation_depth.set(self.evaluation_depth.get() + 1);
+        scopeguard::defer! {
+            self.evaluation_depth.set(self.evaluation_depth.get() - 1);
+            if self.evaluation_depth.get() == 0 {
+                for holder in self.pending_drops.borrow_mut().drain(..) {
+                    // Safety: parked by `dispose`, no longer executing
+                    unsafe { ((*holder).vtable.drop)(holder) }
+                }
+            }
+        }
+        // Safety: `holder` is a BindingHolder producing a `T`; it stays
+        // alive for the duration of this call thanks to the deferral above
+        Some(unsafe { ((*holder).vtable.evaluate)(holder, value) })
     }
 }
 
 impl<T> Drop for DriverSlot<T> {
     fn drop(&mut self) {
+        debug_assert_eq!(self.evaluation_depth.get(), 0);
         self.clear();
+        for holder in self.pending_drops.borrow_mut().drain(..) {
+            // Safety: parked by `dispose`, no longer executing
+            unsafe { ((*holder).vtable.drop)(holder) }
+        }
     }
 }
 
@@ -364,18 +421,13 @@ unsafe impl<
 > BindingCallable<T2> for DriverProjection<T, T2, GetField>
 {
     fn evaluate(self: Pin<&Self>, value: &mut T2) -> BindingResult {
-        let Some(real_binding) = self.slot.holder.get() else {
+        let mut struct_value = self.slot.cache.borrow().clone();
+        let Some(result) =
+            self.slot.evaluate_holder((&mut struct_value as *mut T).cast::<c_void>())
+        else {
             // The driver was dropped (e.g. a value was set on the struct
             // property); keep the common's current value and clean up.
             return BindingResult::RemoveBinding;
-        };
-        let mut struct_value = self.slot.cache.borrow().clone();
-        // Safety: `real_binding` is a BindingHolder producing a `T`
-        let result = unsafe {
-            ((*real_binding).vtable.evaluate)(
-                real_binding,
-                (&mut struct_value as *mut T).cast::<c_void>(),
-            )
         };
         *value = (self.get_field)(&struct_value);
         self.slot.cache.replace(struct_value);
@@ -426,13 +478,9 @@ struct StructMemberBindings<T> {
 // Safety: IS_STRUCT_MEMBER_BINDINGS is true and Self is StructMemberBindings
 unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberBindings<T> {
     fn evaluate(self: Pin<&Self>, value: &mut T) -> BindingResult {
-        if let Some(real_binding) = self.slot.holder.get() {
-            // Safety: `real_binding` is a BindingHolder producing a `T`;
-            // dependencies register on the holder currently being evaluated
-            // (this wrapper's), as with any wrapped binding.
-            let result = unsafe {
-                ((*real_binding).vtable.evaluate)(real_binding, (value as *mut T).cast::<c_void>())
-            };
+        // Dependencies register on the holder currently being evaluated
+        // (this wrapper's), as with any wrapped binding.
+        if let Some(result) = self.slot.evaluate_holder((value as *mut T).cast::<c_void>()) {
             self.slot.cache.replace(value.clone());
             if result == BindingResult::RemoveBinding {
                 self.slot.clear();
@@ -468,7 +516,7 @@ unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberB
             *(*new_binding).dep_nodes.get() = Default::default();
         }
         if let Some(old) = self.slot.holder.replace(Some(new_binding)) {
-            unsafe { ((*old).vtable.drop)(old) }
+            self.slot.dispose(old);
         }
         // The new binding must drive the classes of all mapped fields.
         // Installing the projections also marks the commons' dependents
@@ -519,14 +567,20 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
         field_key: &'static str,
     ) -> Option<Pin<Rc<Property<T2>>>> {
         self.with_struct_member_bindings(|wrapper| {
-            wrapper
-                .mappings
-                .borrow()
-                .iter()
-                .find(|mapping| mapping.key == field_key)
-                .and_then(|mapping| mapping.common.clone().downcast::<Property<T2>>().ok())
-                // Safety: the Rc was created pinned (`Rc::pin`) and never unpinned
-                .map(|rc| unsafe { Pin::new_unchecked(rc) })
+            wrapper.mappings.borrow().iter().find(|mapping| mapping.key == field_key).and_then(
+                |mapping| {
+                    let common = mapping.common.clone().downcast::<Property<T2>>();
+                    debug_assert!(
+                        common.is_ok(),
+                        "two-way binding common for field '{field_key}' created with a \
+                         different type: the code generator must use the property \
+                         representation of the field type for every link"
+                    );
+                    // Safety: the Rc was created pinned (`Rc::pin`) and
+                    // never unpinned
+                    common.ok().map(|rc| unsafe { Pin::new_unchecked(rc) })
+                },
+            )
         })
         .flatten()
     }
@@ -538,10 +592,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
         if self.with_struct_member_bindings(|_| ()).is_some() {
             return;
         }
-        let slot = Rc::new(DriverSlot {
-            holder: Cell::new(None),
-            cache: RefCell::new(self.get_internal()),
-        });
+        let slot = Rc::new(DriverSlot::new(self.get_internal()));
         if let Some(old) = self.handle.detach_binding() {
             debug_assert!(
                 unsafe { !(*old).is_two_way_binding },
@@ -1493,6 +1544,45 @@ mod struct_member_tests {
         outer.as_ref().set(Outer { inner: S1 { s1: "over".into(), i1: 6 }, z: 11 });
         assert_eq!(deep_scalar.as_ref().get(), "over");
         assert_eq!(z_scalar.as_ref().get(), 11);
+    }
+
+    /// A holder cleared or replaced while it is being evaluated (e.g. a
+    /// binding that writes back to its own struct property, evaluated from
+    /// a projection that does not hold the struct property's lock) must not
+    /// be dropped until the evaluation returns.
+    #[test]
+    fn driver_slot_defers_drop_of_executing_holder() {
+        struct DropFlag(Rc<Cell<bool>>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+
+        let dropped = Rc::new(Cell::new(false));
+        let slot = Rc::new(DriverSlot::<i32>::new(0));
+        let holder = alloc_binding_holder::<i32, _>({
+            let slot = slot.clone();
+            let flag = DropFlag(dropped.clone());
+            move |value: &mut i32| {
+                // Clear the slot while this closure is executing: the drop
+                // of the holder (and with it this closure's environment)
+                // must be deferred until the evaluation returned.
+                slot.clear();
+                assert!(!flag.0.get(), "holder dropped while its evaluate() was still running");
+                *value = 42;
+                BindingResult::KeepBinding
+            }
+        });
+        slot.holder.set(Some(holder));
+
+        let mut out = 0i32;
+        let result = slot.evaluate_holder((&mut out as *mut i32).cast::<c_void>());
+        assert_eq!(result, Some(BindingResult::KeepBinding));
+        assert_eq!(out, 42);
+        // the deferred drop ran once the evaluation returned
+        assert!(dropped.get());
+        assert!(slot.holder.get().is_none());
     }
 
     /// Linking a member that is itself already part of a scalar two-way

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -717,35 +717,12 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
         let field_key = field_key.into();
         let member_common = member_prop.check_common_property();
         let member_was_linked = member_common.is_some();
-        let struct_common = struct_prop.struct_member_common::<T2>(&field_key);
-
-        let common = match (member_common, struct_common) {
-            (Some(member_common), Some(struct_common)) => {
-                if !core::ptr::eq(&*member_common, &*struct_common) {
-                    // Both sides are already in (distinct) classes: unify
-                    // them by linking the two commons like ordinary scalar
-                    // properties.
-                    Property::link_two_way(member_common.as_ref(), struct_common.as_ref());
-                }
-                struct_common
-            }
-            (Some(common), None) | (None, Some(common)) => common,
-            (None, None) => {
-                // Seed a new class with the struct's genuine field value,
-                // read before the mapping for this link is installed: the
-                // right-hand side of `<=>` wins, as with `link_two_way`.
-                Rc::pin(Property::new(get_field(&struct_prop.get_untracked())))
-            }
-        };
-
-        // Push the struct's field value into a reused class, unless the
-        // class is driven by a binding — the binding stays authoritative
-        // (and a push would drop it, e.g. sever a model-row binding).
-        if !common.has_binding() {
-            common.as_ref().set(get_field(&struct_prop.get_untracked()));
-        }
-
-        struct_prop.add_struct_member_mapping(field_key, common.clone(), get_field, set_field);
+        let common = struct_prop.struct_member_class_common(
+            member_common,
+            field_key.clone(),
+            get_field,
+            set_field,
+        );
 
         if !member_was_linked {
             #[cfg(slint_debug_property)]
@@ -767,7 +744,11 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                         if preserve_member_binding {
                             // Re-attach the member's binding: the fresh
                             // TwoWayBinding intercepts and forwards it onto
-                            // the common, where it drives the class.
+                            // the common, where it drives the class. Make
+                            // sure it re-evaluates there and drops stale
+                            // registrations from evaluations on the member.
+                            (*old).dirty.set(true);
+                            *(*old).dep_nodes.get() = Default::default();
                             member_prop.handle.set_binding_impl(old);
                         } else {
                             // The member's own binding is dropped: the
@@ -785,6 +766,88 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                 }
             }
         }
+    }
+
+    /// Resolve (or create) the narrow common property of the two-way class
+    /// that `field_key` of this struct property belongs to, and install the
+    /// field's mapping: the shared first half of the `link_two_way_*member*`
+    /// functions. `member_common` is the class common already found on the
+    /// other side of the link, if any.
+    fn struct_member_class_common<T2: PartialEq + Clone + 'static>(
+        self: Pin<&Self>,
+        member_common: Option<Pin<Rc<Property<T2>>>>,
+        field_key: crate::SharedString,
+        get_field: impl Fn(&T) -> T2 + Clone + 'static,
+        set_field: impl Fn(&mut T, &T2) + Clone + 'static,
+    ) -> Pin<Rc<Property<T2>>> {
+        let struct_common = self.struct_member_common::<T2>(&field_key);
+
+        let common = match (member_common, struct_common) {
+            (Some(member_common), Some(struct_common)) => {
+                if !core::ptr::eq(&*member_common, &*struct_common) {
+                    // Both sides are already in (distinct) classes: unify
+                    // them by linking the two commons like ordinary scalar
+                    // properties.
+                    Property::link_two_way(member_common.as_ref(), struct_common.as_ref());
+                }
+                struct_common
+            }
+            (Some(common), None) | (None, Some(common)) => common,
+            (None, None) => {
+                // Seed a new class with the struct's genuine field value,
+                // read before the mapping for this link is installed: the
+                // right-hand side of `<=>` wins, as with `link_two_way`.
+                Rc::pin(Property::new(get_field(&self.get_untracked())))
+            }
+        };
+
+        // Push the struct's field value into a reused class, unless the
+        // class is driven by a binding — the binding stays authoritative
+        // (and a push would drop it, e.g. sever a model-row binding).
+        if !common.has_binding() {
+            common.as_ref().set(get_field(&self.get_untracked()));
+        }
+
+        self.add_struct_member_mapping(field_key, common.clone(), get_field, set_field);
+        common
+    }
+
+    /// Like [`Self::link_two_way_to_member`], for a member property whose
+    /// *storage* type `TM` differs from the representation `T2` that struct
+    /// fields of the same `.slint` type use (e.g. native item properties
+    /// store `length` as `LogicalLength` while struct fields store it as
+    /// plain `f32`). The class' common property uses the field
+    /// representation `T2` — so it is shared with the commons other links
+    /// to the same field create — and the member is attached through a
+    /// converting forwarding binding (`map_to_member`/`map_from_member`
+    /// convert between the two representations). A pre-existing regular
+    /// binding on the member is forwarded onto the common, like with
+    /// `preserve_member_binding` = true.
+    pub fn link_two_way_to_member_mapped<
+        T2: PartialEq + Clone + 'static,
+        TM: PartialEq + Clone + 'static,
+    >(
+        struct_prop: Pin<&Self>,
+        member_prop: Pin<&Property<TM>>,
+        field_key: impl Into<crate::SharedString>,
+        get_field: impl Fn(&T) -> T2 + Clone + 'static,
+        set_field: impl Fn(&mut T, &T2) + Clone + 'static,
+        map_to_member: impl Fn(&T2) -> TM + Clone + 'static,
+        map_from_member: impl Fn(&mut T2, &TM) + Clone + 'static,
+    ) {
+        let common = struct_prop.struct_member_class_common(
+            None,
+            field_key.into(),
+            get_field,
+            set_field,
+        );
+        Property::link_two_way_with_map_to_common_property(
+            common,
+            member_prop,
+            map_to_member,
+            map_from_member,
+            true,
+        );
     }
 
     /// Link `field_key_a` of the struct property `prop_a` two-way with

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use alloc::rc::Rc;
+use alloc::vec::Vec;
 use core::cell::Cell;
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
@@ -87,6 +88,12 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
 
         let prop2_handle_val = prop2.handle.handle.get();
         let handle = if PropertyHandle::is_pointer_to_binding(prop2_handle_val) {
+            debug_assert!(
+                PropertyHandle::pointer_to_binding(prop2_handle_val)
+                    .is_none_or(|holder| unsafe { !(*holder).is_struct_member_bindings }),
+                "whole-struct two-way link on a struct property with member links: \
+                 the compiler should have decomposed this link"
+            );
             // If prop2 is a binding, just "steal it"
             prop2.handle.handle.set(core::ptr::null_mut());
             PropertyHandle { handle: Cell::new(prop2_handle_val) }
@@ -304,6 +311,486 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                 );
             }
         }
+    }
+}
+
+/// State shared between a [`StructMemberBindings`] wrapper installed on a
+/// struct property and the [`DriverProjection`] bindings it installs on the
+/// narrow common properties of the two-way classes its fields belong to.
+struct DriverSlot<T> {
+    /// The struct property's own value-producing binding ("real binding"),
+    /// if any. Owned by this slot; evaluated by the wrapper (to produce the
+    /// whole struct) and by the projections (to drive the commons).
+    holder: Cell<Option<*mut BindingHolder>>,
+    /// Seed value used to evaluate the real binding outside of the struct
+    /// property's own storage (projections have no access to the property).
+    cache: RefCell<T>,
+}
+
+impl<T> DriverSlot<T> {
+    /// Drop the real binding, if any. Projections evaluate to a no-op and
+    /// remove themselves once the slot is empty.
+    fn clear(&self) {
+        if let Some(holder) = self.holder.take() {
+            unsafe { ((*holder).vtable.drop)(holder) }
+        }
+    }
+}
+
+impl<T> Drop for DriverSlot<T> {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+/// Binding installed on a narrow common property so that the struct
+/// property's real binding drives the two-way class ("driver election"):
+/// it evaluates the real binding and extracts the mapped field.
+///
+/// Installed whenever a real binding is (re-)assigned to a wrapped struct
+/// property; the last installed binding on the common wins, like any other
+/// binding installed on a two-way class.
+struct DriverProjection<T, T2, GetField> {
+    slot: Rc<DriverSlot<T>>,
+    get_field: GetField,
+    marker: PhantomData<fn(T) -> T2>,
+}
+
+// Safety: IS_TWO_WAY_BINDING and IS_STRUCT_MEMBER_BINDINGS are false
+unsafe impl<
+    T: PartialEq + Clone + 'static,
+    T2: PartialEq + Clone + 'static,
+    GetField: Fn(&T) -> T2 + 'static,
+> BindingCallable<T2> for DriverProjection<T, T2, GetField>
+{
+    fn evaluate(self: Pin<&Self>, value: &mut T2) -> BindingResult {
+        let Some(real_binding) = self.slot.holder.get() else {
+            // The driver was dropped (e.g. a value was set on the struct
+            // property); keep the common's current value and clean up.
+            return BindingResult::RemoveBinding;
+        };
+        let mut struct_value = self.slot.cache.borrow().clone();
+        // Safety: `real_binding` is a BindingHolder producing a `T`
+        let result = unsafe {
+            ((*real_binding).vtable.evaluate)(
+                real_binding,
+                (&mut struct_value as *mut T).cast::<c_void>(),
+            )
+        };
+        *value = (self.get_field)(&struct_value);
+        self.slot.cache.replace(struct_value);
+        if result == BindingResult::RemoveBinding {
+            self.slot.clear();
+        }
+        BindingResult::KeepBinding
+    }
+
+    fn mark_dirty(self: Pin<&Self>) {
+        if let Some(real_binding) = self.slot.holder.get() {
+            unsafe { ((*real_binding).vtable.mark_dirty)(real_binding, false) }
+        }
+    }
+}
+
+/// One field of a struct property that participates in a two-way binding
+/// class, held by [`StructMemberBindings`].
+struct StructMemberMapping<T> {
+    /// Field path within the struct (e.g. `"field"` or `"outer.inner"`),
+    /// used to find and replace the mapping when the same link is
+    /// re-established (conditional/repeated component re-instantiation).
+    key: &'static str,
+    /// `value.<key> = common.get()`; reading the common registers the
+    /// dependency so the struct re-evaluates when the class changes.
+    apply_from_common: Box<dyn Fn(&mut T)>,
+    /// `common.set(get_field(value))`
+    push_to_common: Box<dyn Fn(&T)>,
+    /// Installs a [`DriverProjection`] for this mapping's field onto the
+    /// common, making the given slot's real binding drive the class.
+    install_projection: Box<dyn Fn(&Rc<DriverSlot<T>>)>,
+    /// The narrow common property (an `Rc<Property<T2>>`, semantically
+    /// pinned), type-erased for the field-keyed reuse lookup.
+    common: Rc<dyn core::any::Any>,
+}
+
+/// The binding wrapper installed on a struct property that has two-way
+/// bindings onto its *fields*. Each mapped field is synchronized with a
+/// narrow common property of the field's type that is shared by every
+/// member of the two-way binding class; the struct's own value-producing
+/// binding, if any, lives in the [`DriverSlot`] and both produces the
+/// unmapped fields and drives the commons via [`DriverProjection`]s.
+struct StructMemberBindings<T> {
+    slot: Rc<DriverSlot<T>>,
+    mappings: RefCell<Vec<StructMemberMapping<T>>>,
+}
+
+// Safety: IS_STRUCT_MEMBER_BINDINGS is true and Self is StructMemberBindings
+unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberBindings<T> {
+    fn evaluate(self: Pin<&Self>, value: &mut T) -> BindingResult {
+        if let Some(real_binding) = self.slot.holder.get() {
+            // Safety: `real_binding` is a BindingHolder producing a `T`;
+            // dependencies register on the holder currently being evaluated
+            // (this wrapper's), as with any wrapped binding.
+            let result = unsafe {
+                ((*real_binding).vtable.evaluate)(real_binding, (value as *mut T).cast::<c_void>())
+            };
+            self.slot.cache.replace(value.clone());
+            if result == BindingResult::RemoveBinding {
+                self.slot.clear();
+            }
+        }
+        for mapping in self.mappings.borrow().iter() {
+            (mapping.apply_from_common)(value);
+        }
+        BindingResult::KeepBinding
+    }
+
+    fn intercept_set(self: Pin<&Self>, value: &T) -> bool {
+        // Setting a value drops the real binding (as it would on an
+        // unwrapped property) and pushes the mapped fields into their
+        // classes. The unmapped fields are stored by `Property::set`.
+        self.slot.clear();
+        for mapping in self.mappings.borrow().iter() {
+            (mapping.push_to_common)(value);
+        }
+        true
+    }
+
+    unsafe fn intercept_set_binding(self: Pin<&Self>, new_binding: *mut BindingHolder) -> bool {
+        unsafe {
+            debug_assert!(
+                !(*new_binding).is_two_way_binding,
+                "whole-struct two-way link on a struct property with member links: \
+                 the compiler should have decomposed this link"
+            );
+            // Drop stale dependency registrations in case this holder was
+            // evaluated while installed elsewhere; new registrations land on
+            // this wrapper's holder when it evaluates the binding.
+            *(*new_binding).dep_nodes.get() = Default::default();
+        }
+        if let Some(old) = self.slot.holder.replace(Some(new_binding)) {
+            unsafe { ((*old).vtable.drop)(old) }
+        }
+        // The new binding must drive the classes of all mapped fields.
+        // Installing the projections also marks the commons' dependents
+        // dirty (including this wrapper and the struct's dependents),
+        // which `set_binding_impl` skips for intercepted assignments.
+        for mapping in self.mappings.borrow().iter() {
+            (mapping.install_projection)(&self.slot);
+        }
+        true
+    }
+
+    fn mark_dirty(self: Pin<&Self>) {
+        if let Some(real_binding) = self.slot.holder.get() {
+            unsafe { ((*real_binding).vtable.mark_dirty)(real_binding, false) }
+        }
+    }
+
+    const IS_STRUCT_MEMBER_BINDINGS: bool = true;
+}
+
+impl<T: PartialEq + Clone + 'static> Property<T> {
+    /// If the property currently wears a [`StructMemberBindings`] wrapper,
+    /// call `f` with it.
+    fn with_struct_member_bindings<R>(
+        self: Pin<&Self>,
+        f: impl FnOnce(&StructMemberBindings<T>) -> R,
+    ) -> Option<R> {
+        let handle_val = self.handle.handle.get();
+        let holder = PropertyHandle::pointer_to_binding(handle_val)?;
+        // Safety: the handle is a pointer to a binding
+        unsafe {
+            if (*holder).is_struct_member_bindings {
+                // Safety: the flag guarantees the binding is a
+                // StructMemberBindings for this property's type
+                let wrapper =
+                    &(*(holder as *const BindingHolder<StructMemberBindings<T>>)).binding;
+                Some(f(wrapper))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// The narrow common property that the given field of this struct
+    /// property is synchronized with, if any.
+    fn struct_member_common<T2: PartialEq + Clone + 'static>(
+        self: Pin<&Self>,
+        field_key: &'static str,
+    ) -> Option<Pin<Rc<Property<T2>>>> {
+        self.with_struct_member_bindings(|wrapper| {
+            wrapper
+                .mappings
+                .borrow()
+                .iter()
+                .find(|mapping| mapping.key == field_key)
+                .and_then(|mapping| mapping.common.clone().downcast::<Property<T2>>().ok())
+                // Safety: the Rc was created pinned (`Rc::pin`) and never unpinned
+                .map(|rc| unsafe { Pin::new_unchecked(rc) })
+        })
+        .flatten()
+    }
+
+    /// Make sure this struct property wears a [`StructMemberBindings`]
+    /// wrapper, moving a pre-existing value-producing binding into the
+    /// wrapper's driver slot.
+    fn ensure_struct_member_bindings(self: Pin<&Self>) {
+        if self.with_struct_member_bindings(|_| ()).is_some() {
+            return;
+        }
+        let slot = Rc::new(DriverSlot {
+            holder: Cell::new(None),
+            cache: RefCell::new(self.get_internal()),
+        });
+        if let Some(old) = self.handle.detach_binding() {
+            debug_assert!(
+                unsafe { !(*old).is_two_way_binding },
+                "whole-struct two-way link on a struct property with member links: \
+                 the compiler should have decomposed this link"
+            );
+            // Drop stale dependency registrations from evaluations that
+            // happened while the binding was still installed directly; new
+            // registrations land on the wrapper when it evaluates the binding.
+            unsafe { *(*old).dep_nodes.get() = Default::default() };
+            slot.holder.set(Some(old));
+        }
+        // Safety: StructMemberBindings<T> is a BindingCallable for type T
+        unsafe {
+            self.handle.set_binding(
+                StructMemberBindings { slot, mappings: RefCell::new(Vec::new()) },
+                #[cfg(slint_debug_property)]
+                &alloc::format!("<members of {}>", self.debug_name.borrow()),
+            );
+        }
+    }
+
+    /// Add (or replace, keyed by `field_key`) a mapping synchronizing
+    /// `field_key` of this struct property with `common`.
+    fn add_struct_member_mapping<T2: PartialEq + Clone + 'static>(
+        self: Pin<&Self>,
+        field_key: &'static str,
+        common: Pin<Rc<Property<T2>>>,
+        get_field: impl Fn(&T) -> T2 + Clone + 'static,
+        set_field: impl Fn(&mut T, &T2) + Clone + 'static,
+    ) {
+        self.ensure_struct_member_bindings();
+        self.with_struct_member_bindings(|wrapper| {
+            let mapping = StructMemberMapping {
+                key: field_key,
+                apply_from_common: Box::new({
+                    let common = common.clone();
+                    move |value: &mut T| {
+                        let field_value = common.as_ref().get();
+                        set_field(value, &field_value);
+                    }
+                }),
+                push_to_common: Box::new({
+                    let common = common.clone();
+                    let get_field = get_field.clone();
+                    move |value: &T| common.as_ref().set(get_field(value))
+                }),
+                install_projection: Box::new({
+                    let common = common.clone();
+                    move |slot: &Rc<DriverSlot<T>>| {
+                        // Safety: DriverProjection is a BindingCallable for T2
+                        unsafe {
+                            common.handle.set_binding(
+                                DriverProjection {
+                                    slot: slot.clone(),
+                                    get_field: get_field.clone(),
+                                    marker: PhantomData,
+                                },
+                                #[cfg(slint_debug_property)]
+                                &alloc::format!("<driver of {}>", common.debug_name.borrow()),
+                            );
+                        }
+                    }
+                }),
+                // Safety: the Rc stays semantically pinned; it is only ever
+                // re-pinned in `struct_member_common`
+                common: unsafe { Pin::into_inner_unchecked(common.clone()) },
+            };
+            // A pre-existing real binding must also drive this field's class
+            // (it may be a new class, or the class' driver may have been
+            // dropped by the value push that preceded this call).
+            if wrapper.slot.holder.get().is_some() {
+                (mapping.install_projection)(&wrapper.slot);
+            }
+            let mut mappings = wrapper.mappings.borrow_mut();
+            if let Some(existing) = mappings.iter_mut().find(|m| m.key == field_key) {
+                *existing = mapping;
+            } else {
+                mappings.push(mapping);
+            }
+        });
+        // The wrapper must re-evaluate to pick up the new mapping's common
+        // (and register the dependency on it, so that later changes of the
+        // class keep dirtying it): mark it and the struct's dependents dirty.
+        if let Some(holder) = PropertyHandle::pointer_to_binding(self.handle.handle.get()) {
+            // Safety: the handle points to the wrapper's binding holder
+            unsafe { (*holder).dirty.set(true) };
+        }
+        if !self.handle.is_constant() {
+            self.handle.mark_dirty(
+                #[cfg(slint_debug_property)]
+                self.debug_name.borrow().as_str(),
+            );
+        }
+    }
+
+    /// Link `field_key` of the struct property `struct_prop` two-way with the
+    /// (typically scalar) property `member_prop`, such that they always have
+    /// the same value, as if they were a single property.
+    ///
+    /// This is the runtime counterpart of `member <=> strct.field` in Slint;
+    /// `struct_prop` is the right-hand side and its current field value wins.
+    /// `get_field`/`set_field` read/write the field at `field_key` of the
+    /// struct.
+    pub fn link_two_way_to_member<T2: PartialEq + Clone + 'static>(
+        struct_prop: Pin<&Self>,
+        member_prop: Pin<&Property<T2>>,
+        field_key: &'static str,
+        get_field: impl Fn(&T) -> T2 + Clone + 'static,
+        set_field: impl Fn(&mut T, &T2) + Clone + 'static,
+    ) {
+        let member_common = member_prop.check_common_property();
+        let member_was_linked = member_common.is_some();
+        let struct_common = struct_prop.struct_member_common::<T2>(field_key);
+
+        let common = match (member_common, struct_common) {
+            (Some(member_common), Some(struct_common)) => {
+                if !core::ptr::eq(&*member_common, &*struct_common) {
+                    // Both sides are already in (distinct) classes: unify
+                    // them by linking the two commons like ordinary scalar
+                    // properties.
+                    Property::link_two_way(member_common.as_ref(), struct_common.as_ref());
+                }
+                struct_common
+            }
+            (Some(common), None) | (None, Some(common)) => common,
+            (None, None) => {
+                // Seed a new class with the struct's genuine field value,
+                // read before the mapping for this link is installed: the
+                // right-hand side of `<=>` wins, as with `link_two_way`.
+                Rc::pin(Property::new(get_field(&struct_prop.get_untracked())))
+            }
+        };
+
+        // Push the struct's field value into a reused class, unless the
+        // class is driven by a binding — the binding stays authoritative
+        // (and a push would drop it, e.g. sever a model-row binding).
+        if !common.has_binding() {
+            common.as_ref().set(get_field(&struct_prop.get_untracked()));
+        }
+
+        struct_prop.add_struct_member_mapping(field_key, common.clone(), get_field, set_field);
+
+        if !member_was_linked {
+            #[cfg(slint_debug_property)]
+            let debug_name = alloc::format!(
+                "<{}<=>{}.{}>",
+                member_prop.debug_name.borrow(),
+                struct_prop.debug_name.borrow(),
+                field_key
+            );
+            let old_binding = member_prop.handle.detach_binding();
+            unsafe {
+                if let Some(old) = old_binding {
+                    let new_binding =
+                        alloc_binding_holder(TwoWayBinding { common_property: common });
+                    if ((*old).vtable.intercept_set_binding)(old, new_binding) {
+                        member_prop.handle.set_binding_impl(old);
+                    } else {
+                        member_prop.handle.set_binding_impl(new_binding);
+                        // The member's own binding is dropped: the struct's
+                        // value wins (as with `link_two_way_with_map`).
+                        ((*old).vtable.drop)(old);
+                    }
+                } else {
+                    member_prop.handle.set_binding(
+                        TwoWayBinding { common_property: common },
+                        #[cfg(slint_debug_property)]
+                        debug_name.as_str(),
+                    );
+                }
+            }
+        }
+    }
+
+    /// Link `field_key_a` of the struct property `prop_a` two-way with
+    /// `field_key_b` of the struct property `prop_b` (both fields have the
+    /// same type `T2`), such that they always have the same value.
+    ///
+    /// This is the runtime counterpart of a whole-struct `<=>` that the
+    /// compiler decomposed into per-field links because the class also
+    /// contains field links; `prop_b` is the right-hand side and its current
+    /// field value wins.
+    pub fn link_two_way_members<TB: PartialEq + Clone + 'static, T2: PartialEq + Clone + 'static>(
+        prop_a: Pin<&Self>,
+        field_key_a: &'static str,
+        get_field_a: impl Fn(&T) -> T2 + Clone + 'static,
+        set_field_a: impl Fn(&mut T, &T2) + Clone + 'static,
+        prop_b: Pin<&Property<TB>>,
+        field_key_b: &'static str,
+        get_field_b: impl Fn(&TB) -> T2 + Clone + 'static,
+        set_field_b: impl Fn(&mut TB, &T2) + Clone + 'static,
+    ) {
+        let common_a = prop_a.struct_member_common::<T2>(field_key_a);
+        let common_b = prop_b.struct_member_common::<T2>(field_key_b);
+
+        let common = match (common_a, common_b) {
+            (Some(common_a), Some(common_b)) => {
+                if !core::ptr::eq(&*common_a, &*common_b) {
+                    Property::link_two_way(common_a.as_ref(), common_b.as_ref());
+                }
+                common_b
+            }
+            (Some(common), None) | (None, Some(common)) => common,
+            (None, None) => {
+                // Seed a new class with `prop_b`'s genuine field value (the
+                // right-hand side of `<=>` wins, as with `link_two_way`).
+                Rc::pin(Property::new(get_field_b(&prop_b.get_untracked())))
+            }
+        };
+
+        // Push `prop_b`'s field value into a reused class, unless the class
+        // is driven by a binding — the binding stays authoritative.
+        if !common.has_binding() {
+            common.as_ref().set(get_field_b(&prop_b.get_untracked()));
+        }
+
+        // `prop_b`'s mapping is installed last, so a real binding on `prop_b`
+        // wins the driver election over one on `prop_a`.
+        prop_a.add_struct_member_mapping(field_key_a, common.clone(), get_field_a, set_field_a);
+        prop_b.add_struct_member_mapping(field_key_b, common, get_field_b, set_field_b);
+    }
+
+    /// Link `field_key` of the struct property `struct_prop` two-way with a
+    /// value stored in a model row (`getter`/`setter` read and write the
+    /// row), such that they always have the same value.
+    ///
+    /// This is the runtime counterpart of a whole-row `strct <=> model-data`
+    /// that the compiler decomposed into per-field links because the struct
+    /// property's fields also participate in two-way binding classes. The
+    /// model is authoritative: the row binding is installed on the class'
+    /// common property and drives it.
+    pub fn link_two_way_member_to_model_data<T2: PartialEq + Clone + 'static, ItemTree: 'static>(
+        struct_prop: Pin<&Self>,
+        field_key: &'static str,
+        get_field: impl Fn(&T) -> T2 + Clone + 'static,
+        set_field: impl Fn(&mut T, &T2) + Clone + 'static,
+        item_tree: ItemTree,
+        getter: impl Fn(&ItemTree) -> Option<T2> + 'static,
+        setter: impl Fn(&ItemTree, &T2) + 'static,
+    ) {
+        let common = struct_prop.struct_member_common::<T2>(field_key).unwrap_or_else(|| {
+            Rc::pin(Property::new(get_field(&struct_prop.get_untracked())))
+        });
+        struct_prop.add_struct_member_mapping(field_key, common.clone(), get_field, set_field);
+        // Install the row binding on the common (replacing a driver
+        // projection a real binding on `struct_prop` may just have
+        // installed): the model wins, as with `link_two_way_to_model_data`.
+        common.as_ref().link_two_way_to_model_data(item_tree, getter, setter);
     }
 }
 
@@ -624,6 +1111,408 @@ fn test_two_way_with_map() {
     assert_eq!(p1.as_ref().get(), Struct { foo: 457, bar: "def".into() });
     assert_eq!(p2.as_ref().get(), 457);
     assert_eq!(p3.as_ref().get(), "def");
+}
+
+#[cfg(test)]
+mod struct_member_tests {
+    use super::*;
+    use alloc::string::String;
+
+    #[derive(PartialEq, Clone, Default, Debug)]
+    struct S1 {
+        s1: String,
+        i1: i32,
+    }
+    #[derive(PartialEq, Clone, Default, Debug)]
+    struct S2 {
+        s2: String,
+        i2: i32,
+    }
+
+    fn link_s1(strct: Pin<&Property<S1>>, member: Pin<&Property<String>>) {
+        Property::link_two_way_to_member(
+            strct,
+            member,
+            "s1",
+            |s: &S1| s.s1.clone(),
+            |s: &mut S1, v: &String| s.s1 = v.clone(),
+        );
+    }
+    fn link_s2(strct: Pin<&Property<S2>>, member: Pin<&Property<String>>) {
+        Property::link_two_way_to_member(
+            strct,
+            member,
+            "s2",
+            |s: &S2| s.s2.clone(),
+            |s: &mut S2, v: &String| s.s2 = v.clone(),
+        );
+    }
+
+    /// The scenario of `two_way_binding_struct_non_const.slint`: one scalar
+    /// two-way bound to fields of TWO struct properties which both carry
+    /// live bindings. The class must converge while the independent fields
+    /// keep tracking their own sources.
+    #[test]
+    fn two_structs_with_live_bindings_share_scalar() {
+        let ext1 = Rc::pin(Property::new(String::from("a")));
+        let ext2 = Rc::pin(Property::new(String::from("b")));
+        let int1 = Rc::pin(Property::new(42));
+        let int2 = Rc::pin(Property::new(43));
+
+        let s1 = Rc::pin(Property::<S1>::default());
+        let s2 = Rc::pin(Property::<S2>::default());
+        let scalar = Rc::pin(Property::new(String::from("XXX")));
+
+        // Link first, install the bindings after, like the generated Rust
+        // code does (links in `init` before `property_init`).
+        link_s1(s1.as_ref(), scalar.as_ref());
+        link_s2(s2.as_ref(), scalar.as_ref());
+
+        s1.as_ref().set_binding({
+            let (ext1, int1) = (ext1.clone(), int1.clone());
+            move || S1 { s1: ext1.as_ref().get(), i1: int1.as_ref().get() }
+        });
+        s2.as_ref().set_binding({
+            let (ext2, int2) = (ext2.clone(), int2.clone());
+            move || S2 { s2: ext2.as_ref().get(), i2: int2.as_ref().get() }
+        });
+
+        // The class converges (last installed binding drives it).
+        let (v1, v2, vs) = (s1.as_ref().get(), s2.as_ref().get(), scalar.as_ref().get());
+        assert_eq!(v1.s1, v2.s2);
+        assert_eq!(v1.s1, vs);
+        assert_eq!(v1.s1, "b");
+        // Independent fields keep tracking their sources.
+        assert_eq!(v1.i1, 42);
+        assert_eq!(v2.i2, 43);
+        int1.as_ref().set(1042);
+        assert_eq!(s1.as_ref().get().i1, 1042);
+        assert_eq!(s1.as_ref().get().s1, s2.as_ref().get().s2);
+
+        // A write to the scalar reaches every member of the class.
+        scalar.as_ref().set("written".into());
+        assert_eq!(s1.as_ref().get().s1, "written");
+        assert_eq!(s2.as_ref().get().s2, "written");
+        assert_eq!(s1.as_ref().get().i1, 1042);
+        assert_eq!(s2.as_ref().get().i2, 43);
+        // The drivers were dropped by the write; sources no longer drive
+        // the shared field, but still drive the independent fields.
+        ext1.as_ref().set("ignored".into());
+        ext2.as_ref().set("ignored".into());
+        int2.as_ref().set(2043);
+        assert_eq!(s1.as_ref().get().s1, "written");
+        assert_eq!(s2.as_ref().get().s2, "written");
+        assert_eq!(s2.as_ref().get().i2, 2043);
+    }
+
+    /// Three struct members converge structurally (single shared common).
+    #[test]
+    fn three_structs_converge() {
+        let s1 = Rc::pin(Property::new(S1 { s1: "one".into(), i1: 1 }));
+        let s2 = Rc::pin(Property::new(S2 { s2: "two".into(), i2: 2 }));
+        let s3 = Rc::pin(Property::new(S1 { s1: "three".into(), i1: 3 }));
+        let scalar = Rc::pin(Property::new(String::from("XXX")));
+
+        link_s1(s1.as_ref(), scalar.as_ref());
+        link_s2(s2.as_ref(), scalar.as_ref());
+        link_s1(s3.as_ref(), scalar.as_ref());
+
+        // Last linked right-hand side wins.
+        assert_eq!(scalar.as_ref().get(), "three");
+        assert_eq!(s1.as_ref().get().s1, "three");
+        assert_eq!(s2.as_ref().get().s2, "three");
+        assert_eq!(s3.as_ref().get().s1, "three");
+
+        // Writes converge from every member, in both directions.
+        s2.as_ref().set(S2 { s2: "via-s2".into(), i2: 22 });
+        assert_eq!(scalar.as_ref().get(), "via-s2");
+        assert_eq!(s1.as_ref().get().s1, "via-s2");
+        assert_eq!(s3.as_ref().get().s1, "via-s2");
+        assert_eq!(s1.as_ref().get().i1, 1);
+        scalar.as_ref().set("via-scalar".into());
+        assert_eq!(s1.as_ref().get().s1, "via-scalar");
+        assert_eq!(s2.as_ref().get().s2, "via-scalar");
+        assert_eq!(s3.as_ref().get().s1, "via-scalar");
+        assert_eq!(s2.as_ref().get().i2, 22);
+    }
+
+    /// A `set` on the struct pushes the mapped field into the class and
+    /// drops the struct's binding, like on an unwrapped property.
+    #[test]
+    fn set_on_struct_pushes_and_clears_binding() {
+        let source = Rc::pin(Property::new(String::from("from-binding")));
+        let s1 = Rc::pin(Property::<S1>::default());
+        let scalar = Rc::pin(Property::<String>::default());
+
+        link_s1(s1.as_ref(), scalar.as_ref());
+        s1.as_ref().set_binding({
+            let source = source.clone();
+            move || S1 { s1: source.as_ref().get(), i1: 7 }
+        });
+        assert_eq!(scalar.as_ref().get(), "from-binding");
+        assert_eq!(s1.as_ref().get().i1, 7);
+
+        s1.as_ref().set(S1 { s1: "set-value".into(), i1: 8 });
+        assert_eq!(scalar.as_ref().get(), "set-value");
+        assert_eq!(s1.as_ref().get(), S1 { s1: "set-value".into(), i1: 8 });
+        // binding dropped
+        source.as_ref().set("changed".into());
+        assert_eq!(scalar.as_ref().get(), "set-value");
+        assert_eq!(s1.as_ref().get(), S1 { s1: "set-value".into(), i1: 8 });
+    }
+
+    /// A member write propagates into the struct without disturbing its
+    /// other fields, and dependents of both get notified.
+    #[test]
+    fn member_write_dirties_dependents() {
+        let s1 = Rc::pin(Property::new(S1 { s1: "init".into(), i1: 1 }));
+        let scalar = Rc::pin(Property::<String>::default());
+        link_s1(s1.as_ref(), scalar.as_ref());
+
+        let depends = Box::pin(Property::new(String::new()));
+        depends.as_ref().set_binding({
+            let s1 = s1.clone();
+            move || s1.as_ref().get().s1
+        });
+        assert_eq!(depends.as_ref().get(), "init");
+        scalar.as_ref().set("poked".into());
+        assert_eq!(depends.as_ref().get(), "poked");
+        assert_eq!(s1.as_ref().get().i1, 1);
+    }
+
+    /// Re-assigning a binding to a linked struct property must dirty the
+    /// struct's dependents even though the assignment is intercepted by the
+    /// wrapper (regression test for the `set_binding_impl` early return).
+    #[test]
+    fn rebinding_after_link_dirties_dependents() {
+        let s1 = Rc::pin(Property::new(S1 { s1: "init".into(), i1: 1 }));
+        let scalar = Rc::pin(Property::<String>::default());
+        link_s1(s1.as_ref(), scalar.as_ref());
+
+        let tracker = Box::pin(<PropertyTracker>::default());
+        let value = tracker.as_ref().evaluate({
+            let s1 = s1.clone();
+            move || s1.as_ref().get()
+        });
+        assert_eq!(value.s1, "init");
+        assert!(!tracker.as_ref().is_dirty());
+
+        s1.as_ref().set_binding(move || S1 { s1: "rebound".into(), i1: 2 });
+        assert!(tracker.as_ref().is_dirty(), "dependents must be notified of the new binding");
+        assert_eq!(s1.as_ref().get(), S1 { s1: "rebound".into(), i1: 2 });
+        assert_eq!(scalar.as_ref().get(), "rebound");
+    }
+
+    /// Driver election: the struct's live binding drives the class (single
+    /// driver behaves like today's wide design); with two drivers the last
+    /// installed one wins deterministically.
+    #[test]
+    fn driver_election() {
+        let source1 = Rc::pin(Property::new(String::from("one")));
+        let source2 = Rc::pin(Property::new(String::from("two")));
+        let s1 = Rc::pin(Property::<S1>::default());
+        let s2 = Rc::pin(Property::<S2>::default());
+        let scalar = Rc::pin(Property::<String>::default());
+
+        link_s1(s1.as_ref(), scalar.as_ref());
+        s1.as_ref().set_binding({
+            let source1 = source1.clone();
+            move || S1 { s1: source1.as_ref().get(), i1: 1 }
+        });
+        // single driver: the binding's output reaches the member reactively
+        assert_eq!(scalar.as_ref().get(), "one");
+        source1.as_ref().set("one-b".into());
+        assert_eq!(scalar.as_ref().get(), "one-b");
+
+        link_s2(s2.as_ref(), scalar.as_ref());
+        s2.as_ref().set_binding({
+            let source2 = source2.clone();
+            move || S2 { s2: source2.as_ref().get(), i2: 2 }
+        });
+        // two drivers: last installed wins, values stay converged
+        assert_eq!(scalar.as_ref().get(), "two");
+        assert_eq!(s1.as_ref().get().s1, "two");
+        source2.as_ref().set("two-b".into());
+        assert_eq!(scalar.as_ref().get(), "two-b");
+        assert_eq!(s1.as_ref().get().s1, "two-b");
+        assert_eq!(s2.as_ref().get().s2, "two-b");
+        // repeated reads are stable (no flip-flopping between drivers)
+        assert_eq!(s1.as_ref().get().s1, "two-b");
+        assert_eq!(scalar.as_ref().get(), "two-b");
+    }
+
+    /// Re-linking the same field (conditional component re-instantiation)
+    /// must not grow the mapping list and must keep the class value.
+    #[test]
+    fn relink_is_idempotent() {
+        let strct = Rc::pin(Property::new(S1 { s1: "start".into(), i1: 1 }));
+
+        let mut previous_scalar: Option<Pin<Rc<Property<String>>>> = None;
+        for iteration in 0..5 {
+            // fresh "child" scalar every round, like a re-instantiated
+            // conditional component
+            let scalar = Rc::pin(Property::<String>::default());
+            link_s1(strct.as_ref(), scalar.as_ref());
+
+            let mapping_count = strct
+                .as_ref()
+                .with_struct_member_bindings(|wrapper| wrapper.mappings.borrow().len())
+                .unwrap();
+            assert_eq!(mapping_count, 1, "mapping list must not grow (iteration {iteration})");
+
+            // the class value survives the re-link
+            let expected = if iteration == 0 { "start" } else { "poked" };
+            assert_eq!(scalar.as_ref().get(), expected);
+            assert_eq!(strct.as_ref().get().s1, expected);
+
+            scalar.as_ref().set("poked".into());
+            assert_eq!(strct.as_ref().get().s1, "poked");
+            previous_scalar = Some(scalar);
+        }
+        drop(previous_scalar);
+    }
+
+    /// The scenario of `issue_11415_two_way_if_struct.slint` after
+    /// decomposition: a whole-struct link decomposed into a member-member
+    /// cell link, re-established against a fresh struct while the value was
+    /// changed only through the class (never read back through the struct).
+    #[test]
+    fn members_link_relink_keeps_class_value() {
+        let root_data = Rc::pin(Property::new(S1 { s1: String::new(), i1: 0 }));
+        let counter = Rc::pin(Property::<i32>::default());
+        Property::link_two_way_to_member(
+            root_data.as_ref(),
+            counter.as_ref(),
+            "i1",
+            |s: &S1| s.i1,
+            |s: &mut S1, v: &i32| s.i1 = *v,
+        );
+
+        let link_page = |page_data: Pin<&Property<S1>>| {
+            Property::link_two_way_members(
+                page_data,
+                "i1",
+                |s: &S1| s.i1,
+                |s: &mut S1, v: &i32| s.i1 = *v,
+                root_data.as_ref(),
+                "i1",
+                |s: &S1| s.i1,
+                |s: &mut S1, v: &i32| s.i1 = *v,
+            );
+        };
+
+        let page1_data = Rc::pin(Property::<S1>::default());
+        link_page(page1_data.as_ref());
+        assert_eq!(root_data.as_ref().get().i1, 0);
+
+        // change through the class only; root_data's cached value stays stale
+        counter.as_ref().set(42);
+
+        // toggle: drop the first page, link a fresh one
+        drop(page1_data);
+        let page2_data = Rc::pin(Property::<S1>::default());
+        link_page(page2_data.as_ref());
+
+        assert_eq!(root_data.as_ref().get().i1, 42);
+        assert_eq!(page2_data.as_ref().get().i1, 42);
+        assert_eq!(counter.as_ref().get(), 42);
+    }
+
+    /// Dependency-list transfer when a bound property is linked: dependents
+    /// registered on the old binding must survive the move into the wrapper
+    /// (analog of `test_two_way_with_map_dependency_list_transfer`).
+    #[test]
+    fn dependency_list_transfer() {
+        let source = Rc::pin(Property::new(10));
+
+        // dropped last, so its dependency node outlives the properties
+        let tracker = Box::pin(<PropertyTracker>::default());
+
+        let strct = Rc::pin(Property::<S1>::default());
+        strct.as_ref().set_binding({
+            let source = source.clone();
+            move || S1 { s1: "x".into(), i1: source.as_ref().get() * 2 }
+        });
+        assert_eq!(strct.as_ref().get().i1, 20);
+
+        let value = tracker.as_ref().evaluate({
+            let strct = strct.clone();
+            move || strct.as_ref().get().i1
+        });
+        assert_eq!(value, 20);
+        assert!(!tracker.as_ref().is_dirty());
+
+        let scalar = Rc::pin(Property::<String>::default());
+        link_s1(strct.as_ref(), scalar.as_ref());
+
+        // the link replaced the struct's direct binding with the wrapper;
+        // the tracker's dependency must have been transferred and notified
+        assert!(tracker.as_ref().is_dirty());
+        assert_eq!(strct.as_ref().get().i1, 20);
+        source.as_ref().set(50);
+        assert_eq!(strct.as_ref().get().i1, 100);
+        assert_eq!(scalar.as_ref().get(), "x");
+    }
+
+    /// Nested field paths keyed by their full path work independently.
+    #[test]
+    fn nested_and_multiple_fields() {
+        #[derive(PartialEq, Clone, Default, Debug)]
+        struct Outer {
+            inner: S1,
+            z: i32,
+        }
+        let outer = Rc::pin(Property::new(Outer {
+            inner: S1 { s1: "deep".into(), i1: 5 },
+            z: 9,
+        }));
+        let deep_scalar = Rc::pin(Property::<String>::default());
+        let z_scalar = Rc::pin(Property::<i32>::default());
+        Property::link_two_way_to_member(
+            outer.as_ref(),
+            deep_scalar.as_ref(),
+            "inner.s1",
+            |s: &Outer| s.inner.s1.clone(),
+            |s: &mut Outer, v: &String| s.inner.s1 = v.clone(),
+        );
+        Property::link_two_way_to_member(
+            outer.as_ref(),
+            z_scalar.as_ref(),
+            "z",
+            |s: &Outer| s.z,
+            |s: &mut Outer, v: &i32| s.z = *v,
+        );
+        assert_eq!(deep_scalar.as_ref().get(), "deep");
+        assert_eq!(z_scalar.as_ref().get(), 9);
+        deep_scalar.as_ref().set("deeper".into());
+        z_scalar.as_ref().set(10);
+        assert_eq!(
+            outer.as_ref().get(),
+            Outer { inner: S1 { s1: "deeper".into(), i1: 5 }, z: 10 }
+        );
+        outer.as_ref().set(Outer { inner: S1 { s1: "over".into(), i1: 6 }, z: 11 });
+        assert_eq!(deep_scalar.as_ref().get(), "over");
+        assert_eq!(z_scalar.as_ref().get(), 11);
+    }
+
+    /// Linking a member that is itself already part of a scalar two-way
+    /// class reuses that class' common (alias-collapsed scalars).
+    #[test]
+    fn member_already_linked_scalar() {
+        let scalar_a = Rc::pin(Property::new(String::from("A")));
+        let scalar_b = Rc::pin(Property::new(String::from("B")));
+        Property::link_two_way(scalar_a.as_ref(), scalar_b.as_ref());
+        assert_eq!(scalar_a.as_ref().get(), "B");
+
+        let strct = Rc::pin(Property::new(S1 { s1: "S".into(), i1: 0 }));
+        link_s1(strct.as_ref(), scalar_a.as_ref());
+        // the struct is the right-hand side: its value wins
+        assert_eq!(scalar_a.as_ref().get(), "S");
+        assert_eq!(scalar_b.as_ref().get(), "S");
+        scalar_b.as_ref().set("via-b".into());
+        assert_eq!(strct.as_ref().get().s1, "via-b");
+        assert_eq!(scalar_a.as_ref().get(), "via-b");
+    }
 }
 
 /// Regression test for use-after-free in `link_two_way_with_map_to_common_property`.

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -314,61 +314,6 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
     }
 }
 
-/// State shared between a [`StructMemberBindings`] wrapper installed on a
-/// struct property and the [`DriverProjection`] bindings it installs on the
-/// narrow common properties of the two-way classes its fields belong to.
-///
-/// The struct's own value-producing binding ("real binding") is installed
-/// on a dedicated [`Property<T>`]: its dirty flag memoizes the evaluation
-/// (the binding runs at most once per change of its inputs, no matter how
-/// many commons and wrappers read it) and the dependency graph
-/// (commons/wrapper → slot property → the binding's inputs) replaces
-/// manual dirty forwarding.
-///
-/// The slot is only ever handled through a `Pin<Rc<Self>>`; `property` is
-/// pinned structurally (it is never moved out, the slot has no `Drop`, and
-/// `Property<T>` makes the slot `!Unpin`).
-struct DriverSlot<T> {
-    property: Property<T>,
-}
-
-impl<T: PartialEq + Clone + 'static> DriverSlot<T> {
-    fn new(seed: T) -> Self {
-        Self { property: Property::new(seed) }
-    }
-
-    /// Structural pin projection to the slot property.
-    fn property(self: Pin<&Self>) -> Pin<&Property<T>> {
-        // Safety: see the pinning notes on the type
-        unsafe { self.map_unchecked(|slot| &slot.property) }
-    }
-
-    /// Drop the real binding, if any. Panics ("Recursion detected") when
-    /// the real binding is currently executing — that only happens when a
-    /// binding writes back to its own struct property, a state in which
-    /// every full-topology route already panicked on a locked common or
-    /// struct handle before this design; the slot property merely fails
-    /// earlier, before any mutation.
-    fn clear(&self) {
-        self.property.handle.remove_binding();
-    }
-
-    fn has_holder(&self) -> bool {
-        self.property.has_binding()
-    }
-
-    /// Install `holder` as the slot property's binding, dropping the
-    /// previous one (bypassing the old binding's `intercept_set_binding`).
-    fn install(&self, holder: *mut BindingHolder) {
-        self.clear();
-        // A stolen (second-hand) holder may have been evaluated in its old
-        // home: its dirty flag is false and its dependency registrations
-        // were wiped, so without this it would never re-evaluate here.
-        unsafe { (*holder).dirty.set(true) };
-        self.property.handle.set_binding_impl(holder);
-    }
-}
-
 /// Binding installed on a narrow common property so that the struct
 /// property's real binding drives the two-way class ("driver election"):
 /// it evaluates the real binding and extracts the mapped field.
@@ -377,7 +322,7 @@ impl<T: PartialEq + Clone + 'static> DriverSlot<T> {
 /// property; the last installed binding on the common wins, like any other
 /// binding installed on a two-way class.
 struct DriverProjection<T, T2, GetField> {
-    slot: Pin<Rc<DriverSlot<T>>>,
+    slot: Pin<Rc<Property<T>>>,
     get_field: GetField,
     marker: PhantomData<fn(T) -> T2>,
 }
@@ -390,7 +335,7 @@ unsafe impl<
 > BindingCallable<T2> for DriverProjection<T, T2, GetField>
 {
     fn evaluate(self: Pin<&Self>, value: &mut T2) -> BindingResult {
-        if !self.slot.has_holder() {
+        if !self.slot.has_binding() {
             // The driver was dropped (e.g. a value was set on the struct
             // property); keep the common's current value and clean up.
             // Not reading the slot property also avoids registering a
@@ -399,7 +344,7 @@ unsafe impl<
         }
         // Reading the slot property registers this projection as its
         // dependent and memoizes the real binding behind its dirty flag.
-        *value = (self.get_field)(&self.slot.as_ref().property().get());
+        *value = (self.get_field)(&self.slot.as_ref().get());
         BindingResult::KeepBinding
     }
 }
@@ -417,8 +362,9 @@ struct StructMemberMapping<T> {
     /// `common.set(get_field(value))`
     push_to_common: Box<dyn Fn(&T)>,
     /// Installs a [`DriverProjection`] for this mapping's field onto the
-    /// common, making the given slot's real binding drive the class.
-    install_projection: Box<dyn Fn(&Pin<Rc<DriverSlot<T>>>)>,
+    /// common, making the real binding on the given slot property drive
+    /// the class.
+    install_projection: Box<dyn Fn(&Pin<Rc<Property<T>>>)>,
     /// The narrow common property (an `Rc<Property<T2>>`, semantically
     /// pinned), type-erased for the field-keyed reuse lookup.
     common: Rc<dyn core::any::Any>,
@@ -428,11 +374,41 @@ struct StructMemberMapping<T> {
 /// bindings onto its *fields*. Each mapped field is synchronized with a
 /// narrow common property of the field's type that is shared by every
 /// member of the two-way binding class; the struct's own value-producing
-/// binding, if any, lives in the [`DriverSlot`] and both produces the
+/// binding, if any, lives on the slot property and both produces the
 /// unmapped fields and drives the commons via [`DriverProjection`]s.
 struct StructMemberBindings<T> {
-    slot: Pin<Rc<DriverSlot<T>>>,
+    /// The struct's own value-producing binding ("real binding") is
+    /// installed on this dedicated property, shared with the
+    /// [`DriverProjection`]s of the mapped fields' commons: its dirty flag
+    /// memoizes the evaluation (the binding runs at most once per change
+    /// of its inputs, no matter how many commons and wrappers read it) and
+    /// the dependency graph (commons/wrapper → slot property → the
+    /// binding's inputs) replaces manual dirty forwarding.
+    slot: Pin<Rc<Property<T>>>,
     mappings: RefCell<Vec<StructMemberMapping<T>>>,
+}
+
+impl<T: PartialEq + Clone + 'static> StructMemberBindings<T> {
+    /// Drop the real binding, if any. Panics ("Recursion detected") when
+    /// the real binding is currently executing — that only happens when a
+    /// binding writes back to its own struct property, a state in which
+    /// every full-topology route already panicked on a locked common or
+    /// struct handle before this design; the slot property merely fails
+    /// earlier, before any mutation.
+    fn clear_driver_binding(&self) {
+        self.slot.handle.remove_binding();
+    }
+
+    /// Install `holder` as the slot property's binding, dropping the
+    /// previous one (bypassing the old binding's `intercept_set_binding`).
+    fn install_driver_binding(&self, holder: *mut BindingHolder) {
+        self.clear_driver_binding();
+        // A stolen (second-hand) holder may have been evaluated in its old
+        // home: its dirty flag is false and its dependency registrations
+        // were wiped, so without this it would never re-evaluate here.
+        unsafe { (*holder).dirty.set(true) };
+        self.slot.handle.set_binding_impl(holder);
+    }
 }
 
 // Safety: IS_STRUCT_MEMBER_BINDINGS is true and Self is StructMemberBindings
@@ -441,8 +417,8 @@ unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberB
         // Only read the slot property while it carries the real binding:
         // when binding-less its stored value is stale and would clobber the
         // struct's own stored value (and register a spurious dependency).
-        if self.slot.has_holder() {
-            *value = self.slot.as_ref().property().get();
+        if self.slot.has_binding() {
+            *value = self.slot.as_ref().get();
         }
         for mapping in self.mappings.borrow().iter() {
             (mapping.apply_from_common)(value);
@@ -454,7 +430,7 @@ unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberB
         // Setting a value drops the real binding (as it would on an
         // unwrapped property) and pushes the mapped fields into their
         // classes. The unmapped fields are stored by `Property::set`.
-        self.slot.clear();
+        self.clear_driver_binding();
         for mapping in self.mappings.borrow().iter() {
             (mapping.push_to_common)(value);
         }
@@ -473,7 +449,7 @@ unsafe impl<T: PartialEq + Clone + 'static> BindingCallable<T> for StructMemberB
             // on the slot property when it evaluates the binding.
             *(*new_binding).dep_nodes.get() = Default::default();
         }
-        self.slot.install(new_binding);
+        self.install_driver_binding(new_binding);
         // The new binding must drive the classes of all mapped fields.
         // Installing the projections also marks the commons' dependents
         // dirty (including this wrapper and the struct's dependents),
@@ -542,7 +518,10 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
         if self.with_struct_member_bindings(|_| ()).is_some() {
             return;
         }
-        let slot = Rc::pin(DriverSlot::new(self.get_internal()));
+        let wrapper = StructMemberBindings {
+            slot: Rc::pin(Property::new(self.get_internal())),
+            mappings: RefCell::new(Vec::new()),
+        };
         if let Some(old) = self.handle.detach_binding() {
             debug_assert!(
                 unsafe { !(*old).is_two_way_binding },
@@ -554,12 +533,12 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
             // registrations land on the slot property when it evaluates the
             // binding.
             unsafe { *(*old).dep_nodes.get() = Default::default() };
-            slot.install(old);
+            wrapper.install_driver_binding(old);
         }
         // Safety: StructMemberBindings<T> is a BindingCallable for type T
         unsafe {
             self.handle.set_binding(
-                StructMemberBindings { slot, mappings: RefCell::new(Vec::new()) },
+                wrapper,
                 #[cfg(slint_debug_property)]
                 &alloc::format!("<members of {}>", self.debug_name.borrow()),
             );
@@ -593,7 +572,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                 }),
                 install_projection: Box::new({
                     let common = common.clone();
-                    move |slot: &Pin<Rc<DriverSlot<T>>>| {
+                    move |slot: &Pin<Rc<Property<T>>>| {
                         // Safety: DriverProjection is a BindingCallable for T2
                         unsafe {
                             common.handle.set_binding(
@@ -615,7 +594,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
             // A pre-existing real binding must also drive this field's class
             // (it may be a new class, or the class' driver may have been
             // dropped by the value push that preceded this call).
-            if wrapper.slot.has_holder() {
+            if wrapper.slot.has_binding() {
                 (mapping.install_projection)(&wrapper.slot);
             }
             let mut mappings = wrapper.mappings.borrow_mut();
@@ -1585,26 +1564,30 @@ mod struct_member_tests {
         assert_eq!(z_scalar.as_ref().get(), 11);
     }
 
-    /// Clearing the slot while its holder is being evaluated (a binding
-    /// that writes back to its own struct property) is a clean "Recursion
-    /// detected" panic: the lock assertion fires before any drop, so a
-    /// use-after-free is impossible by construction. (Every full-topology
-    /// route to this state also panicked under the previous deferred-drop
-    /// design — on the locked common or struct handle instead.)
+    /// Clearing the slot property while its holder is being evaluated (a
+    /// binding that writes back to its own struct property) is a clean
+    /// "Recursion detected" panic: the lock assertion fires before any
+    /// drop, so a use-after-free is impossible by construction. (Every
+    /// full-topology route to this state also panicked under the previous
+    /// deferred-drop design — on the locked common or struct handle
+    /// instead.)
     #[test]
     #[should_panic(expected = "Recursion detected")]
-    fn driver_slot_clear_of_executing_holder_panics_cleanly() {
-        let slot = Rc::pin(DriverSlot::<i32>::new(0));
+    fn clearing_executing_driver_binding_panics_cleanly() {
+        let wrapper = Rc::new(StructMemberBindings::<i32> {
+            slot: Rc::pin(Property::new(0)),
+            mappings: RefCell::new(Vec::new()),
+        });
         let holder = alloc_binding_holder::<i32, _>({
-            let slot = slot.clone();
+            let wrapper = wrapper.clone();
             move |value: &mut i32| {
-                slot.clear();
+                wrapper.clear_driver_binding();
                 *value = 42;
                 BindingResult::KeepBinding
             }
         });
-        slot.install(holder);
-        let _ = slot.as_ref().property().get();
+        wrapper.install_driver_binding(holder);
+        let _ = wrapper.slot.as_ref().get();
     }
 
     /// The full-topology version of the scenario above: a struct binding

--- a/internal/core/properties/two_way_binding.rs
+++ b/internal/core/properties/two_way_binding.rs
@@ -377,7 +377,9 @@ impl<T> DriverSlot<T> {
         scopeguard::defer! {
             self.evaluation_depth.set(self.evaluation_depth.get() - 1);
             if self.evaluation_depth.get() == 0 {
-                for holder in self.pending_drops.borrow_mut().drain(..) {
+                // pop-style drain: the borrow is not held across the drop
+                // call, whose Drop code could re-enter this slot
+                while let Some(holder) = self.pending_drops.borrow_mut().pop() {
                     // Safety: parked by `dispose`, no longer executing
                     unsafe { ((*holder).vtable.drop)(holder) }
                 }
@@ -393,7 +395,7 @@ impl<T> Drop for DriverSlot<T> {
     fn drop(&mut self) {
         debug_assert_eq!(self.evaluation_depth.get(), 0);
         self.clear();
-        for holder in self.pending_drops.borrow_mut().drain(..) {
+        while let Some(holder) = self.pending_drops.borrow_mut().pop() {
             // Safety: parked by `dispose`, no longer executing
             unsafe { ((*holder).vtable.drop)(holder) }
         }
@@ -450,7 +452,7 @@ struct StructMemberMapping<T> {
     /// Field path within the struct (e.g. `"field"` or `"outer.inner"`),
     /// used to find and replace the mapping when the same link is
     /// re-established (conditional/repeated component re-instantiation).
-    key: &'static str,
+    key: crate::SharedString,
     /// `value.<key> = common.get()`; reading the common registers the
     /// dependency so the struct re-evaluates when the class changes.
     apply_from_common: Box<dyn Fn(&mut T)>,
@@ -564,10 +566,10 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
     /// property is synchronized with, if any.
     fn struct_member_common<T2: PartialEq + Clone + 'static>(
         self: Pin<&Self>,
-        field_key: &'static str,
+        field_key: &str,
     ) -> Option<Pin<Rc<Property<T2>>>> {
         self.with_struct_member_bindings(|wrapper| {
-            wrapper.mappings.borrow().iter().find(|mapping| mapping.key == field_key).and_then(
+            wrapper.mappings.borrow().iter().find(|mapping| mapping.key.as_str() == field_key).and_then(
                 |mapping| {
                     let common = mapping.common.clone().downcast::<Property<T2>>();
                     debug_assert!(
@@ -619,7 +621,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
     /// `field_key` of this struct property with `common`.
     fn add_struct_member_mapping<T2: PartialEq + Clone + 'static>(
         self: Pin<&Self>,
-        field_key: &'static str,
+        field_key: crate::SharedString,
         common: Pin<Rc<Property<T2>>>,
         get_field: impl Fn(&T) -> T2 + Clone + 'static,
         set_field: impl Fn(&mut T, &T2) + Clone + 'static,
@@ -627,7 +629,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
         self.ensure_struct_member_bindings();
         self.with_struct_member_bindings(|wrapper| {
             let mapping = StructMemberMapping {
-                key: field_key,
+                key: field_key.clone(),
                 apply_from_common: Box::new({
                     let common = common.clone();
                     move |value: &mut T| {
@@ -697,16 +699,25 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
     /// `struct_prop` is the right-hand side and its current field value wins.
     /// `get_field`/`set_field` read/write the field at `field_key` of the
     /// struct.
+    ///
+    /// A pre-existing regular binding on `member_prop` is dropped when
+    /// `preserve_member_binding` is false (generated code installs bindings
+    /// *after* the links, so the struct's value wins over a leftover
+    /// binding), or forwarded onto the class' common — where it drives the
+    /// class, exactly like a binding installed after the link — when true
+    /// (the interpreter installs bindings *before* the links).
     pub fn link_two_way_to_member<T2: PartialEq + Clone + 'static>(
         struct_prop: Pin<&Self>,
         member_prop: Pin<&Property<T2>>,
-        field_key: &'static str,
+        field_key: impl Into<crate::SharedString>,
         get_field: impl Fn(&T) -> T2 + Clone + 'static,
         set_field: impl Fn(&mut T, &T2) + Clone + 'static,
+        preserve_member_binding: bool,
     ) {
+        let field_key = field_key.into();
         let member_common = member_prop.check_common_property();
         let member_was_linked = member_common.is_some();
-        let struct_common = struct_prop.struct_member_common::<T2>(field_key);
+        let struct_common = struct_prop.struct_member_common::<T2>(&field_key);
 
         let common = match (member_common, struct_common) {
             (Some(member_common), Some(struct_common)) => {
@@ -753,9 +764,17 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                         member_prop.handle.set_binding_impl(old);
                     } else {
                         member_prop.handle.set_binding_impl(new_binding);
-                        // The member's own binding is dropped: the struct's
-                        // value wins (as with `link_two_way_with_map`).
-                        ((*old).vtable.drop)(old);
+                        if preserve_member_binding {
+                            // Re-attach the member's binding: the fresh
+                            // TwoWayBinding intercepts and forwards it onto
+                            // the common, where it drives the class.
+                            member_prop.handle.set_binding_impl(old);
+                        } else {
+                            // The member's own binding is dropped: the
+                            // struct's value wins (as with
+                            // `link_two_way_with_map`).
+                            ((*old).vtable.drop)(old);
+                        }
                     }
                 } else {
                     member_prop.handle.set_binding(
@@ -778,16 +797,18 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
     /// field value wins.
     pub fn link_two_way_members<TB: PartialEq + Clone + 'static, T2: PartialEq + Clone + 'static>(
         prop_a: Pin<&Self>,
-        field_key_a: &'static str,
+        field_key_a: impl Into<crate::SharedString>,
         get_field_a: impl Fn(&T) -> T2 + Clone + 'static,
         set_field_a: impl Fn(&mut T, &T2) + Clone + 'static,
         prop_b: Pin<&Property<TB>>,
-        field_key_b: &'static str,
+        field_key_b: impl Into<crate::SharedString>,
         get_field_b: impl Fn(&TB) -> T2 + Clone + 'static,
         set_field_b: impl Fn(&mut TB, &T2) + Clone + 'static,
     ) {
-        let common_a = prop_a.struct_member_common::<T2>(field_key_a);
-        let common_b = prop_b.struct_member_common::<T2>(field_key_b);
+        let field_key_a = field_key_a.into();
+        let field_key_b = field_key_b.into();
+        let common_a = prop_a.struct_member_common::<T2>(&field_key_a);
+        let common_b = prop_b.struct_member_common::<T2>(&field_key_b);
 
         let common = match (common_a, common_b) {
             (Some(common_a), Some(common_b)) => {
@@ -827,14 +848,15 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
     /// common property and drives it.
     pub fn link_two_way_member_to_model_data<T2: PartialEq + Clone + 'static, ItemTree: 'static>(
         struct_prop: Pin<&Self>,
-        field_key: &'static str,
+        field_key: impl Into<crate::SharedString>,
         get_field: impl Fn(&T) -> T2 + Clone + 'static,
         set_field: impl Fn(&mut T, &T2) + Clone + 'static,
         item_tree: ItemTree,
         getter: impl Fn(&ItemTree) -> Option<T2> + 'static,
         setter: impl Fn(&ItemTree, &T2) + 'static,
     ) {
-        let common = struct_prop.struct_member_common::<T2>(field_key).unwrap_or_else(|| {
+        let field_key = field_key.into();
+        let common = struct_prop.struct_member_common::<T2>(&field_key).unwrap_or_else(|| {
             Rc::pin(Property::new(get_field(&struct_prop.get_untracked())))
         });
         struct_prop.add_struct_member_mapping(field_key, common.clone(), get_field, set_field);
@@ -1187,6 +1209,7 @@ mod struct_member_tests {
             "s1",
             |s: &S1| s.s1.clone(),
             |s: &mut S1, v: &String| s.s1 = v.clone(),
+            false,
         );
     }
     fn link_s2(strct: Pin<&Property<S2>>, member: Pin<&Property<String>>) {
@@ -1196,6 +1219,7 @@ mod struct_member_tests {
             "s2",
             |s: &S2| s.s2.clone(),
             |s: &mut S2, v: &String| s.s2 = v.clone(),
+            false,
         );
     }
 
@@ -1437,6 +1461,7 @@ mod struct_member_tests {
             "i1",
             |s: &S1| s.i1,
             |s: &mut S1, v: &i32| s.i1 = *v,
+            false,
         );
 
         let link_page = |page_data: Pin<&Property<S1>>| {
@@ -1525,6 +1550,7 @@ mod struct_member_tests {
             "inner.s1",
             |s: &Outer| s.inner.s1.clone(),
             |s: &mut Outer, v: &String| s.inner.s1 = v.clone(),
+            false,
         );
         Property::link_two_way_to_member(
             outer.as_ref(),
@@ -1532,6 +1558,7 @@ mod struct_member_tests {
             "z",
             |s: &Outer| s.z,
             |s: &mut Outer, v: &i32| s.z = *v,
+            false,
         );
         assert_eq!(deep_scalar.as_ref().get(), "deep");
         assert_eq!(z_scalar.as_ref().get(), 9);

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -167,6 +167,28 @@ pub trait PropertyInfo<Item, Value> {
         getter: Box<dyn Fn() -> Option<Value>>,
         setter: Box<dyn Fn(&Value)>,
     );
+
+    /// If this property is stored as a `Property<Value>` (struct and array
+    /// properties in the interpreter), return a type-erased pointer to it.
+    fn as_value_property_ptr(&self, item: Pin<&Item>) -> Option<*const c_void>;
+
+    /// Link the field at `field_key` of the struct property `struct_prop`
+    /// two-way with this property, using the narrow-common struct member
+    /// machinery (`Property::link_two_way_to_member`). `get_field` and
+    /// `set_field` read/write the field of the struct `Value`.
+    ///
+    /// # Safety
+    /// `struct_prop` must point to a live, pinned `Property<Value>`
+    /// (obtained e.g. from [`Self::as_value_property_ptr`]).
+    #[allow(unsafe_code)]
+    unsafe fn link_two_way_to_member(
+        &self,
+        item: Pin<&Item>,
+        struct_prop: *const c_void,
+        field_key: &str,
+        get_field: Box<dyn Fn(&Value) -> Value>,
+        set_field: Box<dyn Fn(&mut Value, &Value)>,
+    );
 }
 
 impl<Item: 'static, T, Value> PropertyInfo<Item, Value> for FieldOffset<Item, Property<T>>
@@ -297,6 +319,42 @@ where
             move |_, v: &T| setter(&v.clone().try_into().unwrap_or_default()),
         );
     }
+
+    fn as_value_property_ptr(&self, item: Pin<&Item>) -> Option<*const c_void> {
+        (self as &dyn core::any::Any).downcast_ref::<FieldOffset<Item, Property<Value>>>().map(
+            |field_offset| {
+                field_offset.apply_pin(item).get_ref() as *const Property<Value> as *const c_void
+            },
+        )
+    }
+
+    #[allow(unsafe_code)]
+    unsafe fn link_two_way_to_member(
+        &self,
+        item: Pin<&Item>,
+        struct_prop: *const c_void,
+        field_key: &str,
+        get_field: Box<dyn Fn(&Value) -> Value>,
+        set_field: Box<dyn Fn(&mut Value, &Value)>,
+    ) {
+        let member = self.apply_pin(item);
+        // Safety: guaranteed by the caller
+        let struct_prop = unsafe { Pin::new_unchecked(&*(struct_prop as *const Property<Value>)) };
+        let get_field: Rc<dyn Fn(&Value) -> Value> = get_field.into();
+        let set_field: Rc<dyn Fn(&mut Value, &Value)> = set_field.into();
+        Property::link_two_way_to_member(
+            struct_prop,
+            member,
+            crate::SharedString::from(field_key),
+            move |value: &Value| get_field(value).try_into().unwrap_or_default(),
+            move |value: &mut Value, field: &T| {
+                set_field(value, &field.clone().try_into().unwrap_or_default())
+            },
+            // the interpreter installs bindings before the links: a
+            // pre-existing member binding drives the class
+            true,
+        );
+    }
 }
 
 /// Wrapper for a field offset that optionally implement PropertyInfo and uses
@@ -418,6 +476,24 @@ where
         setter: Box<dyn Fn(&Value)>,
     ) {
         self.0.link_two_way_to_model_data(item, getter, setter)
+    }
+
+    fn as_value_property_ptr(&self, item: Pin<&Item>) -> Option<*const c_void> {
+        self.0.as_value_property_ptr(item)
+    }
+
+    #[allow(unsafe_code)]
+    unsafe fn link_two_way_to_member(
+        &self,
+        item: Pin<&Item>,
+        struct_prop: *const c_void,
+        field_key: &str,
+        get_field: Box<dyn Fn(&Value) -> Value>,
+        set_field: Box<dyn Fn(&mut Value, &Value)>,
+    ) {
+        unsafe {
+            self.0.link_two_way_to_member(item, struct_prop, field_key, get_field, set_field)
+        }
     }
 }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2461,18 +2461,129 @@ export component Win inherits Window {
     assert!((reverted.size.width - base.size.width).abs() < 0.5, "width should revert");
 }
 
+// Component-instance elements are hooked too: their unbound properties get synthetic hooks
+// that must be upgraded with the definition's default bindings during inlining (keeping the
+// *instance* element's hook id). Verifies that the defaults are preserved (regression: they
+// used to be clobbered, rendering repeated items transparent) and that instance properties
+// are live-overridable through the hook callback.
+#[cfg(all(test, feature = "internal", feature = "internal-highlight"))]
+#[test]
+fn test_debug_hook_component_instance_override() {
+    use i_slint_core::Property;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::rc::Rc;
+
+    i_slint_backend_testing::init_no_event_loop();
+
+    let code = r#"
+component Sub inherits Rectangle {
+    in property <color> tint: blue;
+    background: tint;
+}
+export component Win inherits Window {
+    width: 300px;
+    height: 300px;
+    sub := Sub { x: 10px; y: 20px; width: 50px; height: 50px; }
+    for _idx in 2: Sub { width: 10px; height: 10px; }
+    out property <brush> sub-background: sub.background;
+}"#;
+    let path = PathBuf::from("/tmp/debug_hook_instance_test.slint");
+
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).debug_hooks =
+        Some(std::hash::RandomState::new());
+    let compile_result =
+        spin_on::spin_on(compiler.build_from_source(code.to_string(), path.clone()));
+    assert!(!compile_result.has_errors(), "{:?}", compile_result.diagnostics);
+    let instance = compile_result.components().next().unwrap().create().unwrap();
+
+    // Editor-style override store, installed before the first evaluation.
+    type Store = Rc<RefCell<HashMap<SmolStr, Pin<Box<Property<Option<Value>>>>>>>;
+    let store: Store = Default::default();
+    {
+        let store = store.clone();
+        instance.set_debug_hook_callback(Some(Box::new(move |id: &str| -> Option<Value> {
+            let mut map = (*store).borrow_mut();
+            let property =
+                map.entry(SmolStr::from(id)).or_insert_with(|| Box::pin(Property::new(None)));
+            property.as_ref().get()
+        })));
+    }
+
+    // The definition's default must be preserved: `background: tint` with `tint: blue`.
+    let blue = Value::Brush(i_slint_core::Brush::SolidColor(i_slint_core::Color::from_rgb_u8(
+        0, 0, 255,
+    )));
+    assert_eq!(instance.get_property("sub-background").unwrap(), blue);
+
+    // Resolve the instance element and its hash (hooks carry the instance element's id).
+    let offset = code.find("Sub {").unwrap() as u32;
+    let (element, debug_index) = instance
+        .element_node_at_source_code_position(&path, offset)
+        .first()
+        .cloned()
+        .expect("instance element resolved");
+    let element_hash = element.borrow().debug[debug_index].element_hash;
+    assert_ne!(element_hash, 0, "the instance element must carry a hook hash");
+
+    let set_override = |name: &str, value: Option<Value>| {
+        let id = i_slint_compiler::passes::property_id(element_hash, &SmolStr::from(name));
+        let mut map = (*store).borrow_mut();
+        let property = map.entry(id).or_insert_with(|| Box::pin(Property::new(None)));
+        (&**property).set(value);
+    };
+
+    // Override the instance's background (an upgraded synthetic hook) and revert.
+    let red = Value::Brush(i_slint_core::Brush::SolidColor(i_slint_core::Color::from_rgb_u8(
+        255, 0, 0,
+    )));
+    set_override("background", Some(red.clone()));
+    assert_eq!(instance.get_property("sub-background").unwrap(), red);
+    set_override("background", None);
+    assert_eq!(instance.get_property("sub-background").unwrap(), blue);
+
+    // Override the instance's x (wrapped explicit binding) and observe the geometry shift.
+    let base = instance.element_positions(&element).first().expect("geometry").rect;
+    set_override("x", Some(Value::Number(110.0)));
+    let after = instance.element_positions(&element).first().expect("geometry").rect;
+    assert!(
+        (after.origin.x - base.origin.x - 100.0).abs() < 0.5,
+        "x override should shift the instance by 100px (base {}, after {})",
+        base.origin.x,
+        after.origin.x
+    );
+    set_override("x", None);
+
+    // Overriding the injected transform-rotation hook must be possible (the Transform
+    // wrapper element is reified around the instance) and must not affect the geometry.
+    set_override("transform-rotation", Some(Value::Number(45.0)));
+    let rotated = instance.element_positions(&element).first().expect("geometry").rect;
+    assert!((rotated.origin.x - base.origin.x).abs() < 0.5, "rotation must not move the origin");
+    set_override("transform-rotation", None);
+}
+
 // Regression test: debug hooks inject bindings for properties the element may not have
 // natively (geometry, transform-rotation). Every injected binding must end up on a property
 // that actually exists at runtime, for every kind of element — otherwise instantiation
 // aborts with "unknown property ... in ...". Exercise the special cases: the root element,
-// plain items, elements that become component roots later (PopupWindow), non-item types
-// (Timer), repeated and conditional elements, layouts, and menus.
+// plain items, elements that become component roots later (PopupWindow — plain or through
+// component inheritance), non-item types (Timer), repeated and conditional elements,
+// layouts, menus, style widgets, and tooltips with custom content.
 #[cfg(all(test, feature = "internal", feature = "internal-highlight"))]
 #[test]
 fn test_debug_hooks_instantiate_special_elements() {
     i_slint_backend_testing::init_no_event_loop();
 
     let code = r#"
+import { Button } from "std-widgets.slint";
+
+component MyPopup inherits PopupWindow {
+    Rectangle { background: yellow; }
+}
+
 export component Win inherits Window {
     width: 300px;
     height: 300px;
@@ -2490,11 +2601,20 @@ export component Win inherits Window {
         plain := Rectangle { }
     }
 
+    covered := Rectangle {
+        Tooltip {
+            Rectangle { background: #222; }
+        }
+    }
+
+    Button { text: "a widget"; }
+
     popup := PopupWindow {
         Text { text: "popup content"; }
     }
-    callback show-the-popup();
-    show-the-popup() => { popup.show(); }
+    my-popup := MyPopup { }
+    callback show-the-popups();
+    show-the-popups() => { popup.show(); my-popup.show(); }
 
     Timer { interval: 1s; running: false; }
 
@@ -2514,8 +2634,8 @@ export component Win inherits Window {
     assert!(!result.has_errors(), "{:?}", result.diagnostics);
     let instance = result.components().next().unwrap().create().unwrap();
 
-    // Showing the popup instantiates the popup component (its bindings are only set up then).
-    instance.invoke("show-the-popup", &[]).unwrap();
+    // Showing the popups instantiates the popup components (their bindings are only set up then).
+    instance.invoke("show-the-popups", &[]).unwrap();
 }
 
 // Enabling debug_hooks now also materializes hooked default bindings for unbound properties.

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2366,6 +2366,101 @@ export component Foo2 inherits Window  {
     }
 }
 
+// Validates the "live drag" mechanism the visual editor relies on: with `debug_hooks`
+// enabled, a `set_debug_hook_callback` that reads a per-id `Property<Option<Value>>` lets the
+// editor reactively override a property's value (and revert it) without touching the source.
+// Setting the override property re-evaluates the hooked binding via Slint's dependency tracker.
+#[cfg(all(test, feature = "internal", feature = "internal-highlight"))]
+#[test]
+fn test_debug_hook_live_override() {
+    use i_slint_core::Property;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::rc::Rc;
+
+    i_slint_backend_testing::init_no_event_loop();
+
+    let code = r#"
+export component Win inherits Window {
+    width: 300px;
+    height: 300px;
+    rect := Rectangle {
+        x: 10px;
+        y: 20px;
+        width: 30px;
+        height: 40px;
+    }
+}"#;
+    let path = PathBuf::from("/tmp/debug_hook_test.slint");
+
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).debug_hooks =
+        Some(std::hash::RandomState::new());
+    let compile_result =
+        spin_on::spin_on(compiler.build_from_source(code.to_string(), path.clone()));
+    assert!(!compile_result.has_errors(), "{:?}", compile_result.diagnostics);
+    let instance = compile_result.components().next().unwrap().create().unwrap();
+
+    // Resolve the `rect` element and the hash used to build its hook ids.
+    let offset = code.find("Rectangle").unwrap() as u32;
+    let (element, debug_index) = instance
+        .element_node_at_source_code_position(&path, offset)
+        .first()
+        .cloned()
+        .expect("element resolved");
+    let element_hash = element.borrow().debug[debug_index].element_hash;
+    assert_ne!(element_hash, 0, "debug_hooks should populate element_hash");
+
+    // Editor-style override store + callback (must be installed before the first evaluation so
+    // the hooked bindings register a dependency on the override properties while still `None`).
+    type Store = Rc<RefCell<HashMap<SmolStr, Pin<Box<Property<Option<Value>>>>>>>;
+    let store: Store = Default::default();
+    {
+        let store = store.clone();
+        instance.set_debug_hook_callback(Some(Box::new(move |id: &str| -> Option<Value> {
+            let mut m = (*store).borrow_mut();
+            let p = m.entry(SmolStr::from(id)).or_insert_with(|| Box::pin(Property::new(None)));
+            p.as_ref().get()
+        })));
+    }
+
+    let set_override = |name: &str, value: Option<f64>| {
+        let id = i_slint_compiler::passes::property_id(element_hash, &SmolStr::from(name));
+        let mut m = (*store).borrow_mut();
+        let p = m.entry(id).or_insert_with(|| Box::pin(Property::new(None)));
+        (&**p).set(value.map(Value::Number));
+    };
+
+    // Baseline: evaluates the bindings (registering the dependency) with no overrides.
+    let base = instance.element_positions(&element).first().expect("geometry").rect;
+
+    // Override x and width: the hooked bindings must re-evaluate to the new values.
+    set_override("x", Some(100.0));
+    set_override("width", Some(70.0));
+    let after = instance.element_positions(&element).first().expect("geometry").rect;
+    assert!(
+        (after.origin.x - base.origin.x - 90.0).abs() < 0.5,
+        "x override should shift the element by 90px (base {}, after {})",
+        base.origin.x,
+        after.origin.x
+    );
+    assert!(
+        (after.size.width - base.size.width - 40.0).abs() < 0.5,
+        "width override should grow the element by 40px (base {}, after {})",
+        base.size.width,
+        after.size.width
+    );
+
+    // Revert: setting the overrides back to None restores the original geometry.
+    set_override("x", None);
+    set_override("width", None);
+    let reverted = instance.element_positions(&element).first().expect("geometry").rect;
+    assert!((reverted.origin.x - base.origin.x).abs() < 0.5, "x should revert");
+    assert!((reverted.size.width - base.size.width).abs() < 0.5, "width should revert");
+}
+
 #[cfg(feature = "ffi")]
 #[doc(hidden)]
 #[allow(missing_docs)]

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1698,6 +1698,14 @@ impl ComponentInstance {
     ) -> Vec<(i_slint_compiler::object_tree::ElementRc, usize)> {
         crate::highlight::element_node_at_source_code_position(&self.inner, path, offset)
     }
+
+    /// Set a callback triggered by `Expression::DebugHook``.
+    #[cfg(feature = "internal-highlight")]
+    pub fn set_debug_hook_callback(&self, callback: Option<crate::debug_hook::DebugHookCallback>) {
+        generativity::make_guard!(guard);
+        let comp = self.inner.unerase(guard);
+        crate::debug_hook::set_debug_hook_callback(comp, callback);
+    }
 }
 
 impl StrongHandle for ComponentInstance {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2461,6 +2461,63 @@ export component Win inherits Window {
     assert!((reverted.size.width - base.size.width).abs() < 0.5, "width should revert");
 }
 
+// Enabling debug_hooks now also materializes hooked default bindings for unbound properties.
+// This must NOT change the rendered result when no override is set: wrapping default-geometry
+// bindings must preserve fill/implicit sizing, and injecting the type-default for unbound props
+// must equal their unbound value (e.g. the font sentinel that drives Window inheritance).
+#[cfg(all(test, feature = "internal", feature = "internal-highlight"))]
+#[test]
+fn test_debug_hooks_preserve_geometry() {
+    i_slint_backend_testing::init_no_event_loop();
+
+    let code = r#"
+export component Win inherits Window {
+    width: 300px;
+    height: 200px;
+    rect := Rectangle { }            // no explicit geometry -> fills the parent
+    txt := Text { text: "Hello"; }   // implicit (font-dependent) size, inherited font
+}"#;
+    let path = PathBuf::from("/tmp/debug_hook_noregress.slint");
+
+    let geometries = |debug_hooks: bool| -> Vec<(f32, f32, f32, f32)> {
+        let mut compiler = Compiler::default();
+        compiler.set_style("fluent".into());
+        if debug_hooks {
+            compiler.compiler_configuration(i_slint_core::InternalToken).debug_hooks =
+                Some(std::hash::RandomState::new());
+        }
+        let r = spin_on::spin_on(compiler.build_from_source(code.to_string(), path.clone()));
+        assert!(!r.has_errors(), "{:?}", r.diagnostics);
+        let instance = r.components().next().unwrap().create().unwrap();
+        [code.find("Rectangle").unwrap(), code.find("Text").unwrap()]
+            .into_iter()
+            .map(|off| {
+                let (elem, _) = instance
+                    .element_node_at_source_code_position(&path, off as u32)
+                    .first()
+                    .cloned()
+                    .expect("element");
+                let g = instance.element_positions(&elem).first().expect("geometry").rect;
+                (g.origin.x, g.origin.y, g.size.width, g.size.height)
+            })
+            .collect()
+    };
+
+    let without = geometries(false);
+    let with = geometries(true);
+    for (a, b) in without.iter().zip(with.iter()) {
+        assert!(
+            (a.0 - b.0).abs() < 0.5
+                && (a.1 - b.1).abs() < 0.5
+                && (a.2 - b.2).abs() < 0.5
+                && (a.3 - b.3).abs() < 0.5,
+            "geometry differs with vs without debug_hooks: {a:?} vs {b:?}"
+        );
+    }
+    // Sanity: the Rectangle actually filled the 300x200 window (so we know we compared real sizes).
+    assert!((with[0].2 - 300.0).abs() < 0.5 && (with[0].3 - 200.0).abs() < 0.5);
+}
+
 #[cfg(feature = "ffi")]
 #[doc(hidden)]
 #[allow(missing_docs)]

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2461,6 +2461,63 @@ export component Win inherits Window {
     assert!((reverted.size.width - base.size.width).abs() < 0.5, "width should revert");
 }
 
+// Regression test: debug hooks inject bindings for properties the element may not have
+// natively (geometry, transform-rotation). Every injected binding must end up on a property
+// that actually exists at runtime, for every kind of element — otherwise instantiation
+// aborts with "unknown property ... in ...". Exercise the special cases: the root element,
+// plain items, elements that become component roots later (PopupWindow), non-item types
+// (Timer), repeated and conditional elements, layouts, and menus.
+#[cfg(all(test, feature = "internal", feature = "internal-highlight"))]
+#[test]
+fn test_debug_hooks_instantiate_special_elements() {
+    i_slint_backend_testing::init_no_event_loop();
+
+    let code = r#"
+export component Win inherits Window {
+    width: 300px;
+    height: 300px;
+
+    MenuBar {
+        Menu {
+            title: "File";
+            MenuItem { title: "Quit"; }
+        }
+    }
+
+    rect := Rectangle {
+        rotated := Rectangle { transform-rotation: 45deg; }
+        scaled := Rectangle { transform-scale: 150%; }
+        plain := Rectangle { }
+    }
+
+    popup := PopupWindow {
+        Text { text: "popup content"; }
+    }
+    callback show-the-popup();
+    show-the-popup() => { popup.show(); }
+
+    Timer { interval: 1s; running: false; }
+
+    for _ in 3: Rectangle { width: 10px; }
+    if true: Rectangle { height: 5px; }
+
+    VerticalLayout {
+        Rectangle { }
+    }
+}"#;
+
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).debug_hooks =
+        Some(std::hash::RandomState::new());
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics);
+    let instance = result.components().next().unwrap().create().unwrap();
+
+    // Showing the popup instantiates the popup component (its bindings are only set up then).
+    instance.invoke("show-the-popup", &[]).unwrap();
+}
+
 // Enabling debug_hooks now also materializes hooked default bindings for unbound properties.
 // This must NOT change the rendered result when no override is set: wrapping default-geometry
 // bindings must preserve fill/implicit sizing, and injecting the type-default for unbound props

--- a/internal/interpreter/debug_hook.rs
+++ b/internal/interpreter/debug_hook.rs
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use crate::{Value, dynamic_item_tree};
+
+use smol_str::SmolStr;
+
+use std::pin::Pin;
+
+pub type DebugHookCallback = Box<dyn Fn(&str) -> Option<Value>>;
+
+pub(crate) fn set_debug_hook_callback(
+    component: Pin<&dynamic_item_tree::ItemTreeBox>,
+    func: Option<DebugHookCallback>,
+) {
+    let Some(global_storage) = component.description().compiled_globals.clone() else {
+        return;
+    };
+    *(global_storage.debug_hook_callback.borrow_mut()) = func;
+}
+
+pub(crate) fn debug_hook_triggered(
+    component_instance: &dynamic_item_tree::InstanceRef,
+    id: SmolStr,
+) -> Option<Value> {
+    component_instance.description.compiled_globals.clone().and_then(|global_storage| {
+        let callback = global_storage.debug_hook_callback.borrow();
+        callback.as_ref().and_then(|callback| callback(&id))
+    })
+}

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -492,7 +492,7 @@ pub struct ItemTreeDescription<'id> {
     pub(crate) popup_menu_description: PopupMenuDescription,
 
     /// The collection of compiled globals
-    compiled_globals: Option<Rc<CompiledGlobalCollection>>,
+    pub(crate) compiled_globals: Option<Rc<CompiledGlobalCollection>>,
 
     /// The type loader, which will be available only on the top-most `ItemTreeDescription`.
     /// All other `ItemTreeDescription`s have `None` here.

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1852,13 +1852,29 @@ pub fn instantiate(
                                     && let Some(struct_ptr) =
                                         value_struct_property_ptr(property, instance_ref)
                                 {
-                                    let (get_field, set_field) =
-                                        value_field_path_boxed_accessors(field_access);
-                                    let field_key = field_access.join(".");
-                                    // Safety: struct_ptr points to a live pinned Property<Value>
-                                    prop_rtti.link_two_way_to_member(
-                                        item, struct_ptr, &field_key, get_field, set_field,
-                                    );
+                                    if matches!(&property_type, Type::LogicalLength) {
+                                        // Native item properties store `length`
+                                        // as Property<LogicalLength>, while the
+                                        // class common for a length field uses
+                                        // the plain f32 representation (like
+                                        // custom properties and decomposed
+                                        // cells do): attach through a
+                                        // converting link.
+                                        link_native_length_member(
+                                            item,
+                                            prop_rtti.offset(),
+                                            struct_ptr,
+                                            field_access,
+                                        );
+                                    } else {
+                                        let (get_field, set_field) =
+                                            value_field_path_boxed_accessors(field_access);
+                                        let field_key = field_access.join(".");
+                                        // Safety: struct_ptr points to a live pinned Property<Value>
+                                        prop_rtti.link_two_way_to_member(
+                                            item, struct_ptr, &field_key, get_field, set_field,
+                                        );
+                                    }
                                 } else {
                                     // whole struct/array link, or a natively
                                     // stored struct side: wide-common
@@ -2185,6 +2201,7 @@ fn with_typed_cell_accessors<R>(
         Type::Duration => dispatch!(i64),
         Type::Image => dispatch!(i_slint_core::graphics::Image),
         Type::Bool => dispatch!(bool),
+        Type::ComponentFactory => dispatch!(ComponentFactory),
         Type::Easing => dispatch!(i_slint_core::animations::EasingCurve),
         Type::Enumeration(e) => {
             macro_rules! match_enum_type {
@@ -2221,6 +2238,45 @@ trait TypedCellLink<R> {
         T2: Clone + PartialEq + Default + 'static,
         Value: TryInto<T2>,
         T2: TryInto<Value>;
+}
+
+/// Link a native item property of type `length` (stored as
+/// `Property<LogicalLength>`) two-way to the field at `field_access` of the
+/// struct property behind `struct_ptr` (a `Property<Value>`). The class'
+/// common property uses the plain `f32` representation that custom `length`
+/// properties and decomposed cells use, so all links to the same field
+/// share one class; the native member is attached through a converting
+/// forwarding binding.
+fn link_native_length_member(
+    item: Pin<ItemRef>,
+    property_offset: usize,
+    struct_ptr: *const c_void,
+    field_access: &[SmolStr],
+) {
+    use i_slint_core::lengths::LogicalLength;
+    let (get_field, set_field) = value_field_path_accessors(field_access);
+    // Safety: the compiler resolved this property as a `length` property of
+    // the native item, whose storage is a Property<LogicalLength> at the
+    // rtti offset; struct_ptr points to a live pinned Property<Value>
+    unsafe {
+        let member =
+            Pin::new_unchecked(&*(item.as_ptr().add(property_offset)
+                as *const Property<LogicalLength>));
+        let struct_prop = Pin::new_unchecked(&*(struct_ptr as *const Property<Value>));
+        Property::link_two_way_to_member_mapped(
+            struct_prop,
+            member,
+            field_access.join(".").as_str(),
+            move |value: &Value| {
+                get_field(value).try_into().unwrap_or_default()
+            },
+            move |value: &mut Value, field: &f32| {
+                set_field(value, &Value::Number(*field as f64))
+            },
+            |repr: &f32| LogicalLength::new(*repr),
+            |repr: &mut f32, length: &LogicalLength| *repr = length.get(),
+        );
+    }
 }
 
 /// Establish a compiler-decomposed two-way cell link

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1742,7 +1742,7 @@ pub fn instantiate(
                 }
                 for twb in &binding.two_way_bindings {
                     match twb {
-                        TwoWayBinding::Property { property, field_access }
+                        TwoWayBinding::Property { property, field_access, .. }
                             if field_access.is_empty()
                                 && !matches!(
                                     &property_type,
@@ -1753,18 +1753,60 @@ pub fn instantiate(
                             // the same type (except for struct/array, which may map to a Value).
                             prop_info.link_two_ways(item, get_property_ptr(property, instance_ref));
                         }
-                        TwoWayBinding::Property { property, field_access } => {
-                            let (common, map) =
-                                prepare_for_two_way_binding(instance_ref, property, field_access);
-                            prop_info.link_two_way_with_map(item, common, map);
+                        TwoWayBinding::Property { property, field_access, field_access1 } => {
+                            if !field_access1.is_empty() {
+                                // compiler-decomposed cell link: both sides
+                                // are struct properties stored as Value
+                                link_value_member_cell(
+                                    prop_info.as_value_property_ptr(item),
+                                    field_access1,
+                                    value_struct_property_ptr(property, instance_ref),
+                                    field_access,
+                                    &field_path_type(property_type.clone(), field_access1),
+                                );
+                            } else if !field_access.is_empty()
+                                && let Some(struct_ptr) =
+                                    value_struct_property_ptr(property, instance_ref)
+                            {
+                                let (get_field, set_field) =
+                                    value_field_path_boxed_accessors(field_access);
+                                let field_key = field_access.join(".");
+                                // Safety: struct_ptr points to a live pinned Property<Value>
+                                prop_info.link_two_way_to_member(
+                                    item, struct_ptr, &field_key, get_field, set_field,
+                                );
+                            } else {
+                                // whole struct/array link, or a natively
+                                // stored struct side: wide-common machinery
+                                let (common, map) = prepare_for_two_way_binding(
+                                    instance_ref,
+                                    property,
+                                    field_access,
+                                );
+                                prop_info.link_two_way_with_map(item, common, map);
+                            }
                         }
-                        TwoWayBinding::ModelData { repeated_element, field_access } => {
+                        TwoWayBinding::ModelData {
+                            repeated_element,
+                            field_access,
+                            field_access1,
+                        } => {
                             let (getter, setter) = prepare_model_two_way_binding(
                                 instance_ref,
                                 repeated_element,
                                 field_access,
                             );
-                            prop_info.link_two_way_to_model_data(item, getter, setter);
+                            if field_access1.is_empty() {
+                                prop_info.link_two_way_to_model_data(item, getter, setter);
+                            } else {
+                                link_value_member_cell_to_model_data(
+                                    prop_info.as_value_property_ptr(item),
+                                    field_access1,
+                                    getter,
+                                    setter,
+                                    &field_path_type(property_type.clone(), field_access1),
+                                );
+                            }
                         }
                     }
                 }
@@ -1778,7 +1820,7 @@ pub fn instantiate(
 
                     for twb in &binding.two_way_bindings {
                         match twb {
-                            TwoWayBinding::Property { property, field_access }
+                            TwoWayBinding::Property { property, field_access, .. }
                                 if field_access.is_empty()
                                     && !matches!(
                                         &property_type,
@@ -1790,21 +1832,66 @@ pub fn instantiate(
                                 prop_rtti
                                     .link_two_ways(item, get_property_ptr(property, instance_ref));
                             }
-                            TwoWayBinding::Property { property, field_access } => {
-                                let (common, map) = prepare_for_two_way_binding(
-                                    instance_ref,
-                                    property,
-                                    field_access,
-                                );
-                                prop_rtti.link_two_way_with_map(item, common, map);
+                            TwoWayBinding::Property {
+                                property,
+                                field_access,
+                                field_access1,
+                            } => {
+                                if !field_access1.is_empty() {
+                                    // compiler-decomposed cell link: both
+                                    // sides are struct properties stored as
+                                    // Value
+                                    link_value_member_cell(
+                                        prop_rtti.as_value_property_ptr(item),
+                                        field_access1,
+                                        value_struct_property_ptr(property, instance_ref),
+                                        field_access,
+                                        &field_path_type(property_type.clone(), field_access1),
+                                    );
+                                } else if !field_access.is_empty()
+                                    && let Some(struct_ptr) =
+                                        value_struct_property_ptr(property, instance_ref)
+                                {
+                                    let (get_field, set_field) =
+                                        value_field_path_boxed_accessors(field_access);
+                                    let field_key = field_access.join(".");
+                                    // Safety: struct_ptr points to a live pinned Property<Value>
+                                    prop_rtti.link_two_way_to_member(
+                                        item, struct_ptr, &field_key, get_field, set_field,
+                                    );
+                                } else {
+                                    // whole struct/array link, or a natively
+                                    // stored struct side: wide-common
+                                    // machinery
+                                    let (common, map) = prepare_for_two_way_binding(
+                                        instance_ref,
+                                        property,
+                                        field_access,
+                                    );
+                                    prop_rtti.link_two_way_with_map(item, common, map);
+                                }
                             }
-                            TwoWayBinding::ModelData { repeated_element, field_access } => {
+                            TwoWayBinding::ModelData {
+                                repeated_element,
+                                field_access,
+                                field_access1,
+                            } => {
                                 let (getter, setter) = prepare_model_two_way_binding(
                                     instance_ref,
                                     repeated_element,
                                     field_access,
                                 );
-                                prop_rtti.link_two_way_to_model_data(item, getter, setter);
+                                if field_access1.is_empty() {
+                                    prop_rtti.link_two_way_to_model_data(item, getter, setter);
+                                } else {
+                                    link_value_member_cell_to_model_data(
+                                        prop_rtti.as_value_property_ptr(item),
+                                        field_access1,
+                                        getter,
+                                        setter,
+                                        &field_path_type(property_type.clone(), field_access1),
+                                    );
+                                }
                             }
                         }
                     }
@@ -1966,6 +2053,298 @@ fn prepare_model_two_way_binding(
     });
 
     (getter, setter)
+}
+
+/// Type-erased pointer to the `Property<Value>` backing `nr`, when its
+/// storage is a `Value` property (user-declared struct/array properties on
+/// components or globals). `None` for natively stored properties.
+fn value_struct_property_ptr(nr: &NamedReference, instance: InstanceRef) -> Option<*const c_void> {
+    let element = nr.element();
+    generativity::make_guard!(guard);
+    let enclosing_component = eval::enclosing_component_instance_for_element(
+        &element,
+        &eval::ComponentInstance::InstanceRef(instance),
+        guard,
+    );
+    match enclosing_component {
+        eval::ComponentInstance::InstanceRef(enclosing_component) => {
+            let element = element.borrow();
+            if element.id == element.enclosing_component.upgrade().unwrap().root_element.borrow().id
+                && let Some(x) = enclosing_component.description.custom_properties.get(nr.name())
+            {
+                let item =
+                    unsafe { Pin::new_unchecked(&*enclosing_component.as_ptr().add(x.offset)) };
+                return x.prop.as_value_property_ptr(item);
+            }
+            let item_info = enclosing_component.description.items.get(element.id.as_str())?;
+            let prop_info = item_info.rtti.properties.get(nr.name().as_str())?;
+            core::mem::drop(element);
+            let item = unsafe { item_info.item_from_item_tree(enclosing_component.as_ptr()) };
+            prop_info.as_value_property_ptr(item)
+        }
+        eval::ComponentInstance::GlobalComponent(glob) => {
+            glob.as_ref().as_value_property_ptr(nr.name())
+        }
+    }
+}
+
+/// Clone-able getter/setter closures for a field path on a struct `Value`.
+fn value_field_path_accessors(
+    field_access: &[SmolStr],
+) -> (impl Fn(&Value) -> Value + Clone + 'static, impl Fn(&mut Value, &Value) + Clone + 'static) {
+    let path: Rc<[SmolStr]> = field_access.into();
+    let get_field = {
+        let path = path.clone();
+        move |value: &Value| walk_struct_field_path(value.clone(), &path).unwrap_or_default()
+    };
+    let set_field = move |root: &mut Value, from: &Value| {
+        if let Some(leaf) = walk_struct_field_path_mut(root, &path) {
+            *leaf = from.clone();
+        }
+    };
+    (get_field, set_field)
+}
+
+/// Boxed variant of [`value_field_path_accessors`], for the
+/// `link_two_way_to_member` trait methods.
+fn value_field_path_boxed_accessors(
+    field_access: &[SmolStr],
+) -> (Box<dyn Fn(&Value) -> Value>, Box<dyn Fn(&mut Value, &Value)>) {
+    let (get_field, set_field) = value_field_path_accessors(field_access);
+    (Box::new(get_field), Box::new(set_field))
+}
+
+/// The type of the field at `path` within `ty`.
+fn field_path_type(mut ty: Type, path: &[SmolStr]) -> Type {
+    for field in path {
+        ty = match ty {
+            Type::Struct(s) => s.fields.get(field).cloned().unwrap_or_default(),
+            _ => Type::Invalid,
+        };
+    }
+    ty
+}
+
+/// Run `link(get_field1, set_field1, get_field2, set_field2)` with typed
+/// accessors for the two field paths on struct `Value`s, where the shared
+/// type `T2` is the interpreter's *property* representation of `cell_type`
+/// (same mapping as `property_info_for_type`) — so the two-way common
+/// created by a cell link is of the same `Property<T2>` type as the common
+/// a member link to the same field creates.
+fn with_typed_cell_accessors<R>(
+    cell_type: &Type,
+    field_access1: &[SmolStr],
+    field_access2: &[SmolStr],
+    link: impl TypedCellLink<R>,
+) -> R {
+    fn accessors<T2>(
+        path: &[SmolStr],
+    ) -> (impl Fn(&Value) -> T2 + Clone + 'static, impl Fn(&mut Value, &T2) + Clone + 'static)
+    where
+        T2: Clone + Default + 'static,
+        Value: TryInto<T2>,
+        T2: TryInto<Value>,
+    {
+        let path: Rc<[SmolStr]> = path.into();
+        let get_field = {
+            let path = path.clone();
+            move |value: &Value| {
+                walk_struct_field_path(value.clone(), &path)
+                    .unwrap_or_default()
+                    .try_into()
+                    .unwrap_or_default()
+            }
+        };
+        let set_field = move |root: &mut Value, field: &T2| {
+            if let Some(leaf) = walk_struct_field_path_mut(root, &path) {
+                *leaf = field.clone().try_into().unwrap_or_default();
+            }
+        };
+        (get_field, set_field)
+    }
+
+    macro_rules! dispatch {
+        ($T2:ty) => {{
+            let (get_field1, set_field1) = accessors::<$T2>(field_access1);
+            let (get_field2, set_field2) = accessors::<$T2>(field_access2);
+            link.link(get_field1, set_field1, get_field2, set_field2)
+        }};
+    }
+
+    match cell_type {
+        Type::Float32
+        | Type::Angle
+        | Type::PhysicalLength
+        | Type::LogicalLength
+        | Type::Rem
+        | Type::Percent => dispatch!(f32),
+        Type::Int32 => dispatch!(i32),
+        Type::String => dispatch!(SharedString),
+        Type::Color => dispatch!(Color),
+        Type::Brush => dispatch!(Brush),
+        Type::Duration => dispatch!(i64),
+        Type::Image => dispatch!(i_slint_core::graphics::Image),
+        Type::Bool => dispatch!(bool),
+        Type::Easing => dispatch!(i_slint_core::animations::EasingCurve),
+        Type::Enumeration(e) => {
+            macro_rules! match_enum_type {
+                ($( $(#[$enum_doc:meta])* $vis:vis enum $Name:ident { $($body:tt)* })*) => {
+                    match e.name.as_str() {
+                        $(
+                            stringify!($Name) => dispatch!(i_slint_core::items::$Name),
+                        )*
+                        x => unreachable!("Unknown non-builtin enum {x}"),
+                    }
+                }
+            }
+            if e.node.is_some() {
+                dispatch!(Value)
+            } else {
+                i_slint_common::for_each_enums!(match_enum_type)
+            }
+        }
+        _ => dispatch!(Value),
+    }
+}
+
+/// Callback for [`with_typed_cell_accessors`]; generic over the cell type,
+/// which a closure could not express.
+trait TypedCellLink<R> {
+    fn link<T2>(
+        self,
+        get_field1: impl Fn(&Value) -> T2 + Clone + 'static,
+        set_field1: impl Fn(&mut Value, &T2) + Clone + 'static,
+        get_field2: impl Fn(&Value) -> T2 + Clone + 'static,
+        set_field2: impl Fn(&mut Value, &T2) + Clone + 'static,
+    ) -> R
+    where
+        T2: Clone + PartialEq + Default + 'static,
+        Value: TryInto<T2>,
+        T2: TryInto<Value>;
+}
+
+/// Establish a compiler-decomposed two-way cell link
+/// `prop1.field_access1 <=> prop2.field_access`. Both sides are struct
+/// properties stored as `Property<Value>` (the `decompose_two_way_links`
+/// pass only decomposes links between such properties).
+fn link_value_member_cell(
+    prop1: Option<*const c_void>,
+    field_access1: &[SmolStr],
+    prop2: Option<*const c_void>,
+    field_access: &[SmolStr],
+    cell_type: &Type,
+) {
+    let (Some(prop1), Some(prop2)) = (prop1, prop2) else {
+        debug_assert!(false, "decomposed two-way cell link on a natively stored property");
+        return;
+    };
+
+    struct Link {
+        prop1: *const c_void,
+        key1: String,
+        prop2: *const c_void,
+        key2: String,
+    }
+    impl TypedCellLink<()> for Link {
+        fn link<T2>(
+            self,
+            get_field1: impl Fn(&Value) -> T2 + Clone + 'static,
+            set_field1: impl Fn(&mut Value, &T2) + Clone + 'static,
+            get_field2: impl Fn(&Value) -> T2 + Clone + 'static,
+            set_field2: impl Fn(&mut Value, &T2) + Clone + 'static,
+        ) where
+            T2: Clone + PartialEq + Default + 'static,
+            Value: TryInto<T2>,
+            T2: TryInto<Value>,
+        {
+            // Safety: both pointers point to live, pinned Property<Value>
+            unsafe {
+                let prop1 = Pin::new_unchecked(&*(self.prop1 as *const Property<Value>));
+                let prop2 = Pin::new_unchecked(&*(self.prop2 as *const Property<Value>));
+                Property::link_two_way_members(
+                    prop1,
+                    self.key1.as_str(),
+                    get_field1,
+                    set_field1,
+                    prop2,
+                    self.key2.as_str(),
+                    get_field2,
+                    set_field2,
+                );
+            }
+        }
+    }
+
+    with_typed_cell_accessors(
+        cell_type,
+        field_access1,
+        field_access,
+        Link {
+            prop1,
+            key1: field_access1.join("."),
+            prop2,
+            key2: field_access.join("."),
+        },
+    );
+}
+
+/// Establish a compiler-decomposed two-way cell link between
+/// `prop1.field_access1` and a model row field (`getter`/`setter` already
+/// resolve the full row path).
+fn link_value_member_cell_to_model_data(
+    prop1: Option<*const c_void>,
+    field_access1: &[SmolStr],
+    getter: Box<dyn Fn() -> Option<Value>>,
+    setter: Box<dyn Fn(&Value)>,
+    cell_type: &Type,
+) {
+    let Some(prop1) = prop1 else {
+        debug_assert!(false, "decomposed two-way cell link on a natively stored property");
+        return;
+    };
+
+    struct Link {
+        prop1: *const c_void,
+        key1: String,
+        getter: Box<dyn Fn() -> Option<Value>>,
+        setter: Box<dyn Fn(&Value)>,
+    }
+    impl TypedCellLink<()> for Link {
+        fn link<T2>(
+            self,
+            get_field1: impl Fn(&Value) -> T2 + Clone + 'static,
+            set_field1: impl Fn(&mut Value, &T2) + Clone + 'static,
+            _get_field2: impl Fn(&Value) -> T2 + Clone + 'static,
+            _set_field2: impl Fn(&mut Value, &T2) + Clone + 'static,
+        ) where
+            T2: Clone + PartialEq + Default + 'static,
+            Value: TryInto<T2>,
+            T2: TryInto<Value>,
+        {
+            let getter = self.getter;
+            let setter = self.setter;
+            // Safety: prop1 points to a live, pinned Property<Value>
+            unsafe {
+                let prop1 = Pin::new_unchecked(&*(self.prop1 as *const Property<Value>));
+                Property::link_two_way_member_to_model_data(
+                    prop1,
+                    self.key1.as_str(),
+                    get_field1,
+                    set_field1,
+                    (),
+                    move |_| getter().and_then(|value| value.try_into().ok()),
+                    move |_, field: &T2| setter(&field.clone().try_into().unwrap_or_default()),
+                );
+            }
+        }
+    }
+
+    with_typed_cell_accessors(
+        cell_type,
+        field_access1,
+        field_access1,
+        Link { prop1, key1: field_access1.join("."), getter, setter },
+    );
 }
 
 /// Resolve the repeater that backs `repeated_element` and its current row

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1093,6 +1093,7 @@ pub(crate) fn generate_item_tree<'id>(
         repeater_names: HashMap<SmolStr, usize>,
         change_callbacks: Vec<(NamedReference, Expression)>,
         popup_menu_description: PopupMenuDescription,
+        compiled_globals: Option<Rc<CompiledGlobalCollection>>,
     }
     impl generator::ItemTreeBuilder for TreeBuilder<'_> {
         type SubComponentState = ();
@@ -1115,7 +1116,7 @@ pub(crate) fn generate_item_tree<'id>(
                 RepeaterWithinItemTree {
                     item_tree_to_repeat: generate_item_tree(
                         base_component,
-                        None,
+                        self.compiled_globals.clone(),
                         self.popup_menu_description.clone(),
                         false,
                         guard,
@@ -1202,6 +1203,7 @@ pub(crate) fn generate_item_tree<'id>(
         repeater_names: HashMap::new(),
         change_callbacks: Vec::new(),
         popup_menu_description,
+        compiled_globals: compiled_globals.clone(),
     };
 
     if !component.is_global() {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -711,7 +711,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         }
         Expression::EmptyComponentFactory => Value::ComponentFactory(Default::default()),
         Expression::EmptyDataTransfer => Value::DataTransfer(Default::default()),
-        Expression::DebugHook { expression, id: _id } => {
+        Expression::DebugHook { expression, id: _id, .. } => {
             #[cfg(feature = "internal-highlight")]
             {
                 if let Some(hook_value) = crate::debug_hook::debug_hook_triggered(

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -67,6 +67,20 @@ pub trait ErasedPropertyInfo {
         getter: Box<dyn Fn() -> Option<Value>>,
         setter: Box<dyn Fn(&Value)>,
     );
+
+    /// If this property is stored as a `Property<Value>`, return a
+    /// type-erased pointer to it.
+    fn as_value_property_ptr(&self, item: Pin<ItemRef>) -> Option<*const c_void>;
+
+    /// Safety: `struct_prop` must point to a live, pinned `Property<Value>`.
+    unsafe fn link_two_way_to_member(
+        &self,
+        item: Pin<ItemRef>,
+        struct_prop: *const c_void,
+        field_key: &str,
+        get_field: Box<dyn Fn(&Value) -> Value>,
+        set_field: Box<dyn Fn(&mut Value, &Value)>,
+    );
 }
 
 impl<Item: vtable::HasStaticVTable<corelib::items::ItemVTable>> ErasedPropertyInfo
@@ -123,6 +137,30 @@ impl<Item: vtable::HasStaticVTable<corelib::items::ItemVTable>> ErasedPropertyIn
         setter: Box<dyn Fn(&Value)>,
     ) {
         (*self).link_two_way_to_model_data(ItemRef::downcast_pin(item).unwrap(), getter, setter)
+    }
+
+    fn as_value_property_ptr(&self, item: Pin<ItemRef>) -> Option<*const c_void> {
+        (*self).as_value_property_ptr(ItemRef::downcast_pin(item).unwrap())
+    }
+
+    unsafe fn link_two_way_to_member(
+        &self,
+        item: Pin<ItemRef>,
+        struct_prop: *const c_void,
+        field_key: &str,
+        get_field: Box<dyn Fn(&Value) -> Value>,
+        set_field: Box<dyn Fn(&mut Value, &Value)>,
+    ) {
+        // Safety: same requirement as PropertyInfo::link_two_way_to_member
+        unsafe {
+            (*self).link_two_way_to_member(
+                ItemRef::downcast_pin(item).unwrap(),
+                struct_prop,
+                field_key,
+                get_field,
+                set_field,
+            )
+        }
     }
 }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1733,7 +1733,9 @@ fn call_builtin_function(
                     item_info.item_index(),
                 );
 
-                item_rc.map_to_window(Default::default()).to_untyped().into()
+                // Map the item's own geometry origin through the ancestor transforms so the
+                // result is the item's absolute position (not its parent's).
+                item_rc.map_to_window(item_rc.geometry().origin).to_untyped().into()
             } else {
                 panic!("internal error: argument to SetFocusItem must be an element")
             }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -711,7 +711,19 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         }
         Expression::EmptyComponentFactory => Value::ComponentFactory(Default::default()),
         Expression::EmptyDataTransfer => Value::DataTransfer(Default::default()),
-        Expression::DebugHook { expression, .. } => eval_expression(expression, local_context),
+        Expression::DebugHook { expression, id: _id } => {
+            #[cfg(feature = "internal-highlight")]
+            {
+                if let Some(hook_value) = crate::debug_hook::debug_hook_triggered(
+                    &local_context.component_instance,
+                    _id.clone(),
+                ) {
+                    return hook_value;
+                }
+            }
+
+            eval_expression(expression, local_context)
+        }
     }
 }
 

--- a/internal/interpreter/global_component.rs
+++ b/internal/interpreter/global_component.rs
@@ -25,6 +25,9 @@ pub struct CompiledGlobalCollection {
     /// Map of all exported global singletons and their index in the compiled_globals vector. The key
     /// is the normalized name of the global.
     pub exported_globals_by_name: BTreeMap<SmolStr, usize>,
+
+    #[cfg(feature = "internal-highlight")]
+    pub(crate) debug_hook_callback: RefCell<Option<crate::debug_hook::DebugHookCallback>>,
 }
 
 impl CompiledGlobalCollection {
@@ -56,7 +59,12 @@ impl CompiledGlobalCollection {
                 global
             })
             .collect();
-        Self { compiled_globals, exported_globals_by_name }
+        Self {
+            compiled_globals,
+            exported_globals_by_name,
+            #[cfg(feature = "internal-highlight")]
+            debug_hook_callback: RefCell::new(None),
+        }
     }
 }
 

--- a/internal/interpreter/global_component.rs
+++ b/internal/interpreter/global_component.rs
@@ -212,6 +212,11 @@ pub trait GlobalComponent {
         self: Pin<&Self>,
         prop_name: &str,
     ) -> Result<Pin<Rc<Property<Value>>>, ()>;
+
+    /// Type-erased pointer to the `Property<Value>` backing the given
+    /// property, when its storage is a `Value` property (user-declared
+    /// struct/array properties).
+    fn as_value_property_ptr(self: Pin<&Self>, prop_name: &str) -> Option<*const c_void>;
 }
 
 /// Instantiate the global singleton and store it in `globals`
@@ -344,6 +349,15 @@ impl GlobalComponent for GlobalComponentInstance {
         let item = unsafe { Pin::new_unchecked(&*comp.borrow_instance().as_ptr().add(x.offset)) };
         Ok(x.prop.prepare_for_two_way_binding(item))
     }
+
+    fn as_value_property_ptr(self: Pin<&Self>, prop_name: &str) -> Option<*const c_void> {
+        generativity::make_guard!(guard);
+        let comp = self.0.unerase(guard);
+        let description = comp.description();
+        let x = description.custom_properties.get(prop_name)?;
+        let item = unsafe { Pin::new_unchecked(&*comp.borrow_instance().as_ptr().add(x.offset)) };
+        x.prop.as_value_property_ptr(item)
+    }
 }
 
 impl<T: rtti::BuiltinItem + 'static> GlobalComponent for T {
@@ -403,6 +417,12 @@ impl<T: rtti::BuiltinItem + 'static> GlobalComponent for T {
             .ok_or(())?
             .1
             .prepare_for_two_way_binding(self))
+    }
+
+    fn as_value_property_ptr(self: Pin<&Self>, prop_name: &str) -> Option<*const c_void> {
+        let prop: &dyn rtti::PropertyInfo<Self, Value> =
+            Self::properties().into_iter().find(|(k, _)| *k == prop_name)?.1;
+        prop.as_value_property_ptr(self)
     }
 }
 

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -79,6 +79,8 @@ compile_error!(
 );
 
 mod api;
+#[cfg(feature = "internal-highlight")]
+mod debug_hook;
 mod dynamic_item_tree;
 mod dynamic_type;
 mod eval;

--- a/tests/cases/absolute_coords_with_transform.slint
+++ b/tests/cases/absolute_coords_with_transform.slint
@@ -1,0 +1,85 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression: `absolute-position` of elements when a `Transform` wrapper is involved.
+// A `transform-rotation` binding makes `lower_transform_properties` inject a `Transform`
+// wrapper element around the element (via `adjust_geometry_for_injected_parent`). With zero
+// rotation (and unit scale) that transform is the identity, so no absolute position must
+// change compared to the same tree without the transform.
+//
+// Two distinct bugs are exercised:
+//
+// 1. Self offset double-counted. The wrapper takes over the element's geometry and the
+//    element's own origin is redirected to a 0 `dummy`, but the `absolute-position` binding
+//    still added the element's raw `x`/`y` on top of `map_to_window` (which already includes
+//    the wrapper's position), counting the offset twice -> (70, 100) instead of (40, 60).
+//
+// 2. Centered component root double-counted. When a *component instance* carries the transform
+//    and its size is set but its position is implicit (so `default_geometry` centers it), the
+//    component root's own `absolute-position` counts the centered offset twice: once through
+//    `map_to_window` (the wrapper is placed at the centered position) and once through the
+//    origin the `absolute-position` binding adds. The children of that root are unaffected.
+component CenteredRoot {
+    // `root.absolute-position` of the component root itself.
+    out property <length> root-abs-x: root.absolute-position.x;
+    inner := Rectangle { x: 42phx; }
+    // ... and of a child, which must stay consistent with the root.
+    out property <length> inner-abs-x: inner.absolute-position.x;
+}
+
+export component TestCase {
+    width: 500phx;
+    height: 500phx;
+
+    // Case 1: the transformed element's own x/y must not be double-counted.
+    Rectangle {
+        x: 10phx;
+        y: 20phx;
+
+        simple-inner := Rectangle {
+            x: 30phx;
+            y: 40phx;
+            transform-rotation: 0deg;
+        }
+    }
+
+    // Case 2: a centered component instance carrying a transform. Width is 250 with no
+    // explicit x, so the instance is centered at (500 - 250) / 2 = 125. Its root's
+    // absolute-position must be 125 (not 125 + 250/2), and its child at 125 + 42 = 167.
+    centered := CenteredRoot { width: 250phx; height: 100phx; transform-rotation: 0deg; }
+
+    out property <Point> coords <=> simple-inner.absolute-position;
+
+    out property <bool> simple-ok: simple-inner.absolute-position.x == 40phx
+        && simple-inner.absolute-position.y == 60phx;
+    out property <bool> centered-root-ok: centered.root-abs-x == 125phx;
+    out property <bool> centered-inner-ok: centered.inner-abs-x == 167phx;
+
+    out property <bool> test: simple-ok && centered-root-ok && centered-inner-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+let pos: slint::LogicalPosition = instance.get_coords();
+assert_eq!(pos.x, 40.);
+assert_eq!(pos.y, 60.);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+slint::LogicalPosition pos = instance.get_coords();
+assert_eq(pos.x, 40);
+assert_eq(pos.y, 60);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test, 1);
+assert.deepEqual(instance.coords, { x: 40, y: 60});
+```
+
+*/

--- a/tests/cases/bindings/two_way_binding_struct_member_length.slint
+++ b/tests/cases/bindings/two_way_binding_struct_member_length.slint
@@ -1,0 +1,69 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for two-way bindings onto a struct field of type `length`.
+//
+// A `length` struct field is stored as a plain coordinate (`Coord`/`f32` in
+// Rust), while a `length` *property* is a `Property<LogicalLength>`. When a
+// member link (`m <=> s.f`) and a whole-struct link that the compiler
+// decomposes into per-field links (`data <=> root.s` in a conditional
+// component, decomposed because `s.f` is also member-linked) meet on the
+// same field, both must agree on the representation of the shared class,
+// or the two links end up in different classes and writes to one never
+// reach the other.
+
+struct LengthStruct {
+    f: length,
+    g: int,
+}
+
+component Page {
+    in-out property <LengthStruct> data;
+    in-out property <length> page-f <=> data.f;
+}
+
+export component TestCase {
+    in-out property <LengthStruct> s: { f: 10px, g: 1 };
+    in-out property <length> m <=> s.f;
+
+    if true : Page {
+        data <=> root.s;
+    }
+
+    out property <bool> test: m == 10px && s.f == 10px && s.g == 1;
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+instance.set_m(42.0);
+assert_eq!(instance.get_s().f, 42.0);
+assert_eq!(instance.get_m(), 42.0);
+assert_eq!(instance.get_s().g, 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+instance.set_m(42.);
+assert_eq(instance.get_s().f, 42.);
+assert_eq(instance.get_m(), 42.);
+assert_eq(instance.get_s().g, 1);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+
+instance.m = 42;
+assert.equal(instance.s.f, 42);
+assert.equal(instance.m, 42);
+assert.equal(instance.s.g, 1);
+```
+
+*/

--- a/tests/cases/bindings/two_way_binding_struct_member_native_length.slint
+++ b/tests/cases/bindings/two_way_binding_struct_member_native_length.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for two-way bindings from a *native item property* of
+// type `length` onto a struct field, mixed with a custom property linked to
+// the same field.
+//
+// In the interpreter, native item properties store lengths as
+// `Property<LogicalLength>` while custom `length` properties (and struct
+// fields) use plain `f32`. Both links must still end up in one two-way
+// class: the class common uses the field representation and the native
+// member is attached through a converting link.
+
+struct LenStruct {
+    x: length,
+    g: int,
+}
+
+export component TestCase {
+    in-out property <LenStruct> s: { x: 10px, g: 1 };
+    in-out property <length> m <=> s.x;
+
+    r := Rectangle {
+        border-width <=> s.x;
+    }
+
+    out property <length> observed-border-width: r.border-width;
+    out property <bool> test: m == 10px && s.x == 10px && observed-border-width == 10px && s.g == 1;
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+instance.set_m(42.0);
+assert_eq!(instance.get_s().x, 42.0);
+assert_eq!(instance.get_observed_border_width(), 42.0);
+assert_eq!(instance.get_s().g, 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+instance.set_m(42.);
+assert_eq(instance.get_s().x, 42.);
+assert_eq(instance.get_observed_border_width(), 42.);
+assert_eq(instance.get_s().g, 1);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+
+instance.m = 42;
+assert.equal(instance.s.x, 42);
+assert.equal(instance.observed_border_width, 42);
+assert.equal(instance.s.g, 1);
+```
+
+*/

--- a/tests/cases/bindings/two_way_binding_struct_non_const.slint
+++ b/tests/cases/bindings/two_way_binding_struct_non_const.slint
@@ -9,15 +9,15 @@
 // one equivalence class and must always hold the same value (that is the core
 // invariant of two-way bindings), so `s1.s1 == s2.s2` must hold.
 //
-// With CONSTANT struct bindings this unifies correctly (see
+// With CONSTANT struct bindings this unifies trivially (see
 // two_way_binding_structs2.slint). Here `ext1`/`ext2` are settable properties,
-// which makes the `s1`/`s2` bindings non-const. The two live bindings then fail
-// to collapse into the shared value: `s1.s1` stays "a" and `s2.s2` stays "b",
-// so the invariant is violated.
-//
-// NOTE: this currently FAILS (test == false); it documents the bug. It
-// reproduces WITHOUT debug hooks - the debug-hook feature merely exposes the
-// same bug by turning constant initializers into non-const ones.
+// which makes the `s1`/`s2` bindings non-const. Under the old wide-common
+// two-way machinery the two live bindings then failed to collapse into the
+// shared value (`s1.s1` stayed "a" and `s2.s2` stayed "b"); with the
+// narrow-common machinery (`StructMemberBindings`) the class converges
+// structurally: the last installed binding drives the shared field, and the
+// independent fields keep tracking their own sources. The debug-hook feature
+// exposed the same bug by turning constant initializers into non-const ones.
 
 component Link {
     in-out property <string> str1: "XXX";

--- a/tests/cases/bindings/two_way_binding_struct_non_const.slint
+++ b/tests/cases/bindings/two_way_binding_struct_non_const.slint
@@ -1,0 +1,66 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for a two-way binding equivalence class that spans struct
+// *fields* of properties whose bindings are NON-const.
+//
+// `str2 <=> str1` collapses `str1`/`str2` into a single scalar property, which
+// is then two-way bound to BOTH `s1.s1` and `s2.s2`. All three are therefore in
+// one equivalence class and must always hold the same value (that is the core
+// invariant of two-way bindings), so `s1.s1 == s2.s2` must hold.
+//
+// With CONSTANT struct bindings this unifies correctly (see
+// two_way_binding_structs2.slint). Here `ext1`/`ext2` are settable properties,
+// which makes the `s1`/`s2` bindings non-const. The two live bindings then fail
+// to collapse into the shared value: `s1.s1` stays "a" and `s2.s2` stays "b",
+// so the invariant is violated.
+//
+// NOTE: this currently FAILS (test == false); it documents the bug. It
+// reproduces WITHOUT debug hooks - the debug-hook feature merely exposes the
+// same bug by turning constant initializers into non-const ones.
+
+component Link {
+    in-out property <string> str1: "XXX";
+    in-out property <string> str2 <=> str1;
+}
+
+struct S1 { s1: string, i1: int }
+struct S2 { s2: string, i2: int }
+
+export component TestCase {
+    // Referencing settable properties makes the struct bindings non-const.
+    in-out property <string> ext1: "a";
+    in-out property <string> ext2: "b";
+    in-out property <int> int1: 42;
+    in-out property <int> int2: 43;
+    in-out property <S1> s1: { s1: ext1, i1: int1 };
+    in-out property <S2> s2: { s2: ext2, i2: int2 };
+    Link {
+        str1 <=> s1.s1;
+        str2 <=> s2.s2;
+    }
+    out property <bool> test: s1.s1 == s2.s2 && s1.i1 != s2.i2;
+}
+
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.set_int1(43);
+assert_eq!(instance.get_s1().i1, instance.get_s2().i2);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+```
+
+*/

--- a/tests/driver/interpreter/Cargo.toml
+++ b/tests/driver/interpreter/Cargo.toml
@@ -17,8 +17,15 @@ publish = false
 path = "main.rs"
 name = "test-driver-interpreter"
 
+[features]
+# Run every test a second time with debug hooks injected (as the visual editor's
+# live-preview does). Debug hooks must never change program behavior, so each test must
+# pass identically in both runs. Not a default feature to keep regular test runs fast,
+# but CI enables it via --all-features.
+inject-debug-hooks = []
+
 [dev-dependencies]
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "backend-qt"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "backend-qt", "internal"] }
 i-slint-backend-testing = { workspace = true, features = ["internal"] }
 i-slint-core = { workspace = true }
 

--- a/tests/driver/interpreter/interpreter.rs
+++ b/tests/driver/interpreter/interpreter.rs
@@ -9,6 +9,23 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     i_slint_backend_testing::init_no_event_loop();
     i_slint_backend_testing::configure_test_fonts();
 
+    run_test(testcase, false)?;
+
+    // With the `inject-debug-hooks` feature, run every test a second time with debug hooks
+    // injected (as the visual editor's live-preview does). Debug hooks must never change
+    // program behavior, so the test must pass identically in both runs.
+    #[cfg(feature = "inject-debug-hooks")]
+    run_test(testcase, true)?;
+
+    Ok(())
+}
+
+fn run_test(
+    testcase: &test_driver_lib::TestCase,
+    inject_debug_hooks: bool,
+) -> Result<(), Box<dyn Error>> {
+    let mode = if inject_debug_hooks { " (with debug hooks)" } else { "" };
+
     let source = std::fs::read_to_string(&testcase.absolute_path)?;
     let include_paths = test_driver_lib::extract_include_paths(&source)
         .map(std::path::PathBuf::from)
@@ -20,6 +37,11 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     compiler.set_include_paths(include_paths);
     compiler.set_library_paths(library_paths);
     compiler.set_style(testcase.requested_style.unwrap_or("fluent").into());
+
+    if inject_debug_hooks {
+        compiler.compiler_configuration(i_slint_core::InternalToken).debug_hooks =
+            Some(std::hash::RandomState::new());
+    }
 
     // Ensure we get consistent results on all platforms even for OS-dependent
     // behavior like dialog button order.
@@ -52,7 +74,11 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
             _ => {}
         }
 
-        return Err(diagnostics.iter().map(|d| d.to_string()).join("\n").into());
+        return Err(format!(
+            "compilation failed{mode}:\n{}",
+            diagnostics.iter().map(|d| d.to_string()).join("\n")
+        )
+        .into());
     }
 
     for component_name in result.component_names() {
@@ -64,7 +90,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
                 let result = instance.get_property("test")?;
                 if result != Value::Bool(true) {
                     eprintln!(
-                        "FAIL: {}: test returned {:?}",
+                        "FAIL: {}{mode}: test returned {:?}",
                         testcase.relative_path.display(),
                         result
                     );
@@ -72,7 +98,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
                     for (p, _) in component.properties() {
                         eprintln!(" {}: {:?}", p, instance.get_property(&p));
                     }
-                    panic!("Test Failed: {result:?}");
+                    panic!("Test Failed{mode}: {result:?}");
                 }
             }
         };

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -324,8 +324,12 @@ fn insert_property_definitions(
             return Expression::Invalid;
         }
 
-        if let Some(binding) = element.borrow().bindings.get(prop) {
-            let e = binding.borrow().expression.clone();
+        // binding() ignores synthetic debug hooks: a placeholder for an unbound property must
+        // fall through to the base/builtin default below, not read as a user-set value.
+        if let Some(binding) = element.borrow().binding(prop) {
+            // Strip (non-synthetic) debug hook wrappers so the properties panel sees the
+            // binding as written.
+            let e = binding.borrow().expression.ignore_debug_hooks().clone();
             if !matches!(e, Expression::Invalid) {
                 return e;
             }

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -338,7 +338,7 @@ fn insert_property_definitions(
                     TwoWayBinding::Property { property, field_access, .. } => {
                         (binding_value(&property.element(), property.name(), count), field_access)
                     }
-                    TwoWayBinding::ModelData { repeated_element, field_access } => (
+                    TwoWayBinding::ModelData { repeated_element, field_access, .. } => (
                         Expression::RepeaterModelReference { element: repeated_element.clone() },
                         field_access,
                     ),

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -335,7 +335,7 @@ fn insert_property_definitions(
             }
             for twb in &binding.borrow().two_way_bindings {
                 let (mut e, field_access) = match twb {
-                    TwoWayBinding::Property { property, field_access } => {
+                    TwoWayBinding::Property { property, field_access, .. } => {
                         (binding_value(&property.element(), property.name(), count), field_access)
                     }
                     TwoWayBinding::ModelData { repeated_element, field_access } => (

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -108,7 +108,7 @@ fn find_binding_expression(
     let be = elem.bindings.get(&property_name).map(|be| be.borrow().clone())?;
     if matches!(be.expression, expression_tree::Expression::Invalid) {
         for twb in &be.two_way_bindings {
-            let expression_tree::TwoWayBinding::Property { property, field_access } = twb else {
+            let expression_tree::TwoWayBinding::Property { property, field_access, .. } = twb else {
                 continue;
             };
             if let Some(mut e) =


### PR DESCRIPTION
Currently, two-way bindings to struct members use a common property that is of the struct type.
However, this breaks if a two-way bindings binds two structs of different types across a shared member.

This PR reworks the two-way bindings to use a common property that is of the member type.
The wider struct binding is now stored as a separate property, with an additional list of
"overwrites"/"mappings" that are applied for each two-way-bound member.
These overwrites read from the common property of the individual member and is applied after
the main struct binding is evaluated.

By default, the common property of a two-way member binding will itself bind to the structs internal property.
So unless the two-way-binding receives a conflicting value, the member override is mostly a no-op.

This approach is overall more complex than the previous approach, but allows us to handle two-way bindings to struct members, even if they cross different struct types.
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
