### PR TITLE
Resolve color and enum literals by their position in the expression

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/structs-and-enums.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/structs-and-enums.mdx
@@ -53,7 +53,28 @@ export component Example {
 Enum values can be referenced by using the name of the enum and the name of the value
 separated by a dot. (eg: `CardSuit.spade`)
 
-The name of the enum can be omitted in bindings of the type of that enum, or if the
-return value of a callback is of that enum.
+The name of the enum can be omitted wherever a value of that enum type is expected, such as
+in a binding, a struct field, an array element, a function or callback argument, or a return
+value:
+
+```slint
+export enum CardSuit { clubs, diamonds, hearts, spade }
+export struct Card { suit: CardSuit, value: int }
+
+export component Example {
+    // in a struct field and an array element
+    out property<Card> card: { suit: hearts, value: 10 };
+    out property<[CardSuit]> deck: [clubs, diamonds, hearts, spade];
+
+    pure function is-red(suit: CardSuit) -> bool {
+        return suit == hearts || suit == diamonds;
+    }
+    // as a function argument
+    out property<bool> spade-is-red: is-red(spade);
+}
+```
+
+In a comparison the name can be omitted only on the right-hand side, which takes the type of
+the left: `card.suit == hearts` works, but `hearts == card.suit` does not.
 
 The default value of each enum type is always the first value.

--- a/docs/astro/src/content/docs/reference/colors-and-brushes.mdx
+++ b/docs/astro/src/content/docs/reference/colors-and-brushes.mdx
@@ -20,8 +20,8 @@ In addition to plain colors, many elements have properties that are of type `bru
 A brush is a type that can be either a color or gradient. The brush is then used to fill an element or
 draw the outline.
 
-CSS Color names are only in scope in expressions of type `color` or `brush`. Otherwise, access
-colors from the `Colors` namespace.
+CSS color names are in scope wherever a `color` or `brush` value is expected, including struct
+fields, array elements and function arguments. Elsewhere, access colors from the `Colors` namespace.
 
 ## Color Properties
 

--- a/docs/development/type-system.md
+++ b/docs/development/type-system.md
@@ -184,7 +184,8 @@ The `LookupCtx` provides context for resolving identifiers in expressions:
 ```rust
 pub struct LookupCtx<'a> {
     pub property_name: Option<&'a str>,     // Current property being bound
-    pub property_type: Type,                 // Expected type
+    pub property_type: Type,                 // Type of the whole binding
+    pub expected_type: Type,                 // Type expected at the current position
     pub component_scope: &'a [ElementRc],   // Element scope stack
     pub arguments: Vec<SmolStr>,             // Callback/function arguments
     pub type_register: &'a TypeRegister,    // Type registry
@@ -201,8 +202,22 @@ When resolving an identifier, lookup proceeds in this order:
 3. **Special identifiers** - `self`, `parent`, `true`, `false`
 4. **Element IDs** - Named elements in the component
 5. **In-scope properties** - Properties from scope stack (legacy syntax: parent properties)
-6. **Built-in namespaces** - `Colors`, `Math`, `Key`, `Easing`
-7. **Global types** - Types from the type register
+6. **Global types** - Types from the type register
+7. **Built-in namespaces** - `Colors`, `Easing`, `Math`, `Key`, `FontWeight`
+8. **Type-specific values** - Bare `color`, `enum` or `easing` literals (e.g. `red`, `center`), resolved against `expected_type`
+9. **Built-in functions** - Unqualified global functions (`min`, `max`, `clamp`, `abs`, `debug`, ...)
+
+The type-specific step is what makes a bare `red` mean a color: it only matches when
+`expected_type` is a `color`, `brush`, `enum` or `easing`. Because it comes near the end, a
+property, element or variable of the same name still takes precedence.
+
+### Expected type
+
+`property_type` is the type of the whole binding; `expected_type` is the type expected at the
+current position within the expression. As the resolver descends into struct fields, array
+elements and call arguments it updates `expected_type` (via `LookupCtx::with_expected_type`), so a
+bare literal resolves against the locally expected type. This is why `property <S> s: { c: red }`
+resolves `red` as a color even though the binding's type is the struct `S`.
 
 ### LookupResult
 

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -284,6 +284,7 @@ fn compiled(
     let mut ctx =
         crate::lookup::LookupCtx::empty_context(type_register, &mut diag, symbol_counters.clone());
     ctx.property_type = ty.clone();
+    ctx.expected_type = ty.clone();
     let e = Expression::from_binding_expression_node(node.clone().into(), &mut ctx)
         .maybe_convert_to(ty, &node, ctx.diag, &ctx.symbol_counters);
     if diag.has_errors() {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -29,6 +29,12 @@ pub struct LookupCtx<'a> {
     /// (some property come in the scope)
     pub property_type: Type,
 
+    /// The expected type at the current position within the expression, updated as the
+    /// resolver descends into struct fields, array elements and call arguments. Unlike
+    /// `property_type` (the whole binding's type) it drives type-directed name resolution
+    /// (color/easing/enum literals) at that exact position.
+    pub expected_type: Type,
+
     /// Here is the stack in which id applies. (the last element in the scope is looked up first)
     pub component_scope: &'a [ElementRc],
 
@@ -65,6 +71,7 @@ impl<'a> LookupCtx<'a> {
         Self {
             property_name: Default::default(),
             property_type: Default::default(),
+            expected_type: Default::default(),
             component_scope: Default::default(),
             diag,
             symbol_counters,
@@ -81,6 +88,14 @@ impl<'a> LookupCtx<'a> {
             Type::Callback(f) | Type::Function(f) => &f.return_type,
             _ => &self.property_type,
         }
+    }
+
+    /// Run `f` with `expected_type` temporarily set to `ty`, restoring it afterwards.
+    pub fn with_expected_type<R>(&mut self, ty: Type, f: impl FnOnce(&mut Self) -> R) -> R {
+        let old = std::mem::replace(&mut self.expected_type, ty);
+        let r = f(self);
+        self.expected_type = old;
+        r
     }
 
     pub fn is_legacy_component(&self) -> bool {
@@ -618,15 +633,15 @@ impl LookupType {
     }
 }
 
-/// Lookup for things specific to the return type (eg: colors or enums)
-pub struct ReturnTypeSpecificLookup;
-impl LookupObject for ReturnTypeSpecificLookup {
+/// Lookup for things specific to the expected type (eg: colors or enums)
+pub struct TypeSpecificLookup;
+impl LookupObject for TypeSpecificLookup {
     fn for_each_entry<R>(
         &self,
         ctx: &LookupCtx,
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
-        match ctx.return_type() {
+        match &ctx.expected_type {
             Type::Color => ColorSpecific.for_each_entry(ctx, f),
             Type::Brush => ColorSpecific.for_each_entry(ctx, f),
             Type::Easing => EasingSpecific.for_each_entry(ctx, f),
@@ -636,7 +651,7 @@ impl LookupObject for ReturnTypeSpecificLookup {
     }
 
     fn lookup(&self, ctx: &LookupCtx, name: &SmolStr) -> Option<LookupResult> {
-        match ctx.return_type() {
+        match &ctx.expected_type {
             Type::Color => ColorSpecific.lookup(ctx, name),
             Type::Brush => ColorSpecific.lookup(ctx, name),
             Type::Easing => EasingSpecific.lookup(ctx, name),
@@ -945,10 +960,7 @@ pub fn global_lookup() -> impl LookupObject {
                         InScopeLookup,
                         (
                             LookupType,
-                            (
-                                BuiltinNamespaceLookup,
-                                (ReturnTypeSpecificLookup, BuiltinFunctionLookup),
-                            ),
+                            (BuiltinNamespaceLookup, (TypeSpecificLookup, BuiltinFunctionLookup)),
                         ),
                     ),
                 ),

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -92,6 +92,7 @@ fn resolve_alias(
         let mut lookup_ctx = LookupCtx::empty_context(type_register, diag, symbol_counters.clone());
         lookup_ctx.property_name = Some(prop);
         lookup_ctx.property_type = old_type.clone();
+        lookup_ctx.expected_type = old_type.clone();
         lookup_ctx.component_scope = &scope.0;
         crate::passes::resolving::resolve_two_way_binding(node, &mut lookup_ctx)
     };

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1557,7 +1557,7 @@ impl Expression {
         };
         // Convert the arguments once the parameter types are known, so a bare color/enum
         // literal in argument position resolves against its parameter type.
-        let arg_nodes: Vec<_> = sub_expr.collect();
+        let arg_nodes = sub_expr.collect::<Vec<_>>();
         let convert_args = |ctx: &mut LookupCtx, expected: &[Type]| {
             arg_nodes
                 .iter()

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -45,6 +45,7 @@ fn resolve_expression(
         let mut lookup_ctx = LookupCtx {
             property_name,
             property_type,
+            expected_type: Type::default(),
             component_scope: scope,
             diag,
             symbol_counters: type_loader.symbol_counters.clone(),
@@ -54,6 +55,7 @@ fn resolve_expression(
             current_token: None,
             local_variables: Vec::new(),
         };
+        lookup_ctx.expected_type = lookup_ctx.return_type().clone();
 
         let new_expr = match node.kind() {
             SyntaxKind::CallbackConnection => {
@@ -368,11 +370,14 @@ impl Expression {
         // prefix with "local_" to avoid conflicts
         let name: SmolStr = format!("local_{name}",).into();
 
-        let value = Self::from_expression_node(node.Expression(), ctx);
-        let ty = match node.Type() {
-            Some(ty) => type_from_node(ty, ctx.diag, ctx.type_register),
-            None => value.ty(),
+        let declared_ty = node.Type().map(|ty| type_from_node(ty, ctx.diag, ctx.type_register));
+        let value = match &declared_ty {
+            Some(t) => ctx.with_expected_type(t.clone(), |ctx| {
+                Self::from_expression_node(node.Expression(), ctx)
+            }),
+            None => Self::from_expression_node(node.Expression(), ctx),
         };
+        let ty = declared_ty.unwrap_or_else(|| value.ty());
 
         // we can get the last scope exists, because each codeblock creates a new scope and we are inside a codeblock here by necessity
         ctx.local_variables.last_mut().unwrap().push((name.clone(), ty.clone()));
@@ -393,12 +398,9 @@ impl Expression {
             ctx.diag.push_error(format!("Must return a value of type '{return_type}'"), &node);
         }
         Expression::ReturnStatement(e.map(|n| {
-            Box::new(Self::from_expression_node(n, ctx).maybe_convert_to(
-                return_type,
-                &node,
-                ctx.diag,
-                &ctx.symbol_counters,
-            ))
+            let e = ctx
+                .with_expected_type(return_type.clone(), |ctx| Self::from_expression_node(n, ctx));
+            Box::new(e.maybe_convert_to(return_type, &node, ctx.diag, &ctx.symbol_counters))
         }))
     }
 
@@ -901,14 +903,10 @@ impl Expression {
                     )),
                 }
             } else {
-                // To facilitate color literal conversion, adjust the expected return type.
-                let e = {
-                    let old_property_type = std::mem::replace(&mut ctx.property_type, Type::Color);
-                    let e =
-                        Expression::from_expression_node(n.as_node().unwrap().clone().into(), ctx);
-                    ctx.property_type = old_property_type;
-                    e
-                };
+                // To facilitate color literal conversion, adjust the expected type.
+                let e = ctx.with_expected_type(Type::Color, |ctx| {
+                    Expression::from_expression_node(n.as_node().unwrap().clone().into(), ctx)
+                });
                 match std::mem::replace(&mut current_stop, Stop::Finished) {
                     Stop::Empty => {
                         current_stop = Stop::Color(e.maybe_convert_to(
@@ -1557,18 +1555,31 @@ impl Expression {
             }
             return Self::Invalid;
         };
-        let sub_expr = sub_expr.map(|n| {
-            (Self::from_expression_node(n.clone(), ctx), Some(NodeOrToken::from((*n).clone())))
-        });
+        // Convert the arguments once the parameter types are known, so a bare color/enum
+        // literal in argument position resolves against its parameter type.
+        let arg_nodes: Vec<_> = sub_expr.collect();
+        let convert_args = |ctx: &mut LookupCtx, expected: &[Type]| {
+            arg_nodes
+                .iter()
+                .enumerate()
+                .map(|(i, n)| {
+                    let ty = expected.get(i).cloned().unwrap_or(Type::Invalid);
+                    let e = ctx.with_expected_type(ty, |ctx| {
+                        Self::from_expression_node((*n).clone(), ctx)
+                    });
+                    (e, Some(NodeOrToken::from((**n).clone())))
+                })
+                .collect::<Vec<_>>()
+        };
         let Some(function) = function else {
             // Check sub expressions anyway
-            sub_expr.count();
+            convert_args(ctx, &[]);
             assert!(ctx.diag.has_errors());
             return Self::Invalid;
         };
         let LookupResult::Callable(function) = function else {
             // Check sub expressions anyway
-            sub_expr.count();
+            convert_args(ctx, &[]);
             ctx.diag.push_error("The expression is not a function".into(), &node);
             return Self::Invalid;
         };
@@ -1577,7 +1588,7 @@ impl Expression {
         let function = match function {
             LookupResultCallable::Callable(c) => c,
             LookupResultCallable::Macro(mac) => {
-                arguments.extend(sub_expr);
+                arguments.extend(convert_args(ctx, &[]));
                 return crate::builtin_macros::lower_macro(
                     mac,
                     &source_location,
@@ -1592,7 +1603,7 @@ impl Expression {
                 match *member {
                     LookupResultCallable::Callable(c) => c,
                     LookupResultCallable::Macro(mac) => {
-                        arguments.extend(sub_expr);
+                        arguments.extend(convert_args(ctx, &[]));
                         return crate::builtin_macros::lower_macro(
                             mac,
                             &source_location,
@@ -1608,7 +1619,12 @@ impl Expression {
             }
         };
 
-        arguments.extend(sub_expr);
+        match function.ty() {
+            Type::Function(f) | Type::Callback(f) => {
+                arguments.extend(convert_args(ctx, f.args.get(adjust_arg_count..).unwrap_or(&[])));
+            }
+            _ => arguments.extend(convert_args(ctx, &[])),
+        }
 
         if matches!(&function, Callable::Callback(nr) if nr.name() == "init") {
             ctx.diag.push_warning(
@@ -1701,7 +1717,9 @@ impl Expression {
                 Type::Invalid
             }
         };
-        let rhs = Self::from_expression_node(rhs_n.clone(), ctx);
+        let rhs = ctx.with_expected_type(expected_ty.clone(), |ctx| {
+            Self::from_expression_node(rhs_n.clone(), ctx)
+        });
         Expression::SelfAssignment {
             lhs: Box::new(lhs),
             rhs: Box::new(rhs.maybe_convert_to(
@@ -1738,11 +1756,17 @@ impl Expression {
             })
             .unwrap_or('_');
 
+        let op_class = operator_class(op);
         let (lhs_n, rhs_n) = node.Expression();
         let lhs = Self::from_expression_node(lhs_n.clone(), ctx);
-        let rhs = Self::from_expression_node(rhs_n.clone(), ctx);
+        // A comparison's rhs is expected to have the lhs type, so a bare literal resolves.
+        let rhs = if op_class == OperatorClass::ComparisonOp {
+            ctx.with_expected_type(lhs.ty(), |ctx| Self::from_expression_node(rhs_n.clone(), ctx))
+        } else {
+            Self::from_expression_node(rhs_n.clone(), ctx)
+        };
 
-        let expected_ty = match operator_class(op) {
+        let expected_ty = match op_class {
             OperatorClass::ComparisonOp => {
                 let ty =
                     Self::common_target_type_for_type_list([lhs.ty(), rhs.ty()].iter().cloned());
@@ -1930,10 +1954,15 @@ impl Expression {
         let values: BTreeMap<SmolStr, Expression> = node
             .ObjectMember()
             .map(|n| {
-                (
-                    identifier_text(&n).unwrap_or_default(),
-                    Expression::from_expression_node(n.Expression(), ctx),
-                )
+                let name = identifier_text(&n).unwrap_or_default();
+                let field_ty = match &ctx.expected_type {
+                    Type::Struct(s) => s.fields.get(&name).cloned().unwrap_or_default(),
+                    _ => Type::Invalid,
+                };
+                let value = ctx.with_expected_type(field_ty, |ctx| {
+                    Expression::from_expression_node(n.Expression(), ctx)
+                });
+                (name, value)
             })
             .collect();
         let ty = Rc::new(Struct {
@@ -1944,8 +1973,18 @@ impl Expression {
     }
 
     fn from_array_node(node: syntax_nodes::Array, ctx: &mut LookupCtx) -> Expression {
-        let mut values: Vec<Expression> =
-            node.Expression().map(|e| Expression::from_expression_node(e, ctx)).collect();
+        let element_expected = match &ctx.expected_type {
+            Type::Array(el) => (**el).clone(),
+            _ => Type::Invalid,
+        };
+        let mut values: Vec<Expression> = node
+            .Expression()
+            .map(|e| {
+                ctx.with_expected_type(element_expected.clone(), |ctx| {
+                    Expression::from_expression_node(e, ctx)
+                })
+            })
+            .collect();
 
         let element_ty = if values.is_empty() {
             Type::Void
@@ -2245,7 +2284,7 @@ fn continue_lookup_within_element(
         } else if let Some(LookupResult::Expression {
             expression: Expression::EnumerationValue(value),
             ..
-        }) = crate::lookup::ReturnTypeSpecificLookup.lookup(ctx, &elem.borrow().id)
+        }) = crate::lookup::TypeSpecificLookup.lookup(ctx, &elem.borrow().id)
         {
             rest = format!(
                 ". Use '{}.{value}' to access the enumeration value",
@@ -2481,6 +2520,7 @@ fn resolve_two_way_bindings_for_element(
             let mut lookup_ctx = LookupCtx {
                 property_name: Some(prop_name.as_str()),
                 property_type: lhs_lookup.property_type.clone(),
+                expected_type: lhs_lookup.property_type.clone(),
                 component_scope: scope,
                 diag,
                 // Two-way bindings don't generate temporaries; a fresh set is fine.

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1758,12 +1758,20 @@ impl Expression {
 
         let op_class = operator_class(op);
         let (lhs_n, rhs_n) = node.Expression();
-        let lhs = Self::from_expression_node(lhs_n.clone(), ctx);
-        // A comparison's rhs is expected to have the lhs type, so a bare literal resolves.
-        let rhs = if op_class == OperatorClass::ComparisonOp {
-            ctx.with_expected_type(lhs.ty(), |ctx| Self::from_expression_node(rhs_n.clone(), ctx))
+        // `&&`/`||` operands are bool; a comparison's rhs takes the lhs type. Setting the
+        // expected type lets a bare literal resolve (or cleanly fail) at that position.
+        let lhs = if op_class == OperatorClass::LogicalOp {
+            ctx.with_expected_type(Type::Bool, |ctx| Self::from_expression_node(lhs_n.clone(), ctx))
         } else {
-            Self::from_expression_node(rhs_n.clone(), ctx)
+            Self::from_expression_node(lhs_n.clone(), ctx)
+        };
+        let rhs = match op_class {
+            OperatorClass::ComparisonOp => ctx
+                .with_expected_type(lhs.ty(), |ctx| Self::from_expression_node(rhs_n.clone(), ctx)),
+            OperatorClass::LogicalOp => ctx.with_expected_type(Type::Bool, |ctx| {
+                Self::from_expression_node(rhs_n.clone(), ctx)
+            }),
+            OperatorClass::ArithmeticOp => Self::from_expression_node(rhs_n.clone(), ctx),
         };
 
         let expected_ty = match op_class {
@@ -1857,9 +1865,6 @@ impl Expression {
         node: syntax_nodes::UnaryOpExpression,
         ctx: &mut LookupCtx,
     ) -> Expression {
-        let exp_n = node.Expression();
-        let exp = Self::from_expression_node(exp_n, ctx);
-
         let op = node
             .children_with_tokens()
             .find_map(|n| match n.kind() {
@@ -1869,6 +1874,13 @@ impl Expression {
                 _ => None,
             })
             .unwrap_or('_');
+
+        let exp_n = node.Expression();
+        let exp = if op == '!' {
+            ctx.with_expected_type(Type::Bool, |ctx| Self::from_expression_node(exp_n, ctx))
+        } else {
+            Self::from_expression_node(exp_n, ctx)
+        };
 
         let exp = match op {
             '!' => exp.maybe_convert_to(Type::Bool, &node, ctx.diag, &ctx.symbol_counters),
@@ -1902,13 +1914,11 @@ impl Expression {
         ctx: &mut LookupCtx,
     ) -> Expression {
         let (condition_n, true_expr_n, false_expr_n) = node.Expression();
-        // FIXME: we should we add bool to the context
-        let condition = Self::from_expression_node(condition_n.clone(), ctx).maybe_convert_to(
-            Type::Bool,
-            &condition_n,
-            ctx.diag,
-            &ctx.symbol_counters,
-        );
+        let condition = ctx
+            .with_expected_type(Type::Bool, |ctx| {
+                Self::from_expression_node(condition_n.clone(), ctx)
+            })
+            .maybe_convert_to(Type::Bool, &condition_n, ctx.diag, &ctx.symbol_counters);
         let true_expr = Self::from_expression_node(true_expr_n.clone(), ctx);
         let false_expr = Self::from_expression_node(false_expr_n.clone(), ctx);
         let result_ty = common_expression_type(&true_expr, &false_expr);
@@ -1933,12 +1943,11 @@ impl Expression {
     ) -> Expression {
         let (array_expr_n, index_expr_n) = node.Expression();
         let array_expr = Self::from_expression_node(array_expr_n, ctx);
-        let index_expr = Self::from_expression_node(index_expr_n.clone(), ctx).maybe_convert_to(
-            Type::Int32,
-            &index_expr_n,
-            ctx.diag,
-            &ctx.symbol_counters,
-        );
+        let index_expr = ctx
+            .with_expected_type(Type::Int32, |ctx| {
+                Self::from_expression_node(index_expr_n.clone(), ctx)
+            })
+            .maybe_convert_to(Type::Int32, &index_expr_n, ctx.diag, &ctx.symbol_counters);
 
         let ty = array_expr.ty();
         if !matches!(ty, Type::Array(_) | Type::Invalid | Type::Function(_) | Type::Callback(_)) {

--- a/internal/compiler/tests/syntax/basic/expected_type.slint
+++ b/internal/compiler/tests/syntax/basic/expected_type.slint
@@ -1,0 +1,32 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Type-directed resolution of bare literals still reports errors for values that
+// do not match the type expected at their position.
+
+struct S { c: color, a: TextHorizontalAlignment }
+
+export component Test inherits Rectangle {
+    // wrong type in a struct field
+    property<S> s1: { c: 42, a: center };
+//                  >                   <error{Cannot convert float to color}
+
+    // a name that is neither a color nor a valid enum variant
+    property<S> s2: { c: not_a_color, a: bogus };
+//                       >         <error{Unknown unqualified identifier 'not_a_color'}
+//                                       >    <^error{Unknown unqualified identifier 'bogus'}
+
+    // wrong element in an array of colors
+    property<[color]> arr: [red, nope, blue];
+//                               >  <error{Unknown unqualified identifier 'nope'}
+
+    // unknown identifier as a function argument
+    pure function f(c: color) -> color { c }
+    property<color> from_call: f(missing);
+//                               >     <error{Unknown unqualified identifier 'missing'}
+
+    // a bare color literal on the left of a comparison is not resolved
+    property<color> fg: white;
+    property<bool> cmp: red == fg;
+//                      >  <error{Unknown unqualified identifier 'red'}
+}

--- a/internal/compiler/tests/syntax/basic/expected_type.slint
+++ b/internal/compiler/tests/syntax/basic/expected_type.slint
@@ -29,4 +29,27 @@ export component Test inherits Rectangle {
     property<color> fg: white;
     property<bool> cmp: red == fg;
 //                      >  <error{Unknown unqualified identifier 'red'}
+
+    // the condition of a ternary is bool, so `red` is not resolved as a color there
+    property<color> cond: red ? blue : green;
+//                        >  <error{Unknown unqualified identifier 'red'}
+    property<int> cond2: red ? 12 : 45;
+//                       >  <error{Unknown unqualified identifier 'red'}
+
+    // the operands of && and || are bool
+    property<bool> ok;
+    property<bool> logic: ok && red;
+//                              > <error{Unknown unqualified identifier 'red'}
+
+    // the operand of ! is bool
+    property<bool> negate: !red;
+//                          > <error{Unknown unqualified identifier 'red'}
+
+    // an array index is an integer
+    property<color> index: arr[red];
+//                             > <error{Unknown unqualified identifier 'red'}
+
+    // `length` is a property, not a method
+    property<int> len: arr.length();
+//                     >          <error{The expression is not a function}
 }

--- a/tests/cases/types/expected_type.slint
+++ b/tests/cases/types/expected_type.slint
@@ -1,0 +1,202 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Type-directed resolution of bare color/brush/enum literals by their position
+// within an expression (issue #897). One component per scenario, aggregated by
+// the root TestCase. The callback-based scenario lives on the root so the
+// language bindings can invoke it.
+
+// --- struct fields, at any nesting depth ---
+
+struct Inner { c: color, a: TextHorizontalAlignment }
+struct Outer { inner: Inner, cols: [color], b: brush }
+
+component StructsTest {
+    property<Inner> i: { c: red, a: center };
+    property<Outer> o: {
+        inner: { c: blue, a: right },
+        cols: [red, green, blue],
+        b: yellow,
+    };
+    property<[Inner]> arr: [
+        { c: red, a: left },
+        { c: green, a: center },
+    ];
+    property<bool> flag: true;
+    property<Inner> t: { c: flag ? red : blue, a: flag ? center : left };
+    property<Inner> partial: { c: red };
+
+    out property<bool> test:
+        i.c == red && i.a == TextHorizontalAlignment.center
+        && o.inner.c == blue && o.inner.a == TextHorizontalAlignment.right
+        && o.cols[0] == red && o.cols[2] == blue
+        && arr[0].c == red && arr[1].a == TextHorizontalAlignment.center
+        && t.c == red && t.a == TextHorizontalAlignment.center
+        && partial.c == red;
+}
+
+// --- array elements, including nested arrays and arrays of structs ---
+
+struct P { c: color }
+
+component ArraysTest {
+    property<[color]> colors: [red, green, blue, black, white];
+    property<[brush]> brushes: [red, blue, green];
+    property<[TextHorizontalAlignment]> aligns: [left, center, right];
+    property<[[color]]> grid: [[red, green], [blue, yellow]];
+    property<[P]> ps: [{ c: red }, { c: green }, { c: blue }];
+    property<bool> flag: true;
+    property<[color]> chosen: flag ? [red, green] : [blue, yellow];
+
+    out property<bool> test:
+        colors[0] == red && colors[4] == white
+        && aligns[0] == TextHorizontalAlignment.left
+        && aligns[1] == TextHorizontalAlignment.center
+        && grid[0][0] == red && grid[1][1] == yellow
+        && ps[0].c == red && ps[2].c == blue
+        && chosen[0] == red && chosen[1] == green
+        && brushes.length == 3;
+}
+
+// --- deep function bodies: return, typed `let`, call args, nested ternaries ---
+
+struct Item { c: color, a: TextHorizontalAlignment, tags: [color] }
+
+component FunctionsTest {
+    pure function make-item(pick: bool) -> Item {
+        return {
+            c: pick ? red : blue,
+            a: pick ? center : left,
+            tags: pick ? [red, green] : [blue, yellow],
+        };
+    }
+    pure function tint(base: color, strong: bool) -> color {
+        let chosen: color = strong ? base : (base == red ? black : white);
+        return chosen;
+    }
+    pure function first-tag(it: Item) -> color {
+        return it.tags[0];
+    }
+    pure function deep(n: int) -> color {
+        let items: [Item] = [make-item(n > 0), make-item(n > 2)];
+        let picked: Item = n > 1 ? items[1] : items[0];
+        return picked.a == center
+            ? first-tag({ c: green, a: right, tags: [picked.c, red] })
+            : tint(picked.c, n > 3);
+    }
+
+    out property<bool> test:
+        make-item(true).c == red
+        && make-item(false).a == TextHorizontalAlignment.left
+        && make-item(true).tags[1] == green
+        && make-item(false).tags[0] == blue
+        && tint(red, true) == red
+        && tint(red, false) == black
+        && tint(blue, false) == white
+        && first-tag({ c: white, a: left, tags: [orange, red] }) == orange
+        && deep(0) == white
+        && deep(1) == red
+        && deep(2) == white
+        && deep(5) == red;
+}
+
+// --- a bare name that is both an enum variant and a color: position decides ---
+
+enum Shade { red, green, blue }
+struct Mix { shade: Shade, tint: color }
+
+component PositionTest {
+    property<Mix> m: { shade: red, tint: red };
+    property<[Shade]> shades: [red, green, blue];
+    property<[color]> tints: [red, green, blue];
+
+    pure function as-color(c: color) -> color { c }
+    pure function as-shade(s: Shade) -> Shade { s }
+    // a local/argument named like a color wins over the color literal
+    pure function shadow(red: color) -> color { red }
+
+    out property<bool> test:
+        m.shade == Shade.red && m.tint == #ff0000
+        && shades[2] == Shade.blue && tints[2] == #0000ff
+        && as-color(green) == #008000 && as-shade(green) == Shade.green
+        && shadow(#123456) == #123456;
+}
+
+// --- callback bodies: self-assignment, struct literals, arg-typed resolution ---
+
+export enum Align { left, center, right }
+export struct S { c: color, a: Align }
+
+export component TestCase inherits Rectangle {
+    in-out property<color> fg: white;
+    in-out property<Align> align: left;
+    in-out property<S> built;
+    in-out property<bool> ok;
+
+    callback run();
+    run => {
+        fg = red;
+        align = center;
+        built = { c: red, a: center };
+        ok = fg == red && align == center && built.c == red && built.a == center;
+    }
+
+    pure callback make(bool) -> S;
+    make(pick) => { { c: pick ? red : blue, a: pick ? center : left } }
+
+    pure callback echo(color) -> color;
+    echo(x) => { let s: S = { c: x, a: right }; s.c }
+
+    structs := StructsTest { }
+    arrays := ArraysTest { }
+    functions := FunctionsTest { }
+    position := PositionTest { }
+
+    out property<bool> test:
+        structs.test && arrays.test && functions.test && position.test
+        && fg == white && align == left;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.invoke_run();
+assert!(instance.get_ok());
+assert_eq!(instance.get_fg(), slint::Color::from_rgb_u8(0xff, 0, 0));
+assert_eq!(instance.get_align(), Align::Center);
+let m = instance.invoke_make(true);
+assert_eq!(m.c, slint::Color::from_rgb_u8(0xff, 0, 0));
+assert_eq!(m.a, Align::Center);
+assert_eq!(instance.invoke_make(false).a, Align::Left);
+assert_eq!(instance.invoke_echo(slint::Color::from_rgb_u8(1, 2, 3)), slint::Color::from_rgb_u8(1, 2, 3));
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+instance.invoke_run();
+assert(instance.get_ok());
+assert_eq(instance.get_fg(), slint::Color::from_rgb_uint8(0xff, 0, 0));
+assert(instance.get_align() == Align::Center);
+auto m = instance.invoke_make(true);
+assert_eq(m.c, slint::Color::from_rgb_uint8(0xff, 0, 0));
+assert(m.a == Align::Center);
+assert(instance.invoke_make(false).a == Align::Left);
+assert_eq(instance.invoke_echo(slint::Color::from_rgb_uint8(1, 2, 3)), slint::Color::from_rgb_uint8(1, 2, 3));
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+instance.run();
+assert(instance.ok);
+assert.equal(instance.fg.toString(), "#ff0000");
+assert.equal(instance.align, "center");
+let m = instance.make(true);
+assert.equal(m.c.toString(), "#ff0000");
+assert.equal(m.a, "center");
+assert.equal(instance.make(false).a, "left");
+```
+*/

--- a/tests/cases/types/expected_type.slint
+++ b/tests/cases/types/expected_type.slint
@@ -133,8 +133,8 @@ export component TestCase inherits Rectangle {
     in-out property<S> built;
     in-out property<bool> ok;
 
-    callback run();
-    run => {
+    callback activate();
+    activate => {
         fg = red;
         align = center;
         built = { c: red, a: center };
@@ -161,7 +161,7 @@ export component TestCase inherits Rectangle {
 ```rust
 let instance = TestCase::new().unwrap();
 assert!(instance.get_test());
-instance.invoke_run();
+instance.invoke_activate();
 assert!(instance.get_ok());
 assert_eq!(instance.get_fg(), slint::Color::from_rgb_u8(0xff, 0, 0));
 assert_eq!(instance.get_align(), Align::Center);
@@ -176,7 +176,7 @@ assert_eq!(instance.invoke_echo(slint::Color::from_rgb_u8(1, 2, 3)), slint::Colo
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 assert(instance.get_test());
-instance.invoke_run();
+instance.invoke_activate();
 assert(instance.get_ok());
 assert_eq(instance.get_fg(), slint::Color::from_rgb_uint8(0xff, 0, 0));
 assert(instance.get_align() == Align::Center);
@@ -190,7 +190,7 @@ assert_eq(instance.invoke_echo(slint::Color::from_rgb_uint8(1, 2, 3)), slint::Co
 ```js
 var instance = new slint.TestCase({});
 assert(instance.test);
-instance.run();
+instance.activate();
 assert(instance.ok);
 assert.equal(instance.fg.toString(), "#ff0000");
 assert.equal(instance.align, "center");

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -262,6 +262,7 @@ pub fn with_property_lookup_ctx<R>(
     );
     lookup_context.property_name = Some(prop_name);
     lookup_context.property_type = ty.unwrap_or_default();
+    lookup_context.expected_type = lookup_context.return_type().clone();
     lookup_context.component_scope = &scope;
     lookup_context.current_token = Some((**element).clone().into());
 


### PR DESCRIPTION
Bare color, brush, enum and easing literals used to resolve only against the whole binding's type, so `property<S> s: { c: red }` did not compile. Add LookupCtx::expected_type, updated as the resolver descends into struct fields, array elements, call arguments, comparisons, assignments, `let` and return statements, and use it for the type-specific lookup.

ChangeLog: Enum and color values are now inferred from the expected type of the expression

Fixes: #897
