### PR TITLE
Teach dependabot to ignore extension updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,9 @@ updates:
       - dependency-name: "@codingame/monaco-vscode-editor-service-override"
       - dependency-name: "monaco-editor-wrapper"
       - dependency-name: "monaco-languageclient"
+      - dependency-name: "vscode-languageserver"
+      - dependency-name: "vscode-languageclient"
+      - dependency-name: "js-yaml"
       - dependency-name: "tailwindcss"
 
     groups:


### PR DESCRIPTION
These are not minor updates and require more work later.