### PR TITLE
tools/slintpad: brand refresh with a unified first-run startup screen

### DIFF
--- a/tools/slintpad/index.html
+++ b/tools/slintpad/index.html
@@ -17,8 +17,18 @@
 
 <body>
   <div class="loader" id="loader" style="z-index: 1000; position: absolute">
+    <div class="loader-glow loader-glow-a"></div>
+    <div class="loader-glow loader-glow-b"></div>
     <div class="loader-content">
-      <img class="loader-logo" src="static/loader.svg" alt="Slint" />
+      <div class="loader-logo" aria-hidden="true">
+        <svg viewBox="0 0 30 42" fill="#ffffff" xmlns="http://www.w3.org/2000/svg">
+          <path d="M5.49 41.62 28.6 25.5s1.04-.6 1.04-1.55c0-1.27-1.32-1.68-1.32-1.68L15.61 17.2c-.45-.18-1.08.32-.49.96l4.2 4.24s1.17 1.16 1.17 1.92c0 .76-.72 1.43-.72 1.43L4.46 40.65c-.55.53.19 1.49 1.03.97Z" />
+          <path d="M24.15.76 1.04 16.88S0 17.48 0 18.43c0 1.27 1.32 1.68 1.32 1.68l12.71 5.07c.46.17 1.08-.33.5-.97l-4.21-4.25s-1.17-1.16-1.17-1.92c0-.76.72-1.43.72-1.43L25.17 1.73c.56-.53-.18-1.49-1.02-.97Z" />
+        </svg>
+      </div>
+      <div class="loader-tagline">
+        Build the UI once.<br />Run it <span class="loader-grad">on everything.</span>
+      </div>
       <label class="loader-message" id="loader-message" for="loader-progress">Loading…</label>
       <progress class="loader-progress" id="loader-progress"></progress>
     </div>

--- a/tools/slintpad/index.html
+++ b/tools/slintpad/index.html
@@ -26,11 +26,13 @@
           <path d="M24.15.76 1.04 16.88S0 17.48 0 18.43c0 1.27 1.32 1.68 1.32 1.68l12.71 5.07c.46.17 1.08-.33.5-.97l-4.21-4.25s-1.17-1.16-1.17-1.92c0-.76.72-1.43.72-1.43L25.17 1.73c.56-.53-.18-1.49-1.02-.97Z" />
         </svg>
       </div>
-      <div class="loader-tagline">
-        Build the UI once.<br />Run it <span class="loader-grad">on everything.</span>
+      <div class="loader-strip">
+        <progress class="loader-progress" id="loader-progress"></progress>
+        <label class="loader-message" id="loader-message" for="loader-progress">Loading…</label>
       </div>
-      <label class="loader-message" id="loader-message" for="loader-progress">Loading…</label>
-      <progress class="loader-progress" id="loader-progress"></progress>
+      <p class="loader-tagline">
+        Build the UI once. Run it <span class="loader-grad">on everything.</span>
+      </p>
     </div>
   </div>
 </body>

--- a/tools/slintpad/src/editor_widget.ts
+++ b/tools/slintpad/src/editor_widget.ts
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore codingame lumino mimetypes printerdemo
+// cSpell: ignore ccfe codingame lumino mimetypes printerdemo
 
 import * as monaco from "monaco-editor";
 
@@ -37,6 +37,41 @@ let EDITOR_WIDGET: EditorWidget | null = null;
 
 const FILESYSTEM_PROVIDER: RegisteredFileSystemProvider =
     new RegisteredFileSystemProvider(false);
+
+export const SLINT_DARK_THEME = "slint-dark";
+
+// A dark editor theme that matches the slint.dev brand syntax palette.
+// Token names correspond to the Monarch grammar in `highlighting.ts`.
+function define_slint_dark_theme(): void {
+    monaco.editor.defineTheme(SLINT_DARK_THEME, {
+        base: "vs-dark",
+        inherit: true,
+        rules: [
+            { token: "comment", foreground: "5d6b78", fontStyle: "italic" },
+            { token: "keyword", foreground: "c792ea" },
+            { token: "keyword.type", foreground: "5ccfe6" },
+            { token: "string", foreground: "a9dc76" },
+            { token: "string.escape", foreground: "ffc26b" },
+            { token: "string.escape.invalid", foreground: "ff6a3d" },
+            { token: "number", foreground: "ffc26b" },
+            { token: "variable.parameter", foreground: "7ea9ff" },
+            { token: "identifier", foreground: "cdd6e0" },
+        ],
+        colors: {
+            "editor.background": "#0f1418",
+            "editor.foreground": "#cdd6e0",
+            "editorLineNumber.foreground": "#3b4854",
+            "editorLineNumber.activeForeground": "#7e8b96",
+            "editor.selectionBackground": "#2a3f66",
+            "editor.lineHighlightBackground": "#161f26",
+            "editorCursor.foreground": "#7fb6ff",
+            "editorWidget.background": "#141c20",
+            "editorWidget.border": "#243139",
+            "editorGutter.background": "#0f1418",
+            "editorIndentGuide.background1": "#1e2a31",
+        },
+    });
+}
 
 export function initialize(): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -173,6 +208,8 @@ export function initialize(): Promise<void> {
                             slint_language,
                         );
                     });
+
+                    define_slint_dark_theme();
 
                     resolve();
                 })
@@ -313,6 +350,7 @@ class EditorPaneWidget extends Widget {
 
         this.#editor = monaco.editor.create(this.contentNode, {
             model: model_ref.object.textEditorModel,
+            theme: SLINT_DARK_THEME,
         });
 
         this.#editor.onDidFocusEditorText((_) => {

--- a/tools/slintpad/src/editor_widget.ts
+++ b/tools/slintpad/src/editor_widget.ts
@@ -8,6 +8,7 @@ import * as monaco from "monaco-editor";
 import { slint_language } from "./highlighting";
 import type { Lsp } from "./lsp";
 import * as github from "./github";
+import type { Template } from "./welcome";
 
 import { BoxLayout, TabPanel, Widget } from "@lumino/widgets";
 import type { Message as LuminoMessage } from "@lumino/messaging";
@@ -38,7 +39,7 @@ let EDITOR_WIDGET: EditorWidget | null = null;
 const FILESYSTEM_PROVIDER: RegisteredFileSystemProvider =
     new RegisteredFileSystemProvider(false);
 
-export const SLINT_DARK_THEME = "slint-dark";
+const SLINT_DARK_THEME = "slint-dark";
 
 // A dark editor theme that matches the slint.dev brand syntax palette.
 // Token names correspond to the Monarch grammar in `highlighting.ts`.
@@ -463,8 +464,25 @@ export class EditorWidget extends Widget {
             void this.project_from_url(load_url);
         } else if (load_demo) {
             void this.set_demo(load_demo);
-        } else if (!this.restore_from_history_state()) {
-            void this.set_demo("");
+        } else {
+            // On reload, restore the previous project. On a true first run this
+            // does nothing and the editor stays empty: the startup screen
+            // (index.ts) offers starter templates and applies the chosen one
+            // through apply_template().
+            this.restore_from_history_state();
+        }
+    }
+
+    // Load a starter template chosen on the first-run startup screen.
+    public apply_template(template: Template) {
+        if (template.demo) {
+            void this.set_demo(template.demo);
+        } else {
+            this.clear_editors();
+            this.open_file_with_content(
+                internal_file_uri("/main.slint"),
+                template.code ?? "",
+            );
         }
     }
 

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -6,6 +6,7 @@
 import { EditorWidget, initialize as initializeEditor } from "./editor_widget";
 import { LspWaiter, type Lsp, type LoadPhase } from "./lsp";
 import { PreviewWidget } from "./preview_widget";
+import { create_welcome_grid, type Template } from "./welcome";
 
 import {
     export_to_gist,
@@ -36,24 +37,29 @@ function update_loader(phase: LoadPhase) {
     if (loader_message === null || loader_progress === null) {
         return;
     }
+    let text: string;
     if (phase.kind === "downloading") {
         if (phase.total) {
             const percent = Math.round((phase.received / phase.total) * 100);
-            loader_message.textContent = `Downloading Slint runtime… ${percent}%`;
+            text = `Downloading Slint runtime… ${percent}%`;
             loader_progress.max = phase.total;
             loader_progress.value = phase.received;
         } else {
             const kb = Math.round(phase.received / 1024);
-            loader_message.textContent = `Downloading Slint runtime… ${kb} KB`;
+            text = `Downloading Slint runtime… ${kb} KB`;
             loader_progress.removeAttribute("value");
         }
     } else if (phase.kind === "compiling") {
-        loader_message.textContent = "Compiling…";
+        text = "Compiling…";
         loader_progress.removeAttribute("value");
-    } else if (phase.kind === "initializing") {
-        loader_message.textContent = "Initializing…";
+    } else {
+        text = "Initializing…";
         loader_progress.removeAttribute("value");
     }
+    // Once a starter is chosen, keep the runtime status tied to that choice so
+    // the queued pick is clearly what we're waiting on.
+    loader_message.textContent =
+        pending_template !== null ? `Starting ${pending_template.name}…` : text;
 }
 
 const lsp_waiter = new LspWaiter(update_loader);
@@ -63,9 +69,88 @@ const commands = new CommandRegistry();
 const url_params = new URLSearchParams(window.location.search);
 const url_style = url_params.get("style");
 
+// --- Unified startup screen ---
+// The loader doubles as the first-run welcome. On a fresh visit (no content in
+// the URL and nothing to restore) the starter templates render on the loader
+// while the runtime downloads. Picking a card before the runtime is ready
+// queues the choice and applies it the moment it is.
+
+const has_content_param = ["snippet", "gz", "load_url", "load_demo"].some(
+    (key) => url_params.get(key),
+);
+const history_files = (window.history.state?.files ?? {}) as {
+    [path: string]: string;
+};
+const is_first_run =
+    !has_content_param && Object.keys(history_files).length === 0;
+
+let pending_template: Template | null = null;
+let apply_template: ((template: Template) => void) | null = null;
+
+function pick_template(template: Template) {
+    if (apply_template !== null) {
+        apply_template(template);
+        loader?.remove();
+        return;
+    }
+    // Runtime not ready yet: remember the choice, mark the card as queued, and
+    // dim the rest. The pick is applied the moment the runtime is ready.
+    pending_template = template;
+    loader?.classList.add("loader--committed");
+    loader?.querySelectorAll(".welcome-card").forEach((card) => {
+        card.classList.toggle(
+            "welcome-card--queued",
+            (card as HTMLElement).dataset.template === template.id,
+        );
+    });
+    if (loader_message !== null) {
+        loader_message.textContent = `Starting ${template.name}…`;
+    }
+}
+
+function enter_welcome_mode() {
+    // The loader already lays out logo -> loading strip -> tagline. On first run
+    // we insert the welcome header and starter grid between the logo and the
+    // strip, so the loading-then-tagline order stays uniform with the plain
+    // loader.
+    const strip = loader?.querySelector(".loader-strip");
+    if (!loader || !strip) {
+        return;
+    }
+    loader.classList.add("loader--welcome");
+
+    const title = document.createElement("h1");
+    title.className = "loader-title";
+    title.textContent = "Start a new project";
+
+    const subtitle = document.createElement("p");
+    subtitle.className = "loader-subtitle";
+    subtitle.textContent = "Pick a starter and start building.";
+
+    const grid = create_welcome_grid(pick_template);
+
+    strip.insertAdjacentElement("beforebegin", title);
+    strip.insertAdjacentElement("beforebegin", subtitle);
+    strip.insertAdjacentElement("beforebegin", grid);
+}
+
+function mark_runtime_ready() {
+    // Runtime ready with no starter chosen yet. Complete the progress bar and
+    // let the strip recede in place (see CSS) so the layout does not jump.
+    loader?.classList.add("loader--ready");
+    if (loader_progress !== null) {
+        loader_progress.max = 1;
+        loader_progress.value = 1;
+    }
+    if (loader_message !== null) {
+        loader_message.textContent = "Ready";
+    }
+}
+
 function setup(lsp: Lsp) {
     const editor = new EditorWidget(lsp);
     set_panic_share_url_getter(() => editor.share_url());
+    apply_template = (template) => editor.apply_template(template);
     const preview = new PreviewWidget(
         lsp,
         (url: string) => editor.map_url(url),
@@ -99,17 +184,32 @@ function setup(lsp: Lsp) {
     Widget.attach(main, document.body);
 }
 
+// On a fresh visit, add the welcome header and starters to the loader as early
+// as possible (this module runs right after the DOM is parsed, before
+// window.onload). Returning visitors keep the plain loader as authored in HTML.
+if (is_first_run) {
+    enter_welcome_mode();
+}
+
 function main() {
     initializeEditor()
         .then((_) => {
-            if (loader_message !== null) {
+            if (loader_message !== null && !is_first_run) {
                 loader_message.textContent = "Starting language server…";
             }
             lsp_waiter
                 .wait_for_lsp()
                 .then((lsp) => {
                     setup(lsp);
-                    loader?.remove();
+                    if (!is_first_run) {
+                        loader?.remove();
+                    } else if (pending_template !== null) {
+                        // Chosen while the runtime was still loading.
+                        apply_template?.(pending_template);
+                        loader?.remove();
+                    } else {
+                        mark_runtime_ready();
+                    }
                 })
                 .catch((e) => {
                     console.info("LSP fail:", e);

--- a/tools/slintpad/src/welcome.ts
+++ b/tools/slintpad/src/welcome.ts
@@ -1,0 +1,107 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Starter projects offered on the first-run screen. The grid is embedded in
+// the startup screen (see index.ts); picking a card calls the supplied
+// callback with the chosen template.
+
+export interface Template {
+    id: string;
+    name: string;
+    description: string;
+    // Exactly one of these is set. `code` is an inline snippet loaded as
+    // main.slint; `demo` is a repo-relative path loaded via set_demo (the
+    // same demos offered by the toolbar's "Open Demo" menu).
+    code?: string;
+    demo?: string;
+}
+
+const TEMPLATES: Template[] = [
+    {
+        id: "blank",
+        name: "Blank",
+        description: "An empty window to build from.",
+        code: `// A blank canvas. Start building here.
+export component Main inherits Window {
+    width: 400px;
+    height: 300px;
+}
+`,
+    },
+    {
+        id: "hello",
+        name: "Hello World",
+        description: "A greeting and the Slint logo.",
+        code: `import { AboutSlint, VerticalBox } from "std-widgets.slint";
+
+export component Main inherits Window {
+    VerticalBox {
+        Text {
+            text: "Hello, Slint!";
+            font-size: 28px;
+            horizontal-alignment: center;
+        }
+        AboutSlint {
+            preferred-height: 150px;
+        }
+    }
+}
+`,
+    },
+    {
+        id: "printer",
+        name: "Printer Demo",
+        description: "The touchscreen UI for a home printer.",
+        demo: "demos/printerdemo/ui/printerdemo.slint",
+    },
+    {
+        id: "energy",
+        name: "Energy Monitor",
+        description: "A dashboard for a home solar system.",
+        demo: "demos/energy-monitor/ui/desktop_window.slint",
+    },
+    {
+        id: "home-automation",
+        name: "Home Automation",
+        description: "A control panel for a smart home.",
+        demo: "demos/home-automation/ui/demo-debug.slint",
+    },
+    {
+        id: "gallery",
+        name: "Widget Gallery",
+        description: "Every standard widget in one place.",
+        demo: "examples/gallery/gallery.slint",
+    },
+];
+
+/// Build the grid of starter cards. Each card carries `data-template` with the
+/// template id so the caller can reflect a pending/queued selection, and calls
+/// `on_pick` with the chosen template when clicked.
+export function create_welcome_grid(
+    on_pick: (template: Template) => void,
+): HTMLDivElement {
+    const grid = document.createElement("div");
+    grid.className = "welcome-grid";
+
+    for (const template of TEMPLATES) {
+        const card = document.createElement("button");
+        card.type = "button";
+        card.className = "welcome-card";
+        card.dataset.template = template.id;
+
+        const name = document.createElement("span");
+        name.className = "welcome-card-name";
+        name.textContent = template.name;
+
+        const desc = document.createElement("span");
+        desc.className = "welcome-card-desc";
+        desc.textContent = template.description;
+
+        card.appendChild(name);
+        card.appendChild(desc);
+        card.addEventListener("click", () => on_pick(template));
+        grid.appendChild(card);
+    }
+
+    return grid;
+}

--- a/tools/slintpad/styles/colors.css
+++ b/tools/slintpad/styles/colors.css
@@ -38,6 +38,7 @@
     /* Brand design tokens (matches the slint.dev visual language) */
     --brand-ink: var(--color_dark);
     --brand-ink-2: #0f1519;
+    --brand-code-bg: #0f1418;
     --brand-text: #eef3f5;
     --brand-muted: #9fb0b8;
     --brand-line: rgba(255, 255, 255, 0.12);

--- a/tools/slintpad/styles/colors.css
+++ b/tools/slintpad/styles/colors.css
@@ -34,4 +34,25 @@
     --undefined-fg: var(--color_dark);
 
     --default-font: 12px Helvetica, Arial, sans-serif;
+
+    /* Brand design tokens (matches the slint.dev visual language) */
+    --brand-ink: var(--color_dark);
+    --brand-ink-2: #0f1519;
+    --brand-text: #eef3f5;
+    --brand-muted: #9fb0b8;
+    --brand-line: rgba(255, 255, 255, 0.12);
+    --brand-line-strong: rgba(255, 255, 255, 0.2);
+
+    --brand-gradient: linear-gradient(103deg, #2379f4 4%, #6b0dff 96%);
+    --brand-gradient-bright: linear-gradient(103deg, #4f9bff 2%, #9f5bff 98%);
+
+    --brand-radius: 12px;
+    --brand-radius-lg: 18px;
+    --brand-shadow: 0 24px 64px rgba(5, 10, 14, 0.5);
+    --brand-shadow-soft: 0 12px 34px rgba(20, 35, 60, 0.14);
+
+    --brand-display:
+        "Red Hat Display", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --brand-sans: "Archivo", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --brand-mono: "JetBrains Mono", ui-monospace, "Source Code Pro", monospace;
 }

--- a/tools/slintpad/styles/content.css
+++ b/tools/slintpad/styles/content.css
@@ -130,27 +130,108 @@
 }
 
 .dialog {
-    font: var(--default-font);
-    padding: 0px;
+    font-family: var(--brand-sans);
+    font-size: 13px;
+    color: var(--color_dark);
+    padding: 0;
+    border: 1px solid var(--color_gray);
+    border-radius: var(--brand-radius-lg);
+    box-shadow: var(--brand-shadow-soft);
+    background: var(--color_white);
+    max-width: min(440px, 92vw);
+    max-height: 88vh;
+    overflow: auto;
+}
+
+.dialog::backdrop {
+    background: rgba(6, 10, 14, 0.5);
+    backdrop-filter: blur(4px);
 }
 
 .dialog .dialog_content {
-    padding: 5px;
+    padding: 4px 20px 8px;
 }
 
 .dialog .titlebar {
-    border-bottom: 1px solid black;
-    text-align: right;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 8px 10px 0;
 }
 
 .dialog .titlebar .close_button {
-    padding: 5px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
+    color: var(--color_dark_gray);
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease;
+}
+
+.dialog .titlebar .close_button:hover {
+    background: var(--color_gray);
+    color: var(--color_dark);
 }
 
 .dialog .button_row {
-    padding: 5px;
-    margin-top: 10px;
-    text-align: center;
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 8px 20px 20px;
+}
+
+/* Primary action */
+.dialog .button_row button {
+    font-family: var(--brand-sans);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--color_white);
+    background: var(--brand-gradient);
+    border: none;
+    border-radius: var(--brand-radius);
+    padding: 9px 18px;
+    cursor: pointer;
+    transition:
+        transform 0.15s ease,
+        box-shadow 0.2s ease,
+        opacity 0.15s ease;
+}
+
+.dialog .button_row button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 22px rgba(53, 27, 180, 0.35);
+}
+
+.dialog .button_row button:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.dialog .button_row button:focus-visible {
+    outline: 2px solid var(--color_focus_blue);
+    outline-offset: 2px;
+}
+
+/* Secondary buttons (copy / forget token) */
+.dialog .button {
+    font-family: var(--brand-sans);
+    font-size: 13px;
+    color: var(--color_dark);
+    background: var(--color_gray);
+    border: 1px solid var(--color_dark_20);
+    border-radius: var(--brand-radius);
+    padding: 7px 12px;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.dialog .button:hover {
+    background: var(--color_dark_20);
 }
 
 .dialog.report_export_url .url {

--- a/tools/slintpad/styles/content.css
+++ b/tools/slintpad/styles/content.css
@@ -17,6 +17,20 @@
     overflow: auto;
 }
 
+/* Dark brand chrome for the editor and preview panes */
+.content.editor,
+.content.preview {
+    background: var(--brand-code-bg);
+    border-color: var(--brand-line);
+    color: var(--brand-text);
+    box-shadow: none;
+}
+
+.content.editor > div,
+.content.preview > div {
+    border-color: var(--brand-line);
+}
+
 .content input {
     margin: 8px;
 }

--- a/tools/slintpad/styles/index.css
+++ b/tools/slintpad/styles/index.css
@@ -13,6 +13,7 @@ body {
     margin: 0;
     padding: 0;
     overflow: hidden;
+    background: var(--brand-ink);
 }
 
 #menuBar {
@@ -21,6 +22,45 @@ body {
 
 #main {
     flex: 1 1 auto;
+}
+
+/* Lumino chrome, dark brand palette (overrides @lumino/default-theme,
+   which is imported above, so these later rules win on equal specificity) */
+#main.lm-SplitPanel,
+.lm-DockPanel,
+.lm-TabPanel {
+    background: var(--brand-ink);
+}
+
+.lm-SplitPanel-handle {
+    background: var(--brand-line);
+}
+
+.lm-TabBar {
+    background: var(--brand-ink-2);
+}
+
+.lm-TabBar-tab {
+    color: var(--brand-muted);
+    background: transparent;
+    border-color: var(--brand-line);
+    font-family: var(--brand-sans);
+}
+
+.lm-TabBar-tab:hover:not(.lm-mod-current) {
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--brand-text);
+}
+
+.lm-TabBar-tab.lm-mod-current {
+    background: var(--brand-code-bg);
+    color: var(--brand-text);
+    border-bottom-color: transparent;
+}
+
+.lm-TabBar-tabIcon,
+.lm-TabBar-tabCloseIcon {
+    color: var(--brand-muted);
 }
 
 #dock {
@@ -54,7 +94,7 @@ body {
     overflow: hidden;
 }
 
-/* Soft radial glows — composited cheaply (no blur filter) */
+/* Soft radial glows, composited cheaply (no blur filter) */
 .loader-glow {
     position: absolute;
     z-index: 0;
@@ -158,7 +198,7 @@ body {
     border-radius: 999px;
 }
 
-/* Indeterminate phases (compiling / initializing): a travelling sheen */
+/* Indeterminate phases (compiling / initializing): a moving sheen */
 .loader-progress:indeterminate {
     background: var(--brand-line)
         linear-gradient(

--- a/tools/slintpad/styles/index.css
+++ b/tools/slintpad/styles/index.css
@@ -93,7 +93,6 @@ body {
     font-family: var(--brand-sans);
     overflow: hidden;
 }
-
 /* Soft radial glows, composited cheaply (no blur filter) */
 .loader-glow {
     position: absolute;
@@ -144,13 +143,15 @@ body {
     height: 38px;
 }
 
+/* Brand tagline: the muted line under the loading strip, shared by the plain
+   loader and the welcome so the order (loading, then tagline) is uniform. */
 .loader-tagline {
+    margin: 0;
     font-family: var(--brand-display);
-    font-weight: 800;
-    font-size: 20px;
-    line-height: 1.25;
-    letter-spacing: -0.02em;
-    color: var(--brand-text);
+    font-weight: 700;
+    font-size: 15px;
+    letter-spacing: -0.01em;
+    color: var(--brand-muted);
     text-align: center;
 }
 
@@ -161,12 +162,40 @@ body {
     color: transparent;
 }
 
+/* Welcome hero, shown only in first-run mode above the cards. */
+.loader-title {
+    margin: 14px 0 0;
+    font-family: var(--brand-display);
+    font-weight: 800;
+    font-size: 26px;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+    color: var(--brand-text);
+    text-align: center;
+}
+
+/* Loading strip: progress bar and status side by side, above the tagline. */
+.loader-strip {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    max-width: 460px;
+    transition: opacity 0.4s ease;
+}
+
+.loader-strip .loader-progress {
+    flex: 1;
+}
+
 .loader-message {
     font-family: var(--brand-mono);
     font-size: 13px;
     color: var(--brand-muted);
     text-align: center;
     font-variant-numeric: tabular-nums;
+    flex: 0 0 auto;
+    white-space: nowrap;
 }
 
 .loader-progress {
@@ -228,5 +257,115 @@ body {
 @media (prefers-reduced-motion: reduce) {
     .loader-progress:indeterminate {
         animation: none;
+    }
+}
+
+/* First-run starter grid, embedded in the loader (see index.ts). */
+.welcome-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 14px;
+    margin-top: 32px;
+    text-align: left;
+}
+
+.welcome-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 18px;
+    border-radius: var(--brand-radius);
+    border: 1px solid var(--brand-line);
+    background: var(--brand-ink-2);
+    color: inherit;
+    font-family: var(--brand-sans);
+    cursor: pointer;
+    text-align: left;
+    transition:
+        transform 0.15s ease,
+        border-color 0.15s ease,
+        box-shadow 0.2s ease;
+}
+
+.welcome-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--brand-line-strong);
+    box-shadow: 0 14px 34px rgba(5, 10, 14, 0.5);
+}
+
+.welcome-card:focus-visible {
+    outline: 2px solid var(--color_focus_blue);
+    outline-offset: 2px;
+}
+
+.welcome-card-name {
+    font-family: var(--brand-display);
+    font-weight: 700;
+    font-size: 17px;
+}
+
+.welcome-card-desc {
+    color: var(--brand-muted);
+    font-size: 13.5px;
+    line-height: 1.4;
+}
+
+/* Unified startup screen: the loader reframed as the first-run welcome, with
+   the starter grid and a progress strip on one screen. */
+/* Taller welcome content must scroll rather than clip against the centered,
+   overflow-hidden loader. `safe center` keeps it centered when it fits and
+   pins it to the top (scrollable) when it does not. */
+.loader--welcome {
+    flex-direction: column;
+    justify-content: safe center;
+    overflow-y: auto;
+    padding: 32px 16px;
+}
+.loader--welcome .loader-content {
+    width: min(860px, 92vw);
+    gap: 10px;
+}
+.loader-subtitle {
+    margin: 0;
+    max-width: 460px;
+    color: var(--brand-muted);
+    font-size: 14px;
+    text-align: center;
+}
+.loader--welcome .welcome-grid {
+    width: 100%;
+    margin-top: 18px;
+}
+/* When ready with no pick, keep the completed strip in place (so the layout
+   does not jump) but let it recede so it stops drawing attention. */
+.loader--welcome.loader--ready .loader-strip {
+    opacity: 0.4;
+}
+/* A starter chosen before the runtime is ready: highlight it, dim the rest,
+   and spin a small indicator until it loads. */
+.loader--committed .welcome-card:not(.welcome-card--queued) {
+    opacity: 0.45;
+}
+.welcome-card--queued {
+    position: relative;
+    border-color: var(--brand-line-strong);
+    outline: 2px solid var(--color_focus_blue);
+    outline-offset: 2px;
+}
+.welcome-card--queued::after {
+    content: "";
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid var(--brand-line-strong);
+    border-top-color: #4f9bff;
+    animation: welcome-card-spin 0.7s linear infinite;
+}
+@keyframes welcome-card-spin {
+    to {
+        transform: rotate(360deg);
     }
 }

--- a/tools/slintpad/styles/index.css
+++ b/tools/slintpad/styles/index.css
@@ -29,12 +29,17 @@ body {
 
 .browser-error {
     display: flex;
+    flex-direction: column;
+    gap: 12px;
     width: 100%;
     height: 100%;
     justify-content: center;
     align-items: center;
-    background: var(--color_blue);
-    color: var(--color_white);
+    background: var(--brand-ink);
+    color: var(--brand-text);
+    font-family: var(--brand-sans);
+    text-align: center;
+    padding: 0 24px;
 }
 
 .loader {
@@ -43,33 +48,145 @@ body {
     height: 100%;
     justify-content: center;
     align-items: center;
-    background: var(--color_blue);
-    color: var(--color_white);
-    font-family: system-ui, -apple-system, Helvetica, Arial, sans-serif;
+    background: var(--brand-ink);
+    color: var(--brand-text);
+    font-family: var(--brand-sans);
+    overflow: hidden;
+}
+
+/* Soft radial glows — composited cheaply (no blur filter) */
+.loader-glow {
+    position: absolute;
+    z-index: 0;
+    pointer-events: none;
+    width: 560px;
+    height: 560px;
+    border-radius: 50%;
+    opacity: 0.5;
+}
+
+.loader-glow-a {
+    background: radial-gradient(circle, #2379f4 0%, transparent 70%);
+    top: -180px;
+    left: -160px;
+}
+
+.loader-glow-b {
+    background: radial-gradient(circle, #6b0dff 0%, transparent 70%);
+    bottom: -180px;
+    right: -160px;
 }
 
 .loader-content {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 10px;
-    width: min(360px, 60vw);
+    gap: 14px;
+    width: min(340px, 72vw);
 }
 
 .loader-logo {
-    width: 96px;
-    height: 96px;
-    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 76px;
+    height: 76px;
+    border-radius: 20px;
+    background: var(--brand-gradient);
+    box-shadow: 0 16px 40px rgba(53, 27, 180, 0.45);
+    margin-bottom: 4px;
+}
+
+.loader-logo svg {
+    width: 38px;
+    height: 38px;
+}
+
+.loader-tagline {
+    font-family: var(--brand-display);
+    font-weight: 800;
+    font-size: 20px;
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    color: var(--brand-text);
+    text-align: center;
+}
+
+.loader-tagline .loader-grad {
+    background: var(--brand-gradient-bright);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
 }
 
 .loader-message {
+    font-family: var(--brand-mono);
     font-size: 13px;
-    opacity: 0.85;
+    color: var(--brand-muted);
     text-align: center;
     font-variant-numeric: tabular-nums;
 }
 
 .loader-progress {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
     width: 100%;
     height: 6px;
+    border: none;
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--brand-line);
+    color: #2379f4; /* Firefox indeterminate/value colour */
+}
+
+.loader-progress::-webkit-progress-bar {
+    background: var(--brand-line);
+    border-radius: 999px;
+}
+
+.loader-progress::-webkit-progress-value {
+    background: var(--brand-gradient-bright);
+    border-radius: 999px;
+    transition: width 0.2s ease;
+}
+
+.loader-progress::-moz-progress-bar {
+    background: var(--brand-gradient-bright);
+    border-radius: 999px;
+}
+
+/* Indeterminate phases (compiling / initializing): a travelling sheen */
+.loader-progress:indeterminate {
+    background: var(--brand-line)
+        linear-gradient(
+            100deg,
+            transparent 20%,
+            rgba(79, 155, 255, 0.9) 50%,
+            transparent 80%
+        )
+        no-repeat;
+    background-size: 40% 100%;
+    animation: loader-indeterminate 1.2s ease-in-out infinite;
+}
+
+.loader-progress:indeterminate::-webkit-progress-bar {
+    background: transparent;
+}
+
+@keyframes loader-indeterminate {
+    from {
+        background-position: -40% 0;
+    }
+    to {
+        background-position: 140% 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .loader-progress:indeterminate {
+        animation: none;
+    }
 }

--- a/tools/slintpad/tests/smoke-test.spec.ts
+++ b/tools/slintpad/tests/smoke-test.spec.ts
@@ -17,9 +17,16 @@ test("smoke test", async ({ page, browserName }) => {
     });
 
     await page.goto("http://localhost:3000/");
-    await expect(page.locator("#tab-key-1-0")).toContainText("main.slint");
 
-    // Wait for the preview to compile and render the default snippet.
+    // A fresh visit shows the first-run startup screen. Pick the Blank starter
+    // to open the editor with an empty main.slint. (Choosing before the runtime
+    // is ready queues the pick; it is applied once the runtime loads.)
+    await page.locator('.welcome-card[data-template="blank"]').click();
+    await expect(page.locator("#tab-key-1-0")).toContainText("main.slint", {
+        timeout: 30_000,
+    });
+
+    // Wait for the preview to compile and render the chosen starter.
     const canvas = page.locator(".preview-container canvas");
     await expect(canvas).toBeVisible({ timeout: 30_000 });
 


### PR DESCRIPTION
Refreshes the SlintPad front-end with the slint.dev brand visual language and replaces the first-run experience with a single startup screen. Standalone against `master`; supersedes and replaces #12471 and #12472 (closed in favor of this one).

## Commits

1. **Refresh loader and dialogs** — brand color tokens, the branded loader, and the dialog styling.
2. **Dark-theme the editor and surrounding chrome** — Monaco dark theme and the Lumino tab/split chrome.
3. **Add a first-run startup screen with starter templates** — the loader doubles as the welcome.

## The startup screen

Previously a fresh visit showed a loading screen, then swapped it for a near-identical dark welcome screen. These are now one:

- **One screen from first paint** — brand mark, "Start a new project", the starter grid, and a slim progress strip, with the "Build the UI once. Run it on everything." tagline under the bar.
- **Pick while loading** — the chosen card highlights with a spinner, the rest dim, and the strip shows "Starting …". The pick is queued and applied the moment the runtime is ready; changing your mind before then re-queues.
- **Ready, no pick** — the progress strip drops away, leaving just the starters.
- **Returning visitors** (a shared permalink, gist, or `load_demo`) keep the plain branded loader, which dismisses on ready. The starter grid is first-run only.

## Notes

- Front-end only (`index.html`, `index.ts`, `welcome.ts`, `editor_widget.ts`, `colors.css`, `content.css`, `index.css`); no Rust or wasm changes.
- Tall content scrolls instead of clipping at short/narrow window sizes.

https://github.com/user-attachments/assets/05832035-a45e-40e0-9538-d8b5d9f2ae09

