### PR TITLE
tools: persist preview UI settings across SlintPad and VS Code

### DIFF
--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -9,6 +9,7 @@ import * as vscode from "vscode";
 import {
     BaseLanguageClient,
     LanguageClient,
+    NotificationType,
 } from "vscode-languageclient/browser";
 
 import * as wasm_preview from "./wasm_preview";
@@ -73,6 +74,17 @@ function startClient(
                     );
                     return new TextDecoder().decode(contents);
                 });
+
+                // The LSP forwards the preview UI settings for durable storage.
+                cl?.onNotification(
+                    new NotificationType("slint/persist_ui_settings"),
+                    (params: any) => {
+                        context.globalState.update(
+                            wasm_preview.UI_STATE_KEY,
+                            params.settings,
+                        );
+                    },
+                );
             });
 
             cl.start().then(() => (client.client = cl));

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -10,6 +10,7 @@ import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import * as vscode from "vscode";
 import { SlintTelemetrySender } from "./telemetry";
 import * as common from "./common";
+import { UI_STATE_KEY } from "./wasm_preview";
 import { NotificationType } from "vscode-languageclient";
 
 import {
@@ -235,6 +236,15 @@ function startClient(
                 handleTelemetryEvent(params.type, context.globalState);
             },
         );
+
+        // The LSP forwards the preview UI settings for durable storage; save
+        // them under the same key the webview reads.
+        cl?.onNotification(
+            new NotificationType("slint/persist_ui_settings"),
+            (params: any) => {
+                context.globalState.update(UI_STATE_KEY, params.settings);
+            },
+        );
     });
 
     const cl = new LanguageClient(
@@ -246,7 +256,18 @@ function startClient(
 
     common.prepare_client(cl);
 
-    cl.start().then(() => (client.client = cl));
+    cl.start().then(() => {
+        client.client = cl;
+
+        // Seed the preview UI settings persisted from an earlier session so the
+        // next native preview start can restore its panel layout.
+        const stored = context.globalState.get<string>(UI_STATE_KEY, "");
+        if (stored.length > 0) {
+            cl.sendNotification("slint/restore_ui_settings", {
+                settings: stored,
+            });
+        }
+    });
 }
 
 export function activate(context: vscode.ExtensionContext) {

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -6,6 +6,10 @@ import { Uri } from "vscode";
 import * as vscode from "vscode";
 import type { BaseLanguageClient } from "vscode-languageclient";
 
+// The globalState key that holds the opaque preview UI settings blob. Shared
+// with the native preview path so both hosts persist to the same place.
+export const UI_STATE_KEY = "slint.preview.uiState";
+
 let previewPanel: vscode.WebviewPanel | null = null;
 let to_lsp_queue: object[] = [];
 
@@ -95,10 +99,8 @@ function open_preview(context: vscode.ExtensionContext): boolean {
 function getPreviewHtml(
     slint_wasm_preview_url: Uri,
     default_style: string,
+    initial_ui_settings: string,
 ): string {
-    const experimental =
-        typeof process !== "undefined" &&
-        process.env.hasOwnProperty("SLINT_ENABLE_EXPERIMENTAL_FEATURES");
     const result = `<!DOCTYPE html>
 <html lang="en" style="height: 100%; width: 100%;">
 <head>
@@ -149,9 +151,16 @@ function getPreviewHtml(
             vscode.postMessage({ command: "map_url", url: url });
         })},
         "${default_style}",
-        ${experimental ? "true" : "false"},
+        undefined,
         undefined
     );
+
+    // Seed the saved layout here so it is applied before the first paint. The
+    // LSP relays its own RestoreUiSettings too, but that lands after this paint.
+    const initial_ui_settings = ${JSON.stringify(initial_ui_settings)};
+    if (initial_ui_settings.length > 0) {
+        preview_connector.restore_ui_settings(initial_ui_settings);
+    }
 
     window.addEventListener('message', async message => {
         if (message.data.command === "slint/lsp_to_preview") {
@@ -250,9 +259,14 @@ function initPreviewPanel(
     const default_style = vscode.workspace
         .getConfiguration("slint")
         .get("preview.style", "");
+    const initial_ui_settings = context.globalState.get<string>(
+        UI_STATE_KEY,
+        "",
+    );
     panel.webview.html = getPreviewHtml(
         panel.webview.asWebviewUri(lsp_wasm_url),
         default_style,
+        initial_ui_settings,
     );
     panel.onDidDispose(
         () => {

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -64,6 +64,12 @@ pub enum LspToPreviewMessage {
     /// A protocol message because the LSP's browser-compatible WebSocket layer
     /// doesn't expose frame-level pings.
     Ping,
+    /// Seed the opaque preview UI settings blob so the preview restores its
+    /// layout before the first paint. Kept last to preserve postcard
+    /// discriminants for the remote-preview wire format.
+    RestoreUiSettings {
+        settings: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -50,4 +50,8 @@ pub enum PreviewToLspMessage {
     /// Answer to [`super::LspToPreviewMessage::Ping`], consumed by the LSP's
     /// WebSocket connector.
     Pong,
+    /// Persist the opaque preview UI settings blob; the LSP forwards it to the
+    /// editor host for durable storage. Kept last to preserve postcard
+    /// discriminants for the remote-preview wire format.
+    PersistUiSettings { settings: String },
 }

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -461,6 +461,13 @@ impl Connection {
                                                 "Ignoring unexpected RemoteConnectionState over WebSocket"
                                             );
                                         }
+                                        // UI settings persistence is a local-preview
+                                        // concern; remote viewers keep their own layout.
+                                        LspToPreviewMessage::RestoreUiSettings { .. } => {
+                                            tracing::debug!(
+                                                "Ignoring RestoreUiSettings over WebSocket"
+                                            );
+                                        }
                                     }
                                 }
                                 Err(err) => {

--- a/tools/lsp/editor.rs
+++ b/tools/lsp/editor.rs
@@ -293,6 +293,8 @@ async fn lsp_main(
         to_preview,
         pending_recompile: Default::default(),
         host_language_rename_dont_ask_again: Default::default(),
+        #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+        preview_ui_settings: None,
     };
 
     // Load the initial document through the compiler. This triggers the import
@@ -422,6 +424,7 @@ fn handle_preview_message(msg: PreviewToLspMessage, ctx: &language::Context) {
         | TelemetryEvent(..)
         | ConnectRemote { .. }
         | DisconnectRemote
+        | PersistUiSettings { .. }
         | Pong => {
             tracing::debug!("Ignoring message from preview: {msg:?}");
         }

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -94,6 +94,12 @@ fn create_populate_command(
 
 #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
 pub fn send_state_to_preview(ctx: &Context) {
+    // Restore the UI settings before the content so the panels are laid out
+    // before the first paint.
+    if let Some(settings) = ctx.preview_ui_settings.borrow().clone() {
+        ctx.to_preview.send(&LspToPreviewMessage::RestoreUiSettings { settings });
+    }
+
     let mut doc_count = 0;
     #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
     let mut fonts_sent = HashSet::<PathBuf>::new();
@@ -269,6 +275,29 @@ pub struct Context {
     /// Disables the host-language rename prompt for the rest of the session.
     /// TODO(#12111): Persist this setting across sessions.
     pub host_language_rename_dont_ask_again: Rc<Cell<bool>>,
+    /// The opaque preview UI settings blob, owned by the LSP for the session and
+    /// seeded into the preview on start. `RefCell` because the preview message
+    /// handler only has a shared `&Context`; the LSP is single-threaded.
+    #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+    pub preview_ui_settings: std::cell::RefCell<Option<String>>,
+}
+
+/// Carries the opaque preview UI settings blob for the `slint/persist_ui_settings`
+/// and `slint/restore_ui_settings` notifications exchanged with the editor host.
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct UiSettingsParams {
+    pub settings: String,
+}
+
+/// LSP -> editor: save the preview UI settings blob to durable storage.
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
+pub enum PersistUiSettingsNotification {}
+
+#[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
+impl lsp_types::notification::Notification for PersistUiSettingsNotification {
+    type Params = UiSettingsParams;
+    const METHOD: &'static str = "slint/persist_ui_settings";
 }
 
 /// An error from a LSP request

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -195,6 +195,7 @@ fn test_goto_definition_multi_files() {
     let mut ctx = crate::language::Context {
         document_cache: dc,
         preview_config: Default::default(),
+        preview_ui_settings: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
         to_show: None,

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -29,6 +29,7 @@ pub fn mock_context() -> Context {
     crate::language::Context {
         document_cache: empty_document_cache(),
         preview_config: Default::default(),
+        preview_ui_settings: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
         #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
@@ -74,6 +75,7 @@ pub fn loaded_document_cache_with_file_name(
     let mut ctx = crate::language::Context {
         document_cache: dc,
         preview_config: Default::default(),
+        preview_ui_settings: Default::default(),
         server_notifier: crate::ServerNotifier::dummy(),
         init_param: Default::default(),
         to_show: None,

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -536,6 +536,8 @@ async fn run_main_loop(
         to_preview,
         pending_recompile: Default::default(),
         host_language_rename_dont_ask_again: Default::default(),
+        #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+        preview_ui_settings: Default::default(),
     };
 
     let connection = Arc::new(connection);
@@ -775,6 +777,15 @@ async fn handle_notification(
         "slint/preview_to_lsp" => {
             handle_preview_to_lsp_message(serde_json::from_value(req.params)?, ctx).await
         }
+
+        // The editor seeds the preview UI settings it persisted from an earlier
+        // session; store them so the next preview start can restore them.
+        #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
+        "slint/restore_ui_settings" => {
+            let params: UiSettingsParams = serde_json::from_value(req.params)?;
+            *ctx.preview_ui_settings.borrow_mut() = Some(params.settings);
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -869,6 +880,16 @@ async fn handle_preview_to_lsp_message(message: PreviewToLspMessage, ctx: &Conte
             if let Some(remote) = ctx.to_preview.remote() {
                 crate::common::spawn_local(remote.disconnect());
             }
+        }
+        M::PersistUiSettings { settings } => {
+            tracing::debug!("Preview asked to persist UI settings");
+            // Keep the LSP's authoritative copy current so a later preview start
+            // in this session restores what the user just left, then ask the
+            // editor host to save it across sessions.
+            *ctx.preview_ui_settings.borrow_mut() = Some(settings.clone());
+            ctx.server_notifier.send_notification::<PersistUiSettingsNotification>(
+                UiSettingsParams { settings },
+            )?;
         }
         M::Pong => {
             // The remote connector consumes pongs; local previews never send them.

--- a/tools/lsp/preview/connector.rs
+++ b/tools/lsp/preview/connector.rs
@@ -17,6 +17,65 @@ pub mod remote;
 use crate::preview;
 use i_slint_live_preview::protocol::LspToPreviewMessage;
 
+/// The persisted preview UI settings, an opaque JSON blob every host stores and
+/// restores verbatim so new settings can be added without touching the hosts or
+/// the protocol. Today it only carries panel visibility, e.g.
+/// `{"panels":{"library":true,"properties":false,...}}`.
+#[derive(Clone, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+struct UiSettings {
+    #[serde(default)]
+    panels: PanelSettings,
+}
+
+#[derive(Clone, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+struct PanelSettings {
+    #[serde(default)]
+    library: bool,
+    #[serde(default)]
+    properties: bool,
+    #[serde(default)]
+    outline: bool,
+    #[serde(default)]
+    data: bool,
+    #[serde(default)]
+    console: bool,
+}
+
+/// Serialize the current panel visibility into the opaque settings blob the
+/// host persists. Callers must read the getters (and drop any `PREVIEW_STATE`
+/// borrow) before calling this, so we take plain values here.
+#[allow(dead_code)]
+pub fn serialize_ui_settings(
+    library: bool,
+    properties: bool,
+    outline: bool,
+    data: bool,
+    console: bool,
+) -> String {
+    let settings =
+        UiSettings { panels: PanelSettings { library, properties, outline, data, console } };
+    serde_json::to_string(&settings).unwrap_or_default()
+}
+
+/// Apply a settings blob the host restored from an earlier session onto the UI.
+///
+/// Setting the panel properties fires `panels-layout-changed`, whose handler
+/// persists the same values straight back, which is harmless. The caller must
+/// have dropped any `PREVIEW_STATE` borrow before calling this: that handler
+/// borrows `PREVIEW_STATE` again and would otherwise panic.
+#[allow(dead_code)]
+pub fn apply_ui_settings_to_api(api: &preview::ui::Api<'static>, blob: &str) {
+    let Ok(settings) = serde_json::from_str::<UiSettings>(blob) else {
+        return;
+    };
+    let panels = settings.panels;
+    api.set_panel_library_open(panels.library);
+    api.set_panel_properties_open(panels.properties);
+    api.set_panel_outline_open(panels.outline);
+    api.set_panel_data_open(panels.data);
+    api.set_panel_console_open(panels.console);
+}
+
 pub fn lsp_to_preview(message: LspToPreviewMessage) {
     use LspToPreviewMessage as M;
     match message {
@@ -43,6 +102,16 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         }
         M::RemoteConnectionState { state, target, error } => {
             preview::set_remote_connection_state(state, target, error);
+        }
+        M::RestoreUiSettings { settings } => {
+            // Upgrade and drop the PREVIEW_STATE borrow before applying: setting
+            // the panel properties fires panels-layout-changed, whose handler
+            // borrows PREVIEW_STATE again and would otherwise panic.
+            let api =
+                preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
+            if let Some(api) = api {
+                apply_ui_settings_to_api(&api, &settings);
+            }
         }
         M::Quit => {
             tracing::debug!("Preview: Quit requested");

--- a/tools/lsp/preview/connector.rs
+++ b/tools/lsp/preview/connector.rs
@@ -123,3 +123,42 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn panels_of(blob: &str) -> PanelSettings {
+        serde_json::from_str::<UiSettings>(blob).unwrap().panels
+    }
+
+    #[test]
+    fn serialize_round_trips_panel_visibility() {
+        let blob = serialize_ui_settings(true, false, true, false, true);
+        let panels = panels_of(&blob);
+        assert!(panels.library && panels.outline && panels.console);
+        assert!(!panels.properties && !panels.data);
+    }
+
+    #[test]
+    fn missing_fields_default_to_false() {
+        // Hosts must tolerate blobs written before a field existed.
+        let panels = panels_of(r#"{"panels":{"library":true}}"#);
+        assert!(panels.library);
+        assert!(!panels.properties && !panels.outline && !panels.data && !panels.console);
+        assert!(panels_of("{}") == PanelSettings::default());
+    }
+
+    #[test]
+    fn unknown_keys_are_ignored() {
+        // New settings can be added without breaking hosts on the old schema.
+        let panels = panels_of(r#"{"panels":{"library":true,"future_panel":true},"future":1}"#);
+        assert!(panels.library);
+    }
+
+    #[test]
+    fn malformed_blob_is_not_fatal() {
+        // apply_ui_settings_to_api relies on this parse failing to a no-op.
+        assert!(serde_json::from_str::<UiSettings>("not json").is_err());
+    }
+}

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -26,6 +26,7 @@ const CALLBACK_FUNCTION_SECTION: &'static str = r#"
 export type ResourceUrlMapperFunction = (url: string) => Promise<string | undefined>;
 export type SignalLspFunction = (data: any) => void;
 export type InvokeSlintpadCallback = (func: SlintPadCallbackFunction, arg: any) => void | undefined;
+export type PersistUiSettingsFunction = (settings: string) => void | undefined;
 "#;
 
 #[wasm_bindgen]
@@ -40,6 +41,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "InvokeSlintpadCallback")]
     pub type InvokeSlintpadCallback;
+
+    #[wasm_bindgen(typescript_type = "PersistUiSettingsFunction")]
+    pub type PersistUiSettingsFunction;
 }
 
 // We have conceptually two threads: The UI thread and the JS runtime, even though
@@ -50,6 +54,7 @@ struct WasmCallbacks {
     lsp_notifier: SignalLspFunction,
     resource_url_mapper: ResourceUrlMapperFunction,
     invoke_slintpad_callback: InvokeSlintpadCallback,
+    persist_ui_settings: PersistUiSettingsFunction,
 }
 thread_local! {static WASM_CALLBACKS: RefCell<Option<WasmCallbacks>> = Default::default();}
 
@@ -86,11 +91,13 @@ impl PreviewConnector {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: String,
         invoke_slintpad_callback: InvokeSlintpadCallback,
+        persist_ui_settings: PersistUiSettingsFunction,
     ) -> Result<PreviewConnectorPromise, JsValue> {
         WASM_CALLBACKS.set(Some(WasmCallbacks {
             lsp_notifier,
             resource_url_mapper,
             invoke_slintpad_callback,
+            persist_ui_settings,
         }));
 
         Ok(JsValue::from(js_sys::Promise::new(&mut move |resolve, reject| {
@@ -113,6 +120,7 @@ impl PreviewConnector {
                         match ui::create_ui(&to_lsp, &style, false) {
                             Ok(app_window) => {
                                 init_slintpad_specific_ui(&app_window.api());
+                                init_ui_settings(&app_window.api());
                                 preview_state.borrow_mut().api = app_window.api_weak();
                                 preview_state.borrow_mut().app_window = Some(app_window);
                                 *preview_state.borrow().to_lsp.borrow_mut() = Some(to_lsp);
@@ -149,6 +157,29 @@ impl PreviewConnector {
     #[wasm_bindgen]
     pub fn current_style(&self) -> JsValue {
         preview::get_current_style().into()
+    }
+
+    /// Restore the opaque UI settings blob the host persisted from an earlier
+    /// session. Call this before `show_ui()` so the panels appear in the state
+    /// the user left them before the first paint.
+    ///
+    /// Applying the blob sets the panel properties, which fires the change
+    /// handlers, so the host will persist the same values straight back, which
+    /// is harmless.
+    #[wasm_bindgen]
+    pub fn restore_ui_settings(&self, settings: String) -> Result<(), JsValue> {
+        i_slint_core::api::invoke_from_event_loop(move || {
+            // Upgrade and drop the PREVIEW_STATE borrow before touching any
+            // property: setting one triggers panels-layout-changed, whose
+            // handler borrows PREVIEW_STATE again and would otherwise panic.
+            let api =
+                preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.api.upgrade());
+            if let Some(api) = api {
+                connector::apply_ui_settings_to_api(&api, &settings);
+            }
+        })
+        .map_err(|e| -> JsValue { format!("{e:?}").into() })?;
+        Ok(())
     }
 
     #[wasm_bindgen]
@@ -297,6 +328,54 @@ fn init_slintpad_specific_ui(api: &crate::preview::ui::Api) {
         open_demo_url(&url);
     });
     api.on_show_about_slint(show_about_slint);
+}
+
+/// Wire the persistence of the preview UI settings. Unlike the SlintPad-only
+/// helpers above, this runs for every WASM host (SlintPad and the VS Code
+/// webview): both can provide a `persist_ui_settings` callback.
+fn init_ui_settings(api: &crate::preview::ui::Api) {
+    api.on_panels_layout_changed(persist_ui_settings);
+}
+
+fn persist_ui_settings() {
+    // Read the current panel visibility and serialize the settings blob, then
+    // drop the PREVIEW_STATE borrow before calling into JS or the LSP.
+    let blob = preview::PREVIEW_STATE.with_borrow(|preview_state| {
+        preview_state.api.upgrade().map(|api| {
+            connector::serialize_ui_settings(
+                api.get_panel_library_open(),
+                api.get_panel_properties_open(),
+                api.get_panel_outline_open(),
+                api.get_panel_data_open(),
+                api.get_panel_console_open(),
+            )
+        })
+    });
+    let Some(blob) = blob else {
+        return;
+    };
+
+    // SlintPad provides a `persist_ui_settings` callback and stores the blob in
+    // its own JS host (localStorage). The VS Code webview provides none, so we
+    // route the persist through the LSP like the native host, letting the LSP
+    // own the settings authoritatively and forward them to the extension.
+    let callback = WASM_CALLBACKS.with_borrow(|callbacks| {
+        let maybe_callback = wasm_bindgen::JsValue::from(
+            callbacks.as_ref().expect("Callbacks were set up earlier").persist_ui_settings.clone(),
+        );
+        maybe_callback.is_function().then(|| js_sys::Function::from(maybe_callback))
+    });
+
+    if let Some(persist) = callback {
+        let _ = persist.call1(&JsValue::UNDEFINED, &JsValue::from_str(&blob));
+        return;
+    }
+
+    let to_lsp =
+        preview::PREVIEW_STATE.with_borrow(|preview_state| preview_state.to_lsp.borrow().clone());
+    if let Some(to_lsp) = to_lsp {
+        let _ = to_lsp.send(&PreviewToLspMessage::PersistUiSettings { settings: blob });
+    }
 }
 
 fn new_file() {

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -236,6 +236,31 @@ pub fn create_ui(
     #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
     super::remote::setup(&app_window, to_lsp);
 
+    // Persist the preview UI settings on the native hosts. The WASM connector
+    // wires its own panels handler (persisting through the JS host), so this
+    // only runs off the WASM target.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let lsp = to_lsp.clone();
+        let api_weak = app_window.api_weak();
+        api.on_panels_layout_changed(move || {
+            let Some(api) = api_weak.upgrade() else {
+                return;
+            };
+            let settings = preview::connector::serialize_ui_settings(
+                api.get_panel_library_open(),
+                api.get_panel_properties_open(),
+                api.get_panel_outline_open(),
+                api.get_panel_data_open(),
+                api.get_panel_console_open(),
+            );
+            let _ =
+                lsp.send(&i_slint_live_preview::protocol::PreviewToLspMessage::PersistUiSettings {
+                    settings,
+                });
+        });
+    }
+
     #[cfg(target_vendor = "apple")]
     api.set_control_key_name("command".into());
 

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -606,6 +606,7 @@ export component Main { }
             let mut ctx = crate::language::Context {
                 document_cache: common::DocumentCache::new(config),
                 preview_config: Default::default(),
+                preview_ui_settings: Default::default(),
                 server_notifier: crate::ServerNotifier::dummy(),
                 init_param: Default::default(),
                 to_show: None,

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -303,6 +303,16 @@ export global Api {
     in-out property <bool> always-on-top;
     in property <bool> focus-previewed-element;
 
+    // ## Panel layout, persisted by the SlintPad host across reloads.
+    // The host restores these on startup and is notified through
+    // panels-layout-changed() whenever the user shows or hides a panel.
+    in-out property <bool> panel-library-open;
+    in-out property <bool> panel-properties-open;
+    in-out property <bool> panel-outline-open;
+    in-out property <bool> panel-data-open;
+    in-out property <bool> panel-console-open;
+    callback panels-layout-changed();
+
     // ## Component Data for ComponentList:
     // All the components
     in property <[ComponentListItem]> known-components;

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -41,11 +41,18 @@ export component PreviewUi inherits Window {
     property <bool> show-floating-table-editor <=> WindowManager.showing-table-editor;
     property <bool> show-color-stop-picker <=> WindowManager.showing-color-stop-picker;
     property <length> initial-floating-x;
-    property <bool> console-panel-expanded: false;
-    property <bool> properties-widget: false;
-    property <bool> data-widget: false;
-    property <bool> outline-widget: false;
-    property <bool> library-widget: false;
+    // Panel visibility is aliased to Api so the SlintPad host can restore it on
+    // startup and persist it whenever the user toggles a panel.
+    property <bool> console-panel-expanded <=> Api.panel-console-open;
+    property <bool> properties-widget <=> Api.panel-properties-open;
+    property <bool> data-widget <=> Api.panel-data-open;
+    property <bool> outline-widget <=> Api.panel-outline-open;
+    property <bool> library-widget <=> Api.panel-library-open;
+    changed console-panel-expanded => { Api.panels-layout-changed(); }
+    changed properties-widget => { Api.panels-layout-changed(); }
+    changed data-widget => { Api.panels-layout-changed(); }
+    changed outline-widget => { Api.panels-layout-changed(); }
+    changed library-widget => { Api.panels-layout-changed(); }
     property <bool> remote-mode: Api.preview-mode == PreviewMode.Remote;
     in-out property <bool> select-mode: false;
 

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -295,6 +295,7 @@ pub fn create(
             to_preview,
             pending_recompile: Default::default(),
             host_language_rename_dont_ask_again: Default::default(),
+            preview_ui_settings: Default::default(),
         }),
         rh: Rc::new(rh),
     })
@@ -390,6 +391,17 @@ impl SlintServer {
             }
             M::ConnectRemote { .. } | M::DisconnectRemote | M::Pong => {
                 tracing::debug!("Ignoring remote-preview control message in WASM LSP");
+            }
+            M::PersistUiSettings { settings } => {
+                // The VS Code webview routes its persist through the LSP (SlintPad
+                // persists in its JS host instead). Keep the authoritative copy
+                // current, then ask the editor host to save it across sessions.
+                *ctx.preview_ui_settings.borrow_mut() = Some(settings.clone());
+                let _ = ctx
+                    .server_notifier
+                    .send_notification::<language::PersistUiSettingsNotification>(
+                        language::UiSettingsParams { settings },
+                    );
             }
         }
         Ok(())

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -63,6 +63,27 @@ const commands = new CommandRegistry();
 const url_params = new URLSearchParams(window.location.search);
 const url_style = url_params.get("style");
 
+// The preview owns an opaque JSON settings blob; SlintPad just stores it
+// verbatim. This key namespaces it; the earlier "slintpad-panel-layout" key
+// held a different (panel-only) shape and is intentionally not migrated.
+const UI_SETTINGS_KEY = "slintpad-ui-settings";
+
+function load_ui_settings(): string | null {
+    try {
+        return window.localStorage.getItem(UI_SETTINGS_KEY);
+    } catch (_) {
+        return null;
+    }
+}
+
+function save_ui_settings(settings: string): void {
+    try {
+        window.localStorage.setItem(UI_SETTINGS_KEY, settings);
+    } catch (_) {
+        // Ignore storage failures (e.g. private mode with a full quota).
+    }
+}
+
 function setup(lsp: Lsp) {
     const editor = new EditorWidget(lsp);
     set_panic_share_url_getter(() => editor.share_url());
@@ -79,6 +100,15 @@ function setup(lsp: Lsp) {
                 void editor.copy_permalink_to_clipboard();
             } else if (func_type === SlintPadCallbackFunction.NewFile) {
                 void editor.set_demo("");
+            }
+        },
+        (settings: string) => {
+            save_ui_settings(settings);
+        },
+        (previewer) => {
+            const settings = load_ui_settings();
+            if (settings !== null) {
+                previewer.restore_ui_settings(settings);
             }
         },
     );

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -30,11 +30,13 @@ import { report_panic_dialog } from "./dialogs";
 import {
     type ResourceUrlMapperFunction,
     type InvokeSlintpadCallback,
+    type PersistUiSettingsFunction,
     SlintPadCallbackFunction,
 } from "@lsp/slint_lsp_wasm.js";
 export {
     ResourceUrlMapperFunction,
     InvokeSlintpadCallback,
+    PersistUiSettingsFunction,
     SlintPadCallbackFunction,
 };
 
@@ -216,6 +218,10 @@ export class Previewer {
     current_style(): string {
         return this.#preview_connector.current_style();
     }
+
+    restore_ui_settings(settings: string): void {
+        this.#preview_connector.restore_ui_settings(settings);
+    }
 }
 
 export class Lsp {
@@ -333,6 +339,7 @@ export class Lsp {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
         slintpad_callback: InvokeSlintpadCallback,
+        persist_ui_settings: PersistUiSettingsFunction,
     ): Promise<Previewer> {
         if (this.#preview_connector === null) {
             slint_preview.run_event_loop();
@@ -349,6 +356,7 @@ export class Lsp {
                     resource_url_mapper,
                     style,
                     slintpad_callback,
+                    persist_ui_settings,
                 );
         }
         return new Previewer(this.#preview_connector);

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -11,6 +11,7 @@ import type {
     Lsp,
     ResourceUrlMapperFunction,
     InvokeSlintpadCallback,
+    PersistUiSettingsFunction,
 } from "./lsp";
 
 const canvas_id = "canvas";
@@ -40,6 +41,8 @@ export class PreviewWidget extends Widget {
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
         slintpad_callback: InvokeSlintpadCallback,
+        persist_ui_settings: PersistUiSettingsFunction,
+        on_ready?: (previewer: Previewer) => void,
     ) {
         super({ node: PreviewWidget.createNode() });
 
@@ -51,9 +54,18 @@ export class PreviewWidget extends Widget {
         this.title.closable = true;
 
         void lsp
-            .previewer(resource_url_mapper, style, slintpad_callback)
+            .previewer(
+                resource_url_mapper,
+                style,
+                slintpad_callback,
+                persist_ui_settings,
+            )
             .then((p) => {
                 this.#previewer = p;
+
+                // Restore the persisted panel layout before the first paint so
+                // the panels appear in the state the user left them.
+                on_ready?.(p);
 
                 // Give the UI some time to wire up the canvas so it can be found
                 // when searching the document.


### PR DESCRIPTION
Remembers the Live Preview panel layout (Library / Properties / Outline / Simulation Data / Console) across sessions on all three hosts.

It introduces the panel-visibility state (`Api.panel-*-open` + `panels-layout-changed()`, aliased from the preview UI) and persists it as an opaque JSON settings blob. The LSP owns the blob for the session and seeds it into the preview on start, so the layout is restored before the first paint:
- SlintPad stores it in localStorage.
- VS Code (webview and native, desktop and web) persist through the LSP, which forwards it to the extension's `globalState` for durable storage.

Adds `PersistUiSettings` / `RestoreUiSettings` to the preview protocol (kept last in their enums for postcard wire-compat), and unit tests for the settings-blob contract (round-trip plus tolerance for missing and unknown keys).

Stacked on #12488 (the visual chrome). #12488 tints the panels; this PR makes their state persist.



https://github.com/user-attachments/assets/194849fd-3fbb-4828-9aeb-1fe898500da3


