### PR TITLE
FlexboxLayout: re-measure height-for-width cells through the measure callback when a repeater is present

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -1287,6 +1287,15 @@ public:
         }
     }
 
+    /// The typed instance at position `i` (`0..len()`), or nullptr if not instantiated.
+    const C *typed_instance_at(std::size_t i) const
+    {
+        if (!inner || i >= inner->data.size())
+            return nullptr;
+        const auto &x = inner->data[i];
+        return x.ptr ? &(**x.ptr) : nullptr;
+    }
+
     bool recurse_ensure_instantiated() const
     {
         if (!inner)
@@ -1381,6 +1390,12 @@ public:
         if (instance) {
             f(*instance);
         }
+    }
+
+    /// The typed instance at position `i` (`0..len()`), or nullptr if not instantiated.
+    const C *typed_instance_at(std::size_t i) const
+    {
+        return (i == 0 && instance) ? &(**instance) : nullptr;
     }
 
     bool recurse_ensure_instantiated() const

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4527,61 +4527,134 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             repeater_indices,
             measure_cells,
             default_cells,
+            cells_variables,
         } => {
             let data = compile_expression(data, ctx);
             let repeater_indices = compile_expression(repeater_indices, ctx);
             // cbindgen does not expose `LayoutInfo::preferred_bounded()`, so
             // inline it: preferred_bounded = max(min(preferred, max), min).
-            let mut v_cases = String::new();
-            let mut h_cases = String::new();
-            for (i, item) in measure_cells.iter().enumerate() {
-                if let Either::Left((h_info, v_info)) = item {
-                    let v = compile_expression(v_info, ctx);
-                    let h = compile_expression(h_info, ctx);
-                    v_cases.push_str(&format!(
-                        "case {i}: {{ auto li = {v}; nh = std::max(std::min(li.preferred, li.max), li.min); break; }}\n"
-                    ));
-                    h_cases.push_str(&format!(
-                        "case {i}: {{ auto li = {h}; nw = std::max(std::min(li.preferred, li.max), li.min); break; }}\n"
-                    ));
+            const BOUNDED: &str = "std::max(std::min(li.preferred, li.max), li.min)";
+            // Without a repeater the cell index is known at compile time, so switch
+            // on it (O(1) dispatch). With a repeater the count is only known at
+            // runtime: walk the elements, advancing `cursor` by 1 per static cell
+            // and by the repeater's instance count per repeater, until `index`'s
+            // range is found.
+            let (v_body, h_body) = if cells_variables.is_none() {
+                let mut v_cases = String::new();
+                let mut h_cases = String::new();
+                for (i, item) in measure_cells.iter().enumerate() {
+                    if let Either::Left((h_info, v_info)) = item {
+                        let v = compile_expression(v_info, ctx);
+                        let h = compile_expression(h_info, ctx);
+                        v_cases.push_str(&format!(
+                            "case {i}: {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n"
+                        ));
+                        h_cases.push_str(&format!(
+                            "case {i}: {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n"
+                        ));
+                    }
                 }
-            }
-            // Preferred (default-constraint) size per cell, returned when taffy
-            // asks for a dimension without a known cross-axis size.
-            let mut pref_w = String::new();
-            let mut pref_h = String::new();
-            for item in default_cells {
-                if let Either::Left((h_info, v_info)) = item {
-                    let h = compile_expression(h_info, ctx);
-                    let v = compile_expression(v_info, ctx);
-                    pref_w.push_str(&format!(
-                        "[&]{{ auto li = {h}; return std::max(std::min(li.preferred, li.max), li.min); }}(),\n"
-                    ));
-                    pref_h.push_str(&format!(
-                        "[&]{{ auto li = {v}; return std::max(std::min(li.preferred, li.max), li.min); }}(),\n"
-                    ));
+                (
+                    format!("switch (index) {{\n{v_cases}default: break;\n}}\n"),
+                    format!("switch (index) {{\n{h_cases}default: break;\n}}\n"),
+                )
+            } else {
+                let mut v_steps = String::new();
+                let mut h_steps = String::new();
+                for item in measure_cells {
+                    match item {
+                        Either::Left((h_info, v_info)) => {
+                            let v = compile_expression(v_info, ctx);
+                            let h = compile_expression(h_info, ctx);
+                            v_steps.push_str(&format!(
+                                "if (index == cursor) {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n\
+                                 cursor += 1;\n"
+                            ));
+                            h_steps.push_str(&format!(
+                                "if (index == cursor) {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n\
+                                 cursor += 1;\n"
+                            ));
+                        }
+                        Either::Right(repeater) => {
+                            let i = usize::from(repeater.repeater_index);
+                            v_steps.push_str(&format!(
+                                "{{ auto len = self->repeater_{i}.len(); \
+                                 if (index >= cursor && index < cursor + len) {{ \
+                                     if (auto *sub_comp = self->repeater_{i}.typed_instance_at(index - cursor)) {{ \
+                                         auto li = sub_comp->flexbox_layout_item_info_at_cross_width(w).constraint; \
+                                         return {{ w, {BOUNDED} }}; }} \
+                                     return {{ w, h }}; }} \
+                                 cursor += len; }}\n"
+                            ));
+                            // No width-for-height accessor on a repeated instance: keep its default.
+                            h_steps.push_str(&format!("cursor += self->repeater_{i}.len();\n"));
+                        }
+                    }
                 }
-            }
+                (
+                    format!("[[maybe_unused]] uintptr_t cursor = 0;\n{v_steps}"),
+                    format!("[[maybe_unused]] uintptr_t cursor = 0;\n{h_steps}"),
+                )
+            };
+            // Preferred size per cell, returned when taffy asks for a dimension
+            // without a known cross-axis size. With a repeater the cell count is
+            // only known at runtime, so read the flat cell arrays the enclosing
+            // `WithFlexboxLayoutItemInfo` built; otherwise inline the constants.
+            let (defaults_decl, default_w, default_h) = match cells_variables {
+                Some((cells_h, cells_v)) => {
+                    let (cells_h, cells_v) = (ident(cells_h), ident(cells_v));
+                    (
+                        String::new(),
+                        format!(
+                            "index < {cells_h}.len ? [&]{{ auto li = {cells_h}.ptr[index].constraint; return {BOUNDED}; }}() : 0.0f"
+                        ),
+                        format!(
+                            "index < {cells_v}.len ? [&]{{ auto li = {cells_v}.ptr[index].constraint; return {BOUNDED}; }}() : 0.0f"
+                        ),
+                    )
+                }
+                None => {
+                    let mut pref_w = String::new();
+                    let mut pref_h = String::new();
+                    for item in default_cells {
+                        if let Either::Left((h_info, v_info)) = item {
+                            let h = compile_expression(h_info, ctx);
+                            let v = compile_expression(v_info, ctx);
+                            pref_w.push_str(&format!(
+                                "[&]{{ auto li = {h}; return {BOUNDED}; }}(),\n"
+                            ));
+                            pref_h.push_str(&format!(
+                                "[&]{{ auto li = {v}; return {BOUNDED}; }}(),\n"
+                            ));
+                        }
+                    }
+                    (
+                        format!(
+                            "const float pref_w[] = {{ {pref_w} }};\n\
+                             const float pref_h[] = {{ {pref_h} }};\n\
+                             const size_t cell_count = sizeof(pref_w) / sizeof(float);\n"
+                        ),
+                        "index < cell_count ? pref_w[index] : 0.0f".to_owned(),
+                        "index < cell_count ? pref_h[index] : 0.0f".to_owned(),
+                    )
+                }
+            };
             format!(
                 "slint::private_api::solve_flexbox_layout_with_measure({data}, {repeater_indices}, \
                  [&](uintptr_t index, std::optional<float> known_w, std::optional<float> known_h) \
                  -> std::pair<float, float> {{\n\
-                    const float pref_w[] = {{ {pref_w} }};\n\
-                    const float pref_h[] = {{ {pref_h} }};\n\
-                    const size_t cell_count = sizeof(pref_w) / sizeof(float);\n\
-                    float w = known_w.value_or(index < cell_count ? pref_w[index] : 0.0f);\n\
-                    float h = known_h.value_or(index < cell_count ? pref_h[index] : 0.0f);\n\
+                    {defaults_decl}\
+                    float w = known_w.value_or({default_w});\n\
+                    float h = known_h.value_or({default_h});\n\
                     if (known_w.has_value() && !known_h.has_value()) {{\n\
                         [[maybe_unused]] float measure_known_w = w;\n\
-                        float nh = h;\n\
-                        switch (index) {{\n{v_cases}default: break;\n}}\n\
-                        return {{ w, nh }};\n\
+                        {v_body}\
+                        return {{ w, h }};\n\
                     }}\n\
                     if (known_h.has_value() && !known_w.has_value()) {{\n\
                         [[maybe_unused]] float measure_known_h = h;\n\
-                        float nw = w;\n\
-                        switch (index) {{\n{h_cases}default: break;\n}}\n\
-                        return {{ nw, h }};\n\
+                        {h_body}\
+                        return {{ w, h }};\n\
                     }}\n\
                     return {{ w, h }};\n\
                  }})"

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3387,11 +3387,13 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             repeater_indices,
             measure_cells,
             default_cells,
+            cells_variables,
         } => generate_solve_flexbox_layout_with_measure(
             data,
             repeater_indices,
             measure_cells,
             default_cells,
+            cells_variables.as_ref(),
             ctx,
         ),
 
@@ -5310,6 +5312,7 @@ fn generate_solve_flexbox_layout_with_measure(
     repeater_indices: &Expression,
     measure_cells: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
     default_cells: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
+    cells_variables: Option<&(SmolStr, SmolStr)>,
     ctx: &EvaluationContext,
 ) -> TokenStream {
     let data = compile_expression(data, ctx);
@@ -5318,52 +5321,127 @@ fn generate_solve_flexbox_layout_with_measure(
     let known_h_ident = ident("measure_known_h");
 
     // Height-for-width / width-for-height: recompute the perpendicular info at
-    // the dimension taffy assigned.
-    let mut v_arms = Vec::new();
-    let mut h_arms = Vec::new();
-    for (i, item) in measure_cells.iter().enumerate() {
-        if let Either::Left((h_info, v_info)) = item {
-            let idx = proc_macro2::Literal::usize_unsuffixed(i);
-            let v = compile_expression(v_info, ctx);
-            let h = compile_expression(h_info, ctx);
-            v_arms.push(quote!(#idx => ({ #v }).preferred_bounded(),));
-            h_arms.push(quote!(#idx => ({ #h }).preferred_bounded(),));
+    // the dimension taffy assigned. Without a repeater the cell index is known at
+    // compile time, so match on it (O(1) dispatch). With a repeater the count is
+    // only known at runtime: walk the elements, advancing `cursor` by 1 per static
+    // cell and by the repeater's instance count per repeater, until `index`'s range
+    // is found.
+    let (v_body, h_body) = if cells_variables.is_none() {
+        let mut v_arms = Vec::new();
+        let mut h_arms = Vec::new();
+        for (i, item) in measure_cells.iter().enumerate() {
+            if let Either::Left((h_info, v_info)) = item {
+                let idx = proc_macro2::Literal::usize_unsuffixed(i);
+                let v = compile_expression(v_info, ctx);
+                let h = compile_expression(h_info, ctx);
+                v_arms.push(quote!(#idx => return (w, ({ #v }).preferred_bounded()),));
+                h_arms.push(quote!(#idx => return (({ #h }).preferred_bounded(), h),));
+            }
         }
-        // Repeater cells (the `Right` case) are not emitted; they fall through
-        // to the preferred default below.
-    }
+        (quote!(match index { #(#v_arms)* _ => {} }), quote!(match index { #(#h_arms)* _ => {} }))
+    } else {
+        let mut v_steps = Vec::new();
+        let mut h_steps = Vec::new();
+        for item in measure_cells {
+            match item {
+                Either::Left((h_info, v_info)) => {
+                    let v = compile_expression(v_info, ctx);
+                    let h = compile_expression(h_info, ctx);
+                    v_steps.push(quote!(
+                        if index == cursor { return (w, ({ #v }).preferred_bounded()); }
+                        cursor += 1;
+                    ));
+                    h_steps.push(quote!(
+                        if index == cursor { return (({ #h }).preferred_bounded(), h); }
+                        cursor += 1;
+                    ));
+                }
+                Either::Right(repeater) => {
+                    let repeater_id =
+                        format_ident!("repeater{}", usize::from(repeater.repeater_index));
+                    v_steps.push(quote!(
+                        {
+                            let len = _self.#repeater_id.len();
+                            if index >= cursor && index < cursor + len {
+                                if let Some(sub_comp) = _self.#repeater_id.instance_at(index - cursor) {
+                                    return (w, sub_comp
+                                        .as_pin_ref()
+                                        .flexbox_layout_item_info_at_cross_width(w)
+                                        .constraint
+                                        .preferred_bounded());
+                                }
+                                return (w, h);
+                            }
+                            cursor += len;
+                        }
+                    ));
+                    // No width-for-height accessor on a repeated instance: keep its default.
+                    h_steps.push(quote!(cursor += _self.#repeater_id.len();));
+                }
+            }
+        }
+        // The final `cursor += …` is a dead write; `let _ = cursor;` consumes it
+        // to avoid an `unused_assignments` warning in the generated code.
+        (
+            quote!(let mut cursor = 0usize; #(#v_steps)* let _ = cursor;),
+            quote!(let mut cursor = 0usize; #(#h_steps)* let _ = cursor;),
+        )
+    };
 
-    // Preferred (default-constraint) size per cell, returned when taffy asks
-    // for a dimension without a known cross-axis size (mirrors the plain
-    // `solve_flexbox_layout` measure).
-    let mut def_w = Vec::new();
-    let mut def_h = Vec::new();
-    for item in default_cells {
-        if let Either::Left((h_info, v_info)) = item {
-            let h = compile_expression(h_info, ctx);
-            let v = compile_expression(v_info, ctx);
-            def_w.push(quote!(({ #h }).preferred_bounded(),));
-            def_h.push(quote!(({ #v }).preferred_bounded(),));
+    // Preferred size per cell, returned when taffy asks for a dimension without
+    // a known cross-axis size (mirrors the plain `solve_flexbox_layout` measure).
+    // With a repeater, read the flat cell arrays; otherwise inline the constants.
+    let (defaults_decl, default_w, default_h) = match cells_variables {
+        Some((cells_h, cells_v)) => {
+            let cells_h = ident(cells_h);
+            let cells_v = ident(cells_v);
+            (
+                quote!(
+                    let pref_h_cells = #cells_h.as_slice();
+                    let pref_v_cells = #cells_v.as_slice();
+                ),
+                quote!(pref_h_cells.get(index).map_or(0f32, |c| c.constraint.preferred_bounded())),
+                quote!(pref_v_cells.get(index).map_or(0f32, |c| c.constraint.preferred_bounded())),
+            )
         }
-    }
+        None => {
+            let mut def_w = Vec::new();
+            let mut def_h = Vec::new();
+            for item in default_cells {
+                if let Either::Left((h_info, v_info)) = item {
+                    let h = compile_expression(h_info, ctx);
+                    let v = compile_expression(v_info, ctx);
+                    def_w.push(quote!(({ #h }).preferred_bounded(),));
+                    def_h.push(quote!(({ #v }).preferred_bounded(),));
+                }
+            }
+            (
+                quote!(
+                    let pref_w: &[f32] = &[#(#def_w)*];
+                    let pref_h: &[f32] = &[#(#def_h)*];
+                ),
+                quote!(pref_w.get(index).copied().unwrap_or(0f32)),
+                quote!(pref_h.get(index).copied().unwrap_or(0f32)),
+            )
+        }
+    };
 
     quote! { {
-        let pref_w: &[f32] = &[#(#def_w)*];
-        let pref_h: &[f32] = &[#(#def_h)*];
+        #defaults_decl
         let mut measure = |index: usize, known_w: Option<f32>, known_h: Option<f32>| -> (f32, f32) {
-            let w = known_w.unwrap_or_else(|| pref_w.get(index).copied().unwrap_or(0f32));
-            let h = known_h.unwrap_or_else(|| pref_h.get(index).copied().unwrap_or(0f32));
+            let w = known_w.unwrap_or_else(|| #default_w);
+            let h = known_h.unwrap_or_else(|| #default_h);
             if known_w.is_some() && known_h.is_none() {
                 let #known_w_ident = w;
                 let _ = #known_w_ident;
-                let nh = match index { #(#v_arms)* _ => h };
-                return (w, nh);
+                #v_body
+                return (w, h);
             }
             if known_h.is_some() && known_w.is_none() {
                 let #known_h_ident = h;
                 let _ = #known_h_ident;
-                let nw = match index { #(#h_arms)* _ => w };
-                return (nw, h);
+                #h_body
+                return (w, h);
             }
             (w, h)
         };

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -269,15 +269,23 @@ pub enum Expression {
     /// `(h_info, v_info)` at the default constraint (matching `data`'s cells);
     /// it provides the preferred size returned when taffy asks for a dimension
     /// without a known cross-axis size (mirroring the plain `solve_flexbox_layout`
-    /// measure). Repeater cells (the `Right` case) are not routed through the
-    /// callback yet.
+    /// measure). A repeater cell (the `Right` case) is measured by calling
+    /// `flexbox_layout_item_info_at_cross_width` on the instance taffy asks for.
     SolveFlexboxLayoutWithMeasure {
         /// The `FlexboxLayoutData` (built inline with the cell arrays, so its
         /// temporaries live for the duration of the solve call).
         data: Box<Expression>,
         repeater_indices: Box<Expression>,
         measure_cells: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
+        /// Only used when `cells_variables` is `None`; empty otherwise.
         default_cells: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
+        /// Names of the flat `(cells_h, cells_v)` locals set up by the enclosing
+        /// `WithFlexboxLayoutItemInfo`. `Some` exactly when the layout has a
+        /// repeater: a repeater expands to a runtime number of cells, so the
+        /// callback maps taffy's flat cell index to an element with a runtime
+        /// cursor, and takes per-cell defaults from these arrays instead of the
+        /// per-element `default_cells`.
+        cells_variables: Option<(SmolStr, SmolStr)>,
     },
     /// Will call the sub_expression, with the cells variable set to the
     /// array of GridLayoutInputData from the elements
@@ -584,6 +592,7 @@ macro_rules! visit_impl {
                 repeater_indices,
                 measure_cells,
                 default_cells,
+                cells_variables: _,
             } => {
                 $visitor(data);
                 $visitor(repeater_indices);

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -414,33 +414,47 @@ pub(super) fn solve_flexbox_layout(
     let repeated_cross_width = container_width_for_cells
         .as_ref()
         .map(|e| Box::new(super::lower_expression::lower_expression(e, ctx)));
+    // Only height-for-width-capable cells benefit from re-measuring;
+    // a flexbox without any keeps the cheaper plain solve.
+    let needs_measure = layout.elems.iter().any(|li| {
+        let elem = &li.item.element;
+        is_height_for_width_cell(elem)
+            || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
+    });
     match fld.compute_cells {
-        Some((cells_h_var, cells_v_var, elements)) => llr_Expression::WithFlexboxLayoutItemInfo {
-            cells_h_variable: cells_h_var,
-            cells_v_variable: cells_v_var,
-            repeater_indices_var_name: Some("repeated_indices".into()),
-            elements,
-            repeated_cross_width,
-            sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
-                function: "solve_flexbox_layout".into(),
-                arguments: vec![
-                    data,
-                    llr_Expression::ReadLocalVariable {
-                        name: "repeated_indices".into(),
-                        ty: Type::Array(Type::Int32.into()),
-                    },
-                ],
-                return_ty: Type::LayoutCache,
-            }),
-        },
+        Some((cells_h_var, cells_v_var, elements)) => {
+            let repeated_indices = || llr_Expression::ReadLocalVariable {
+                name: "repeated_indices".into(),
+                ty: Type::Array(Type::Int32.into()),
+            };
+            // With a repeater, the cell defaults come from the flat cell arrays
+            // the enclosing `WithFlexboxLayoutItemInfo` just built, so no
+            // `default_cells`.
+            let sub_expression = if needs_measure {
+                llr_Expression::SolveFlexboxLayoutWithMeasure {
+                    data: Box::new(data),
+                    repeater_indices: Box::new(repeated_indices()),
+                    measure_cells: measure_cells_for(layout, ctx),
+                    default_cells: vec![],
+                    cells_variables: Some((cells_h_var.clone().into(), cells_v_var.clone().into())),
+                }
+            } else {
+                llr_Expression::ExtraBuiltinFunctionCall {
+                    function: "solve_flexbox_layout".into(),
+                    arguments: vec![data, repeated_indices()],
+                    return_ty: Type::LayoutCache,
+                }
+            };
+            llr_Expression::WithFlexboxLayoutItemInfo {
+                cells_h_variable: cells_h_var,
+                cells_v_variable: cells_v_var,
+                repeater_indices_var_name: Some("repeated_indices".into()),
+                elements,
+                repeated_cross_width,
+                sub_expression: Box::new(sub_expression),
+            }
+        }
         None => {
-            // Only height-for-width-capable cells benefit from re-measuring;
-            // a flexbox without any keeps the cheaper plain solve.
-            let needs_measure = layout.elems.iter().any(|li| {
-                let elem = &li.item.element;
-                is_height_for_width_cell(elem)
-                    || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
-            });
             if !needs_measure {
                 return llr_Expression::ExtraBuiltinFunctionCall {
                     function: "solve_flexbox_layout".into(),
@@ -448,45 +462,6 @@ pub(super) fn solve_flexbox_layout(
                     return_ty: Type::LayoutCache,
                 };
             }
-            // Static cells only: emit a generated measure callback so the
-            // cross-axis size of height-for-width cells is recomputed at the
-            // width/height taffy assigns, instead of the cell's preferred
-            // size (parity with the interpreter).
-            let measure_cells = layout
-                .elems
-                .iter()
-                .map(|li| {
-                    let elem = &li.item.element;
-                    let v_constraint = is_height_for_width_cell(elem).then(|| {
-                        crate::expression_tree::Expression::ReadLocalVariable {
-                            name: "measure_known_w".into(),
-                            ty: Type::LogicalLength,
-                        }
-                    });
-                    let v_info = get_layout_info(
-                        elem,
-                        ctx,
-                        &li.item.constraints,
-                        Orientation::Vertical,
-                        v_constraint,
-                    );
-                    let h_constraint =
-                        elem.borrow().inherited_layout_info_h_with_constraint().is_some().then(
-                            || crate::expression_tree::Expression::ReadLocalVariable {
-                                name: "measure_known_h".into(),
-                                ty: Type::LogicalLength,
-                            },
-                        );
-                    let h_info = get_layout_info(
-                        elem,
-                        ctx,
-                        &li.item.constraints,
-                        Orientation::Horizontal,
-                        h_constraint,
-                    );
-                    Either::Left((h_info, v_info))
-                })
-                .collect();
             // Preferred (default-constraint) info per cell, matching the cells
             // carried by `data`. Returned by the measure callback when taffy
             // asks for a dimension without a known cross-axis size, so the
@@ -530,11 +505,69 @@ pub(super) fn solve_flexbox_layout(
             llr_Expression::SolveFlexboxLayoutWithMeasure {
                 data: Box::new(data),
                 repeater_indices: Box::new(empty_int32_slice()),
-                measure_cells,
+                measure_cells: measure_cells_for(layout, ctx),
                 default_cells,
+                cells_variables: None,
             }
         }
     }
+}
+
+/// Per-element measure inputs for `SolveFlexboxLayoutWithMeasure`: the cell's
+/// `(h_info, v_info)` measured at the dimension taffy assigns, read from the
+/// `measure_known_w` / `measure_known_h` locals. A repeated element becomes a
+/// `Right`: its instances are only known at solve time, so the generated
+/// callback queries the instance directly.
+fn measure_cells_for(
+    layout: &crate::layout::FlexboxLayout,
+    ctx: &mut ExpressionLoweringCtx,
+) -> Vec<Either<(llr_Expression, llr_Expression), LayoutRepeatedElement>> {
+    layout
+        .elems
+        .iter()
+        .map(|li| {
+            let elem = &li.item.element;
+            if elem.borrow().repeated.is_some() {
+                let repeater_index =
+                    match ctx.mapping.element_mapping.get(&elem.clone().into()).unwrap() {
+                        LoweredElement::Repeated { repeated_index } => *repeated_index,
+                        _ => panic!("repeated flexbox element not lowered as Repeated"),
+                    };
+                return Either::Right(LayoutRepeatedElement {
+                    repeater_index,
+                    row_child_templates: None,
+                });
+            }
+            let v_constraint = is_height_for_width_cell(elem).then(|| {
+                crate::expression_tree::Expression::ReadLocalVariable {
+                    name: "measure_known_w".into(),
+                    ty: Type::LogicalLength,
+                }
+            });
+            let v_info = get_layout_info(
+                elem,
+                ctx,
+                &li.item.constraints,
+                Orientation::Vertical,
+                v_constraint,
+            );
+            let h_constraint =
+                elem.borrow().inherited_layout_info_h_with_constraint().is_some().then(|| {
+                    crate::expression_tree::Expression::ReadLocalVariable {
+                        name: "measure_known_h".into(),
+                        ty: Type::LogicalLength,
+                    }
+                });
+            let h_info = get_layout_info(
+                elem,
+                ctx,
+                &li.item.constraints,
+                Orientation::Horizontal,
+                h_constraint,
+            );
+            Either::Left((h_info, v_info))
+        })
+        .collect()
 }
 
 pub(super) fn compute_flexbox_layout_info(

--- a/tests/cases/layout/flexbox_repeater_row_height_for_width.slint
+++ b/tests/cases/layout/flexbox_repeater_row_height_for_width.slint
@@ -1,0 +1,183 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A height-for-width cell in a *row* FlexboxLayout only learns its width during
+// the solve (the main axis distributes it), so it must be re-measured through
+// the measure callback. Cover both a repeated cell and a static cell sharing a
+// flexbox with a repeater — the presence of a repeater must not disable the
+// callback for anyone.
+
+component Card inherits Rectangle {
+    in property <string> label;
+    VerticalLayout {
+        Text { text: root.label; wrap: word-wrap; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 1400px;
+    height: 500px;
+
+    property <string> long: "A really long card text that will almost certainly need to wrap onto two or more lines when the flex space is tight";
+    property <[int]> empty-model: [];
+
+    // Single-line reference, so the assertions stay font-independent
+    // (the nodejs backend has no test fonts).
+    refLine := Text { x: -3000px; text: "Short"; wrap: no-wrap; }
+    out property <length> line-height: refLine.height;
+
+    // Each flexbox wraps: the card takes line 1, the 150px-wide anchor is
+    // pushed to line 2, so `anchor.y` == the solved height of the card.
+
+    // A: repeated height-for-width card.
+    FlexboxLayout {
+        x: 0; y: 0; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        for s in [long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; }
+        aAnchor := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // B: static reference, no repeater in the flexbox.
+    FlexboxLayout {
+        x: 200px; y: 0; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        Card { label: long; flex-shrink: 0; flex-basis: 150px; }
+        bAnchor := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // C: static height-for-width card sharing a flexbox with a (non-h4w)
+    // repeater declared after it.
+    FlexboxLayout {
+        x: 400px; y: 0; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        Card { label: long; flex-shrink: 0; flex-basis: 150px; }
+        cAnchor := Rectangle { width: 150px; height: 5px; }
+        for x in [1]: Rectangle { width: 0px; height: 0px; }
+    }
+
+    // D: repeater declared *before* the static card, so the card's flat cell
+    // index is offset by the repeater's instance count.
+    FlexboxLayout {
+        x: 600px; y: 0; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        for x in [1, 2]: Rectangle { width: 0px; height: 0px; }
+        Card { label: long; flex-shrink: 0; flex-basis: 150px; }
+        dAnchor := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // E: two repeated h4w cards. Each fills a line and wraps, so the second is
+    // measured at `index - cursor == 1` and the anchor lands at twice the card
+    // height — this exercises the multi-instance walk.
+    FlexboxLayout {
+        x: 800px; y: 0; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        for s in [long, long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; }
+        eAnchor := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // F: `if`-conditional h4w card, lowered as a repeater with one instance
+    // (covers Conditional::typed_instance_at).
+    FlexboxLayout {
+        x: 1000px; y: 0; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        if true: Card { label: long; flex-shrink: 0; flex-basis: 150px; }
+        fAnchor := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // G: an empty repeater before a static h4w card: `cursor += 0` must not
+    // shift the card's flat cell index.
+    FlexboxLayout {
+        x: 1200px; y: 0; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        for x in empty-model: Rectangle { width: 0px; height: 0px; }
+        Card { label: long; flex-shrink: 0; flex-basis: 150px; }
+        gAnchor := Rectangle { width: 150px; height: 5px; }
+    }
+
+    out property <length> repeated-h: aAnchor.y;
+    out property <length> static-h: bAnchor.y;
+    out property <length> mixed-h: cAnchor.y;
+    out property <length> offset-h: dAnchor.y;
+    out property <length> multi-h: eAnchor.y;
+    out property <length> cond-h: fAnchor.y;
+    out property <length> empty-h: gAnchor.y;
+
+    // The reference card really did wrap (more than two lines), otherwise the
+    // equalities below would hold trivially.
+    out property <bool> wrapped: static-h > 2 * line-height;
+
+    out property <bool> repeated-ok: abs(repeated-h - static-h) < 1px;
+    out property <bool> mixed-ok: abs(mixed-h - static-h) < 1px;
+    out property <bool> offset-ok: abs(offset-h - static-h) < 1px;
+    // Two wrapped cards stacked, so the anchor is at twice the single height.
+    out property <bool> multi-ok: abs(multi-h - 2 * static-h) < 1px;
+    out property <bool> cond-ok: abs(cond-h - static-h) < 1px;
+    out property <bool> empty-ok: abs(empty-h - static-h) < 1px;
+
+    out property <bool> test: wrapped && repeated-ok && mixed-ok && offset-ok
+        && multi-ok && cond-ok && empty-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_wrapped(), "reference card did not wrap");
+assert!(instance.get_repeated_ok(), "repeated h4w row cell not re-measured");
+assert!(instance.get_mixed_ok(), "static h4w row cell not re-measured next to a repeater");
+assert!(instance.get_offset_ok(), "static h4w row cell after a repeater not re-measured");
+assert!(instance.get_multi_ok(), "second repeated h4w instance not re-measured");
+assert!(instance.get_cond_ok(), "conditional h4w cell not re-measured");
+assert!(instance.get_empty_ok(), "empty repeater shifted the static h4w cell index");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_wrapped());
+assert(instance.get_repeated_ok());
+assert(instance.get_mixed_ok());
+assert(instance.get_offset_ok());
+assert(instance.get_multi_ok());
+assert(instance.get_cond_ok());
+assert(instance.get_empty_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.wrapped);
+assert(instance.repeated_ok);
+assert(instance.mixed_ok);
+assert(instance.offset_ok);
+assert(instance.multi_ok);
+assert(instance.cond_ok);
+assert(instance.empty_ok);
+```
+*/


### PR DESCRIPTION
A row FlexboxLayout only learns a cell's width during the solve, so a
height-for-width cell must be re-measured from taffy's measure callback. The
code generators emitted that callback only when the layout had no repeater at
all, so a single `for` in the flexbox left every height-for-width cell —
repeated *and* static — stuck at its preferred single-line height, while the
interpreter wrapped them.

Emit the callback in the repeater path too. A repeater expands to a runtime
number of cells, so the callback walks the elements with a runtime cursor to map
taffy's flat cell index onto an element, and measures a repeated instance with
the `flexbox_layout_item_info_at_cross_width` accessor added by the prequel.

The C++ Repeater/Conditional gain `typed_instance_at`: `instance_at` erases the
component type, so generated code cannot call the accessor through it.