### PR TITLE
Upgrade cfg_aliases to 0.2.2 and drop the nightly lint workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,9 +1138,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"
@@ -8496,7 +8496,7 @@ checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
  "memchr",
  "nom 8.0.0",
- "petgraph 0.8.3",
+ "petgraph",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ vtable = { version = "0.5", path = "helper_crates/vtable" }
 by_address = { version = "1.0.4" }
 bytemuck = { version = "1.13.1" }
 cbindgen = { version = "0.29", default-features = false }
-cfg_aliases = { version = "0.2.0" }
+cfg_aliases = { version = "0.2.2" }
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 clru = { version = "0.6.0" }
 css-color-parser2 = { version = "1.0.1" }

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -935,9 +935,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2969,9 +2969,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -74,7 +74,7 @@ i-slint-core = { version = "=1.18.0", path = "../internal/core", default-feature
 i-slint-renderer-software = { version = "=1.18.0", path = "../internal/renderers/software", default-features = false }
 
 bytemuck = { version = "1.13.1" }
-cfg_aliases = { version = "0.2.0" }
+cfg_aliases = { version = "0.2.2" }
 derive_more = { version = "2.0.0", default-features = false, features = ["deref", "deref_mut", "into", "from", "add", "add_assign", "mul", "not", "display"] }
 glow = { version = "0.17" }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }

--- a/examples/gstreamer-player/build.rs
+++ b/examples/gstreamer-player/build.rs
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-// The expansion of cfg_aliases! places macro-emitted semicolons in expression
-// position, which nightly rejects by default since 2026-07. Allow it until a
-// fixed cfg-aliases release is available.
-#![allow(semicolon_in_expressions_from_macros)]
-
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/internal/backends/linuxkms/build.rs
+++ b/internal/backends/linuxkms/build.rs
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// The expansion of cfg_aliases! places macro-emitted semicolons in expression
-// position, which nightly rejects by default since 2026-07. Allow it until a
-// fixed cfg-aliases release is available.
-#![allow(semicolon_in_expressions_from_macros)]
-
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/internal/backends/selector/build.rs
+++ b/internal/backends/selector/build.rs
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// The expansion of cfg_aliases! places macro-emitted semicolons in expression
-// position, which nightly rejects by default since 2026-07. Allow it until a
-// fixed cfg-aliases release is available.
-#![allow(semicolon_in_expressions_from_macros)]
-
 // cSpell: ignore qttype
 use std::path::Path;
 

--- a/internal/backends/testing/build.rs
+++ b/internal/backends/testing/build.rs
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// The expansion of cfg_aliases! places macro-emitted semicolons in expression
-// position, which nightly rejects by default since 2026-07. Allow it until a
-// fixed cfg-aliases release is available.
-#![allow(semicolon_in_expressions_from_macros)]
-
 // cSpell: ignore rsplit Sfixed
 fn main() {
     cfg_aliases::cfg_aliases! {

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// The expansion of cfg_aliases! places macro-emitted semicolons in expression
-// position, which nightly rejects by default since 2026-07. Allow it until a
-// fixed cfg-aliases release is available.
-#![allow(semicolon_in_expressions_from_macros)]
-
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/internal/renderers/skia/build.rs
+++ b/internal/renderers/skia/build.rs
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// The expansion of cfg_aliases! places macro-emitted semicolons in expression
-// position, which nightly rejects by default since 2026-07. Allow it until a
-// fixed cfg-aliases release is available.
-#![allow(semicolon_in_expressions_from_macros)]
-
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -926,9 +926,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"


### PR DESCRIPTION
cfg_aliases 0.2.2 fixes the macro expansion that placed semicolons in expression position (https://github.com/katharostech/cfg_aliases/pull/15), which nightly rejects via the semicolon_in_expressions_from_macros lint since 2026-07-16.

Bump the minimum version to 0.2.2 and revert the
allow(semicolon_in_expressions_from_macros) workaround from commit b7a7676e7137 in the affected build scripts.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
