### PR TITLE
torizon demos: speed up build, add slint-viewer

### DIFF
--- a/docker/Dockerfile.torizon-demos
+++ b/docker/Dockerfile.torizon-demos
@@ -36,7 +36,9 @@ WORKDIR /slint
 RUN mkdir demos_compiled \
     && cargo build --release --target $RUST_TOOLCHAIN_ARCH --features slint/renderer-skia,slint/backend-linuxkms-noseat \
         -p printerdemo -p slide_puzzle -p gallery -p opengl_underlay -p carousel -p todo -p energy-monitor -p weather-demo \
-    && for demo in printerdemo slide_puzzle gallery opengl_underlay carousel todo energy-monitor weather-demo; do \
+    && cargo build --release --target $RUST_TOOLCHAIN_ARCH --features slint/renderer-skia,slint/backend-linuxkms-noseat \
+        -p slint-viewer \
+    && for demo in printerdemo slide_puzzle gallery opengl_underlay carousel todo energy-monitor weather-demo slint-viewer; do \
         cp target/$RUST_TOOLCHAIN_ARCH/release/$demo ./demos_compiled/; \
     done \
     && if [ "$BUILD_HOME_AUTOMATION_SW_RENDERER" = "true" ]; then \
@@ -54,7 +56,7 @@ FROM --platform=${IMAGE_ARCH} torizon/${BASE_NAME}:${BASE_VERSION} AS deploy
 ARG BUILD_HOME_AUTOMATION_SW_RENDERER
 
 LABEL org.opencontainers.image.source=https://github.com/slint-ui/slint
-LABEL org.opencontainers.image.description="Container image providing Slint demos for use on Torizon. Run with docker run  --user=torizon -v /run/udev:/run/udev -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' --device-cgroup-rule='c 13:* rmw' --device-cgroup-rule='c 4:* rmw'. Available demos: printerdemo slide_puzzle gallery opengl_underlay carousel todo"
+LABEL org.opencontainers.image.description="Container image providing Slint demos for use on Torizon. Run with docker run  --user=torizon -v /run/udev:/run/udev -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' --device-cgroup-rule='c 13:* rmw' --device-cgroup-rule='c 4:* rmw'. Available demos: printerdemo slide_puzzle gallery opengl_underlay carousel todo. slint-viewer is included to use the device as a remote live-preview target."
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install libfontconfig1 libxkbcommon0 libinput10 fonts-noto-core fonts-noto-cjk fonts-noto-cjk-extra fonts-noto-color-emoji fonts-noto-ui-core fonts-noto-ui-extra \

--- a/docker/Dockerfile.torizon-demos
+++ b/docker/Dockerfile.torizon-demos
@@ -9,7 +9,11 @@ ARG BASE_VERSION=4
 ARG BASE_NAME=wayland-base
 ARG BUILD_HOME_AUTOMATION_SW_RENDERER=false
 
-FROM torizon/cross-toolchain-$TOOLCHAIN_ARCH:${BASE_VERSION} AS build
+# The cross-toolchain image is multi-arch. Without an explicit platform,
+# `docker buildx build --platform linux/arm64` selects the arm64 variant and
+# runs the entire Rust build under QEMU emulation. Pin the build stage to the
+# build host's platform and cross-compile instead.
+FROM --platform=$BUILDPLATFORM torizon/cross-toolchain-$TOOLCHAIN_ARCH:${BASE_VERSION} AS build
 ARG TOOLCHAIN_ARCH
 ARG RUST_TOOLCHAIN_ARCH=aarch64-unknown-linux-gnu
 ARG BUILD_HOME_AUTOMATION_SW_RENDERER
@@ -24,6 +28,14 @@ RUN rustup target add $RUST_TOOLCHAIN_ARCH
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
+
+# pkg-config and bindgen need to find the target-architecture libraries and
+# headers when cross-compiling (see docker/Dockerfile.aarch64-unknown-linux-gnu).
+ENV PKG_CONFIG_PATH_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH_armv7_unknown_linux_gnueabihf=/usr/lib/arm-linux-gnueabihf/pkgconfig
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu=-I/usr/include
+ENV BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf=-I/usr/include
 
 # Install Slint build dependencies for linuxkms backend
 RUN apt-get update && \


### PR DESCRIPTION
- Speed up the build by using cross-compilation instead of qemu
- Add slint-viewer to the containers. Not entirely useful by itself yet with `--remote` because of networking, but it belongs there :)