### PR TITLE
demos: fix home-automation esp-idf build by excluding broken gt911 re…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -532,6 +532,14 @@ jobs:
               run: |
                   . ${IDF_PATH}/export.sh
                   idf.py -D SLINT_ESP_LOCAL_EXAMPLE=OFF build
+            - name: Build Home Automation demo (ESP32-P4)
+              # The demo requires ESP-IDF >= 5.4, so skip the v5.2 matrix entry
+              if: ${{ inputs.full && matrix.esp-idf-version != 'release-v5.2' }}
+              shell: bash
+              working-directory: demos/home-automation/esp-idf
+              run: |
+                  . ${IDF_PATH}/export.sh
+                  idf.py build
 
     android:
         needs: files-changed

--- a/demos/home-automation/esp-idf/main/idf_component.yml
+++ b/demos/home-automation/esp-idf/main/idf_component.yml
@@ -5,3 +5,8 @@
 dependencies:
   idf: ">=5.4"
   espressif/esp32_p4_function_ev_board_noglib: "^4.2.1"
+  # Exclude esp_lcd_touch_gt911 1.2.0~2: it lists the designators in
+  # ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG() out of declaration order, which is a
+  # hard error in C++ (esp-bsp commit f6cb4c2, same regression as esp-bsp#797).
+  # Drop this line once a fixed release is out.
+  espressif/esp_lcd_touch_gt911: "^1,!=1.2.0~2"


### PR DESCRIPTION
…lease

esp_lcd_touch_gt911 1.2.0~2 (esp-bsp commit f6cb4c2) added a default .scl_speed_hz as the first designator in ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG(), but scl_speed_hz is the last field of esp_lcd_panel_io_i2c_config_t. C++ requires designators in declaration order, so GCC rejects the macro with:

    esp_lcd_touch_gt911.h: error: designator order for field
    'esp_lcd_panel_io_i2c_config_t::dev_addr' does not match declaration order

The demo pulls the component transitively via esp32_p4_function_ev_board_noglib (constraint: ^1), so fresh builds started resolving to the broken release. Exclude exactly that release; the solver then picks 1.2.0~1 and will move to a fixed release automatically once Espressif publishes one. The same regression is tracked upstream for the sibling FT5x06 driver as esp-bsp#797.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Closes #12338