### PR TITLE
compiler(rust): Reduce stack usage

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3198,154 +3198,29 @@ impl quote::ToTokens for crate::expression_tree::ImageReference {
 }
 
 /// Compile `expr` to a Rust expression which may potentially return a reference.
+///
+/// The body of every non-trivial match arm lives in its own `#[inline(never)]`
+/// helper function: this function recurses for nested expressions, and with all
+/// arm bodies inlined, its stack frame in unoptimized builds becomes so large
+/// that deeply nested expressions overflow the stack.
 fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
     match expr {
         Expression::StringLiteral(s) => {
             let s = s.as_str();
             quote!(sp::SharedString::from(#s))
         }
-        Expression::KeysLiteral(keys) => {
-                let key = &*keys.key;
-                let alt = keys.modifiers.alt;
-                let control = keys.modifiers.control;
-                let shift = keys.modifiers.shift;
-                let meta = keys.modifiers.meta;
-                let ignore_shift = keys.ignore_shift;
-                let ignore_alt = keys.ignore_alt;
-
-                quote!(
-                    sp::make_keys(
-                        #key.into(),
-                        {
-                            let mut modifiers = sp::KeyboardModifiers::default();
-                            modifiers.alt = #alt;
-                            modifiers.control = #control;
-                            modifiers.shift = #shift;
-                            modifiers.meta = #meta;
-                            modifiers
-                        },
-                        #ignore_shift,
-                        #ignore_alt))
-        },
+        Expression::KeysLiteral(..) => compile_keys_literal(expr),
         Expression::NumberLiteral(n) => {
             if n.is_nan() {
                 quote!(f64::NAN)
             } else if n.is_infinite() {
-                if *n > 0. {
-                    quote!(f64::INFINITY)
-                } else {
-                    quote!(f64::NEG_INFINITY)
-                }
+                if *n > 0. { quote!(f64::INFINITY) } else { quote!(f64::NEG_INFINITY) }
             } else {
                 quote!(#n)
             }
         }
         Expression::BoolLiteral(b) => quote!(#b),
-        Expression::Cast { from, to } => {
-            let f = compile_expression(from, ctx);
-            match (from.ty(ctx), to) {
-                (Type::Float32, Type::Int32) => {
-                    quote!(((#f) as i32))
-                }
-                (from, Type::String) if from.as_unit_product().is_some() => {
-                    quote!(sp::shared_string_from_number((#f) as f64))
-                }
-                (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
-                    quote!(sp::ModelRc::new(#f.max(::core::default::Default::default()) as usize))
-                }
-                (Type::Float32, Type::Color) => {
-                    quote!(sp::Color::from_argb_encoded((#f) as u32))
-                }
-                (Type::Color, Type::Brush) => {
-                    quote!(slint::Brush::SolidColor(#f))
-                }
-                (Type::Brush, Type::Color) => {
-                    quote!(#f.color())
-                }
-                (Type::Struct(lhs), Type::Struct(rhs)) => {
-                    debug_assert_eq!(
-                        lhs.fields, rhs.fields,
-                        "cast of struct with deferent fields should be handled before llr"
-                    );
-                    match (&lhs.name, &rhs.name) {
-                        (StructName::None, targetstruct) if targetstruct.is_some() => {
-                            // Convert from an anonymous struct to a named one
-                            let fields = lhs.fields.iter().enumerate().map(|(index, (name, _))| {
-                                let index = proc_macro2::Literal::usize_unsuffixed(index);
-                                let name = ident(name);
-                                quote!(the_struct.#name = (obj.#index).clone() as _;)
-                            });
-                            let id = struct_name_to_tokens(targetstruct).unwrap();
-                            quote!({ let obj = #f; let mut the_struct = #id::default(); #(#fields)* the_struct })
-                        }
-                        (sourcestruct, StructName::None) if sourcestruct.is_some() => {
-                            // Convert from a named struct to an anonymous one
-                            let fields = lhs.fields.keys().map(|name| ident(name));
-                            quote!({ let obj = #f; (#(obj.#fields,)*) })
-                        }
-                        _ => f,
-                    }
-                }
-                (Type::Array(..), Type::PathData)
-                    if matches!(
-                        from.as_ref(),
-                        Expression::Array { element_ty: Type::Struct { .. }, .. }
-                    ) =>
-                {
-                    let path_elements = match from.as_ref() {
-                        Expression::Array { element_ty: _, values, output: _ } => values
-                            .iter()
-                            .map(|path_elem_expr|
-                                // Close{} is a struct with no fields in markup, and PathElement::Close has no fields
-                                if matches!(path_elem_expr, Expression::Struct { ty, .. } if ty.fields.is_empty()) {
-                                    quote!(sp::PathElement::Close)
-                                } else {
-                                    compile_expression(path_elem_expr, ctx)
-                                }
-                            ),
-                        _ => {
-                            unreachable!()
-                        }
-                    };
-                    quote!(sp::PathData::Elements(sp::SharedVector::<_>::from_slice(&[#((#path_elements).into()),*])))
-                }
-                (Type::Struct { .. }, Type::PathData)
-                    if matches!(from.as_ref(), Expression::Struct { .. }) =>
-                {
-                    let (events, points) = match from.as_ref() {
-                        Expression::Struct { ty: _, values } => (
-                            compile_expression(&values["events"], ctx),
-                            compile_expression(&values["points"], ctx),
-                        ),
-                        _ => {
-                            unreachable!()
-                        }
-                    };
-                    quote!(sp::PathData::Events(sp::SharedVector::<_>::from_slice(&#events), sp::SharedVector::<_>::from_slice(&#points)))
-                }
-                (Type::String, Type::PathData) => {
-                    quote!(sp::PathData::Commands(#f))
-                }
-                (Type::Enumeration(e), Type::String) => {
-                    let cases = e.values.iter().enumerate().map(|(idx, v)| {
-                        let c = compile_expression(
-                            &Expression::EnumerationValue(EnumerationValue {
-                                value: idx,
-                                enumeration: e.clone(),
-                            }),
-                            ctx,
-                        );
-                        let v = v.as_str();
-                        quote!(#c => sp::SharedString::from(#v))
-                    });
-                    quote!(match #f { #(#cases,)*  _ => sp::SharedString::default() })
-                }
-                (_, Type::Void) => {
-                    quote!({#f;})
-                }
-                _ => f,
-            }
-        }
+        Expression::Cast { .. } => compile_cast(expr, ctx),
         Expression::PropertyReference(nr) => {
             let access = access_member(nr, ctx);
             let prop_type = ctx.property_ty(nr);
@@ -3354,41 +3229,11 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         Expression::BuiltinFunctionCall { function, arguments } => {
             compile_builtin_function_call(function.clone(), arguments, ctx)
         }
-        Expression::CallBackCall { callback, arguments } => {
-            let f = access_member(callback, ctx);
-            let tracker = access_callback_tracker(callback, ctx);
-            let register_dep = tracker.map(|t| {
-                quote!(#t.get();)
-            });
-            let a = arguments.iter().map(|a| compile_expression_to_value(a, ctx));
-            if expr.ty(ctx) == Type::Void {
-                f.then(|f| quote!({ #register_dep #f.call(&(#(#a as _,)*)); }))
-            } else {
-                f.map_or_default(|f| quote!({ #register_dep #f.call(&(#(#a as _,)*)) }))
-            }
-        }
-        Expression::FunctionCall { function, arguments } => {
-            let a = arguments.iter().map(|a| compile_expression(a, ctx));
-            let f = access_member(function, ctx);
-            if expr.ty(ctx) == Type::Void {
-                f.then(|f| quote!(#f( #(#a as _),*)))
-            } else {
-                f.map_or_default(|f| quote!(#f( #(#a as _),*)))
-            }
-        }
-        Expression::ItemMemberFunctionCall { function } => {
-            let fun = access_member(function, ctx);
-            let item_rc = access_item_rc(function, ctx);
-            let window_adapter_tokens = access_window_adapter_field(ctx);
-            fun.map_or_default(|fun| quote!(#fun(#window_adapter_tokens, #item_rc)))
-        }
-        Expression::ExtraBuiltinFunctionCall { function, arguments, return_ty: _ } => {
-            let f = ident(function);
-            let a = arguments.iter().map(|a| {
-                let arg = compile_expression(a, ctx);
-                if matches!(a.ty(ctx), Type::Struct { .. }) { quote!(&#arg) } else { arg }
-            });
-            quote! { sp::#f(#(#a as _),*) }
+        Expression::CallBackCall { .. } => compile_callback_call(expr, ctx),
+        Expression::FunctionCall { .. } => compile_function_call(expr, ctx),
+        Expression::ItemMemberFunctionCall { .. } => compile_item_member_function_call(expr, ctx),
+        Expression::ExtraBuiltinFunctionCall { .. } => {
+            compile_extra_builtin_function_call(expr, ctx)
         }
         Expression::FunctionParameterReference { index } => {
             let i = proc_macro2::Literal::usize_unsuffixed(*index);
@@ -3402,116 +3247,20 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             }
             _ => panic!("Expression::StructFieldAccess's base expression is not an Object type"),
         },
-        Expression::ArrayIndex { array, index } => {
-            debug_assert!(matches!(array.ty(ctx), Type::Array(_)));
-            let base_e = compile_expression(array, ctx);
-            let index_e = compile_expression(index, ctx);
-            quote!(match &#base_e { x => {
-                let index = (#index_e) as usize;
-                x.row_data_tracked(index).unwrap_or_default()
-            }})
-        }
-        Expression::CodeBlock(sub) => {
-            let mut body = TokenStream::new();
-            for (i, e) in sub.iter().enumerate() {
-                body.extend(compile_expression_no_parenthesis(e, ctx));
-                if i + 1 < sub.len() && !matches!(e, Expression::StoreLocalVariable { .. }) {
-                    body.extend(quote!(;));
-                }
-            }
-            quote!({ #body })
-        }
+        Expression::ArrayIndex { .. } => compile_array_index(expr, ctx),
+        Expression::CodeBlock(..) => compile_code_block(expr, ctx),
         Expression::PropertyAssignment { property, value } => {
             let value = compile_expression(value, ctx);
             property_set_value_tokens(property, value, ctx)
         }
-        Expression::ModelDataAssignment { level, value } => {
-            let value = compile_expression(value, ctx);
-            let mut path = quote!(_self);
-            let EvaluationScope::SubComponent(mut sc, mut par) = ctx.current_scope else {
-                unreachable!()
-            };
-            let mut repeater_index = None;
-            for _ in 0..=*level {
-                let x = par.unwrap();
-                par = x.parent;
-                repeater_index = x.repeater_index;
-                sc = x.sub_component;
-                path = quote!(#path.parent.upgrade().unwrap());
-            }
-            let repeater_index = repeater_index.unwrap();
-            let sub_component = &ctx.compilation_unit.sub_components[sc];
-            let local_reference = sub_component.repeated[repeater_index].index_prop.unwrap().into();
-            let index_prop =
-                llr::MemberReference::Relative { parent_level: *level, local_reference };
-            let index_access = access_member(&index_prop, ctx).get_property();
-            let repeater = access_component_field_offset(
-                &inner_component_id(sub_component),
-                &format_ident!("repeater{}", usize::from(repeater_index)),
-            );
-            quote!(#repeater.apply_pin(#path.as_pin_ref()).model_set_row_data(#index_access as _, #value as _))
-        }
-        Expression::ArrayIndexAssignment { array, index, value } => {
-            debug_assert!(matches!(array.ty(ctx), Type::Array(_)));
-            let base_e = compile_expression(array, ctx);
-            let index_e = compile_expression(index, ctx);
-            let value_e = compile_expression(value, ctx);
-            quote!((#base_e).set_row_data(#index_e as isize as usize, #value_e as _))
-        }
+        Expression::ModelDataAssignment { .. } => compile_model_data_assignment(expr, ctx),
+        Expression::ArrayIndexAssignment { .. } => compile_array_index_assignment(expr, ctx),
         Expression::SliceIndexAssignment { slice_name, index, value } => {
             let slice_ident = ident(slice_name);
             let value_e = compile_expression(value, ctx);
             quote!(#slice_ident[#index] = #value_e)
         }
-        Expression::BinaryExpression { lhs, rhs, op } => {
-            let lhs_ty = lhs.ty(ctx);
-            let lhs = compile_expression_to_value_no_parenthesis(lhs, ctx);
-            let rhs = compile_expression_to_value_no_parenthesis(rhs, ctx);
-
-            if lhs_ty.as_unit_product().is_some() && (*op == '=' || *op == '!') {
-                let maybe_negate = if *op == '!' { quote!(!) } else { quote!() };
-                quote!(#maybe_negate sp::ApproxEq::<f64>::approx_eq(&(#lhs as f64), &(#rhs as f64)))
-            } else {
-                let (conv1, conv2) = match crate::expression_tree::operator_class(*op) {
-                    OperatorClass::ArithmeticOp => match lhs_ty {
-                        Type::String => (None, Some(quote!(.as_str()))),
-                        Type::Struct { .. } => (None, None),
-                        _ => (Some(quote!(as f64)), Some(quote!(as f64))),
-                    },
-                    OperatorClass::ComparisonOp
-                        if matches!(
-                            lhs_ty,
-                            Type::Int32
-                                | Type::Float32
-                                | Type::Duration
-                                | Type::PhysicalLength
-                                | Type::LogicalLength
-                                | Type::Angle
-                                | Type::Percent
-                                | Type::Rem
-                        ) =>
-                    {
-                        (Some(quote!(as f64)), Some(quote!(as f64)))
-                    }
-                    _ => (None, None),
-                };
-
-                let op = match op {
-                    '=' => quote!(==),
-                    '!' => quote!(!=),
-                    '≤' => quote!(<=),
-                    '≥' => quote!(>=),
-                    '&' => quote!(&&),
-                    '|' => quote!(||),
-                    _ => proc_macro2::TokenTree::Punct(proc_macro2::Punct::new(
-                        *op,
-                        proc_macro2::Spacing::Alone,
-                    ))
-                    .into(),
-                };
-                quote!( (((#lhs) #conv1 ) #op ((#rhs) #conv2)) )
-            }
-        }
+        Expression::BinaryExpression { .. } => compile_binary_expression(expr, ctx),
         Expression::UnaryOp { sub, op } => {
             let sub = compile_expression(sub, ctx);
             if *op == '+' {
@@ -3521,97 +3270,10 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             let op = proc_macro2::Punct::new(*op, proc_macro2::Spacing::Alone);
             quote!( (#op #sub) )
         }
-        Expression::ImageReference { resource_ref, nine_slice } => {
-            match &nine_slice {
-                Some([a, b, c, d]) => {
-                    quote! {{ let mut image = #resource_ref; image.set_nine_slice_edges(#a, #b, #c, #d); image }}
-                }
-                None => quote!(#resource_ref),
-            }
-        }
-        Expression::Condition { condition, true_expr, false_expr } => {
-            let condition_code = compile_expression_no_parenthesis(condition, ctx);
-            let true_code = compile_expression(true_expr, ctx);
-            let false_code = compile_expression_no_parenthesis(false_expr, ctx);
-            let semi = if false_expr.ty(ctx) == Type::Void { quote!(;) } else { quote!(as _) };
-            quote!(
-                if #condition_code {
-                    (#true_code) #semi
-                } else {
-                    #false_code
-                }
-            )
-        }
-        Expression::Array { values, element_ty, output } => {
-            let val = values.iter().map(|e| compile_expression_to_value(e, ctx));
-            match output {
-                ArrayOutput::Model => {
-                    let rust_element_ty = rust_primitive_type(element_ty).unwrap();
-                    quote!(sp::ModelRc::new(
-                        sp::VecModel::<#rust_element_ty>::from(
-                            sp::vec![#(#val as _),*]
-                        )
-                    ))
-                }
-                ArrayOutput::Slice => quote!(sp::Slice::from_slice(&[#(#val),*])),
-                ArrayOutput::Vector => quote!(sp::vec![#(#val as _),*]),
-            }
-        }
-        Expression::Struct { ty, values } => {
-            if ty.name.is_some() {
-                let name_tokens = struct_name_to_tokens(&ty.name).unwrap();
-                // A struct literal can only be used when all the fields are public, there
-                // is no hidden field (like euclid's `_unit`), and the struct is not
-                // `#[non_exhaustive]`. That holds for the generated user structs and for
-                // the listed builtin structs.
-                use crate::langtype::BuiltinStruct as BS;
-                let supports_struct_literal = match &ty.name {
-                    StructName::User { .. } => true,
-                    StructName::Builtin(b) => {
-                        b.is_layout_data()
-                            || matches!(
-                                b,
-                                BS::LayoutInfo
-                                    | BS::LayoutItemInfo
-                                    | BS::FlexboxLayoutItemInfo
-                                    | BS::Padding
-                                    | BS::PropertyAnimation
-                                    | BS::StateInfo
-                            )
-                    }
-                    StructName::None => false,
-                };
-                if supports_struct_literal {
-                    let (keys, elem): (Vec<_>, Vec<_>) = ty
-                        .fields
-                        .keys()
-                        .filter(|k| values.contains_key(*k))
-                        .map(|k| (ident(k), compile_expression_to_value(&values[k], ctx)))
-                        .unzip();
-                    let default_rest = (keys.len() != ty.fields.len())
-                        .then(|| quote!(..::core::default::Default::default()));
-                    quote!(#name_tokens{#(#keys: #elem as _,)* #default_rest})
-                } else {
-                    let elem = ty.fields.keys().map(|k| values.get(k).map(|e| compile_expression_to_value(e, ctx)));
-                    let keys = ty.fields.keys().map(|k| ident(k));
-                    quote!({ let mut the_struct = #name_tokens::default(); #(the_struct.#keys = #elem as _;)* the_struct})
-                }
-            } else {
-                let elem = ty.fields.keys().map(|k| values.get(k).map(|e| compile_expression_to_value(e, ctx)));
-                let as_ = ty.fields.values().map(|t| {
-                    if t.as_unit_product().is_some() {
-                        // number needs to be converted to the right things because intermediate
-                        // result might be f64 and that's usually not what the type of the tuple is in the end
-                        let t = rust_primitive_type(t).unwrap();
-                        quote!(as #t)
-                    } else {
-                        quote!()
-                    }
-                });
-                // This will produce a tuple
-                quote!((#((#elem).clone() #as_,)*))
-            }
-        }
+        Expression::ImageReference { .. } => compile_image_reference(expr),
+        Expression::Condition { .. } => compile_condition(expr, ctx),
+        Expression::Array { .. } => compile_array(expr, ctx),
+        Expression::Struct { .. } => compile_struct(expr, ctx),
 
         Expression::StoreLocalVariable { name, value } => {
             let value = compile_expression_to_value_no_parenthesis(value, ctx);
@@ -3626,15 +3288,15 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             llr::MouseCursorInner::BuiltIn(expression) => {
                 let expression = compile_expression(expression, ctx);
                 quote!(sp::MouseCursorInner::BuiltIn(#expression.clone()))
-            },
+            }
             llr::MouseCursorInner::CustomMouseCursor { image, hotspot_x, hotspot_y } => {
                 let image = compile_expression(image, ctx);
                 let hotspot_x = compile_expression(hotspot_x, ctx);
                 let hotspot_y = compile_expression(hotspot_y, ctx);
 
                 quote!(sp::MouseCursorInner::CustomMouseCursor { image: #image.clone(), hotspot_x: #hotspot_x.clone() as i32, hotspot_y: #hotspot_y.clone() as i32 })
-            },
-        }
+            }
+        },
         Expression::EasingCurve(EasingCurve::CubicBezier(a, b, c, d)) => {
             quote!(sp::EasingCurve::CubicBezier([#a, #b, #c, #d]))
         }
@@ -3643,56 +3305,9 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             let ident = format_ident!("{e:?}");
             quote!(sp::EasingCurve::#ident)
         }
-        Expression::LinearGradient { angle, stops } => {
-            let angle = compile_expression(angle, ctx);
-            let stops = stops.iter().map(|(color, stop)| {
-                let color = compile_expression(color, ctx);
-                let position = compile_expression(stop, ctx);
-                quote!(sp::GradientStop{ color: #color, position: #position as _ })
-            });
-            quote!(slint::Brush::LinearGradient(
-                sp::LinearGradientBrush::new(#angle as _, [#(#stops),*])
-            ))
-        }
-        Expression::RadialGradient { center, radius, stops } => {
-            let stops = stops.iter().map(|(color, stop)| {
-                let color = compile_expression(color, ctx);
-                let position = compile_expression(stop, ctx);
-                quote!(sp::GradientStop{ color: #color, position: #position as _ })
-            });
-            let brush_expr = quote!(sp::RadialGradientBrush::new_circle([#(#stops),*]));
-            let brush_expr = if let Some((cx, cy)) = center {
-                let cx = compile_expression(cx, ctx);
-                let cy = compile_expression(cy, ctx);
-                quote!(#brush_expr.with_center(#cx as f32, #cy as f32))
-            } else {
-                brush_expr
-            };
-            let brush_expr = if let Some(r) = radius {
-                let r = compile_expression(r, ctx);
-                quote!(#brush_expr.with_radius(#r as f32))
-            } else {
-                brush_expr
-            };
-            quote!(slint::Brush::RadialGradient(#brush_expr))
-        }
-        Expression::ConicGradient { from_angle, center, stops } => {
-            let from_angle = compile_expression(from_angle, ctx);
-            let stops = stops.iter().map(|(color, stop)| {
-                let color = compile_expression(color, ctx);
-                let position = compile_expression(stop, ctx);
-                quote!(sp::GradientStop{ color: #color, position: #position as _ })
-            });
-            let brush_expr = quote!(sp::ConicGradientBrush::new(#from_angle as _, [#(#stops),*]));
-            let brush_expr = if let Some((cx, cy)) = center {
-                let cx = compile_expression(cx, ctx);
-                let cy = compile_expression(cy, ctx);
-                quote!(#brush_expr.with_center(#cx as f32, #cy as f32))
-            } else {
-                brush_expr
-            };
-            quote!(slint::Brush::ConicGradient(#brush_expr))
-        }
+        Expression::LinearGradient { .. } => compile_linear_gradient(expr, ctx),
+        Expression::RadialGradient { .. } => compile_radial_gradient(expr, ctx),
+        Expression::ConicGradient { .. } => compile_conic_gradient(expr, ctx),
         Expression::EnumerationValue(value) => {
             let base_ident = ident(&value.enumeration.name);
             let value_ident = ident(&value.to_pascal_case());
@@ -3702,47 +3317,8 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 quote!(sp::#base_ident::#value_ident)
             }
         }
-        Expression::LayoutCacheAccess {
-            layout_cache_prop,
-            index,
-            repeater_index,
-            entries_per_item,
-        } => {
-            access_member(layout_cache_prop, ctx).map_or_default(|cache| {
-                if let Some(ri) = repeater_index {
-                    let offset = compile_expression(ri, ctx);
-                    quote!({
-                        let cache = #cache.get();
-                        *cache.get((cache[#index] as usize) + #offset as usize * #entries_per_item).unwrap_or(&(0 as _))
-                    })
-                } else {
-                    quote!(#cache.get()[#index])
-                }
-            })
-        }
-        Expression::GridRepeaterCacheAccess {
-            layout_cache_prop,
-            index,
-            repeater_index,
-            stride,
-            child_offset,
-            inner_repeater_index,
-            entries_per_item,
-        } => access_member(layout_cache_prop, ctx).map_or_default(|cache| {
-            let offset = compile_expression(repeater_index, ctx);
-            let stride_val = compile_expression(stride, ctx);
-            let inner_offset = inner_repeater_index.as_ref().map(|inner_ri| {
-                let inner_offset = compile_expression(inner_ri, ctx);
-                quote!(+ #inner_offset as usize * #entries_per_item)
-            });
-
-            quote!({
-                let cache = #cache.get();
-                let base = cache[#index] as usize;
-                let data_idx = base + #offset as usize * (#stride_val as usize) + #child_offset #inner_offset;
-                *cache.get(data_idx).unwrap_or(&(0 as _))
-            })
-        }),
+        Expression::LayoutCacheAccess { .. } => compile_layout_cache_access(expr, ctx),
+        Expression::GridRepeaterCacheAccess { .. } => compile_grid_repeater_cache_access(expr, ctx),
         Expression::WithLayoutItemInfo {
             cells_variable,
             repeater_indices_var_name,
@@ -3803,46 +3379,572 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             ctx,
         ),
 
-        Expression::MinMax { ty, op, lhs, rhs } => {
-            let lhs = compile_expression(lhs, ctx);
-            let t = rust_primitive_type(ty);
-            let (lhs, rhs) = match t {
-                Some(t) => {
-                    let rhs = compile_expression(rhs, ctx);
-                    (quote!((#lhs as #t)), quote!(#rhs as #t))
-                }
-                None => {
-                    let rhs = compile_expression_no_parenthesis(rhs, ctx);
-                    (lhs, rhs)
-                }
-            };
-            match op {
-                MinMaxOp::Min => {
-                    quote!(#lhs.min(#rhs))
-                }
-                MinMaxOp::Max => {
-                    quote!(#lhs.max(#rhs))
-                }
-            }
-        }
+        Expression::MinMax { .. } => compile_min_max(expr, ctx),
         Expression::EmptyComponentFactory => quote!(slint::ComponentFactory::default()),
         Expression::EmptyDataTransfer => quote!(slint::DataTransfer::default()),
-        Expression::TranslationReference { format_args, string_index, plural } => {
-            let args = compile_expression(format_args, ctx);
-            match plural {
-                Some(plural) => {
-                    let plural = compile_expression(plural, ctx);
-                    quote!(sp::translate_from_bundle_with_plural(
-                        &self::_SLINT_TRANSLATED_STRINGS_PLURALS[#string_index],
-                        &self::_SLINT_TRANSLATED_PLURAL_RULES,
-                        sp::Slice::<sp::SharedString>::from(#args).as_slice(),
-                        #plural as _
-                    ))
+        Expression::TranslationReference { .. } => compile_translation_reference(expr, ctx),
+    }
+}
+
+#[inline(never)]
+fn compile_keys_literal(expr: &Expression) -> TokenStream {
+    let Expression::KeysLiteral(keys) = expr else { unreachable!() };
+    let key = &*keys.key;
+    let alt = keys.modifiers.alt;
+    let control = keys.modifiers.control;
+    let shift = keys.modifiers.shift;
+    let meta = keys.modifiers.meta;
+    let ignore_shift = keys.ignore_shift;
+    let ignore_alt = keys.ignore_alt;
+
+    quote!(
+        sp::make_keys(
+            #key.into(),
+            {
+                let mut modifiers = sp::KeyboardModifiers::default();
+                modifiers.alt = #alt;
+                modifiers.control = #control;
+                modifiers.shift = #shift;
+                modifiers.meta = #meta;
+                modifiers
+            },
+            #ignore_shift,
+            #ignore_alt))
+}
+
+#[inline(never)]
+fn compile_cast(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::Cast { from, to } = expr else { unreachable!() };
+    let f = compile_expression(from, ctx);
+    match (from.ty(ctx), to) {
+        (Type::Float32, Type::Int32) => {
+            quote!(((#f) as i32))
+        }
+        (from, Type::String) if from.as_unit_product().is_some() => {
+            quote!(sp::shared_string_from_number((#f) as f64))
+        }
+        (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
+            quote!(sp::ModelRc::new(#f.max(::core::default::Default::default()) as usize))
+        }
+        (Type::Float32, Type::Color) => {
+            quote!(sp::Color::from_argb_encoded((#f) as u32))
+        }
+        (Type::Color, Type::Brush) => {
+            quote!(slint::Brush::SolidColor(#f))
+        }
+        (Type::Brush, Type::Color) => {
+            quote!(#f.color())
+        }
+        (Type::Struct(lhs), Type::Struct(rhs)) => {
+            debug_assert_eq!(
+                lhs.fields, rhs.fields,
+                "cast of struct with deferent fields should be handled before llr"
+            );
+            match (&lhs.name, &rhs.name) {
+                (StructName::None, targetstruct) if targetstruct.is_some() => {
+                    // Convert from an anonymous struct to a named one
+                    let fields = lhs.fields.iter().enumerate().map(|(index, (name, _))| {
+                        let index = proc_macro2::Literal::usize_unsuffixed(index);
+                        let name = ident(name);
+                        quote!(the_struct.#name = (obj.#index).clone() as _;)
+                    });
+                    let id = struct_name_to_tokens(targetstruct).unwrap();
+                    quote!({ let obj = #f; let mut the_struct = #id::default(); #(#fields)* the_struct })
                 }
-                None => {
-                    quote!(sp::translate_from_bundle(&self::_SLINT_TRANSLATED_STRINGS[#string_index], sp::Slice::<sp::SharedString>::from(#args).as_slice()))
+                (sourcestruct, StructName::None) if sourcestruct.is_some() => {
+                    // Convert from a named struct to an anonymous one
+                    let fields = lhs.fields.keys().map(|name| ident(name));
+                    quote!({ let obj = #f; (#(obj.#fields,)*) })
                 }
+                _ => f,
             }
+        }
+        (Type::Array(..), Type::PathData)
+            if matches!(
+                from.as_ref(),
+                Expression::Array { element_ty: Type::Struct { .. }, .. }
+            ) =>
+        {
+            let path_elements = match from.as_ref() {
+                Expression::Array { element_ty: _, values, output: _ } => values
+                    .iter()
+                    .map(|path_elem_expr|
+                        // Close{} is a struct with no fields in markup, and PathElement::Close has no fields
+                        if matches!(path_elem_expr, Expression::Struct { ty, .. } if ty.fields.is_empty()) {
+                            quote!(sp::PathElement::Close)
+                        } else {
+                            compile_expression(path_elem_expr, ctx)
+                        }
+                    ),
+                _ => {
+                    unreachable!()
+                }
+            };
+            quote!(sp::PathData::Elements(sp::SharedVector::<_>::from_slice(&[#((#path_elements).into()),*])))
+        }
+        (Type::Struct { .. }, Type::PathData)
+            if matches!(from.as_ref(), Expression::Struct { .. }) =>
+        {
+            let (events, points) = match from.as_ref() {
+                Expression::Struct { ty: _, values } => (
+                    compile_expression(&values["events"], ctx),
+                    compile_expression(&values["points"], ctx),
+                ),
+                _ => {
+                    unreachable!()
+                }
+            };
+            quote!(sp::PathData::Events(sp::SharedVector::<_>::from_slice(&#events), sp::SharedVector::<_>::from_slice(&#points)))
+        }
+        (Type::String, Type::PathData) => {
+            quote!(sp::PathData::Commands(#f))
+        }
+        (Type::Enumeration(e), Type::String) => {
+            let cases = e.values.iter().enumerate().map(|(idx, v)| {
+                let c = compile_expression(
+                    &Expression::EnumerationValue(EnumerationValue {
+                        value: idx,
+                        enumeration: e.clone(),
+                    }),
+                    ctx,
+                );
+                let v = v.as_str();
+                quote!(#c => sp::SharedString::from(#v))
+            });
+            quote!(match #f { #(#cases,)*  _ => sp::SharedString::default() })
+        }
+        (_, Type::Void) => {
+            quote!({#f;})
+        }
+        _ => f,
+    }
+}
+
+#[inline(never)]
+fn compile_callback_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::CallBackCall { callback, arguments } = expr else { unreachable!() };
+    let f = access_member(callback, ctx);
+    let tracker = access_callback_tracker(callback, ctx);
+    let register_dep = tracker.map(|t| quote!(#t.get();));
+    let a = arguments.iter().map(|a| compile_expression_to_value(a, ctx));
+    if expr.ty(ctx) == Type::Void {
+        f.then(|f| quote!({ #register_dep #f.call(&(#(#a as _,)*)); }))
+    } else {
+        f.map_or_default(|f| quote!({ #register_dep #f.call(&(#(#a as _,)*)) }))
+    }
+}
+
+#[inline(never)]
+fn compile_function_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::FunctionCall { function, arguments } = expr else { unreachable!() };
+    let a = arguments.iter().map(|a| compile_expression(a, ctx));
+    let f = access_member(function, ctx);
+    if expr.ty(ctx) == Type::Void {
+        f.then(|f| quote!(#f( #(#a as _),*)))
+    } else {
+        f.map_or_default(|f| quote!(#f( #(#a as _),*)))
+    }
+}
+
+#[inline(never)]
+fn compile_item_member_function_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::ItemMemberFunctionCall { function } = expr else { unreachable!() };
+    let fun = access_member(function, ctx);
+    let item_rc = access_item_rc(function, ctx);
+    let window_adapter_tokens = access_window_adapter_field(ctx);
+    fun.map_or_default(|fun| quote!(#fun(#window_adapter_tokens, #item_rc)))
+}
+
+#[inline(never)]
+fn compile_extra_builtin_function_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::ExtraBuiltinFunctionCall { function, arguments, return_ty: _ } = expr else {
+        unreachable!()
+    };
+    let f = ident(function);
+    let a = arguments.iter().map(|a| {
+        let arg = compile_expression(a, ctx);
+        if matches!(a.ty(ctx), Type::Struct { .. }) { quote!(&#arg) } else { arg }
+    });
+    quote! { sp::#f(#(#a as _),*) }
+}
+
+#[inline(never)]
+fn compile_array_index(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::ArrayIndex { array, index } = expr else { unreachable!() };
+    debug_assert!(matches!(array.ty(ctx), Type::Array(_)));
+    let base_e = compile_expression(array, ctx);
+    let index_e = compile_expression(index, ctx);
+    quote!(match &#base_e { x => {
+        let index = (#index_e) as usize;
+        x.row_data_tracked(index).unwrap_or_default()
+    }})
+}
+
+#[inline(never)]
+fn compile_code_block(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::CodeBlock(sub) = expr else { unreachable!() };
+    let mut body = TokenStream::new();
+    for (i, e) in sub.iter().enumerate() {
+        body.extend(compile_expression_no_parenthesis(e, ctx));
+        if i + 1 < sub.len() && !matches!(e, Expression::StoreLocalVariable { .. }) {
+            body.extend(quote!(;));
+        }
+    }
+    quote!({ #body })
+}
+
+#[inline(never)]
+fn compile_model_data_assignment(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::ModelDataAssignment { level, value } = expr else { unreachable!() };
+    let value = compile_expression(value, ctx);
+    let mut path = quote!(_self);
+    let EvaluationScope::SubComponent(mut sc, mut par) = ctx.current_scope else { unreachable!() };
+    let mut repeater_index = None;
+    for _ in 0..=*level {
+        let x = par.unwrap();
+        par = x.parent;
+        repeater_index = x.repeater_index;
+        sc = x.sub_component;
+        path = quote!(#path.parent.upgrade().unwrap());
+    }
+    let repeater_index = repeater_index.unwrap();
+    let sub_component = &ctx.compilation_unit.sub_components[sc];
+    let local_reference = sub_component.repeated[repeater_index].index_prop.unwrap().into();
+    let index_prop = llr::MemberReference::Relative { parent_level: *level, local_reference };
+    let index_access = access_member(&index_prop, ctx).get_property();
+    let repeater = access_component_field_offset(
+        &inner_component_id(sub_component),
+        &format_ident!("repeater{}", usize::from(repeater_index)),
+    );
+    quote!(#repeater.apply_pin(#path.as_pin_ref()).model_set_row_data(#index_access as _, #value as _))
+}
+
+#[inline(never)]
+fn compile_array_index_assignment(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::ArrayIndexAssignment { array, index, value } = expr else { unreachable!() };
+    debug_assert!(matches!(array.ty(ctx), Type::Array(_)));
+    let base_e = compile_expression(array, ctx);
+    let index_e = compile_expression(index, ctx);
+    let value_e = compile_expression(value, ctx);
+    quote!((#base_e).set_row_data(#index_e as isize as usize, #value_e as _))
+}
+
+#[inline(never)]
+fn compile_binary_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::BinaryExpression { lhs, rhs, op } = expr else { unreachable!() };
+    let lhs_ty = lhs.ty(ctx);
+    let lhs = compile_expression_to_value_no_parenthesis(lhs, ctx);
+    let rhs = compile_expression_to_value_no_parenthesis(rhs, ctx);
+
+    if lhs_ty.as_unit_product().is_some() && (*op == '=' || *op == '!') {
+        let maybe_negate = if *op == '!' { quote!(!) } else { quote!() };
+        quote!(#maybe_negate sp::ApproxEq::<f64>::approx_eq(&(#lhs as f64), &(#rhs as f64)))
+    } else {
+        let (conv1, conv2) = match crate::expression_tree::operator_class(*op) {
+            OperatorClass::ArithmeticOp => match lhs_ty {
+                Type::String => (None, Some(quote!(.as_str()))),
+                Type::Struct { .. } => (None, None),
+                _ => (Some(quote!(as f64)), Some(quote!(as f64))),
+            },
+            OperatorClass::ComparisonOp
+                if matches!(
+                    lhs_ty,
+                    Type::Int32
+                        | Type::Float32
+                        | Type::Duration
+                        | Type::PhysicalLength
+                        | Type::LogicalLength
+                        | Type::Angle
+                        | Type::Percent
+                        | Type::Rem
+                ) =>
+            {
+                (Some(quote!(as f64)), Some(quote!(as f64)))
+            }
+            _ => (None, None),
+        };
+
+        let op = match op {
+            '=' => quote!(==),
+            '!' => quote!(!=),
+            '≤' => quote!(<=),
+            '≥' => quote!(>=),
+            '&' => quote!(&&),
+            '|' => quote!(||),
+            _ => proc_macro2::TokenTree::Punct(proc_macro2::Punct::new(
+                *op,
+                proc_macro2::Spacing::Alone,
+            ))
+            .into(),
+        };
+        quote!( (((#lhs) #conv1 ) #op ((#rhs) #conv2)) )
+    }
+}
+
+#[inline(never)]
+fn compile_image_reference(expr: &Expression) -> TokenStream {
+    let Expression::ImageReference { resource_ref, nine_slice } = expr else { unreachable!() };
+    match &nine_slice {
+        Some([a, b, c, d]) => {
+            quote! {{ let mut image = #resource_ref; image.set_nine_slice_edges(#a, #b, #c, #d); image }}
+        }
+        None => quote!(#resource_ref),
+    }
+}
+
+#[inline(never)]
+fn compile_condition(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::Condition { condition, true_expr, false_expr } = expr else { unreachable!() };
+    let condition_code = compile_expression_no_parenthesis(condition, ctx);
+    let true_code = compile_expression(true_expr, ctx);
+    let false_code = compile_expression_no_parenthesis(false_expr, ctx);
+    let semi = if false_expr.ty(ctx) == Type::Void { quote!(;) } else { quote!(as _) };
+    quote!(
+        if #condition_code {
+            (#true_code) #semi
+        } else {
+            #false_code
+        }
+    )
+}
+
+#[inline(never)]
+fn compile_array(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::Array { values, element_ty, output } = expr else { unreachable!() };
+    let val = values.iter().map(|e| compile_expression_to_value(e, ctx));
+    match output {
+        ArrayOutput::Model => {
+            let rust_element_ty = rust_primitive_type(element_ty).unwrap();
+            quote!(sp::ModelRc::new(
+                sp::VecModel::<#rust_element_ty>::from(
+                    sp::vec![#(#val as _),*]
+                )
+            ))
+        }
+        ArrayOutput::Slice => quote!(sp::Slice::from_slice(&[#(#val),*])),
+        ArrayOutput::Vector => quote!(sp::vec![#(#val as _),*]),
+    }
+}
+
+#[inline(never)]
+fn compile_struct(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::Struct { ty, values } = expr else { unreachable!() };
+    if ty.name.is_some() {
+        let name_tokens = struct_name_to_tokens(&ty.name).unwrap();
+        // A struct literal can only be used when all the fields are public, there
+        // is no hidden field (like euclid's `_unit`), and the struct is not
+        // `#[non_exhaustive]`. That holds for the generated user structs and for
+        // the listed builtin structs.
+        use crate::langtype::BuiltinStruct as BS;
+        let supports_struct_literal = match &ty.name {
+            StructName::User { .. } => true,
+            StructName::Builtin(b) => {
+                b.is_layout_data()
+                    || matches!(
+                        b,
+                        BS::LayoutInfo
+                            | BS::LayoutItemInfo
+                            | BS::FlexboxLayoutItemInfo
+                            | BS::Padding
+                            | BS::PropertyAnimation
+                            | BS::StateInfo
+                    )
+            }
+            StructName::None => false,
+        };
+        if supports_struct_literal {
+            let (keys, elem): (Vec<_>, Vec<_>) = ty
+                .fields
+                .keys()
+                .filter(|k| values.contains_key(*k))
+                .map(|k| (ident(k), compile_expression_to_value(&values[k], ctx)))
+                .unzip();
+            let default_rest = (keys.len() != ty.fields.len())
+                .then(|| quote!(..::core::default::Default::default()));
+            quote!(#name_tokens{#(#keys: #elem as _,)* #default_rest})
+        } else {
+            let elem = ty
+                .fields
+                .keys()
+                .map(|k| values.get(k).map(|e| compile_expression_to_value(e, ctx)));
+            let keys = ty.fields.keys().map(|k| ident(k));
+            quote!({ let mut the_struct = #name_tokens::default(); #(the_struct.#keys = #elem as _;)* the_struct})
+        }
+    } else {
+        let elem =
+            ty.fields.keys().map(|k| values.get(k).map(|e| compile_expression_to_value(e, ctx)));
+        let as_ = ty.fields.values().map(|t| {
+            if t.as_unit_product().is_some() {
+                // number needs to be converted to the right things because intermediate
+                // result might be f64 and that's usually not what the type of the tuple is in the end
+                let t = rust_primitive_type(t).unwrap();
+                quote!(as #t)
+            } else {
+                quote!()
+            }
+        });
+        // This will produce a tuple
+        quote!((#((#elem).clone() #as_,)*))
+    }
+}
+
+#[inline(never)]
+fn compile_linear_gradient(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::LinearGradient { angle, stops } = expr else { unreachable!() };
+    let angle = compile_expression(angle, ctx);
+    let stops = stops.iter().map(|(color, stop)| {
+        let color = compile_expression(color, ctx);
+        let position = compile_expression(stop, ctx);
+        quote!(sp::GradientStop{ color: #color, position: #position as _ })
+    });
+    quote!(slint::Brush::LinearGradient(
+        sp::LinearGradientBrush::new(#angle as _, [#(#stops),*])
+    ))
+}
+
+#[inline(never)]
+fn compile_radial_gradient(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::RadialGradient { center, radius, stops } = expr else { unreachable!() };
+    let stops = stops.iter().map(|(color, stop)| {
+        let color = compile_expression(color, ctx);
+        let position = compile_expression(stop, ctx);
+        quote!(sp::GradientStop{ color: #color, position: #position as _ })
+    });
+    let brush_expr = quote!(sp::RadialGradientBrush::new_circle([#(#stops),*]));
+    let brush_expr = if let Some((cx, cy)) = center {
+        let cx = compile_expression(cx, ctx);
+        let cy = compile_expression(cy, ctx);
+        quote!(#brush_expr.with_center(#cx as f32, #cy as f32))
+    } else {
+        brush_expr
+    };
+    let brush_expr = if let Some(r) = radius {
+        let r = compile_expression(r, ctx);
+        quote!(#brush_expr.with_radius(#r as f32))
+    } else {
+        brush_expr
+    };
+    quote!(slint::Brush::RadialGradient(#brush_expr))
+}
+
+#[inline(never)]
+fn compile_conic_gradient(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::ConicGradient { from_angle, center, stops } = expr else { unreachable!() };
+    let from_angle = compile_expression(from_angle, ctx);
+    let stops = stops.iter().map(|(color, stop)| {
+        let color = compile_expression(color, ctx);
+        let position = compile_expression(stop, ctx);
+        quote!(sp::GradientStop{ color: #color, position: #position as _ })
+    });
+    let brush_expr = quote!(sp::ConicGradientBrush::new(#from_angle as _, [#(#stops),*]));
+    let brush_expr = if let Some((cx, cy)) = center {
+        let cx = compile_expression(cx, ctx);
+        let cy = compile_expression(cy, ctx);
+        quote!(#brush_expr.with_center(#cx as f32, #cy as f32))
+    } else {
+        brush_expr
+    };
+    quote!(slint::Brush::ConicGradient(#brush_expr))
+}
+
+#[inline(never)]
+fn compile_layout_cache_access(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::LayoutCacheAccess {
+        layout_cache_prop,
+        index,
+        repeater_index,
+        entries_per_item,
+    } = expr
+    else {
+        unreachable!()
+    };
+    access_member(layout_cache_prop, ctx).map_or_default(|cache| {
+        if let Some(ri) = repeater_index {
+            let offset = compile_expression(ri, ctx);
+            quote!({
+                let cache = #cache.get();
+                *cache.get((cache[#index] as usize) + #offset as usize * #entries_per_item).unwrap_or(&(0 as _))
+            })
+        } else {
+            quote!(#cache.get()[#index])
+        }
+    })
+}
+
+#[inline(never)]
+fn compile_grid_repeater_cache_access(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::GridRepeaterCacheAccess {
+        layout_cache_prop,
+        index,
+        repeater_index,
+        stride,
+        child_offset,
+        inner_repeater_index,
+        entries_per_item,
+    } = expr
+    else {
+        unreachable!()
+    };
+    access_member(layout_cache_prop, ctx).map_or_default(|cache| {
+        let offset = compile_expression(repeater_index, ctx);
+        let stride_val = compile_expression(stride, ctx);
+        let inner_offset = inner_repeater_index.as_ref().map(|inner_ri| {
+            let inner_offset = compile_expression(inner_ri, ctx);
+            quote!(+ #inner_offset as usize * #entries_per_item)
+        });
+
+        quote!({
+            let cache = #cache.get();
+            let base = cache[#index] as usize;
+            let data_idx = base + #offset as usize * (#stride_val as usize) + #child_offset #inner_offset;
+            *cache.get(data_idx).unwrap_or(&(0 as _))
+        })
+    })
+}
+
+#[inline(never)]
+fn compile_min_max(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::MinMax { ty, op, lhs, rhs } = expr else { unreachable!() };
+    let lhs = compile_expression(lhs, ctx);
+    let t = rust_primitive_type(ty);
+    let (lhs, rhs) = match t {
+        Some(t) => {
+            let rhs = compile_expression(rhs, ctx);
+            (quote!((#lhs as #t)), quote!(#rhs as #t))
+        }
+        None => {
+            let rhs = compile_expression_no_parenthesis(rhs, ctx);
+            (lhs, rhs)
+        }
+    };
+    match op {
+        MinMaxOp::Min => {
+            quote!(#lhs.min(#rhs))
+        }
+        MinMaxOp::Max => {
+            quote!(#lhs.max(#rhs))
+        }
+    }
+}
+
+#[inline(never)]
+fn compile_translation_reference(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
+    let Expression::TranslationReference { format_args, string_index, plural } = expr else {
+        unreachable!()
+    };
+    let args = compile_expression(format_args, ctx);
+    match plural {
+        Some(plural) => {
+            let plural = compile_expression(plural, ctx);
+            quote!(sp::translate_from_bundle_with_plural(
+                &self::_SLINT_TRANSLATED_STRINGS_PLURALS[#string_index],
+                &self::_SLINT_TRANSLATED_PLURAL_RULES,
+                sp::Slice::<sp::SharedString>::from(#args).as_slice(),
+                #plural as _
+            ))
+        }
+        None => {
+            quote!(sp::translate_from_bundle(&self::_SLINT_TRANSLATED_STRINGS[#string_index], sp::Slice::<sp::SharedString>::from(#args).as_slice()))
         }
     }
 }

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -41,233 +41,31 @@ pub fn const_propagation(component: &Component, global_analysis: &GlobalAnalysis
 }
 
 /// Returns false if the expression still contains a reference to an element
+///
+/// The body of every non-trivial match arm lives in its own `#[inline(never)]`
+/// helper function: this function recurses for nested expressions, and with all
+/// arm bodies inlined, its stack frame in unoptimized builds becomes so large
+/// that deeply nested expressions overflow the stack.
 fn simplify_expression(
     expr: &mut Expression,
     ga: &GlobalAnalysis,
     cache: &mut ConstPropCache,
 ) -> bool {
     match expr {
-        Expression::PropertyReference(nr) => {
-            if nr.is_constant()
-                && !match nr.ty() {
-                    Type::Struct(s) => {
-                        matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo))
-                    }
-                    _ => false,
-                }
-            {
-                // Inline the constant value
-                if let Some(result) = extract_constant_property_reference(nr, ga, cache) {
-                    *expr = result;
-                    return true;
-                }
-            }
-            false
-        }
-        Expression::BinaryExpression { lhs, op, rhs } => {
-            let mut can_inline = simplify_expression(lhs, ga, cache);
-            can_inline &= simplify_expression(rhs, ga, cache);
-
-            let new = match (*op, &mut **lhs, &mut **rhs) {
-                // constant folding
-                ('+', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
-                    Some(Expression::StringLiteral(format_smolstr!("{}{}", a, b)))
-                }
-                ('+', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, _)) => {
-                    Some(Expression::NumberLiteral(*a + *b, *un1))
-                }
-                ('-', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, _)) => {
-                    Some(Expression::NumberLiteral(*a - *b, *un1))
-                }
-                ('*', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
-                    if *un1 == Unit::None || *un2 == Unit::None =>
-                {
-                    let preserved_unit = if *un1 == Unit::None { *un2 } else { *un1 };
-                    Some(Expression::NumberLiteral(*a * *b, preserved_unit))
-                }
-                (
-                    '/',
-                    Expression::NumberLiteral(a, un1),
-                    Expression::NumberLiteral(b, Unit::None),
-                ) => Some(Expression::NumberLiteral(*a / *b, *un1)),
-                ('/', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
-                    if un1 == un2 =>
-                {
-                    Some(Expression::NumberLiteral(*a / *b, Unit::None))
-                }
-                // TODO: fold * and / that produce a unit product
-
-                // arithmetic identities
-                ('+', e, Expression::NumberLiteral(n, _))
-                | ('+', Expression::NumberLiteral(n, _), e)
-                | ('-', e, Expression::NumberLiteral(n, _))
-                    if *n == 0. =>
-                {
-                    Some(std::mem::take(e))
-                }
-                ('*', e, Expression::NumberLiteral(n, Unit::None))
-                | ('*', Expression::NumberLiteral(n, Unit::None), e)
-                | ('/', e, Expression::NumberLiteral(n, Unit::None))
-                    if *n == 1. =>
-                {
-                    Some(std::mem::take(e))
-                }
-
-                // comparisons
-                (
-                    '=' | '!' | '<' | '>' | '≤' | '≥',
-                    Expression::NumberLiteral(a, _),
-                    Expression::NumberLiteral(b, _),
-                ) => Some(Expression::BoolLiteral(match op {
-                    '=' => a == b,
-                    '!' => a != b,
-                    '<' => a < b,
-                    '>' => a > b,
-                    '≤' => a <= b,
-                    _ => a >= b,
-                })),
-                ('=' | '!', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
-                    Some(Expression::BoolLiteral((a == b) == (*op == '=')))
-                }
-                ('=' | '!', Expression::EnumerationValue(a), Expression::EnumerationValue(b)) => {
-                    Some(Expression::BoolLiteral((a == b) == (*op == '=')))
-                }
-                ('=' | '!', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
-                    Some(Expression::BoolLiteral((a == b) == (*op == '=')))
-                }
-                // TODO: more types and more comparison operators
-
-                // boolean logic
-                ('&', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
-                    Some(Expression::BoolLiteral(*a && *b))
-                }
-                ('|', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
-                    Some(Expression::BoolLiteral(*a || *b))
-                }
-                ('&', Expression::BoolLiteral(false), _) => {
-                    can_inline = true;
-                    Some(Expression::BoolLiteral(false))
-                }
-                ('|', Expression::BoolLiteral(true), _) => {
-                    can_inline = true;
-                    Some(Expression::BoolLiteral(true))
-                }
-                ('&', Expression::BoolLiteral(true), e)
-                | ('&', e, Expression::BoolLiteral(true))
-                | ('|', Expression::BoolLiteral(false), e)
-                | ('|', e, Expression::BoolLiteral(false)) => Some(std::mem::take(e)),
-                _ => None,
-            };
-            if let Some(new) = new {
-                *expr = new;
-            }
-            can_inline
-        }
-        Expression::UnaryOp { sub, op } => {
-            let can_inline = simplify_expression(sub, ga, cache);
-            let new = match (*op, &mut **sub) {
-                ('!', Expression::BoolLiteral(b)) => Some(Expression::BoolLiteral(!*b)),
-                ('-', Expression::NumberLiteral(n, u)) => Some(Expression::NumberLiteral(-*n, *u)),
-                ('+', Expression::NumberLiteral(n, u)) => Some(Expression::NumberLiteral(*n, *u)),
-                _ => None,
-            };
-            if let Some(new) = new {
-                *expr = new;
-            }
-            can_inline
-        }
-        Expression::StructFieldAccess { base, name } => {
-            if let Expression::PropertyReference(nr) = &**base
-                && nr.is_constant()
-                && let Some(field_expr) = extract_struct_field_from_constant(nr, name, ga, cache)
-            {
-                *expr = field_expr;
-                return simplify_expression(expr, ga, cache);
-            }
-            let r = simplify_expression(base, ga, cache);
-            if let Expression::Struct { values, .. } = &mut **base
-                && let Some(e) = values.remove(name)
-            {
-                *expr = e;
-                return simplify_expression(expr, ga, cache);
-            }
-            r
-        }
-        Expression::Cast { from, to } => {
-            let can_inline = simplify_expression(from, ga, cache);
-            let new = if from.ty() == *to {
-                Some(std::mem::take(&mut **from))
-            } else {
-                match (&**from, to) {
-                    (Expression::NumberLiteral(x, Unit::None), Type::String) => {
-                        locale_independent_number_to_string(*x).map(Expression::StringLiteral)
-                    }
-                    (Expression::NumberLiteral(x, _), Type::Float32) => {
-                        Some(Expression::NumberLiteral(*x, Unit::None))
-                    }
-                    (Expression::Struct { values, .. }, Type::Struct(ty)) => {
-                        Some(Expression::Struct { ty: ty.clone(), values: values.clone() })
-                    }
-                    _ => None,
-                }
-            };
-            if let Some(new) = new {
-                *expr = new;
-            }
-            can_inline
-        }
-        Expression::MinMax { op, lhs, rhs, ty: _ } => {
-            let can_inline =
-                simplify_expression(lhs, ga, cache) & simplify_expression(rhs, ga, cache);
-            if let (Expression::NumberLiteral(lhs, u), Expression::NumberLiteral(rhs, _)) =
-                (&**lhs, &**rhs)
-            {
-                let v = match op {
-                    MinMaxOp::Min => lhs.min(*rhs),
-                    MinMaxOp::Max => lhs.max(*rhs),
-                };
-                *expr = Expression::NumberLiteral(v, *u);
-            }
-            can_inline
-        }
-        Expression::Condition { condition, true_expr, false_expr } => {
-            let mut can_inline = simplify_expression(condition, ga, cache);
-            can_inline &= match &**condition {
-                Expression::BoolLiteral(true) => {
-                    *expr = *true_expr.clone();
-                    simplify_expression(expr, ga, cache)
-                }
-                Expression::BoolLiteral(false) => {
-                    *expr = *false_expr.clone();
-                    simplify_expression(expr, ga, cache)
-                }
-                _ => {
-                    simplify_expression(true_expr, ga, cache)
-                        & simplify_expression(false_expr, ga, cache)
-                }
-            };
-            can_inline
-        }
+        Expression::PropertyReference(..) => simplify_property_reference(expr, ga, cache),
+        Expression::BinaryExpression { .. } => simplify_binary_expression(expr, ga, cache),
+        Expression::UnaryOp { .. } => simplify_unary_op(expr, ga, cache),
+        Expression::StructFieldAccess { .. } => simplify_struct_field_access(expr, ga, cache),
+        Expression::Cast { .. } => simplify_cast(expr, ga, cache),
+        Expression::MinMax { .. } => simplify_min_max(expr, ga, cache),
+        Expression::Condition { .. } => simplify_condition(expr, ga, cache),
         // disable this simplification for store local variable, as "let" is not an expression in rust
         Expression::CodeBlock(stmts)
             if stmts.len() == 1 && !matches!(stmts[0], Expression::StoreLocalVariable { .. }) =>
         {
-            *expr = stmts[0].clone();
-            simplify_expression(expr, ga, cache)
+            simplify_single_statement_code_block(expr, ga, cache)
         }
-        Expression::FunctionCall { function, arguments, .. } => {
-            let mut args_can_inline = true;
-            for arg in arguments.iter_mut() {
-                args_can_inline &= simplify_expression(arg, ga, cache);
-            }
-            if args_can_inline
-                && let Some(inlined) = try_inline_function(function, arguments, ga, cache)
-            {
-                *expr = inlined;
-                return true;
-            }
-            false
-        }
+        Expression::FunctionCall { .. } => simplify_function_call(expr, ga, cache),
         Expression::ElementReference { .. } => false,
         Expression::LayoutCacheAccess { .. } => false,
         Expression::OrganizeGridLayout { .. } => false,
@@ -283,6 +81,287 @@ fn simplify_expression(
             result
         }
     }
+}
+
+#[inline(never)]
+fn simplify_property_reference(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::PropertyReference(nr) = expr else { unreachable!() };
+    if nr.is_constant()
+        && !match nr.ty() {
+            Type::Struct(s) => {
+                matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo))
+            }
+            _ => false,
+        }
+    {
+        // Inline the constant value
+        if let Some(result) = extract_constant_property_reference(nr, ga, cache) {
+            *expr = result;
+            return true;
+        }
+    }
+    false
+}
+
+#[inline(never)]
+fn simplify_binary_expression(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::BinaryExpression { lhs, op, rhs } = expr else { unreachable!() };
+    let mut can_inline = simplify_expression(lhs, ga, cache);
+    can_inline &= simplify_expression(rhs, ga, cache);
+
+    // The folding lives in a separate function: in unoptimized builds its many
+    // `Expression` temporaries would otherwise be part of this function's stack
+    // frame, which is live during the recursion above.
+    let new = fold_binary_expression(*op, lhs, rhs, &mut can_inline);
+    if let Some(new) = new {
+        *expr = new;
+    }
+    can_inline
+}
+
+#[inline(never)]
+fn fold_binary_expression(
+    op: char,
+    lhs: &mut Expression,
+    rhs: &mut Expression,
+    can_inline: &mut bool,
+) -> Option<Expression> {
+    match (op, lhs, rhs) {
+        // constant folding
+        ('+', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
+            Some(Expression::StringLiteral(format_smolstr!("{}{}", a, b)))
+        }
+        ('+', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, _)) => {
+            Some(Expression::NumberLiteral(*a + *b, *un1))
+        }
+        ('-', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, _)) => {
+            Some(Expression::NumberLiteral(*a - *b, *un1))
+        }
+        ('*', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
+            if *un1 == Unit::None || *un2 == Unit::None =>
+        {
+            let preserved_unit = if *un1 == Unit::None { *un2 } else { *un1 };
+            Some(Expression::NumberLiteral(*a * *b, preserved_unit))
+        }
+        ('/', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, Unit::None)) => {
+            Some(Expression::NumberLiteral(*a / *b, *un1))
+        }
+        ('/', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
+            if un1 == un2 =>
+        {
+            Some(Expression::NumberLiteral(*a / *b, Unit::None))
+        }
+        // TODO: fold * and / that produce a unit product
+
+        // arithmetic identities
+        ('+', e, Expression::NumberLiteral(n, _))
+        | ('+', Expression::NumberLiteral(n, _), e)
+        | ('-', e, Expression::NumberLiteral(n, _))
+            if *n == 0. =>
+        {
+            Some(std::mem::take(e))
+        }
+        ('*', e, Expression::NumberLiteral(n, Unit::None))
+        | ('*', Expression::NumberLiteral(n, Unit::None), e)
+        | ('/', e, Expression::NumberLiteral(n, Unit::None))
+            if *n == 1. =>
+        {
+            Some(std::mem::take(e))
+        }
+
+        // comparisons
+        (
+            '=' | '!' | '<' | '>' | '≤' | '≥',
+            Expression::NumberLiteral(a, _),
+            Expression::NumberLiteral(b, _),
+        ) => Some(Expression::BoolLiteral(match op {
+            '=' => a == b,
+            '!' => a != b,
+            '<' => a < b,
+            '>' => a > b,
+            '≤' => a <= b,
+            _ => a >= b,
+        })),
+        ('=' | '!', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
+            Some(Expression::BoolLiteral((a == b) == (op == '=')))
+        }
+        ('=' | '!', Expression::EnumerationValue(a), Expression::EnumerationValue(b)) => {
+            Some(Expression::BoolLiteral((a == b) == (op == '=')))
+        }
+        ('=' | '!', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
+            Some(Expression::BoolLiteral((a == b) == (op == '=')))
+        }
+        // TODO: more types and more comparison operators
+
+        // boolean logic
+        ('&', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
+            Some(Expression::BoolLiteral(*a && *b))
+        }
+        ('|', Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => {
+            Some(Expression::BoolLiteral(*a || *b))
+        }
+        ('&', Expression::BoolLiteral(false), _) => {
+            *can_inline = true;
+            Some(Expression::BoolLiteral(false))
+        }
+        ('|', Expression::BoolLiteral(true), _) => {
+            *can_inline = true;
+            Some(Expression::BoolLiteral(true))
+        }
+        ('&', Expression::BoolLiteral(true), e)
+        | ('&', e, Expression::BoolLiteral(true))
+        | ('|', Expression::BoolLiteral(false), e)
+        | ('|', e, Expression::BoolLiteral(false)) => Some(std::mem::take(e)),
+        _ => None,
+    }
+}
+
+#[inline(never)]
+fn simplify_unary_op(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::UnaryOp { sub, op } = expr else { unreachable!() };
+    let can_inline = simplify_expression(sub, ga, cache);
+    let new = match (*op, &mut **sub) {
+        ('!', Expression::BoolLiteral(b)) => Some(Expression::BoolLiteral(!*b)),
+        ('-', Expression::NumberLiteral(n, u)) => Some(Expression::NumberLiteral(-*n, *u)),
+        ('+', Expression::NumberLiteral(n, u)) => Some(Expression::NumberLiteral(*n, *u)),
+        _ => None,
+    };
+    if let Some(new) = new {
+        *expr = new;
+    }
+    can_inline
+}
+
+#[inline(never)]
+fn simplify_struct_field_access(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::StructFieldAccess { base, name } = expr else { unreachable!() };
+    if let Expression::PropertyReference(nr) = &**base
+        && nr.is_constant()
+        && let Some(field_expr) = extract_struct_field_from_constant(nr, name, ga, cache)
+    {
+        *expr = field_expr;
+        return simplify_expression(expr, ga, cache);
+    }
+    let r = simplify_expression(base, ga, cache);
+    if let Expression::Struct { values, .. } = &mut **base
+        && let Some(e) = values.remove(name)
+    {
+        *expr = e;
+        return simplify_expression(expr, ga, cache);
+    }
+    r
+}
+
+#[inline(never)]
+fn simplify_cast(expr: &mut Expression, ga: &GlobalAnalysis, cache: &mut ConstPropCache) -> bool {
+    let Expression::Cast { from, to } = expr else { unreachable!() };
+    let can_inline = simplify_expression(from, ga, cache);
+    let new = if from.ty() == *to {
+        Some(std::mem::take(&mut **from))
+    } else {
+        match (&**from, &*to) {
+            (Expression::NumberLiteral(x, Unit::None), Type::String) => {
+                locale_independent_number_to_string(*x).map(Expression::StringLiteral)
+            }
+            (Expression::NumberLiteral(x, _), Type::Float32) => {
+                Some(Expression::NumberLiteral(*x, Unit::None))
+            }
+            (Expression::Struct { values, .. }, Type::Struct(ty)) => {
+                Some(Expression::Struct { ty: ty.clone(), values: values.clone() })
+            }
+            _ => None,
+        }
+    };
+    if let Some(new) = new {
+        *expr = new;
+    }
+    can_inline
+}
+
+#[inline(never)]
+fn simplify_min_max(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::MinMax { op, lhs, rhs, ty: _ } = expr else { unreachable!() };
+    let can_inline = simplify_expression(lhs, ga, cache) & simplify_expression(rhs, ga, cache);
+    if let (Expression::NumberLiteral(lhs, u), Expression::NumberLiteral(rhs, _)) = (&**lhs, &**rhs)
+    {
+        let v = match op {
+            MinMaxOp::Min => lhs.min(*rhs),
+            MinMaxOp::Max => lhs.max(*rhs),
+        };
+        *expr = Expression::NumberLiteral(v, *u);
+    }
+    can_inline
+}
+
+#[inline(never)]
+fn simplify_condition(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::Condition { condition, true_expr, false_expr } = expr else { unreachable!() };
+    let mut can_inline = simplify_expression(condition, ga, cache);
+    can_inline &= match &**condition {
+        Expression::BoolLiteral(true) => {
+            *expr = *true_expr.clone();
+            simplify_expression(expr, ga, cache)
+        }
+        Expression::BoolLiteral(false) => {
+            *expr = *false_expr.clone();
+            simplify_expression(expr, ga, cache)
+        }
+        _ => simplify_expression(true_expr, ga, cache) & simplify_expression(false_expr, ga, cache),
+    };
+    can_inline
+}
+
+#[inline(never)]
+fn simplify_single_statement_code_block(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::CodeBlock(stmts) = expr else { unreachable!() };
+    *expr = stmts[0].clone();
+    simplify_expression(expr, ga, cache)
+}
+
+#[inline(never)]
+fn simplify_function_call(
+    expr: &mut Expression,
+    ga: &GlobalAnalysis,
+    cache: &mut ConstPropCache,
+) -> bool {
+    let Expression::FunctionCall { function, arguments, .. } = expr else { unreachable!() };
+    let mut args_can_inline = true;
+    for arg in arguments.iter_mut() {
+        args_can_inline &= simplify_expression(arg, ga, cache);
+    }
+    if args_can_inline && let Some(inlined) = try_inline_function(function, arguments, ga, cache) {
+        *expr = inlined;
+        return true;
+    }
+    false
 }
 
 /// Will extract the property binding from the given named reference

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -447,146 +447,146 @@ impl Expression {
     }
 
     pub fn from_expression_node(node: syntax_nodes::Expression, ctx: &mut LookupCtx) -> Self {
-        node.children_with_tokens()
-            .find_map(|child| match child {
+        // This function recurses for nested expressions. Dispatch with early returns
+        // instead of a `find_map` closure: in unoptimized builds, every arm of a match
+        // producing a value gets its own stack slot for the resulting `Expression`,
+        // adding up to a frame so large that deeply nested expressions overflow the
+        // stack. A `return` writes directly into the return slot instead.
+        for child in node.children_with_tokens() {
+            match child {
                 NodeOrToken::Node(node) => match node.kind() {
-                    SyntaxKind::Expression => Some(Self::from_expression_node(node.into(), ctx)),
+                    SyntaxKind::Expression => return Self::from_expression_node(node.into(), ctx),
                     SyntaxKind::AtImageUrl => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("@image-url() expressions are", &node);
-                        Some(Self::from_at_image_url_node(node.into(), ctx))
+                        return Self::from_at_image_url_node(node.into(), ctx);
                     }
                     SyntaxKind::AtGradient => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("@gradient expressions are", &node);
-                        Some(Self::from_at_gradient(node.into(), ctx))
+                        return Self::from_at_gradient(node.into(), ctx);
                     }
                     SyntaxKind::AtTr => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("@tr() expressions are", &node);
-                        Some(Self::from_at_tr(node.into(), ctx))
+                        return Self::from_at_tr(node.into(), ctx);
                     }
                     SyntaxKind::AtMarkdown => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("@markdown() expressions are", &node);
-                        Some(Self::from_at_markdown(node.into(), ctx))
+                        return Self::from_at_markdown(node.into(), ctx);
                     }
                     SyntaxKind::AtKeys => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("@keys() expressions are", &node);
-                        Some(Self::from_at_keys_node(node.into(), ctx))
+                        return Self::from_at_keys_node(node.into(), ctx);
                     }
                     SyntaxKind::QualifiedName => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Identifier references are", &node);
-                        Some(Self::from_qualified_name_node(node.clone().into(), ctx))
+                        return Self::from_qualified_name_node(node.clone().into(), ctx);
                     }
                     SyntaxKind::FunctionCallExpression => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Function calls are", &node);
-                        Some(Self::from_function_call_node(node.into(), ctx))
+                        return Self::from_function_call_node(node.into(), ctx);
                     }
                     SyntaxKind::MemberAccess => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Member access expressions are", &node);
-                        Some(Self::from_member_access_node(node.into(), ctx))
+                        return Self::from_member_access_node(node.into(), ctx);
                     }
                     SyntaxKind::IndexExpression => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Index expressions are", &node);
-                        Some(Self::from_index_expression_node(node.into(), ctx))
+                        return Self::from_index_expression_node(node.into(), ctx);
                     }
                     SyntaxKind::SelfAssignment => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Self-assignment expressions are", &node);
-                        Some(Self::from_self_assignment_node(node.into(), ctx))
+                        return Self::from_self_assignment_node(node.into(), ctx);
                     }
                     SyntaxKind::BinaryExpression => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Binary expressions are", &node);
-                        Some(Self::from_binary_expression_node(node.into(), ctx))
+                        return Self::from_binary_expression_node(node.into(), ctx);
                     }
                     SyntaxKind::UnaryOpExpression => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Unary expressions are", &node);
-                        Some(Self::from_unaryop_expression_node(node.into(), ctx))
+                        return Self::from_unaryop_expression_node(node.into(), ctx);
                     }
                     SyntaxKind::ConditionalExpression => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Conditional expressions are", &node);
-                        Some(Self::from_conditional_expression_node(node.into(), ctx))
+                        return Self::from_conditional_expression_node(node.into(), ctx);
                     }
                     SyntaxKind::ObjectLiteral => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Object literal expressions are", &node);
-                        Some(Self::from_object_literal_node(node.into(), ctx))
+                        return Self::from_object_literal_node(node.into(), ctx);
                     }
                     SyntaxKind::Array => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Array expressions are", &node);
-                        Some(Self::from_array_node(node.into(), ctx))
+                        return Self::from_array_node(node.into(), ctx);
                     }
                     SyntaxKind::CodeBlock => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Code blocks are", &node);
-                        Some(Self::from_codeblock_node(node.into(), ctx))
+                        return Self::from_codeblock_node(node.into(), ctx);
                     }
                     SyntaxKind::StringTemplate => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("String interpolation expressions are", &node);
-                        Some(Self::from_string_template_node(node.into(), ctx))
+                        return Self::from_string_template_node(node.into(), ctx);
                     }
-                    _ => None,
+                    _ => {}
                 },
                 NodeOrToken::Token(token) => match token.kind() {
                     SyntaxKind::StringLiteral => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("String literals are", &token);
-                        Some(
-                            crate::literals::unescape_string_reporting(
-                                Some(&token),
-                                ctx.diag,
-                                &token,
-                            )
-                            .map(Self::StringLiteral)
-                            .unwrap_or(Self::Invalid),
+                        return crate::literals::unescape_string_reporting(
+                            Some(&token),
+                            ctx.diag,
+                            &token,
                         )
+                        .map(Self::StringLiteral)
+                        .unwrap_or(Self::Invalid);
                     }
                     SyntaxKind::NumberLiteral => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Number literals are", &token);
-                        Some(
-                            crate::literals::parse_number_literal(token.text().into())
-                                .map(|(value, unit)| {
-                                    let (value, unit) = unit.normalize(value);
-                                    Expression::NumberLiteral(value, unit)
-                                })
-                                .unwrap_or_else(|e| {
-                                    ctx.diag.push_error(e.to_string(), &node);
-                                    Self::Invalid
-                                }),
-                        )
+                        return crate::literals::parse_number_literal(token.text().into())
+                            .map(|(value, unit)| {
+                                let (value, unit) = unit.normalize(value);
+                                Expression::NumberLiteral(value, unit)
+                            })
+                            .unwrap_or_else(|e| {
+                                ctx.diag.push_error(e.to_string(), &node);
+                                Self::Invalid
+                            });
                     }
                     SyntaxKind::ColorLiteral => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Color literals are", &token);
-                        Some(
-                            i_slint_common::color_parsing::parse_color_literal(token.text())
-                                .map(|i| Expression::Cast {
-                                    from: Box::new(Expression::NumberLiteral(i as _, Unit::None)),
-                                    to: Type::Color,
-                                })
-                                .unwrap_or_else(|| {
-                                    ctx.diag.push_error("Invalid color literal".into(), &node);
-                                    Self::Invalid
-                                }),
-                        )
+                        return i_slint_common::color_parsing::parse_color_literal(token.text())
+                            .map(|i| Expression::Cast {
+                                from: Box::new(Expression::NumberLiteral(i as _, Unit::None)),
+                                to: Type::Color,
+                            })
+                            .unwrap_or_else(|| {
+                                ctx.diag.push_error("Invalid color literal".into(), &node);
+                                Self::Invalid
+                            });
                     }
 
-                    _ => None,
+                    _ => {}
                 },
-            })
-            .unwrap_or(Self::Invalid)
+            }
+        }
+        Self::Invalid
     }
 
     fn from_at_image_url_node(node: syntax_nodes::AtImageUrl, ctx: &mut LookupCtx) -> Self {
@@ -1774,7 +1774,13 @@ impl Expression {
             OperatorClass::ArithmeticOp => Self::from_expression_node(rhs_n.clone(), ctx),
         };
 
-        let expected_ty = match op_class {
+        // The conversion target for each operand; `None` keeps the operand as-is.
+        // Convert both operands at a single construction site below: in unoptimized
+        // builds, every `Expression::BinaryExpression { .. }` construction gets its
+        // own stack slots for the operand temporaries, and this function is part of
+        // the recursion over nested expressions, where large stack frames make
+        // deeply nested expressions overflow the stack.
+        let (lhs_target, rhs_target) = match op_class {
             OperatorClass::ComparisonOp => {
                 let ty =
                     Self::common_target_type_for_type_list([lhs.ty(), rhs.ty()].iter().cloned());
@@ -1782,83 +1788,51 @@ impl Expression {
                 {
                     ctx.diag.push_error(format!("Values of type {ty} cannot be compared"), &node);
                 }
-                ty
+                (Some(ty.clone()), Some(ty))
             }
-            OperatorClass::LogicalOp => Type::Bool,
+            OperatorClass::LogicalOp => (Some(Type::Bool), Some(Type::Bool)),
             OperatorClass::ArithmeticOp => {
                 let (lhs_ty, rhs_ty) = (lhs.ty(), rhs.ty());
-                if op == '+' && (lhs_ty == Type::String || rhs_ty == Type::String) {
-                    Type::String
-                } else if op == '+' || op == '-' {
-                    if lhs_ty.default_unit().is_some() {
-                        lhs_ty
-                    } else if rhs_ty.default_unit().is_some() {
-                        rhs_ty
-                    } else if matches!(lhs_ty, Type::UnitProduct(_)) {
-                        lhs_ty
-                    } else if matches!(rhs_ty, Type::UnitProduct(_)) {
-                        rhs_ty
-                    } else {
-                        Type::Float32
-                    }
-                } else if op == '*' || op == '/' {
+                if op == '*' || op == '/' {
                     let has_unit = |ty: &Type| {
                         matches!(ty, Type::UnitProduct(_)) || ty.default_unit().is_some()
                     };
                     match (has_unit(&lhs_ty), has_unit(&rhs_ty)) {
-                        (true, true) => {
-                            return Expression::BinaryExpression {
-                                lhs: Box::new(lhs),
-                                rhs: Box::new(rhs),
-                                op,
-                            };
-                        }
-                        (true, false) => {
-                            return Expression::BinaryExpression {
-                                lhs: Box::new(lhs),
-                                rhs: Box::new(rhs.maybe_convert_to(
-                                    Type::Float32,
-                                    &rhs_n,
-                                    ctx.diag,
-                                    &ctx.symbol_counters,
-                                )),
-                                op,
-                            };
-                        }
-                        (false, true) => {
-                            return Expression::BinaryExpression {
-                                lhs: Box::new(lhs.maybe_convert_to(
-                                    Type::Float32,
-                                    &lhs_n,
-                                    ctx.diag,
-                                    &ctx.symbol_counters,
-                                )),
-                                rhs: Box::new(rhs),
-                                op,
-                            };
-                        }
-                        (false, false) => Type::Float32,
+                        (true, true) => (None, None),
+                        (true, false) => (None, Some(Type::Float32)),
+                        (false, true) => (Some(Type::Float32), None),
+                        (false, false) => (Some(Type::Float32), Some(Type::Float32)),
                     }
+                } else if op == '+' || op == '-' {
+                    let expected_ty =
+                        if op == '+' && (lhs_ty == Type::String || rhs_ty == Type::String) {
+                            Type::String
+                        } else if lhs_ty.default_unit().is_some() {
+                            lhs_ty
+                        } else if rhs_ty.default_unit().is_some() {
+                            rhs_ty
+                        } else if matches!(lhs_ty, Type::UnitProduct(_)) {
+                            lhs_ty
+                        } else if matches!(rhs_ty, Type::UnitProduct(_)) {
+                            rhs_ty
+                        } else {
+                            Type::Float32
+                        };
+                    (Some(expected_ty.clone()), Some(expected_ty))
                 } else {
                     unreachable!()
                 }
             }
         };
-        Expression::BinaryExpression {
-            lhs: Box::new(lhs.maybe_convert_to(
-                expected_ty.clone(),
-                &lhs_n,
-                ctx.diag,
-                &ctx.symbol_counters,
-            )),
-            rhs: Box::new(rhs.maybe_convert_to(
-                expected_ty,
-                &rhs_n,
-                ctx.diag,
-                &ctx.symbol_counters,
-            )),
-            op,
-        }
+        let lhs = match lhs_target {
+            Some(ty) => lhs.maybe_convert_to(ty, &lhs_n, ctx.diag, &ctx.symbol_counters),
+            None => lhs,
+        };
+        let rhs = match rhs_target {
+            Some(ty) => rhs.maybe_convert_to(ty, &rhs_n, ctx.diag, &ctx.symbol_counters),
+            None => rhs,
+        };
+        Expression::BinaryExpression { lhs: Box::new(lhs), rhs: Box::new(rhs), op }
     }
 
     fn from_unaryop_expression_node(

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -269,6 +269,24 @@ fn compile_and_generate(
     source: &str,
     testcase: &test_driver_lib::TestCase,
 ) -> Result<Vec<u8>, std::io::Error> {
+    // Run the compiler in a thread with a reduced stack size to catch excessive
+    // stack usage, which would break compilation in environments with small
+    // default stack sizes.
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .stack_size(512 * 1024)
+            .spawn_scoped(scope, || compile_and_generate_impl(source, testcase))
+            .expect("failed to spawn compiler thread")
+            .join()
+            .expect("compiler thread panicked")
+    })
+}
+
+#[cfg(feature = "build-time")]
+fn compile_and_generate_impl(
+    source: &str,
+    testcase: &test_driver_lib::TestCase,
+) -> Result<Vec<u8>, std::io::Error> {
     use i_slint_compiler::{diagnostics::BuildDiagnostics, *};
 
     let include_paths = test_driver_lib::extract_include_paths(source)


### PR DESCRIPTION
Two fixes to reduce stack usage during compilation (especially debug builds), guarded by running the tests in the CI with a tiny 512KB stack.