### PR TITLE
CI: Prospective fix for cross builds

### DIFF
--- a/.github/workflows/cross_containers_and_demos.yaml
+++ b/.github/workflows/cross_containers_and_demos.yaml
@@ -16,6 +16,12 @@ jobs:
     build_demos:
         needs: [build_containers]
         runs-on: ubuntu-22.04
+        env:
+            # cross looks for Cross.toml in the workspace root of the manifest it
+            # builds. The examples/ and demos/ workspaces don't have one, so without
+            # this they would fall back to the stock cross images, which lack the
+            # fontconfig/Skia build dependencies of our custom containers.
+            CROSS_CONFIG: ${{ github.workspace }}/Cross.toml
         strategy:
             matrix:
                 target:


### PR DESCRIPTION
After the workspace split, cross would look for Cross.toml in examples/ and demos/ when compiling the examples and demos. Since the file is in the root instead, it would fall back to using the upstream cross container, which doesn't have our pkg-config fixes for fontconfig, clang fixes for skia, etc. applied and the build would fail. So set CROSS_CONFIG to help cross locate the correct config file.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
