### PR TITLE
Add public Window API to drive copy/cut/paste of the focused text input; adopt it in the winit web backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+ - Rust: Added `Window::copy_focused_text_selection()`, `Window::cut_focused_text_selection()`, and
+   `Window::paste_into_focused_text()` so custom backends can drive clipboard operations on the focused
+   text input from their own event handlers (e.g. web `ClipboardEvent`s); the winit web backend now uses them.
+ - Rust: Added `Window::has_focused_text_input()` so custom backends can tell when a text input holds the
+   focus (e.g. to keep a hidden editable element focused for web clipboard/IME events).
+
 ## [1.17.1] - 2026-07-07
 
  - Fixed a panic/crash on startup when a global reads `Palette.color-scheme` (or accent-color) during its initialization.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,7 +3377,6 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "rgb",
- "scoped-tls-hkt",
  "scopeguard",
  "slint",
  "softbuffer",

--- a/api/rs/slint/tests/window_focused_text_clipboard.rs
+++ b/api/rs/slint/tests/window_focused_text_clipboard.rs
@@ -1,0 +1,188 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Tests for the `Window` focused-text clipboard API:
+//! [`Window::copy_focused_text_selection`], [`Window::cut_focused_text_selection`], and
+//! [`Window::paste_into_focused_text`] — the seam that lets custom backends service
+//! copy/cut/paste from their own event handlers (e.g. web `ClipboardEvent`s).
+
+mod common;
+
+use slint::platform::{Key, WindowEvent};
+
+const WIDTH: u32 = 200;
+const HEIGHT: u32 = 32;
+
+slint::slint! {
+    export component TestCase inherits Window {
+        width: 200px;
+        height: 32px;
+        in property <bool> ti-enabled: true;
+        in property <bool> ti-read-only: false;
+        in-out property <string> ti-text <=> ti.text;
+        public function focus-ti() { ti.focus(); }
+        ti := TextInput {
+            enabled: root.ti-enabled;
+            read-only: root.ti-read-only;
+            font-size: 12px;
+        }
+    }
+}
+
+/// Extend the selection by `n` graphemes to the right, from the current cursor position.
+fn select_right(window: &slint::Window, n: usize) {
+    window.dispatch_event(WindowEvent::KeyPressed { text: Key::Shift.into() });
+    for _ in 0..n {
+        window.dispatch_event(WindowEvent::KeyPressed { text: Key::RightArrow.into() });
+        window.dispatch_event(WindowEvent::KeyReleased { text: Key::RightArrow.into() });
+    }
+    window.dispatch_event(WindowEvent::KeyReleased { text: Key::Shift.into() });
+}
+
+/// Move the cursor `n` graphemes to the right without selecting.
+fn move_right(window: &slint::Window, n: usize) {
+    for _ in 0..n {
+        window.dispatch_event(WindowEvent::KeyPressed { text: Key::RightArrow.into() });
+        window.dispatch_event(WindowEvent::KeyReleased { text: Key::RightArrow.into() });
+    }
+}
+
+#[test]
+fn copy_returns_selection_and_cut_deletes_it() {
+    common::setup(WIDTH, HEIGHT);
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+    ui.set_ti_text("Hello World".into());
+    ui.invoke_focus_ti();
+
+    // No selection yet: copy and cut return None, and cut deletes nothing.
+    assert_eq!(ui.window().copy_focused_text_selection(), None);
+    assert_eq!(ui.window().cut_focused_text_selection(), None);
+    assert_eq!(ui.get_ti_text(), "Hello World");
+
+    // Select "Hello" (cursor starts at 0).
+    select_right(ui.window(), 5);
+
+    // Copy returns the selection and leaves the text untouched.
+    assert_eq!(ui.window().copy_focused_text_selection().as_deref(), Some("Hello"));
+    assert_eq!(ui.get_ti_text(), "Hello World");
+
+    // Cut returns the same selection and deletes it.
+    assert_eq!(ui.window().cut_focused_text_selection().as_deref(), Some("Hello"));
+    assert_eq!(ui.get_ti_text(), " World");
+}
+
+#[test]
+fn paste_inserts_at_cursor_and_replaces_selection() {
+    common::setup(WIDTH, HEIGHT);
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+    ui.set_ti_text("AB".into());
+    ui.invoke_focus_ti();
+
+    // Insert between "A" and "B"; the cursor ends up after the inserted text.
+    move_right(ui.window(), 1);
+    assert!(ui.window().paste_into_focused_text("X"));
+    assert_eq!(ui.get_ti_text(), "AXB");
+
+    // Select the trailing "B" and paste over it.
+    select_right(ui.window(), 1);
+    assert!(ui.window().paste_into_focused_text("Y"));
+    assert_eq!(ui.get_ti_text(), "AXY");
+}
+
+#[test]
+fn no_focused_text_input_refuses_everything() {
+    common::setup(WIDTH, HEIGHT);
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+    ui.set_ti_text("text".into());
+    // Nothing focused.
+    assert_eq!(ui.window().copy_focused_text_selection(), None);
+    assert_eq!(ui.window().cut_focused_text_selection(), None);
+    assert!(!ui.window().paste_into_focused_text("nope"));
+    assert_eq!(ui.get_ti_text(), "text");
+}
+
+#[test]
+fn read_only_gates_cut_and_paste_but_not_copy() {
+    common::setup(WIDTH, HEIGHT);
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+    ui.set_ti_text("Secret".into());
+    ui.set_ti_read_only(true);
+    ui.invoke_focus_ti();
+    select_right(ui.window(), 6);
+
+    // Copy is allowed on a read-only input, matching the Copy keyboard shortcut.
+    assert_eq!(ui.window().copy_focused_text_selection().as_deref(), Some("Secret"));
+    // Cut and paste refuse, matching the shortcuts' `!read-only` gate; nothing changes.
+    assert_eq!(ui.window().cut_focused_text_selection(), None);
+    assert!(!ui.window().paste_into_focused_text("overwrite"));
+    assert_eq!(ui.get_ti_text(), "Secret");
+}
+
+#[test]
+fn disabled_gates_cut_and_paste() {
+    common::setup(WIDTH, HEIGHT);
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+    ui.set_ti_text("Frozen".into());
+    ui.invoke_focus_ti();
+    select_right(ui.window(), 6);
+    // Disable after focusing and selecting.
+    ui.set_ti_enabled(false);
+
+    assert_eq!(ui.window().cut_focused_text_selection(), None);
+    assert!(!ui.window().paste_into_focused_text("thaw"));
+    assert_eq!(ui.get_ti_text(), "Frozen");
+}
+
+#[test]
+fn has_focused_text_input_tracks_text_focus() {
+    common::setup(WIDTH, HEIGHT);
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+    // Nothing focused yet.
+    assert!(!ui.window().has_focused_text_input());
+    // Focusing the TextInput reports true.
+    ui.invoke_focus_ti();
+    assert!(ui.window().has_focused_text_input());
+}
+
+#[test]
+fn has_focused_text_input_false_for_non_text_focus() {
+    slint::slint! {
+        export component FocusCase inherits Window {
+            width: 200px;
+            height: 32px;
+            public function focus-fs() { fs.focus(); }
+            fs := FocusScope {}
+        }
+    }
+    common::setup(WIDTH, HEIGHT);
+    let ui = FocusCase::new().unwrap();
+    ui.show().unwrap();
+    // A focused non-text item (a FocusScope) is not a text input.
+    ui.invoke_focus_fs();
+    assert!(!ui.window().has_focused_text_input());
+}
+
+#[test]
+fn multi_byte_selection_boundaries() {
+    common::setup(WIDTH, HEIGHT);
+    let ui = TestCase::new().unwrap();
+    ui.show().unwrap();
+    ui.set_ti_text("héllo".into()); // cspell:disable-line
+    ui.invoke_focus_ti();
+
+    // Select "hé" — the selection edge falls after a two-byte character.
+    select_right(ui.window(), 2);
+    assert_eq!(ui.window().copy_focused_text_selection().as_deref(), Some("hé"));
+    assert_eq!(ui.window().cut_focused_text_selection().as_deref(), Some("hé"));
+    assert_eq!(ui.get_ti_text(), "llo");
+
+    // Paste multi-byte text back at the cursor.
+    assert!(ui.window().paste_into_focused_text("→"));
+    assert_eq!(ui.get_ti_text(), "→llo");
+}

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2448,7 +2448,6 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "rgb",
- "scoped-tls-hkt",
  "scopeguard",
  "softbuffer",
  "strum",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -7131,7 +7131,6 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "rgb",
- "scoped-tls-hkt",
  "scopeguard",
  "softbuffer",
  "strum 0.28.0",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -73,7 +73,6 @@ cfg-if = "1"
 derive_more = { workspace = true }
 lyon_path = { workspace = true }
 pin-weak = "1"
-scoped-tls-hkt = "0.1"
 strum = { workspace = true }
 winit = { version = "0.30.2", default-features = false, features = ["rwh_06"] }
 raw-window-handle = { version = "0.6", features = ["alloc"] }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -874,22 +874,17 @@ impl i_slint_core::platform::Platform for Backend {
         )))
     }
 
-    #[cfg(target_arch = "wasm32")]
-    fn set_clipboard_text(&self, text: &str, clipboard: i_slint_core::platform::Clipboard) {
-        crate::wasm_input_helper::set_clipboard_text(text.into(), clipboard);
-    }
-
+    // On wasm, the clipboard hooks keep their default no-op implementations: the browser
+    // clipboard is asynchronous and gesture-gated, so copy/cut/paste are serviced entirely from
+    // the `ClipboardEvent` handlers in `wasm_input_helper`, via
+    // `Window::copy_focused_text_selection` / `cut_focused_text_selection` /
+    // `paste_into_focused_text`.
     #[cfg(not(target_arch = "wasm32"))]
     fn set_clipboard_text(&self, text: &str, clipboard: i_slint_core::platform::Clipboard) {
         let mut pair = self.shared_data.clipboard.borrow_mut();
         if let Some(clipboard) = clipboard::select_clipboard(&mut pair, clipboard) {
             clipboard.set_contents(text.into()).ok();
         }
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn clipboard_text(&self, clipboard: i_slint_core::platform::Clipboard) -> Option<String> {
-        crate::wasm_input_helper::get_clipboard_text(clipboard)
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -77,44 +77,19 @@ impl WasmInputHelper {
                 else {
                     return;
                 };
-                e.prevent_default();
-                let synthetic_clipboard_data = RefCell::new(text);
-                CURRENT_WASM_CLIPBOARD_DATA.set(&synthetic_clipboard_data, || {
-                    if let Some(focus_item) = WindowInner::from_pub(&window_adapter.window())
-                        .focus_item
-                        .borrow()
-                        .upgrade()
-                    {
-                        if let Some(text_input) =
-                            focus_item.downcast::<i_slint_core::items::TextInput>()
-                        {
-                            text_input.as_pin_ref().paste(&window_adapter, &focus_item);
-                        }
-                    }
-                })
+                if window_adapter.window().paste_into_focused_text(&text) {
+                    e.prevent_default();
+                }
             }
         });
         let win = window_adapter.clone();
         h.add_event_listener("copy", move |e: web_sys::ClipboardEvent| {
             if let Some(window_adapter) = win.upgrade() {
-                e.prevent_default();
-
-                let synthetic_clipboard_data = RefCell::new(String::default());
-                CURRENT_WASM_CLIPBOARD_DATA.set(&synthetic_clipboard_data, || {
-                    if let Some(focus_item) = WindowInner::from_pub(&window_adapter.window())
-                        .focus_item
-                        .borrow()
-                        .upgrade()
-                    {
-                        if let Some(text_input) =
-                            focus_item.downcast::<i_slint_core::items::TextInput>()
-                        {
-                            let text = text_input.as_pin_ref().copy(&window_adapter, &focus_item);
-                        }
+                if let Some(text) = window_adapter.window().copy_focused_text_selection() {
+                    if let Some(data) = e.clipboard_data() {
+                        data.set_data("text", &text).ok();
                     }
-                });
-                if let Some(data) = e.clipboard_data() {
-                    data.set_data("text", &synthetic_clipboard_data.into_inner()).ok();
+                    e.prevent_default();
                 }
             }
         });
@@ -122,28 +97,11 @@ impl WasmInputHelper {
         let win = window_adapter.clone();
         h.add_event_listener("cut", move |e: web_sys::ClipboardEvent| {
             if let Some(window_adapter) = win.upgrade() {
-                e.prevent_default();
-                if let Some(focus_item) =
-                    WindowInner::from_pub(&window_adapter.window()).focus_item.borrow().upgrade()
-                {
-                    if let Some(text_input) =
-                        focus_item.downcast::<i_slint_core::items::TextInput>()
-                    {
-                        let (anchor, cursor) =
-                            text_input.as_pin_ref().selection_anchor_and_cursor();
-                        if anchor == cursor {
-                            return;
-                        }
-                        let text = text_input.as_pin_ref().text();
-                        if let Some(data) = e.clipboard_data() {
-                            data.set_data("text", &text[anchor..cursor]).ok();
-                        }
-                        text_input.as_pin_ref().delete_selection(
-                            &window_adapter,
-                            &focus_item,
-                            i_slint_core::items::TextChangeNotify::TriggerCallbacks,
-                        );
+                if let Some(text) = window_adapter.window().cut_focused_text_selection() {
+                    if let Some(data) = e.clipboard_data() {
+                        data.set_data("text", &text).ok();
                     }
+                    e.prevent_default();
                 }
             }
         });
@@ -323,25 +281,5 @@ fn event_text(e: &web_sys::KeyboardEvent, is_apple: bool) -> Option<SharedString
     match chars.next() {
         Some(first_char) if chars.next().is_none() => Some(first_char.into()),
         _ => None,
-    }
-}
-
-scoped_tls_hkt::scoped_thread_local!(static CURRENT_WASM_CLIPBOARD_DATA : for<'a> &'a RefCell<String>);
-
-pub(crate) fn set_clipboard_text(data: String, clipboard: i_slint_core::platform::Clipboard) {
-    if CURRENT_WASM_CLIPBOARD_DATA.is_set()
-        && matches!(clipboard, i_slint_core::platform::Clipboard::DefaultClipboard)
-    {
-        CURRENT_WASM_CLIPBOARD_DATA.with(|current_data| *current_data.borrow_mut() = data)
-    }
-}
-
-pub(crate) fn get_clipboard_text(clipboard: i_slint_core::platform::Clipboard) -> Option<String> {
-    if CURRENT_WASM_CLIPBOARD_DATA.is_set()
-        && matches!(clipboard, i_slint_core::platform::Clipboard::DefaultClipboard)
-    {
-        Some(CURRENT_WASM_CLIPBOARD_DATA.with(|current_data| current_data.borrow().clone()))
-    } else {
-        None
     }
 }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -812,6 +812,106 @@ impl Window {
     pub fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         self.0.window_adapter().renderer().take_snapshot()
     }
+
+    /// Returns the selected text of the currently focused text input, if any, as it would be
+    /// placed on the clipboard by a copy.
+    ///
+    /// The text is returned to the caller directly rather than written to the system clipboard
+    /// through [`Platform::set_clipboard_text`](crate::platform::Platform::set_clipboard_text).
+    /// This lets a custom backend service a copy from within its own clipboard-event handler —
+    /// most notably the web platform, where the browser clipboard is asynchronous and reachable
+    /// only from a `copy` [`ClipboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent)
+    /// during a user gesture, which the synchronous `Platform` clipboard hooks cannot satisfy.
+    ///
+    /// Returns `None` when the focused item is not a text input or has no selection.
+    pub fn copy_focused_text_selection(&self) -> Option<SharedString> {
+        self.with_focused_text_input(|text_input, _, _| {
+            let (anchor, cursor) = text_input.selection_anchor_and_cursor();
+            (anchor != cursor).then(|| text_input.text()[anchor..cursor].into())
+        })
+        .flatten()
+    }
+
+    /// Removes the selected text of the currently focused text input and returns it, as a cut
+    /// would place it on the clipboard.
+    ///
+    /// This is [`Self::copy_focused_text_selection`] followed by deleting the selection. See that
+    /// method for why the text is returned to the caller instead of routed through the `Platform`
+    /// clipboard.
+    ///
+    /// Returns `None` when the focused item is not a text input, has no selection, or refuses the
+    /// cut because it is read-only or disabled — the same gate the Cut keyboard shortcut honors.
+    /// Nothing is deleted in any of these cases.
+    pub fn cut_focused_text_selection(&self) -> Option<SharedString> {
+        self.with_focused_text_input(|text_input, window_adapter, focus_item| {
+            if text_input.read_only() || !text_input.enabled() {
+                return None;
+            }
+            let (anchor, cursor) = text_input.selection_anchor_and_cursor();
+            if anchor == cursor {
+                return None;
+            }
+            let selection: SharedString = text_input.text()[anchor..cursor].into();
+            text_input.delete_selection(
+                window_adapter,
+                focus_item,
+                crate::items::TextChangeNotify::TriggerCallbacks,
+            );
+            Some(selection)
+        })
+        .flatten()
+    }
+
+    /// Inserts `text` into the currently focused text input at the cursor position, replacing the
+    /// current selection, as a paste would.
+    ///
+    /// The text is supplied by the caller rather than read from
+    /// [`Platform::clipboard_text`](crate::platform::Platform::clipboard_text), so a custom backend
+    /// can service a paste from within its own clipboard-event handler — most notably the web
+    /// platform, whose `paste` [`ClipboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent)
+    /// carries the text directly.
+    ///
+    /// Returns `true` if a focused text input received the text, and `false` when the focused item
+    /// is not a text input or refuses the paste because it is read-only or disabled — the same
+    /// gate the Paste keyboard shortcut honors.
+    pub fn paste_into_focused_text(&self, text: &str) -> bool {
+        self.with_focused_text_input(|text_input, window_adapter, focus_item| {
+            if text_input.read_only() || !text_input.enabled() {
+                return false;
+            }
+            text_input.insert_text(text, window_adapter, focus_item);
+            true
+        })
+        .unwrap_or(false)
+    }
+
+    /// Returns `true` if a [`TextInput`](crate::items::TextInput) currently holds this window's
+    /// focus.
+    ///
+    /// This lets a custom backend decide when to route keyboard and clipboard input into the
+    /// focused text field — most notably the web platform, which keeps a hidden editable element
+    /// focused (so browser `ClipboardEvent`s and IME reach an editable context) exactly while a
+    /// Slint text input is being edited, and otherwise hands focus back to its render surface.
+    pub fn has_focused_text_input(&self) -> bool {
+        self.with_focused_text_input(|_, _, _| ()).is_some()
+    }
+
+    /// Runs `f` with the currently focused [`TextInput`](crate::items::TextInput) item, the window
+    /// adapter and the item's [`ItemRc`](crate::item_tree::ItemRc). Returns `None` (without running
+    /// `f`) when no text input holds the focus.
+    fn with_focused_text_input<R>(
+        &self,
+        f: impl FnOnce(
+            core::pin::Pin<&crate::items::TextInput>,
+            &alloc::rc::Rc<dyn WindowAdapter>,
+            &crate::item_tree::ItemRc,
+        ) -> R,
+    ) -> Option<R> {
+        let focus_item = self.0.focus_item.borrow().upgrade()?;
+        let text_input = focus_item.downcast::<crate::items::TextInput>()?;
+        let window_adapter = self.0.window_adapter();
+        Some(f(text_input.as_pin_ref(), &window_adapter, &focus_item))
+    }
 }
 
 #[i_slint_core_macros::slint_doc]

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -2034,9 +2034,26 @@ impl TextInput {
             .platform()
             .clipboard_text(clipboard)
         {
-            self.preedit_text.set(Default::default());
-            self.insert(&text, window_adapter, self_rc);
+            self.insert_text(&text, window_adapter, self_rc);
         }
+    }
+
+    /// Inserts `text` at the cursor position, replacing the current selection, as a paste does.
+    ///
+    /// Unlike [`Self::paste`], the text is provided by the caller instead of being read from
+    /// [`Platform::clipboard_text`](crate::platform::Platform::clipboard_text). This is meant for
+    /// backends that receive clipboard contents through their own channels — for example the web
+    /// backend, whose `paste` browser event delivers the text directly and whose clipboard access
+    /// is asynchronous and gesture-gated, so the synchronous `Platform` clipboard hook cannot serve
+    /// it.
+    pub fn insert_text(
+        self: Pin<&Self>,
+        text: &str,
+        window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
+    ) {
+        self.preedit_text.set(Default::default());
+        self.insert(text, window_adapter, self_rc);
     }
 
     /// Returns a [`TextInputVisualRepresentation`] struct that contains all the fields necessary for rendering the text input,

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2263,7 +2263,6 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "rgb",
- "scoped-tls-hkt",
  "scopeguard",
  "softbuffer",
  "strum",


### PR DESCRIPTION
Disclosure: this change was developed and verified with the aid of an LLM.

---

Fixes #12482.

Adds three methods to `Window`: `copy_focused_text_selection`, `cut_focused_text_selection` (both returning the selected text), and `paste_into_focused_text`. Cut and paste honor the same `read_only()`/`enabled()` gates as the keyboard shortcuts; copy is deliberately ungated, matching the Copy shortcut. `TextInput::insert_text` is extracted from `paste_clipboard` (behavior-preserving; undo entries unchanged) so paste can insert caller-supplied text.

The winit wasm backend's `copy`/`cut`/`paste` DOM handlers now call the new API instead of reaching into `WindowInner`/`TextInput` privates. This also removes the `CURRENT_WASM_CLIPBOARD_DATA` thread-local shuttle (now unreferenced) and its `scoped-tls-hkt` dependency, and fixes a latent hazard: the old handler held the `focus_item` RefCell borrow across `TextInput` calls that can run `edited`/`accepted` callbacks into app code; the new helper drops the borrow before dispatch.

Tests: `api/rs/slint/tests/window_focused_text_clipboard.rs` — copy/cut/paste semantics, selection replacement, no-focus and empty-selection refusal, read-only (copy allowed, cut/paste refused), disabled, and multi-byte selection boundaries. CHANGELOG entry included (in an `Unreleased` section; will fold into master's on rebase).

One disclosed question: `copy_focused_text_selection` returns the real text of `input-type: password` fields, because the existing copy path has no password guard — this PR matches that behavior rather than silently diverging. Happy to add an `InputType::Password` refusal here (or in both places) if that's preferred.
