### PR TITLE
Fix `.mise/tasks/fix/text/trailing_spaces` in a worktree on macOS

### DIFF
--- a/.mise/tasks/fix/text/trailing_spaces
+++ b/.mise/tasks/fix/text/trailing_spaces
@@ -12,7 +12,7 @@ else
     SED_INPLACE="sed -i"
 fi
 
-if test -f .git/HEAD ; then
+if git rev-parse --git-dir >/dev/null 2>&1 ; then
     git grep -I -l -O"$SED_INPLACE \"s/[[:space:]]*$//\"" -e '' -- ':!*.patch'
 else
     while IFS= read -r -d '' -u 9


### PR DESCRIPTION
In a worktree this task takes the non-git route because `.git` is a file. On macOS, BSD sed doesn't support `--` (line 22). Additionally, `sed -i` refuses to edit a file through a symlink. Rather than try to fix these sed issues, we change the git check to something that works for git worktrees too.
