### PR TITLE
tools: persist and polish the SlintPad panels

### DIFF
--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -20,6 +20,7 @@ pub enum SlintPadCallbackFunction {
     CopyPermalink,
     NewFile,
     OpenCommandPalette,
+    SavePanelLayout,
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -174,6 +175,35 @@ impl PreviewConnector {
         array.into()
     }
 
+    /// Restore the panel visibility the host persisted from an earlier session.
+    /// Setting the properties fires the change handlers, so the host will save
+    /// the same values straight back, which is harmless.
+    #[wasm_bindgen]
+    pub fn restore_panels(
+        &self,
+        library: bool,
+        properties: bool,
+        outline: bool,
+        data: bool,
+        console: bool,
+    ) -> Result<(), JsValue> {
+        i_slint_core::api::invoke_from_event_loop(move || {
+            // Upgrade and drop the PREVIEW_STATE borrow before touching any
+            // property: setting one triggers panels-layout-changed, whose
+            // handler borrows PREVIEW_STATE again and would otherwise panic.
+            let api = preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
+            if let Some(api) = api {
+                api.set_panel_library_open(library);
+                api.set_panel_properties_open(properties);
+                api.set_panel_outline_open(outline);
+                api.set_panel_data_open(data);
+                api.set_panel_console_open(console);
+            }
+        })
+        .map_err(|e| -> JsValue { format!("{e:?}").into() })?;
+        Ok(())
+    }
+
     #[wasm_bindgen]
     pub fn show_ui(&self) -> Result<js_sys::Promise, JsValue> {
         invoke_from_event_loop_wrapped_in_promise(|instance| instance.show())
@@ -321,6 +351,58 @@ fn init_slintpad_specific_ui(api: &crate::preview::ui::Api) {
     });
     api.on_show_about_slint(show_about_slint);
     api.on_open_command_palette(open_command_palette);
+    api.on_panels_layout_changed(save_panel_layout);
+}
+
+fn save_panel_layout() {
+    // Read the current panel visibility, then drop the PREVIEW_STATE borrow
+    // before calling into JS.
+    let layout = preview::PREVIEW_STATE.with_borrow(|preview_state| {
+        preview_state.api.upgrade().map(|api| {
+            (
+                api.get_panel_library_open(),
+                api.get_panel_properties_open(),
+                api.get_panel_outline_open(),
+                api.get_panel_data_open(),
+                api.get_panel_console_open(),
+            )
+        })
+    });
+    let Some((library, properties, outline, data, console)) = layout else {
+        return;
+    };
+
+    WASM_CALLBACKS.with_borrow(|callbacks| {
+        let maybe_callback = wasm_bindgen::JsValue::from(
+            callbacks
+                .as_ref()
+                .expect("Callbacks were set up earlier")
+                .invoke_slintpad_callback
+                .clone(),
+        );
+        if !maybe_callback.is_function() {
+            return;
+        }
+        let opener = js_sys::Function::from(maybe_callback);
+        let obj = js_sys::Object::new();
+        let _ =
+            js_sys::Reflect::set(&obj, &JsValue::from_str("library"), &JsValue::from_bool(library));
+        let _ = js_sys::Reflect::set(
+            &obj,
+            &JsValue::from_str("properties"),
+            &JsValue::from_bool(properties),
+        );
+        let _ =
+            js_sys::Reflect::set(&obj, &JsValue::from_str("outline"), &JsValue::from_bool(outline));
+        let _ = js_sys::Reflect::set(&obj, &JsValue::from_str("data"), &JsValue::from_bool(data));
+        let _ =
+            js_sys::Reflect::set(&obj, &JsValue::from_str("console"), &JsValue::from_bool(console));
+        let _ = opener.call2(
+            &JsValue::UNDEFINED,
+            &wasm_bindgen::JsValue::from(SlintPadCallbackFunction::SavePanelLayout),
+            &obj.into(),
+        );
+    });
 }
 
 fn open_command_palette() {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -303,6 +303,16 @@ export global Api {
     in-out property <bool> always-on-top;
     in property <bool> focus-previewed-element;
 
+    // ## Panel layout, persisted by the SlintPad host across reloads.
+    // The host restores these on startup and is notified through
+    // panels-layout-changed() whenever the user shows or hides a panel.
+    in-out property <bool> panel-library-open;
+    in-out property <bool> panel-properties-open;
+    in-out property <bool> panel-outline-open;
+    in-out property <bool> panel-data-open;
+    in-out property <bool> panel-console-open;
+    callback panels-layout-changed();
+
     // ## Component Data for ComponentList:
     // All the components
     in property <[ComponentListItem]> known-components;

--- a/tools/lsp/ui/components/group.slint
+++ b/tools/lsp/ui/components/group.slint
@@ -3,7 +3,7 @@
 
 import { HorizontalBox, Palette } from "std-widgets.slint";
 import { HeaderText } from "./header-text.slint";
-import { EditorSizeSettings } from "./styling.slint";
+import { EditorSizeSettings, ConsoleStyles } from "./styling.slint";
 
 export component GroupHeader {
     in property <string> title;
@@ -32,7 +32,7 @@ export component Group {
     min-height: content-layer.min-height;
 
     background-layer := Rectangle {
-        background: Palette.background;
+        background: ConsoleStyles.panel-background;
     }
 
     content-layer := VerticalLayout {
@@ -42,6 +42,6 @@ export component Group {
     Rectangle {
         x: root.width - self.width;
         width: 2px;
-        background: Palette.border;
+        background: ConsoleStyles.panel-border;
     }
 }

--- a/tools/lsp/ui/components/styling.slint
+++ b/tools/lsp/ui/components/styling.slint
@@ -101,6 +101,10 @@ export global ConsoleStyles {
     out property <color> log-background: dark-scheme ? (branded ? Brand.ink : #262626) : #ffffff;
     out property <color> text-color: dark-scheme ? #cccccc : #525252;
     out property <color> toolbar-background: dark-scheme ? (branded ? Brand.surface : #2c2c2c) : #f3f3f3;
+    // Panel body surface and border: match the brand chrome in SlintPad,
+    // otherwise fall back to the active widget style.
+    out property <color> panel-background: (branded && dark-scheme) ? Brand.ink : Palette.background;
+    out property <color> panel-border: (branded && dark-scheme) ? Brand.line : Palette.border;
     out property <length> header-height: 28px;
     out property <length> log-height: 120px;
     out property <color> slint-blue: #0088ff;

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -41,11 +41,18 @@ export component PreviewUi inherits Window {
     property <bool> show-floating-table-editor <=> WindowManager.showing-table-editor;
     property <bool> show-color-stop-picker <=> WindowManager.showing-color-stop-picker;
     property <length> initial-floating-x;
-    property <bool> console-panel-expanded: false;
-    property <bool> properties-widget: false;
-    property <bool> data-widget: false;
-    property <bool> outline-widget: false;
-    property <bool> library-widget: false;
+    // Panel visibility is aliased to Api so the SlintPad host can restore it on
+    // startup and persist it whenever the user toggles a panel.
+    property <bool> console-panel-expanded <=> Api.panel-console-open;
+    property <bool> properties-widget <=> Api.panel-properties-open;
+    property <bool> data-widget <=> Api.panel-data-open;
+    property <bool> outline-widget <=> Api.panel-outline-open;
+    property <bool> library-widget <=> Api.panel-library-open;
+    changed console-panel-expanded => { Api.panels-layout-changed(); }
+    changed properties-widget => { Api.panels-layout-changed(); }
+    changed data-widget => { Api.panels-layout-changed(); }
+    changed outline-widget => { Api.panels-layout-changed(); }
+    changed library-widget => { Api.panels-layout-changed(); }
     property <bool> remote-mode: Api.preview-mode == PreviewMode.Remote;
     in-out property <bool> select-mode: false;
 
@@ -345,7 +352,7 @@ export component PreviewUi inherits Window {
                             }
                             mouse-cursor: ns-resize;
                             Rectangle {
-                                background: Palette.border;
+                                background: root.brand-dark ? Brand.line : Palette.border;
                             }
                         }
 
@@ -369,7 +376,7 @@ export component PreviewUi inherits Window {
                             }
                             mouse-cursor: ns-resize;
                             Rectangle {
-                                background: Palette.border;
+                                background: root.brand-dark ? Brand.line : Palette.border;
                             }
                         }
 

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -4,7 +4,12 @@
 // cSpell: ignore cupertino lumino permalink
 
 import { EditorWidget, initialize as initializeEditor } from "./editor_widget";
-import { LspWaiter, type Lsp, type LoadPhase } from "./lsp";
+import {
+    LspWaiter,
+    type Lsp,
+    type LoadPhase,
+    type PanelLayout,
+} from "./lsp";
 import { PreviewWidget } from "./preview_widget";
 
 import {
@@ -68,6 +73,35 @@ const commands = new CommandRegistry();
 const url_params = new URLSearchParams(window.location.search);
 const url_style = url_params.get("style");
 
+const PANEL_LAYOUT_KEY = "slintpad-panel-layout";
+
+function load_panel_layout(): PanelLayout | null {
+    try {
+        const raw = window.localStorage.getItem(PANEL_LAYOUT_KEY);
+        if (raw === null) {
+            return null;
+        }
+        const parsed = JSON.parse(raw);
+        return {
+            library: !!parsed.library,
+            properties: !!parsed.properties,
+            outline: !!parsed.outline,
+            data: !!parsed.data,
+            console: !!parsed.console,
+        };
+    } catch (_) {
+        return null;
+    }
+}
+
+function save_panel_layout(layout: PanelLayout): void {
+    try {
+        window.localStorage.setItem(PANEL_LAYOUT_KEY, JSON.stringify(layout));
+    } catch (_) {
+        // Ignore storage failures (e.g. private mode with a full quota).
+    }
+}
+
 function setup(lsp: Lsp) {
     const editor = new EditorWidget(lsp);
     set_panic_share_url_getter(() => editor.share_url());
@@ -122,6 +156,14 @@ function setup(lsp: Lsp) {
                 func_type === SlintPadCallbackFunction.OpenCommandPalette
             ) {
                 palette.open();
+            } else if (func_type === SlintPadCallbackFunction.SavePanelLayout) {
+                save_panel_layout(args as PanelLayout);
+            }
+        },
+        (previewer) => {
+            const layout = load_panel_layout();
+            if (layout !== null) {
+                previewer.restore_panels(layout);
             }
         },
     );

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -223,6 +223,24 @@ export class Previewer {
             url: string;
         }[];
     }
+
+    restore_panels(layout: PanelLayout): void {
+        this.#preview_connector.restore_panels(
+            layout.library,
+            layout.properties,
+            layout.outline,
+            layout.data,
+            layout.console,
+        );
+    }
+}
+
+export interface PanelLayout {
+    library: boolean;
+    properties: boolean;
+    outline: boolean;
+    data: boolean;
+    console: boolean;
 }
 
 export class Lsp {

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -40,6 +40,7 @@ export class PreviewWidget extends Widget {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
         slintpad_callback: InvokeSlintpadCallback,
+        on_ready?: (previewer: Previewer) => void,
     ) {
         super({ node: PreviewWidget.createNode() });
 
@@ -54,6 +55,10 @@ export class PreviewWidget extends Widget {
             .previewer(resource_url_mapper, style, slintpad_callback)
             .then((p) => {
                 this.#previewer = p;
+
+                // Restore the persisted panel layout before the first paint so
+                // the panels appear in the state the user left them.
+                on_ready?.(p);
 
                 // Give the UI some time to wire up the canvas so it can be found
                 // when searching the document.


### PR DESCRIPTION
Part of the SlintPad UI refresh (Phase 1). Stacked on #12478 (command palette) → #12473 (chrome brand).

## What

Remember which panels the user has open (Library, Properties, Outline, Simulation Data, Console) and restore them on the next visit, so the workspace comes back the way it was left. Also tidies the panel surfaces so they match the brand chrome in the dark theme.

## How

- **Persist**: the panel visibility is aliased to new `Api` properties (`panel-*-open`). The SlintPad host restores them before the first paint and is notified through `panels-layout-changed()` whenever a panel is toggled, then stores the layout in `localStorage`. The bridge mirrors the existing slintpad callbacks: a new `SavePanelLayout` variant carries the state out to TS, and `PreviewConnector.restore_panels(...)` sets the state back on startup.
  - `restore_panels` upgrades and drops the `PREVIEW_STATE` borrow before setting any property, since setting one fires `panels-layout-changed`, whose handler borrows `PREVIEW_STATE` again.
- **Polish**: in the dark brand theme the library panel body and the right-panel splitters now use the brand ink and line colors (new `ConsoleStyles.panel-background` / `panel-border`) instead of the default widget style. In light mode nothing changes.

This only affects SlintPad (`Api.runs-in-slintpad`); the native LSP preview keeps its current defaults, since no host is registered to persist or restore.

## Verified

- Restore: seeding `localStorage` and reloading brings the panels back open (confirmed in the browser).
- Save: toggling a panel writes the normalized layout back to `localStorage`; a partial stored object is rewritten in full on the next load.
- No reentrancy panic on the restore→save round-trip.
- `tsc --noEmit`, `cspell`, and `knip` (no new findings) pass. wasm build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)