### PR TITLE
linuxkms: Improve diagnostics when allocating drm buffers fails

### DIFF
--- a/internal/backends/linuxkms/display/swdisplay.rs
+++ b/internal/backends/linuxkms/display/swdisplay.rs
@@ -39,6 +39,15 @@ pub fn new(
     if std::env::var_os("SLINT_BACKEND_LINUXFB").is_some() {
         return linuxfb::LinuxFBDisplay::new(device_opener, renderer_formats);
     }
-    dumbbuffer::DumbBufferDisplay::new(device_opener, renderer_formats)
-        .or_else(|_| linuxfb::LinuxFBDisplay::new(device_opener, renderer_formats))
+    dumbbuffer::DumbBufferDisplay::new(device_opener, renderer_formats).or_else(
+        |dumb_buffer_error| {
+            linuxfb::LinuxFBDisplay::new(device_opener, renderer_formats).map_err(
+                |linuxfb_error| {
+                    PlatformError::Other(format!(
+                        "Could not initialize software display.\nError using DRM dumb buffers: {dumb_buffer_error}\nError using legacy framebuffer: {linuxfb_error}"
+                    ))
+                },
+            )
+        },
+    )
 }

--- a/internal/backends/linuxkms/drmoutput.rs
+++ b/internal/backends/linuxkms/drmoutput.rs
@@ -159,7 +159,11 @@ impl DrmOutput {
                     std::process::exit(1);
                 }
                 let mode_index: usize =
-                    mode_str.parse().map_err(|_| format!("Invalid mode index {mode_str}"))?;
+                    mode_str.parse().map_err(|_| {
+                        format!(
+                            "Invalid SLINT_DRM_MODE value '{mode_str}': expected a mode index or 'list' to list the available modes"
+                        )
+                    })?;
                 modes_and_index.nth(mode_index).map_or_else(
                     || Err(format!("Mode index is out of bounds: {mode_index}")),
                     |(_, mode)| Ok(mode),


### PR DESCRIPTION
For example, when the cma is too small to allocate framebuffers for a large resolution, it's valuable to retain the error message and show it, so that the correct diagnosis can be done quickly.

A workaround for such a situation is to reduce the resolution, for which we can also improve diagnostics using the SLINT_DRM_MODE environment variable.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
