### PR TITLE
Fix crashes with opacity/visible on repeated GridLayout children

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3507,11 +3507,8 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
 
     new_root.borrow_mut().child_of_layout =
         std::mem::replace(&mut old_root.borrow_mut().child_of_layout, false);
-    // The injected parent becomes the repeated element, so it takes over the grid
-    // cell role. Some callers already moved the cell onto it; don't clobber that.
-    if new_root.borrow().grid_layout_cell.is_none() {
-        new_root.borrow_mut().grid_layout_cell = old_root.borrow_mut().grid_layout_cell.take();
-    }
+    // The injected parent becomes the repeated element, so it takes over the grid cell role.
+    new_root.borrow_mut().grid_layout_cell = old_root.borrow_mut().grid_layout_cell.take();
     let layout_info_prop = old_root.borrow().layout_info_prop.clone().or_else(|| {
         // generate the layout_info_prop that forward to the implicit layout for that item
         let li_v = crate::layout::create_new_prop(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3507,6 +3507,11 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
 
     new_root.borrow_mut().child_of_layout =
         std::mem::replace(&mut old_root.borrow_mut().child_of_layout, false);
+    // The injected parent becomes the repeated element, so it takes over the grid
+    // cell role. Some callers already moved the cell onto it; don't clobber that.
+    if new_root.borrow().grid_layout_cell.is_none() {
+        new_root.borrow_mut().grid_layout_cell = old_root.borrow_mut().grid_layout_cell.take();
+    }
     let layout_info_prop = old_root.borrow().layout_info_prop.clone().or_else(|| {
         // generate the layout_info_prop that forward to the implicit layout for that item
         let li_v = crate::layout::create_new_prop(

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -88,7 +88,6 @@ pub fn handle_visible(
 }
 
 fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -> ElementRc {
-    let child_grid_layout_cell = child.borrow_mut().grid_layout_cell.take();
     let element = Element {
         id: format_smolstr!("{}-visibility", child.borrow().id),
         base_type: ElementType::Native(native_clip.clone()),
@@ -107,7 +106,6 @@ fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -
             ),
         ))
         .collect(),
-        grid_layout_cell: child_grid_layout_cell,
         ..Default::default()
     };
     Element::make_rc(element)

--- a/tests/cases/layout/grid_repeated_opacity.slint
+++ b/tests/cases/layout/grid_repeated_opacity.slint
@@ -1,0 +1,56 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #12442: a conditional opacity (or visible) binding on a
+// repeated GridLayout child injects a wrapper element as the repeated root.
+// That wrapper must take over the grid-cell role, otherwise the generated code
+// (and interpreter) reference a `grid_layout_input_for_repeated` accessor on a
+// component that doesn't have it.
+
+export component TestCase inherits Window {
+    width: 300phx;
+    height: 300phx;
+    in-out property <bool> cond: false;
+
+    GridLayout {
+        spacing: 0px;
+        padding: 0px;
+        // Repeated cells whose root gets wrapped: opacity injects an Opacity,
+        // visible injects a Clip. Both must keep the grid-cell role.
+        Row { for x in [0, 1, 2]: Rectangle { opacity: cond ? 1 : 0.4; } }
+        Row { for x in [0, 1, 2]: Rectangle { visible: cond; } }
+        // Repeated Row whose cells carry a conditional opacity.
+        for r in [0, 1]: Row {
+            Rectangle { opacity: cond ? 1 : 0.3; }
+            Rectangle { }
+            Rectangle { }
+        }
+        // Static row with a wrapped cell, used to assert the resulting geometry.
+        Row {
+            c0 := Rectangle { }
+            c1 := Rectangle { }
+            c2 := Rectangle { }
+        }
+    }
+
+    out property <bool> test: c0.x == 0phx && c1.x == 100phx && c2.x == 200phx
+        && c0.y == 240phx && c0.width == 100phx && c0.height == 60phx;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/grid_repeated_row_visible.slint
+++ b/tests/cases/layout/grid_repeated_row_visible.slint
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test: a `visible` binding on a cell inside a repeated Row used to
+// move the grid-cell info onto the injected Clip wrapper, while the row template
+// still referred to the inner element, panicking the compiler and interpreter.
+
+export component TestCase inherits Window {
+    width: 300phx;
+    height: 300phx;
+    in-out property <bool> cond: false;
+
+    GridLayout {
+        spacing: 0px;
+        padding: 0px;
+        for r in [0, 1]: Row {
+            Rectangle { visible: cond; }
+            Rectangle { }
+            Rectangle { }
+        }
+        Row {
+            c0 := Rectangle { }
+            c1 := Rectangle { }
+            c2 := Rectangle { }
+        }
+    }
+
+    out property <bool> test: c0.x == 0phx && c1.x == 100phx && c2.x == 200phx
+        && c0.y == 200phx && c0.height == 100phx;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/


### PR DESCRIPTION

When a conditional `opacity` or `visible` binding wraps a repeated
GridLayout child, the compiler injects a wrapper element and the grid
cell role got detached from where the layout code looks for it.
  
  - opacity/visible on a repeated cell whose wrapper becomes the repeated
    root: the `grid_layout_input_for_repeated` accessor was generated on the
    wrong sub-component, failing to compile (#12442). The injected root now
    takes over the grid cell.
  - `visible` on a static cell inside a repeated Row: the cell was moved
    onto the injected Clip while the row template still pointed at the inner
    element, panicking codegen and the interpreter. The cell now stays on
    the inner element, matching how `opacity` is lowered.
    
  Fixes: #12442

