### PR TITLE
tools: add a ⌘K command palette for demos and actions

### DIFF
--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -144,6 +144,7 @@ export component MenuItemBase {
 
                     Image {
                         source: entry.icon;
+                        colorize: root.default-foreground;
                         accessible-role: none;
                         image-fit: contain;
                         width: 100%;

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1960,6 +1960,21 @@ fn get_current_style() -> String {
     })
 }
 
+/// The list of built-in demos (title, url), so the SlintPad command palette
+/// can offer the same demos as the "Open Demo" menu without duplicating them.
+fn get_demos() -> Vec<(String, String)> {
+    PREVIEW_STATE.with_borrow(|preview_state| -> Vec<(String, String)> {
+        if let Some(api) = preview_state.api.upgrade() {
+            use slint::Model;
+            // The `{title, url}` struct compiles to a tuple with fields sorted
+            // alphabetically, so `.0` is `title` and `.1` is `url`.
+            api.get_demos().iter().map(|d| (d.0.to_string(), d.1.to_string())).collect()
+        } else {
+            Vec::new()
+        }
+    })
+}
+
 fn set_status_text(text: &str) {
     let text = text.to_string();
 

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -19,6 +19,7 @@ pub enum SlintPadCallbackFunction {
     ShowAbout,
     CopyPermalink,
     NewFile,
+    OpenCommandPalette,
     SavePanelLayout,
 }
 
@@ -327,6 +328,7 @@ fn init_slintpad_specific_ui(api: &crate::preview::ui::Api) {
         open_demo_url(&url);
     });
     api.on_show_about_slint(show_about_slint);
+    api.on_open_command_palette(open_command_palette);
     api.on_panels_layout_changed(save_panel_layout);
 }
 
@@ -377,6 +379,27 @@ fn save_panel_layout() {
             &JsValue::UNDEFINED,
             &wasm_bindgen::JsValue::from(SlintPadCallbackFunction::SavePanelLayout),
             &obj.into(),
+        );
+    });
+}
+
+fn open_command_palette() {
+    WASM_CALLBACKS.with_borrow(|callbacks| {
+        let maybe_callback = wasm_bindgen::JsValue::from(
+            callbacks
+                .as_ref()
+                .expect("Callbacks were set up earlier")
+                .invoke_slintpad_callback
+                .clone(),
+        );
+        if !maybe_callback.is_function() {
+            return;
+        }
+        let opener = js_sys::Function::from(maybe_callback);
+        let _ = opener.call2(
+            &JsValue::UNDEFINED,
+            &wasm_bindgen::JsValue::from(SlintPadCallbackFunction::OpenCommandPalette),
+            &wasm_bindgen::JsValue::undefined(),
         );
     });
 }

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -169,7 +169,8 @@ impl PreviewConnector {
             // Upgrade and drop the PREVIEW_STATE borrow before touching any
             // property: setting one triggers panels-layout-changed, whose
             // handler borrows PREVIEW_STATE again and would otherwise panic.
-            let api = preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
+            let api =
+                preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
             if let Some(api) = api {
                 api.set_panel_library_open(library);
                 api.set_panel_properties_open(properties);
@@ -194,11 +195,8 @@ impl PreviewConnector {
                 &JsValue::from_str("title"),
                 &JsValue::from_str(&title),
             );
-            let _ = js_sys::Reflect::set(
-                &entry,
-                &JsValue::from_str("url"),
-                &JsValue::from_str(&url),
-            );
+            let _ =
+                js_sys::Reflect::set(&entry, &JsValue::from_str("url"), &JsValue::from_str(&url));
             array.push(&entry);
         }
         array.into()

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -19,6 +19,7 @@ pub enum SlintPadCallbackFunction {
     ShowAbout,
     CopyPermalink,
     NewFile,
+    SavePanelLayout,
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -149,6 +150,35 @@ impl PreviewConnector {
     #[wasm_bindgen]
     pub fn current_style(&self) -> JsValue {
         preview::get_current_style().into()
+    }
+
+    /// Restore the panel visibility the host persisted from an earlier session.
+    /// Setting the properties fires the change handlers, so the host will save
+    /// the same values straight back, which is harmless.
+    #[wasm_bindgen]
+    pub fn restore_panels(
+        &self,
+        library: bool,
+        properties: bool,
+        outline: bool,
+        data: bool,
+        console: bool,
+    ) -> Result<(), JsValue> {
+        i_slint_core::api::invoke_from_event_loop(move || {
+            // Upgrade and drop the PREVIEW_STATE borrow before touching any
+            // property: setting one triggers panels-layout-changed, whose
+            // handler borrows PREVIEW_STATE again and would otherwise panic.
+            let api = preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
+            if let Some(api) = api {
+                api.set_panel_library_open(library);
+                api.set_panel_properties_open(properties);
+                api.set_panel_outline_open(outline);
+                api.set_panel_data_open(data);
+                api.set_panel_console_open(console);
+            }
+        })
+        .map_err(|e| -> JsValue { format!("{e:?}").into() })?;
+        Ok(())
     }
 
     #[wasm_bindgen]
@@ -297,6 +327,58 @@ fn init_slintpad_specific_ui(api: &crate::preview::ui::Api) {
         open_demo_url(&url);
     });
     api.on_show_about_slint(show_about_slint);
+    api.on_panels_layout_changed(save_panel_layout);
+}
+
+fn save_panel_layout() {
+    // Read the current panel visibility, then drop the PREVIEW_STATE borrow
+    // before calling into JS.
+    let layout = preview::PREVIEW_STATE.with_borrow(|preview_state| {
+        preview_state.api.upgrade().map(|api| {
+            (
+                api.get_panel_library_open(),
+                api.get_panel_properties_open(),
+                api.get_panel_outline_open(),
+                api.get_panel_data_open(),
+                api.get_panel_console_open(),
+            )
+        })
+    });
+    let Some((library, properties, outline, data, console)) = layout else {
+        return;
+    };
+
+    WASM_CALLBACKS.with_borrow(|callbacks| {
+        let maybe_callback = wasm_bindgen::JsValue::from(
+            callbacks
+                .as_ref()
+                .expect("Callbacks were set up earlier")
+                .invoke_slintpad_callback
+                .clone(),
+        );
+        if !maybe_callback.is_function() {
+            return;
+        }
+        let opener = js_sys::Function::from(maybe_callback);
+        let obj = js_sys::Object::new();
+        let _ =
+            js_sys::Reflect::set(&obj, &JsValue::from_str("library"), &JsValue::from_bool(library));
+        let _ = js_sys::Reflect::set(
+            &obj,
+            &JsValue::from_str("properties"),
+            &JsValue::from_bool(properties),
+        );
+        let _ =
+            js_sys::Reflect::set(&obj, &JsValue::from_str("outline"), &JsValue::from_bool(outline));
+        let _ = js_sys::Reflect::set(&obj, &JsValue::from_str("data"), &JsValue::from_bool(data));
+        let _ =
+            js_sys::Reflect::set(&obj, &JsValue::from_str("console"), &JsValue::from_bool(console));
+        let _ = opener.call2(
+            &JsValue::UNDEFINED,
+            &wasm_bindgen::JsValue::from(SlintPadCallbackFunction::SavePanelLayout),
+            &obj.into(),
+        );
+    });
 }
 
 fn new_file() {

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -182,6 +182,28 @@ impl PreviewConnector {
         Ok(())
     }
 
+    /// Returns the built-in demos as an array of `{ title, url }`, so the
+    /// command palette can offer the same list as the "Open Demo" menu.
+    #[wasm_bindgen]
+    pub fn demos(&self) -> JsValue {
+        let array = js_sys::Array::new();
+        for (title, url) in preview::get_demos() {
+            let entry = js_sys::Object::new();
+            let _ = js_sys::Reflect::set(
+                &entry,
+                &JsValue::from_str("title"),
+                &JsValue::from_str(&title),
+            );
+            let _ = js_sys::Reflect::set(
+                &entry,
+                &JsValue::from_str("url"),
+                &JsValue::from_str(&url),
+            );
+            array.push(&entry);
+        }
+        array.into()
+    }
+
     #[wasm_bindgen]
     pub fn show_ui(&self) -> Result<js_sys::Promise, JsValue> {
         invoke_from_event_loop_wrapped_in_promise(|instance| instance.show())

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -303,6 +303,16 @@ export global Api {
     in-out property <bool> always-on-top;
     in property <bool> focus-previewed-element;
 
+    // ## Panel layout, persisted by the SlintPad host across reloads.
+    // The host restores these on startup and is notified through
+    // panels-layout-changed() whenever the user shows or hides a panel.
+    in-out property <bool> panel-library-open;
+    in-out property <bool> panel-properties-open;
+    in-out property <bool> panel-outline-open;
+    in-out property <bool> panel-data-open;
+    in-out property <bool> panel-console-open;
+    callback panels-layout-changed();
+
     // ## Component Data for ComponentList:
     // All the components
     in property <[ComponentListItem]> known-components;

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -662,4 +662,5 @@ export global Api {
     callback share-permalink-to-clipboard();
     callback load-demo(url: string);
     callback show-about-slint();
+    callback open-command-palette();
 }

--- a/tools/lsp/ui/components/group.slint
+++ b/tools/lsp/ui/components/group.slint
@@ -3,7 +3,7 @@
 
 import { HorizontalBox, Palette } from "std-widgets.slint";
 import { HeaderText } from "./header-text.slint";
-import { EditorSizeSettings } from "./styling.slint";
+import { EditorSizeSettings, ConsoleStyles } from "./styling.slint";
 
 export component GroupHeader {
     in property <string> title;
@@ -32,7 +32,7 @@ export component Group {
     min-height: content-layer.min-height;
 
     background-layer := Rectangle {
-        background: Palette.background;
+        background: ConsoleStyles.panel-background;
     }
 
     content-layer := VerticalLayout {
@@ -42,6 +42,6 @@ export component Group {
     Rectangle {
         x: root.width - self.width;
         width: 2px;
-        background: Palette.border;
+        background: ConsoleStyles.panel-border;
     }
 }

--- a/tools/lsp/ui/components/styling.slint
+++ b/tools/lsp/ui/components/styling.slint
@@ -101,6 +101,10 @@ export global ConsoleStyles {
     out property <color> log-background: dark-scheme ? (branded ? Brand.ink : #262626) : #ffffff;
     out property <color> text-color: dark-scheme ? #cccccc : #525252;
     out property <color> toolbar-background: dark-scheme ? (branded ? Brand.surface : #2c2c2c) : #f3f3f3;
+    // Panel body surface and border: match the brand chrome in SlintPad,
+    // otherwise fall back to the active widget style.
+    out property <color> panel-background: (branded && dark-scheme) ? Brand.ink : Palette.background;
+    out property <color> panel-border: (branded && dark-scheme) ? Brand.line : Palette.border;
     out property <length> header-height: 28px;
     out property <length> log-height: 120px;
     out property <color> slint-blue: #0088ff;

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -41,11 +41,18 @@ export component PreviewUi inherits Window {
     property <bool> show-floating-table-editor <=> WindowManager.showing-table-editor;
     property <bool> show-color-stop-picker <=> WindowManager.showing-color-stop-picker;
     property <length> initial-floating-x;
-    property <bool> console-panel-expanded: false;
-    property <bool> properties-widget: false;
-    property <bool> data-widget: false;
-    property <bool> outline-widget: false;
-    property <bool> library-widget: false;
+    // Panel visibility is aliased to Api so the SlintPad host can restore it on
+    // startup and persist it whenever the user toggles a panel.
+    property <bool> console-panel-expanded <=> Api.panel-console-open;
+    property <bool> properties-widget <=> Api.panel-properties-open;
+    property <bool> data-widget <=> Api.panel-data-open;
+    property <bool> outline-widget <=> Api.panel-outline-open;
+    property <bool> library-widget <=> Api.panel-library-open;
+    changed console-panel-expanded => { Api.panels-layout-changed(); }
+    changed properties-widget => { Api.panels-layout-changed(); }
+    changed data-widget => { Api.panels-layout-changed(); }
+    changed outline-widget => { Api.panels-layout-changed(); }
+    changed library-widget => { Api.panels-layout-changed(); }
     property <bool> remote-mode: Api.preview-mode == PreviewMode.Remote;
     in-out property <bool> select-mode: false;
 
@@ -345,7 +352,7 @@ export component PreviewUi inherits Window {
                             }
                             mouse-cursor: ns-resize;
                             Rectangle {
-                                background: Palette.border;
+                                background: root.brand-dark ? Brand.line : Palette.border;
                             }
                         }
 
@@ -369,7 +376,7 @@ export component PreviewUi inherits Window {
                             }
                             mouse-cursor: ns-resize;
                             Rectangle {
-                                background: Palette.border;
+                                background: root.brand-dark ? Brand.line : Palette.border;
                             }
                         }
 

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -39,6 +39,32 @@ export component HeaderView {
                 horizontal-stretch: 0;
                 spacing: EditorSpaceSettings.default-spacing / 2;
 
+                // SlintPad brand mark: a gradient chip with the Slint bolt,
+                // matching the loader and the rest of the brand chrome.
+                if Api.runs-in-slintpad: Rectangle {
+                    width: 26px;
+                    height: 26px;
+                    border-radius: 7px;
+                    background: @linear-gradient(103deg, #2379f4 4%, #6b0dff 96%);
+                    Path {
+                        width: 13px;
+                        height: 18px;
+                        viewbox-width: 30;
+                        viewbox-height: 42;
+                        fill: #ffffff;
+                        commands: "M5.49 41.62 28.6 25.5s1.04-.6 1.04-1.55c0-1.27-1.32-1.68-1.32-1.68L15.61 17.2c-.45-.18-1.08.32-.49.96l4.2 4.24s1.17 1.16 1.17 1.92c0 .76-.72 1.43-.72 1.43L4.46 40.65c-.55.53.19 1.49 1.03.97Z M24.15.76 1.04 16.88S0 17.48 0 18.43c0 1.27 1.32 1.68 1.32 1.68l12.71 5.07c.46.17 1.08-.33.5-.97l-4.21-4.25s-1.17-1.16-1.17-1.92c0-.76.72-1.43.72-1.43L25.17 1.73c.56-.53-.18-1.49-1.02-.97Z";
+                    }
+                }
+
+                if Api.runs-in-slintpad: Text {
+                    vertical-alignment: center;
+                    text: "SlintPad";
+                    color: root.brand-dark ? Brand.text : Palette.foreground;
+                    font-family: "Inter";
+                    font-size: 15px;
+                    font-weight: 800;
+                }
+
                 Button {
                     icon: Icons.sync;
                     colorize-icon: true;
@@ -47,7 +73,7 @@ export component HeaderView {
                     }
                 }
 
-                label := Text {
+                if !Api.runs-in-slintpad: Text {
                     horizontal-alignment: left;
                     vertical-alignment: center;
                     color: ConsoleStyles.text-color;

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -73,6 +73,16 @@ export component HeaderView {
                     }
                 }
 
+                // Discoverable entry point for the command palette (⌘K).
+                if Api.runs-in-slintpad: Button {
+                    icon: Icons.search;
+                    colorize-icon: true;
+                    text: Platform.os == OperatingSystemType.macos ? "Commands  ⌘K" : "Commands  Ctrl+K";
+                    clicked => {
+                        Api.open-command-palette();
+                    }
+                }
+
                 if !Api.runs-in-slintpad: Text {
                     horizontal-alignment: left;
                     vertical-alignment: center;

--- a/tools/slintpad/src/command_palette.ts
+++ b/tools/slintpad/src/command_palette.ts
@@ -112,8 +112,13 @@ function inject_styles(): void {
     document.head.appendChild(style);
 }
 
-export function install_command_palette(commands: Command[]): CommandPalette {
+export function install_command_palette(
+    get_commands: () => Command[],
+): CommandPalette {
     inject_styles();
+    // Recomputed each time the palette opens, so dynamic entries (e.g. the
+    // demo list read from the LSP) are always current.
+    let commands: Command[] = [];
     let overlay: HTMLDivElement | null = null;
     let input: HTMLInputElement | null = null;
     let list: HTMLDivElement | null = null;
@@ -186,6 +191,7 @@ export function install_command_palette(commands: Command[]): CommandPalette {
         if (overlay !== null) {
             return;
         }
+        commands = get_commands();
         active = 0;
 
         overlay = document.createElement("div");

--- a/tools/slintpad/src/command_palette.ts
+++ b/tools/slintpad/src/command_palette.ts
@@ -1,0 +1,269 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore cmdk Archivo
+
+// A ⌘K / Ctrl+K command palette: fuzzy-ish search over demos and actions.
+
+export interface Command {
+    id: string;
+    title: string;
+    hint?: string;
+    run: () => void;
+}
+
+export interface CommandPalette {
+    open: () => void;
+}
+
+// Self-contained styles (literal brand colors) so the palette does not
+// depend on any external stylesheet.
+const CMDK_STYLES = `
+.cmdk-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 12vh;
+    background: rgba(6, 10, 14, 0.6);
+    backdrop-filter: blur(4px);
+    font-family: "Archivo", system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+.cmdk-panel {
+    width: min(560px, 92vw);
+    max-height: 60vh;
+    display: flex;
+    flex-direction: column;
+    background: #0f1519;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 14px;
+    box-shadow: 0 30px 80px rgba(5, 10, 14, 0.6);
+    overflow: hidden;
+}
+.cmdk-input {
+    width: 100%;
+    box-sizing: border-box;
+    border: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    background: transparent;
+    color: #eef3f5;
+    font: inherit;
+    font-size: 15px;
+    padding: 15px 18px;
+    outline: none;
+}
+.cmdk-input::placeholder {
+    color: #9fb0b8;
+}
+.cmdk-list {
+    overflow-y: auto;
+    padding: 6px;
+}
+.cmdk-empty {
+    padding: 16px 18px;
+    color: #9fb0b8;
+    font-size: 14px;
+}
+.cmdk-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: transparent;
+    color: #9fb0b8;
+    font: inherit;
+    font-size: 14px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    cursor: pointer;
+}
+.cmdk-row.cmdk-active {
+    background: rgba(35, 121, 244, 0.16);
+    color: #eef3f5;
+}
+.cmdk-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.cmdk-hint {
+    flex-shrink: 0;
+    font-family: "JetBrains Mono", ui-monospace, "Source Code Pro", monospace;
+    font-size: 11px;
+    color: #9fb0b8;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    padding: 2px 9px;
+}
+`;
+
+function inject_styles(): void {
+    if (document.getElementById("cmdk-styles") !== null) {
+        return;
+    }
+    const style = document.createElement("style");
+    style.id = "cmdk-styles";
+    style.textContent = CMDK_STYLES;
+    document.head.appendChild(style);
+}
+
+export function install_command_palette(commands: Command[]): CommandPalette {
+    inject_styles();
+    let overlay: HTMLDivElement | null = null;
+    let input: HTMLInputElement | null = null;
+    let list: HTMLDivElement | null = null;
+    let filtered: Command[] = [];
+    let active = 0;
+
+    const close = () => {
+        overlay?.remove();
+        overlay = null;
+    };
+
+    const run_active = () => {
+        const cmd = filtered[active];
+        close();
+        cmd?.run();
+    };
+
+    const render = () => {
+        if (list === null || input === null) {
+            return;
+        }
+        const query = input.value.trim().toLowerCase();
+        filtered = query
+            ? commands.filter((c) => c.title.toLowerCase().includes(query))
+            : commands;
+        if (active >= filtered.length) {
+            active = Math.max(0, filtered.length - 1);
+        }
+        list.innerHTML = "";
+        if (filtered.length === 0) {
+            const empty = document.createElement("div");
+            empty.className = "cmdk-empty";
+            empty.textContent = "No matching commands";
+            list.appendChild(empty);
+            return;
+        }
+        filtered.forEach((cmd, i) => {
+            const row = document.createElement("button");
+            row.type = "button";
+            row.className = i === active ? "cmdk-row cmdk-active" : "cmdk-row";
+            const title = document.createElement("span");
+            title.className = "cmdk-title";
+            title.textContent = cmd.title;
+            row.appendChild(title);
+            if (cmd.hint) {
+                const hint = document.createElement("span");
+                hint.className = "cmdk-hint";
+                hint.textContent = cmd.hint;
+                row.appendChild(hint);
+            }
+            row.addEventListener("mousemove", () => {
+                if (active !== i) {
+                    active = i;
+                    render();
+                }
+            });
+            row.addEventListener("click", () => {
+                active = i;
+                run_active();
+            });
+            list?.appendChild(row);
+        });
+    };
+
+    const scroll_active_into_view = () => {
+        list?.children[active]?.scrollIntoView({ block: "nearest" });
+    };
+
+    const open = () => {
+        if (overlay !== null) {
+            return;
+        }
+        active = 0;
+
+        overlay = document.createElement("div");
+        overlay.className = "cmdk-overlay";
+        overlay.setAttribute("role", "dialog");
+        overlay.setAttribute("aria-label", "Command palette");
+
+        const panel = document.createElement("div");
+        panel.className = "cmdk-panel";
+
+        input = document.createElement("input");
+        input.className = "cmdk-input";
+        input.type = "text";
+        input.placeholder = "Type a command or demo…";
+        input.setAttribute("aria-label", "Command palette search");
+        input.autocomplete = "off";
+        input.spellcheck = false;
+
+        list = document.createElement("div");
+        list.className = "cmdk-list";
+
+        panel.appendChild(input);
+        panel.appendChild(list);
+        overlay.appendChild(panel);
+        document.body.appendChild(overlay);
+
+        overlay.addEventListener("mousedown", (e) => {
+            if (e.target === overlay) {
+                close();
+            }
+        });
+
+        input.addEventListener("input", () => {
+            active = 0;
+            render();
+        });
+
+        input.addEventListener("keydown", (e) => {
+            if (e.key === "ArrowDown") {
+                e.preventDefault();
+                active = Math.min(active + 1, filtered.length - 1);
+                render();
+                scroll_active_into_view();
+            } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                active = Math.max(active - 1, 0);
+                render();
+                scroll_active_into_view();
+            } else if (e.key === "Enter") {
+                e.preventDefault();
+                run_active();
+            } else if (e.key === "Escape") {
+                e.preventDefault();
+                close();
+            }
+        });
+
+        render();
+        input.focus();
+    };
+
+    // Global shortcut. Capture phase so it wins over the editor's own ⌘K
+    // chord handling.
+    document.addEventListener(
+        "keydown",
+        (e: KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+                e.preventDefault();
+                e.stopPropagation();
+                if (overlay === null) {
+                    open();
+                } else {
+                    close();
+                }
+            }
+        },
+        { capture: true },
+    );
+
+    return { open };
+}

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -21,8 +21,32 @@ import {
     set_panic_share_url_getter,
 } from "./dialogs";
 
+import { install_command_palette, type Command } from "./command_palette";
+
 import { CommandRegistry } from "@lumino/commands";
 import { Menu, MenuBar, SplitPanel, Widget } from "@lumino/widgets";
+
+// Demos offered in the command palette, matching tools/lsp/ui/api.slint.
+const DEMOS: { title: string; url: string }[] = [
+    { title: "Gallery", url: "examples/gallery/gallery.slint" },
+    {
+        title: "Home Automation",
+        url: "demos/home-automation/ui/demo-debug.slint",
+    },
+    { title: "Use Cases", url: "demos/usecases/ui/app.slint" },
+    { title: "Printer Demo", url: "demos/printerdemo/ui/printerdemo.slint" },
+    {
+        title: "Energy Monitor",
+        url: "demos/energy-monitor/ui/desktop_window.slint",
+    },
+    { title: "Todo", url: "examples/todo/ui/todo.slint" },
+    { title: "IOT Dashboard", url: "examples/iot-dashboard/main.slint" },
+    { title: "Fancy Switches", url: "examples/fancy-switches/demo.slint" },
+    { title: "Fancy Dial", url: "examples/dial/dial.slint" },
+    { title: "Fancy Animations", url: "examples/orbit-animation/demo.slint" },
+    { title: "Fancy Repeater", url: "examples/repeater/demo.slint" },
+    { title: "Sprite Sheet", url: "examples/sprite-sheet/demo.slint" },
+];
 
 import { type InvokeSlintpadCallback, SlintPadCallbackFunction } from "./lsp";
 
@@ -95,6 +119,35 @@ function save_panel_layout(layout: PanelLayout): void {
 function setup(lsp: Lsp) {
     const editor = new EditorWidget(lsp);
     set_panic_share_url_getter(() => editor.share_url());
+
+    const palette_commands: Command[] = [
+        {
+            id: "new-file",
+            title: "New File",
+            hint: "Action",
+            run: () => void editor.set_demo(""),
+        },
+        ...DEMOS.map((demo) => ({
+            id: `demo:${demo.url}`,
+            title: `Open Demo: ${demo.title}`,
+            hint: "Demo",
+            run: () => void editor.set_demo(demo.url),
+        })),
+        {
+            id: "copy-permalink",
+            title: "Copy Permalink to Clipboard",
+            hint: "Share",
+            run: () => void editor.copy_permalink_to_clipboard(),
+        },
+        {
+            id: "about",
+            title: "About SlintPad",
+            hint: "Help",
+            run: () => about_dialog(),
+        },
+    ];
+    const palette = install_command_palette(palette_commands);
+
     const preview = new PreviewWidget(
         lsp,
         (url: string) => editor.map_url(url),
@@ -108,6 +161,10 @@ function setup(lsp: Lsp) {
                 void editor.copy_permalink_to_clipboard();
             } else if (func_type === SlintPadCallbackFunction.NewFile) {
                 void editor.set_demo("");
+            } else if (
+                func_type === SlintPadCallbackFunction.OpenCommandPalette
+            ) {
+                palette.open();
             } else if (func_type === SlintPadCallbackFunction.SavePanelLayout) {
                 save_panel_layout(args as PanelLayout);
             }

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -26,28 +26,6 @@ import { install_command_palette, type Command } from "./command_palette";
 import { CommandRegistry } from "@lumino/commands";
 import { Menu, MenuBar, SplitPanel, Widget } from "@lumino/widgets";
 
-// Demos offered in the command palette, matching tools/lsp/ui/api.slint.
-const DEMOS: { title: string; url: string }[] = [
-    { title: "Gallery", url: "examples/gallery/gallery.slint" },
-    {
-        title: "Home Automation",
-        url: "demos/home-automation/ui/demo-debug.slint",
-    },
-    { title: "Use Cases", url: "demos/usecases/ui/app.slint" },
-    { title: "Printer Demo", url: "demos/printerdemo/ui/printerdemo.slint" },
-    {
-        title: "Energy Monitor",
-        url: "demos/energy-monitor/ui/desktop_window.slint",
-    },
-    { title: "Todo", url: "examples/todo/ui/todo.slint" },
-    { title: "IOT Dashboard", url: "examples/iot-dashboard/main.slint" },
-    { title: "Fancy Switches", url: "examples/fancy-switches/demo.slint" },
-    { title: "Fancy Dial", url: "examples/dial/dial.slint" },
-    { title: "Fancy Animations", url: "examples/orbit-animation/demo.slint" },
-    { title: "Fancy Repeater", url: "examples/repeater/demo.slint" },
-    { title: "Sprite Sheet", url: "examples/sprite-sheet/demo.slint" },
-];
-
 import { type InvokeSlintpadCallback, SlintPadCallbackFunction } from "./lsp";
 
 const loader = document.getElementById("loader");
@@ -120,19 +98,24 @@ function setup(lsp: Lsp) {
     const editor = new EditorWidget(lsp);
     set_panic_share_url_getter(() => editor.share_url());
 
-    const palette_commands: Command[] = [
+    // Built fresh each time the palette opens; the demo list is read from the
+    // LSP (Api.demos) so it always matches the toolbar's Open Demo menu.
+    const palette_commands = (): Command[] => [
         {
             id: "new-file",
             title: "New File",
             hint: "Action",
             run: () => void editor.set_demo(""),
         },
-        ...DEMOS.map((demo) => ({
-            id: `demo:${demo.url}`,
-            title: `Open Demo: ${demo.title}`,
-            hint: "Demo",
-            run: () => void editor.set_demo(demo.url),
-        })),
+        ...lsp
+            .demos()
+            .filter((demo) => demo.url !== "")
+            .map((demo) => ({
+                id: `demo:${demo.url}`,
+                title: `Open Demo: ${demo.title}`,
+                hint: "Demo",
+                run: () => void editor.set_demo(demo.url),
+            })),
         {
             id: "copy-permalink",
             title: "Copy Permalink to Clipboard",

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -4,7 +4,7 @@
 // cSpell: ignore cupertino lumino permalink
 
 import { EditorWidget, initialize as initializeEditor } from "./editor_widget";
-import { LspWaiter, type Lsp, type LoadPhase } from "./lsp";
+import { LspWaiter, type Lsp, type LoadPhase, type PanelLayout } from "./lsp";
 import { PreviewWidget } from "./preview_widget";
 
 import {
@@ -63,6 +63,35 @@ const commands = new CommandRegistry();
 const url_params = new URLSearchParams(window.location.search);
 const url_style = url_params.get("style");
 
+const PANEL_LAYOUT_KEY = "slintpad-panel-layout";
+
+function load_panel_layout(): PanelLayout | null {
+    try {
+        const raw = window.localStorage.getItem(PANEL_LAYOUT_KEY);
+        if (raw === null) {
+            return null;
+        }
+        const parsed = JSON.parse(raw);
+        return {
+            library: !!parsed.library,
+            properties: !!parsed.properties,
+            outline: !!parsed.outline,
+            data: !!parsed.data,
+            console: !!parsed.console,
+        };
+    } catch (_) {
+        return null;
+    }
+}
+
+function save_panel_layout(layout: PanelLayout): void {
+    try {
+        window.localStorage.setItem(PANEL_LAYOUT_KEY, JSON.stringify(layout));
+    } catch (_) {
+        // Ignore storage failures (e.g. private mode with a full quota).
+    }
+}
+
 function setup(lsp: Lsp) {
     const editor = new EditorWidget(lsp);
     set_panic_share_url_getter(() => editor.share_url());
@@ -79,6 +108,14 @@ function setup(lsp: Lsp) {
                 void editor.copy_permalink_to_clipboard();
             } else if (func_type === SlintPadCallbackFunction.NewFile) {
                 void editor.set_demo("");
+            } else if (func_type === SlintPadCallbackFunction.SavePanelLayout) {
+                save_panel_layout(args as PanelLayout);
+            }
+        },
+        (previewer) => {
+            const layout = load_panel_layout();
+            if (layout !== null) {
+                previewer.restore_panels(layout);
             }
         },
     );

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -217,6 +217,13 @@ export class Previewer {
         return this.#preview_connector.current_style();
     }
 
+    demos(): { title: string; url: string }[] {
+        return this.#preview_connector.demos() as {
+            title: string;
+            url: string;
+        }[];
+    }
+
     restore_panels(layout: PanelLayout): void {
         this.#preview_connector.restore_panels(
             layout.library,

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -216,6 +216,24 @@ export class Previewer {
     current_style(): string {
         return this.#preview_connector.current_style();
     }
+
+    restore_panels(layout: PanelLayout): void {
+        this.#preview_connector.restore_panels(
+            layout.library,
+            layout.properties,
+            layout.outline,
+            layout.data,
+            layout.console,
+        );
+    }
+}
+
+export interface PanelLayout {
+    library: boolean;
+    properties: boolean;
+    outline: boolean;
+    data: boolean;
+    console: boolean;
 }
 
 export class Lsp {

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -354,6 +354,17 @@ export class Lsp {
         return lsp_client;
     }
 
+    // Synchronous view of the demo list for callers that already run after the
+    // preview connector is up (the command palette). Returns an empty list if
+    // the connector is not ready yet, so it never throws. The full Previewer is
+    // reached via previewer() when the connector needs to be created.
+    demos(): { title: string; url: string }[] {
+        return (this.#preview_connector?.demos() ?? []) as {
+            title: string;
+            url: string;
+        }[];
+    }
+
     async previewer(
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -40,6 +40,7 @@ export class PreviewWidget extends Widget {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
         slintpad_callback: InvokeSlintpadCallback,
+        on_ready?: (previewer: Previewer) => void,
     ) {
         super({ node: PreviewWidget.createNode() });
 
@@ -54,6 +55,10 @@ export class PreviewWidget extends Widget {
             .previewer(resource_url_mapper, style, slintpad_callback)
             .then((p) => {
                 this.#previewer = p;
+
+                // Restore the persisted panel layout before the first paint so
+                // the panels appear in the state the user left them.
+                on_ready?.(p);
 
                 // Give the UI some time to wire up the canvas so it can be found
                 // when searching the document.


### PR DESCRIPTION
A ⌘K command palette for SlintPad: run demos and actions from one search box, with a discoverable "Commands" button in the header. The demo list is read from the LSP (`Api.demos`) so it always matches the toolbar's Open Demo menu.

Stacked on #12488 (the Phase 1 chrome/panels/toolbar work); will retarget to `master` once that lands.

- `command_palette.ts` — self-contained ⌘K overlay (own styles, global shortcut).
- Header gets a "Commands ⌘K" button wired to `Api.open-command-palette()`.
- WASM bridge: `OpenCommandPalette` callback + `PreviewConnector.demos()` reading `preview::get_demos()`.
- `cargo check --target wasm32`, `tsc`, and biome (2.5.2) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)