### PR TITLE
Allow semicolon_in_expressions_from_macros lint in build scripts usin…

### DIFF
--- a/examples/gstreamer-player/build.rs
+++ b/examples/gstreamer-player/build.rs
@@ -1,6 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
+// The expansion of cfg_aliases! places macro-emitted semicolons in expression
+// position, which nightly rejects by default since 2026-07. Allow it until a
+// fixed cfg-aliases release is available.
+#![allow(semicolon_in_expressions_from_macros)]
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/internal/backends/linuxkms/build.rs
+++ b/internal/backends/linuxkms/build.rs
@@ -1,6 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// The expansion of cfg_aliases! places macro-emitted semicolons in expression
+// position, which nightly rejects by default since 2026-07. Allow it until a
+// fixed cfg-aliases release is available.
+#![allow(semicolon_in_expressions_from_macros)]
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/internal/backends/selector/build.rs
+++ b/internal/backends/selector/build.rs
@@ -1,6 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// The expansion of cfg_aliases! places macro-emitted semicolons in expression
+// position, which nightly rejects by default since 2026-07. Allow it until a
+// fixed cfg-aliases release is available.
+#![allow(semicolon_in_expressions_from_macros)]
+
 // cSpell: ignore qttype
 use std::path::Path;
 

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -1,6 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// The expansion of cfg_aliases! places macro-emitted semicolons in expression
+// position, which nightly rejects by default since 2026-07. Allow it until a
+// fixed cfg-aliases release is available.
+#![allow(semicolon_in_expressions_from_macros)]
+
 // cSpell: ignore rsplit Sfixed
 fn main() {
     cfg_aliases::cfg_aliases! {

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -1,6 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// The expansion of cfg_aliases! places macro-emitted semicolons in expression
+// position, which nightly rejects by default since 2026-07. Allow it until a
+// fixed cfg-aliases release is available.
+#![allow(semicolon_in_expressions_from_macros)]
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -26,7 +26,7 @@
 #[macro_export]
 macro_rules! for_each_builtin_structs {
     ($macro:ident) => {
-        $macro![
+        $macro! {
             /// The `KeyboardModifiers` struct provides booleans to indicate possible modifier keys on a keyboard, such as Shift, Control, etc.
             /// It is provided as part of `KeyEvent`'s `modifiers` field.
             ///
@@ -173,6 +173,6 @@ macro_rules! for_each_builtin_structs {
                 /// The bottom edge value
                 bottom: Coord,
             }
-        ];
+        }
     };
 }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -23,7 +23,7 @@
 #[macro_export]
 macro_rules! for_each_enums {
     ($macro:ident) => {
-        $macro![
+        $macro! {
             /// This enum describes the different types of alignment of text along the horizontal axis of a `Text` or `StyledText` element.
             #[non_exhaustive]
             enum TextHorizontalAlignment {
@@ -684,6 +684,6 @@ macro_rules! for_each_enums {
                 /// This variant is reported when the operating system is none of the above.
                 Other,
             }
-        ];
+        }
     };
 }

--- a/internal/renderers/skia/build.rs
+++ b/internal/renderers/skia/build.rs
@@ -1,6 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// The expansion of cfg_aliases! places macro-emitted semicolons in expression
+// position, which nightly rejects by default since 2026-07. Allow it until a
+// fixed cfg-aliases release is available.
+#![allow(semicolon_in_expressions_from_macros)]
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {


### PR DESCRIPTION
…g cfg_aliases

Rust nightly from 2026-07-16 on turns this lint into a deny-by-default error, and the expansion of the cfg_aliases! macro trips it. This broke the rust-cpp-docs and cpp_cmake nightly CI jobs when compiling the i-slint-renderer-skia build script; the other build scripts using cfg_aliases would fail the same way once reached.

Allow the lint in the affected build scripts until the upstream fix (https://github.com/katharostech/cfg_aliases/pull/15) is merged and released.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
