### PR TITLE
tools: persist preview UI settings across SlintPad and VS Code

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -10,6 +10,7 @@ import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import * as vscode from "vscode";
 import { SlintTelemetrySender } from "./telemetry";
 import * as common from "./common";
+import { UI_STATE_KEY } from "./wasm_preview";
 import { NotificationType } from "vscode-languageclient";
 
 import {
@@ -235,6 +236,15 @@ function startClient(
                 handleTelemetryEvent(params.type, context.globalState);
             },
         );
+
+        // The native preview persists its UI settings through the LSP: store
+        // the opaque blob in the same globalState key the WASM preview uses.
+        cl?.onNotification(
+            new NotificationType("slint/persist_ui_settings"),
+            (params: any) => {
+                context.globalState.update(UI_STATE_KEY, params.settings);
+            },
+        );
     });
 
     const cl = new LanguageClient(
@@ -246,7 +256,18 @@ function startClient(
 
     common.prepare_client(cl);
 
-    cl.start().then(() => (client.client = cl));
+    cl.start().then(() => {
+        client.client = cl;
+
+        // Seed the preview UI settings persisted from an earlier session so the
+        // next native preview start can restore its panel layout.
+        const stored = context.globalState.get<string>(UI_STATE_KEY, "");
+        if (stored.length > 0) {
+            cl.sendNotification("slint/restore_ui_settings", {
+                settings: stored,
+            });
+        }
+    });
 }
 
 export function activate(context: vscode.ExtensionContext) {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -238,11 +238,17 @@ function startClient(
         );
 
         // The native preview persists its UI settings through the LSP: store
-        // the opaque blob in the same globalState key the WASM preview uses.
+        // the opaque blob in the same globalState key the WASM preview uses, and
+        // echo it back so the LSP keeps its in-memory copy current. Without the
+        // echo the LSP only learns the settings on startup, so reopening the
+        // preview in the same session would restore a stale (or empty) layout.
         cl?.onNotification(
             new NotificationType("slint/persist_ui_settings"),
             (params: any) => {
                 context.globalState.update(UI_STATE_KEY, params.settings);
+                cl.sendNotification("slint/restore_ui_settings", {
+                    settings: params.settings,
+                });
             },
         );
     });

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -6,6 +6,10 @@ import { Uri } from "vscode";
 import * as vscode from "vscode";
 import type { BaseLanguageClient } from "vscode-languageclient";
 
+// The globalState key that holds the opaque preview UI settings blob. Shared
+// with the native preview path so both hosts persist to the same place.
+export const UI_STATE_KEY = "slint.preview.uiState";
+
 let previewPanel: vscode.WebviewPanel | null = null;
 let to_lsp_queue: object[] = [];
 
@@ -95,10 +99,8 @@ function open_preview(context: vscode.ExtensionContext): boolean {
 function getPreviewHtml(
     slint_wasm_preview_url: Uri,
     default_style: string,
+    initial_ui_settings: string,
 ): string {
-    const experimental =
-        typeof process !== "undefined" &&
-        process.env.hasOwnProperty("SLINT_ENABLE_EXPERIMENTAL_FEATURES");
     const result = `<!DOCTYPE html>
 <html lang="en" style="height: 100%; width: 100%;">
 <head>
@@ -149,9 +151,14 @@ function getPreviewHtml(
             vscode.postMessage({ command: "map_url", url: url });
         })},
         "${default_style}",
-        ${experimental ? "true" : "false"},
-        undefined
+        undefined,
+        (settings) => { vscode.postMessage({ command: "persist_ui_settings", settings: settings }); }
     );
+
+    const initial_ui_settings = ${JSON.stringify(initial_ui_settings)};
+    if (initial_ui_settings.length > 0) {
+        preview_connector.restore_ui_settings(initial_ui_settings);
+    }
 
     window.addEventListener('message', async message => {
         if (message.data.command === "slint/lsp_to_preview") {
@@ -238,6 +245,9 @@ function initPreviewPanel(
                 case "slint/preview_to_lsp":
                     send_to_lsp(message.params);
                     return;
+                case "persist_ui_settings":
+                    context.globalState.update(UI_STATE_KEY, message.settings);
+                    return;
             }
         },
         undefined,
@@ -250,9 +260,14 @@ function initPreviewPanel(
     const default_style = vscode.workspace
         .getConfiguration("slint")
         .get("preview.style", "");
+    const initial_ui_settings = context.globalState.get<string>(
+        UI_STATE_KEY,
+        "",
+    );
     panel.webview.html = getPreviewHtml(
         panel.webview.asWebviewUri(lsp_wasm_url),
         default_style,
+        initial_ui_settings,
     );
     panel.onDidDispose(
         () => {

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -247,6 +247,14 @@ function initPreviewPanel(
                     return;
                 case "persist_ui_settings":
                     context.globalState.update(UI_STATE_KEY, message.settings);
+                    // Keep the LSP's own copy current. It still pushes a
+                    // RestoreUiSettings to the preview when a webview opens, so
+                    // without this echo it would clobber the freshly restored
+                    // layout with the stale value it was seeded with at startup.
+                    language_client?.sendNotification(
+                        "slint/restore_ui_settings",
+                        { settings: message.settings },
+                    );
                     return;
             }
         },

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -64,6 +64,16 @@ pub enum LspToPreviewMessage {
     /// A protocol message because the LSP's browser-compatible WebSocket layer
     /// doesn't expose frame-level pings.
     Ping,
+    /// Seed the opaque preview UI settings blob the editor host persisted from
+    /// an earlier session. Sent as part of the startup handshake so the preview
+    /// can restore its panel layout before the first paint. The preview reports
+    /// changes back via [`super::PreviewToLspMessage::PersistUiSettings`].
+    ///
+    /// Appended at the end of the enum to keep the postcard discriminants of
+    /// the existing variants stable for the remote-preview wire format.
+    RestoreUiSettings {
+        settings: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -50,4 +50,11 @@ pub enum PreviewToLspMessage {
     /// Answer to [`super::LspToPreviewMessage::Ping`], consumed by the LSP's
     /// WebSocket connector.
     Pong,
+    /// Persist the opaque preview UI settings blob. The LSP forwards it to the
+    /// editor host, which stores it so it can be restored in a later session
+    /// via [`super::LspToPreviewMessage::RestoreUiSettings`].
+    ///
+    /// Appended at the end of the enum to keep the postcard discriminants of
+    /// the existing variants stable for the remote-preview wire format.
+    PersistUiSettings { settings: String },
 }

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -461,6 +461,13 @@ impl Connection {
                                                 "Ignoring unexpected RemoteConnectionState over WebSocket"
                                             );
                                         }
+                                        // UI settings persistence is a local-preview
+                                        // concern; remote viewers keep their own layout.
+                                        LspToPreviewMessage::RestoreUiSettings { .. } => {
+                                            tracing::debug!(
+                                                "Ignoring RestoreUiSettings over WebSocket"
+                                            );
+                                        }
                                     }
                                 }
                                 Err(err) => {

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -293,6 +293,8 @@ async fn lsp_main(
         to_preview,
         pending_recompile: Default::default(),
         host_language_rename_dont_ask_again: Default::default(),
+        #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+        preview_ui_settings: None,
     };
 
     // Load the initial document through the compiler. This triggers the import
@@ -422,6 +424,7 @@ fn handle_preview_message(msg: PreviewToLspMessage, ctx: &language::Context) {
         | TelemetryEvent(..)
         | ConnectRemote { .. }
         | DisconnectRemote
+        | PersistUiSettings { .. }
         | Pong => {
             tracing::debug!("Ignoring message from preview: {msg:?}");
         }

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -94,6 +94,13 @@ fn create_populate_command(
 
 #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
 pub fn send_state_to_preview(ctx: &Context) {
+    // Seed any persisted UI settings first so the preview restores its panel
+    // layout before the first paint. Only the native host populates this; the
+    // WASM webview persists directly in the editor and leaves it None.
+    if let Some(settings) = ctx.preview_ui_settings.clone() {
+        ctx.to_preview.send(&LspToPreviewMessage::RestoreUiSettings { settings });
+    }
+
     let mut doc_count = 0;
     #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
     let mut fonts_sent = HashSet::<PathBuf>::new();
@@ -269,6 +276,10 @@ pub struct Context {
     /// Disables the host-language rename prompt for the rest of the session.
     /// TODO(#12111): Persist this setting across sessions.
     pub host_language_rename_dont_ask_again: Rc<Cell<bool>>,
+    /// The opaque preview UI settings blob the editor host persisted from an
+    /// earlier session, seeded into the preview when it requests its state.
+    #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+    pub preview_ui_settings: Option<String>,
 }
 
 /// An error from a LSP request

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -536,6 +536,8 @@ async fn run_main_loop(
         to_preview,
         pending_recompile: Default::default(),
         host_language_rename_dont_ask_again: Default::default(),
+        #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+        preview_ui_settings: None,
     };
 
     let connection = Arc::new(connection);
@@ -775,6 +777,15 @@ async fn handle_notification(
         "slint/preview_to_lsp" => {
             handle_preview_to_lsp_message(serde_json::from_value(req.params)?, ctx).await
         }
+
+        // The editor seeds the preview UI settings it persisted from an earlier
+        // session; store them so the next preview start can restore them.
+        #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+        "slint/restore_ui_settings" => {
+            let params: UiSettingsParams = serde_json::from_value(req.params)?;
+            ctx.preview_ui_settings = Some(params.settings);
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -799,6 +810,26 @@ async fn send_workspace_edit(
             .into());
     }
     Ok(())
+}
+
+/// Params for the `slint/persist_ui_settings` and `slint/restore_ui_settings`
+/// custom notifications exchanged with the editor host, carrying the opaque
+/// preview UI settings blob.
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+struct UiSettingsParams {
+    settings: String,
+}
+
+/// LSP -> editor: persist the opaque preview UI settings blob. The editor
+/// stores it and seeds it back via `slint/restore_ui_settings`.
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
+enum PersistUiSettingsNotification {}
+
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
+impl Notification for PersistUiSettingsNotification {
+    type Params = UiSettingsParams;
+    const METHOD: &'static str = "slint/persist_ui_settings";
 }
 
 #[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
@@ -869,6 +900,12 @@ async fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Conte
             if let Some(remote) = ctx.to_preview.remote() {
                 crate::common::spawn_local(remote.disconnect());
             }
+        }
+        M::PersistUiSettings { settings } => {
+            tracing::debug!("Preview asked to persist UI settings");
+            ctx.server_notifier.send_notification::<PersistUiSettingsNotification>(
+                UiSettingsParams { settings },
+            )?;
         }
         M::Pong => {
             // The remote connector consumes pongs; local previews never send them.

--- a/tools/lsp/preview/connector.rs
+++ b/tools/lsp/preview/connector.rs
@@ -17,6 +17,67 @@ pub mod remote;
 use crate::preview;
 use i_slint_live_preview::protocol::LspToPreviewMessage;
 
+/// The persisted preview UI settings, serialized into a single opaque JSON blob
+/// that every host stores and restores verbatim. Keeping it opaque means new
+/// settings can be added here without touching any host or the LSP protocol.
+///
+/// Today the blob only carries the panel visibility, e.g.
+/// `{"panels":{"library":true,"properties":false,...}}`.
+#[derive(Clone, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+struct UiSettings {
+    #[serde(default)]
+    panels: PanelSettings,
+}
+
+#[derive(Clone, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+struct PanelSettings {
+    #[serde(default)]
+    library: bool,
+    #[serde(default)]
+    properties: bool,
+    #[serde(default)]
+    outline: bool,
+    #[serde(default)]
+    data: bool,
+    #[serde(default)]
+    console: bool,
+}
+
+/// Serialize the current panel visibility into the opaque settings blob the
+/// host persists. Callers must read the getters (and drop any `PREVIEW_STATE`
+/// borrow) before calling this, so we take plain values here.
+#[allow(dead_code)]
+pub fn serialize_ui_settings(
+    library: bool,
+    properties: bool,
+    outline: bool,
+    data: bool,
+    console: bool,
+) -> String {
+    let settings =
+        UiSettings { panels: PanelSettings { library, properties, outline, data, console } };
+    serde_json::to_string(&settings).unwrap_or_default()
+}
+
+/// Apply a settings blob the host restored from an earlier session onto the UI.
+///
+/// Setting the panel properties fires `panels-layout-changed`, whose handler
+/// persists the same values straight back, which is harmless. The caller must
+/// have dropped any `PREVIEW_STATE` borrow before calling this: that handler
+/// borrows `PREVIEW_STATE` again and would otherwise panic.
+#[allow(dead_code)]
+pub fn apply_ui_settings_to_api(api: &preview::ui::Api<'static>, blob: &str) {
+    let Ok(settings) = serde_json::from_str::<UiSettings>(blob) else {
+        return;
+    };
+    let panels = settings.panels;
+    api.set_panel_library_open(panels.library);
+    api.set_panel_properties_open(panels.properties);
+    api.set_panel_outline_open(panels.outline);
+    api.set_panel_data_open(panels.data);
+    api.set_panel_console_open(panels.console);
+}
+
 pub fn lsp_to_preview(message: LspToPreviewMessage) {
     use LspToPreviewMessage as M;
     match message {

--- a/tools/lsp/preview/connector.rs
+++ b/tools/lsp/preview/connector.rs
@@ -105,6 +105,16 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         M::RemoteConnectionState { state, target, error } => {
             preview::set_remote_connection_state(state, target, error);
         }
+        M::RestoreUiSettings { settings } => {
+            // Upgrade and drop the PREVIEW_STATE borrow before applying: setting
+            // the panel properties fires panels-layout-changed, whose handler
+            // borrows PREVIEW_STATE again and would otherwise panic.
+            let api =
+                preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
+            if let Some(api) = api {
+                apply_ui_settings_to_api(&api, &settings);
+            }
+        }
         M::Quit => {
             tracing::debug!("Preview: Quit requested");
             #[cfg(not(target_arch = "wasm32"))]

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -19,7 +19,6 @@ pub enum SlintPadCallbackFunction {
     ShowAbout,
     CopyPermalink,
     NewFile,
-    SavePanelLayout,
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -27,6 +26,7 @@ const CALLBACK_FUNCTION_SECTION: &'static str = r#"
 export type ResourceUrlMapperFunction = (url: string) => Promise<string | undefined>;
 export type SignalLspFunction = (data: any) => void;
 export type InvokeSlintpadCallback = (func: SlintPadCallbackFunction, arg: any) => void | undefined;
+export type PersistUiSettingsFunction = (settings: string) => void | undefined;
 "#;
 
 #[wasm_bindgen]
@@ -41,6 +41,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "InvokeSlintpadCallback")]
     pub type InvokeSlintpadCallback;
+
+    #[wasm_bindgen(typescript_type = "PersistUiSettingsFunction")]
+    pub type PersistUiSettingsFunction;
 }
 
 // We have conceptually two threads: The UI thread and the JS runtime, even though
@@ -51,6 +54,7 @@ struct WasmCallbacks {
     lsp_notifier: SignalLspFunction,
     resource_url_mapper: ResourceUrlMapperFunction,
     invoke_slintpad_callback: InvokeSlintpadCallback,
+    persist_ui_settings: PersistUiSettingsFunction,
 }
 thread_local! {static WASM_CALLBACKS: RefCell<Option<WasmCallbacks>> = Default::default();}
 
@@ -87,11 +91,13 @@ impl PreviewConnector {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: String,
         invoke_slintpad_callback: InvokeSlintpadCallback,
+        persist_ui_settings: PersistUiSettingsFunction,
     ) -> Result<PreviewConnectorPromise, JsValue> {
         WASM_CALLBACKS.set(Some(WasmCallbacks {
             lsp_notifier,
             resource_url_mapper,
             invoke_slintpad_callback,
+            persist_ui_settings,
         }));
 
         Ok(JsValue::from(js_sys::Promise::new(&mut move |resolve, reject| {
@@ -114,6 +120,7 @@ impl PreviewConnector {
                         match ui::create_ui(&to_lsp, &style, false) {
                             Ok(app_window) => {
                                 init_slintpad_specific_ui(&app_window.api());
+                                init_ui_settings(&app_window.api());
                                 preview_state.borrow_mut().api = app_window.api_weak();
                                 preview_state.borrow_mut().app_window = Some(app_window);
                                 *preview_state.borrow().to_lsp.borrow_mut() = Some(to_lsp);
@@ -152,18 +159,15 @@ impl PreviewConnector {
         preview::get_current_style().into()
     }
 
-    /// Restore the panel visibility the host persisted from an earlier session.
-    /// Setting the properties fires the change handlers, so the host will save
-    /// the same values straight back, which is harmless.
+    /// Restore the opaque UI settings blob the host persisted from an earlier
+    /// session. Call this before `show_ui()` so the panels appear in the state
+    /// the user left them before the first paint.
+    ///
+    /// Applying the blob sets the panel properties, which fires the change
+    /// handlers, so the host will persist the same values straight back, which
+    /// is harmless.
     #[wasm_bindgen]
-    pub fn restore_panels(
-        &self,
-        library: bool,
-        properties: bool,
-        outline: bool,
-        data: bool,
-        console: bool,
-    ) -> Result<(), JsValue> {
+    pub fn restore_ui_settings(&self, settings: String) -> Result<(), JsValue> {
         i_slint_core::api::invoke_from_event_loop(move || {
             // Upgrade and drop the PREVIEW_STATE borrow before touching any
             // property: setting one triggers panels-layout-changed, whose
@@ -171,11 +175,7 @@ impl PreviewConnector {
             let api =
                 preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
             if let Some(api) = api {
-                api.set_panel_library_open(library);
-                api.set_panel_properties_open(properties);
-                api.set_panel_outline_open(outline);
-                api.set_panel_data_open(data);
-                api.set_panel_console_open(console);
+                connector::apply_ui_settings_to_api(&api, &settings);
             }
         })
         .map_err(|e| -> JsValue { format!("{e:?}").into() })?;
@@ -328,15 +328,21 @@ fn init_slintpad_specific_ui(api: &crate::preview::ui::Api) {
         open_demo_url(&url);
     });
     api.on_show_about_slint(show_about_slint);
-    api.on_panels_layout_changed(save_panel_layout);
 }
 
-fn save_panel_layout() {
-    // Read the current panel visibility, then drop the PREVIEW_STATE borrow
-    // before calling into JS.
-    let layout = preview::PREVIEW_STATE.with_borrow(|preview_state| {
+/// Wire the persistence of the preview UI settings. Unlike the SlintPad-only
+/// helpers above, this runs for every WASM host (SlintPad and the VS Code
+/// webview): both can provide a `persist_ui_settings` callback.
+fn init_ui_settings(api: &crate::preview::ui::Api) {
+    api.on_panels_layout_changed(persist_ui_settings);
+}
+
+fn persist_ui_settings() {
+    // Read the current panel visibility and serialize the settings blob, then
+    // drop the PREVIEW_STATE borrow before calling into JS.
+    let blob = preview::PREVIEW_STATE.with_borrow(|preview_state| {
         preview_state.api.upgrade().map(|api| {
-            (
+            connector::serialize_ui_settings(
                 api.get_panel_library_open(),
                 api.get_panel_properties_open(),
                 api.get_panel_outline_open(),
@@ -345,40 +351,19 @@ fn save_panel_layout() {
             )
         })
     });
-    let Some((library, properties, outline, data, console)) = layout else {
+    let Some(blob) = blob else {
         return;
     };
 
     WASM_CALLBACKS.with_borrow(|callbacks| {
         let maybe_callback = wasm_bindgen::JsValue::from(
-            callbacks
-                .as_ref()
-                .expect("Callbacks were set up earlier")
-                .invoke_slintpad_callback
-                .clone(),
+            callbacks.as_ref().expect("Callbacks were set up earlier").persist_ui_settings.clone(),
         );
         if !maybe_callback.is_function() {
             return;
         }
-        let opener = js_sys::Function::from(maybe_callback);
-        let obj = js_sys::Object::new();
-        let _ =
-            js_sys::Reflect::set(&obj, &JsValue::from_str("library"), &JsValue::from_bool(library));
-        let _ = js_sys::Reflect::set(
-            &obj,
-            &JsValue::from_str("properties"),
-            &JsValue::from_bool(properties),
-        );
-        let _ =
-            js_sys::Reflect::set(&obj, &JsValue::from_str("outline"), &JsValue::from_bool(outline));
-        let _ = js_sys::Reflect::set(&obj, &JsValue::from_str("data"), &JsValue::from_bool(data));
-        let _ =
-            js_sys::Reflect::set(&obj, &JsValue::from_str("console"), &JsValue::from_bool(console));
-        let _ = opener.call2(
-            &JsValue::UNDEFINED,
-            &wasm_bindgen::JsValue::from(SlintPadCallbackFunction::SavePanelLayout),
-            &obj.into(),
-        );
+        let persist = js_sys::Function::from(maybe_callback);
+        let _ = persist.call1(&JsValue::UNDEFINED, &JsValue::from_str(&blob));
     });
 }
 

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -236,6 +236,31 @@ pub fn create_ui(
     #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
     super::remote::setup(&app_window, to_lsp);
 
+    // Persist the preview UI settings on the native hosts. The WASM connector
+    // wires its own panels handler (persisting through the JS host), so this
+    // only runs off the WASM target.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let lsp = to_lsp.clone();
+        let api_weak = app_window.api_weak();
+        api.on_panels_layout_changed(move || {
+            let Some(api) = api_weak.upgrade() else {
+                return;
+            };
+            let settings = preview::connector::serialize_ui_settings(
+                api.get_panel_library_open(),
+                api.get_panel_properties_open(),
+                api.get_panel_outline_open(),
+                api.get_panel_data_open(),
+                api.get_panel_console_open(),
+            );
+            let _ =
+                lsp.send(&i_slint_live_preview::protocol::PreviewToLspMessage::PersistUiSettings {
+                    settings,
+                });
+        });
+    }
+
     #[cfg(target_vendor = "apple")]
     api.set_control_key_name("command".into());
 

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -295,6 +295,7 @@ pub fn create(
             to_preview,
             pending_recompile: Default::default(),
             host_language_rename_dont_ask_again: Default::default(),
+            preview_ui_settings: None,
         }),
         rh: Rc::new(rh),
     })
@@ -390,6 +391,11 @@ impl SlintServer {
             }
             M::ConnectRemote { .. } | M::DisconnectRemote | M::Pong => {
                 tracing::debug!("Ignoring remote-preview control message in WASM LSP");
+            }
+            M::PersistUiSettings { .. } => {
+                // The WASM webview persists its UI settings directly in the
+                // editor host, so the WASM LSP never sees this.
+                tracing::debug!("Ignoring PersistUiSettings in WASM LSP");
             }
         }
         Ok(())

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -4,7 +4,7 @@
 // cSpell: ignore cupertino lumino permalink
 
 import { EditorWidget, initialize as initializeEditor } from "./editor_widget";
-import { LspWaiter, type Lsp, type LoadPhase, type PanelLayout } from "./lsp";
+import { LspWaiter, type Lsp, type LoadPhase } from "./lsp";
 import { PreviewWidget } from "./preview_widget";
 
 import {
@@ -63,30 +63,22 @@ const commands = new CommandRegistry();
 const url_params = new URLSearchParams(window.location.search);
 const url_style = url_params.get("style");
 
-const PANEL_LAYOUT_KEY = "slintpad-panel-layout";
+// The preview owns an opaque JSON settings blob; SlintPad just stores it
+// verbatim. This key namespaces it; the earlier "slintpad-panel-layout" key
+// held a different (panel-only) shape and is intentionally not migrated.
+const UI_SETTINGS_KEY = "slintpad-ui-settings";
 
-function load_panel_layout(): PanelLayout | null {
+function load_ui_settings(): string | null {
     try {
-        const raw = window.localStorage.getItem(PANEL_LAYOUT_KEY);
-        if (raw === null) {
-            return null;
-        }
-        const parsed = JSON.parse(raw);
-        return {
-            library: !!parsed.library,
-            properties: !!parsed.properties,
-            outline: !!parsed.outline,
-            data: !!parsed.data,
-            console: !!parsed.console,
-        };
+        return window.localStorage.getItem(UI_SETTINGS_KEY);
     } catch (_) {
         return null;
     }
 }
 
-function save_panel_layout(layout: PanelLayout): void {
+function save_ui_settings(settings: string): void {
     try {
-        window.localStorage.setItem(PANEL_LAYOUT_KEY, JSON.stringify(layout));
+        window.localStorage.setItem(UI_SETTINGS_KEY, settings);
     } catch (_) {
         // Ignore storage failures (e.g. private mode with a full quota).
     }
@@ -108,14 +100,15 @@ function setup(lsp: Lsp) {
                 void editor.copy_permalink_to_clipboard();
             } else if (func_type === SlintPadCallbackFunction.NewFile) {
                 void editor.set_demo("");
-            } else if (func_type === SlintPadCallbackFunction.SavePanelLayout) {
-                save_panel_layout(args as PanelLayout);
             }
         },
+        (settings: string) => {
+            save_ui_settings(settings);
+        },
         (previewer) => {
-            const layout = load_panel_layout();
-            if (layout !== null) {
-                previewer.restore_panels(layout);
+            const settings = load_ui_settings();
+            if (settings !== null) {
+                previewer.restore_ui_settings(settings);
             }
         },
     );

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -30,11 +30,13 @@ import { report_panic_dialog } from "./dialogs";
 import {
     type ResourceUrlMapperFunction,
     type InvokeSlintpadCallback,
+    type PersistUiSettingsFunction,
     SlintPadCallbackFunction,
 } from "@lsp/slint_lsp_wasm.js";
 export {
     ResourceUrlMapperFunction,
     InvokeSlintpadCallback,
+    PersistUiSettingsFunction,
     SlintPadCallbackFunction,
 };
 
@@ -217,23 +219,9 @@ export class Previewer {
         return this.#preview_connector.current_style();
     }
 
-    restore_panels(layout: PanelLayout): void {
-        this.#preview_connector.restore_panels(
-            layout.library,
-            layout.properties,
-            layout.outline,
-            layout.data,
-            layout.console,
-        );
+    restore_ui_settings(settings: string): void {
+        this.#preview_connector.restore_ui_settings(settings);
     }
-}
-
-export interface PanelLayout {
-    library: boolean;
-    properties: boolean;
-    outline: boolean;
-    data: boolean;
-    console: boolean;
 }
 
 export class Lsp {
@@ -351,6 +339,7 @@ export class Lsp {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
         slintpad_callback: InvokeSlintpadCallback,
+        persist_ui_settings: PersistUiSettingsFunction,
     ): Promise<Previewer> {
         if (this.#preview_connector === null) {
             slint_preview.run_event_loop();
@@ -367,6 +356,7 @@ export class Lsp {
                     resource_url_mapper,
                     style,
                     slintpad_callback,
+                    persist_ui_settings,
                 );
         }
         return new Previewer(this.#preview_connector);

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -11,6 +11,7 @@ import type {
     Lsp,
     ResourceUrlMapperFunction,
     InvokeSlintpadCallback,
+    PersistUiSettingsFunction,
 } from "./lsp";
 
 const canvas_id = "canvas";
@@ -40,6 +41,7 @@ export class PreviewWidget extends Widget {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
         slintpad_callback: InvokeSlintpadCallback,
+        persist_ui_settings: PersistUiSettingsFunction,
         on_ready?: (previewer: Previewer) => void,
     ) {
         super({ node: PreviewWidget.createNode() });
@@ -52,7 +54,12 @@ export class PreviewWidget extends Widget {
         this.title.closable = true;
 
         void lsp
-            .previewer(resource_url_mapper, style, slintpad_callback)
+            .previewer(
+                resource_url_mapper,
+                style,
+                slintpad_callback,
+                persist_ui_settings,
+            )
             .then((p) => {
                 this.#previewer = p;
 


### PR DESCRIPTION
## Summary

Makes the Slint Live Preview remember its panel layout (Library, Properties, Outline, Simulation Data, Console) across sessions for all three hosts, not just SlintPad. Stacks on #12488 (base branch `slintpad-phase1`, which carries the Phase 0 typed `panel-*-open` props and `panels-layout-changed()` callback).

The design separates WHAT is persisted (one opaque JSON settings blob owned by the preview) from WHERE (a per-host backing store), joined by one uniform channel. The blob stays opaque, so future settings need no protocol or host changes. Today it carries just the five panel booleans, e.g. `{"panels":{"library":true,...}}`.

## Phase 1 - Generalize the preview-side channel

- `tools/lsp/preview/connector.rs`: shared `serialize_ui_settings(...)` and `apply_ui_settings_to_api(...)` helpers plus the `UiSettings`/`PanelSettings` serde types (missing keys default to false).
- `tools/lsp/preview/connector/wasm.rs`: adds a dedicated `persist_ui_settings` host callback (distinct from the SlintPad-only `invoke_slintpad_callback`, so the VS Code webview can provide it too) and a `restore_ui_settings(blob)` method. Drops the panel-specific `restore_panels`/`SavePanelLayout`. The panels handler is now wired for every WASM host.
- `tools/slintpad/src/{index,lsp,preview_widget}.ts`: SlintPad keeps using `localStorage`, under a namespaced key `slintpad-ui-settings`. The old panel-only key `slintpad-panel-layout` is intentionally not migrated since the shape changed.

## Phase 2 - VS Code WASM (webview)

- `editors/vscode/src/wasm_preview.ts`: on change the webview posts the blob to the extension; on start the extension reads it back and seeds it into the HTML so restore happens before first paint. Also removes a stale `experimental` argument that was being passed to `PreviewConnector.create()` in a slot the function never had.
- `editors/vscode/src/extension.ts` stores/reads the blob in `context.globalState` under `slint.preview.uiState`.

## Phase 3 - VS Code native preview (child process)

- `internal/live-preview/protocol/*`: adds `PreviewToLspMessage::PersistUiSettings { settings }` and `LspToPreviewMessage::RestoreUiSettings { settings }`, both appended at the end of their enums so the postcard discriminants used by the remote-preview wire format stay stable.
- `tools/lsp/preview/{ui,connector}.rs`: native panels handler sends `PersistUiSettings`; `lsp_to_preview` applies `RestoreUiSettings`, honoring the read-getters-then-send and upgrade-and-drop-borrow discipline to avoid a re-entrant `PREVIEW_STATE` borrow.
- `tools/lsp/main.rs` forwards `PersistUiSettings` to the editor over a `slint/persist_ui_settings` notification and stores an incoming `slint/restore_ui_settings` blob on the `Context`; `tools/lsp/language.rs` replays it as `RestoreUiSettings` in `send_state_to_preview` before `ShowPreview`.
- `editors/vscode/src/extension.ts` stores the forwarded blob in the same `slint.preview.uiState` globalState key and seeds it back to the LSP after the client starts.

Decisions per the design: global scope (`globalState`, not per-workspace), opaque JSON blob, dedicated protocol message, SlintPad stays on `localStorage`.

## Verification

- `cargo check -p slint-lsp` (native) and `cargo check -p slint-lsp --target wasm32-unknown-unknown --lib`: both clean. `cargo check -p i-slint-live-preview --all-features`: clean.
- SlintPad wasm pkg builds; `tools/slintpad` and `editors/vscode` type-check; `editors/vscode` esbuild bundle succeeds.
- biome 2.5.2, cspell, and root knip clean on the changed files (knip only flags the gitignored built `pkg`/`out` dirs; it exits 0 once those are absent).
- SlintPad runtime-verified in a browser end to end: seeding a blob restores the exact panels before first paint, and a pretty-printed blob with missing keys is rewritten by Rust into its canonical compact form via the persist callback, confirming both the restore and save paths (including serde defaulting).

## Needs manual testing

No VS Code was available, so the two VS Code hosts were compiled and type-checked but not exercised at runtime. Worth a manual check:

- WASM webview preview: toggle panels, close and reopen the preview, confirm the layout is restored from `globalState`.
- Native preview: toggle panels, restart the preview (and VS Code) and confirm the layout is restored, verifying the `slint/persist_ui_settings` / `slint/restore_ui_settings` round trip through the LSP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)