### PR TITLE
Add support for default values on struct fields

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -561,6 +561,7 @@ srcroot
 SRCS
 SRGBA
 standardbutton
+startswith
 staticlib
 staticmethod
 stdset

--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -111,11 +111,11 @@ impl JsComponentCompiler {
                     let name = s.name.slint_name().unwrap();
                     let struct_instance = crate::to_js_unknown(
                         env,
-                        &Value::Struct(slint_interpreter::Struct::from_iter(s.fields.iter().map(
-                            |(name, field_type)| {
+                        &Value::Struct(slint_interpreter::Struct::from_iter(s.fields.keys().map(
+                            |name| {
                                 (
                                     name.to_string(),
-                                    slint_interpreter::default_value_for_type(field_type),
+                                    slint_interpreter::default_value_for_struct_field(s, name),
                                 )
                             },
                         ))),

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -319,7 +319,7 @@ pub fn to_value(
                         let prop: Unknown =
                             js_object.get_named_property(&pro_name.replace('-', "_"))?;
                         let prop_value = if prop.get_type()? == napi::ValueType::Undefined {
-                            slint_interpreter::default_value_for_type(pro_ty)
+                            slint_interpreter::default_value_for_struct_field(s, pro_name)
                         } else {
                             to_value(env, prop, pro_ty, anchor_owner)?
                         };

--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -182,14 +182,12 @@ impl CompilationResult {
             match struct_or_enum {
                 Type::Struct(s) if s.node().is_some() => {
                     let struct_instance = self.type_collection.struct_to_py(
-                        slint_interpreter::Struct::from_iter(s.fields.iter().map(
-                            |(name, field_type)| {
-                                (
-                                    ident(&name).into(),
-                                    slint_interpreter::default_value_for_type(field_type),
-                                )
-                            },
-                        )),
+                        slint_interpreter::Struct::from_iter(s.fields.keys().map(|name| {
+                            (
+                                ident(&name).into(),
+                                slint_interpreter::default_value_for_struct_field(s, name),
+                            )
+                        })),
                         None,
                     );
 

--- a/docs/astro/src/content/docs/guide/language/coding/structs-and-enums.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/structs-and-enums.mdx
@@ -22,6 +22,27 @@ export component Example {
 
 The default value of a struct, is initialized with all its fields set to their default value.
 
+### Field Default Values
+
+Declare a default value for a field with `= expression` after its type.
+The expression must be a compile-time constant.
+The default applies whenever an instance of the struct is created without a value for the field:
+in struct literals that omit the field, for properties that are never set,
+and when constructing the struct from Rust (`Player::default()`), C++ (`Player{}`),
+JavaScript (`new ui.Player()`), or Python (`ui.Player()`).
+
+```slint
+export struct Player  {
+    name: string = "unknown",
+    score: int = 100,
+}
+
+export component Example {
+    // player.name is "Foo", player.score is 100
+    in-out property<Player> player: { name: "Foo" };
+}
+```
+
 ### Anonymous Structures
 
 Declare anonymous structures using `{ identifier1: type1, identifier2: type2 }`

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -213,7 +213,12 @@ module.exports = grammar({
       seq("interface", field("name", $.user_type_identifier), $.interface_block),
 
     struct_field_definition: ($) =>
-      seq(field("name", $.simple_identifier), ":", field("type", $.type)),
+      seq(
+        field("name", $.simple_identifier),
+        ":",
+        field("type", $.type),
+        optional(seq("=", field("default_value", $.expression))),
+      ),
 
     struct_block: ($) =>
       seq(

--- a/editors/tree-sitter-slint/test/corpus/struct_field_defaults.txt
+++ b/editors/tree-sitter-slint/test/corpus/struct_field_defaults.txt
@@ -1,0 +1,28 @@
+================================================================================
+struct with field default values
+================================================================================
+
+struct Player {
+    name: string = "unknown",
+    score: int = 42,
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (struct_field_definition
+        (simple_identifier)
+        (type
+          (builtin_type_identifier))
+        (expression
+          (value
+            (string_value))))
+      (struct_field_definition
+        (simple_identifier)
+        (type
+          (builtin_type_identifier))
+        (expression
+          (value
+            (int_value)))))))

--- a/internal/compiler/benches/semantic_analysis.rs
+++ b/internal/compiler/benches/semantic_analysis.rs
@@ -472,6 +472,7 @@ mod phase_breakdown {
             &mut diag,
             &type_registry,
             false,
+            &loader.symbol_counters,
         ));
     }
 
@@ -498,6 +499,7 @@ mod phase_breakdown {
             &mut diag,
             &type_registry,
             false,
+            &loader.symbol_counters,
         );
 
         // Benchmark just run_passes

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -243,49 +243,37 @@ declare_builtin_function_types!(
     StringEndsWith: (Type::String, Type::String) -> Type::Bool,
     KeysToString: (Type::Keys) -> Type::String,
     ImplicitLayoutInfo(..): (Type::ElementReference, Type::Float32) -> typeregister::layout_info_type().into(),
-    ColorRgbaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
-        fields: IntoIterator::into_iter([
+    ColorRgbaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("red"), Type::Int32),
             (SmolStr::new_static("green"), Type::Int32),
             (SmolStr::new_static("blue"), Type::Int32),
             (SmolStr::new_static("alpha"), Type::Int32),
         ])
-        .collect(),
-        name: BuiltinStruct::Color.into(),
-    })),
-    ColorHsvaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
-        fields: IntoIterator::into_iter([
+        .collect(), BuiltinStruct::Color))),
+    ColorHsvaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("hue"), Type::Float32),
             (SmolStr::new_static("saturation"), Type::Float32),
             (SmolStr::new_static("value"), Type::Float32),
             (SmolStr::new_static("alpha"), Type::Float32),
         ])
-        .collect(),
-        name: BuiltinStruct::Color.into(),
-    })),
-    ColorOklchStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
-        fields: IntoIterator::into_iter([
+        .collect(), BuiltinStruct::Color))),
+    ColorOklchStruct: (Type::Color) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("lightness"), Type::Float32),
             (SmolStr::new_static("chroma"), Type::Float32),
             (SmolStr::new_static("hue"), Type::Float32),
             (SmolStr::new_static("alpha"), Type::Float32),
         ])
-        .collect(),
-        name: BuiltinStruct::Color.into(),
-    })),
+        .collect(), BuiltinStruct::Color))),
     ColorBrighter: (Type::Brush, Type::Float32) -> Type::Brush,
     ColorDarker: (Type::Brush, Type::Float32) -> Type::Brush,
     ColorTransparentize: (Type::Brush, Type::Float32) -> Type::Brush,
     ColorWithAlpha: (Type::Brush, Type::Float32) -> Type::Brush,
     ColorMix: (Type::Color, Type::Color, Type::Float32) -> Type::Color,
-    ImageSize: (Type::Image) -> Type::Struct(Rc::new(Struct {
-        fields: IntoIterator::into_iter([
+    ImageSize: (Type::Image) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("width"), Type::Int32),
             (SmolStr::new_static("height"), Type::Int32),
         ])
-        .collect(),
-        name: crate::langtype::BuiltinStruct::Size.into(),
-    })),
+        .collect(), crate::langtype::BuiltinStruct::Size))),
     ArrayLength: (Type::Model) -> Type::Int32,
     // Using Type::InferredProperty as there is currently no valid type for the data argument.
     ArrayPush: (Type::Model, Type::InferredProperty) -> Type::Void,
@@ -1576,7 +1564,7 @@ impl Expression {
                         let mut new_values = BTreeMap::new();
                         for (key, ty) in &right.fields {
                             let (key, expression) = values.remove_entry(key).map_or_else(
-                                || (key.clone(), Expression::default_value_for_type(ty)),
+                                || (key.clone(), right.default_value_for_field(key)),
                                 |(k, e)| {
                                     (k, e.maybe_convert_to(ty.clone(), node, diag, symbol_counters))
                                 },
@@ -1603,7 +1591,7 @@ impl Expression {
                                 symbol_counters,
                             )
                         } else {
-                            Expression::default_value_for_type(ty)
+                            right.default_value_for_field(key)
                         };
                         new_values.insert(key.clone(), expression);
                     }
@@ -1695,8 +1683,9 @@ impl Expression {
                     return self;
                 }
             }
-            for (f, t) in fields {
-                new_values.insert(f, Expression::default_value_for_type(&t));
+            for f in fields.into_keys() {
+                let default_value = struct_type.default_value_for_field(&f);
+                new_values.insert(f, default_value);
             }
             Expression::Struct { ty: struct_type.clone(), values: new_values }
         } else {
@@ -1769,8 +1758,8 @@ impl Expression {
                 ty: s.clone(),
                 values: s
                     .fields
-                    .iter()
-                    .map(|(k, v)| (k.clone(), Expression::default_value_for_type(v)))
+                    .keys()
+                    .map(|k| (k.clone(), s.default_value_for_field(k)))
                     .collect(),
             },
             Type::Easing => Expression::EasingCurve(EasingCurve::default()),

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -464,6 +464,7 @@ use crate::langtype::{
     BuiltinStruct, Enumeration, EnumerationValue, NativeClass, StructName, Type,
 };
 use crate::layout::Orientation;
+use crate::llr::lower_expression::lower_constant_expression;
 use crate::llr::{
     self, EvaluationContext as llr_EvaluationContext, EvaluationScope, ParentScope,
     TypeResolutionContext as _,
@@ -790,13 +791,13 @@ pub fn generate(
         return super::cpp_live_preview::generate(doc, config, compiler_config);
     }
 
-    let mut file = generate_types(&doc.used_types.borrow().structs_and_enums, &config);
+    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+
+    let mut file = generate_types(&doc.used_types.borrow().structs_and_enums, &config, &llr);
 
     for (resource_id, er) in doc.embedded_file_resources.borrow().iter_enumerated() {
         embed_resource(er, resource_id, &mut file.resources);
     }
-
-    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
 
     #[cfg(feature = "bundle-translations")]
     if let Some(translations) = &llr.translations {
@@ -1036,7 +1037,7 @@ pub fn generate(
     Ok(file)
 }
 
-pub fn generate_types(used_types: &[Type], config: &Config) -> File {
+pub fn generate_types(used_types: &[Type], config: &Config, unit: &llr::CompilationUnit) -> File {
     let mut file = File { namespace: config.namespace.clone(), ..Default::default() };
 
     file.includes.push("<array>".into());
@@ -1052,10 +1053,15 @@ pub fn generate_types(used_types: &[Type], config: &Config) -> File {
         z = env!("CARGO_PKG_VERSION_PATCH")
     );
 
+    // The evaluation context for the field default values needs an instance,
+    // but the constant expressions cannot call any of the functions that
+    // record a conditional include
+    let conditional_includes = ConditionalIncludes::default();
+
     for ty in used_types {
         match ty {
             Type::Struct(s) if s.node().is_some() => {
-                generate_struct(&mut file, &s.name, &s.fields);
+                generate_struct(&mut file, s, unit, &conditional_includes);
             }
             Type::Enumeration(en) => {
                 generate_enum(&mut file, en);
@@ -1063,6 +1069,13 @@ pub fn generate_types(used_types: &[Type], config: &Config) -> File {
             _ => (),
         }
     }
+
+    debug_assert!(
+        !conditional_includes.iostream.get()
+            && !conditional_includes.cstdlib.get()
+            && !conditional_includes.cmath.get(),
+        "a constant expression recorded a conditional include; apply them to the file"
+    );
 
     file
 }
@@ -1305,20 +1318,44 @@ fn embed_resource(
     }
 }
 
-fn generate_struct(file: &mut File, name: &StructName, fields: &BTreeMap<SmolStr, Type>) {
-    let StructName::User { name: user_name, node } = name else {
+fn generate_struct(
+    file: &mut File,
+    the_struct: &crate::langtype::Struct,
+    unit: &llr::CompilationUnit,
+    conditional_includes: &ConditionalIncludes,
+) {
+    let StructName::User { name: user_name, node } = &the_struct.name else {
         panic!("internal error: Cannot generate anonymous struct");
     };
+    // Constant expressions cannot access the globals; make sure a bug in that
+    // assumption breaks the build of the generated code with a clear message
+    let ctx = EvaluationContext::new_const(
+        unit,
+        CppGeneratorContext {
+            global_access: "no_global_access_in_a_constant_expression".into(),
+            conditional_includes,
+        },
+    );
     let name = ident(user_name);
     let mut members = node
         .ObjectTypeMember()
         .map(|n| crate::parser::identifier_text(&n).unwrap())
         .map(|name| {
+            // When any field has a declared default value, initialize the remaining fields, too,
+            // so that default construction is fully deterministic, like in the other language backends.
+            let init = match the_struct.field_defaults.get(&name) {
+                Some(default_value) => {
+                    Some(compile_expression(&lower_constant_expression(default_value), &ctx))
+                }
+                None if !the_struct.field_defaults.is_empty() => Some("{}".into()),
+                None => None,
+            };
             (
                 Access::Public,
                 Declaration::Var(Var {
-                    ty: fields.get(&name).unwrap().cpp_type().unwrap(),
+                    ty: the_struct.fields.get(&name).unwrap().cpp_type().unwrap(),
                     name: ident(&name),
+                    init,
                     ..Default::default()
                 }),
             )

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -16,13 +16,14 @@ pub fn generate(
     config: Config,
     compiler_config: &CompilerConfiguration,
 ) -> std::io::Result<File> {
-    let mut file = super::cpp::generate_types(&doc.used_types.borrow().structs_and_enums, &config);
+    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+
+    let mut file =
+        super::cpp::generate_types(&doc.used_types.borrow().structs_and_enums, &config, &llr);
 
     file.includes.push("<private/slint_live_preview.h>".into());
 
     generate_value_conversions(&mut file, &doc.used_types.borrow().structs_and_enums);
-
-    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
 
     let main_file = doc
         .node

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3706,16 +3706,38 @@ fn compile_array_index_assignment(expr: &Expression, ctx: &EvaluationContext) ->
 
 #[inline(never)]
 fn compile_binary_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
-    let Expression::BinaryExpression { lhs, rhs, op } = expr else { unreachable!() };
-    let lhs_ty = lhs.ty(ctx);
-    let lhs = compile_expression_to_value_no_parenthesis(lhs, ctx);
+    // Long chains of binary operators, such as `a && b && c && ...`, nest on the
+    // left side. Iterate that spine instead of recursing into it, so that the
+    // stack depth stays bounded no matter how long the chain is.
+    let mut spine = Vec::new();
+    let mut node = expr;
+    while let Expression::BinaryExpression { lhs, rhs, op } = node {
+        spine.push((rhs, *op));
+        node = lhs;
+    }
+    let mut result = compile_expression_to_value_no_parenthesis(node, ctx);
+    let mut result_ty = node.ty(ctx);
+    for (rhs, op) in spine.into_iter().rev() {
+        result = compile_binary_operator(result, &result_ty, rhs, op, ctx);
+        result_ty = llr::binary_expression_ty(op, || result_ty);
+    }
+    result
+}
+
+fn compile_binary_operator(
+    lhs: TokenStream,
+    lhs_ty: &Type,
+    rhs: &Expression,
+    op: char,
+    ctx: &EvaluationContext,
+) -> TokenStream {
     let rhs = compile_expression_to_value_no_parenthesis(rhs, ctx);
 
-    if lhs_ty.as_unit_product().is_some() && (*op == '=' || *op == '!') {
-        let maybe_negate = if *op == '!' { quote!(!) } else { quote!() };
+    if lhs_ty.as_unit_product().is_some() && (op == '=' || op == '!') {
+        let maybe_negate = if op == '!' { quote!(!) } else { quote!() };
         quote!(#maybe_negate sp::ApproxEq::<f64>::approx_eq(&(#lhs as f64), &(#rhs as f64)))
     } else {
-        let (conv1, conv2) = match crate::expression_tree::operator_class(*op) {
+        let (conv1, conv2) = match crate::expression_tree::operator_class(op) {
             OperatorClass::ArithmeticOp => match lhs_ty {
                 Type::String => (None, Some(quote!(.as_str()))),
                 Type::Struct { .. } => (None, None),
@@ -3747,7 +3769,7 @@ fn compile_binary_expression(expr: &Expression, ctx: &EvaluationContext) -> Toke
             '&' => quote!(&&),
             '|' => quote!(||),
             _ => proc_macro2::TokenTree::Punct(proc_macro2::Punct::new(
-                *op,
+                op,
                 proc_macro2::Spacing::Alone,
             ))
             .into(),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -17,6 +17,7 @@ use crate::CompilerConfiguration;
 use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp, OperatorClass};
 use crate::langtype::{Enumeration, EnumerationValue, Struct, StructName, Type};
 use crate::layout::Orientation;
+use crate::llr::lower_expression::lower_constant_expression;
 use crate::llr::{
     self, ArrayOutput, EvaluationContext as llr_EvaluationContext, EvaluationScope, Expression,
     ParentScope, TypeResolutionContext as _,
@@ -205,14 +206,14 @@ pub fn generate(
             .collect::<Vec<_>>()
     };
 
-    let (structs_and_enums_ids, inner_module) =
-        generate_types(&doc.used_types.borrow().structs_and_enums);
-
     let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
 
     if llr.public_components.is_empty() {
         return Ok(Default::default());
     }
+
+    let (structs_and_enums_ids, inner_module) =
+        generate_types(&doc.used_types.borrow().structs_and_enums, &llr);
 
     let sub_compos = llr
         .used_sub_components
@@ -295,13 +296,16 @@ pub(super) fn generate_module_header() -> TokenStream {
 }
 
 /// Generate the struct and enums. Return a vector of names to import and a token stream with the inner module
-pub fn generate_types(used_types: &[Type]) -> (Vec<Ident>, TokenStream) {
+pub fn generate_types(
+    used_types: &[Type],
+    unit: &llr::CompilationUnit,
+) -> (Vec<Ident>, TokenStream) {
     let (structs_and_enums_ids, structs_and_enum_def): (Vec<_>, Vec<_>) = used_types
         .iter()
         .filter_map(|ty| match ty {
             Type::Struct(s) => match s.as_ref() {
-                Struct { fields, name: struct_name @ StructName::User { name, .. } } => {
-                    Some((ident(name), generate_struct(struct_name, fields)))
+                the_struct @ Struct { name: StructName::User { name, .. }, .. } => {
+                    Some((ident(name), generate_struct(the_struct, unit)))
                 }
                 _ => None,
             },
@@ -704,12 +708,17 @@ fn generate_shared_globals(
     }
 }
 
-fn generate_struct(name: &StructName, fields: &BTreeMap<SmolStr, Type>) -> TokenStream {
-    let component_id = struct_name_to_tokens(name).unwrap();
-    let (declared_property_vars, declared_property_types): (Vec<_>, Vec<_>) =
-        fields.iter().map(|(name, ty)| (ident(name), rust_primitive_type(ty).unwrap())).unzip();
+fn generate_struct(the_struct: &Struct, unit: &llr::CompilationUnit) -> TokenStream {
+    let component_id = struct_name_to_tokens(&the_struct.name).unwrap();
+    let (declared_property_vars, declared_property_types): (Vec<_>, Vec<_>) = the_struct
+        .fields
+        .iter()
+        .map(|(name, ty)| (ident(name), rust_primitive_type(ty).unwrap()))
+        .unzip();
 
-    let StructName::User { name, node } = name else { unreachable!("generating non-user struct") };
+    let StructName::User { name, node } = &the_struct.name else {
+        unreachable!("generating non-user struct")
+    };
 
     let attributes =
         node.parent().and_then(crate::parser::syntax_nodes::StructDeclaration::new).map(|node| {
@@ -728,12 +737,47 @@ fn generate_struct(name: &StructName, fields: &BTreeMap<SmolStr, Type>) -> Token
             quote! { #(#attrs)* }
         });
 
+    // With user-declared field default values, `Default` cannot be derived anymore
+    let default_impl = (!the_struct.field_defaults.is_empty()).then(|| {
+        // Constant expressions cannot access the globals; make sure a bug in that
+        // assumption breaks the build of the generated code with a clear message
+        let ctx = EvaluationContext::new_const(
+            unit,
+            RustGeneratorContext {
+                global_access: quote!(compile_error!("no global access in a constant expression")),
+            },
+        );
+        let (field_names, field_values): (Vec<_>, Vec<_>) = the_struct
+            .fields
+            .keys()
+            .map(|field_name| {
+                let value = match the_struct.field_defaults.get(field_name) {
+                    Some(expr) => {
+                        let value = compile_expression(&lower_constant_expression(expr), &ctx);
+                        quote!(#value as _)
+                    }
+                    None => quote!(::core::default::Default::default()),
+                };
+                (ident(field_name), value)
+            })
+            .unzip();
+        quote! {
+            impl ::core::default::Default for #component_id {
+                fn default() -> Self {
+                    Self { #(#field_names: #field_values,)* }
+                }
+            }
+        }
+    });
+    let default_derive = default_impl.is_none().then(|| quote!(Default,));
+
     quote! {
         #attributes
-        #[derive(Default, PartialEq, Debug, Clone)]
+        #[derive(#default_derive PartialEq, Debug, Clone)]
         pub struct #component_id {
             #(pub #declared_property_vars : #declared_property_types),*
         }
+        #default_impl
     }
 }
 

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -17,9 +17,6 @@ pub fn generate(
 ) -> std::io::Result<TokenStream> {
     let module_header = super::rust::generate_module_header();
 
-    let (structs_and_enums_ids, inner_module) =
-        super::rust::generate_types(&doc.used_types.borrow().structs_and_enums);
-
     let type_value_conversions =
         generate_value_conversions(&doc.used_types.borrow().structs_and_enums);
 
@@ -28,6 +25,9 @@ pub fn generate(
     if llr.public_components.is_empty() {
         return Ok(Default::default());
     }
+
+    let (structs_and_enums_ids, inner_module) =
+        super::rust::generate_types(&doc.used_types.borrow().structs_and_enums, &llr);
 
     let main_file = doc
         .node

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -998,14 +998,126 @@ impl From<BuiltinStruct> for StructName {
 #[derive(Debug, Clone)]
 pub struct Struct {
     pub fields: BTreeMap<SmolStr, Type>,
+    /// User-declared default values for fields (`struct Foo { bar: int = 42 }`).
+    /// The expressions are resolved, converted to the field type, and constant-folded.
+    /// Like the syntax node in `name`, this is ignored by `Type`'s equality comparison.
+    pub field_defaults: BTreeMap<SmolStr, ConstantExpression>,
     pub name: StructName,
 }
 
 impl Struct {
+    /// Create a struct without user-declared field default values
+    /// (only named struct declarations in .slint can have those).
+    pub fn new(fields: BTreeMap<SmolStr, Type>, name: impl Into<StructName>) -> Self {
+        Self { fields, field_defaults: Default::default(), name: name.into() }
+    }
+
     pub fn node(&self) -> Option<&syntax_nodes::ObjectType> {
         match &self.name {
             StructName::User { node, .. } => Some(node),
             _ => None,
+        }
+    }
+
+    /// The default value for the given field: the user-declared default if there is one,
+    /// otherwise the default value for the field's type.
+    pub fn default_value_for_field(&self, name: &SmolStr) -> Expression {
+        self.field_defaults.get(name).map(ConstantExpression::to_expression).unwrap_or_else(|| {
+            Expression::default_value_for_type(
+                self.fields.get(name).expect("default value requested for unknown struct field"),
+            )
+        })
+    }
+}
+
+/// A constant expression, used for the default values of struct fields
+/// (see [`Struct::field_defaults`]).
+///
+/// This is deliberately neither [`Expression`] nor an llr expression:
+/// unlike those, it cannot reference any properties, elements, or syntax nodes,
+/// so a [`Struct`] carrying one can safely outlive the object tree.
+/// The variants are the subset that every consumer can materialize.
+/// Keep the matches over this type exhaustive,
+/// so that adding a variant is a compile error in each consumer:
+/// the conversion to an expression tree ([`Self::to_expression`]),
+/// the lowering for the code generators (`lower_constant_expression` in the llr module),
+/// and the interpreter's evaluator (`eval_constant_expression` there).
+#[derive(Debug, Clone)]
+pub enum ConstantExpression {
+    StringLiteral(SmolStr),
+    /// A number and its unit, in normalized form
+    NumberLiteral(f64, Unit),
+    BoolLiteral(bool),
+    EnumerationValue(EnumerationValue),
+    Cast {
+        from: Box<ConstantExpression>,
+        to: Type,
+    },
+    UnaryOp {
+        sub: Box<ConstantExpression>,
+        op: char,
+    },
+    Struct {
+        ty: Rc<Struct>,
+        values: BTreeMap<SmolStr, ConstantExpression>,
+    },
+    Array {
+        element_ty: Type,
+        values: Vec<ConstantExpression>,
+    },
+}
+
+impl ConstantExpression {
+    /// Create a constant expression from a resolved, converted, and constant-folded
+    /// expression, or `None` if the expression is not in the constant subset.
+    pub fn from_expression(expression: &Expression) -> Option<Self> {
+        Some(match expression {
+            Expression::StringLiteral(s) => Self::StringLiteral(s.clone()),
+            Expression::NumberLiteral(n, unit) => Self::NumberLiteral(*n, *unit),
+            Expression::BoolLiteral(b) => Self::BoolLiteral(*b),
+            Expression::EnumerationValue(e) => Self::EnumerationValue(e.clone()),
+            Expression::Cast { from, to } => {
+                Self::Cast { from: Box::new(Self::from_expression(from)?), to: to.clone() }
+            }
+            Expression::UnaryOp { sub, op } => {
+                Self::UnaryOp { sub: Box::new(Self::from_expression(sub)?), op: *op }
+            }
+            Expression::Struct { ty, values } => Self::Struct {
+                ty: ty.clone(),
+                values: values
+                    .iter()
+                    .map(|(k, v)| Some((k.clone(), Self::from_expression(v)?)))
+                    .collect::<Option<_>>()?,
+            },
+            Expression::Array { element_ty, values } => Self::Array {
+                element_ty: element_ty.clone(),
+                values: values.iter().map(Self::from_expression).collect::<Option<_>>()?,
+            },
+            _ => return None,
+        })
+    }
+
+    /// The expression tree form, for splicing the constant into bindings at compile time
+    pub fn to_expression(&self) -> Expression {
+        match self {
+            Self::StringLiteral(s) => Expression::StringLiteral(s.clone()),
+            Self::NumberLiteral(n, unit) => Expression::NumberLiteral(*n, *unit),
+            Self::BoolLiteral(b) => Expression::BoolLiteral(*b),
+            Self::EnumerationValue(e) => Expression::EnumerationValue(e.clone()),
+            Self::Cast { from, to } => {
+                Expression::Cast { from: Box::new(from.to_expression()), to: to.clone() }
+            }
+            Self::UnaryOp { sub, op } => {
+                Expression::UnaryOp { sub: Box::new(sub.to_expression()), op: *op }
+            }
+            Self::Struct { ty, values } => Expression::Struct {
+                ty: ty.clone(),
+                values: values.iter().map(|(k, v)| (k.clone(), v.to_expression())).collect(),
+            },
+            Self::Array { element_ty, values } => Expression::Array {
+                element_ty: element_ty.clone(),
+                values: values.iter().map(Self::to_expression).collect(),
+            },
         }
     }
 }

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -343,6 +343,7 @@ pub async fn compile_syntax_node(
         &mut diagnostics,
         &type_registry,
         ignore_missing_font_files,
+        &loader.symbol_counters,
     );
 
     if !diagnostics.has_errors() {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -314,6 +314,17 @@ pub enum Expression {
     },
 }
 
+/// The type of a binary expression with the given operator:
+/// comparison and logic operators produce a bool,
+/// while the arithmetic operators keep the type of the left operand
+pub fn binary_expression_ty(op: char, lhs_ty: impl FnOnce() -> Type) -> Type {
+    if crate::expression_tree::operator_class(op) != OperatorClass::ArithmeticOp {
+        Type::Bool
+    } else {
+        lhs_ty()
+    }
+}
+
 impl Expression {
     pub fn default_value_for_type(ty: &Type) -> Option<Self> {
         Some(match ty {
@@ -425,13 +436,7 @@ impl Expression {
             Self::ModelDataAssignment { .. } => Type::Void,
             Self::ArrayIndexAssignment { .. } => Type::Void,
             Self::SliceIndexAssignment { .. } => Type::Void,
-            Self::BinaryExpression { lhs, rhs: _, op } => {
-                if crate::expression_tree::operator_class(*op) != OperatorClass::ArithmeticOp {
-                    Type::Bool
-                } else {
-                    lhs.ty(ctx)
-                }
-            }
+            Self::BinaryExpression { lhs, rhs: _, op } => binary_expression_ty(*op, || lhs.ty(ctx)),
             Self::UnaryOp { sub, .. } => sub.ty(ctx),
             Self::ImageReference { .. } => Type::Image,
             Self::Condition { false_expr, .. } => false_expr.ty(ctx),

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -356,7 +356,15 @@ impl Expression {
                 values: s
                     .fields
                     .iter()
-                    .map(|(k, v)| Some((k.clone(), Expression::default_value_for_type(v)?)))
+                    .map(|(k, v)| {
+                        let value = match s.field_defaults.get(k) {
+                            Some(default_value) => {
+                                super::lower_expression::lower_constant_expression(default_value)
+                            }
+                            None => Expression::default_value_for_type(v)?,
+                        };
+                        Some((k.clone(), value))
+                    })
                     .collect::<Option<_>>()?,
             },
             Type::Easing => Expression::EasingCurve(crate::expression_tree::EasingCurve::default()),
@@ -711,6 +719,9 @@ pub enum EvaluationScope<'a> {
     SubComponent(SubComponentIdx, Option<&'a ParentScope<'a>>),
     /// The evaluation context is in a global
     Global(GlobalIdx),
+    /// The evaluation context is a constant expression that cannot reference any
+    /// properties or elements, such as the default value of a struct field
+    Const,
 }
 
 #[derive(Clone)]
@@ -746,6 +757,18 @@ impl<'a, T> EvaluationContext<'a, T> {
         Self {
             compilation_unit,
             current_scope: EvaluationScope::Global(global),
+            generator_state,
+            argument_types: &[],
+        }
+    }
+
+    /// A context for compiling a constant expression that cannot reference any
+    /// properties or elements, such as the default value of a struct field
+    /// (see [`crate::langtype::Struct::field_defaults`])
+    pub fn new_const(compilation_unit: &'a super::CompilationUnit, generator_state: T) -> Self {
+        Self {
+            compilation_unit,
+            current_scope: EvaluationScope::Const,
             generator_state,
             argument_types: &[],
         }
@@ -873,6 +896,9 @@ impl<'a, T> EvaluationContext<'a, T> {
                             local_reference,
                             ContextMap::from_parent_level(*parent_level),
                         )
+                    }
+                    EvaluationScope::Const => {
+                        panic!("property reference in a constant expression")
                     }
                 }
             }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -16,7 +16,7 @@ use super::{Animation, LocalMemberReference, MemberReference, PropertyIdx};
 use crate::expression_tree::{
     BuiltinFunction, Callable, Expression as tree_Expression, MouseCursorInner,
 };
-use crate::langtype::{BuiltinStruct, Struct, StructName, Type};
+use crate::langtype::{BuiltinStruct, ConstantExpression, Struct, StructName, Type};
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
 use crate::namedreference::NamedReference;
@@ -65,6 +65,33 @@ impl ExpressionLoweringCtx<'_> {
 impl super::TypeResolutionContext for ExpressionLoweringCtx<'_> {
     fn property_ty(&self, _: &MemberReference) -> &Type {
         unimplemented!()
+    }
+}
+
+/// Lower a constant expression, such as the default value of a struct field
+/// (see [`crate::langtype::Struct::field_defaults`]),
+/// so that the code generators can compile it with their regular expression compilation.
+pub fn lower_constant_expression(expression: &ConstantExpression) -> llr_Expression {
+    match expression {
+        ConstantExpression::StringLiteral(s) => llr_Expression::StringLiteral(s.clone()),
+        ConstantExpression::NumberLiteral(n, _unit) => llr_Expression::NumberLiteral(*n),
+        ConstantExpression::BoolLiteral(b) => llr_Expression::BoolLiteral(*b),
+        ConstantExpression::EnumerationValue(e) => llr_Expression::EnumerationValue(e.clone()),
+        ConstantExpression::Cast { from, to } => {
+            llr_Expression::Cast { from: Box::new(lower_constant_expression(from)), to: to.clone() }
+        }
+        ConstantExpression::UnaryOp { sub, op } => {
+            llr_Expression::UnaryOp { sub: Box::new(lower_constant_expression(sub)), op: *op }
+        }
+        ConstantExpression::Struct { ty, values } => llr_Expression::Struct {
+            ty: ty.clone(),
+            values: values.iter().map(|(k, v)| (k.clone(), lower_constant_expression(v))).collect(),
+        },
+        ConstantExpression::Array { element_ty, values } => llr_Expression::Array {
+            element_ty: element_ty.clone(),
+            values: values.iter().map(lower_constant_expression).collect(),
+            output: llr_ArrayOutput::Model,
+        },
     }
 }
 
@@ -601,10 +628,7 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
     }
 
     fn animation_ty() -> Rc<Struct> {
-        Rc::new(Struct {
-            fields: animation_fields().collect(),
-            name: BuiltinStruct::PropertyAnimation.into(),
-        })
+        Rc::new(Struct::new(animation_fields().collect(), BuiltinStruct::PropertyAnimation))
     }
 
     match a {
@@ -645,15 +669,15 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             }
             let result = llr_Expression::Struct {
                 // This is going to be a tuple
-                ty: Rc::new(Struct {
-                    fields: IntoIterator::into_iter([
+                ty: Rc::new(Struct::new(
+                    IntoIterator::into_iter([
                         (SmolStr::new_static("0"), animation_ty),
                         // The type is an instant, which does not exist in our type system
                         (SmolStr::new_static("1"), Type::Invalid),
                     ])
                     .collect(),
-                    name: StructName::None,
-                }),
+                    StructName::None,
+                )),
                 values: IntoIterator::into_iter([
                     (SmolStr::new_static("0"), get_anim),
                     (
@@ -696,14 +720,14 @@ fn compile_path(
             let converted_elements = elements
                 .iter()
                 .map(|element| {
-                    let element_type = Rc::new(Struct {
-                        fields: element
+                    let element_type = Rc::new(Struct::new(
+                        element
                             .element_type
                             .properties
                             .iter()
                             .map(|(k, v)| (k.clone(), v.ty.clone()))
                             .collect(),
-                        name: StructName::Builtin(
+                        StructName::Builtin(
                             element
                                 .element_type
                                 .native_class
@@ -711,7 +735,7 @@ fn compile_path(
                                 .clone()
                                 .expect("path elements should have a native_type"),
                         ),
-                    });
+                    ));
 
                     llr_Expression::Struct {
                         ty: element_type,
@@ -754,14 +778,14 @@ fn compile_path(
 
             llr_Expression::Cast {
                 from: llr_Expression::Struct {
-                    ty: Rc::new(Struct {
-                        fields: IntoIterator::into_iter([
+                    ty: Rc::new(Struct::new(
+                        IntoIterator::into_iter([
                             (SmolStr::new_static("events"), Type::Array(event_type.clone().into())),
                             (SmolStr::new_static("points"), Type::Array(point_type.clone().into())),
                         ])
                         .collect(),
-                        name: StructName::None,
-                    }),
+                        StructName::None,
+                    )),
                     values: IntoIterator::into_iter([
                         (
                             SmolStr::new_static("events"),
@@ -804,5 +828,5 @@ pub fn make_struct(
         values.insert(SmolStr::new(name), expr);
     }
 
-    llr_Expression::Struct { ty: Rc::new(Struct { fields, name: name.into() }), values }
+    llr_Expression::Struct { ty: Rc::new(Struct::new(fields, name)), values }
 }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -95,6 +95,10 @@ pub fn lower_constant_expression(expression: &ConstantExpression) -> llr_Express
     }
 }
 
+/// The body of every non-trivial match arm lives in its own `#[inline(never)]`
+/// helper function: this function recurses for nested expressions, and with all
+/// arm bodies inlined, its stack frame in unoptimized builds becomes so large
+/// that deeply nested expressions overflow the stack.
 pub fn lower_expression(
     expression: &tree_Expression,
     ctx: &mut ExpressionLoweringCtx<'_>,
@@ -110,26 +114,7 @@ pub fn lower_expression(
         tree_Expression::PropertyReference(nr) => {
             llr_Expression::PropertyReference(ctx.map_property_reference(nr))
         }
-        tree_Expression::ElementReference(e) => {
-            let elem = e.upgrade().unwrap();
-            let enclosing = elem.borrow().enclosing_component.upgrade().unwrap();
-            // When within a ShowPopupMenu builtin function, this is a reference to the root of the menu item tree
-            if Rc::ptr_eq(&elem, &enclosing.root_element)
-                && let Some(idx) = ctx
-                    .component
-                    .menu_item_tree
-                    .borrow()
-                    .iter()
-                    .position(|c| Rc::ptr_eq(c, &enclosing))
-            {
-                return llr_Expression::NumberLiteral(idx as _);
-            }
-
-            // We map an element reference to a reference to the property "" inside that native item
-            llr_Expression::PropertyReference(
-                ctx.map_property_reference(&NamedReference::new(&elem, SmolStr::default())),
-            )
-        }
+        tree_Expression::ElementReference(_) => lower_element_reference(expression, ctx),
         tree_Expression::RepeaterIndexReference { element } => llr_Expression::PropertyReference(
             repeater_special_property(element, ctx.component, PropertyIdx::REPEATER_INDEX),
         ),
@@ -160,61 +145,11 @@ pub fn lower_expression(
         tree_Expression::CodeBlock(expr) => {
             llr_Expression::CodeBlock(expr.iter().map(|e| lower_expression(e, ctx)).collect::<_>())
         }
-        tree_Expression::FunctionCall { function, arguments, .. } => match function {
-            Callable::Builtin(BuiltinFunction::RestartTimer) => lower_restart_timer(arguments),
-            Callable::Builtin(BuiltinFunction::ShowPopupWindow) => {
-                lower_show_popup_window(arguments, ctx)
-            }
-            Callable::Builtin(BuiltinFunction::ClosePopupWindow) => {
-                lower_close_popup_window(arguments, ctx)
-            }
-            Callable::Builtin(f) => {
-                let mut arguments =
-                    arguments.iter().map(|e| lower_expression(e, ctx)).collect::<Vec<_>>();
-                // https://github.com/rust-lang/rust-clippy/issues/16191
-                #[allow(clippy::collapsible_if)]
-                if *f == BuiltinFunction::Translate {
-                    if let llr_Expression::Array { output, .. } = &mut arguments[3] {
-                        *output = llr_ArrayOutput::Slice;
-                    }
-                    #[cfg(feature = "bundle-translations")]
-                    if let Some(translation_builder) = ctx.state.translation_builder.as_mut() {
-                        return translation_builder.lower_translate_call(arguments);
-                    }
-                }
-                if *f == BuiltinFunction::ParseMarkdown
-                    && let Some(llr_Expression::Array { output, .. }) = &mut arguments.get_mut(1)
-                {
-                    *output = llr_ArrayOutput::Slice;
-                }
-                llr_Expression::BuiltinFunctionCall { function: f.clone(), arguments }
-            }
-            Callable::Callback(nr) => {
-                let arguments = arguments.iter().map(|e| lower_expression(e, ctx)).collect::<_>();
-                llr_Expression::CallBackCall { callback: ctx.map_property_reference(nr), arguments }
-            }
-            Callable::Function(nr)
-                if nr
-                    .element()
-                    .borrow()
-                    .native_class()
-                    .is_some_and(|n| n.properties.contains_key(nr.name())) =>
-            {
-                llr_Expression::ItemMemberFunctionCall { function: ctx.map_property_reference(nr) }
-            }
-            Callable::Function(nr) => {
-                let arguments = arguments.iter().map(|e| lower_expression(e, ctx)).collect::<_>();
-                llr_Expression::FunctionCall { function: ctx.map_property_reference(nr), arguments }
-            }
-        },
+        tree_Expression::FunctionCall { .. } => lower_function_call(expression, ctx),
         tree_Expression::SelfAssignment { lhs, rhs, op, .. } => {
             lower_assignment(lhs, rhs, *op, ctx)
         }
-        tree_Expression::BinaryExpression { lhs, rhs, op } => llr_Expression::BinaryExpression {
-            lhs: Box::new(lower_expression(lhs, ctx)),
-            rhs: Box::new(lower_expression(rhs, ctx)),
-            op: *op,
-        },
+        tree_Expression::BinaryExpression { .. } => lower_binary_expression(expression, ctx),
         tree_Expression::UnaryOp { sub, op } => {
             llr_Expression::UnaryOp { sub: Box::new(lower_expression(sub, ctx)), op: *op }
         }
@@ -224,25 +159,7 @@ pub fn lower_expression(
                 nine_slice: *nine_slice,
             }
         }
-        tree_Expression::Condition { condition, true_expr, false_expr } => {
-            let (true_ty, false_ty) = (true_expr.ty(), false_expr.ty());
-            llr_Expression::Condition {
-                condition: Box::new(lower_expression(condition, ctx)),
-                true_expr: Box::new(lower_expression(true_expr, ctx)),
-                false_expr: if false_ty == Type::Invalid
-                    || false_ty == Type::Void
-                    || true_ty == false_ty
-                {
-                    Box::new(lower_expression(false_expr, ctx))
-                } else {
-                    // Because the type of the Condition is based on the false expression, we need to insert a cast
-                    Box::new(llr_Expression::Cast {
-                        from: Box::new(lower_expression(false_expr, ctx)),
-                        to: Type::Void,
-                    })
-                },
-            }
-        }
+        tree_Expression::Condition { .. } => lower_condition(expression, ctx),
         tree_Expression::Array { element_ty, values } => llr_Expression::Array {
             element_ty: if *element_ty == Type::Void { Type::Int32 } else { element_ty.clone() },
             values: values.iter().map(|e| lower_expression(e, ctx)).collect::<_>(),
@@ -257,84 +174,19 @@ pub fn lower_expression(
         },
         tree_Expression::PathData(data) => compile_path(data, ctx),
         tree_Expression::EasingCurve(x) => llr_Expression::EasingCurve(x.clone()),
-        tree_Expression::MouseCursor(cursor) => llr_Expression::MouseCursor(match cursor {
-            MouseCursorInner::BuiltIn(expression) => {
-                crate::llr::MouseCursorInner::BuiltIn(Box::new(lower_expression(expression, ctx)))
-            }
-            MouseCursorInner::CustomMouseCursor { image, hotspot_x, hotspot_y } => {
-                crate::llr::MouseCursorInner::CustomMouseCursor {
-                    image: Box::new(lower_expression(image, ctx)),
-                    hotspot_x: Box::new(lower_expression(hotspot_x, ctx)),
-                    hotspot_y: Box::new(lower_expression(hotspot_y, ctx)),
-                }
-            }
-        }),
-        tree_Expression::LinearGradient { angle, stops } => llr_Expression::LinearGradient {
-            angle: Box::new(lower_expression(angle, ctx)),
-            stops: stops
-                .iter()
-                .map(|(a, b)| (lower_expression(a, ctx), lower_expression(b, ctx)))
-                .collect::<_>(),
-        },
-        tree_Expression::RadialGradient { center, radius, stops } => {
-            llr_Expression::RadialGradient {
-                center: center.as_ref().map(|(cx, cy)| {
-                    (Box::new(lower_expression(cx, ctx)), Box::new(lower_expression(cy, ctx)))
-                }),
-                radius: radius.as_ref().map(|r| Box::new(lower_expression(r, ctx))),
-                stops: stops
-                    .iter()
-                    .map(|(a, b)| (lower_expression(a, ctx), lower_expression(b, ctx)))
-                    .collect::<_>(),
-            }
-        }
-        tree_Expression::ConicGradient { from_angle, center, stops } => {
-            llr_Expression::ConicGradient {
-                from_angle: Box::new(lower_expression(from_angle, ctx)),
-                center: center.as_ref().map(|(cx, cy)| {
-                    (Box::new(lower_expression(cx, ctx)), Box::new(lower_expression(cy, ctx)))
-                }),
-                stops: stops
-                    .iter()
-                    .map(|(a, b)| (lower_expression(a, ctx), lower_expression(b, ctx)))
-                    .collect::<_>(),
-            }
-        }
+        tree_Expression::MouseCursor(_) => lower_mouse_cursor(expression, ctx),
+        tree_Expression::LinearGradient { .. } => lower_linear_gradient(expression, ctx),
+        tree_Expression::RadialGradient { .. } => lower_radial_gradient(expression, ctx),
+        tree_Expression::ConicGradient { .. } => lower_conic_gradient(expression, ctx),
         tree_Expression::EnumerationValue(e) => llr_Expression::EnumerationValue(e.clone()),
         tree_Expression::Keys(ks) => llr_Expression::KeysLiteral(ks.clone()),
         tree_Expression::ReturnStatement(..) => {
             panic!("The remove return pass should have removed all return")
         }
-        tree_Expression::LayoutCacheAccess {
-            layout_cache_prop,
-            index,
-            repeater_index,
-            entries_per_item,
-        } => llr_Expression::LayoutCacheAccess {
-            layout_cache_prop: ctx.map_property_reference(layout_cache_prop),
-            index: *index,
-            repeater_index: repeater_index.as_ref().map(|e| lower_expression(e, ctx).into()),
-            entries_per_item: *entries_per_item,
-        },
-        tree_Expression::GridRepeaterCacheAccess {
-            layout_cache_prop,
-            index,
-            repeater_index,
-            stride,
-            child_offset,
-            inner_repeater_index,
-            entries_per_item,
-        } => llr_Expression::GridRepeaterCacheAccess {
-            layout_cache_prop: ctx.map_property_reference(layout_cache_prop),
-            index: *index,
-            repeater_index: lower_expression(repeater_index, ctx).into(),
-            stride: lower_expression(stride, ctx).into(),
-            child_offset: *child_offset,
-            inner_repeater_index: inner_repeater_index
-                .as_ref()
-                .map(|e| lower_expression(e, ctx).into()),
-            entries_per_item: *entries_per_item,
-        },
+        tree_Expression::LayoutCacheAccess { .. } => lower_layout_cache_access(expression, ctx),
+        tree_Expression::GridRepeaterCacheAccess { .. } => {
+            lower_grid_repeater_cache_access(expression, ctx)
+        }
         tree_Expression::OrganizeGridLayout(l) => organize_grid_layout(l, ctx),
         tree_Expression::ComputeBoxLayoutInfo { layout, orientation, cross_axis_size } => {
             compute_box_layout_info(layout, *orientation, ctx, cross_axis_size.as_deref())
@@ -368,6 +220,261 @@ pub fn lower_expression(
         tree_Expression::EmptyComponentFactory => llr_Expression::EmptyComponentFactory,
         tree_Expression::EmptyDataTransfer => llr_Expression::EmptyDataTransfer,
         tree_Expression::DebugHook { expression, .. } => lower_expression(expression, ctx),
+    }
+}
+
+#[inline(never)]
+fn lower_binary_expression(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    // Long chains of binary operators, such as `a && b && c && ...`, nest on the
+    // left side. Iterate that spine instead of recursing into it, so that the
+    // stack depth stays bounded no matter how long the chain is.
+    let mut spine = Vec::new();
+    let mut node = expression;
+    while let tree_Expression::BinaryExpression { lhs, rhs, op } = node {
+        spine.push((rhs, *op));
+        node = lhs;
+    }
+    let mut result = lower_expression(node, ctx);
+    for (rhs, op) in spine.into_iter().rev() {
+        result = llr_Expression::BinaryExpression {
+            lhs: Box::new(result),
+            rhs: Box::new(lower_expression(rhs, ctx)),
+            op,
+        };
+    }
+    result
+}
+
+#[inline(never)]
+fn lower_element_reference(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::ElementReference(e) = expression else { unreachable!() };
+    let elem = e.upgrade().unwrap();
+    let enclosing = elem.borrow().enclosing_component.upgrade().unwrap();
+    // When within a ShowPopupMenu builtin function, this is a reference to the root of the menu item tree
+    if Rc::ptr_eq(&elem, &enclosing.root_element)
+        && let Some(idx) =
+            ctx.component.menu_item_tree.borrow().iter().position(|c| Rc::ptr_eq(c, &enclosing))
+    {
+        return llr_Expression::NumberLiteral(idx as _);
+    }
+
+    // We map an element reference to a reference to the property "" inside that native item
+    llr_Expression::PropertyReference(
+        ctx.map_property_reference(&NamedReference::new(&elem, SmolStr::default())),
+    )
+}
+
+#[inline(never)]
+fn lower_function_call(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::FunctionCall { function, arguments, .. } = expression else {
+        unreachable!()
+    };
+    match function {
+        Callable::Builtin(BuiltinFunction::RestartTimer) => lower_restart_timer(arguments),
+        Callable::Builtin(BuiltinFunction::ShowPopupWindow) => {
+            lower_show_popup_window(arguments, ctx)
+        }
+        Callable::Builtin(BuiltinFunction::ClosePopupWindow) => {
+            lower_close_popup_window(arguments, ctx)
+        }
+        Callable::Builtin(f) => {
+            let mut arguments =
+                arguments.iter().map(|e| lower_expression(e, ctx)).collect::<Vec<_>>();
+            // https://github.com/rust-lang/rust-clippy/issues/16191
+            #[allow(clippy::collapsible_if)]
+            if *f == BuiltinFunction::Translate {
+                if let llr_Expression::Array { output, .. } = &mut arguments[3] {
+                    *output = llr_ArrayOutput::Slice;
+                }
+                #[cfg(feature = "bundle-translations")]
+                if let Some(translation_builder) = ctx.state.translation_builder.as_mut() {
+                    return translation_builder.lower_translate_call(arguments);
+                }
+            }
+            if *f == BuiltinFunction::ParseMarkdown
+                && let Some(llr_Expression::Array { output, .. }) = &mut arguments.get_mut(1)
+            {
+                *output = llr_ArrayOutput::Slice;
+            }
+            llr_Expression::BuiltinFunctionCall { function: f.clone(), arguments }
+        }
+        Callable::Callback(nr) => {
+            let arguments = arguments.iter().map(|e| lower_expression(e, ctx)).collect::<_>();
+            llr_Expression::CallBackCall { callback: ctx.map_property_reference(nr), arguments }
+        }
+        Callable::Function(nr)
+            if nr
+                .element()
+                .borrow()
+                .native_class()
+                .is_some_and(|n| n.properties.contains_key(nr.name())) =>
+        {
+            llr_Expression::ItemMemberFunctionCall { function: ctx.map_property_reference(nr) }
+        }
+        Callable::Function(nr) => {
+            let arguments = arguments.iter().map(|e| lower_expression(e, ctx)).collect::<_>();
+            llr_Expression::FunctionCall { function: ctx.map_property_reference(nr), arguments }
+        }
+    }
+}
+
+#[inline(never)]
+fn lower_condition(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::Condition { condition, true_expr, false_expr } = expression else {
+        unreachable!()
+    };
+    let (true_ty, false_ty) = (true_expr.ty(), false_expr.ty());
+    llr_Expression::Condition {
+        condition: Box::new(lower_expression(condition, ctx)),
+        true_expr: Box::new(lower_expression(true_expr, ctx)),
+        false_expr: if false_ty == Type::Invalid || false_ty == Type::Void || true_ty == false_ty {
+            Box::new(lower_expression(false_expr, ctx))
+        } else {
+            // Because the type of the Condition is based on the false expression, we need to insert a cast
+            Box::new(llr_Expression::Cast {
+                from: Box::new(lower_expression(false_expr, ctx)),
+                to: Type::Void,
+            })
+        },
+    }
+}
+
+#[inline(never)]
+fn lower_mouse_cursor(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::MouseCursor(cursor) = expression else { unreachable!() };
+    llr_Expression::MouseCursor(match cursor {
+        MouseCursorInner::BuiltIn(expression) => {
+            crate::llr::MouseCursorInner::BuiltIn(Box::new(lower_expression(expression, ctx)))
+        }
+        MouseCursorInner::CustomMouseCursor { image, hotspot_x, hotspot_y } => {
+            crate::llr::MouseCursorInner::CustomMouseCursor {
+                image: Box::new(lower_expression(image, ctx)),
+                hotspot_x: Box::new(lower_expression(hotspot_x, ctx)),
+                hotspot_y: Box::new(lower_expression(hotspot_y, ctx)),
+            }
+        }
+    })
+}
+
+#[inline(never)]
+fn lower_linear_gradient(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::LinearGradient { angle, stops } = expression else { unreachable!() };
+    llr_Expression::LinearGradient {
+        angle: Box::new(lower_expression(angle, ctx)),
+        stops: stops
+            .iter()
+            .map(|(a, b)| (lower_expression(a, ctx), lower_expression(b, ctx)))
+            .collect::<_>(),
+    }
+}
+
+#[inline(never)]
+fn lower_radial_gradient(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::RadialGradient { center, radius, stops } = expression else {
+        unreachable!()
+    };
+    llr_Expression::RadialGradient {
+        center: center.as_ref().map(|(cx, cy)| {
+            (Box::new(lower_expression(cx, ctx)), Box::new(lower_expression(cy, ctx)))
+        }),
+        radius: radius.as_ref().map(|r| Box::new(lower_expression(r, ctx))),
+        stops: stops
+            .iter()
+            .map(|(a, b)| (lower_expression(a, ctx), lower_expression(b, ctx)))
+            .collect::<_>(),
+    }
+}
+
+#[inline(never)]
+fn lower_conic_gradient(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::ConicGradient { from_angle, center, stops } = expression else {
+        unreachable!()
+    };
+    llr_Expression::ConicGradient {
+        from_angle: Box::new(lower_expression(from_angle, ctx)),
+        center: center.as_ref().map(|(cx, cy)| {
+            (Box::new(lower_expression(cx, ctx)), Box::new(lower_expression(cy, ctx)))
+        }),
+        stops: stops
+            .iter()
+            .map(|(a, b)| (lower_expression(a, ctx), lower_expression(b, ctx)))
+            .collect::<_>(),
+    }
+}
+
+#[inline(never)]
+fn lower_layout_cache_access(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::LayoutCacheAccess {
+        layout_cache_prop,
+        index,
+        repeater_index,
+        entries_per_item,
+    } = expression
+    else {
+        unreachable!()
+    };
+    llr_Expression::LayoutCacheAccess {
+        layout_cache_prop: ctx.map_property_reference(layout_cache_prop),
+        index: *index,
+        repeater_index: repeater_index.as_ref().map(|e| lower_expression(e, ctx).into()),
+        entries_per_item: *entries_per_item,
+    }
+}
+
+#[inline(never)]
+fn lower_grid_repeater_cache_access(
+    expression: &tree_Expression,
+    ctx: &mut ExpressionLoweringCtx<'_>,
+) -> llr_Expression {
+    let tree_Expression::GridRepeaterCacheAccess {
+        layout_cache_prop,
+        index,
+        repeater_index,
+        stride,
+        child_offset,
+        inner_repeater_index,
+        entries_per_item,
+    } = expression
+    else {
+        unreachable!()
+    };
+    llr_Expression::GridRepeaterCacheAccess {
+        layout_cache_prop: ctx.map_property_reference(layout_cache_prop),
+        index: *index,
+        repeater_index: lower_expression(repeater_index, ctx).into(),
+        stride: lower_expression(stride, ctx).into(),
+        child_offset: *child_offset,
+        inner_repeater_index: inner_repeater_index
+            .as_ref()
+            .map(|e| lower_expression(e, ctx).into()),
+        entries_per_item: *entries_per_item,
     }
 }
 

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1516,8 +1516,8 @@ fn grid_layout_input_data(
 }
 
 pub(super) fn grid_layout_input_data_ty() -> Type {
-    Type::Struct(Rc::new(Struct {
-        fields: IntoIterator::into_iter([
+    Type::Struct(Rc::new(Struct::new(
+        IntoIterator::into_iter([
             (SmolStr::new_static("new_row"), Type::Bool),
             (SmolStr::new_static("row"), Type::Int32),
             (SmolStr::new_static("col"), Type::Int32),
@@ -1525,8 +1525,8 @@ pub(super) fn grid_layout_input_data_ty() -> Type {
             (SmolStr::new_static("colspan"), Type::Int32),
         ])
         .collect(),
-        name: BuiltinStruct::GridLayoutInputData.into(),
-    }))
+        BuiltinStruct::GridLayoutInputData,
+    )))
 }
 
 fn generate_layout_padding_and_spacing(

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -817,7 +817,7 @@ fn lower_geometry(
         values
             .insert(f.into(), super::Expression::PropertyReference(ctx.map_property_reference(v)));
     }
-    super::Expression::Struct { ty: Rc::new(Struct { fields, name: StructName::None }), values }
+    super::Expression::Struct { ty: Rc::new(Struct::new(fields, StructName::None)), values }
 }
 
 fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::PropertyAnalysis {

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -103,6 +103,9 @@ pub fn remove_unused(root: &mut CompilationUnit) {
                     EvaluationScope::Global(global_idx) => {
                         self.glob_mappings[*global_idx].$field[*p]
                     }
+                    EvaluationScope::Const => {
+                        panic!("member reference in a constant expression")
+                    }
                 }
                 .unwrap();
             }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -86,6 +86,7 @@ impl Document {
         diag: &mut BuildDiagnostics,
         parent_registry: &Rc<RefCell<TypeRegister>>,
         ignore_missing_font_files: bool,
+        symbol_counters: &Rc<crate::symbol_counters::SymbolCounters>,
     ) -> Self {
         debug_assert_eq!(node.kind(), SyntaxKind::Document);
 
@@ -144,6 +145,7 @@ impl Document {
                 diag,
                 local_registry,
                 parser::identifier_text(&n.DeclaredIdentifier()),
+                Some(symbol_counters),
             );
             assert!(matches!(ty, Type::Struct(_)));
             if !local_registry.insert_type(ty.clone()) {
@@ -2587,7 +2589,7 @@ pub fn type_from_node(
     } else if let Some(object_node) = node.ObjectType() {
         #[cfg(feature = "slint-sc")]
         diag.slint_sc_error("Inline struct types are", &object_node);
-        type_struct_from_node(object_node, diag, tr, None)
+        type_struct_from_node(object_node, diag, tr, None, None)
     } else if let Some(array_node) = node.ArrayType() {
         #[cfg(feature = "slint-sc")]
         diag.slint_sc_error("Array types are", &array_node);
@@ -2599,25 +2601,84 @@ pub fn type_from_node(
 }
 
 /// Create a [`Type::Struct`] from a [`syntax_nodes::ObjectType`]
+///
+/// `symbol_counters` is only available for named struct declarations,
+/// where field default values (`struct Foo { bar: int = 42 }`) are supported.
 pub fn type_struct_from_node(
     object_node: syntax_nodes::ObjectType,
     diag: &mut BuildDiagnostics,
     tr: &TypeRegister,
     name: Option<SmolStr>,
+    symbol_counters: Option<&Rc<crate::symbol_counters::SymbolCounters>>,
 ) -> Type {
-    let fields = object_node
+    let mut field_defaults = BTreeMap::default();
+    let fields: BTreeMap<SmolStr, Type> = object_node
         .ObjectTypeMember()
         .map(|member| {
-            (
-                parser::identifier_text(&member).unwrap_or_default(),
-                type_from_node(member.Type(), diag, tr),
-            )
+            let field_name = parser::identifier_text(&member).unwrap_or_default();
+            let field_ty = type_from_node(member.Type(), diag, tr);
+            if let Some(default_value_node) = member.Expression() {
+                if name.is_none() {
+                    diag.push_error(
+                        "Field default values are only supported in named struct declarations"
+                            .into(),
+                        &default_value_node,
+                    );
+                } else if let Some(expr) = resolve_struct_field_default_value(
+                    default_value_node,
+                    &field_ty,
+                    diag,
+                    tr,
+                    symbol_counters.expect("named struct declarations have symbol counters"),
+                ) {
+                    field_defaults.insert(field_name.clone(), expr);
+                }
+            }
+            (field_name, field_ty)
         })
         .collect();
     Type::Struct(Rc::new(Struct {
         fields,
+        field_defaults,
         name: name.map_or(StructName::None, |name| StructName::User { name, node: object_node }),
     }))
+}
+
+/// Resolve, type-check, and constant-fold the default value expression of a struct field.
+/// Returns `None` (with a diagnostic) if the expression is not a compile time constant.
+fn resolve_struct_field_default_value(
+    node: syntax_nodes::Expression,
+    field_ty: &Type,
+    diag: &mut BuildDiagnostics,
+    tr: &TypeRegister,
+    symbol_counters: &Rc<crate::symbol_counters::SymbolCounters>,
+) -> Option<crate::langtype::ConstantExpression> {
+    let mut expr = {
+        let mut ctx = crate::lookup::LookupCtx::empty_context(tr, diag, symbol_counters.clone());
+        ctx.property_type = field_ty.clone();
+        Expression::from_expression_node(node.clone(), &mut ctx).maybe_convert_to(
+            field_ty.clone(),
+            &node,
+            ctx.diag,
+            &ctx.symbol_counters,
+        )
+    };
+    crate::passes::const_propagation::fold_const_expression(&mut expr);
+    // An error was already reported when a part of the expression failed to resolve
+    // or convert; don't report a confusing constant-ness error on top of it
+    let mut has_invalid = false;
+    expr.visit_recursive(&mut |e| has_invalid |= matches!(e, Expression::Invalid));
+    if has_invalid {
+        return None;
+    }
+    let constant = crate::langtype::ConstantExpression::from_expression(&expr);
+    if constant.is_none() {
+        diag.push_error(
+            "The default value of a struct field must be a constant expression".into(),
+            &node,
+        );
+    }
+    constant
 }
 
 fn animation_element_from_node(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2673,12 +2673,47 @@ fn resolve_struct_field_default_value(
     }
     let constant = crate::langtype::ConstantExpression::from_expression(&expr);
     if constant.is_none() {
+        let reason = non_constant_expression_reason(&expr)
+            .map_or_else(Default::default, |reason| format!(": {reason}"));
         diag.push_error(
-            "The default value of a struct field must be a constant expression".into(),
+            format!("The default value of a struct field must be a constant expression{reason}"),
             &node,
         );
     }
     constant
+}
+
+/// A user-facing explanation of what makes the expression non-constant, if there is
+/// a better one than "it is not in the supported subset"
+fn non_constant_expression_reason(expr: &Expression) -> Option<String> {
+    use crate::expression_tree::{BuiltinFunction, Callable};
+    let mut reason = None;
+    expr.visit_recursive(&mut |e| {
+        if reason.is_some() {
+            return;
+        }
+        reason = match e {
+            Expression::PropertyReference(nr) => {
+                Some(format!("it references the property '{}'", nr.name()))
+            }
+            Expression::FunctionCall { function, .. } => match function {
+                Callable::Function(nr) => Some(format!("it calls the function '{}'", nr.name())),
+                Callable::Callback(nr) => Some(format!("it calls the callback '{}'", nr.name())),
+                Callable::Builtin(BuiltinFunction::GetWindowScaleFactor) => Some(
+                    "the conversion to logical pixels depends on the window's scale factor".into(),
+                ),
+                Callable::Builtin(BuiltinFunction::GetWindowDefaultFontSize) => Some(
+                    "the conversion from 'rem' depends on the window's default font size".into(),
+                ),
+                Callable::Builtin(BuiltinFunction::Translate) => {
+                    Some("the translation is selected at run-time".into())
+                }
+                Callable::Builtin(_) => Some("functions are not evaluated at compile time".into()),
+            },
+            _ => None,
+        };
+    });
+    reason
 }
 
 fn animation_element_from_node(

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -462,8 +462,8 @@ declare_syntax! {
         Type -> [ ?QualifiedName, ?ObjectType, ?ArrayType ],
         /// `{foo: string, bar: string} `
         ObjectType ->[ *ObjectTypeMember ],
-        /// `foo: type` inside an ObjectType
-        ObjectTypeMember -> [ Type ],
+        /// `foo: type` or `foo: type = default-value` inside an ObjectType
+        ObjectTypeMember -> [ Type, ?Expression ],
         /// `[ type ]`
         ArrayType -> [ Type ],
         /// `struct Foo { ... }`

--- a/internal/compiler/parser/type.rs
+++ b/internal/compiler/parser/type.rs
@@ -4,6 +4,7 @@
 //! Module containing the parsing functions for type names
 
 use super::document::parse_qualified_name;
+use super::expressions::parse_expression;
 use super::prelude::*;
 
 #[cfg_attr(test, parser_test)]
@@ -30,6 +31,8 @@ pub fn parse_type(p: &mut impl Parser) {
 /// {a: string}
 /// {a: string,}
 /// {a: { foo: string, bar: int, }, q: {} }
+/// {a: string = "hello", b: int = 42}
+/// {a: int = 1 + 2, b: color = #f00,}
 /// ```
 pub fn parse_type_object(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::ObjectType);
@@ -41,6 +44,9 @@ pub fn parse_type_object(p: &mut impl Parser) {
         p.expect(SyntaxKind::Identifier);
         p.expect(SyntaxKind::Colon);
         parse_type(&mut *p);
+        if p.test(SyntaxKind::Equal) {
+            parse_expression(&mut *p);
+        }
         if p.peek().kind() == SyntaxKind::Semicolon {
             p.error("Expected ','. Use ',' instead of ';' to separate fields in a struct");
             p.consume();
@@ -72,6 +78,7 @@ pub fn parse_type_array(p: &mut impl Parser) {
 /// struct Bar := {}
 /// struct Foo { foo: bar, xxx: { aaa: bbb, } }
 /// struct Bar {}
+/// struct Player { name: string = "unknown", score: int = 0 }
 /// ```
 pub fn parse_struct_declaration<P: Parser>(p: &mut P, checkpoint: Option<P::Checkpoint>) -> bool {
     debug_assert_eq!(p.peek().as_str(), "struct");

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -16,7 +16,7 @@ mod collect_libraries;
 mod collect_structs_and_enums;
 mod collect_subcomponents;
 mod compile_paths;
-mod const_propagation;
+pub(crate) mod const_propagation;
 mod deduplicate_property_read;
 mod default_geometry;
 mod deprecated_rotation_origin;

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -147,14 +147,14 @@ fn compile_path_from_string_literal(
     let path = builder.build();
 
     let event_enum = crate::typeregister::BUILTIN.with(|e| e.enums.PathEvent.clone());
-    let point_type = Rc::new(Struct {
-        fields: IntoIterator::into_iter([
+    let point_type = Rc::new(Struct::new(
+        IntoIterator::into_iter([
             (SmolStr::new_static("x"), Type::Float32),
             (SmolStr::new_static("y"), Type::Float32),
         ])
         .collect(),
-        name: BuiltinStruct::Point.into(),
-    });
+        BuiltinStruct::Point,
+    ));
 
     let mut points = Vec::new();
     let events = path

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -14,6 +14,14 @@ use smol_str::format_smolstr;
 
 type ConstPropCache = HashMap<NamedReference, Option<Expression>>;
 
+/// Fold constants in an expression that stands on its own, outside of a component.
+///
+/// This is used for expressions that cannot reference any properties or elements,
+/// such as the default values of struct fields.
+pub(crate) fn fold_const_expression(expr: &mut Expression) {
+    simplify_expression(expr, &GlobalAnalysis::default(), &mut ConstPropCache::default());
+}
+
 pub fn const_propagation(component: &Component, global_analysis: &GlobalAnalysis) {
     let mut cache = ConstPropCache::new();
     visit_all_expressions(component, |expr, _ty| {

--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -582,7 +582,7 @@ fn make_struct(it: impl Iterator<Item = (&'static str, Type, Expression)>) -> Ex
     }
     codeblock_with_expr(
         voids,
-        Expression::Struct { ty: Rc::new(Struct { fields, name: StructName::None }), values },
+        Expression::Struct { ty: Rc::new(Struct::new(fields, StructName::None)), values },
     )
 }
 
@@ -595,10 +595,10 @@ fn convert_struct(from: Expression, to: Type, symbol_counters: &SymbolCounters) 
     };
     if let Expression::Struct { mut values, .. } = from {
         let mut new_values = BTreeMap::new();
-        for (key, ty) in &to.fields {
+        for key in to.fields.keys() {
             let (key, expression) = values
                 .remove_entry(key)
-                .unwrap_or_else(|| (key.clone(), Expression::default_value_for_type(ty)));
+                .unwrap_or_else(|| (key.clone(), to.default_value_for_field(key)));
             new_values.insert(key, expression);
         }
         return Expression::Struct { values: new_values, ty: to };
@@ -610,7 +610,7 @@ fn convert_struct(from: Expression, to: Type, symbol_counters: &SymbolCounters) 
         assert_eq!(from_ty, Type::Invalid);
         return Expression::Invalid;
     };
-    for (key, ty) in &to.fields {
+    for key in to.fields.keys() {
         let expression = if from_s.fields.contains_key(key) {
             Expression::StructFieldAccess {
                 base: Box::new(Expression::ReadLocalVariable {
@@ -620,7 +620,7 @@ fn convert_struct(from: Expression, to: Type, symbol_counters: &SymbolCounters) 
                 name: key.clone(),
             }
         } else {
-            Expression::default_value_for_type(ty)
+            to.default_value_for_field(key)
         };
         new_values.insert(key.clone(), expression);
     }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1948,10 +1948,10 @@ impl Expression {
                 (name, value)
             })
             .collect();
-        let ty = Rc::new(Struct {
-            fields: values.iter().map(|(k, v)| (k.clone(), v.ty())).collect(),
-            name: StructName::None,
-        });
+        let ty = Rc::new(Struct::new(
+            values.iter().map(|(k, v)| (k.clone(), v.ty())).collect(),
+            StructName::None,
+        ));
         Expression::Struct { ty, values }
     }
 
@@ -2046,9 +2046,12 @@ impl Expression {
                                 }
                             }
                         }
+                        // The field defaults must come from the same struct as the name
+                        let source = if result.name.is_some() { &result } else { &elem };
                         Type::Struct(Rc::new(Struct {
-                            name: result.name.clone().or(elem.name.clone()),
                             fields,
+                            field_defaults: source.field_defaults.clone(),
+                            name: source.name.clone(),
                         }))
                     }
                     (Type::Array(lhs), Type::Array(rhs)) => Type::Array(if *lhs == Type::Void {
@@ -2097,7 +2100,7 @@ fn common_expression_type(true_expr: &Expression, false_expr: &Expression) -> Ty
     fn merge_struct(origin: &Struct, other: &Struct) -> Type {
         let mut fields = other.fields.clone();
         fields.extend(origin.fields.iter().map(|(k, v)| (k.clone(), v.clone())));
-        Rc::new(Struct { fields, name: StructName::None }).into()
+        Rc::new(Struct::new(fields, StructName::None)).into()
     }
 
     if let Expression::Struct { ty, values } = true_expr {
@@ -2115,7 +2118,7 @@ fn common_expression_type(true_expr: &Expression, false_expr: &Expression) -> Ty
                     fields.insert(k.clone(), v.ty());
                 }
             }
-            return Type::Struct(Rc::new(Struct { fields, name: StructName::None }));
+            return Type::Struct(Rc::new(Struct::new(fields, StructName::None)));
         } else if let Type::Struct(false_ty) = false_expr.ty() {
             return merge_struct(&false_ty, ty);
         }

--- a/internal/compiler/tests/syntax/basic/struct_field_defaults.slint
+++ b/internal/compiler/tests/syntax/basic/struct_field_defaults.slint
@@ -1,0 +1,39 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+struct Ok1 {
+    a: int = 42,
+    b: string = "hello",
+    c: float = 0.5 * 2,
+    d: duration = -2s,
+}
+
+struct Ok2 {
+    nested: Ok1 = { a: 1 },
+    tags: [string] = ["x"],
+}
+
+struct WrongType {
+    a: int = "hello",
+//           >     <error{Cannot convert string to int}
+}
+
+struct NotConstant {
+    a: string = some-function(),
+//              >           <error{Unknown unqualified identifier 'some-function'}
+    b: duration = animation-tick(),
+//                >              <error{The default value of a struct field must be a constant expression}
+}
+
+struct ForwardReference {
+    e: LaterEnum = LaterEnum.x,
+//     >        <error{Unknown type 'LaterEnum'}
+//                 >         <^error{Cannot access id 'LaterEnum'}
+}
+
+enum LaterEnum { x, y }
+
+export component Foo {
+    in property <{a: int = 1}> anonymous;
+//                         ^error{Field default values are only supported in named struct declarations}
+}

--- a/internal/compiler/tests/syntax/basic/struct_field_defaults.slint
+++ b/internal/compiler/tests/syntax/basic/struct_field_defaults.slint
@@ -22,7 +22,32 @@ struct NotConstant {
     a: string = some-function(),
 //              >           <error{Unknown unqualified identifier 'some-function'}
     b: duration = animation-tick(),
-//                >              <error{The default value of a struct field must be a constant expression}
+//                >              <error{The default value of a struct field must be a constant expression: functions are not evaluated at compile time}
+}
+
+global SomeGlobal {
+    out property <int> some-value: 42;
+    pure public function some-const-function() -> int {
+        return 7;
+    }
+}
+
+struct NotConstantGlobals {
+    a: int = SomeGlobal.some-value,
+//           >                   <error{The default value of a struct field must be a constant expression: it references the property 'some-value'}
+    b: int = SomeGlobal.some-const-function(),
+//           >                              <error{The default value of a struct field must be a constant expression: it calls the function 'some-const-function'}
+}
+
+struct NotConstantRuntime {
+    a: string = @tr("foobar"),
+//              >           <error{The default value of a struct field must be a constant expression: the translation is selected at run-time}
+    b: length = 44phx,
+//              >   <error{The default value of a struct field must be a constant expression: the conversion to logical pixels depends on the window's scale factor}
+    c: length = 3rem,
+//              >  <error{The default value of a struct field must be a constant expression: the conversion from 'rem' depends on the window's default font size}
+    d: int = min(42, Math.sqrt(100)),
+//           >                     <error{The default value of a struct field must be a constant expression: functions are not evaluated at compile time}
 }
 
 struct ForwardReference {

--- a/internal/compiler/tests/syntax/parse_error/struct_field_default_codeblock.slint
+++ b/internal/compiler/tests/syntax/parse_error/struct_field_default_codeblock.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Braces in expression position are object literals, so a code block cannot be
+// used as a field default value
+
+struct WithBlock {
+    a: int = { 42 },
+//             ><error{Syntax error: expected Identifier}
+//             ><^error{Syntax error: expected ':'}
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1601,6 +1601,7 @@ impl TypeLoader {
 
         let ignore_missing_font_files =
             state.borrow().tl.compiler_config.resource_url_mapper.is_some();
+        let symbol_counters = state.borrow().tl.symbol_counters.clone();
         if state.borrow().diag.has_errors() {
             // If there was error (esp parse error) we don't want to report further error in this document.
             // because they might be nonsense (TODO: we should check that the parse error were really in this document).
@@ -1617,6 +1618,7 @@ impl TypeLoader {
                 &mut ignore_diag,
                 &dependency_registry,
                 ignore_missing_font_files,
+                &symbol_counters,
             );
             return (path.to_owned(), doc);
         }
@@ -1629,6 +1631,7 @@ impl TypeLoader {
             state.diag,
             &dependency_registry,
             ignore_missing_font_files,
+            &symbol_counters,
         );
         (path.to_owned(), doc)
     }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -104,8 +104,8 @@ pub struct BuiltinTypes {
 
 impl BuiltinTypes {
     fn new() -> Self {
-        let layout_info_type = Rc::new(Struct {
-            fields: ["min", "max", "preferred"]
+        let layout_info_type = Rc::new(Struct::new(
+            ["min", "max", "preferred"]
                 .iter()
                 .map(|s| (SmolStr::new_static(s), Type::LogicalLength))
                 .chain(
@@ -114,38 +114,38 @@ impl BuiltinTypes {
                         .map(|s| (SmolStr::new_static(s), Type::Float32)),
                 )
                 .collect(),
-            name: BuiltinStruct::LayoutInfo.into(),
-        });
+            BuiltinStruct::LayoutInfo,
+        ));
         let enums = BuiltinEnums::new();
         let flex_align_self_type = Type::Enumeration(enums.FlexboxLayoutAlignSelf.clone());
         Self {
             enums,
-            logical_point_type: Rc::new(Struct {
-                fields: IntoIterator::into_iter([
+            logical_point_type: Rc::new(Struct::new(
+                IntoIterator::into_iter([
                     (SmolStr::new_static("x"), Type::LogicalLength),
                     (SmolStr::new_static("y"), Type::LogicalLength),
                 ])
                 .collect(),
-                name: BuiltinStruct::LogicalPosition.into(),
-            }),
-            logical_size_type: Rc::new(Struct {
-                fields: IntoIterator::into_iter([
+                BuiltinStruct::LogicalPosition,
+            )),
+            logical_size_type: Rc::new(Struct::new(
+                IntoIterator::into_iter([
                     (SmolStr::new_static("width"), Type::LogicalLength),
                     (SmolStr::new_static("height"), Type::LogicalLength),
                 ])
                 .collect(),
-                name: BuiltinStruct::LogicalSize.into(),
-            }),
-            font_metrics_type: Type::Struct(Rc::new(Struct {
-                fields: IntoIterator::into_iter([
+                BuiltinStruct::LogicalSize,
+            )),
+            font_metrics_type: Type::Struct(Rc::new(Struct::new(
+                IntoIterator::into_iter([
                     (SmolStr::new_static("ascent"), Type::LogicalLength),
                     (SmolStr::new_static("descent"), Type::LogicalLength),
                     (SmolStr::new_static("x-height"), Type::LogicalLength),
                     (SmolStr::new_static("cap-height"), Type::LogicalLength),
                 ])
                 .collect(),
-                name: BuiltinStruct::FontMetrics.into(),
-            })),
+                BuiltinStruct::FontMetrics,
+            ))),
             noarg_callback_type: Type::Callback(Rc::new(Function {
                 return_type: Type::Void,
                 args: Vec::new(),
@@ -157,29 +157,26 @@ impl BuiltinTypes {
                 arg_names: Vec::new(),
             })),
             layout_info_type: layout_info_type.clone(),
-            state_info_type: Rc::new(Struct {
-                fields: IntoIterator::into_iter([
+            state_info_type: Rc::new(Struct::new(
+                IntoIterator::into_iter([
                     (SmolStr::new_static("current-state"), Type::Int32),
                     (SmolStr::new_static("previous-state"), Type::Int32),
                     (SmolStr::new_static("change-time"), Type::Duration),
                 ])
                 .collect(),
-                name: BuiltinStruct::StateInfo.into(),
-            }),
-            path_element_type: Type::Struct(Rc::new(Struct {
-                fields: Default::default(),
-                name: BuiltinStruct::PathElement.into(),
-            })),
-            layout_item_info_type: Type::Struct(Rc::new(Struct {
-                fields: IntoIterator::into_iter([(
-                    "constraint".into(),
-                    layout_info_type.clone().into(),
-                )])
-                .collect(),
-                name: BuiltinStruct::LayoutItemInfo.into(),
-            })),
-            flexbox_layout_item_info_type: Type::Struct(Rc::new(Struct {
-                fields: IntoIterator::into_iter([
+                BuiltinStruct::StateInfo,
+            )),
+            path_element_type: Type::Struct(Rc::new(Struct::new(
+                Default::default(),
+                BuiltinStruct::PathElement,
+            ))),
+            layout_item_info_type: Type::Struct(Rc::new(Struct::new(
+                IntoIterator::into_iter([("constraint".into(), layout_info_type.clone().into())])
+                    .collect(),
+                BuiltinStruct::LayoutItemInfo,
+            ))),
+            flexbox_layout_item_info_type: Type::Struct(Rc::new(Struct::new(
+                IntoIterator::into_iter([
                     ("constraint".into(), layout_info_type.into()),
                     ("flex-grow".into(), Type::Float32),
                     ("flex-shrink".into(), Type::Float32),
@@ -188,18 +185,18 @@ impl BuiltinTypes {
                     ("flex-order".into(), Type::Int32),
                 ])
                 .collect(),
-                name: BuiltinStruct::FlexboxLayoutItemInfo.into(),
-            })),
-            gridlayout_input_data_type: Type::Struct(Rc::new(Struct {
-                fields: IntoIterator::into_iter([
+                BuiltinStruct::FlexboxLayoutItemInfo,
+            ))),
+            gridlayout_input_data_type: Type::Struct(Rc::new(Struct::new(
+                IntoIterator::into_iter([
                     ("row".into(), Type::Int32),
                     ("column".into(), Type::Int32),
                     ("rowspan".into(), Type::Int32),
                     ("colspan".into(), Type::Int32),
                 ])
                 .collect(),
-                name: BuiltinStruct::GridLayoutInputData.into(),
-            })),
+                BuiltinStruct::GridLayoutInputData,
+            ))),
         }
     }
 }
@@ -865,12 +862,12 @@ pub mod builtin_structs {
                 pub fn new() -> Self {
                     $(
                     #[allow(non_snake_case)]
-                    let $Name = Rc::new(Struct{
-                        fields: BTreeMap::from([
+                    let $Name = Rc::new(Struct::new(
+                        BTreeMap::from([
                             $((stringify!($field).replace_smolstr("_", "-"), map_type!($field_type, $field_type))),*
                         ]),
-                        name: BuiltinStruct::$Name.into(),
-                    });
+                        BuiltinStruct::$Name,
+                    ));
                     )*
 
                     Self {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2241,10 +2241,10 @@ fn lang_type_to_value_type() {
     assert_eq!(ValueType::from(LangType::Array(Rc::new(LangType::Void))), ValueType::Model);
     assert_eq!(ValueType::from(LangType::Bool), ValueType::Bool);
     assert_eq!(
-        ValueType::from(LangType::Struct(Rc::new(LangStruct {
-            fields: BTreeMap::default(),
-            name: i_slint_compiler::langtype::StructName::None,
-        }))),
+        ValueType::from(LangType::Struct(Rc::new(LangStruct::new(
+            BTreeMap::default(),
+            i_slint_compiler::langtype::StructName::None
+        )))),
         ValueType::Struct
     );
     assert_eq!(ValueType::from(LangType::Image), ValueType::Image);

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -20,7 +20,7 @@ use i_slint_compiler::expression_tree::{
     BuiltinFunction, Callable, EasingCurve, Expression, MinMaxOp, MouseCursorInner,
     Path as ExprPath, PathElement as ExprPathElement,
 };
-use i_slint_compiler::langtype::Type;
+use i_slint_compiler::langtype::{ConstantExpression, Type};
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_core::api::ToSharedString;
@@ -253,19 +253,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 _ => Value::Void,
             }
         }
-        Expression::Cast { from, to } => {
-            let value = eval_expression(from, local_context);
-            match (value, to) {
-                (Value::Number(n), Type::Int32) => Value::Number(n.trunc()),
-                (Value::Number(n), Type::String) => {
-                    Value::String(i_slint_core::string::shared_string_from_number(n))
-                }
-                (Value::Number(n), Type::Color) => Color::from_argb_encoded(n as u32).into(),
-                (Value::Brush(brush), Type::Color) => brush.color().into(),
-                (Value::EnumerationValue(_, val), Type::String) => Value::String(val.into()),
-                (v, _) => v,
-            }
-        }
+        Expression::Cast { from, to } => cast_value(eval_expression(from, local_context), to),
         Expression::CodeBlock(sub) => {
             let mut v = Value::Void;
             for e in sub {
@@ -365,12 +353,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         }
         Expression::UnaryOp { sub, op } => {
             let sub = eval_expression(sub, local_context);
-            match (sub, op) {
-                (Value::Number(a), '+') => Value::Number(a),
-                (Value::Number(a), '-') => Value::Number(-a),
-                (Value::Bool(a), '!') => Value::Bool(!a),
-                (sub, op) => panic!("unsupported {op} {sub:?}"),
-            }
+            eval_unary_op(sub, *op).unwrap_or_else(|sub| panic!("unsupported {op} {sub:?}"))
         }
         Expression::ImageReference { resource_ref, nine_slice, .. } => {
             let mut image = match resource_ref {
@@ -2276,8 +2259,8 @@ fn check_value_type(value: &mut Value, ty: &Type) -> bool {
             {
                 return false;
             }
-            for (k, v) in &s.fields {
-                str.0.entry(k.clone()).or_insert_with(|| default_value_for_type(v));
+            for k in s.fields.keys() {
+                str.0.entry(k.clone()).or_insert_with(|| default_value_for_struct_field(s, k));
             }
             true
         }
@@ -2592,8 +2575,8 @@ pub fn default_value_for_type(ty: &Type) -> Value {
         Type::Callback { .. } => Value::Void,
         Type::Struct(s) => Value::Struct(
             s.fields
-                .iter()
-                .map(|(n, t)| (n.to_string(), default_value_for_type(t)))
+                .keys()
+                .map(|n| (n.to_string(), default_value_for_struct_field(s, n)))
                 .collect::<Struct>(),
         ),
         Type::Array(_) | Type::Model => Value::Model(Default::default()),
@@ -2619,6 +2602,77 @@ pub fn default_value_for_type(ty: &Type) -> Value {
             panic!("There can't be such property")
         }
         Type::StyledText => Value::StyledText(Default::default()),
+    }
+}
+
+/// Create a value for the default of a struct field:
+/// the user-declared default value (`struct Foo { bar: int = 42 }`) if there is one,
+/// otherwise the default value for the field's type.
+pub fn default_value_for_struct_field(
+    s: &i_slint_compiler::langtype::Struct,
+    field_name: &str,
+) -> Value {
+    match s.field_defaults.get(field_name) {
+        Some(expr) => eval_constant_expression(expr),
+        None => default_value_for_type(
+            s.fields.get(field_name).expect("default value requested for unknown struct field"),
+        ),
+    }
+}
+
+/// Convert a value to the given type, as [`Expression::Cast`] does
+fn cast_value(value: Value, to: &Type) -> Value {
+    match (value, to) {
+        (Value::Number(n), Type::Int32) => Value::Number(n.trunc()),
+        (Value::Number(n), Type::String) => {
+            Value::String(i_slint_core::string::shared_string_from_number(n))
+        }
+        (Value::Number(n), Type::Color) => Color::from_argb_encoded(n as u32).into(),
+        (Value::Brush(brush), Type::Color) => brush.color().into(),
+        (Value::EnumerationValue(_, val), Type::String) => Value::String(val.into()),
+        (v, _) => v,
+    }
+}
+
+/// Apply a unary operator to a value; returns the unmodified value as the error
+/// for unsupported combinations
+fn eval_unary_op(sub: Value, op: char) -> Result<Value, Value> {
+    match (sub, op) {
+        (Value::Number(a), '+') => Ok(Value::Number(a)),
+        (Value::Number(a), '-') => Ok(Value::Number(-a)),
+        (Value::Bool(a), '!') => Ok(Value::Bool(!a)),
+        (sub, _) => Err(sub),
+    }
+}
+
+/// Evaluate a constant expression as stored in [`i_slint_compiler::langtype::Struct::field_defaults`],
+/// which needs no evaluation context.
+/// Mirrors [`eval_expression`] for the corresponding expressions.
+fn eval_constant_expression(expr: &ConstantExpression) -> Value {
+    match expr {
+        ConstantExpression::StringLiteral(s) => Value::String(s.as_str().into()),
+        ConstantExpression::NumberLiteral(n, _unit) => Value::Number(*n),
+        ConstantExpression::BoolLiteral(b) => Value::Bool(*b),
+        ConstantExpression::EnumerationValue(value) => {
+            Value::EnumerationValue(value.enumeration.name.to_string(), value.to_string())
+        }
+        ConstantExpression::Cast { from, to } => cast_value(eval_constant_expression(from), to),
+        ConstantExpression::UnaryOp { sub, op } => {
+            // The resolver only accepts the unary operators on matching operand types
+            eval_unary_op(eval_constant_expression(sub), *op)
+                .unwrap_or_else(|sub| panic!("unsupported {op} {sub:?}"))
+        }
+        ConstantExpression::Struct { values, .. } => Value::Struct(
+            values
+                .iter()
+                .map(|(k, v)| (k.to_string(), eval_constant_expression(v)))
+                .collect::<Struct>(),
+        ),
+        ConstantExpression::Array { values, .. } => {
+            Value::Model(ModelRc::new(corelib::model::SharedVectorModel::from(
+                values.iter().map(eval_constant_expression).collect::<SharedVector<_>>(),
+            )))
+        }
     }
 }
 

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -98,7 +98,7 @@ pub use api::*;
 
 #[cfg(feature = "internal")]
 #[doc(hidden)]
-pub use eval::default_value_for_type;
+pub use eval::{default_value_for_struct_field, default_value_for_type};
 
 #[cfg(test)]
 mod tests;

--- a/tests/cases/types/struct_field_defaults.slint
+++ b/tests/cases/types/struct_field_defaults.slint
@@ -43,6 +43,15 @@ export component TestCase {
     out property <PlayerWithDefault> picked-early: pick-player(true);
     out property <PlayerWithDefault> picked-late: pick-player(false);
 
+    in property <bool> flag: true;
+    // Conditional with the same fields in both branches: the defaults apply to all
+    // missing fields
+    out property <PlayerWithDefault> cond-same: flag ? { name: "x" } : { name: "y" };
+    // A field that only one branch sets becomes part of the common type of the two
+    // branches, so the other branch gets that anonymous type's zero default (not the
+    // declared one). Fields absent from both branches take the declared defaults.
+    out property <PlayerWithDefault> cond-mixed: flag ? { name: "a" } : { name: "b", score: 1 };
+
     out property <bool> test:
         partial.name == "partial" && partial.score == 42 && partial.energy == 1
         && partial.alive && partial.tint == #00ff00 && partial.rank == Rank.gold
@@ -54,7 +63,11 @@ export component TestCase {
         && made.rank == Rank.gold && made.time == 2s && made.plain == 0
         && picked-early.name == "early" && picked-early.score == 42 && picked-early.alive
         && picked-late.name == "late" && picked-late.score == 1 && !picked-late.alive
-        && picked-late.energy == 1 && picked-late.rank == Rank.gold;
+        && picked-late.energy == 1 && picked-late.rank == Rank.gold
+        && cond-same.name == "x" && cond-same.score == 42 && cond-same.alive
+        && cond-same.rank == Rank.gold && cond-same.time == 2s
+        && cond-mixed.name == "a" && cond-mixed.score == 0
+        && cond-mixed.alive && cond-mixed.energy == 1 && cond-mixed.rank == Rank.gold;
 }
 
 /*
@@ -85,6 +98,15 @@ assert_eq!(nested.tags.row_data(1).unwrap(), slint::SharedString::from("b"));
 let custom = PlayerWithDefault { name: "custom".into(), ..Default::default() };
 assert_eq!(custom.name, "custom");
 assert_eq!(custom.score, 42);
+
+// Take the other conditional branches
+instance.set_flag(false);
+assert_eq!(instance.get_cond_same().name, "y");
+assert_eq!(instance.get_cond_same().score, 42);
+assert!(instance.get_cond_same().alive);
+assert_eq!(instance.get_cond_mixed().name, "b");
+assert_eq!(instance.get_cond_mixed().score, 1);
+assert!(instance.get_cond_mixed().alive);
 ```
 
 ```cpp

--- a/tests/cases/types/struct_field_defaults.slint
+++ b/tests/cases/types/struct_field_defaults.slint
@@ -43,6 +43,31 @@ export component TestCase {
     out property <PlayerWithDefault> picked-early: pick-player(true);
     out property <PlayerWithDefault> picked-late: pick-player(false);
 
+    // Struct literal nested inside another struct literal: defaults apply at
+    // every depth, and the omitted tags field takes NestedDefault's own default
+    out property <NestedDefault> deep: { player: { name: "deep" } };
+
+    // Array elements with the same fields take the defaults
+    out property <[PlayerWithDefault]> team: [{ name: "a" }, { name: "b" }];
+    // Like cond-mixed below: a field set in only one element becomes part of the
+    // elements' common type and is zero-padded in the others
+    out property <[PlayerWithDefault]> team-mixed: [{ name: "m0" }, { name: "m1", score: 1 }];
+
+    // Struct literals as function call arguments and in typed let statements
+    pure function score-of(p: PlayerWithDefault) -> int {
+        return p.score;
+    }
+    pure function let-player(name: string) -> PlayerWithDefault {
+        let p: PlayerWithDefault = { name: name };
+        return p;
+    }
+
+    // Struct literal returned from a callback
+    pure callback make-cb() -> PlayerWithDefault;
+    make-cb() => {
+        { name: "cb" }
+    }
+
     in property <bool> flag: true;
     // Conditional with the same fields in both branches: the defaults apply to all
     // missing fields
@@ -67,7 +92,15 @@ export component TestCase {
         && cond-same.name == "x" && cond-same.score == 42 && cond-same.alive
         && cond-same.rank == Rank.gold && cond-same.time == 2s
         && cond-mixed.name == "a" && cond-mixed.score == 0
-        && cond-mixed.alive && cond-mixed.energy == 1 && cond-mixed.rank == Rank.gold;
+        && cond-mixed.alive && cond-mixed.energy == 1 && cond-mixed.rank == Rank.gold
+        && deep.player.name == "deep" && deep.player.score == 42 && deep.player.alive
+        && deep.player.rank == Rank.gold && deep.tags.length == 2 && deep.tags[0] == "a"
+        && team[0].name == "a" && team[0].score == 42 && team[0].alive
+        && team[1].name == "b" && team[1].score == 42 && team[1].rank == Rank.gold
+        && team-mixed[0].score == 0 && team-mixed[0].alive && team-mixed[1].score == 1
+        && score-of({ name: "arg" }) == 42
+        && let-player("let").name == "let" && let-player("let").score == 42
+        && make-cb().name == "cb" && make-cb().score == 42 && make-cb().rank == Rank.gold;
 }
 
 /*
@@ -99,6 +132,12 @@ let custom = PlayerWithDefault { name: "custom".into(), ..Default::default() };
 assert_eq!(custom.name, "custom");
 assert_eq!(custom.score, 42);
 
+// A callback returning a partial struct literal applies the defaults
+let from_cb = instance.invoke_make_cb();
+assert_eq!(from_cb.name, "cb");
+assert_eq!(from_cb.score, 42);
+assert_eq!(from_cb.rank, Rank::Gold);
+
 // Take the other conditional branches
 instance.set_flag(false);
 assert_eq!(instance.get_cond_same().name, "y");
@@ -126,6 +165,11 @@ assert_eq(default_player.plain, 0);
 
 PlayerWithDefault aggregate {};
 assert_eq(aggregate.score, 42);
+
+auto from_cb = instance.invoke_make_cb();
+assert_eq(from_cb.name, "cb");
+assert_eq(from_cb.score, 42);
+assert(from_cb.rank == Rank::Gold);
 
 NestedDefault nested;
 assert_eq(nested.player.name, "nested");
@@ -159,6 +203,10 @@ assert.equal(instance.partial.score, 42);
 let nested = new slint.NestedDefault();
 assert.equal(nested.player.name, "nested");
 assert.equal(nested.player.score, 42);
+
+let from_cb = instance.make_cb();
+assert.equal(from_cb.name, "cb");
+assert.equal(from_cb.score, 42);
 ```
 
 ```python
@@ -180,5 +228,9 @@ assert custom.score == 42
 nested = NestedDefault()
 assert nested.player.name == "nested"
 assert nested.player.score == 42
+
+from_cb = instance.make_cb()
+assert from_cb.name == "cb"
+assert from_cb.score == 42
 ```
 */

--- a/tests/cases/types/struct_field_defaults.slint
+++ b/tests/cases/types/struct_field_defaults.slint
@@ -19,6 +19,25 @@ export struct NestedDefault {
     tags: [string] = ["a", "b"],
 }
 
+export struct HeldItem {
+    abc: int,
+}
+
+export struct Holder {
+    model: [HeldItem] = [{ abc: 45 }],
+}
+
+export struct Edge {
+    // Folds to infinity; the backends saturate when converting to int
+    big: int = 45 / 0,
+    // The number to string conversion respects the locale's decimal separator,
+    // so it stays a runtime conversion instead of a compile time string
+    text: string = 42.1,
+    size: length = 44px,
+    // No default here, but the field type declares its own defaults
+    inner: PlayerWithDefault,
+}
+
 export component TestCase {
     // Missing fields in a struct literal take the declared defaults
     in-out property <PlayerWithDefault> partial: { name: "partial" };
@@ -68,6 +87,13 @@ export component TestCase {
         { name: "cb" }
     }
 
+    in-out property <Edge> edge;
+    in-out property <Holder> holder;
+
+    // Two-way bindings between struct properties with field defaults
+    in-out property <PlayerWithDefault> tw-a: { name: "tw" };
+    in-out property <PlayerWithDefault> tw-b <=> tw-a;
+
     in property <bool> flag: true;
     // Conditional with the same fields in both branches: the defaults apply to all
     // missing fields
@@ -100,7 +126,11 @@ export component TestCase {
         && team-mixed[0].score == 0 && team-mixed[0].alive && team-mixed[1].score == 1
         && score-of({ name: "arg" }) == 42
         && let-player("let").name == "let" && let-player("let").score == 42
-        && make-cb().name == "cb" && make-cb().score == 42 && make-cb().rank == Rank.gold;
+        && make-cb().name == "cb" && make-cb().score == 42 && make-cb().rank == Rank.gold
+        && edge.big > 2000000000 && edge.text.starts-with("42") && edge.size == 44px
+        && edge.inner.name == "unknown" && edge.inner.score == 42 && edge.inner.alive
+        && holder.model.length == 1 && holder.model[0].abc == 45
+        && tw-a.name == "tw" && tw-b.name == "tw" && tw-b.score == 42 && tw-b.alive;
 }
 
 /*
@@ -131,6 +161,20 @@ assert_eq!(nested.tags.row_data(1).unwrap(), slint::SharedString::from("b"));
 let custom = PlayerWithDefault { name: "custom".into(), ..Default::default() };
 assert_eq!(custom.name, "custom");
 assert_eq!(custom.score, 42);
+
+// Each instance gets its own copy of a default model
+let h1 = Holder::default();
+let h2 = Holder::default();
+h1.model.as_any().downcast_ref::<slint::VecModel<HeldItem>>().unwrap().push(HeldItem { abc: 46 });
+assert_eq!(h1.model.row_count(), 2);
+assert_eq!(h2.model.row_count(), 1);
+
+let edge = Edge::default();
+assert_eq!(edge.big, i32::MAX);
+assert!(edge.text.starts_with("42"));
+assert_eq!(edge.size, 44.);
+assert_eq!(edge.inner.score, 42);
+assert!(edge.inner.alive);
 
 // A callback returning a partial struct literal applies the defaults
 let from_cb = instance.invoke_make_cb();
@@ -165,6 +209,21 @@ assert_eq(default_player.plain, 0);
 
 PlayerWithDefault aggregate {};
 assert_eq(aggregate.score, 42);
+
+// Each instance gets its own copy of a default model
+Holder h1, h2;
+auto vec_model = std::dynamic_pointer_cast<slint::VectorModel<HeldItem>>(h1.model);
+assert(vec_model);
+vec_model->push_back(HeldItem { 46 });
+assert_eq(h1.model->row_count(), 2);
+assert_eq(h2.model->row_count(), 1);
+
+Edge edge;
+assert_eq(edge.big, std::numeric_limits<int>::max());
+assert(std::string_view(edge.text).starts_with("42"));
+assert_eq(edge.size, 44.f);
+assert_eq(edge.inner.score, 42);
+assert(edge.inner.alive);
 
 auto from_cb = instance.invoke_make_cb();
 assert_eq(from_cb.name, "cb");
@@ -204,6 +263,11 @@ let nested = new slint.NestedDefault();
 assert.equal(nested.player.name, "nested");
 assert.equal(nested.player.score, 42);
 
+let edge = new slint.Edge();
+assert(edge.big > 2000000000);
+assert(edge.text.startsWith("42"));
+assert.equal(edge.inner.score, 42);
+
 let from_cb = instance.make_cb();
 assert.equal(from_cb.name, "cb");
 assert.equal(from_cb.score, 42);
@@ -228,6 +292,16 @@ assert custom.score == 42
 nested = NestedDefault()
 assert nested.player.name == "nested"
 assert nested.player.score == 42
+
+edge = Edge()
+assert edge.big > 2000000000
+assert str(edge.text).startswith("42")
+assert edge.inner.score == 42
+assert edge.size == 44
+
+h1 = Holder()
+h2 = Holder()
+assert len(list(h1.model)) == 1 and len(list(h2.model)) == 1
 
 from_cb = instance.make_cb()
 assert from_cb.name == "cb"

--- a/tests/cases/types/struct_field_defaults.slint
+++ b/tests/cases/types/struct_field_defaults.slint
@@ -1,0 +1,140 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export enum Rank { bronze, silver, gold }
+
+export struct PlayerWithDefault {
+    name: string = "unknown",
+    score: int = 42,
+    energy: float = 0.5 * 2,
+    alive: bool = true,
+    tint: color = #00ff00,
+    rank: Rank = Rank.gold,
+    time: duration = 2s,
+    plain: int,
+}
+
+export struct NestedDefault {
+    player: PlayerWithDefault = { name: "nested" },
+    tags: [string] = ["a", "b"],
+}
+
+export component TestCase {
+    // Missing fields in a struct literal take the declared defaults
+    in-out property <PlayerWithDefault> partial: { name: "partial" };
+    // A property that is never set is initialized with the declared defaults
+    in-out property <PlayerWithDefault> never-set;
+    in-out property <NestedDefault> nested;
+
+    out property <bool> test:
+        partial.name == "partial" && partial.score == 42 && partial.energy == 1
+        && partial.alive && partial.tint == #00ff00 && partial.rank == Rank.gold
+        && partial.time == 2s && partial.plain == 0
+        && never-set.name == "unknown" && never-set.score == 42 && never-set.alive
+        && nested.player.name == "nested" && nested.player.score == 42
+        && nested.tags.length == 2 && nested.tags[0] == "a";
+}
+
+/*
+```rust
+use slint::Model;
+
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+let default_player = PlayerWithDefault::default();
+assert_eq!(default_player.name, "unknown");
+assert_eq!(default_player.score, 42);
+assert_eq!(default_player.energy, 1.);
+assert!(default_player.alive);
+assert_eq!(default_player.tint, slint::Color::from_rgb_u8(0, 255, 0));
+assert_eq!(default_player.rank, Rank::Gold);
+assert_eq!(default_player.time, 2000);
+assert_eq!(default_player.plain, 0);
+
+let nested = NestedDefault::default();
+assert_eq!(nested.player.name, "nested");
+assert_eq!(nested.player.score, 42);
+assert_eq!(nested.tags.row_count(), 2);
+assert_eq!(nested.tags.row_data(0).unwrap(), slint::SharedString::from("a"));
+assert_eq!(nested.tags.row_data(1).unwrap(), slint::SharedString::from("b"));
+
+// Fields left out in a Rust struct literal take the declared defaults, too
+let custom = PlayerWithDefault { name: "custom".into(), ..Default::default() };
+assert_eq!(custom.name, "custom");
+assert_eq!(custom.score, 42);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+PlayerWithDefault default_player;
+assert_eq(default_player.name, "unknown");
+assert_eq(default_player.score, 42);
+assert_eq(default_player.energy, 1.f);
+assert(default_player.alive);
+assert_eq(default_player.tint, slint::Color::from_rgb_uint8(0, 255, 0));
+assert(default_player.rank == Rank::Gold);
+assert_eq(default_player.time, 2000);
+assert_eq(default_player.plain, 0);
+
+PlayerWithDefault aggregate {};
+assert_eq(aggregate.score, 42);
+
+NestedDefault nested;
+assert_eq(nested.player.name, "nested");
+assert_eq(nested.player.score, 42);
+assert_eq(nested.tags->row_count(), 2);
+assert_eq(nested.tags->row_data(0).value(), "a");
+assert_eq(nested.tags->row_data(1).value(), "b");
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+
+let default_player = new slint.PlayerWithDefault();
+assert.equal(default_player.name, "unknown");
+assert.equal(default_player.score, 42);
+assert.equal(default_player.energy, 1);
+assert.equal(default_player.alive, true);
+assert.equal(default_player.time, 2000);
+assert.equal(default_player.plain, 0);
+
+let custom = new slint.PlayerWithDefault({ name: "custom" });
+assert.equal(custom.name, "custom");
+assert.equal(custom.score, 42);
+
+// Missing fields of a plain object assigned to a struct property take the defaults
+instance.partial = { name: "js" };
+assert.equal(instance.partial.name, "js");
+assert.equal(instance.partial.score, 42);
+
+let nested = new slint.NestedDefault();
+assert.equal(nested.player.name, "nested");
+assert.equal(nested.player.score, 42);
+```
+
+```python
+instance = TestCase()
+assert instance.test
+
+default_player = PlayerWithDefault()
+assert default_player.name == "unknown"
+assert default_player.score == 42
+assert default_player.energy == 1
+assert default_player.alive
+assert default_player.time == 2000
+assert default_player.plain == 0
+
+custom = PlayerWithDefault(name="custom")
+assert custom.name == "custom"
+assert custom.score == 42
+
+nested = NestedDefault()
+assert nested.player.name == "nested"
+assert nested.player.score == 42
+```
+*/

--- a/tests/cases/types/struct_field_defaults.slint
+++ b/tests/cases/types/struct_field_defaults.slint
@@ -26,13 +26,35 @@ export component TestCase {
     in-out property <PlayerWithDefault> never-set;
     in-out property <NestedDefault> nested;
 
+    // A struct literal returned from a function takes the declared defaults, too
+    function make-player(name: string) -> PlayerWithDefault {
+        return { name: name };
+    }
+
+    // Early returns from different branches are each filled with the defaults
+    function pick-player(early: bool) -> PlayerWithDefault {
+        if (early) {
+            return { name: "early" };
+        }
+        return { name: "late", score: 1, alive: false };
+    }
+
+    out property <PlayerWithDefault> made: make-player("made");
+    out property <PlayerWithDefault> picked-early: pick-player(true);
+    out property <PlayerWithDefault> picked-late: pick-player(false);
+
     out property <bool> test:
         partial.name == "partial" && partial.score == 42 && partial.energy == 1
         && partial.alive && partial.tint == #00ff00 && partial.rank == Rank.gold
         && partial.time == 2s && partial.plain == 0
         && never-set.name == "unknown" && never-set.score == 42 && never-set.alive
         && nested.player.name == "nested" && nested.player.score == 42
-        && nested.tags.length == 2 && nested.tags[0] == "a";
+        && nested.tags.length == 2 && nested.tags[0] == "a"
+        && made.name == "made" && made.score == 42 && made.energy == 1 && made.alive
+        && made.rank == Rank.gold && made.time == 2s && made.plain == 0
+        && picked-early.name == "early" && picked-early.score == 42 && picked-early.alive
+        && picked-late.name == "late" && picked-late.score == 1 && !picked-late.alive
+        && picked-late.energy == 1 && picked-late.rank == Rank.gold;
 }
 
 /*

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2039,11 +2039,16 @@ fn format_object_type_member(
     writer: &mut impl TokenWriter,
     state: &mut FormatState,
 ) -> Result<(), std::io::Error> {
-    // Format a single struct field: `name: Type` (comma handled if present).
+    // Format a single struct field: `name: Type` or `name: Type = default-value`
+    // (comma handled if present).
     let mut sub = node.children_with_tokens();
     let _ok = whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?
         && whitespace_to(&mut sub, SyntaxKind::Colon, writer, state, "")?
         && whitespace_to(&mut sub, SyntaxKind::Type, writer, state, " ")?;
+    if node.child_token(SyntaxKind::Equal).is_some() {
+        let _ok = whitespace_to(&mut sub, SyntaxKind::Equal, writer, state, " ")?
+            && whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, " ")?;
+    }
     if node.child_token(SyntaxKind::Comma).is_some() {
         whitespace_to(&mut sub, SyntaxKind::Comma, writer, state, "")?;
     }
@@ -3271,6 +3276,28 @@ struct Bar {
 
 component HelloWorld {
     // ...
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn struct_field_default_values() {
+        assert_formatting(
+            r#"
+struct Foo {
+    a: int=42,
+    b: string    =   "hello",
+    c: color= #ff0000,
+    d: int,
+}
+"#,
+            r#"
+struct Foo {
+    a: int = 42,
+    b: string = "hello",
+    c: color = #ff0000,
+    d: int,
 }
 "#,
         );


### PR DESCRIPTION
Struct fields can declare a default value with `= expression` after the type, for example `struct Player { name: string = "unknown" }`. The expression must be a compile-time constant. The default applies whenever an instance is created without a value for the field: in struct literals that omit the field, for properties that are never set, and when constructing the struct from Rust (Player::default()), C++ (Player{}), JavaScript (new ui.Player()), or Python (ui.Player()).

changelog: Struct fields can declare a default value (`struct Player { name: string = "unknown" }`) that applies when an instance is created without a value for the field.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
