### PR TITLE
Fix SlintPad LSP panic on loading demos with imports (regression of #11258)

### DIFF
--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -877,3 +877,39 @@ async fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Conte
     }
     Ok(())
 }
+
+/// Guards the invariant documented on `SlintServer` in `wasm_main.rs`: every
+/// exported `async` method must take `&self`, never `&mut self`. wasm-bindgen
+/// holds its borrow of the exported object for the whole lifetime of the
+/// returned future, so a `&mut self` async method that suspends at an `.await`
+/// keeps an exclusive borrow while the JS event loop dispatches the next LSP
+/// message — the next `SlintServer` call then panics with "recursive use of an
+/// object detected which would lead to unsafe aliasing in rust". This is a
+/// deterministic complement to the behavior regression test in
+/// `tools/slintpad/tests/demo-load.spec.ts`.
+// cSpell:ignore reentrancy
+#[cfg(test)]
+mod wasm_export_reentrancy {
+    // The wasm entry points live in a sibling file that is only compiled for
+    // wasm32; read it as text so this guard runs on the host under `cargo test`.
+    const WASM_MAIN: &str = include_str!("wasm_main.rs");
+
+    #[test]
+    fn no_exported_async_method_takes_mut_self() {
+        let offenders: Vec<&str> = WASM_MAIN
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.contains("async fn") && line.contains("&mut self"))
+            .collect();
+
+        assert!(
+            offenders.is_empty(),
+            "wasm-bindgen-exported async methods must take `&self`, not `&mut self`: a \
+             `&mut self` receiver is held as an exclusive borrow across the future's \
+             `.await` points, so the LSP panics with \"recursive use of an object ... \
+             unsafe aliasing in rust\" when re-entered by the JS event loop. \
+             Offending line(s):\n{}",
+            offenders.join("\n"),
+        );
+    }
+}

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -236,6 +236,14 @@ pub struct SlintServer {
     /// but the document cache does not support concurrent access, so we serialize them.
     /// (So that a request being sent when we are await'ing for a file from the typeloader
     /// doesn't access the document cache)
+    ///
+    /// For this reason every exported `async` method below must take `&self`, never
+    /// `&mut self`: wasm-bindgen holds its borrow of the exported object for the whole
+    /// lifetime of the returned future, so a `&mut self` method that suspends at an
+    /// `.await` would keep an exclusive borrow while the JS event loop dispatches the
+    /// next message, and any other method call would then panic with "recursive use of
+    /// an object detected which would lead to unsafe aliasing in rust". Interior
+    /// mutability is handled through `ctx`'s async lock instead.
     ctx: ReentryGuard<Context>,
     rh: Rc<RequestHandler>,
 }
@@ -408,7 +416,7 @@ impl SlintServer {
     }
 
     #[wasm_bindgen]
-    pub async fn trigger_file_watcher(&mut self, url: JsValue, typ: JsValue) -> JsResult<JsValue> {
+    pub async fn trigger_file_watcher(&self, url: JsValue, typ: JsValue) -> JsResult<JsValue> {
         let mut ctx = self.ctx.lock().await;
         let url: Url = serde_wasm_bindgen::from_value(url)?;
         let typ: lsp_types::FileChangeType = serde_wasm_bindgen::from_value(typ)?;
@@ -454,7 +462,7 @@ impl SlintServer {
     }
 
     #[wasm_bindgen]
-    pub async fn close_document(&mut self, uri: JsValue) -> JsResult<JsValue> {
+    pub async fn close_document(&self, uri: JsValue) -> JsResult<JsValue> {
         let mut ctx = self.ctx.lock().await;
         let uri: Url = serde_wasm_bindgen::from_value(uri)?;
         language::close_document(&mut ctx, uri).await.map_err(|e| JsError::new(&e.to_string()))?;

--- a/tools/slintpad/tests/demo-load.spec.ts
+++ b/tools/slintpad/tests/demo-load.spec.ts
@@ -1,0 +1,121 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell:ignore reentrancy macrotask networkidle
+
+// Regression test for the wasm LSP "recursive use of an object detected which
+// would lead to unsafe aliasing in rust" panic when loading a demo that pulls
+// in local imports (e.g. the gallery).
+//
+// Root cause: the exported async methods `trigger_file_watcher` and
+// `close_document` on `SlintServer` (tools/lsp/wasm_main.rs) used to take
+// `&mut self`. wasm-bindgen holds its borrow of the exported object for the
+// whole lifetime of the returned future, so a `&mut self` method suspended at
+// an `.await` kept an exclusive borrow while the JS event loop dispatched the
+// next LSP message — and the next `SlintServer` call then hit wasm-bindgen's
+// WasmRefCell borrow check and threw. Loading the gallery triggers it because
+// registering the demo's imported files fires file-watcher notifications that
+// interleave with the `open_document` calls for those same files.
+import { test, expect } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+// Playwright runs from tools/slintpad; the repository root is two levels up.
+const REPO_ROOT = path.resolve(process.cwd(), "..", "..");
+
+const CONTENT_TYPES: Record<string, string> = {
+    ".slint": "text/plain; charset=utf-8",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".svg": "image/svg+xml",
+};
+
+test("loading the gallery demo does not panic the LSP", async ({
+    page,
+    browserName,
+}) => {
+    // Headless Firefox on CI has no WebGL, so the preview panics on init.
+    test.skip(browserName === "firefox", "preview panics without WebGL");
+
+    // The wasm-bindgen reentrancy guard throws this exact string; a Rust panic
+    // (should the failure mode change) logs "panicked at". The failure surfaces
+    // both as a worker console error and as an uncaught page error, so watch
+    // both. Note the LSP worker panics independently of the preview, which keeps
+    // rendering — so the console/page-error signal, not the preview state, is
+    // what tells us the LSP broke.
+    const panics: string[] = [];
+    const is_panic = (text: string) =>
+        text.includes("recursive use of an object") ||
+        text.includes("panicked at");
+    page.on("console", (msg) => {
+        if (msg.type() === "error" && is_panic(msg.text())) {
+            panics.push(msg.text());
+        }
+    });
+    page.on("pageerror", (error) => {
+        if (is_panic(error.message)) {
+            panics.push(error.message);
+        }
+    });
+
+    // Serve the demo and every file it imports from this checkout instead of
+    // GitHub, so the test is hermetic and pinned to the current sources. SlintPad
+    // resolves `load_demo` against raw.githubusercontent.com and the LSP fetches
+    // each import from the same host, all on the main thread we intercept here.
+    //
+    // The delay matters: this is a race between the file-watcher future
+    // suspending on an import load and the next LSP message being dispatched.
+    // Instant local reads resolve within a microtask, so the futures never
+    // overlap and the buggy `&mut self` borrow is never caught. A small
+    // network-like latency keeps the load suspended across a macrotask, which is
+    // what real GitHub fetches did when the panic was first observed. It does not
+    // make the test flaky in the failing direction: the fixed `&self` code takes
+    // reentrant-safe shared borrows and never panics regardless of timing.
+    const NETWORK_LATENCY_MS = 150;
+    await page.route(
+        /raw\.githubusercontent\.com\/slint-ui\/slint\/[^/]+\/(.*)/,
+        async (route) => {
+            const rel = new URL(route.request().url()).pathname.replace(
+                /^\/slint-ui\/slint\/[^/]+\//,
+                "",
+            );
+            await new Promise((resolve) =>
+                setTimeout(resolve, NETWORK_LATENCY_MS),
+            );
+            try {
+                const body = await readFile(path.join(REPO_ROOT, rel));
+                await route.fulfill({
+                    status: 200,
+                    contentType:
+                        CONTENT_TYPES[path.extname(rel)] ?? "text/plain",
+                    body,
+                });
+            } catch {
+                await route.fulfill({ status: 404, body: "" });
+            }
+        },
+    );
+
+    await page.goto(
+        "http://localhost:3000/?load_demo=examples/gallery/gallery.slint",
+    );
+
+    // Wait for the preview to render the gallery — the demo has loaded far
+    // enough that its imports have been requested.
+    const canvas = page.locator(".preview-container canvas");
+    await expect(canvas).toBeVisible({ timeout: 40_000 });
+
+    // Then let the LSP worker finish opening every imported document. The panic
+    // fires while these imports are processed, so we must wait for that traffic
+    // to settle before asserting it did not happen.
+    await page.waitForLoadState("networkidle");
+
+    // The critical assertion: the wasm LSP never hit the reentrancy guard. On a
+    // regression `panics` holds the "recursive use of an object" message and its
+    // stack, which the reporter prints.
+    expect(panics, "wasm LSP panics during demo load").toHaveLength(0);
+    // The panic also raises a user-visible dialog in real browsers; assert it is
+    // absent too (it does not render in headless Chromium, but this guards the
+    // interactive path).
+    await expect(page.locator("dialog.panic_dialog")).toHaveCount(0);
+});


### PR DESCRIPTION
## Problem

Loading a SlintPad demo that pulls in local imports panics the wasm LSP with:

```
recursive use of an object detected which would lead to unsafe aliasing in rust
```

The panic dialog reads "The Slint LSP has panicked." and the preview stops working.

## This is a regression of #11258

- #11258 reported the same error; #11259 fixed it by moving `Context` behind the `ReentryGuard` async mutex and switching every exported async `SlintServer` method to `&self`.
- Commit 69a3917 ("Add public system-testing features") later reworked `trigger_file_watcher` and `close_document` and wrote them back as `&mut self`, reviving the panic. The sibling methods stayed `&self`, so it slipped through as a silent, partial regression.

## Root cause

wasm-bindgen holds its borrow of the exported object for the whole lifetime of the returned future. So a `&mut self` async method that suspends at an `.await` keeps an **exclusive** borrow while the JS event loop dispatches the next LSP message — and the next `SlintServer` call then trips wasm-bindgen's `WasmRefCell` borrow check and throws. The stack trace confirms the entry point:

```
SlintServer::trigger_file_watcher::{{closure}}
  -> <SlintServer as RefMutFromWasmAbi>::ref_mut_from_abi
  -> WasmRefCell::borrow_mut -> borrow_fail -> throw_str
```

Loading the gallery triggers it because registering the demo's imported files fires file-watcher notifications that interleave with the `open_document` calls for those same files.

Mutable state is already serialized through `ctx`'s async lock, so `&mut self` was never needed.

## Fix

Switch `trigger_file_watcher` and `close_document` back to `&self`, and document the invariant on `SlintServer`.

## Tests

This PR adds two guards, each verified to **fail on the buggy `&mut self` build and pass on the fix**:

- `tools/slintpad/tests/demo-load.spec.ts` — loads the gallery demo (served from the local checkout with a small network-like latency to provoke the race) and asserts the LSP does not panic. 8/8 fail on the buggy build; passes on chromium + webkit (firefox skipped, as the other preview tests do).
- A source-level test in `tools/lsp/main.rs` asserting that no exported async wasm-bindgen method in `wasm_main.rs` takes `&mut self` — a deterministic complement that would have caught 69a3917 directly.
