### PR TITLE
visual editor: fix building in Xcode

### DIFF
--- a/scripts/build_macos_app_with_cargo.bash
+++ b/scripts/build_macos_app_with_cargo.bash
@@ -19,6 +19,7 @@ fi
 
 shift 2
 
+CARGO_TARGET_NAME=""
 CARGO_PROFILE=dev
 
 while [[ $# -gt 0 ]]; do
@@ -80,7 +81,7 @@ log "cargo build start: $RUST_TARGET"
 
 env RUSTFLAGS='-Clink-args=-Wl,-rpath,@loader_path/../Frameworks' \
     cargo build \
-        "${CARGO_TIMINGS_ARGS[@]}" \
+        ${CARGO_TIMINGS_ARGS[@]+"${CARGO_TIMINGS_ARGS[@]}"} \
         --target "$RUST_TARGET" \
         --bin "$CARGO_TARGET_NAME" \
         --profile "$CARGO_PROFILE" \

--- a/scripts/build_macos_app_with_cargo.bash
+++ b/scripts/build_macos_app_with_cargo.bash
@@ -17,8 +17,6 @@ if [ "$#" -lt 2 ]; then
     exit 2
 fi
 
-shift 2
-
 CARGO_TARGET_NAME=""
 CARGO_PROFILE=dev
 


### PR DESCRIPTION
- Fix building outside of the CI, where CARGO_TIMINGS isn't set.
- Don't shift out arguments, so that choosing a release build actually works.