### PR TITLE
widgets: colorize MenuItem icons so they follow the menu foreground

### DIFF
--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -144,6 +144,7 @@ export component MenuItemBase {
 
                     Image {
                         source: entry.icon;
+                        colorize: root.default-foreground;
                         accessible-role: none;
                         image-fit: contain;
                         width: 100%;


### PR DESCRIPTION
MenuItem rendered its icon as a plain `Image` with no `colorize`, so `currentColor` SVG icons fell back to black and were invisible on dark menus. The label text and the sub-menu arrow beside it are already colorized; this does the same for the item icon so it adapts to the active color scheme.

Surfaced while giving SlintPad a dark chrome (the View-menu icons were invisible), but it is a general fix: any dark Slint menu with icons is affected.

## Testing
- `pnpm build:wasm_lsp` builds clean; cspell passes.
- Confirmed in SlintPad: the View-menu icons (Library, Properties, Outline, Simulation Data) are now visible on the dark menu.

## Note
`colorize` tints the icon to the foreground, matching the label (as the checkmark and sub-menu arrow already do). Multi-color menu icons, if any, would be flattened to the foreground colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)