### PR TITLE
Suggest `Colors.x` or `EnumName.x` for unresolved identifiers

### DIFF
--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -689,6 +689,29 @@ impl ColorSpecific {
     }
 }
 
+/// Given a bare identifier `name` that failed to resolve, return the qualified forms that would
+/// resolve it as an enum value or a named color, e.g. `["Colors.red"]` or
+/// `["LayoutAlignment.center", "TextHorizontalAlignment.center"]`. This is the reverse of the
+/// `ColorSpecific` / enum lookups above, used to build "did you mean" suggestions. The result is
+/// sorted and deduplicated so it is deterministic.
+pub fn enum_or_color_suggestions(type_register: &TypeRegister, name: &str) -> Vec<SmolStr> {
+    let name = crate::parser::normalize_identifier(name);
+    let mut result = Vec::new();
+    if named_colors().contains_key(name.as_str()) {
+        result.push(smol_str::format_smolstr!("{}.{name}", BuiltinNamespace::Colors));
+    }
+    for ty in type_register.all_types().values() {
+        if let Type::Enumeration(e) = ty {
+            if e.values.contains(&name) {
+                result.push(smol_str::format_smolstr!("{}.{name}", e.name));
+            }
+        }
+    }
+    result.sort();
+    result.dedup();
+    result
+}
+
 pub struct KeysLookup;
 
 macro_rules! special_keys_lookup {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -716,6 +716,29 @@ impl ColorSpecific {
     }
 }
 
+/// Given a bare identifier `name` that failed to resolve, return the qualified forms that would
+/// resolve it as an enum value or a named color, e.g. `["Colors.red"]` or
+/// `["LayoutAlignment.center", "TextHorizontalAlignment.center"]`. This is the reverse of the
+/// `ColorSpecific` / enum lookups above, used to build "did you mean" suggestions. The result is
+/// sorted and deduplicated so it is deterministic.
+pub fn enum_or_color_suggestions(type_register: &TypeRegister, name: &str) -> Vec<SmolStr> {
+    let name = crate::parser::normalize_identifier(name);
+    let mut result = Vec::new();
+    if named_colors().contains_key(name.as_str()) {
+        result.push(smol_str::format_smolstr!("{}.{name}", BuiltinNamespace::Colors));
+    }
+    for ty in type_register.all_types().values() {
+        if let Type::Enumeration(e) = ty {
+            if e.values.contains(&name) {
+                result.push(smol_str::format_smolstr!("{}.{name}", e.name));
+            }
+        }
+    }
+    result.sort();
+    result.dedup();
+    result
+}
+
 pub struct KeysLookup;
 
 macro_rules! special_keys_lookup {

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2221,8 +2221,18 @@ fn lookup_qualified_name_node(
             if it.next().is_some() {
                 ctx.diag.push_error(format!("Cannot access id '{}'", first.text()), &node);
             } else {
+                let mut parts =
+                    crate::lookup::enum_or_color_suggestions(ctx.type_register, &first_str)
+                        .iter()
+                        .map(|s| format!("'{s}'"))
+                        .collect::<Vec<_>>();
+                let hint = match parts.pop() {
+                    None => String::new(),
+                    Some(last) if parts.is_empty() => format!(". Did you mean {last}?"),
+                    Some(last) => format!(". Did you mean {} or {last}?", parts.join(", ")),
+                };
                 ctx.diag.push_error(
-                    format!("Unknown unqualified identifier '{}'", first.text()),
+                    format!("Unknown unqualified identifier '{}'{hint}", first.text()),
                     &node,
                 );
             }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2373,8 +2373,18 @@ fn lookup_qualified_name_node(
             if it.next().is_some() {
                 ctx.diag.push_error(format!("Cannot access id '{}'", first.text()), &node);
             } else {
+                let mut parts =
+                    crate::lookup::enum_or_color_suggestions(ctx.type_register, &first_str)
+                        .iter()
+                        .map(|s| format!("'{s}'"))
+                        .collect::<Vec<_>>();
+                let hint = match parts.pop() {
+                    None => String::new(),
+                    Some(last) if parts.is_empty() => format!(". Did you mean {last}?"),
+                    Some(last) => format!(". Did you mean {} or {last}?", parts.join(", ")),
+                };
                 ctx.diag.push_error(
-                    format!("Unknown unqualified identifier '{}'", first.text()),
+                    format!("Unknown unqualified identifier '{}'{hint}", first.text()),
                     &node,
                 );
             }

--- a/internal/compiler/tests/syntax/basic/expected_type.slint
+++ b/internal/compiler/tests/syntax/basic/expected_type.slint
@@ -28,26 +28,26 @@ export component Test inherits Rectangle {
     // a bare color literal on the left of a comparison is not resolved
     property<color> fg: white;
     property<bool> cmp: red == fg;
-//                      >  <error{Unknown unqualified identifier 'red'}
+//                      >  <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
 
     // the condition of a ternary is bool, so `red` is not resolved as a color there
     property<color> cond: red ? blue : green;
-//                        >  <error{Unknown unqualified identifier 'red'}
+//                        >  <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
     property<int> cond2: red ? 12 : 45;
-//                       >  <error{Unknown unqualified identifier 'red'}
+//                       >  <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
 
     // the operands of && and || are bool
     property<bool> ok;
     property<bool> logic: ok && red;
-//                              > <error{Unknown unqualified identifier 'red'}
+//                              > <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
 
     // the operand of ! is bool
     property<bool> negate: !red;
-//                          > <error{Unknown unqualified identifier 'red'}
+//                          > <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
 
     // an array index is an integer
     property<color> index: arr[red];
-//                             > <error{Unknown unqualified identifier 'red'}
+//                             > <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
 
     // `length` is a property, not a method
     property<int> len: arr.length();

--- a/internal/compiler/tests/syntax/basic/inline_component.slint
+++ b/internal/compiler/tests/syntax/basic/inline_component.slint
@@ -14,6 +14,6 @@ export SubElements := Rectangle {
         background: yellow;
         invalid: yellow;
 //      >     <error{Unknown property invalid in Inline1}
-//               >    <^error{Unknown unqualified identifier 'yellow'}
+//               >    <^error{Unknown unqualified identifier 'yellow'. Did you mean 'Colors.yellow'?}
     }
 }

--- a/internal/compiler/tests/syntax/basic/states_transitions.slint
+++ b/internal/compiler/tests/syntax/basic/states_transitions.slint
@@ -18,12 +18,12 @@ export TestCase := Rectangle {
 //          >          <error{'text.foo.bar' is not a valid property}
             colour: yellow;
 //          >    <error{'colour' is not a valid property}
-//                  >    <^error{Unknown unqualified identifier 'yellow'}
+//                  >    <^error{Unknown unqualified identifier 'yellow'. Did you mean 'Colors.yellow'?}
             fox.color: yellow;
 //          >       <error{'fox' is not a valid element id}
             text.fox: yellow;
 //          >      <error{'fox' not found in 'text'}
-//                    >    <^error{Unknown unqualified identifier 'yellow'}
+//                    >    <^error{Unknown unqualified identifier 'yellow'. Did you mean 'Colors.yellow'?}
         }
     ]
 
@@ -73,12 +73,12 @@ export component NewSyntax {
 //          >          <error{'text.foo.bar' is not a valid property}
             colour: yellow;
 //          >    <error{'colour' is not a valid property}
-//                  >    <^error{Unknown unqualified identifier 'yellow'}
+//                  >    <^error{Unknown unqualified identifier 'yellow'. Did you mean 'Colors.yellow'?}
             fox.color: yellow;
 //          >       <error{'fox' is not a valid element id}
             text.fox: yellow;
 //          >      <error{'fox' not found in 'text'}
-//                    >    <^error{Unknown unqualified identifier 'yellow'}
+//                    >    <^error{Unknown unqualified identifier 'yellow'. Did you mean 'Colors.yellow'?}
 
             in  {
                 animate * { duration: 88ms; }
@@ -116,12 +116,12 @@ export component OldInNewSyntax {
 //          >          <error{'text.foo.bar' is not a valid property}
             colour: yellow;
 //          >    <error{'colour' is not a valid property}
-//                  >    <^error{Unknown unqualified identifier 'yellow'}
+//                  >    <^error{Unknown unqualified identifier 'yellow'. Did you mean 'Colors.yellow'?}
             fox.color: yellow;
 //          >       <error{'fox' is not a valid element id}
             text.fox: yellow;
 //          >      <error{'fox' not found in 'text'}
-//                    >    <^error{Unknown unqualified identifier 'yellow'}
+//                    >    <^error{Unknown unqualified identifier 'yellow'. Did you mean 'Colors.yellow'?}
         }
     ]
 

--- a/internal/compiler/tests/syntax/basic/unknown_item.slint
+++ b/internal/compiler/tests/syntax/basic/unknown_item.slint
@@ -23,7 +23,7 @@ export SuperSimple := Rectangle {
             background: blue;
             foo_bar: blue;
 //          >     <error{Unknown property foo-bar in Rectangle}
-//                   >  <^error{Unknown unqualified identifier 'blue'}
+//                   >  <^error{Unknown unqualified identifier 'blue'. Did you mean 'Colors.blue'?}
         }
     }
 
@@ -47,7 +47,7 @@ export SuperSimple := Rectangle {
     Rectangle {
         foo_bar: blue;
 //      >     <error{Unknown property foo-bar in Rectangle}
-//               >  <^error{Unknown unqualified identifier 'blue'}
+//               >  <^error{Unknown unqualified identifier 'blue'. Did you mean 'Colors.blue'?}
     }
 
     NativeLineEdit { }

--- a/internal/compiler/tests/syntax/expressions/enum_color_suggestion.slint
+++ b/internal/compiler/tests/syntax/expressions/enum_color_suggestion.slint
@@ -1,0 +1,58 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+enum Foo { bar }
+
+// The same value in several enums. `-` and `_` are the same identifier once
+// normalized, so mixing them in the declarations and in the references still
+// matches, and the suggestions always use the normalized (`-`) spelling.
+enum Ma { pair_value }
+enum Mb { pair-value }
+
+enum Na { trio-value }
+enum Nb { trio_value }
+enum Nc { trio-value }
+
+enum Oa { quad_value }
+enum Ob { quad-value }
+enum Oc { quad_value }
+enum Od { quad-value }
+
+enum Pa { many-value }
+enum Pb { many_value }
+enum Pc { many-value }
+enum Pd { many_value }
+enum Pe { many-value }
+
+// Each value below sits at a position whose expected type is not that color or enum, so
+// type-directed resolution does not resolve it and the suggestion is what tells the user how to
+// qualify it.
+export component TestCase {
+    // A named color where a string is expected: suggest `Colors.red`.
+    property <string> s: red;
+//                       > <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
+
+    // An enum value where an int is expected: suggest `Foo.bar`.
+    property <int> i: bar;
+//                    > <error{Unknown unqualified identifier 'bar'. Did you mean 'Foo.bar'?}
+
+    // Two matching enums.
+    property <int> p2: pair-value;
+//                     >        <error{Unknown unqualified identifier 'pair-value'. Did you mean 'Ma.pair-value' or 'Mb.pair-value'?}
+
+    // Three matching enums.
+    property <int> p3: trio_value;
+//                     >        <error{Unknown unqualified identifier 'trio_value'. Did you mean 'Na.trio-value', 'Nb.trio-value' or 'Nc.trio-value'?}
+
+    // Four matching enums.
+    property <int> p4: quad-value;
+//                     >        <error{Unknown unqualified identifier 'quad-value'. Did you mean 'Oa.quad-value', 'Ob.quad-value', 'Oc.quad-value' or 'Od.quad-value'?}
+
+    // Five matching enums.
+    property <int> p5: many_value;
+//                     >        <error{Unknown unqualified identifier 'many_value'. Did you mean 'Pa.many-value', 'Pb.many-value', 'Pc.many-value', 'Pd.many-value' or 'Pe.many-value'?}
+
+    // An identifier that is neither an enum value nor a color: no suggestion.
+    property <int> j: doesnotexist;
+//                    >          <error{Unknown unqualified identifier 'doesnotexist'}
+}

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -16,6 +16,6 @@ export component X inherits Rectangle {
 //      >        <error{Use spacing-horizontal instead of column-gap}
         justify-content: center;
 //      >             <error{Use alignment instead of justify-content}
-//                       >    <^error{Unknown unqualified identifier 'center'}
+//                       >    <^error{Unknown unqualified identifier 'center'. Did you mean 'CrossAxisAlignment.center', 'FlexboxLayoutAlignContent.center', 'FlexboxLayoutAlignSelf.center', 'ImageHorizontalAlignment.center', 'ImageVerticalAlignment.center', 'LayoutAlignment.center', 'TextHorizontalAlignment.center', 'TextStrokeStyle.center' or 'TextVerticalAlignment.center'?}
     }
 }

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -16,6 +16,6 @@ export component X inherits Rectangle {
 //      >        <error{Use spacing-horizontal instead of column-gap}
         justify-content: center;
 //      >             <error{Use alignment instead of justify-content}
-//                       >    <^error{Unknown unqualified identifier 'center'}
+//                       >    <^error{Unknown unqualified identifier 'center'. Did you mean 'CrossAxisAlignment.center', 'CrossAxisLineAlignment.center', 'CrossAxisSelfAlignment.center', 'ImageHorizontalAlignment.center', 'ImageVerticalAlignment.center', 'LayoutAlignment.center', 'TextHorizontalAlignment.center', 'TextStrokeStyle.center' or 'TextVerticalAlignment.center'?}
     }
 }

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1635,6 +1635,47 @@ fn get_code_actions(
                 },
             );
         }
+    } else if token.kind() == SyntaxKind::Identifier
+        && node.kind() == SyntaxKind::QualifiedName
+        && node.parent().map(|n| n.kind()) == Some(SyntaxKind::Expression)
+        && node.children_with_tokens().filter(|n| n.kind() == SyntaxKind::Identifier).count() == 1
+    {
+        // Qualify a bare identifier that doesn't resolve but is an enum value or named color
+        // (`red` -> `Colors.red`). Like the import action above, re-derive the lookup error rather
+        // than reading diagnostics, so nothing is offered when the identifier does resolve.
+        use i_slint_compiler::lookup::LookupObject;
+        let is_lookup_error = util::with_lookup_ctx(document_cache, node.clone(), None, |ctx| {
+            let name = i_slint_compiler::parser::normalize_identifier(token.text());
+            i_slint_compiler::lookup::global_lookup().lookup(ctx, &name).is_none()
+        })
+        .unwrap_or(true);
+        if is_lookup_error {
+            let suggestions = {
+                let global_tr = document_cache.global_type_registry();
+                let tr = document_cache
+                    .get_document_for_source_file(&token.source_file)
+                    .map(|doc| &doc.local_registry)
+                    .unwrap_or(&global_tr);
+                i_slint_compiler::lookup::enum_or_color_suggestions(tr, token.text())
+            };
+            let range = util::text_range_to_lsp_range(
+                &token.source_file,
+                token.text_range(),
+                document_cache.format,
+            );
+            for suggestion in suggestions {
+                result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                    title: format!("Qualify as '{suggestion}'"),
+                    kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                    edit: common::create_workspace_edit_from_path(
+                        document_cache,
+                        token.source_file.path(),
+                        vec![TextEdit::new(range, suggestion.to_string())],
+                    ),
+                    ..Default::default()
+                }));
+            }
+        }
     }
 
     (!result.is_empty()).then_some(result)
@@ -2978,6 +3019,92 @@ export component TestWindow inherits Window {
                 get_code_actions(&mut document_cache_with_import, token, &capabilities)
             });
         assert_eq!(action2, None, "import action should not appear when type is already imported");
+    }
+
+    #[test]
+    fn test_qualify_enum_or_color() {
+        // Build the expected "Qualify as ..." quick-fix that replaces `range` with `new_text`.
+        let expect_qualify = |new_text: &str, range: lsp_types::Range, uri: &Url| {
+            CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                title: format!("Qualify as '{new_text}'"),
+                kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                edit: Some(WorkspaceEdit {
+                    document_changes: Some(lsp_types::DocumentChanges::Edits(vec![
+                        lsp_types::TextDocumentEdit {
+                            text_document: lsp_types::OptionalVersionedTextDocumentIdentifier {
+                                version: Some(42),
+                                uri: uri.clone(),
+                            },
+                            edits: vec![lsp_types::OneOf::Left(TextEdit::new(
+                                range,
+                                new_text.into(),
+                            ))],
+                        },
+                    ])),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        };
+
+        let capabilities = ClientCapabilities::default();
+
+        // A named color used where no color type is expected does not resolve, so the code action
+        // offers to qualify `red` as `Colors.red`.
+        let (mut dc, url, _) = test::loaded_document_cache(
+            r#"export component TestCase {
+    property <string> s: red;
+}
+"#
+            .into(),
+        );
+
+        // Cursor on `red` in `    property <string> s: red;` (line 1, col 25)
+        let pos = Position::new(1, 25);
+        let range = lsp_types::Range::new(Position::new(1, 25), Position::new(1, 28));
+
+        let action = token_descr(&dc, &url, &pos)
+            .and_then(|(token, _)| get_code_actions(&mut dc, token, &capabilities));
+        assert_eq!(action, Some(vec![expect_qualify("Colors.red", range, &url)]));
+
+        // The same `red` bound to a `color` property resolves, so no action is offered.
+        let (mut dc, url, _) = test::loaded_document_cache(
+            r#"export component TestCase {
+    property <color> c: red;
+}
+"#
+            .into(),
+        );
+        // Cursor on `red` in `    property <color> c: red;` (line 1, col 24)
+        let action = token_descr(&dc, &url, &Position::new(1, 24))
+            .and_then(|(token, _)| get_code_actions(&mut dc, token, &capabilities));
+        assert_eq!(action, None);
+
+        // A value shared by several enums: one quick-fix per match (the menu is not capped),
+        // sorted by the qualified name.
+        let (mut dc, url, _) = test::loaded_document_cache(
+            r#"enum EA { shared_value }
+enum EB { shared_value }
+export component TestCase {
+    property <int> foo: shared_value;
+}
+"#
+            .into(),
+        );
+
+        // Cursor on `shared_value` in `    property <int> foo: shared_value;` (line 3, col 24)
+        let pos = Position::new(3, 24);
+        let range = lsp_types::Range::new(Position::new(3, 24), Position::new(3, 36));
+
+        let action = token_descr(&dc, &url, &pos)
+            .and_then(|(token, _)| get_code_actions(&mut dc, token, &capabilities));
+        assert_eq!(
+            action,
+            Some(vec![
+                expect_qualify("EA.shared-value", range, &url),
+                expect_qualify("EB.shared-value", range, &url),
+            ])
+        );
     }
 
     #[test]

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1715,6 +1715,47 @@ fn get_code_actions(
                 },
             );
         }
+    } else if token.kind() == SyntaxKind::Identifier
+        && node.kind() == SyntaxKind::QualifiedName
+        && node.parent().map(|n| n.kind()) == Some(SyntaxKind::Expression)
+        && node.children_with_tokens().filter(|n| n.kind() == SyntaxKind::Identifier).count() == 1
+    {
+        // Qualify a bare identifier that doesn't resolve but is an enum value or named color
+        // (`red` -> `Colors.red`). Like the import action above, re-derive the lookup error rather
+        // than reading diagnostics, so nothing is offered when the identifier does resolve.
+        use i_slint_compiler::lookup::LookupObject;
+        let is_lookup_error = util::with_lookup_ctx(document_cache, node.clone(), None, |ctx| {
+            let name = i_slint_compiler::parser::normalize_identifier(token.text());
+            i_slint_compiler::lookup::global_lookup().lookup(ctx, &name).is_none()
+        })
+        .unwrap_or(true);
+        if is_lookup_error {
+            let suggestions = {
+                let global_tr = document_cache.global_type_registry();
+                let tr = document_cache
+                    .get_document_for_source_file(&token.source_file)
+                    .map(|doc| &doc.local_registry)
+                    .unwrap_or(&global_tr);
+                i_slint_compiler::lookup::enum_or_color_suggestions(tr, token.text())
+            };
+            let range = util::text_range_to_lsp_range(
+                &token.source_file,
+                token.text_range(),
+                document_cache.format,
+            );
+            for suggestion in suggestions {
+                result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                    title: format!("Qualify as '{suggestion}'"),
+                    kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                    edit: common::create_workspace_edit_from_path(
+                        document_cache,
+                        token.source_file.path(),
+                        vec![TextEdit::new(range, suggestion.to_string())],
+                    ),
+                    ..Default::default()
+                }));
+            }
+        }
     }
 
     (!result.is_empty()).then_some(result)
@@ -3104,6 +3145,92 @@ export component TestWindow inherits Window {
             LspToPreviewMessage::SetConfiguration { config } if config == &ctx.preview_config
         )));
         assert!(!messages.iter().any(|m| matches!(m, LspToPreviewMessage::SetUserSettings { .. })));
+    }
+
+    #[test]
+    fn test_qualify_enum_or_color() {
+        // Build the expected "Qualify as ..." quick-fix that replaces `range` with `new_text`.
+        let expect_qualify = |new_text: &str, range: lsp_types::Range, uri: &Url| {
+            CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
+                title: format!("Qualify as '{new_text}'"),
+                kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                edit: Some(WorkspaceEdit {
+                    document_changes: Some(lsp_types::DocumentChanges::Edits(vec![
+                        lsp_types::TextDocumentEdit {
+                            text_document: lsp_types::OptionalVersionedTextDocumentIdentifier {
+                                version: Some(42),
+                                uri: uri.clone(),
+                            },
+                            edits: vec![lsp_types::OneOf::Left(TextEdit::new(
+                                range,
+                                new_text.into(),
+                            ))],
+                        },
+                    ])),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        };
+
+        let capabilities = ClientCapabilities::default();
+
+        // A named color used where no color type is expected does not resolve, so the code action
+        // offers to qualify `red` as `Colors.red`.
+        let (mut dc, url, _) = test::loaded_document_cache(
+            r#"export component TestCase {
+    property <string> s: red;
+}
+"#
+            .into(),
+        );
+
+        // Cursor on `red` in `    property <string> s: red;` (line 1, col 25)
+        let pos = Position::new(1, 25);
+        let range = lsp_types::Range::new(Position::new(1, 25), Position::new(1, 28));
+
+        let action = token_descr(&dc, &url, &pos)
+            .and_then(|(token, _)| get_code_actions(&mut dc, token, &capabilities));
+        assert_eq!(action, Some(vec![expect_qualify("Colors.red", range, &url)]));
+
+        // The same `red` bound to a `color` property resolves, so no action is offered.
+        let (mut dc, url, _) = test::loaded_document_cache(
+            r#"export component TestCase {
+    property <color> c: red;
+}
+"#
+            .into(),
+        );
+        // Cursor on `red` in `    property <color> c: red;` (line 1, col 24)
+        let action = token_descr(&dc, &url, &Position::new(1, 24))
+            .and_then(|(token, _)| get_code_actions(&mut dc, token, &capabilities));
+        assert_eq!(action, None);
+
+        // A value shared by several enums: one quick-fix per match (the menu is not capped),
+        // sorted by the qualified name.
+        let (mut dc, url, _) = test::loaded_document_cache(
+            r#"enum EA { shared_value }
+enum EB { shared_value }
+export component TestCase {
+    property <int> foo: shared_value;
+}
+"#
+            .into(),
+        );
+
+        // Cursor on `shared_value` in `    property <int> foo: shared_value;` (line 3, col 24)
+        let pos = Position::new(3, 24);
+        let range = lsp_types::Range::new(Position::new(3, 24), Position::new(3, 36));
+
+        let action = token_descr(&dc, &url, &pos)
+            .and_then(|(token, _)| get_code_actions(&mut dc, token, &capabilities));
+        assert_eq!(
+            action,
+            Some(vec![
+                expect_qualify("EA.shared-value", range, &url),
+                expect_qualify("EB.shared-value", range, &url),
+            ])
+        );
     }
 
     #[test]


### PR DESCRIPTION
When a bare identifier doesn't resolve but is a named color or an enum value,
tell the user the qualified form they probably meant. 
  
- The compiler error "Unknown unqualified identifier 'red'" now adds
  "Did you mean 'Colors.red'?". When a value belongs to several enums it lists
  a few and summarizes the rest as "or N more".
- The LSP offers a quick-fix that rewrites the identifier to its qualified form
  (one action per matching enum or color). Like the "import missing component"
  action, it re-derives the error via a lookup instead of reading diagnostics,
  so it stays out of the way when the identifier already resolves.

Fixes #4397
