### PR TITLE
tools/lsp: add a SlintPad brand mark to the header toolbar

### DIFF
--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -39,6 +39,32 @@ export component HeaderView {
                 horizontal-stretch: 0;
                 spacing: EditorSpaceSettings.default-spacing / 2;
 
+                // SlintPad brand mark: a gradient chip with the Slint bolt,
+                // matching the loader and the rest of the brand chrome.
+                if Api.runs-in-slintpad: Rectangle {
+                    width: 26px;
+                    height: 26px;
+                    border-radius: 7px;
+                    background: @linear-gradient(103deg, #2379f4 4%, #6b0dff 96%);
+                    Path {
+                        width: 13px;
+                        height: 18px;
+                        viewbox-width: 30;
+                        viewbox-height: 42;
+                        fill: #ffffff;
+                        commands: "M5.49 41.62 28.6 25.5s1.04-.6 1.04-1.55c0-1.27-1.32-1.68-1.32-1.68L15.61 17.2c-.45-.18-1.08.32-.49.96l4.2 4.24s1.17 1.16 1.17 1.92c0 .76-.72 1.43-.72 1.43L4.46 40.65c-.55.53.19 1.49 1.03.97Z M24.15.76 1.04 16.88S0 17.48 0 18.43c0 1.27 1.32 1.68 1.32 1.68l12.71 5.07c.46.17 1.08-.33.5-.97l-4.21-4.25s-1.17-1.16-1.17-1.92c0-.76.72-1.43.72-1.43L25.17 1.73c.56-.53-.18-1.49-1.02-.97Z";
+                    }
+                }
+
+                if Api.runs-in-slintpad: Text {
+                    vertical-alignment: center;
+                    text: "SlintPad";
+                    color: root.brand-dark ? Brand.text : Palette.foreground;
+                    font-family: "Inter";
+                    font-size: 15px;
+                    font-weight: 800;
+                }
+
                 Button {
                     icon: Icons.sync;
                     colorize-icon: true;
@@ -47,7 +73,7 @@ export component HeaderView {
                     }
                 }
 
-                label := Text {
+                if !Api.runs-in-slintpad: Text {
                     horizontal-alignment: left;
                     vertical-alignment: center;
                     color: ConsoleStyles.text-color;


### PR DESCRIPTION
Phase 1 header polish (first step): give the SlintPad header a product identity with a gradient brand chip (the Slint bolt) plus a "SlintPad" wordmark on the left of the toolbar, matching the loader and the rest of the brand chrome.

> Stacked on #12473 (chrome branding) since it uses the `Brand` palette and `brand-dark` from there. Base is `slintpad-chrome-brand`; retarget to master once #12473 merges.

Gated on `Api.runs-in-slintpad`, so the VS Code extension and desktop live preview keep their plain "Preview" label.

## Testing
- `pnpm build:wasm_lsp` builds clean (validates the bolt `Path` commands); cspell passes.
- Confirmed in SlintPad: the gradient chip + bolt + wordmark render correctly on the dark header.

## Deferred
- **Editable project name**: there is no project-name property in the Api and no light logo asset, so it needs a small backend addition. Done here: the logo + wordmark. The editable name can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)