### PR TITLE
femtovg: enable the WGPU TextureImporter impl on wasm

### DIFF
--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -37,8 +37,15 @@ impl TextureImporter for femtovg::renderer::OpenGl {
     }
 }
 
-#[cfg(all(feature = "wgpu-29", not(target_family = "wasm")))]
+// The FemtoVG WGPU renderer implements `TextureImporter` on every platform: the
+// renderer's associated type bound (`GraphicsBackend::Renderer: TextureImporter`)
+// must be satisfied for `unstable-wgpu-29` to build at all, and WGPU (unlike the
+// OpenGL backend) is available on wasm too. `convert_opengl_texture` is only part
+// of the trait off-wasm, so gate it to match; on wasm only the identity
+// `convert_wgpu_29_texture` is required.
+#[cfg(feature = "wgpu-29")]
 impl TextureImporter for femtovg::renderer::WGPURenderer {
+    #[cfg(not(target_family = "wasm"))]
     fn convert_opengl_texture(_opengl_texture: std::num::NonZero<u32>) -> Self::NativeTexture {
         todo!()
     }


### PR DESCRIPTION
Disclosure: this fix was developed with the aid of an LLM.

---

`renderer-femtovg-wgpu` fails to compile for wasm targets: the `impl TextureImporter for femtovg::renderer::WGPURenderer` is gated behind `not(target_family = "wasm")`, but FemtoVG's `GraphicsBackend` requires `Renderer: femtovg::Renderer + TextureImporter`, so the bound is unsatisfiable on wasm and the WGPU renderer cannot build for the browser (E0277: `WGPURenderer: TextureImporter` not satisfied).

WGPU is available on wasm via WebGPU, so this enables the impl there. `TextureImporter` declares `convert_opengl_texture` only off-wasm, so that method is gated to match; on wasm only the identity `convert_wgpu_29_texture` is required. 9-line diff.
