### PR TITLE
Fix SlintPad LSP panic on loading demos with imports (regression of #11258)

### DIFF
--- a/tools/lsp/tests/wasm_export_reentrancy.rs
+++ b/tools/lsp/tests/wasm_export_reentrancy.rs
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Every wasm-bindgen-exported async method on `SlintServer` must take `&self`,
+// not `&mut self`: a `&mut self` receiver is held as an exclusive borrow across
+// the future's `.await` points, so re-entering from the JS event loop trips
+// wasm-bindgen's borrow check (regression of #11258).
+// cSpell:ignore reentrancy
+
+// wasm_main.rs is only compiled for wasm32, so check the invariant as text.
+const WASM_MAIN: &str = include_str!("../wasm_main.rs");
+
+#[test]
+fn no_exported_async_method_takes_mut_self() {
+    let offenders: Vec<&str> = WASM_MAIN
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.contains("async fn") && line.contains("&mut self"))
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "exported async SlintServer methods must take `&self`, not `&mut self`:\n{}",
+        offenders.join("\n"),
+    );
+}

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -230,12 +230,17 @@ extern "C" {
     fn log(s: &str);
 }
 
+// cSpell:ignore reentrancy
 #[wasm_bindgen]
 pub struct SlintServer {
     /// Multiple requests/notifications from the language client can arrive concurrently,
     /// but the document cache does not support concurrent access, so we serialize them.
     /// (So that a request being sent when we are await'ing for a file from the typeloader
     /// doesn't access the document cache)
+    ///
+    /// Every exported `async` method must therefore take `&self`, not `&mut self`:
+    /// wasm-bindgen holds a `&mut self` borrow across the future's `.await` points,
+    /// which re-entrant messages would trip (see tests/wasm_export_reentrancy.rs).
     ctx: ReentryGuard<Context>,
     rh: Rc<RequestHandler>,
 }
@@ -408,7 +413,7 @@ impl SlintServer {
     }
 
     #[wasm_bindgen]
-    pub async fn trigger_file_watcher(&mut self, url: JsValue, typ: JsValue) -> JsResult<JsValue> {
+    pub async fn trigger_file_watcher(&self, url: JsValue, typ: JsValue) -> JsResult<JsValue> {
         let mut ctx = self.ctx.lock().await;
         let url: Url = serde_wasm_bindgen::from_value(url)?;
         let typ: lsp_types::FileChangeType = serde_wasm_bindgen::from_value(typ)?;
@@ -454,7 +459,7 @@ impl SlintServer {
     }
 
     #[wasm_bindgen]
-    pub async fn close_document(&mut self, uri: JsValue) -> JsResult<JsValue> {
+    pub async fn close_document(&self, uri: JsValue) -> JsResult<JsValue> {
         let mut ctx = self.ctx.lock().await;
         let uri: Url = serde_wasm_bindgen::from_value(uri)?;
         language::close_document(&mut ctx, uri).await.map_err(|e| JsError::new(&e.to_string()))?;

--- a/tools/slintpad/tests/demo-load.spec.ts
+++ b/tools/slintpad/tests/demo-load.spec.ts
@@ -1,0 +1,78 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell:ignore networkidle githubusercontent
+
+// Loading a demo that pulls in imports (the gallery) must render its preview
+// without panicking the wasm LSP or the preview. Regression of #11258, where
+// exported async SlintServer methods took `&mut self` and tripped wasm-bindgen's
+// borrow check when file-watcher and open-document notifications interleaved.
+import { test, expect } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+// Playwright runs from tools/slintpad; the repository root is two levels up.
+const REPO_ROOT = path.resolve(process.cwd(), "..", "..");
+
+// Any Rust panic or wasm trap, not just the specific error we regressed.
+const PANIC =
+    /panic|recursive use of an object|unsafe aliasing|RuntimeError|unreachable/i;
+
+test("loading the gallery demo does not panic the LSP", async ({
+    page,
+    browserName,
+}) => {
+    // Headless Firefox on CI has no WebGL, so the preview panics on init.
+    test.skip(browserName === "firefox", "preview panics without WebGL");
+
+    // The LSP worker panics independently of the preview, so watch its console
+    // and page errors rather than the preview state.
+    const panics: string[] = [];
+    page.on("console", (msg) => {
+        if (msg.type() === "error" && PANIC.test(msg.text())) {
+            panics.push(msg.text());
+        }
+    });
+    page.on("pageerror", (error) => {
+        if (PANIC.test(error.message)) {
+            panics.push(error.message);
+        }
+    });
+
+    // Serve the demo and its imports from this checkout so the test is hermetic
+    // and pinned to the current sources. The latency is deliberate: the panic is
+    // a race between a file-watcher future suspending on an import load and the
+    // next LSP message being dispatched, which instant local reads never expose.
+    await page.route(
+        /raw\.githubusercontent\.com\/slint-ui\/slint\/[^/]+\/(.*)/,
+        async (route) => {
+            const rel = new URL(route.request().url()).pathname.replace(
+                /^\/slint-ui\/slint\/[^/]+\//,
+                "",
+            );
+            await new Promise((resolve) => setTimeout(resolve, 150));
+            try {
+                await route.fulfill({
+                    status: 200,
+                    body: await readFile(path.join(REPO_ROOT, rel)),
+                });
+            } catch {
+                await route.fulfill({ status: 404, body: "" });
+            }
+        },
+    );
+
+    await page.goto(
+        "http://localhost:3000/?load_demo=examples/gallery/gallery.slint",
+    );
+
+    // The example loads: its live preview renders.
+    await expect(page.locator(".preview-container canvas")).toBeVisible({
+        timeout: 40_000,
+    });
+    // Let the LSP finish processing the imports, where the panic would occur.
+    await page.waitForLoadState("networkidle");
+
+    expect(panics, "the wasm LSP or preview panicked").toHaveLength(0);
+    await expect(page.locator("dialog.panic_dialog")).toHaveCount(0);
+});


### PR DESCRIPTION
## Problem

Loading a SlintPad demo that pulls in local imports panics the wasm LSP with:

```
recursive use of an object detected which would lead to unsafe aliasing in rust
```

The panic dialog reads "The Slint LSP has panicked." and the preview stops working.

## This is a regression of #11258

- #11258 reported the same error; #11259 fixed it by moving `Context` behind the `ReentryGuard` async mutex and switching every exported async `SlintServer` method to `&self`.
- Commit 69a3917 ("Add public system-testing features") later reworked `trigger_file_watcher` and `close_document` and wrote them back as `&mut self`, reviving the panic. The sibling methods stayed `&self`, so it slipped through as a silent, partial regression.

## Root cause

wasm-bindgen holds its borrow of the exported object for the whole lifetime of the returned future. So a `&mut self` async method that suspends at an `.await` keeps an **exclusive** borrow while the JS event loop dispatches the next LSP message — and the next `SlintServer` call then trips wasm-bindgen's `WasmRefCell` borrow check and throws. The stack trace confirms the entry point:

```
SlintServer::trigger_file_watcher::{{closure}}
  -> <SlintServer as RefMutFromWasmAbi>::ref_mut_from_abi
  -> WasmRefCell::borrow_mut -> borrow_fail -> throw_str
```

Loading the gallery triggers it because registering the demo's imported files fires file-watcher notifications that interleave with the `open_document` calls for those same files.

Mutable state is already serialized through `ctx`'s async lock, so `&mut self` was never needed.

## Fix

Switch `trigger_file_watcher` and `close_document` back to `&self`, and document the invariant on `SlintServer`.

## Tests

This PR adds two guards, each verified to **fail on the buggy `&mut self` build and pass on the fix**:

- `tools/slintpad/tests/demo-load.spec.ts` — loads the gallery demo (served from the local checkout with a small network-like latency to provoke the race) and asserts the LSP does not panic. 8/8 fail on the buggy build; passes on chromium + webkit (firefox skipped, as the other preview tests do).
- A source-level test in `tools/lsp/main.rs` asserting that no exported async wasm-bindgen method in `wasm_main.rs` takes `&mut self` — a deterministic complement that would have caught 69a3917 directly.


----

Fixes #12489