### PR TITLE
schedule_ci: trigger on branch tip change instead of a time window

### DIFF
--- a/.github/workflows/schedule_ci.yaml
+++ b/.github/workflows/schedule_ci.yaml
@@ -30,15 +30,17 @@ jobs:
             exit 0
           fi
 
-          BRANCHES=$(gh api repos/${{ github.repository }}/branches --paginate -q '.[].name | select(test("^(master|feature/|pre-release/)"))' )
-          for branch in $BRANCHES; do
-            # Check for commits in the last 9 hours
-            since=$(date -u -d '9 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
-            count=$(gh api "repos/${{ github.repository }}/commits?sha=$branch&since=$since&per_page=1" -q 'length')
-            if [ "$count" -gt 0 ]; then
-              echo "Triggering full CI for $branch"
+          # Trigger CI when the branch tip differs from the tip the last CI run
+          # tested. This is independent of commit timestamps, so it catches
+          # rebase-and-merge or late merges that a time window would miss.
+          gh api repos/${{ github.repository }}/branches --paginate \
+            -q '.[] | select(.name | test("^(master|feature/|pre-release/)")) | .name + " " + .commit.sha' \
+          | while read -r branch head_sha; do
+            last_sha=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yaml/runs?branch=$branch&event=workflow_dispatch&per_page=1" -q '.workflow_runs[0].head_sha // ""')
+            if [ "$head_sha" != "$last_sha" ]; then
+              echo "Triggering full CI for $branch ($head_sha, last CI ran on ${last_sha:-none})"
               gh workflow run "CI" --repo ${{ github.repository }} --ref "$branch" -f full=true
             else
-              echo "No recent changes on $branch, skipping"
+              echo "No changes on $branch since last CI ($head_sha), skipping"
             fi
           done


### PR DESCRIPTION
Comparing the branch tip against the last CI run's head SHA catches rebase-and-merge and late merges that the 9-hour commit-date window would miss.


(That's the reason why the CI hasn't been running in the feature/winit-3.11 branch for a long time because we merged commit to the branch that were older than 9 hours)