### PR TITLE
tools/slintpad: brand the preview chrome, panels, and toolbar (Phase 1)

### DIFF
--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -144,6 +144,7 @@ export component MenuItemBase {
 
                     Image {
                         source: entry.icon;
+                        colorize: root.default-foreground;
                         accessible-role: none;
                         image-fit: contain;
                         width: 100%;

--- a/tools/lsp/ui/components/group.slint
+++ b/tools/lsp/ui/components/group.slint
@@ -3,7 +3,7 @@
 
 import { HorizontalBox, Palette } from "std-widgets.slint";
 import { HeaderText } from "./header-text.slint";
-import { EditorSizeSettings } from "./styling.slint";
+import { EditorSizeSettings, ConsoleStyles } from "./styling.slint";
 
 export component GroupHeader {
     in property <string> title;
@@ -32,7 +32,7 @@ export component Group {
     min-height: content-layer.min-height;
 
     background-layer := Rectangle {
-        background: Palette.background;
+        background: ConsoleStyles.panel-background;
     }
 
     content-layer := VerticalLayout {
@@ -42,6 +42,6 @@ export component Group {
     Rectangle {
         x: root.width - self.width;
         width: 2px;
-        background: Palette.border;
+        background: ConsoleStyles.panel-border;
     }
 }

--- a/tools/lsp/ui/components/styling.slint
+++ b/tools/lsp/ui/components/styling.slint
@@ -101,6 +101,10 @@ export global ConsoleStyles {
     out property <color> log-background: dark-scheme ? (branded ? Brand.ink : #262626) : #ffffff;
     out property <color> text-color: dark-scheme ? #cccccc : #525252;
     out property <color> toolbar-background: dark-scheme ? (branded ? Brand.surface : #2c2c2c) : #f3f3f3;
+    // Panel body surface and border: match the brand chrome in SlintPad,
+    // otherwise fall back to the active widget style.
+    out property <color> panel-background: (branded && dark-scheme) ? Brand.ink : Palette.background;
+    out property <color> panel-border: (branded && dark-scheme) ? Brand.line : Palette.border;
     out property <length> header-height: 28px;
     out property <length> log-height: 120px;
     out property <color> slint-blue: #0088ff;

--- a/tools/lsp/ui/components/styling.slint
+++ b/tools/lsp/ui/components/styling.slint
@@ -3,6 +3,21 @@
 
 // cSpell: ignore eightbit
 import { Palette } from "std-widgets.slint";
+import { Api } from "../api.slint";
+
+// Brand palette matching the slint.dev visual language, used to give the
+// SlintPad chrome a consistent dark look regardless of the widget style.
+export global Brand {
+    out property <color> ink: #151d21;
+    out property <color> surface: #1a242a;
+    out property <color> panel: #1e2a31;
+    out property <color> code-bg: #0f1418;
+    out property <color> text: #eef3f5;
+    out property <color> muted: #9fb0b8;
+    out property <color> line: #ffffff1f;
+    out property <color> accent: #2379f4;
+    out property <color> accent-2: #6b0dff;
+}
 
 export global Icons {
     out property <image> add: @image-url("../assets/add.svg");
@@ -79,11 +94,13 @@ export global PickerStyles {
 
 export global ConsoleStyles {
     property <bool> dark-scheme: Palette.color-scheme == ColorScheme.dark;
-    out property <color> header-background: dark-scheme ? #2c2c2c : #eaeaea;
-    out property <color> divider-line: dark-scheme ? #454a54 : #e0e0e0;
-    out property <color> log-background: dark-scheme ? #262626 : #ffffff;
+    // In SlintPad, tint the console/panel surfaces with the brand palette.
+    property <bool> branded: Api.runs-in-slintpad;
+    out property <color> header-background: dark-scheme ? (branded ? Brand.surface : #2c2c2c) : #eaeaea;
+    out property <color> divider-line: dark-scheme ? (branded ? Brand.line : #454a54) : #e0e0e0;
+    out property <color> log-background: dark-scheme ? (branded ? Brand.ink : #262626) : #ffffff;
     out property <color> text-color: dark-scheme ? #cccccc : #525252;
-    out property <color> toolbar-background: dark-scheme ? #2c2c2c : #f3f3f3;
+    out property <color> toolbar-background: dark-scheme ? (branded ? Brand.surface : #2c2c2c) : #f3f3f3;
     out property <length> header-height: 28px;
     out property <length> log-height: 120px;
     out property <color> slint-blue: #0088ff;

--- a/tools/lsp/ui/components/widgets/basics.slint
+++ b/tools/lsp/ui/components/widgets/basics.slint
@@ -25,9 +25,11 @@ export component NameLabel inherits HorizontalLayout {
         height: root.property-name != "" ? self.preferred-height : 0;
         text: root.property-name;
         font-size: 1rem;
-        font-weight: root.property-value.code != "" ? FontWeight.normal : FontWeight.thin;
+        // Unset properties stay distinguishable (lighter weight + italic) but
+        // must remain readable on the dark panel, so keep the opacity high.
+        font-weight: root.property-value.code != "" ? FontWeight.normal : FontWeight.light;
         font-italic: root.property-value.code == "";
-        opacity: root.property-value.code != "" ? 1.0 : 0.5;
+        opacity: root.property-value.code != "" ? 1.0 : 0.75;
 
         overflow: elide;
     }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -53,9 +53,18 @@ export component PreviewUi inherits Window {
     icon: @image-url("assets/slint-logo-small-light.png");
     always-on-top <=> Api.always-on-top;
     // Brand the chrome with the dark slint.dev look, matching the editor.
-    background: Api.runs-in-slintpad ? Brand.ink : Palette.background;
+    // runs-in-slintpad is set by the host after construction, so force the
+    // scheme both on init and reactively when it flips true.
+    property <bool> is-slintpad: Api.runs-in-slintpad;
+    property <bool> brand-dark: is-slintpad && Palette.color-scheme == ColorScheme.dark;
+    background: brand-dark ? Brand.ink : Palette.background;
+    changed is-slintpad => {
+        if is-slintpad {
+            Palette.color-scheme = ColorScheme.dark;
+        }
+    }
     init => {
-        if Api.runs-in-slintpad {
+        if is-slintpad {
             Palette.color-scheme = ColorScheme.dark;
         }
         WindowGlobal.window-width = self.width;
@@ -307,7 +316,7 @@ export component PreviewUi inherits Window {
                         right-panel-border := Rectangle {
                             x: 0px;
                             width: 2px;
-                            background: Api.runs-in-slintpad ? Brand.line : Palette.border;
+                            background: root.brand-dark ? Brand.line : Palette.border;
                         }
 
                         property <float> ratio1: 0.5;

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -345,7 +345,7 @@ export component PreviewUi inherits Window {
                             }
                             mouse-cursor: ns-resize;
                             Rectangle {
-                                background: Palette.border;
+                                background: root.brand-dark ? Brand.line : Palette.border;
                             }
                         }
 
@@ -369,7 +369,7 @@ export component PreviewUi inherits Window {
                             }
                             mouse-cursor: ns-resize;
                             Rectangle {
-                                background: Palette.border;
+                                background: root.brand-dark ? Brand.line : Palette.border;
                             }
                         }
 

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -7,7 +7,7 @@ import { Button, TabWidget, Palette, Switch, ScrollView} from "std-widgets.slint
 import { Api, ComponentItem, DiagnosticSummary, PreviewMode, RemoteConnectionState } from "api.slint";
 
 import { EditorUi } from "./editor.slint";
-import { EditorSizeSettings, EditorSpaceSettings, Icons, PickerStyles, ConsoleStyles } from "./components/styling.slint";
+import { EditorSizeSettings, EditorSpaceSettings, Icons, PickerStyles, ConsoleStyles, Brand } from "./components/styling.slint";
 import { StatusLine } from "./components/status-line.slint";
 import { HeaderView } from "./views/header-view.slint";
 import { LibraryView } from "./views/library-view.slint";
@@ -52,7 +52,12 @@ export component PreviewUi inherits Window {
     title: @tr("Slint Live-Preview");
     icon: @image-url("assets/slint-logo-small-light.png");
     always-on-top <=> Api.always-on-top;
+    // Brand the chrome with the dark slint.dev look, matching the editor.
+    background: Api.runs-in-slintpad ? Brand.ink : Palette.background;
     init => {
+        if Api.runs-in-slintpad {
+            Palette.color-scheme = ColorScheme.dark;
+        }
         WindowGlobal.window-width = self.width;
         WindowGlobal.window-height = self.height;
         initial-floating-x = (self.width - PickerStyles.picker-width - 350px).max(0);
@@ -302,7 +307,7 @@ export component PreviewUi inherits Window {
                         right-panel-border := Rectangle {
                             x: 0px;
                             width: 2px;
-                            background: Palette.border;
+                            background: Api.runs-in-slintpad ? Brand.line : Palette.border;
                         }
 
                         property <float> ratio1: 0.5;

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -58,11 +58,6 @@ export component PreviewUi inherits Window {
     property <bool> is-slintpad: Api.runs-in-slintpad;
     property <bool> brand-dark: is-slintpad && Palette.color-scheme == ColorScheme.dark;
     background: brand-dark ? Brand.ink : Palette.background;
-    changed is-slintpad => {
-        if is-slintpad {
-            Palette.color-scheme = ColorScheme.dark;
-        }
-    }
     init => {
         if is-slintpad {
             Palette.color-scheme = ColorScheme.dark;

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -26,8 +26,10 @@ export component HeaderView {
         mode-combobox.current-index = root.preview-mode == PreviewMode.Remote ? 1 : 0;
     }
 
+    property <bool> brand-dark: Api.runs-in-slintpad && Palette.color-scheme == ColorScheme.dark;
+
     background-layer := Rectangle {
-        background: Api.runs-in-slintpad ? Brand.surface : Palette.alternate-background;
+        background: root.brand-dark ? Brand.surface : Palette.alternate-background;
 
         content-layer := HorizontalBox {
             horizontal-stretch: 1;
@@ -159,7 +161,7 @@ export component HeaderView {
             y: parent.height - self.height;
             height: 1px;
 
-            background: Api.runs-in-slintpad ? Brand.line : Palette.border;
+            background: root.brand-dark ? Brand.line : Palette.border;
         }
     }
 }

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -39,6 +39,32 @@ export component HeaderView {
                 horizontal-stretch: 0;
                 spacing: EditorSpaceSettings.default-spacing / 2;
 
+                // SlintPad brand mark: a gradient chip with the Slint bolt,
+                // matching the loader and the rest of the brand chrome.
+                if Api.runs-in-slintpad: Rectangle {
+                    width: 26px;
+                    height: 26px;
+                    border-radius: 7px;
+                    background: @linear-gradient(103deg, #2379f4 4%, #6b0dff 96%);
+                    Path {
+                        width: 13px;
+                        height: 18px;
+                        viewbox-width: 30;
+                        viewbox-height: 42;
+                        fill: #ffffff;
+                        commands: "M5.49 41.62 28.6 25.5s1.04-.6 1.04-1.55c0-1.27-1.32-1.68-1.32-1.68L15.61 17.2c-.45-.18-1.08.32-.49.96l4.2 4.24s1.17 1.16 1.17 1.92c0 .76-.72 1.43-.72 1.43L4.46 40.65c-.55.53.19 1.49 1.03.97Z M24.15.76 1.04 16.88S0 17.48 0 18.43c0 1.27 1.32 1.68 1.32 1.68l12.71 5.07c.46.17 1.08-.33.5-.97l-4.21-4.25s-1.17-1.16-1.17-1.92c0-.76.72-1.43.72-1.43L25.17 1.73c.56-.53-.18-1.49-1.02-.97Z";
+                    }
+                }
+
+                if Api.runs-in-slintpad: Text {
+                    vertical-alignment: center;
+                    text: "SlintPad";
+                    color: root.brand-dark ? Brand.text : Palette.foreground;
+                    font-family: "Inter";
+                    font-size: 15px;
+                    font-weight: 800;
+                }
+
                 Button {
                     icon: Icons.sync;
                     colorize-icon: true;
@@ -47,7 +73,7 @@ export component HeaderView {
                     }
                 }
 
-                label := Text {
+                if !Api.runs-in-slintpad: Text {
                     horizontal-alignment: left;
                     vertical-alignment: center;
                     color: ConsoleStyles.text-color;

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -5,7 +5,7 @@ import { Button, HorizontalBox, Switch, Palette, ComboBox } from "std-widgets.sl
 import { BodyText } from "../components/body-text.slint";
 import { HeaderText } from "../components/header-text.slint";
 import { Api, ComponentItem, PreviewMode } from "../api.slint";
-import { EditorSpaceSettings, Icons, ConsoleStyles } from "../components/styling.slint";
+import { EditorSpaceSettings, Icons, ConsoleStyles, Brand } from "../components/styling.slint";
 
 
 export component HeaderView {
@@ -27,7 +27,7 @@ export component HeaderView {
     }
 
     background-layer := Rectangle {
-        background: Palette.alternate-background;
+        background: Api.runs-in-slintpad ? Brand.surface : Palette.alternate-background;
 
         content-layer := HorizontalBox {
             horizontal-stretch: 1;
@@ -159,7 +159,7 @@ export component HeaderView {
             y: parent.height - self.height;
             height: 1px;
 
-            background: Palette.border;
+            background: Api.runs-in-slintpad ? Brand.line : Palette.border;
         }
     }
 }


### PR DESCRIPTION
## What's in here

- **Brand the preview chrome** — the LSP preview UI (toolbar, panels, console) follows the dark slint.dev look when running in SlintPad, and reliably forces the dark scheme. Unset property labels stay readable on the dark panel.
- **Colorize MenuItem icons** — a general std-widgets fix so menu icons follow the menu foreground (they were invisible on dark menus).
- **Brand mark in the header toolbar** — a small SlintPad mark in the preview header.
- **Tint the panel surfaces** — the panel bodies and splitters use the brand ink/line colors in the dark theme instead of the default widget style.

NOTE: This PR adds the dark theme to the wasm part whereas #12487 only implemented the dark theme for the html part.

https://github.com/user-attachments/assets/34618bbc-96f2-419d-a797-8fd7a2e82715
