### PR TITLE
compiler: unify interface implementation under a single implement … <=> target; statement

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -36,7 +36,7 @@ An interface can be exported with `export interface`.
 ## Implementing an interface
 
 A component declares that it implements an interface with an `implement I <=> self;` statement in its body.
-The component may override property defaults. The component must provide an implementation of the functions listed in the interface, with matching types and signatures.
+The component must provide an implementation of the functions listed in the interface, with matching types and signatures.
 
 An `implement` statement's target must be `self` or the id of a child element (see delegation below), and the statement
 is only allowed directly in a component's root element, not in a nested child element. `root` and `parent` are not valid
@@ -58,7 +58,7 @@ export component MyText {
 }
 ```
 
-A component can combine `implement <=> self` with `inherits`:
+A component can combine `implement` with `inherits`:
 
 ```slint no-test
 component MyText inherits Rectangle {
@@ -67,7 +67,8 @@ component MyText inherits Rectangle {
 }
 ```
 
-A component can implement more than one interface, each with its own `implement <=> self;` statement.
+A component can implement more than one interface, each with its own `implement` statement. Multiple `implement`
+statements exposing properties, callbacks or functions with the same name is an error.
 
 ## Delegating to a child with `implement <=> child`
 
@@ -82,7 +83,6 @@ component Container {
 ```
 
 The named child must satisfy the interface API (directly or through its own delegation) the listed interface.
-If two `implement` statements expose properties with the same name, the first one wins and a diagnostic is emitted for the conflict.
 
 ## Full example
 

--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -81,7 +81,7 @@ component Container {
 }
 ```
 
-The named child must implement (directly or through its own delegation) the listed interface.
+The named child must satisfy the interface API (directly or through its own delegation) the listed interface.
 If two `implement` statements expose properties with the same name, the first one wins and a diagnostic is emitted for the conflict.
 
 ## Full example
@@ -93,7 +93,8 @@ interface Counter {
 }
 
 component CounterButton {
-    implement Counter <=> self;
+    // It is not necessary for CounterButton to `implement Counter <=> self;`
+    // implement Counter <=> self;
 
     preferred-width: 100%;
     preferred-height: 100%;

--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -1,13 +1,13 @@
 ---
 title: Interface
-description: Experimental interface, implements, and uses keywords.
+description: Experimental interface keyword and implement statement.
 ---
 
 An `interface` describes a contract that a component can promise to fulfill.
 It lists the properties, callbacks, and functions that an implementing component must provide.
 This lets you write code that works with any component that implements the interface, without caring about the concrete type.
 
-> **Note**: `interface`, `implements`, and `uses` are experimental and subject to change.
+> **Note**: `interface` and `implement` are experimental and subject to change.
 > Tracking issue: [slint-ui/slint#1870](https://github.com/slint-ui/slint/issues/1870).
 
 ## Declaring an interface
@@ -35,11 +35,13 @@ An interface can be exported with `export interface`.
 
 ## Implementing an interface
 
-A component declares that it implements an interface with the `implements` keyword.
+A component declares that it implements an interface with an `implement I <=> self;` statement in its body.
 The component may override property defaults. The component must provide an implementation of the functions listed in the interface, with matching types and signatures.
 
 ```slint no-test
-export component MyText implements TextInterface {
+export component MyText {
+    implement TextInterface <=> self;
+
     text <=> input.text;
 
     input := TextInput {
@@ -52,30 +54,31 @@ export component MyText implements TextInterface {
 }
 ```
 
-A component can combine `implements` with `inherits`:
+A component can combine `implement <=> self` with `inherits`:
 
 ```slint no-test
-component MyText implements TextInterface inherits Rectangle {
+component MyText inherits Rectangle {
+    implement TextInterface <=> self;
     // ...
 }
 ```
 
-A component can only implement one interface.
+A component can implement more than one interface, each with its own `implement <=> self;` statement.
 
-## Delegating to a child with `uses`
+## Delegating to a child with `implement <=> child`
 
 Sometimes a component does not implement an interface itself but contains a child that does.
-The `uses` keyword exposes the child's interface on the parent, so users of the parent see the same properties, callbacks, and functions as if the parent implemented the interface directly.
+`implement I <=> child-id;` exposes the child's interface on the parent, so users of the parent see the same properties, callbacks, and functions as if the parent implemented the interface directly.
 
 ```slint no-test
-component Container uses { TextInterface from inner } {
+component Container {
+    implement TextInterface <=> inner;
     inner := MyText { }
 }
 ```
 
-`uses` takes a list of `InterfaceName from child-id` entries separated by commas.
-The named child must implement (directly or through its own `uses`) the listed interface.
-If two `uses` entries expose properties with the same name, the first one wins and a diagnostic is emitted for the conflict.
+The named child must implement (directly or through its own delegation) the listed interface.
+If two `implement` statements expose properties with the same name, the first one wins and a diagnostic is emitted for the conflict.
 
 ## Full example
 
@@ -85,7 +88,9 @@ interface Counter {
     callback increment();
 }
 
-component CounterButton implements Counter {
+component CounterButton {
+    implement Counter <=> self;
+
     preferred-width: 100%;
     preferred-height: 100%;
 
@@ -95,7 +100,9 @@ component CounterButton implements Counter {
     }
 }
 
-export component App uses { Counter from button } {
+export component App {
+    implement Counter <=> button;
+
     button := CounterButton { }
     Text { text: "Count: \{button.value}"; }
 }

--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -38,6 +38,10 @@ An interface can be exported with `export interface`.
 A component declares that it implements an interface with an `implement I <=> self;` statement in its body.
 The component may override property defaults. The component must provide an implementation of the functions listed in the interface, with matching types and signatures.
 
+An `implement` statement's target must be `self` or the id of a child element (see delegation below), and the statement
+is only allowed directly in a component's root element, not in a nested child element. `root` and `parent` are not valid
+targets: since `implement` is root-only, `root` and `self` refer to the same element there, so use `self` instead.
+
 ```slint no-test
 export component MyText {
     implement TextInterface <=> self;

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -96,30 +96,7 @@ module.exports = grammar({
         $.block,
       ),
 
-    component_modifier: ($) =>
-      choice(
-        $.uses_clause,
-        $.implements_clause,
-        seq("inherits", field("base_type", $.user_type_identifier)),
-      ),
-
-    uses_clause: ($) =>
-      seq(
-        "uses",
-        "{",
-        commaSep1($.used_interface),
-        optional(","),
-        "}",
-      ),
-
-    used_interface: ($) =>
-      seq(
-        field("interface", $.user_type_identifier),
-        "from",
-        field("source", $.simple_identifier),
-      ),
-
-    implements_clause: ($) => seq("implements", commaSep1($.user_type_identifier)),
+    component_modifier: ($) => seq("inherits", field("base_type", $.user_type_identifier)),
 
     _property_type: ($) => seq("<", field("type", $.type), ">"),
 

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -177,6 +177,15 @@ module.exports = grammar({
         ";",
       ),
 
+    implement_statement: ($) =>
+      seq(
+        "implement",
+        field("interface", $.user_type_identifier),
+        "<=>",
+        field("target", $.simple_identifier),
+        ";",
+      ),
+
     global_block: ($) =>
       seq(
         "{",
@@ -280,6 +289,7 @@ module.exports = grammar({
         $.for_loop,
         $.function_definition,
         $.if_statement,
+        $.implement_statement,
         $.match_statement,
         $.property,
         $.property_assignment,

--- a/editors/zed/languages/slint/highlights.scm
+++ b/editors/zed/languages/slint/highlights.scm
@@ -250,15 +250,11 @@
 (component_modifier
   "inherits" @keyword)
 
-(uses_clause
-  "uses" @keyword)
+(interface_definition
+  "interface" @keyword)
 
-(used_interface
-  "from" @keyword
-  source: (_) @variable)
-
-(implements_clause
-  "implements" @keyword)
+(implement_statement
+  "implement" @keyword)
 
 (enum_definition
   "enum" @keyword)

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -415,3 +415,21 @@ pub async fn load_root_file_with_raw_type_loader(
 
     (path, diagnostics, loader, raw_type_loader)
 }
+
+/// Returns true and emits an error if experimental features should be disabled.
+///
+/// Some experimental features are used internally which is why this function also checks
+/// `TypeRegister::expose_internal_types`.
+fn reject_experimental_feature(
+    diagnostics: &mut diagnostics::BuildDiagnostics,
+    type_register: &typeregister::TypeRegister,
+    feature: &str,
+    source: &dyn diagnostics::Spanned,
+) -> bool {
+    if !diagnostics.enable_experimental && !type_register.expose_internal_types {
+        diagnostics.push_error(format!("'{feature}' is an experimental feature"), source);
+        true
+    } else {
+        false
+    }
+}

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -497,6 +497,23 @@ pub struct Component {
     pub from_library: Cell<bool>,
 }
 
+/// True (and a diagnostic emitted) if the given experimental feature should be rejected: such
+/// features are only permitted when either the compiler's experimental flag is enabled, or the
+/// file is exposing internal types (e.g. the standard widgets library).
+fn reject_experimental_feature(
+    diag: &mut BuildDiagnostics,
+    tr: &TypeRegister,
+    feature: &str,
+    source: &dyn Spanned,
+) -> bool {
+    if !diag.enable_experimental && !tr.expose_internal_types {
+        diag.push_error(format!("'{feature}' is an experimental feature"), source);
+        true
+    } else {
+        false
+    }
+}
+
 impl Component {
     pub fn from_node(
         node: syntax_nodes::Component,
@@ -518,8 +535,7 @@ impl Component {
                         ElementType::Global
                     }
                     Some(t) if t == "interface" => {
-                        if !diag.enable_experimental && !tr.expose_internal_types {
-                            diag.push_error("'interface' is an experimental feature".into(), &node);
+                        if reject_experimental_feature(diag, tr, "interface", &node) {
                             ElementType::Error
                         } else {
                             ElementType::Interface
@@ -545,7 +561,6 @@ impl Component {
                 *qualified_id = format_smolstr!("{}::{}", c.id, qualified_id);
             }
         });
-        interfaces::apply_uses_statement(&c.root_element, node.UsesSpecifier(), tr, diag);
         c
     }
 
@@ -1218,6 +1233,14 @@ impl Element {
             if parent_type == ElementType::Interface {
                 node.Binding().for_each(|n| error_on(&n, "bindings"));
                 node.TwoWayBinding().for_each(|n| error_on(&n, "two-way bindings"));
+
+                node.ImplementStatement().for_each(|stmt| {
+                    diag.push_error("Interfaces cannot implement another interface".into(), &stmt);
+                });
+            } else {
+                node.ImplementStatement().for_each(|stmt| {
+                    diag.push_error("Globals cannot implement an interface".into(), &stmt);
+                });
             }
 
             parent_type
@@ -1393,8 +1416,17 @@ impl Element {
             }
         }
 
-        let implemented_interface = interfaces::get_implemented_interface(&r, &node, tr, diag);
-        interfaces::apply_properties(&mut r, &implemented_interface, diag);
+        let (implemented_interfaces, child_implements) =
+            if matches!(r.base_type, ElementType::Global | ElementType::Interface) {
+                // Already rejected above with a more specific diagnostic.
+                (Vec::new(), Vec::new())
+            } else if r.id == "root" {
+                interfaces::get_implemented_interfaces(&r, &node, tr, diag)
+            } else {
+                interfaces::disallow_implement_in_non_root(&node, tr, diag);
+                (Vec::new(), Vec::new())
+            };
+        interfaces::apply_properties(&mut r, &implemented_interfaces, diag);
 
         for (prop_name, csn, source) in property_bindings {
             match r.bindings.entry(prop_name.clone()) {
@@ -1526,7 +1558,7 @@ impl Element {
             );
         }
 
-        interfaces::apply_callbacks(&mut r, &implemented_interface, diag);
+        interfaces::apply_callbacks(&mut r, &implemented_interfaces, diag);
 
         for func in node.Function() {
             #[cfg(feature = "slint-sc")]
@@ -1979,7 +2011,8 @@ impl Element {
             }
         }
 
-        interfaces::validate_function_implementations(&r.borrow(), &implemented_interface, diag);
+        interfaces::validate_function_implementations(&r.borrow(), &implemented_interfaces, diag);
+        interfaces::apply_child_implement_statements(&r, child_implements, diag);
 
         r
     }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1979,7 +1979,6 @@ impl Element {
             }
         }
 
-        interfaces::apply_default_property_values(&r, &implemented_interface);
         interfaces::validate_function_implementations(&r.borrow(), &implemented_interface, diag);
 
         r

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -16,10 +16,10 @@ use crate::langtype::{
 use crate::langtype::{ElementType, PropertyLookupResult};
 use crate::layout::{LayoutConstraints, Orientation};
 use crate::namedreference::NamedReference;
-use crate::parser;
 use crate::parser::{SyntaxKind, SyntaxNode, syntax_nodes};
 use crate::typeloader::{ImportKind, ImportedTypes, LibraryInfo};
 use crate::typeregister::TypeRegister;
+use crate::{parser, reject_experimental_feature};
 use itertools::Either;
 use smol_str::{SmolStr, ToSmolStr, format_smolstr};
 use std::cell::{Cell, OnceCell, RefCell};
@@ -495,23 +495,6 @@ pub struct Component {
 
     /// True if this component is imported from an external library.
     pub from_library: Cell<bool>,
-}
-
-/// True (and a diagnostic emitted) if the given experimental feature should be rejected: such
-/// features are only permitted when either the compiler's experimental flag is enabled, or the
-/// file is exposing internal types (e.g. the standard widgets library).
-fn reject_experimental_feature(
-    diag: &mut BuildDiagnostics,
-    tr: &TypeRegister,
-    feature: &str,
-    source: &dyn Spanned,
-) -> bool {
-    if !diag.enable_experimental && !tr.expose_internal_types {
-        diag.push_error(format!("'{feature}' is an experimental feature"), source);
-        true
-    } else {
-        false
-    }
 }
 
 impl Component {

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -145,10 +145,6 @@ fn resolve_implement_statement(
     }
 }
 
-/// Filter out conflicting `implement` statements across the combined self+child list, emitting
-/// diagnostics for each conflict. Two statements conflict if they target the same interface, or if
-/// they introduce properties/callbacks/functions with the same name. In that case we keep the first
-/// one and filter out the rest.
 fn filter_conflicting_implement_statements(
     diag: &mut BuildDiagnostics,
     statements: Vec<ImplementedInterface>,
@@ -189,9 +185,6 @@ fn filter_conflicting_implement_statements(
         .collect()
 }
 
-/// Gather the `implement` statements on the element, resolve their interfaces, run the unified
-/// conflict check across self- and child-targeted statements, and partition the survivors. Emits
-/// diagnostics for invalid or conflicting statements.
 pub(super) fn get_implemented_interfaces(
     e: &Element,
     node: &syntax_nodes::Element,
@@ -217,8 +210,6 @@ pub(super) fn get_implemented_interfaces(
     (self_interfaces, child_implements)
 }
 
-/// `implement` statements are only supported on the root element for now. Emits a diagnostic for
-/// each one found on a non-root element.
 pub(super) fn disallow_implement_in_non_root(
     node: &syntax_nodes::Element,
     tr: &TypeRegister,
@@ -483,8 +474,6 @@ pub(super) fn validate_function_implementations(
     }
 }
 
-/// Apply the child-targeted `implement` statements, forwarding each interface's members from the
-/// element onto the named child (today's `uses`). Emits diagnostics for invalid statements.
 pub(super) fn apply_child_implement_statements(
     e: &ElementRc,
     child_implements: Vec<ImplementedInterface>,

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -98,12 +98,15 @@ fn resolve_implement_statement(
     let interface_name = QualifiedTypeName::from_node(qualified_name.clone()).to_smolstr();
     let target_id = parser::identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
 
-    if let Some(message) = match target_id.as_str() {
-        "parent" => Some("Cannot implement an interface on a parent element"),
-        "root" => Some("Cannot implement an interface on the root element; use 'self' instead"),
+    if let Some(target) = match target_id.as_str() {
+        "parent" => Some("a parent element"),
+        "root" => Some("the root element; use 'self' instead"),
         _ => None,
     } {
-        diag.push_error(message.into(), &node.DeclaredIdentifier());
+        diag.push_error(
+            format!("Cannot implement an interface based on {}", target),
+            &node.DeclaredIdentifier(),
+        );
         return None;
     }
 

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -17,7 +17,6 @@ use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
     Component, Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
-    visit_named_references_in_expression,
 };
 use crate::parser;
 use crate::parser::{SyntaxKind, syntax_nodes};
@@ -323,52 +322,6 @@ fn apply_interface_property_declaration(
     }
 
     e.property_declarations.insert(unresolved_prop_name.clone(), prop_decl.clone());
-}
-
-/// Apply default property values defined in the interface to the element.
-pub(super) fn apply_default_property_values(
-    e: &ElementRc,
-    implemented_interface: &Option<ImplementedInterface>,
-) {
-    let Some(ImplementedInterface { interface, .. }) = implemented_interface else {
-        return;
-    };
-
-    let interface_root = interface.clone();
-
-    // Collect the bindings to apply first, to avoid borrow conflicts
-    let bindings_to_apply: Vec<_> = interface
-        .borrow()
-        .property_declarations
-        .iter()
-        .filter(|(_, prop_decl)| {
-            // Only apply default bindings for properties
-            !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
-        })
-        .filter_map(|(property_name, _)| {
-            interface
-                .borrow()
-                .bindings
-                .get(property_name)
-                .map(|binding| (property_name.clone(), binding.clone()))
-        })
-        .filter(|(property_name, _)| {
-            // Only apply the default binding if there isn't already a binding set on the element.
-            // `need_explicit: false` includes two-way bindings from a `uses { ... }` alias on
-            // a base component — overriding those with an interface default would sever the alias.
-            !e.borrow().is_binding_set(property_name, false)
-        })
-        .collect();
-
-    for (property_name, binding) in bindings_to_apply {
-        // Remap NamedReferences from the interface's root element to the implementing element
-        visit_named_references_in_expression(&mut binding.borrow_mut().expression, &mut |nr| {
-            if Rc::ptr_eq(&nr.element(), &interface_root) {
-                *nr = NamedReference::new(e, nr.name().clone());
-            }
-        });
-        e.borrow_mut().bindings.insert(property_name, binding);
-    }
 }
 
 /// Validate that the functions declared in the interface are correctly implemented in the element. Emits diagnostics if not.

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -16,79 +16,12 @@ use crate::expression_tree::{BindingExpression, Callable, Expression};
 use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
-    Component, Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
+    Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
+    reject_experimental_feature,
 };
 use crate::parser;
 use crate::parser::{SyntaxKind, syntax_nodes};
 use crate::typeregister::TypeRegister;
-
-/// A parsed [syntax_nodes::UsesIdentifier].
-#[derive(Clone, Debug)]
-struct UsesStatement {
-    interface_name: QualifiedTypeName,
-    child_id: SmolStr,
-    node: syntax_nodes::UsesIdentifier,
-}
-
-impl UsesStatement {
-    /// Get the node representing the interface name.
-    fn interface_name_node(&self) -> syntax_nodes::QualifiedName {
-        self.node.QualifiedName()
-    }
-
-    /// Get the node representing the child identifier.
-    fn child_id_node(&self) -> syntax_nodes::DeclaredIdentifier {
-        self.node.DeclaredIdentifier()
-    }
-
-    /// Lookup the interface component for this uses statement. Emits an error if the interface could not be found, or
-    /// was not actually an interface.
-    fn lookup_interface(
-        &self,
-        tr: &TypeRegister,
-        diag: &mut BuildDiagnostics,
-    ) -> Result<Rc<Component>, ()> {
-        let interface_name = self.interface_name.to_smolstr();
-        match tr.lookup_element(&interface_name) {
-            Ok(element_type) => match element_type {
-                ElementType::Component(component) => {
-                    if !component.is_interface() {
-                        diag.push_error(
-                            format!("'{}' is not an interface", self.interface_name),
-                            &self.interface_name_node(),
-                        );
-                        return Err(());
-                    }
-
-                    Ok(component)
-                }
-                _ => {
-                    diag.push_error(
-                        format!("'{}' is not an interface", self.interface_name),
-                        &self.interface_name_node(),
-                    );
-                    Err(())
-                }
-            },
-            Err(error) => {
-                diag.push_error(error, &self.interface_name_node());
-                Err(())
-            }
-        }
-    }
-}
-
-impl From<&syntax_nodes::UsesIdentifier> for UsesStatement {
-    fn from(node: &syntax_nodes::UsesIdentifier) -> UsesStatement {
-        UsesStatement {
-            interface_name: QualifiedTypeName::from_node(
-                node.child_node(SyntaxKind::QualifiedName).unwrap().clone().into(),
-            ),
-            child_id: parser::identifier_text(&node.DeclaredIdentifier()).unwrap_or_default(),
-            node: node.clone(),
-        }
-    }
-}
 
 enum InterfaceUseMode {
     Implements,
@@ -123,125 +56,231 @@ fn validate_property_declaration_for_interface(
     }
 }
 
-/// An ImplementsSpecifier and the corresponding interface element.
+/// A resolved `implement` statement, targeting `self`.
 pub(super) struct ImplementedInterface {
-    implements_specifier: syntax_nodes::ImplementsSpecifier,
+    node: syntax_nodes::ImplementStatement,
     interface: ElementRc,
     interface_name: SmolStr,
 }
 
-/// If the element implements a valid interface, return the corresponding ImplementedInterface. Otherwise return None.
-/// Emits diagnostics if the implements specifier is invalid.
-pub(super) fn get_implemented_interface(
+/// A resolved `implement` statement targeting a child element, which forwards the child's API.
+pub(super) struct ChildImplement {
+    node: syntax_nodes::ImplementStatement,
+    interface: ElementRc,
+    interface_name: SmolStr,
+    child_id: SmolStr,
+}
+
+/// An `implement` statement resolved to its interface, before partitioning into self/child targets.
+struct ResolvedImplementStatement {
+    node: syntax_nodes::ImplementStatement,
+    interface: ElementRc,
+    interface_name: SmolStr,
+    target_id: SmolStr,
+}
+
+/// Resolve a single `implement` statement's interface. Emits diagnostics if the interface could not
+/// be found, or was not actually an interface.
+fn resolve_implement_statement(
     e: &Element,
-    node: &syntax_nodes::Element,
+    node: syntax_nodes::ImplementStatement,
     tr: &TypeRegister,
     diag: &mut BuildDiagnostics,
-) -> Option<ImplementedInterface> {
-    let parent: syntax_nodes::Component =
-        node.parent().filter(|p| p.kind() == SyntaxKind::Component)?.into();
-
-    let implements_specifier = parent.ImplementsSpecifier()?;
-
+) -> Option<ResolvedImplementStatement> {
     #[cfg(feature = "slint-sc")]
-    diag.slint_sc_error("'implements' is", &implements_specifier);
+    diag.slint_sc_error("'implement' is", &node);
 
-    if !diag.enable_experimental && !tr.expose_internal_types {
-        diag.push_error("'implements' is an experimental feature".into(), &implements_specifier);
+    if reject_experimental_feature(diag, tr, "implement", &node) {
         return None;
     }
 
-    let interface_name =
-        QualifiedTypeName::from_node(implements_specifier.QualifiedName()).to_smolstr();
+    let qualified_name = node.QualifiedName();
+    let interface_name = QualifiedTypeName::from_node(qualified_name.clone()).to_smolstr();
+    let target_id = parser::identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
 
     match e.base_type.lookup_type_for_child_element(&interface_name, tr) {
         Ok(ElementType::Component(c)) => {
             if !c.is_interface() {
                 diag.push_error(
                     format!("Cannot implement {}. It is not an interface", interface_name),
-                    &implements_specifier.QualifiedName(),
+                    &qualified_name,
                 );
                 return None;
             }
 
             c.used.set(true);
-            Some(ImplementedInterface {
-                implements_specifier,
+            Some(ResolvedImplementStatement {
+                node,
                 interface: c.root_element.clone(),
                 interface_name,
+                target_id,
             })
         }
         Ok(_) => {
-            diag.push_error(
-                format!("Cannot implement {}. It is not an interface", interface_name),
-                &implements_specifier.QualifiedName(),
-            );
+            // `lookup_type_for_child_element` resolves names like `Row` that are only valid
+            // within a specific parent context (e.g. `GridLayout`), since it accounts for the
+            // element's own base type. `tr.lookup_element` ignores that context and, for such
+            // names, fails with a more specific diagnostic instead - reuse it here when it
+            // applies, rather than the generic "not an interface" message.
+            let message = match tr.lookup_element(&interface_name) {
+                Err(context_restricted_message) => context_restricted_message,
+                Ok(_) => format!("Cannot implement {}. It is not an interface", interface_name),
+            };
+            diag.push_error(message, &qualified_name);
             None
         }
         Err(err) => {
-            diag.push_error(err, &implements_specifier.QualifiedName());
+            diag.push_error(err, &qualified_name);
             None
         }
     }
 }
 
-/// Apply the properties declared in the interface to the element, emitting diagnostics if there are any conflicts.
-/// Existing property declarations are permitted, provided they match the declaration from the interface.
-pub(super) fn apply_properties(
-    e: &mut Element,
-    implemented_interface: &Option<ImplementedInterface>,
+/// Filter out conflicting `implement` statements across the combined self+child list, emitting
+/// diagnostics for each conflict. Two statements conflict if they target the same interface, or if
+/// they introduce properties/callbacks/functions with the same name. In that case we keep the first
+/// one and filter out the rest.
+fn filter_conflicting_implement_statements(
+    diag: &mut BuildDiagnostics,
+    statements: Vec<ResolvedImplementStatement>,
+) -> Vec<ResolvedImplementStatement> {
+    let mut seen_interfaces: Vec<ElementRc> = Vec::new();
+    let mut seen_interface_api: BTreeMap<SmolStr, SmolStr> = BTreeMap::new();
+    statements
+        .into_iter()
+        .filter(|stmt| {
+            // Interface identity is the resolved interface's root element, not the syntactic name,
+            // so this also catches the same interface implemented twice under different aliases.
+            if seen_interfaces.iter().any(|seen| Rc::ptr_eq(seen, &stmt.interface)) {
+                diag.push_error(
+                    format!("'{}' is implemented multiple times", stmt.interface_name),
+                    &stmt.node,
+                );
+                return false;
+            }
+            seen_interfaces.push(stmt.interface.clone());
+
+            let mut valid = true;
+            for (prop_name, _) in stmt.interface.borrow().property_declarations.iter() {
+                if let Some(existing_interface) = seen_interface_api.get(prop_name) {
+                    diag.push_error(
+                        format!(
+                            "'{}' occurs in '{}' and '{}'",
+                            prop_name, stmt.interface_name, existing_interface
+                        ),
+                        &stmt.node.QualifiedName(),
+                    );
+                    valid = false;
+                } else {
+                    seen_interface_api.insert(prop_name.clone(), stmt.interface_name.clone());
+                }
+            }
+            valid
+        })
+        .collect()
+}
+
+/// Gather the `implement` statements on the element, resolve their interfaces, run the unified
+/// conflict check across self- and child-targeted statements, and partition the survivors. Emits
+/// diagnostics for invalid or conflicting statements.
+pub(super) fn get_implemented_interfaces(
+    e: &Element,
+    node: &syntax_nodes::Element,
+    tr: &TypeRegister,
+    diag: &mut BuildDiagnostics,
+) -> (Vec<ImplementedInterface>, Vec<ChildImplement>) {
+    let resolved: Vec<ResolvedImplementStatement> = node
+        .ImplementStatement()
+        .filter_map(|stmt| resolve_implement_statement(e, stmt, tr, diag))
+        .collect();
+
+    let filtered = filter_conflicting_implement_statements(diag, resolved);
+
+    let mut self_interfaces = Vec::new();
+    let mut child_implements = Vec::new();
+    for stmt in filtered {
+        if matches!(stmt.target_id.as_str(), "self" | "root") {
+            self_interfaces.push(ImplementedInterface {
+                node: stmt.node,
+                interface: stmt.interface,
+                interface_name: stmt.interface_name,
+            });
+        } else {
+            child_implements.push(ChildImplement {
+                node: stmt.node,
+                interface: stmt.interface,
+                interface_name: stmt.interface_name,
+                child_id: stmt.target_id,
+            });
+        }
+    }
+    (self_interfaces, child_implements)
+}
+
+/// `implement` statements are only supported on the root element for now. Emits a diagnostic for
+/// each one found on a non-root element.
+pub(super) fn disallow_implement_in_non_root(
+    node: &syntax_nodes::Element,
+    tr: &TypeRegister,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
-        implemented_interface
-    else {
-        return;
-    };
-
-    for (unresolved_prop_name, prop_decl) in
-        interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-            // Functions are expected to be implemented manually, so we don't automatically add them.
-            !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
-        })
-    {
-        apply_interface_property_declaration(
-            e,
-            unresolved_prop_name,
-            prop_decl,
-            implements_specifier,
-            interface_name,
-            diag,
-        );
+    for stmt in node.ImplementStatement() {
+        if reject_experimental_feature(diag, tr, "implement", &stmt) {
+            continue;
+        }
+        diag.push_error("'implement' is only allowed in the root element".into(), &stmt);
     }
 }
 
-/// Apply the callbacks declared in the interface to the element, emitting diagnostics if there are any conflicts.
+/// Apply the properties declared in the interfaces to the element, emitting diagnostics if there are any conflicts.
+/// Existing property declarations are permitted, provided they match the declaration from the interface.
+pub(super) fn apply_properties(
+    e: &mut Element,
+    implemented_interfaces: &[ImplementedInterface],
+    diag: &mut BuildDiagnostics,
+) {
+    for ImplementedInterface { interface, node, interface_name } in implemented_interfaces {
+        for (unresolved_prop_name, prop_decl) in
+            interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
+                // Functions are expected to be implemented manually, so we don't automatically add them.
+                !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
+            })
+        {
+            apply_interface_property_declaration(
+                e,
+                unresolved_prop_name,
+                prop_decl,
+                node,
+                interface_name,
+                diag,
+            );
+        }
+    }
+}
+
+/// Apply the callbacks declared in the interfaces to the element, emitting diagnostics if there are any conflicts.
 /// Existing callback declarations are permitted, provided they match the declaration from the interface.
 pub(super) fn apply_callbacks(
     e: &mut Element,
-    implemented_interface: &Option<ImplementedInterface>,
+    implemented_interfaces: &[ImplementedInterface],
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
-        implemented_interface
-    else {
-        return;
-    };
-
-    for (unresolved_prop_name, prop_decl) in
-        interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-            // Functions are expected to be implemented manually, so we don't automatically add them.
-            matches!(prop_decl.property_type, Type::Callback { .. })
-        })
-    {
-        apply_interface_property_declaration(
-            e,
-            unresolved_prop_name,
-            prop_decl,
-            implements_specifier,
-            interface_name,
-            diag,
-        );
+    for ImplementedInterface { interface, node, interface_name } in implemented_interfaces {
+        for (unresolved_prop_name, prop_decl) in
+            interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
+                // Functions are expected to be implemented manually, so we don't automatically add them.
+                matches!(prop_decl.property_type, Type::Callback { .. })
+            })
+        {
+            apply_interface_property_declaration(
+                e,
+                unresolved_prop_name,
+                prop_decl,
+                node,
+                interface_name,
+                diag,
+            );
+        }
     }
 }
 
@@ -251,7 +290,7 @@ fn apply_interface_property_declaration(
     e: &mut Element,
     unresolved_prop_name: &SmolStr,
     prop_decl: &PropertyDeclaration,
-    implements_specifier: &syntax_nodes::ImplementsSpecifier,
+    node: &syntax_nodes::ImplementStatement,
     interface_name: &SmolStr,
     diag: &mut BuildDiagnostics,
 ) {
@@ -299,7 +338,7 @@ fn apply_interface_property_declaration(
             }
             Err(error) => {
                 // Attempt to find a node for the existing property for better diagnostics. If the property is not local
-                // to the component, we fall back to pointing at the implements specifier below.
+                // to the component, we fall back to pointing at the implement statement below.
                 if let Some(local_property_node) = find_conflicting_node(e, unresolved_prop_name) {
                     diag.push_error(
                         format!("Conflict with '{}' which {}", interface_name, error),
@@ -317,7 +356,7 @@ fn apply_interface_property_declaration(
         &e.base_type,
         &interface_name,
     ) {
-        diag.push_error(message, &implements_specifier.QualifiedName());
+        diag.push_error(message, &node.QualifiedName());
         return;
     }
 
@@ -327,163 +366,163 @@ fn apply_interface_property_declaration(
 /// Validate that the functions declared in the interface are correctly implemented in the element. Emits diagnostics if not.
 pub(super) fn validate_function_implementations(
     e: &Element,
-    implemented_interface: &Option<ImplementedInterface>,
+    implemented_interfaces: &[ImplementedInterface],
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
-        implemented_interface
-    else {
-        return;
-    };
+    for ImplementedInterface { interface, node, interface_name } in implemented_interfaces {
+        for (function_name, function_property_decl) in interface
+            .borrow()
+            .property_declarations
+            .iter()
+            .filter(|(_, prop_decl)| matches!(prop_decl.property_type, Type::Function { .. }))
+        {
+            let Type::Function(ref function_declaration) = function_property_decl.property_type
+            else {
+                debug_assert!(false, "Non-functions should have been filtered out already");
+                continue;
+            };
 
-    for (function_name, function_property_decl) in interface
-        .borrow()
-        .property_declarations
-        .iter()
-        .filter(|(_, prop_decl)| matches!(prop_decl.property_type, Type::Function { .. }))
-    {
-        let Type::Function(ref function_declaration) = function_property_decl.property_type else {
-            debug_assert!(false, "Non-functions should have been filtered out already");
-            continue;
-        };
+            let push_interface_error =
+                |diag: &mut BuildDiagnostics, is_local_to_component, error| {
+                    if is_local_to_component {
+                        let source = e
+                            .property_declarations
+                            .get(function_name)
+                            .and_then(|decl| decl.node.clone())
+                            .map_or_else(
+                                || parser::NodeOrToken::Node(node.QualifiedName().into()),
+                                parser::NodeOrToken::Node,
+                            );
+                        diag.push_error(error, &source);
+                    } else {
+                        diag.push_error(error, &node.QualifiedName());
+                    }
+                };
 
-        let push_interface_error = |diag: &mut BuildDiagnostics, is_local_to_component, error| {
-            if is_local_to_component {
-                let source = e
-                    .property_declarations
-                    .get(function_name)
-                    .and_then(|decl| decl.node.clone())
-                    .map_or_else(
-                        || parser::NodeOrToken::Node(implements_specifier.QualifiedName().into()),
-                        parser::NodeOrToken::Node,
+            let found_function = e.lookup_property(function_name);
+            let function_impl = match found_function.property_type {
+                Type::Invalid => {
+                    diag.push_error(
+                        format!("Missing implementation of function '{}'", function_name),
+                        &node.QualifiedName(),
                     );
-                diag.push_error(error, &source);
-            } else {
-                diag.push_error(error, &implements_specifier.QualifiedName());
-            }
-        };
+                    None
+                }
+                Type::Function(function) => Some(function.clone()),
+                _ => {
+                    push_interface_error(
+                        diag,
+                        found_function.is_local_to_component,
+                        format!(
+                            "Cannot override '{}' from interface '{}'",
+                            function_name, interface_name
+                        ),
+                    );
+                    None
+                }
+            };
+            let Some(function_impl) = function_impl else { continue };
 
-        let found_function = e.lookup_property(function_name);
-        let function_impl = match found_function.property_type {
-            Type::Invalid => {
-                diag.push_error(
-                    format!("Missing implementation of function '{}'", function_name),
-                    &implements_specifier.QualifiedName(),
-                );
-                None
+            match (function_property_decl.pure, found_function.declared_pure) {
+                (Some(true), Some(false)) | (Some(true), None) => push_interface_error(
+                    diag,
+                    found_function.is_local_to_component,
+                    format!(
+                        "Implementation of pure function '{}' from interface '{}' cannot be impure",
+                        function_name, interface_name
+                    ),
+                ),
+                _ => {
+                    // If the implementation is pure but the declaration is not, we allow it.
+                }
             }
-            Type::Function(function) => Some(function.clone()),
-            _ => {
+
+            if function_property_decl.visibility != found_function.property_visibility {
                 push_interface_error(
                     diag,
                     found_function.is_local_to_component,
                     format!(
-                        "Cannot override '{}' from interface '{}'",
-                        function_name, interface_name
+                        "Incorrect visibility for implementation of '{}' from interface '{}'. Expected '{}'",
+                        function_name, interface_name, function_property_decl.visibility,
                     ),
                 );
-                None
             }
-        };
-        let Some(function_impl) = function_impl else { continue };
 
-        match (function_property_decl.pure, found_function.declared_pure) {
-            (Some(true), Some(false)) | (Some(true), None) => push_interface_error(
-                diag,
-                found_function.is_local_to_component,
-                format!(
-                    "Implementation of pure function '{}' from interface '{}' cannot be impure",
-                    function_name, interface_name
-                ),
-            ),
-            _ => {
-                // If the implementation is pure but the declaration is not, we allow it.
+            if function_impl.args != function_declaration.args {
+                let display_args = |args: &Vec<Type>| -> SmolStr {
+                    args.iter().map(|t| t.to_string()).join(", ").into()
+                };
+
+                push_interface_error(
+                    diag,
+                    found_function.is_local_to_component,
+                    format!(
+                        "Incorrect arguments for implementation of '{}' from interface '{}'. Expected ({}) but got ({})",
+                        function_name,
+                        interface_name,
+                        display_args(&function_declaration.args),
+                        display_args(&function_impl.args),
+                    ),
+                );
             }
-        }
 
-        if function_property_decl.visibility != found_function.property_visibility {
-            push_interface_error(
-                diag,
-                found_function.is_local_to_component,
-                format!(
-                    "Incorrect visibility for implementation of '{}' from interface '{}'. Expected '{}'",
-                    function_name, interface_name, function_property_decl.visibility,
-                ),
-            );
-        }
-
-        if function_impl.args != function_declaration.args {
-            let display_args = |args: &Vec<Type>| -> SmolStr {
-                args.iter().map(|t| t.to_string()).join(", ").into()
-            };
-
-            push_interface_error(
-                diag,
-                found_function.is_local_to_component,
-                format!(
-                    "Incorrect arguments for implementation of '{}' from interface '{}'. Expected ({}) but got ({})",
-                    function_name,
-                    interface_name,
-                    display_args(&function_declaration.args),
-                    display_args(&function_impl.args),
-                ),
-            );
-        }
-
-        if function_impl.return_type != function_declaration.return_type {
-            push_interface_error(
-                diag,
-                found_function.is_local_to_component,
-                format!(
-                    "Incorrect return type for implementation of '{}' from interface '{}'. Expected '{}' but got '{}'",
-                    function_name,
-                    interface_name,
-                    function_declaration.return_type,
-                    function_impl.return_type,
-                ),
-            );
+            if function_impl.return_type != function_declaration.return_type {
+                push_interface_error(
+                    diag,
+                    found_function.is_local_to_component,
+                    format!(
+                        "Incorrect return type for implementation of '{}' from interface '{}'. Expected '{}' but got '{}'",
+                        function_name,
+                        interface_name,
+                        function_declaration.return_type,
+                        function_impl.return_type,
+                    ),
+                );
+            }
         }
     }
 }
 
-pub(super) fn apply_uses_statement(
+/// Apply the child-targeted `implement` statements, forwarding each interface's members from the
+/// element onto the named child (today's `uses`). Emits diagnostics for invalid statements.
+pub(super) fn apply_child_implement_statements(
     e: &ElementRc,
-    uses_specifier: Option<syntax_nodes::UsesSpecifier>,
-    tr: &TypeRegister,
+    child_implements: Vec<ChildImplement>,
     diag: &mut BuildDiagnostics,
 ) {
-    let Some(uses_specifier) = uses_specifier else {
-        return;
-    };
+    for ChildImplement { node, interface, interface_name, child_id } in child_implements {
+        let Some(child) = find_element_by_id(e, &child_id) else {
+            diag.push_error(format!("'{}' does not exist", child_id), &node.DeclaredIdentifier());
+            continue;
+        };
 
-    #[cfg(feature = "slint-sc")]
-    diag.slint_sc_error("'uses' is", &uses_specifier);
+        if !element_implements_interface(
+            &child,
+            &interface,
+            &child_id,
+            &interface_name,
+            &node,
+            diag,
+        ) {
+            continue;
+        }
 
-    if !diag.enable_experimental && !tr.expose_internal_types {
-        diag.push_error("'uses' is an experimental feature".into(), &uses_specifier);
-        return;
-    }
-
-    let uses_statements = gather_valid_uses_statements(e, tr, diag, uses_specifier);
-    let uses_statements = filter_conflicting_uses_statements(diag, uses_statements);
-
-    for ValidUsesStatement { uses_statement, interface, child } in uses_statements {
         for (name, prop_decl) in interface.borrow().property_declarations.iter() {
             let lookup_result = e.borrow().base_type.lookup_property(name);
             if let Err(message) = validate_property_declaration_for_interface(
                 InterfaceUseMode::Uses,
                 &lookup_result,
                 &e.borrow().base_type,
-                &uses_statement.interface_name,
+                &interface_name,
             ) {
-                diag.push_error(message, &uses_statement.interface_name_node());
+                diag.push_error(message, &node.QualifiedName());
                 continue;
             }
 
             // Replace the node with the interface name for better diagnostics later, since the declaration won't have a
             // node in this element.
             let mut prop_decl = prop_decl.clone();
-            prop_decl.node = Some(uses_statement.interface_name_node().into());
+            prop_decl.node = Some(node.QualifiedName().into());
 
             if let Some(existing_property) =
                 e.borrow_mut().property_declarations.insert(name.clone(), prop_decl.clone())
@@ -494,12 +533,12 @@ pub(super) fn apply_uses_statement(
                     .and_then(|node| node.child_node(SyntaxKind::DeclaredIdentifier))
                     .and_then(|node| node.child_token(SyntaxKind::Identifier))
                     .map_or_else(
-                        || parser::NodeOrToken::Node(uses_statement.child_id_node().into()),
+                        || parser::NodeOrToken::Node(node.DeclaredIdentifier().into()),
                         parser::NodeOrToken::Token,
                     );
 
                 diag.push_error(
-                    format!("Cannot override '{}' from '{}'", name, uses_statement.interface_name),
+                    format!("Cannot override '{}' from '{}'", name, interface_name),
                     &source,
                 );
                 continue;
@@ -521,107 +560,25 @@ pub(super) fn apply_uses_statement(
             if let Some(existing_binding) = existing_binding {
                 let message = format!(
                     "Cannot override binding for '{}' from interface '{}'",
-                    name, uses_statement.interface_name
+                    name, interface_name
                 );
                 if let Some(location) = &existing_binding.borrow().span {
                     diag.push_error(message, location);
                 } else {
-                    diag.push_error(message, &uses_statement.interface_name_node());
+                    diag.push_error(message, &node.QualifiedName());
                 }
             }
         }
     }
-}
-
-/// A valid `uses` statement, containing the looked up interface and child element.
-struct ValidUsesStatement {
-    uses_statement: UsesStatement,
-    interface: ElementRc,
-    child: ElementRc,
-}
-
-/// Gather valid `uses` statements, emitting diagnostics for invalid ones. A valid `uses` statement is one where the
-/// interface can be found, the child element can be found, and the child element implements the interface.
-fn gather_valid_uses_statements(
-    e: &Rc<RefCell<Element>>,
-    tr: &TypeRegister,
-    diag: &mut BuildDiagnostics,
-    uses_specifier: syntax_nodes::UsesSpecifier,
-) -> Vec<ValidUsesStatement> {
-    let mut valid_uses_statements: Vec<ValidUsesStatement> = Vec::new();
-
-    for uses_identifier_node in uses_specifier.UsesIdentifier() {
-        let uses_statement: UsesStatement = (&uses_identifier_node).into();
-        let Ok(interface_component) = uses_statement.lookup_interface(tr, diag) else {
-            continue;
-        };
-
-        let Some(child) = find_element_by_id(e, &uses_statement.child_id) else {
-            diag.push_error(
-                format!("'{}' does not exist", uses_statement.child_id),
-                &uses_statement.child_id_node(),
-            );
-            continue;
-        };
-
-        let interface = interface_component.root_element.clone();
-        if !element_implements_interface(&child, &interface, &uses_statement, diag) {
-            continue;
-        }
-
-        valid_uses_statements.push(ValidUsesStatement { uses_statement, interface, child });
-    }
-    valid_uses_statements
-}
-
-/// Filter out conflicting `uses` statements, emitting diagnostics for each conflict. Two `uses` statements conflict if
-/// they introduce properties/callbacks/functions with the same name. In that case we keep the first one and filter out
-/// the rest.
-fn filter_conflicting_uses_statements(
-    diag: &mut BuildDiagnostics,
-    uses_statements: Vec<ValidUsesStatement>,
-) -> Vec<ValidUsesStatement> {
-    let mut seen_interfaces: Vec<SmolStr> = Vec::new();
-    let mut seen_interface_api: BTreeMap<SmolStr, SmolStr> = BTreeMap::new();
-    let valid_uses_statements: Vec<ValidUsesStatement> = uses_statements
-        .into_iter()
-        .filter(|vus| {
-            let interface_name = vus.uses_statement.interface_name.to_smolstr();
-            if seen_interfaces.contains(&interface_name) {
-                diag.push_error(
-                    format!("'{}' is used multiple times", vus.uses_statement.interface_name),
-                    &vus.uses_statement.interface_name_node(),
-                );
-                return false;
-            }
-            seen_interfaces.push(interface_name.clone());
-
-            let mut valid = true;
-            for prop_name in vus.interface.borrow().property_declarations.keys() {
-                if let Some(existing_interface) = seen_interface_api.get(prop_name) {
-                    diag.push_error(
-                        format!(
-                            "'{}' occurs in '{}' and '{}'",
-                            prop_name, vus.uses_statement.interface_name, existing_interface
-                        ),
-                        &vus.uses_statement.interface_name_node(),
-                    );
-                    valid = false;
-                } else {
-                    seen_interface_api.insert(prop_name.clone(), interface_name.clone());
-                }
-            }
-            valid
-        })
-        .collect();
-    valid_uses_statements
 }
 
 /// Check that the given element implements the given interface. Emits a diagnostic if the interface is not implemented.
 fn element_implements_interface(
     element: &ElementRc,
     interface: &ElementRc,
-    uses_statement: &UsesStatement,
+    child_id: &SmolStr,
+    interface_name: &SmolStr,
+    node: &syntax_nodes::ImplementStatement,
     diag: &mut BuildDiagnostics,
 ) -> bool {
     let mut valid = true;
@@ -631,9 +588,9 @@ fn element_implements_interface(
             diag.push_error(
                 format!(
                     "'{}' does not implement '{}' from '{}' - {}",
-                    uses_statement.child_id, property_name, uses_statement.interface_name, e
+                    child_id, property_name, interface_name, e
                 ),
-                &uses_statement.child_id_node(),
+                &node.DeclaredIdentifier(),
             );
             valid = false;
         }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -17,10 +17,10 @@ use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
     Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
-    reject_experimental_feature,
 };
 use crate::parser;
 use crate::parser::{SyntaxKind, syntax_nodes};
+use crate::reject_experimental_feature;
 use crate::typeregister::TypeRegister;
 
 enum InterfaceUseMode {

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -56,27 +56,27 @@ fn validate_property_declaration_for_interface(
     }
 }
 
-/// A resolved `implement` statement, targeting `self`.
+#[derive(Debug, PartialEq)]
+pub(super) enum ImplementBinding {
+    OnSelf,
+    OnChild(SmolStr),
+}
+
+impl ImplementBinding {
+    fn from_target(target_id: &SmolStr) -> ImplementBinding {
+        if target_id.as_str() == "self" {
+            ImplementBinding::OnSelf
+        } else {
+            ImplementBinding::OnChild(target_id.clone())
+        }
+    }
+}
+
 pub(super) struct ImplementedInterface {
     node: syntax_nodes::ImplementStatement,
     interface: ElementRc,
     interface_name: SmolStr,
-}
-
-/// A resolved `implement` statement targeting a child element, which forwards the child's API.
-pub(super) struct ChildImplement {
-    node: syntax_nodes::ImplementStatement,
-    interface: ElementRc,
-    interface_name: SmolStr,
-    child_id: SmolStr,
-}
-
-/// An `implement` statement resolved to its interface, before partitioning into self/child targets.
-struct ResolvedImplementStatement {
-    node: syntax_nodes::ImplementStatement,
-    interface: ElementRc,
-    interface_name: SmolStr,
-    target_id: SmolStr,
+    binding: ImplementBinding,
 }
 
 /// Resolve a single `implement` statement's interface. Emits diagnostics if the interface could not
@@ -86,7 +86,7 @@ fn resolve_implement_statement(
     node: syntax_nodes::ImplementStatement,
     tr: &TypeRegister,
     diag: &mut BuildDiagnostics,
-) -> Option<ResolvedImplementStatement> {
+) -> Option<ImplementedInterface> {
     #[cfg(feature = "slint-sc")]
     diag.slint_sc_error("'implement' is", &node);
 
@@ -118,11 +118,11 @@ fn resolve_implement_statement(
             }
 
             c.used.set(true);
-            Some(ResolvedImplementStatement {
+            Some(ImplementedInterface {
                 node,
                 interface: c.root_element.clone(),
                 interface_name,
-                target_id,
+                binding: ImplementBinding::from_target(&target_id),
             })
         }
         Ok(_) => {
@@ -151,8 +151,8 @@ fn resolve_implement_statement(
 /// one and filter out the rest.
 fn filter_conflicting_implement_statements(
     diag: &mut BuildDiagnostics,
-    statements: Vec<ResolvedImplementStatement>,
-) -> Vec<ResolvedImplementStatement> {
+    statements: Vec<ImplementedInterface>,
+) -> Vec<ImplementedInterface> {
     let mut seen_interfaces: Vec<ElementRc> = Vec::new();
     let mut seen_interface_api: BTreeMap<SmolStr, SmolStr> = BTreeMap::new();
     statements
@@ -197,8 +197,8 @@ pub(super) fn get_implemented_interfaces(
     node: &syntax_nodes::Element,
     tr: &TypeRegister,
     diag: &mut BuildDiagnostics,
-) -> (Vec<ImplementedInterface>, Vec<ChildImplement>) {
-    let resolved: Vec<ResolvedImplementStatement> = node
+) -> (Vec<ImplementedInterface>, Vec<ImplementedInterface>) {
+    let resolved: Vec<ImplementedInterface> = node
         .ImplementStatement()
         .filter_map(|stmt| resolve_implement_statement(e, stmt, tr, diag))
         .collect();
@@ -208,19 +208,10 @@ pub(super) fn get_implemented_interfaces(
     let mut self_interfaces = Vec::new();
     let mut child_implements = Vec::new();
     for stmt in filtered {
-        if stmt.target_id == "self" {
-            self_interfaces.push(ImplementedInterface {
-                node: stmt.node,
-                interface: stmt.interface,
-                interface_name: stmt.interface_name,
-            });
+        if stmt.binding == ImplementBinding::OnSelf {
+            self_interfaces.push(stmt);
         } else {
-            child_implements.push(ChildImplement {
-                node: stmt.node,
-                interface: stmt.interface,
-                interface_name: stmt.interface_name,
-                child_id: stmt.target_id,
-            });
+            child_implements.push(stmt);
         }
     }
     (self_interfaces, child_implements)
@@ -248,7 +239,7 @@ pub(super) fn apply_properties(
     implemented_interfaces: &[ImplementedInterface],
     diag: &mut BuildDiagnostics,
 ) {
-    for ImplementedInterface { interface, node, interface_name } in implemented_interfaces {
+    for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
         for (unresolved_prop_name, prop_decl) in
             interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
                 // Functions are expected to be implemented manually, so we don't automatically add them.
@@ -274,7 +265,7 @@ pub(super) fn apply_callbacks(
     implemented_interfaces: &[ImplementedInterface],
     diag: &mut BuildDiagnostics,
 ) {
-    for ImplementedInterface { interface, node, interface_name } in implemented_interfaces {
+    for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
         for (unresolved_prop_name, prop_decl) in
             interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
                 // Functions are expected to be implemented manually, so we don't automatically add them.
@@ -378,7 +369,7 @@ pub(super) fn validate_function_implementations(
     implemented_interfaces: &[ImplementedInterface],
     diag: &mut BuildDiagnostics,
 ) {
-    for ImplementedInterface { interface, node, interface_name } in implemented_interfaces {
+    for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
         for (function_name, function_property_decl) in interface
             .borrow()
             .property_declarations
@@ -496,10 +487,14 @@ pub(super) fn validate_function_implementations(
 /// element onto the named child (today's `uses`). Emits diagnostics for invalid statements.
 pub(super) fn apply_child_implement_statements(
     e: &ElementRc,
-    child_implements: Vec<ChildImplement>,
+    child_implements: Vec<ImplementedInterface>,
     diag: &mut BuildDiagnostics,
 ) {
-    for ChildImplement { node, interface, interface_name, child_id } in child_implements {
+    for ImplementedInterface { node, interface, interface_name, binding } in child_implements {
+        debug_assert_ne!(binding, ImplementBinding::OnSelf);
+        let ImplementBinding::OnChild(child_id) = binding else {
+            continue;
+        };
         let Some(child) = find_element_by_id(e, &child_id) else {
             diag.push_error(format!("'{}' does not exist", child_id), &node.DeclaredIdentifier());
             continue;

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -98,6 +98,15 @@ fn resolve_implement_statement(
     let interface_name = QualifiedTypeName::from_node(qualified_name.clone()).to_smolstr();
     let target_id = parser::identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
 
+    if let Some(message) = match target_id.as_str() {
+        "parent" => Some("Cannot implement an interface on a parent element"),
+        "root" => Some("Cannot implement an interface on the root element; use 'self' instead"),
+        _ => None,
+    } {
+        diag.push_error(message.into(), &node.DeclaredIdentifier());
+        return None;
+    }
+
     match e.base_type.lookup_type_for_child_element(&interface_name, tr) {
         Ok(ElementType::Component(c)) => {
             if !c.is_interface() {
@@ -199,7 +208,7 @@ pub(super) fn get_implemented_interfaces(
     let mut self_interfaces = Vec::new();
     let mut child_implements = Vec::new();
     for stmt in filtered {
-        if matches!(stmt.target_id.as_str(), "self" | "root") {
+        if stmt.target_id == "self" {
             self_interfaces.push(ImplementedInterface {
                 node: stmt.node,
                 interface: stmt.interface,

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -354,7 +354,7 @@ declare_syntax! {
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
                      *CallbackDeclaration, *ConditionalElement, *MatchElement, *Function, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
-                     *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder ],
+                     *TwoWayBinding, *States, *Transitions, *ImplementStatement, ?ChildrenPlaceholder ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],
         ConditionalElement -> [ Expression , SubElement],
@@ -386,6 +386,8 @@ declare_syntax! {
         Binding-> [ BindingExpression ],
         /// `xxx <=> something`
         TwoWayBinding -> [ Expression ],
+        /// `implement Interface <=> target;`
+        ImplementStatement -> [ QualifiedName, DeclaredIdentifier ],
         /// the right-hand-side of a binding
         // Fixme: the test should be a or
         BindingExpression-> [ ?CodeBlock, ?Expression ],

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -348,7 +348,7 @@ declare_syntax! {
     {
         Document -> [ *Component, *ExportsList, *ImportSpecifier, *StructDeclaration, *EnumDeclaration ],
         /// `DeclaredIdentifier := Element { ... }`
-        Component -> [ DeclaredIdentifier, ?UsesSpecifier, ?ImplementsSpecifier, Element ],
+        Component -> [ DeclaredIdentifier, Element ],
         /// `id := Element { ... }`
         SubElement -> [ Element ],
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
@@ -476,12 +476,6 @@ declare_syntax! {
         EnumValue -> [],
         /// `@rust-attr(...)`
         AtRustAttr -> [],
-        /// `uses { Foo from Bar, Baz from Qux }`
-        UsesSpecifier -> [ *UsesIdentifier ],
-        /// `Interface.Foo from bar`
-        UsesIdentifier -> [QualifiedName, DeclaredIdentifier],
-        /// `implements Interface.Foo`
-        ImplementsSpecifier -> [ QualifiedName ],
     }
 }
 

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -104,15 +104,6 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
 /// component C { property<int> xx; }
 /// component C inherits D { }
 /// interface I { property<int> xx; }
-/// component E implements I { }
-/// component E implements I inherits D { }
-/// component F uses { I from A } { }
-/// component F uses { I from A } implements J { }
-/// component F uses { I from A } inherits B { }
-/// component F uses { I from A, J from B } { }
-/// component F uses { I from A, J from B } implements J { }
-/// component F uses { I from A, J from B } inherits C { }
-/// component F uses { I from A, J from B } implements J inherits D { }
 /// ```
 pub fn parse_component(p: &mut impl Parser) -> bool {
     let simple_component = p.nth(1).kind() == SyntaxKind::ColonEqual;
@@ -132,33 +123,6 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
     if !p.start_node(SyntaxKind::DeclaredIdentifier).expect(SyntaxKind::Identifier) {
         drop(p.start_node(SyntaxKind::Element));
         return false;
-    }
-    if p.peek().as_str() == "uses" {
-        if !is_new_component {
-            p.error("Only components can have 'uses' clauses");
-            drop(p.start_node(SyntaxKind::Element));
-            return false;
-        }
-
-        if !parse_uses_specifier(&mut *p) {
-            drop(p.start_node(SyntaxKind::Element));
-            return false;
-        }
-    }
-    if p.peek().as_str() == "implements" {
-        if is_global {
-            p.error("Globals cannot implement an interface");
-            drop(p.start_node(SyntaxKind::Element));
-            return false;
-        } else if is_interface {
-            p.error("Interfaces cannot implement another interface");
-            drop(p.start_node(SyntaxKind::Element));
-            return false;
-        }
-        if !parse_implements_specifier(&mut *p) {
-            drop(p.start_node(SyntaxKind::Element));
-            return false;
-        }
     }
     if is_global {
         if p.peek().kind() == SyntaxKind::ColonEqual {
@@ -186,7 +150,7 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
         parse_element_content(&mut *p);
         return p.expect(SyntaxKind::RBrace);
     } else {
-        p.error("Expected '{', keyword 'implements' or keyword 'inherits'");
+        p.error("Expected '{' or keyword 'inherits'");
         drop(p.start_node(SyntaxKind::Element));
         return false;
     }
@@ -405,72 +369,4 @@ fn parse_import_identifier(p: &mut impl Parser) -> bool {
         }
     }
     true
-}
-
-#[cfg_attr(test, parser_test)]
-/// ```test,UsesSpecifier
-/// uses { Interface from child }
-/// uses { Interface from child, }
-/// uses { Interface1 from child1, Interface2 from child2 }
-/// uses { Interface1 from child2, Qualified.Interface from child2 }
-/// uses { Qualified.Interface from child }
-/// uses { Qualified.Interface from child, }
-/// uses { Qualified.Interface from child1, Interface from child2 }
-/// uses { Interface from child1, Qualified.Interface from child2 }
-/// ```
-fn parse_uses_specifier(p: &mut impl Parser) -> bool {
-    debug_assert_eq!(p.peek().as_str(), "uses");
-    let mut p = p.start_node(SyntaxKind::UsesSpecifier);
-    p.expect(SyntaxKind::Identifier); // "uses"
-    if !p.expect(SyntaxKind::LBrace) {
-        return false;
-    }
-    loop {
-        if p.test(SyntaxKind::RBrace) {
-            return true;
-        }
-        if !parse_uses_identifier(&mut *p) {
-            return false;
-        }
-        if !p.test(SyntaxKind::Comma) && p.nth(0).kind() != SyntaxKind::RBrace {
-            p.error("Expected comma or brace");
-            return false;
-        }
-    }
-}
-
-#[cfg_attr(test, parser_test)]
-/// ```test,UsesIdentifier
-/// Interface from child
-/// Fully.Qualified.Interface from child-component
-/// ```
-fn parse_uses_identifier(p: &mut impl Parser) -> bool {
-    let mut p = p.start_node(SyntaxKind::UsesIdentifier);
-
-    if !parse_qualified_name(&mut *p) {
-        drop(p.start_node(SyntaxKind::DeclaredIdentifier));
-        return false;
-    }
-
-    if !(p.nth(0).kind() == SyntaxKind::Identifier && p.peek().as_str() == "from") {
-        p.error("Expected 'from' keyword in uses specifier");
-        drop(p.start_node(SyntaxKind::DeclaredIdentifier));
-        return false;
-    }
-    p.consume();
-
-    let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
-    p.expect(SyntaxKind::Identifier)
-}
-
-#[cfg_attr(test, parser_test)]
-/// ```test,ImplementsSpecifier
-/// implements Foo
-/// implements Foo.Bar
-/// ```
-fn parse_implements_specifier(p: &mut impl Parser) -> bool {
-    debug_assert_eq!(p.peek().as_str(), "implements");
-    let mut p = p.start_node(SyntaxKind::ImplementsSpecifier);
-    p.expect(SyntaxKind::Identifier); // "implements"
-    parse_qualified_name(&mut *p)
 }

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -140,6 +140,9 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 SyntaxKind::LBracket if p.peek().as_str() == "transitions" => {
                     parse_transitions(&mut *p);
                 }
+                SyntaxKind::Identifier if p.peek().as_str() == "implement" => {
+                    parse_implement_statement(&mut *p);
+                }
                 _ => {
                     if p.peek().as_str() == "changed" {
                         // Try to recover some errors
@@ -434,6 +437,27 @@ fn parse_two_way_binding(p: &mut impl Parser) {
     p.consume(); // the identifier
     p.expect(SyntaxKind::DoubleArrow);
     parse_expression(&mut *p);
+    p.expect(SyntaxKind::Semicolon);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,ImplementStatement
+/// implement Foo <=> self;
+/// implement Foo <=> root;
+/// implement Foo <=> parent;
+/// implement Foo <=> inner;
+/// implement Qualified.Foo <=> self;
+/// ```
+fn parse_implement_statement(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "implement");
+    let mut p = p.start_node(SyntaxKind::ImplementStatement);
+    p.expect(SyntaxKind::Identifier); // "implement"
+    parse_qualified_name(&mut *p);
+    p.expect(SyntaxKind::DoubleArrow);
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
     p.expect(SyntaxKind::Semicolon);
 }
 

--- a/internal/compiler/tests/syntax/interfaces/callbacks.slint
+++ b/internal/compiler/tests/syntax/interfaces/callbacks.slint
@@ -5,12 +5,16 @@ interface Inverter {
     pure callback invert(bool) -> bool;
 }
 
-export component InverterDuplicate implements Inverter {
+export component InverterDuplicate {
+    implement Inverter <=> self;
+
     callback invert(bool) -> bool;
 //  >                            <error{Conflict with 'Inverter' which declares a callback with the same name}
 }
 
-export component InverterAliases implements Inverter {
+export component InverterAliases {
+    implement Inverter <=> self;
+
     pure callback invert-alias <=> invert;
 }
 
@@ -24,5 +28,7 @@ interface Clickable {
     callback clicked();
 }
 
-export component MyClicker implements Clickable inherits TouchArea { }
-//                                    >        <error{Cannot implement interface 'Clickable' because 'moved' conflicts with an existing callback in 'TouchArea'}
+export component MyClicker inherits TouchArea {
+    implement Clickable <=> self;
+//            >        <error{Cannot implement interface 'Clickable' because 'moved' conflicts with an existing callback in 'TouchArea'}
+}

--- a/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
+++ b/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
@@ -17,7 +17,9 @@ export component Impl {
     @children
 }
 
-export component ComponentImplementsInterface implements ValidInterface inherits Impl { }
+export component ComponentImplementsInterface inherits Impl {
+    implement ValidInterface <=> self;
+}
 
 export component IncorrectImpl {
     in-out property <float> value;
@@ -29,12 +31,16 @@ export component IncorrectImpl {
     @children
 }
 
-export component DerivedImplementsInterfaceIncorrectly implements ValidInterface inherits IncorrectImpl { }
-//                                                                >             <error{Cannot implement interface 'ValidInterface' because 'value' conflicts with an existing property in 'IncorrectImpl'}
-//                                                                >             <^error{Cannot implement interface 'ValidInterface' because 'speak' conflicts with an existing callback in 'IncorrectImpl'}
-//                                                                >             <^^error{Incorrect arguments for implementation of 'reset' from interface 'ValidInterface'. Expected () but got (float)}
+export component DerivedImplementsInterfaceIncorrectly inherits IncorrectImpl {
+    implement ValidInterface <=> self;
+//            >             <error{Cannot implement interface 'ValidInterface' because 'value' conflicts with an existing property in 'IncorrectImpl'}
+//            >             <^error{Cannot implement interface 'ValidInterface' because 'speak' conflicts with an existing callback in 'IncorrectImpl'}
+//            >             <^^error{Incorrect arguments for implementation of 'reset' from interface 'ValidInterface'. Expected () but got (float)}
+}
 
-export component ComponentDeclaresInterfaceAPI implements ValidInterface {
+export component ComponentDeclaresInterfaceAPI {
+    implement ValidInterface <=> self;
+
     in-out property <int> value: 24;
 //  >                              <error{Conflict with 'ValidInterface' which declares a property with the same name}
     callback speak();
@@ -44,7 +50,9 @@ export component ComponentDeclaresInterfaceAPI implements ValidInterface {
     }
 }
 
-export component ComponentDeclaresInterfaceAPIWithTwoWayBinding implements ValidInterface {
+export component ComponentDeclaresInterfaceAPIWithTwoWayBinding {
+    implement ValidInterface <=> self;
+
     in-out property <int> other: 32;
     in-out property <int> value <=> self.other;
 //  >                                         <error{Conflict with 'ValidInterface' which declares a property with the same name}
@@ -55,7 +63,9 @@ export component ComponentDeclaresInterfaceAPIWithTwoWayBinding implements Valid
     }
 }
 
-export component ComponentDeclaresInterfaceAPIIncorrectly implements ValidInterface {
+export component ComponentDeclaresInterfaceAPIIncorrectly {
+    implement ValidInterface <=> self;
+
     in-out property <float> value;
 //  >                            <error{Conflict with 'ValidInterface' which declares a property with the same name}
     callback speak(string);

--- a/internal/compiler/tests/syntax/interfaces/global_interfaces.slint
+++ b/internal/compiler/tests/syntax/interfaces/global_interfaces.slint
@@ -5,8 +5,7 @@ export interface HelloInterface {
     out property <string> message;
 }
 
-export global GlobalHello implements
-//                        >        <error{Globals cannot implement an interface}
- HelloInterface {
-    message := "Hello from Global";
+export global GlobalHello {
+    implement HelloInterface <=> self;
+//  >                                <error{Globals cannot implement an interface}
 }

--- a/internal/compiler/tests/syntax/interfaces/implement_conflicts.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_conflicts.slint
@@ -1,0 +1,43 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Verifies that the same-interface and member-collision checks are unified across self- and
+// child-targeted `implement` statements, not just checked within each group separately.
+
+interface I {
+    in-out property <bool> value;
+}
+
+interface J {
+    in-out property <bool> value;
+}
+
+component ChildA { }
+
+export component SelfChildSameInterface {
+    implement I <=> self;
+    implement I <=> child;
+//  >                    <error{'I' is implemented multiple times}
+
+    child := ChildA { }
+}
+
+export component SelfSelfSameInterface {
+    implement I <=> self;
+    implement I <=> self;
+//  >                   <error{'I' is implemented multiple times}
+}
+
+export component SelfSelfMemberConflict {
+    implement I <=> self;
+    implement J <=> self;
+//            ><error{'value' occurs in 'J' and 'I'}
+}
+
+export component SelfChildMemberConflict {
+    implement I <=> self;
+    implement J <=> child;
+//            ><error{'value' occurs in 'J' and 'I'}
+
+    child := ChildA { }
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_functions.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_functions.slint
@@ -31,7 +31,9 @@ export interface InvalidFunctionVisibility {
 //  >                                                <error{Function declarations in an interface must be public}
 }
 
-export component CalculatorImpl implements Calculator {
+export component CalculatorImpl {
+    implement Calculator <=> self;
+
     pure public function add(a: int, b: int) -> int {
         return a + b;
     }
@@ -44,11 +46,14 @@ export component CalculatorImpl implements Calculator {
 }
 
 // Using interfaces with functions is valid
-export component MyCalculator uses { Calculator from impl } inherits Rectangle {
+export component MyCalculator inherits Rectangle {
+    implement Calculator <=> impl;
     impl := CalculatorImpl { }
 }
 
-export component OverrideImpl implements Calculator {
+export component OverrideImpl {
+    implement Calculator <=> self;
+
     public function add(a: int, b: int) -> int {
 //  >error{Implementation of pure function 'add' from interface 'Calculator' cannot be impure}
         return a + b;
@@ -70,13 +75,17 @@ export component OverrideBase {
     @children
 }
 
-export component OverrideInherited implements Calculator inherits OverrideBase { }
-//                                            >         <error{Implementation of pure function 'add' from interface 'Calculator' cannot be impure}
-//                                            >         <^error{Cannot override 'format' from interface 'Calculator'}
-//                                            >         <^^error{Cannot override 'reset' from interface 'Calculator'}
+export component OverrideInherited inherits OverrideBase {
+    implement Calculator <=> self;
+//            >         <error{Implementation of pure function 'add' from interface 'Calculator' cannot be impure}
+//            >         <^error{Cannot override 'format' from interface 'Calculator'}
+//            >         <^^error{Cannot override 'reset' from interface 'Calculator'}
+}
 
-export component IncorrectImpl implements Calculator {
-//                                        >         <error{Missing implementation of function 'add'}
+export component IncorrectImpl {
+    implement Calculator <=> self;
+//            >         <error{Missing implementation of function 'add'}
+
     // Missing add() function
     public function format(fmt: string, value: int) {
 //  >error{Incorrect arguments for implementation of 'format' from interface 'Calculator'. Expected (int) but got (string, int)}
@@ -101,8 +110,10 @@ export component IncorrectBase {
     @children
 }
 
-export component IncorrectImplInherited implements Calculator inherits IncorrectBase { }
-//                                                 >         <error{Missing implementation of function 'add'}
-//                                                 >         <^error{Incorrect arguments for implementation of 'format' from interface 'Calculator'. Expected (int) but got (string, int)}
-//                                                 >         <^^error{Incorrect return type for implementation of 'format' from interface 'Calculator'. Expected 'string' but got 'void'}
-//                                                 >         <^^^error{Incorrect visibility for implementation of 'reset' from interface 'Calculator'. Expected 'public'}
+export component IncorrectImplInherited inherits IncorrectBase {
+    implement Calculator <=> self;
+//            >         <error{Missing implementation of function 'add'}
+//            >         <^error{Incorrect arguments for implementation of 'format' from interface 'Calculator'. Expected (int) but got (string, int)}
+//            >         <^^error{Incorrect return type for implementation of 'format' from interface 'Calculator'. Expected 'string' but got 'void'}
+//            >         <^^^error{Incorrect visibility for implementation of 'reset' from interface 'Calculator'. Expected 'public'}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_implements.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_implements.slint
@@ -5,6 +5,7 @@ export interface TestInterface {
     in-out property <bool> test;
 }
 
-export interface ImplementingInterface implements
-//                                     >        <error{Interfaces cannot implement another interface}
- TestInterface { }
+export interface ImplementingInterface {
+    implement TestInterface <=> self;
+//  >                               <error{Interfaces cannot implement another interface}
+ }

--- a/internal/compiler/tests/syntax/interfaces/interface_invalid_property_type.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_invalid_property_type.slint
@@ -19,4 +19,6 @@ export component Impl {
     @children
 }
 
-export component ComponentImplementsInterface implements InvalidPropertyTypeInterface inherits Impl { }
+export component ComponentImplementsInterface inherits Impl {
+    implement InvalidPropertyTypeInterface <=> self;
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_properties.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_properties.slint
@@ -14,7 +14,9 @@ export interface ValidInterfacePropertyDeclarations {
     in_out property <angle> in-out-underscore-property;
 }
 
-export component ComponentWithDuplicateProperty implements ValidInterfacePropertyDeclarations {
+export component ComponentWithDuplicateProperty {
+    implement ValidInterfacePropertyDeclarations <=> self;
+
     out property <string> out-property;
 //  >                                 <error{Conflict with 'ValidInterfacePropertyDeclarations' which declares a property with the same name}
 }
@@ -24,9 +26,11 @@ export interface Background {
     callback clip();
 }
 
-export component MyComponent implements Background inherits Rectangle { }
-//                                      >         <error{Cannot implement interface 'Background' because 'background' conflicts with an existing property in 'Rectangle'}
-//                                      >         <^error{Cannot implement interface 'Background' because 'clip' conflicts with an existing property in 'Rectangle'}
+export component MyComponent inherits Rectangle {
+    implement Background <=> self;
+//            >         <error{Cannot implement interface 'Background' because 'background' conflicts with an existing property in 'Rectangle'}
+//            >         <^error{Cannot implement interface 'Background' because 'clip' conflicts with an existing property in 'Rectangle'}
+}
 
 export interface InterfaceWithDefaultPropertyValues {
     in property <int> in-property: 42;

--- a/internal/compiler/tests/syntax/interfaces/interface_uses1.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_uses1.slint
@@ -1,13 +1,16 @@
 // Copyright © 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-
 interface InterfaceI {
     out property <bool> test;
 }
 
-component Base implements InterfaceI { }
+component Base {
+    implement InterfaceI <=> self;
+}
 
-export component InvalidUses uses { InterfaceI
-} {}
-//^<<error{Expected 'from' keyword in uses specifier}
+export component InvalidUses {
+    implement InterfaceI;
+//                      ^error{Syntax error: expected '<=>'}
+//                      ^^error{Syntax error: expected Identifier}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_uses2.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_uses2.slint
@@ -1,13 +1,16 @@
 // Copyright © 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-
 interface InterfaceI {
     out property <bool> test;
 }
 
-component Base implements InterfaceI { }
+component Base {
+    implement InterfaceI <=> self;
+}
 
-export component AnotherInvalidUses uses { from
-Base } {}
-//>  <<<error{Expected 'from' keyword in uses specifier}
+export component AnotherInvalidUses {
+    implement <=> base;
+//  >       <error{Unknown property implement}
+    base := Base { }
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_uses3.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_uses3.slint
@@ -1,13 +1,15 @@
 // Copyright © 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-
 interface InterfaceI {
     out property <bool> test;
 }
 
-component Base implements InterfaceI { }
+component Base {
+    implement InterfaceI <=> self;
+}
 
-export component InvalidUses uses { InterfaceI from
-, } { }
-//^<<error{Syntax error: expected Identifier}
+export component InvalidUses {
+    implement InterfaceI <=>;
+//                          ^error{Syntax error: expected Identifier}
+}

--- a/internal/compiler/tests/syntax/interfaces/interfaces.slint
+++ b/internal/compiler/tests/syntax/interfaces/interfaces.slint
@@ -9,7 +9,9 @@ interface LineEditInterface {
     in-out property <string> text;
 }
 
-export component LineEditBase implements LineEditInterface {
+export component LineEditBase {
+    implement LineEditInterface <=> self;
+
     text <=> text-input.text;
     color <=> text-input.color;
 //  >   <error{Unknown property color}
@@ -20,35 +22,58 @@ interface Inverter {
     pure callback invert(bool) -> bool;
 }
 
-export component InverterImpl implements Inverter {
+export component InverterImpl {
+    implement Inverter <=> self;
+
     invert(b) => {
         return !b;
     }
 }
 
-export component LineEditBase2 implements LineEditInterface inherits Rectangle { }
+export component LineEditBase2 inherits Rectangle {
+    implement LineEditInterface <=> self;
+}
 
-export component MyLineEdit uses { LineEditInterface from base } {
+export component MyLineEdit {
+    implement LineEditInterface <=> base;
     base := LineEditBase { }
 }
 
-export component Foo implements Bar { }
-//                              >  <error{Unknown element 'Bar'}
+export component Foo {
+    implement Bar <=> self;
+//            >  <error{Unknown element 'Bar'}
+}
 
-export component MyRectangle implements Rectangle { }
-//                                      >        <error{Cannot implement Rectangle. It is not an interface}
+export component MyRectangle {
+    implement Rectangle <=> self;
+//            >        <error{Cannot implement Rectangle. It is not an interface}
+}
 
-export component ImplementsRow implements Row { }
-//                                        >  <error{Row can only be within a GridLayout element}
+export component ImplementsRow {
+    implement Row <=> self;
+//            >  <error{Row can only be within a GridLayout element}
+}
 
-export component LineEdit implements LineEditBase { }
-//                                   >           <error{Cannot implement LineEditBase. It is not an interface}
+export component LineEdit {
+    implement LineEditBase <=> self;
+//            >           <error{Cannot implement LineEditBase. It is not an interface}
+}
 
 global MyGlobal { }
 
-export component MyGlobalG implements MyGlobal { }
-//                                    >       <error{Cannot implement MyGlobal. It is not an interface}
+export component MyGlobalG {
+    implement MyGlobal <=> self;
+//            >       <error{Cannot implement MyGlobal. It is not an interface}
+}
 
 export component LineEditNewSyntax {
     implement LineEdit <=> self;
+//            >       <error{Cannot implement LineEdit. It is not an interface}
+}
+
+export component ImplementInNonRootElement {
+    inner := Rectangle {
+        implement Inverter <=> self;
+//      >                          <error{'implement' is only allowed in the root element}
+    }
 }

--- a/internal/compiler/tests/syntax/interfaces/interfaces.slint
+++ b/internal/compiler/tests/syntax/interfaces/interfaces.slint
@@ -87,3 +87,11 @@ export component ImplementOnRoot {
     implement Inverter <=> root;
 //                         >  <error{Cannot implement an interface on the root element; use 'self' instead}
 }
+
+export component ChildImplicitlyImplements {
+    implement LineEditInterface <=> child;
+
+    child := Rectangle {
+        in-out property <string> text;
+    }
+}

--- a/internal/compiler/tests/syntax/interfaces/interfaces.slint
+++ b/internal/compiler/tests/syntax/interfaces/interfaces.slint
@@ -80,12 +80,12 @@ export component ImplementInNonRootElement {
 
 export component ImplementOnParent {
     implement Inverter <=> parent;
-//                         >    <error{Cannot implement an interface on a parent element}
+//                         >    <error{Cannot implement an interface based on a parent element}
 }
 
 export component ImplementOnRoot {
     implement Inverter <=> root;
-//                         >  <error{Cannot implement an interface on the root element; use 'self' instead}
+//                         >  <error{Cannot implement an interface based on the root element; use 'self' instead}
 }
 
 export component ChildImplicitlyImplements {

--- a/internal/compiler/tests/syntax/interfaces/interfaces.slint
+++ b/internal/compiler/tests/syntax/interfaces/interfaces.slint
@@ -48,3 +48,7 @@ global MyGlobal { }
 
 export component MyGlobalG implements MyGlobal { }
 //                                    >       <error{Cannot implement MyGlobal. It is not an interface}
+
+export component LineEditNewSyntax {
+    implement LineEdit <=> self;
+}

--- a/internal/compiler/tests/syntax/interfaces/interfaces.slint
+++ b/internal/compiler/tests/syntax/interfaces/interfaces.slint
@@ -77,3 +77,13 @@ export component ImplementInNonRootElement {
 //      >                          <error{'implement' is only allowed in the root element}
     }
 }
+
+export component ImplementOnParent {
+    implement Inverter <=> parent;
+//                         >    <error{Cannot implement an interface on a parent element}
+}
+
+export component ImplementOnRoot {
+    implement Inverter <=> root;
+//                         >  <error{Cannot implement an interface on the root element; use 'self' instead}
+}

--- a/internal/compiler/tests/syntax/interfaces/uses_errors.slint
+++ b/internal/compiler/tests/syntax/interfaces/uses_errors.slint
@@ -1,38 +1,47 @@
 // Copyright © 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export component UsesBuiltin uses { Rectangle from base } {
-//                                  >        <error{'Rectangle' is not an interface}
+export component UsesBuiltin {
+    implement Rectangle <=> base;
+//            >        <error{Cannot implement Rectangle. It is not an interface}
     base := Rectangle { }
 }
 
 component ComponentA { }
 
-export component UsesComponent uses { ComponentA from base } {
-//                                    >         <error{'ComponentA' is not an interface}
+export component UsesComponent {
+    implement ComponentA <=> base;
+//            >         <error{Cannot implement ComponentA. It is not an interface}
     base := ComponentA { }
 }
 
-export component UsesMissing uses { MissingInterface from base } {
-//                                  >               <error{Unknown element 'MissingInterface'}
+export component UsesMissing {
+    implement MissingInterface <=> base;
+//            >               <error{Unknown element 'MissingInterface'}
     base := ComponentA { }
 }
 
-export component UsesRow uses { Row from base } {
-//                              >  <error{Row can only be within a GridLayout element}
+export component UsesRow {
+    implement Row <=> base;
+//            >  <error{Row can only be within a GridLayout element}
     base := ComponentA { }
 }
 
-export component UsesRowInGridLayout uses { Row from base } inherits GridLayout {
-//                                          >  <error{Row can only be within a GridLayout element}
+export component UsesRowInGridLayout inherits GridLayout {
+    implement Row <=> base;
+//            >  <error{Row can only be within a GridLayout element}
     base := ComponentA { }
 }
 
-export component MultipleErrors uses { MissingInterface from base, Rectangle from base, ComponentA from base, Row from base } {
-//                                     >               <error{Unknown element 'MissingInterface'}
-//                                                                 >        <^error{'Rectangle' is not an interface}
-//                                                                                      >         <^^error{'ComponentA' is not an interface}
-//                                                                                                            >  <^^^error{Row can only be within a GridLayout element}
+export component MultipleErrors {
+    implement MissingInterface <=> base;
+//            >               <error{Unknown element 'MissingInterface'}
+    implement Rectangle <=> base;
+//            >        <error{Cannot implement Rectangle. It is not an interface}
+    implement ComponentA <=> base;
+//            >         <error{Cannot implement ComponentA. It is not an interface}
+    implement Row <=> base;
+//            >  <error{Row can only be within a GridLayout element}
     base := ComponentA { }
 }
 
@@ -42,13 +51,16 @@ export interface ValidInterface {
     public pure function reset();
 }
 
-export component MissingChild uses { ValidInterface from base} { }
-//                                                       >  <error{'base' does not exist}
+export component MissingChild {
+    implement ValidInterface <=> base;
+//                               >  <error{'base' does not exist}
+}
 
-export component ChildDoesNotImplementInterface1 uses { ValidInterface from base } {
-//                                                                          >  <error{'base' does not implement 'reset' from 'ValidInterface' - not found}
-//                                                                          >  <^error{'base' does not implement 'speak' from 'ValidInterface' - not found}
-//                                                                          >  <^^error{'base' does not implement 'value' from 'ValidInterface' - not found}
+export component ChildDoesNotImplementInterface1 {
+    implement ValidInterface <=> base;
+//                               >  <error{'base' does not implement 'reset' from 'ValidInterface' - not found}
+//                               >  <^error{'base' does not implement 'speak' from 'ValidInterface' - not found}
+//                               >  <^^error{'base' does not implement 'value' from 'ValidInterface' - not found}
     base := ComponentA { }
 }
 
@@ -59,8 +71,9 @@ component IncorrectPropertyVisibility {
     }
 }
 
-export component ChildDoesNotImplementInterfaceProperty1 uses { ValidInterface from impl } {
-//                                                                                  >  <error{'impl' does not implement 'value' from 'ValidInterface' - expected visibility: 'input output'}
+export component ChildDoesNotImplementInterfaceProperty1 {
+    implement ValidInterface <=> impl;
+//                               >  <error{'impl' does not implement 'value' from 'ValidInterface' - expected visibility: 'input output'}
     impl := IncorrectPropertyVisibility { }
 }
 
@@ -71,8 +84,9 @@ component IncorrectPropertyType {
     }
 }
 
-export component ChildDoesNotImplementInterfaceProperty2 uses { ValidInterface from impl } {
-//                                                                                  >  <error{'impl' does not implement 'value' from 'ValidInterface' - expected type: 'int'}
+export component ChildDoesNotImplementInterfaceProperty2 {
+    implement ValidInterface <=> impl;
+//                               >  <error{'impl' does not implement 'value' from 'ValidInterface' - expected type: 'int'}
     impl := IncorrectPropertyType { }
 }
 
@@ -83,8 +97,9 @@ component IncorrectCallbackReturnType {
     }
 }
 
-export component ChildDoesNotImplementInterfaceCallback1 uses { ValidInterface from impl } {
-//                                                                                  >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void'}
+export component ChildDoesNotImplementInterfaceCallback1 {
+    implement ValidInterface <=> impl;
+//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void'}
     impl := IncorrectCallbackReturnType { }
 }
 
@@ -95,8 +110,9 @@ component IncorrectSpeakType {
     }
 }
 
-export component ChildDoesNotImplementInterfaceCallback uses { ValidInterface from impl } {
-//                                                                                 >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void', visibility: 'input output'}
+export component ChildDoesNotImplementInterfaceCallback {
+    implement ValidInterface <=> impl;
+//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void', visibility: 'input output'}
     impl := IncorrectSpeakType { }
 }
 
@@ -110,8 +126,9 @@ export component IncorrectPurity {
     }
 }
 
-export component ChildDoesNotImplementInterface2 uses { FunctionInterface from base } {
-//                                                                             >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected purity declaration: 'true'}
+export component ChildDoesNotImplementInterface2 {
+    implement FunctionInterface <=> base;
+//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected purity declaration: 'true'}
     base := IncorrectPurity { }
 }
 
@@ -121,8 +138,9 @@ export component IncorrectArgTypes {
     }
 }
 
-export component ChildDoesNotImplementInterface3 uses { FunctionInterface from base } {
-//                                                                             >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
+export component ChildDoesNotImplementInterface3 {
+    implement FunctionInterface <=> base;
+//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
     base := IncorrectArgTypes { }
 }
 
@@ -132,8 +150,9 @@ export component IncorrectArgNames {
     }
 }
 
-export component ChildDoesNotImplementInterface4 uses { FunctionInterface from base } {
-//                                                                             >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
+export component ChildDoesNotImplementInterface4 {
+    implement FunctionInterface <=> base;
+//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
     base := IncorrectArgNames { }
 }
 
@@ -142,17 +161,21 @@ export component IncorrectReturnType {
     }
 }
 
-export component ChildDoesNotImplementInterface5 uses { FunctionInterface from base } {
-//                                                                             >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
+export component ChildDoesNotImplementInterface5 {
+    implement FunctionInterface <=> base;
+//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
     base := IncorrectReturnType { }
 }
 
-component ValidBase implements ValidInterface {
+component ValidBase {
+    implement ValidInterface <=> self;
+
     public pure function reset() {
     }
 }
 
-export component ConflictingNames uses { ValidInterface from base } {
+export component ConflictingNames {
+    implement ValidInterface <=> base;
     base := ValidBase { }
 
     in-out property <int> value;
@@ -174,10 +197,11 @@ component BaseWithConflicts {
     @children
 }
 
-export component DuplicatePropertyOnBase uses { ValidInterface from base } inherits BaseWithConflicts {
-//                                              >             <error{Cannot use interface 'ValidInterface' because 'reset' conflicts with an existing function in 'BaseWithConflicts'}
-//                                              >             <^error{Cannot use interface 'ValidInterface' because 'speak' conflicts with an existing callback in 'BaseWithConflicts'}
-//                                              >             <^^error{Cannot use interface 'ValidInterface' because 'value' conflicts with an existing property in 'BaseWithConflicts'}
+export component DuplicatePropertyOnBase inherits BaseWithConflicts {
+    implement ValidInterface <=> base;
+//            >             <error{Cannot use interface 'ValidInterface' because 'reset' conflicts with an existing function in 'BaseWithConflicts'}
+//            >             <^error{Cannot use interface 'ValidInterface' because 'speak' conflicts with an existing callback in 'BaseWithConflicts'}
+//            >             <^^error{Cannot use interface 'ValidInterface' because 'value' conflicts with an existing property in 'BaseWithConflicts'}
     base := ValidBase { }
 }
 
@@ -187,7 +211,9 @@ interface InterfaceA {
     pure public function test-function();
 }
 
-component AImpl implements InterfaceA {
+component AImpl {
+    implement InterfaceA <=> self;
+
     pure public function test-function() {
     }
 }
@@ -198,23 +224,31 @@ interface InterfaceB {
     pure public function test-function(i: int) -> int;
 }
 
-component BImpl implements InterfaceB {
+component BImpl {
+    implement InterfaceB <=> self;
+
     pure public function test-function(i: int) -> int {
         return i;
     }
 }
 
-export component ConflictingUses uses { InterfaceA from a, InterfaceB from b } {
-//                                                         >         <error{'test' occurs in 'InterfaceB' and 'InterfaceA'}
-//                                                         >         <^error{'test-callback' occurs in 'InterfaceB' and 'InterfaceA'}
-//                                                         >         <^^error{'test-function' occurs in 'InterfaceB' and 'InterfaceA'}
+export component ConflictingUses {
+    implement InterfaceA <=> a;
+    implement InterfaceB <=> b;
+//            >         <error{'test' occurs in 'InterfaceB' and 'InterfaceA'}
+//            >         <^error{'test-callback' occurs in 'InterfaceB' and 'InterfaceA'}
+//            >         <^^error{'test-function' occurs in 'InterfaceB' and 'InterfaceA'}
+
     a := AImpl { }
 
     b := BImpl { }
 }
 
-export component DuplicateUses uses { InterfaceA from a, InterfaceA from b } {
-//                                                       >         <error{'InterfaceA' is used multiple times}
+export component DuplicateUses {
+    implement InterfaceA <=> a;
+    implement InterfaceA <=> b;
+//  >                         <error{'InterfaceA' is implemented multiple times}
+
     a := AImpl { }
 
     b := AImpl { }

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -3,7 +3,9 @@
 
 import { LineEditInterface } from "std-widget-interfaces.slint";
 
-export component LineEditBase implements LineEditInterface inherits Rectangle {
+export component LineEditBase inherits Rectangle {
+    implement LineEditInterface <=> self;
+
     font-size <=> text-input.font-size;
     font-family <=> text-input.font-family;
     font-italic <=> text-input.font-italic;

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -6,7 +6,8 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 
 import { LineEditInterface } from "../common/std-widget-interfaces.slint";
 
-export component LineEdit uses { LineEditInterface from base } {
+export component LineEdit {
+    implement LineEditInterface <=> base;
 
     accessible-role: text-input;
     accessible-enabled: root.enabled;

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -7,7 +7,8 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 
 import { LineEditInterface } from "../common/std-widget-interfaces.slint";
 
-export component LineEdit uses { LineEditInterface from base } {
+export component LineEdit {
+    implement LineEditInterface <=> base;
 
     accessible-role: text-input;
     accessible-enabled: root.enabled;

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -6,7 +6,8 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 
 import { LineEditInterface } from "../common/std-widget-interfaces.slint";
 
-export component LineEdit uses { LineEditInterface from base } {
+export component LineEdit {
+    implement LineEditInterface <=> base;
 
     accessible-role: text-input;
     accessible-enabled: root.enabled;

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -7,7 +7,8 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 import { LineEditInterface } from "../common/std-widget-interfaces.slint";
 
 // Single line text input field with Material Design Outline TextField look and feel.
-export component LineEdit uses { LineEditInterface from base } {
+export component LineEdit {
+    implement LineEditInterface <=> base;
 
     accessible-role: text-input;
     accessible-enabled: root.enabled;

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -5,7 +5,8 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 
 import { LineEditInterface } from "../common/std-widget-interfaces.slint";
 
-export component LineEdit uses { LineEditInterface from inner } {
+export component LineEdit {
+    implement LineEditInterface <=> inner;
 
     accessible-role: text-input;
     accessible-enabled: root.enabled;

--- a/tests/cases/imports/external_interfaces.slint
+++ b/tests/cases/imports/external_interfaces.slint
@@ -7,12 +7,13 @@
 //include_path: ../../helper_components
 import { ExportedInterface } from "export_interfaces.slint";
 
-component Base
- implements ExportedInterface {
+component Base {
+    implement ExportedInterface <=> self;
     value: 2.71;
 }
 
-export component TestCase uses { ExportedInterface from base } {
+export component TestCase {
+    implement ExportedInterface <=> base;
     base := Base {}
 
     out property <bool> test: self.value == 2.71;

--- a/tests/cases/imports/external_interfaces_as.slint
+++ b/tests/cases/imports/external_interfaces_as.slint
@@ -10,8 +10,8 @@ import {
     ExportedInterface as Interface,
 } from "export_interfaces.slint";
 
-export component TestCase
- uses { Interface from base } {
+export component TestCase {
+    implement Interface <=> base;
     base := Base {}
 
     out property <bool> test: self.value == 2.71;

--- a/tests/cases/imports/property_bindings.slint
+++ b/tests/cases/imports/property_bindings.slint
@@ -13,12 +13,14 @@ import { ComboBoxInterface } from "export_interfaces.slint";
 // the binding expression point to elements that don't exist in the element tree of the components
 // in this file.
 
-component ComboBoxBase implements ComboBoxInterface {
+component ComboBoxBase {
+    implement ComboBoxInterface <=> self;
     current-value: root.model[root.current-index];
     model: ["Kiwi", "Mango"];
 }
 
-export component TestCase uses { ComboBoxInterface from base } {
+export component TestCase {
+    implement ComboBoxInterface <=> base;
     out property <bool> test: self.current-value == "Apples";
 
     base := ComboBoxBase {

--- a/tests/cases/interfaces/callbacks.slint
+++ b/tests/cases/interfaces/callbacks.slint
@@ -12,7 +12,9 @@ interface Speaker {
     pure callback speak() -> string;
 }
 
-component SpeakerImpl implements Speaker {
+component SpeakerImpl {
+    implement Speaker <=> self;
+
     property <string> message;
 
     add-message(text) => {
@@ -28,7 +30,10 @@ component SpeakerImpl implements Speaker {
     }
 }
 
-export component TestCase uses { Speaker from speaker } implements TestInterface {
+export component TestCase {
+    implement Speaker <=> speaker;
+    implement TestInterface <=> self;
+
     invert(b) => {
         return !b;
     }

--- a/tests/cases/interfaces/child_implicitly_implements.slint
+++ b/tests/cases/interfaces/child_implicitly_implements.slint
@@ -1,0 +1,68 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface Interface {
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    in property <float> confidence;
+
+    public pure function length(text: string) -> int;
+    callback checked();
+}
+
+component Base {
+    in-out property <string> text: "Hello";
+    out property <bool> enabled: true;
+    in property <int> precision;
+    in property <float> confidence: 0.5;
+
+    public pure function length(text: string) -> int {
+        text.character-count
+    }
+    callback checked();
+}
+
+export component TestCase {
+    implement Interface <=> child;
+
+    child := Base {
+        // Base does not explicitly implement Interface, but satisfies the API.
+        precision: 3;
+    }
+
+    // We expect to be using the child values for the properties
+    out property <bool> test: self.text == "Hello" && self.enabled && self.precision == 3 && self.confidence == 0.5;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_text(), "Hello");
+assert_eq!(instance.get_enabled(), true);
+assert_eq!(instance.get_precision(), 3);
+assert_eq!(instance.get_confidence(), 0.5);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+// TODO: Interface properties aren't part of the public API
+// assert_eq(instance.get_text(), "");
+// assert_eq(instance.get_enabled(), false);
+// assert_eq(instance.get_precision(), 0);
+// assert_eq(instance.get_confidence(), 0.5);
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+// TODO: Interface properties aren't part of the public API
+// assert.equal(instance.text, "");
+// assert.equal(instance.enabled, false);
+// assert.equal(instance.precision, 0);
+// assert.equal(instance.confidence, 0.5);
+assert(instance.test);
+```
+*/

--- a/tests/cases/interfaces/component_overrides_defaults.slint
+++ b/tests/cases/interfaces/component_overrides_defaults.slint
@@ -11,7 +11,8 @@ interface InterfaceWithDefaults {
     callback checked();
 }
 
-export component TestCase implements InterfaceWithDefaults {
+export component TestCase {
+    implement InterfaceWithDefaults <=> self;
 
     out property <bool> test: self.text == "" && !self.enabled && self.precision == 0 && self.confidence == 0.5;
 

--- a/tests/cases/interfaces/derived_implements_defaults.slint
+++ b/tests/cases/interfaces/derived_implements_defaults.slint
@@ -11,7 +11,8 @@ interface InterfaceWithDefaults {
     callback checked();
 }
 
-component Base implements InterfaceWithDefaults {
+component Base {
+    implement InterfaceWithDefaults <=> self;
 
     // Base provides its own default value
     confidence: 0.5;

--- a/tests/cases/interfaces/derived_implicitly_implements.slint
+++ b/tests/cases/interfaces/derived_implicitly_implements.slint
@@ -29,7 +29,8 @@ component Base {
     @children
 }
 
-export component TestCase implements InterfaceWithDefaults inherits Base {
+export component TestCase inherits Base {
+    implement InterfaceWithDefaults <=> self;
 
     // Explicitly override the InterfaceWithDefaults default for precision
     precision: 3;

--- a/tests/cases/interfaces/implements.slint
+++ b/tests/cases/interfaces/implements.slint
@@ -7,7 +7,9 @@ interface TextInterface {
     public pure function length(text: string) -> int;
 }
 
-export component TestCase implements TextInterface {
+export component TestCase {
+    implement TextInterface <=> self;
+
     text <=> text-input.text;
 
     text-input := TextInput {

--- a/tests/cases/interfaces/implements_defaults.slint
+++ b/tests/cases/interfaces/implements_defaults.slint
@@ -11,7 +11,8 @@ interface InterfaceWithDefaults {
     callback checked();
 }
 
-export component TestCase implements InterfaceWithDefaults {
+export component TestCase {
+    implement InterfaceWithDefaults <=> self;
 
     confidence: 0.5;
 

--- a/tests/cases/interfaces/implements_inherits.slint
+++ b/tests/cases/interfaces/implements_inherits.slint
@@ -5,7 +5,9 @@ interface TestInterface {
     in-out property <bool> test;
 }
 
-export component TestCase implements TestInterface inherits Rectangle {
+export component TestCase inherits Rectangle {
+    implement TestInterface <=> self;
+
     test: true;
     background: Colors.lightblue;
 }

--- a/tests/cases/interfaces/implements_inherits_aliased_property.slint
+++ b/tests/cases/interfaces/implements_inherits_aliased_property.slint
@@ -1,8 +1,8 @@
 // Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// When a component `implements` an interface whose property has a default
-// value AND inherits a base that exposes the same property via a `uses { ... }`
+// When a component implements an interface (`implement I <=> self;`) whose property has a
+// default value AND inherits a base that exposes the same property via an `implement I <=> child;`
 // alias, the interface's default value must not override the alias.
 //
 // `sink.value` defaults to `true`, so if the alias is intact, `value` reads
@@ -13,17 +13,21 @@ interface I {
     in-out property <bool> value;
 }
 
-component Sink implements I {
+component Sink {
+    implement I <=> self;
     value: true;
 }
 
-component Base uses { I from sink } {
+component Base {
+    implement I <=> sink;
     sink := Sink { }
 
     @children
 }
 
-component Derived implements I inherits Base { }
+component Derived inherits Base {
+    implement I <=> self;
+}
 
 export component TestCase {
     out property <bool> test: derived.value;

--- a/tests/cases/interfaces/uses.slint
+++ b/tests/cases/interfaces/uses.slint
@@ -6,18 +6,22 @@ interface TestInterface {
     pure public function double(i: int) -> int;
 }
 
-component TestBase implements TestInterface {
+component TestBase {
+    implement TestInterface <=> self;
+
     test: true;
     pure public function double(i: int) -> int {
         return i * 2;
     }
 }
 
-component TestA uses { TestInterface from base } {
+component TestA {
+    implement TestInterface <=> base;
     base := TestBase { }
 }
 
-component TestB uses { TestInterface from base } {
+component TestB {
+    implement TestInterface <=> base;
     base := TestBase { }
 }
 

--- a/tests/helper_components/export_interfaces.slint
+++ b/tests/helper_components/export_interfaces.slint
@@ -5,7 +5,8 @@ export interface ExportedInterface {
     in-out property <float> value;
 }
 
-export component ExportedBase implements ExportedInterface {
+export component ExportedBase {
+    implement ExportedInterface <=> self;
     value: 2.71;
 }
 

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -604,6 +604,8 @@ pub struct ComponentInformation {
     pub is_std_widget: bool,
     /// This type was exported
     pub is_exported: bool,
+    /// This type is an interface
+    pub is_interface: bool,
     /// This is a primitive element that reacts to events in some way
     pub is_interactive: bool,
     /// This is a layout

--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -48,6 +48,7 @@ fn builtin_component_info(name: &str) -> ComponentInformation {
         is_layout,
         is_interactive,
         is_exported: true,
+        is_interface: false,
         defined_at: None,
         default_properties,
     }
@@ -81,6 +82,7 @@ fn std_widgets_info(name: &str, is_global: bool) -> ComponentInformation {
         is_layout,
         is_interactive: false,
         is_exported: true,
+        is_interface: false,
         defined_at: None,
         default_properties,
     }
@@ -89,6 +91,7 @@ fn std_widgets_info(name: &str, is_global: bool) -> ComponentInformation {
 fn exported_project_component_info(
     name: &str,
     is_global: bool,
+    is_interface: bool,
     position: Position,
 ) -> ComponentInformation {
     ComponentInformation {
@@ -100,6 +103,7 @@ fn exported_project_component_info(
         is_layout: false,
         is_interactive: false,
         is_exported: true,
+        is_interface,
         defined_at: Some(position),
         default_properties: Vec::new(),
     }
@@ -110,6 +114,7 @@ fn file_local_component_info(
     name: &str,
     position: Position,
     is_global: bool,
+    is_interface: bool,
 ) -> ComponentInformation {
     ComponentInformation {
         name: name.to_string(),
@@ -120,6 +125,7 @@ fn file_local_component_info(
         is_layout: false,
         is_interactive: false,
         is_exported: false,
+        is_interface,
         defined_at: Some(position),
         default_properties: Vec::new(),
     }
@@ -196,6 +202,7 @@ pub fn all_exported_components(
                 Some(exported_project_component_info(
                     exported_name.as_str(),
                     c.is_global(),
+                    c.is_interface(),
                     Position { url: url.clone(), offset },
                 ))
             } else {
@@ -296,6 +303,7 @@ pub fn file_local_components(
                 &component.id,
                 Position { url: url.clone(), offset },
                 component.is_global(),
+                component.is_interface(),
             ));
         }
     }

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -104,6 +104,9 @@ fn format_node(
         SyntaxKind::TwoWayBinding => {
             return format_two_way_binding(node, writer, state);
         }
+        SyntaxKind::ImplementStatement => {
+            return format_implement_statement(node, writer, state);
+        }
         SyntaxKind::CallbackConnection => {
             return format_callback_connection(node, writer, state);
         }
@@ -618,6 +621,26 @@ fn format_two_way_binding(
     }
     let _ok = whitespace_to(&mut sub, SyntaxKind::DoubleArrow, writer, state, " ")?
         && whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, " ")?;
+    if node.child_token(SyntaxKind::Semicolon).is_some() {
+        whitespace_to(&mut sub, SyntaxKind::Semicolon, writer, state, "")?;
+        state.new_line();
+    }
+    for s in sub {
+        fold(s, writer, state)?;
+    }
+    Ok(())
+}
+
+fn format_implement_statement(
+    node: &SyntaxNode,
+    writer: &mut impl TokenWriter,
+    state: &mut FormatState,
+) -> Result<(), std::io::Error> {
+    let mut sub = node.children_with_tokens();
+    whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?; // "implement"
+    let _ok = whitespace_to(&mut sub, SyntaxKind::QualifiedName, writer, state, " ")?
+        && whitespace_to(&mut sub, SyntaxKind::DoubleArrow, writer, state, " ")?
+        && whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, " ")?;
     if node.child_token(SyntaxKind::Semicolon).is_some() {
         whitespace_to(&mut sub, SyntaxKind::Semicolon, writer, state, "")?;
         state.new_line();
@@ -3424,6 +3447,17 @@ export component MainWindow2 inherits Rectangle {
     property <int> xx <=> ff.mm;
     callback doo <=> moo;
     property e-e <=> f-f;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn implement_statement() {
+        assert_formatting(
+            "export component Foobar{implement   Foo<=>self ;}",
+            r#"export component Foobar {
+    implement Foo <=> self;
 }
 "#,
         );

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -206,12 +206,6 @@ fn format_node(
         SyntaxKind::ImportSpecifier => {
             return format_import_specifier(node, writer, state);
         }
-        SyntaxKind::UsesSpecifier => {
-            return format_uses_specifier(node, writer, state);
-        }
-        SyntaxKind::ImplementsSpecifier => {
-            return format_implements_specifier(node, writer, state);
-        }
         _ => (),
     }
 
@@ -420,7 +414,7 @@ fn format_component(
             && whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, " ")?;
         let r = whitespace_to_one_of(
             &mut sub,
-            &[SyntaxKind::Identifier, SyntaxKind::UsesSpecifier, SyntaxKind::Element],
+            &[SyntaxKind::Identifier, SyntaxKind::Element],
             writer,
             state,
             " ",
@@ -2266,71 +2260,6 @@ fn format_import_identifier(
             }
             _ => {
                 state.skip_all_whitespace = true;
-                fold(n, writer, state)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Formats a uses specifier.
-///
-/// Ensures that the QualifiedName and `from` Identifier are separated by a space.
-fn format_uses_specifier(
-    node: &SyntaxNode,
-    writer: &mut impl TokenWriter,
-    state: &mut FormatState,
-) -> Result<(), std::io::Error> {
-    let sub = node.children_with_tokens();
-    for n in sub {
-        match n.kind() {
-            SyntaxKind::Whitespace => {
-                fold(n, writer, state)?;
-            }
-            SyntaxKind::LBrace => {
-                fold(n, writer, state)?;
-            }
-            SyntaxKind::UsesIdentifier => {
-                if let Some(uses_node) = n.as_node() {
-                    state.skip_all_whitespace = true;
-                    for child in uses_node.children_with_tokens() {
-                        match child.kind() {
-                            SyntaxKind::Identifier => {
-                                state.whitespace_to_add = Some(" ".into());
-                                fold(child, writer, state)?;
-                            }
-                            _ => {
-                                fold(child, writer, state)?;
-                            }
-                        }
-                    }
-                }
-            }
-            SyntaxKind::RBrace => {
-                fold(n, writer, state)?;
-            }
-            _ => {
-                state.skip_all_whitespace = true;
-                fold(n, writer, state)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-fn format_implements_specifier(
-    node: &SyntaxNode,
-    writer: &mut impl TokenWriter,
-    state: &mut FormatState,
-) -> Result<(), std::io::Error> {
-    let sub = node.children_with_tokens();
-    for n in sub {
-        match n.kind() {
-            SyntaxKind::Identifier | SyntaxKind::QualifiedName => {
-                fold(n, writer, state)?;
-                state.insert_whitespace(" ");
-            }
-            _ => {
                 fold(n, writer, state)?;
             }
         }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -80,6 +80,8 @@ pub(crate) fn completion_at(
         .and_then(|caps| caps.snippet_support)
         .unwrap_or(false);
 
+    let enable_experimental = document_cache.compiler_configuration().enable_experimental;
+
     if token.kind() == SyntaxKind::StringLiteral {
         if matches!(node.kind(), SyntaxKind::ImportSpecifier | SyntaxKind::AtImageUrl) {
             return complete_path_in_string(
@@ -108,10 +110,17 @@ pub(crate) fn completion_at(
 
         let with_snippets = snippet_support && !is_followed_by_brace(&token);
         return resolve_element_scope(element, document_cache, with_snippets).map(|mut r| {
-            let is_global = node
-                .parent()
+            let parent = node.parent();
+            let is_global = parent
+                .as_ref()
                 .and_then(|n| n.child_text(SyntaxKind::Identifier))
                 .is_some_and(|k| k == "global");
+            let is_interface = parent
+                .as_ref()
+                .and_then(|n| n.child_text(SyntaxKind::Identifier))
+                .is_some_and(|k| k == "interface");
+            let is_root_element =
+                parent.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Component);
 
             // add keywords
             r.extend(
@@ -160,6 +169,17 @@ pub(crate) fn completion_at(
                 );
             }
 
+            if is_root_element && !is_global && !is_interface && enable_experimental {
+                r.push(
+                    CompletionItem::new_simple("implement".to_string(), String::new())
+                        .with_kind(CompletionItemKind::KEYWORD)
+                        .with_insert_text(
+                            "implement ${1:Interface} <=> ${2:self};",
+                            snippet_support,
+                        ),
+                );
+            }
+
             if !is_global && snippet_support {
                 add_components_to_import(&token, document_cache, &mut r);
             }
@@ -193,6 +213,16 @@ pub(crate) fn completion_at(
         return with_lookup_ctx(document_cache, node, Some(offset), |ctx| {
             resolve_expression_scope(ctx, document_cache, snippet_support)
         })?;
+    } else if let Some(implement_statement) = syntax_nodes::ImplementStatement::new(node.clone()) {
+        if !enable_experimental {
+            return None;
+        }
+        if let Some(double_arrow) = implement_statement.child_token(SyntaxKind::DoubleArrow)
+            && offset >= double_arrow.text_range().end()
+        {
+            return resolve_implement_target_scope(node);
+        }
+        return None;
     } else if let Some(n) = syntax_nodes::CallbackConnection::new(node.clone()) {
         if token.kind() == SyntaxKind::Whitespace || token.kind() == SyntaxKind::FatArrow {
             let ident = n.child_token(SyntaxKind::Identifier)?;
@@ -274,7 +304,7 @@ pub(crate) fn completion_at(
                     .into_iter()
                     .filter_map(|(k, t)| {
                         match t {
-                            ElementType::Component(c) if !c.is_global() => (),
+                            ElementType::Component(c) if !c.is_global() && !c.is_interface() => (),
                             ElementType::Builtin(b) if !b.is_internal && !b.is_global => (),
                             _ => return None,
                         };
@@ -291,6 +321,17 @@ pub(crate) fn completion_at(
                 }
 
                 return Some(result);
+            }
+            SyntaxKind::ImplementStatement => {
+                if !enable_experimental {
+                    return None;
+                }
+                return resolve_implement_interface_name_scope(
+                    &q,
+                    &token,
+                    document_cache,
+                    snippet_support,
+                );
             }
             SyntaxKind::Type => {
                 return resolve_type_scope(token, document_cache);
@@ -431,6 +472,12 @@ pub(crate) fn completion_at(
         let parent = node.parent()?;
         if parent.kind() == SyntaxKind::PropertyChangedCallback {
             return properties_for_changed_callbacks(parent, document_cache);
+        }
+        if parent.kind() == SyntaxKind::ImplementStatement {
+            if !enable_experimental {
+                return None;
+            }
+            return resolve_implement_target_scope(node);
         }
     } else if node.kind() == SyntaxKind::PropertyChangedCallback
         && offset > node.child_token(SyntaxKind::Identifier)?.text_range().end()
@@ -701,7 +748,7 @@ fn resolve_element_scope(
         if accepts_children {
             result.extend(tr.all_elements().into_iter().filter_map(|(k, t)| {
                 match t {
-                    ElementType::Component(c) if !c.is_global() => (),
+                    ElementType::Component(c) if !c.is_global() && !c.is_interface() => (),
                     ElementType::Builtin(b) if !b.is_internal && !b.is_global => (),
                     _ => return None,
                 };
@@ -1002,6 +1049,104 @@ fn complete_path_in_string(
     )
 }
 
+fn resolve_implement_interface_name_scope(
+    node: &SyntaxNode,
+    token: &SyntaxToken,
+    document_cache: &common::DocumentCache,
+    snippet_support: bool,
+) -> Option<Vec<CompletionItem>> {
+    let global_type_register = document_cache.global_type_registry();
+    let type_register = node
+        .source_file()
+        .and_then(|source_file| document_cache.get_document_for_source_file(source_file))
+        .map(|document| &document.local_registry)
+        .unwrap_or(&global_type_register);
+
+    let mut result = type_register
+        .all_elements()
+        .into_iter()
+        .filter_map(|(key, element_type)| {
+            matches!(&element_type, ElementType::Component(component) if component.is_interface())
+                .then(|| {
+                    let mut completion =
+                        CompletionItem::new_simple(key.to_string(), "interface".into());
+                    completion.kind = Some(CompletionItemKind::INTERFACE);
+                    completion
+                })
+        })
+        .collect::<Vec<_>>();
+
+    drop(global_type_register);
+
+    if snippet_support {
+        add_interfaces_to_import(token, document_cache, &mut result);
+    }
+
+    Some(result)
+}
+
+fn resolve_implement_target_scope(node: SyntaxNode) -> Option<Vec<CompletionItem>> {
+    let root_element_node = {
+        let mut candidate = node;
+        loop {
+            if candidate.kind() == SyntaxKind::Element {
+                break candidate;
+            }
+            candidate = candidate.parent()?;
+        }
+    };
+    let root_element = syntax_nodes::Element::new(root_element_node)?;
+
+    let mut result = vec![
+        CompletionItem::new_simple("self".into(), String::new())
+            .with_kind(CompletionItemKind::KEYWORD),
+    ];
+    collect_child_ids(&root_element, &mut result);
+    Some(result)
+}
+
+fn collect_child_ids(element: &syntax_nodes::Element, result: &mut Vec<CompletionItem>) {
+    for sub_element in element.SubElement() {
+        if let Some(id) = sub_element.child_token(SyntaxKind::Identifier) {
+            result.push(
+                CompletionItem::new_simple(id.text().to_string(), "element".into())
+                    .with_kind(CompletionItemKind::CLASS),
+            );
+        }
+        collect_child_ids(&sub_element.Element(), result);
+    }
+}
+
+fn add_interfaces_to_import(
+    token: &SyntaxToken,
+    document_cache: &common::DocumentCache,
+    result: &mut Vec<CompletionItem>,
+) {
+    let available_types: HashSet<_> =
+        result.iter().map(|completion| completion.label.clone()).collect();
+    build_component_import_statements_edits(
+        token,
+        document_cache,
+        &mut |component: &common::ComponentInformation| {
+            component.is_interface
+                && component.is_exported
+                && !available_types.contains(&component.name)
+        },
+        &mut |exported_name, file, the_import| {
+            result.push(CompletionItem {
+                label: format!("{exported_name} (import from \"{file}\")"),
+                insert_text: Some(exported_name.to_string()),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                filter_text: Some(exported_name.to_string()),
+                kind: Some(CompletionItemKind::INTERFACE),
+                detail: Some(format!("(import from \"{file}\")")),
+                additional_text_edits: Some(vec![the_import]),
+                ..Default::default()
+            });
+        },
+    );
+}
+
 /// Add the components that are available when adding import to the `result`
 ///
 /// `available_types`  are the component which are already available and need no
@@ -1017,6 +1162,7 @@ fn add_components_to_import(
         document_cache,
         &mut |component: &common::ComponentInformation| {
             !component.is_global
+                && !component.is_interface
                 && component.is_exported
                 && !available_types.contains(&component.name)
         },
@@ -1334,10 +1480,22 @@ mod tests {
 
     /// Given a source text containing the unicode emoji `🔺`, the emoji will be removed and then an autocompletion request will be done as if the cursor was there
     fn get_completions(file: &str) -> Option<Vec<CompletionItem>> {
+        get_completions_impl(file, false)
+    }
+
+    fn get_completions_experimental(file: &str) -> Option<Vec<CompletionItem>> {
+        get_completions_impl(file, true)
+    }
+
+    fn get_completions_impl(file: &str, enable_experimental: bool) -> Option<Vec<CompletionItem>> {
         const CURSOR_EMOJI: char = '🔺';
         let offset = (file.find(CURSOR_EMOJI).unwrap() as u32).into();
         let source = file.replace(CURSOR_EMOJI, "");
-        let (mut dc, uri, _) = crate::language::test::loaded_document_cache(source);
+        let (mut dc, uri, _) = if enable_experimental {
+            crate::language::test::loaded_document_cache_with_experimental(source)
+        } else {
+            crate::language::test::loaded_document_cache(source)
+        };
 
         let doc = dc.get_document(&uri).unwrap();
         let token = crate::language::token_at_offset(doc.node.as_ref().unwrap(), offset)?;
@@ -2374,6 +2532,39 @@ mod tests {
         main_file_name: &str,
         main_file_with_cursor: &str,
     ) -> Option<Vec<CompletionItem>> {
+        get_completions_multi_file_with(
+            crate::language::test::empty_document_cache(),
+            types_file_name,
+            types_content,
+            main_file_name,
+            main_file_with_cursor,
+        )
+    }
+
+    /// Same as [`get_completions_multi_file`], but with experimental features enabled — needed
+    /// to exercise `interface` declarations and `implement` statements.
+    fn get_completions_multi_file_experimental(
+        types_file_name: &str,
+        types_content: &str,
+        main_file_name: &str,
+        main_file_with_cursor: &str,
+    ) -> Option<Vec<CompletionItem>> {
+        get_completions_multi_file_with(
+            crate::language::test::empty_document_cache_with_experimental(),
+            types_file_name,
+            types_content,
+            main_file_name,
+            main_file_with_cursor,
+        )
+    }
+
+    fn get_completions_multi_file_with(
+        mut dc: common::DocumentCache,
+        types_file_name: &str,
+        types_content: &str,
+        main_file_name: &str,
+        main_file_with_cursor: &str,
+    ) -> Option<Vec<CompletionItem>> {
         use i_slint_compiler::diagnostics::BuildDiagnostics;
         use lsp_types::Url;
 
@@ -2381,7 +2572,6 @@ mod tests {
         let main_content = main_file_with_cursor.replace(CURSOR_EMOJI, "");
         let cursor_offset = (main_file_with_cursor.find(CURSOR_EMOJI).unwrap() as u32).into();
 
-        let mut dc = crate::language::test::empty_document_cache();
         spin_on::spin_on(dc.preload_builtins());
         let mut diagnostics = BuildDiagnostics::default();
 
@@ -2477,5 +2667,233 @@ export component TestWindow inherits Window {
             !results.iter().any(|ci| ci.label == "MyPoint (import from \"types.slint\")"),
             "unexpected import-suggestion for already-imported type"
         );
+    }
+
+    #[test]
+    fn implement_keyword_in_root_element() {
+        let sources = ["component Foo { 🔺 }", "export component Foo { 🔺 }"];
+        for source in sources {
+            let completions = get_completions_experimental(source).unwrap();
+            completions
+                .iter()
+                .find(|completion| completion.label == "implement")
+                .unwrap_or_else(|| panic!("no 'implement' completion for {source:?}"));
+        }
+    }
+
+    #[test]
+    fn implement_keyword_in_global_or_interface_or_none_root_element() {
+        let sources =
+            ["global Foo { 🔺 }", "interface Foo { 🔺 }", "component Foo { Rectangle { 🔺 } }"];
+        for source in sources {
+            let Some(completions) = get_completions_experimental(source) else { continue };
+            assert!(
+                !completions.iter().any(|completion| completion.label == "implement"),
+                "completion for {source:?} contains 'implement'"
+            );
+        }
+    }
+
+    #[test]
+    fn implement_interface_name() {
+        let source = r#"
+            interface MyInterface { property <int> x; }
+            component NotAnInterface { }
+            component Foo {
+                implement M🔺
+            }
+        "#;
+        let results = get_completions_experimental(source).unwrap();
+        let completion =
+            results.iter().find(|completion| completion.label == "MyInterface").unwrap();
+        assert_eq!(completion.kind, Some(CompletionItemKind::INTERFACE));
+        assert!(!results.iter().any(|completion| completion.label == "NotAnInterface"));
+    }
+
+    #[test]
+    fn implement_interface_name_suggests_import() {
+        let types_content = r#"export interface MyInterface { property <int> x; }
+"#;
+        let main_content = r#"component Foo {
+    implement M🔺
+}
+"#;
+        let results = get_completions_multi_file_experimental(
+            "types.slint",
+            types_content,
+            "main.slint",
+            main_content,
+        )
+        .unwrap();
+
+        assert_completion_found(
+            &CompletionItem {
+                label: "MyInterface (import from \"types.slint\")".into(),
+                insert_text: Some("MyInterface".into()),
+                filter_text: Some("MyInterface".into()),
+                additional_text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                    new_text: "import { MyInterface } from \"types.slint\";\n".into(),
+                }]),
+                ..Default::default()
+            },
+            &results,
+        );
+    }
+
+    #[test]
+    fn implement_interface_name_no_import_suggestion_when_already_imported() {
+        let types_content = r#"export interface MyInterface { property <int> x; }
+"#;
+        let main_content = r#"import { MyInterface } from "types.slint";
+component Foo {
+    implement MyI🔺
+}
+"#;
+        let results = get_completions_multi_file_experimental(
+            "types.slint",
+            types_content,
+            "main.slint",
+            main_content,
+        )
+        .unwrap();
+
+        assert_completion_found(
+            &CompletionItem { label: "MyInterface".into(), ..Default::default() },
+            &results,
+        );
+        assert!(
+            !results.iter().any(|ci| ci.label == "MyInterface (import from \"types.slint\")"),
+            "unexpected import-suggestion for already-imported interface"
+        );
+    }
+
+    #[test]
+    fn implement_target() {
+        let sources = [
+            r#"
+                interface MyInterface { property <int> x; }
+                component Foo {
+                    bar := Rectangle {}
+                    for i in [1, 2, 3]: repeated-child := Rectangle { }
+                    if true: conditional-child := Rectangle { inner-child := Text {} }
+                    implement MyInterface <=> 🔺
+                }
+            "#,
+            r#"
+                interface MyInterface { property <int> x; }
+                component Foo {
+                    bar := Rectangle {}
+                    for i in [1, 2, 3]: repeated-child := Rectangle { }
+                    if true: conditional-child := Rectangle { inner-child := Text {} }
+                    implement MyInterface <=> 🔺;
+                }
+            "#,
+            r#"
+                interface MyInterface { property <int> x; }
+                component Foo {
+                    bar := Rectangle {}
+                    for i in [1, 2, 3]: repeated-child := Rectangle { }
+                    if true: conditional-child := Rectangle { inner-child := Text {} }
+                    implement MyInterface <=> b🔺
+                }
+            "#,
+            r#"
+                interface MyInterface { property <int> x; }
+                component Foo {
+                    bar := Rectangle {}
+                    for i in [1, 2, 3]: repeated-child := Rectangle { }
+                    if true: conditional-child := Rectangle { inner-child := Text {} }
+                    implement MyInterface <=> b🔺;
+                }
+            "#,
+            r#"
+                interface MyInterface { property <int> x; }
+                component Foo {
+                    implement MyInterface <=> 🔺;
+                    bar := Rectangle {}
+                    for i in [1, 2, 3]: repeated-child := Rectangle { }
+                    if true: conditional-child := Rectangle { inner-child := Text {} }
+                }
+            "#,
+            r#"
+                interface MyInterface { property <int> x; }
+                component Foo {
+                    implement MyInterface <=> b🔺;
+                    bar := Rectangle {}
+                    for i in [1, 2, 3]: repeated-child := Rectangle { }
+                    if true: conditional-child := Rectangle { inner-child := Text {} }
+                }
+            "#,
+        ];
+        for source in sources {
+            let results = get_completions_experimental(source).unwrap();
+            results.iter().find(|completion| completion.label == "self").unwrap();
+            results.iter().find(|completion| completion.label == "bar").unwrap();
+            assert!(!results.iter().any(|completion| completion.label == "repeated-child"));
+            assert!(!results.iter().any(|completion| completion.label == "conditional-child"));
+            assert!(!results.iter().any(|completion| completion.label == "inner-child"));
+        }
+    }
+
+    #[test]
+    fn implement_interface_name_does_not_repeat() {
+        // Interface name fully typed but the double-arrow not typed yet: the trailing whitespace
+        // is owned by `ImplementStatement` directly (the `DeclaredIdentifier` node for the
+        // target hasn't started yet), but re-suggesting interface names here would be wrong —
+        // the name is already complete, so there's nothing sensible to complete before `<=>`.
+        let source = r#"
+            interface MyInterface { property <int> x; }
+            component Foo {
+                implement MyInterface 🔺;
+            }
+        "#;
+        assert!(get_completions_experimental(source).is_none());
+    }
+
+    #[test]
+    fn implement_completions_require_experimental() {
+        let results: Vec<CompletionItem> = get_completions("component Foo { 🔺 }").unwrap();
+        assert!(!results.iter().any(|completion| completion.label == "implement"));
+        assert!(get_completions("component Foo { implement M🔺 }").is_none());
+
+        let results = get_completions("component Foo { implement 🔺; }").unwrap();
+        assert!(!results.iter().any(|completion| completion.label == "implement"));
+
+        assert!(
+            get_completions("component Foo { bar := Rectangle {} implement Foo <=> b🔺; }")
+                .is_none()
+        );
+        assert!(
+            get_completions("component Foo { bar := Rectangle {} implement Foo <=> 🔺; }")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn implement_unterminated_input() {
+        for source in [
+            // Nothing typed after the double-arrow, cut off at EOF, no `;`, no closing braces.
+            "component Foo { bar := Rectangle {} implement MyInterface <=> 🔺",
+            // Same, but with the component/element properly closed.
+            "component Foo { bar := Rectangle {} implement MyInterface <=> 🔺 }",
+            // Partial target typed, cut off at EOF.
+            "component Foo { bar := Rectangle {} implement MyInterface <=> ba🔺",
+        ] {
+            let results = get_completions_experimental(source).unwrap();
+            results.iter().find(|completion| completion.label == "self").unwrap();
+            results.iter().find(|completion| completion.label == "bar").unwrap();
+        }
+
+        // Interface name position, cut off at EOF.
+        for source in ["component Foo { implement MyInterface🔺", "component Foo { implement My🔺"]
+        {
+            let results = get_completions_experimental(source).unwrap();
+            assert!(results.is_empty(), "expected no completions for {source:?}, got {results:?}");
+        }
+
+        // Nothing typed after `implement` at all, cut off at EOF.
+        let results = get_completions_experimental("component Foo { implement 🔺").unwrap();
+        assert!(results.iter().any(|completion| completion.label == "property"));
     }
 }

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -49,6 +49,16 @@ pub fn empty_document_cache() -> common::DocumentCache {
     common::DocumentCache::new(config)
 }
 
+/// Create an empty `DocumentCache` with experimental features enabled.
+pub fn empty_document_cache_with_experimental() -> common::DocumentCache {
+    let config = crate::common::document_cache::CompilerConfiguration {
+        style: Some("fluent".to_string()),
+        enable_experimental: true,
+        ..Default::default()
+    };
+    common::DocumentCache::new(config)
+}
+
 /// Create a `DocumentCache` with one document loaded into it.
 pub fn loaded_document_cache(
     content: String,
@@ -60,8 +70,20 @@ pub fn loaded_document_cache_with_file_name(
     content: String,
     file_name: &str,
 ) -> (common::DocumentCache, Url, HashMap<Url, Vec<Diagnostic>>) {
-    let mut dc = empty_document_cache();
+    load_content_with_document_cache(empty_document_cache(), content, file_name)
+}
 
+pub fn loaded_document_cache_with_experimental(
+    content: String,
+) -> (common::DocumentCache, Url, HashMap<Url, Vec<Diagnostic>>) {
+    load_content_with_document_cache(empty_document_cache_with_experimental(), content, "bar.slint")
+}
+
+fn load_content_with_document_cache(
+    mut dc: common::DocumentCache,
+    content: String,
+    file_name: &str,
+) -> (common::DocumentCache, Url, HashMap<Url, Vec<Diagnostic>>) {
     // Pre-load std-widgets.slint:
     spin_on::spin_on(dc.preload_builtins());
 


### PR DESCRIPTION
This branch replaces the two separate component-header clauses for interfaces — `implements I` (implement on self) and `uses { I from child }` (forward from a child) — with one unified element-body statement:

```slint
component Example {
    implement TextInterface <=> self;   // implement on this component
    implement OtherInterface <=> child; // forward from a child element
    child := SomeElement { }
}
```

Both versions now flow through a single resolution path in `Element::from_node`, so one conflict check covers duplicate interfaces and duplicate members uniformly across self- and child-targets. The underlying implementation remains unchanged: self-targets copy the interface's members onto the element, child-targets forward them. Converting to checking only for self-targets will be handled in a follow-up commit.

This PR does introduce a new behaviour: a component can implement more than one interface with multiple `implement` statements. This was agreed as a desired behaviour in the interfaces review meeting that prompted this syntax change.

Relates to #1870.