### PR TITLE
Add a demo launcher app for embedded devices

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -496,6 +496,7 @@ Randriana
 rasterizer
 rasterizes
 RBUTTONUP
+recompiles
 rects
 redoable
 REFR

--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -261,6 +261,7 @@ hlayout
 hmenu
 horizontalbox
 horizontallayout
+hotplug
 hspace
 HSPI
 HSYNC

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2417,8 +2417,10 @@ dependencies = [
  "i-slint-common",
  "i-slint-core",
  "i-slint-renderer-femtovg",
+ "i-slint-renderer-skia",
  "i-slint-renderer-software",
  "input",
+ "libseat",
  "memmap2",
  "nix",
  "raw-window-handle",
@@ -2439,6 +2441,8 @@ dependencies = [
  "i-slint-core",
  "i-slint-core-macros",
  "i-slint-renderer-femtovg",
+ "i-slint-renderer-skia",
+ "input",
 ]
 
 [[package]]
@@ -2448,6 +2452,7 @@ dependencies = [
  "cfg_aliases",
  "i-slint-common",
  "i-slint-core",
+ "i-slint-renderer-skia",
  "i-slint-renderer-software",
  "vtable",
 ]
@@ -3211,6 +3216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "launcher"
+version = "1.18.0"
+dependencies = [
+ "input",
+ "slint",
+ "slint-build",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,6 +3278,26 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.9.0",
+]
+
+[[package]]
+name = "libseat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6656c69b6e0366ffb83faa232f3e4fda5fc91161722d140f2c95ce2e90b1ef31"
+dependencies = [
+ "errno",
+ "libseat-sys",
+ "log",
+]
+
+[[package]]
+name = "libseat-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a484fa48be5f62a8d3ffed767779d0ab808cfead91de98ef4362d469097dfb"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -5416,6 +5450,7 @@ dependencies = [
  "i-slint-core",
  "i-slint-core-macros",
  "i-slint-renderer-femtovg",
+ "i-slint-renderer-skia",
  "i-slint-renderer-software",
  "num-traits",
  "once_cell",
@@ -5544,6 +5579,7 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "as-raw-xcb-connection",
  "bytemuck",
+ "drm",
  "fastrand",
  "js-sys",
  "memmap2",

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -11,6 +11,7 @@
 members = [
   'energy-monitor',
   'home-automation/rust',
+  'launcher',
   'printerdemo/rust',
   'printerdemo_mcu',
   'usecases/rust',

--- a/demos/launcher/Cargo.toml
+++ b/demos/launcher/Cargo.toml
@@ -1,0 +1,36 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "launcher"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+build = "build.rs"
+license = "MIT"
+publish = false
+description = "Launcher to start the installed Slint demos and examples, for use on embedded devices"
+
+[[bin]]
+path = "main.rs"
+name = "slint-demo-launcher"
+
+[features]
+# The desktop flavor, for development: the demos run alongside the launcher.
+default = ["slint/default"]
+## Use this backend on embedded devices without a windowing system. The
+## launched demo then replaces the launcher, instead of running side by side.
+backend-linuxkms = ["slint/backend-linuxkms", "slint/unstable-libinput-09", "dep:input"]
+backend-linuxkms-noseat = ["slint/backend-linuxkms-noseat", "slint/unstable-libinput-09", "dep:input"]
+renderer-skia = ["slint/renderer-skia"]
+
+[dependencies]
+slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "accessibility", "compat-1-2", "renderer-femtovg", "renderer-software"] }
+
+# To inspect the events that slint::BackendSelector::with_libinput_event_hook
+# delivers, for detecting whether a keyboard is attached.
+[target.'cfg(target_os = "linux")'.dependencies]
+input = { version = "0.10.0", optional = true }
+
+[build-dependencies]
+slint-build = { path = "../../api/rs/build" }

--- a/demos/launcher/README.md
+++ b/demos/launcher/README.md
@@ -1,0 +1,13 @@
+# Demo Launcher
+
+A little helper application for embedded devices that lists the Slint demos
+and examples installed on the system and launches them, along with an entry to
+start `slint-viewer --remote` to turn the device into a live-preview target
+for the Slint IDE integrations.
+
+At startup, the launcher checks a built-in catalog of known demo and example
+binary names against the directories in the `PATH` environment variable, and
+only shows the ones that are installed. The launcher's own directory is
+searched, too: in a development build the workspace's demos and examples land
+in the same cargo target directory, so `cargo run -p launcher` shows the ones
+that were built.

--- a/demos/launcher/build.rs
+++ b/demos/launcher/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    slint_build::compile("ui/launcher.slint").unwrap();
+}

--- a/demos/launcher/input_device_monitor.rs
+++ b/demos/launcher/input_device_monitor.rs
@@ -1,0 +1,149 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+//! Tracking of attached input devices, to drive the `Launcher` global's
+//! `keyboard-attached` and `input-device-attached` properties.
+//!
+//! On LinuxKMS, input devices can come and go: without a keyboard the focus
+//! ring in the UI makes no sense, and without any input device at all the UI
+//! shows a hint. [`install()`] selects the backend with a libinput event hook
+//! that tracks the attached keyboards, pointer devices, and touch screens.
+//! The hook runs on the event loop thread. Outside LinuxKMS, a no-op twin of
+//! [`install()`] keeps `main()` free of conditional compilation: input
+//! devices are assumed to be present (the Launcher global's property
+//! defaults) and the backend is selected as usual.
+
+#[cfg(all(
+    target_os = "linux",
+    any(feature = "backend-linuxkms", feature = "backend-linuxkms-noseat")
+))]
+mod linuxkms {
+    use crate::{Launcher, LauncherWindow};
+    use slint::ComponentHandle;
+    use std::cell::{Cell, OnceCell};
+    use std::rc::Rc;
+
+    #[derive(Clone, Copy, Default, PartialEq)]
+    struct AttachedInputDevices {
+        keyboard: bool,
+        pointer: bool,
+        touch: bool,
+    }
+
+    impl AttachedInputDevices {
+        fn any(self) -> bool {
+            self.keyboard || self.pointer || self.touch
+        }
+    }
+
+    fn is_keyboard(device: &input::Device) -> bool {
+        if !device.has_capability(input::DeviceCapability::Keyboard) {
+            return false;
+        }
+        // The keyboard capability is also claimed by devices that merely have
+        // keys, such as power buttons. Require udev's ID_INPUT_KEYBOARD, which
+        // is only set for devices with a full set of keys.
+        // SAFETY: the returned udev device is dropped before the libinput
+        // device, and no udev context is shared with other threads.
+        unsafe { device.udev_device() }.is_some_and(|udev_device| {
+            udev_device.property_value("ID_INPUT_KEYBOARD").is_some_and(|value| value == "1")
+        })
+    }
+
+    /// Connects the window to the monitor installed by [`install()`].
+    pub struct Monitor {
+        window: Rc<OnceCell<slint::Weak<LauncherWindow>>>,
+    }
+
+    impl Monitor {
+        pub fn attach(&self, ui: &LauncherWindow) {
+            // No input devices until libinput reports them.
+            let launcher = ui.global::<Launcher>();
+            launcher.set_keyboard_attached(false);
+            launcher.set_input_device_attached(false);
+            let _ = self.window.set(ui.as_weak());
+        }
+    }
+
+    pub fn install() -> Result<Monitor, slint::PlatformError> {
+        let window: Rc<OnceCell<slint::Weak<LauncherWindow>>> = Rc::new(OnceCell::new());
+        let hook_window = window.clone();
+        let keyboards = Cell::new(0usize);
+        let pointers = Cell::new(0usize);
+        let touch_screens = Cell::new(0usize);
+        slint::BackendSelector::new()
+            // This build of the launcher launches demos by replacing itself,
+            // which only makes sense on LinuxKMS. Pin the backend so that the
+            // runtime selection cannot diverge from that launch mode.
+            .backend_name("linuxkms".into())
+            .with_libinput_event_hook(move |event| {
+                use input::event::DeviceEvent;
+                if let input::Event::Device(device_event) = event {
+                    use input::event::EventTrait;
+                    let delta = match device_event {
+                        DeviceEvent::Added(_) => 1,
+                        DeviceEvent::Removed(_) => -1,
+                        _ => return false,
+                    };
+                    let state = || AttachedInputDevices {
+                        keyboard: keyboards.get() > 0,
+                        pointer: pointers.get() > 0,
+                        touch: touch_screens.get() > 0,
+                    };
+                    let previous = state();
+                    let device = device_event.device();
+                    let update = |counter: &Cell<usize>, claimed: bool| {
+                        if claimed {
+                            counter.set(counter.get().saturating_add_signed(delta));
+                        }
+                    };
+                    update(&keyboards, is_keyboard(&device));
+                    update(&pointers, device.has_capability(input::DeviceCapability::Pointer));
+                    update(&touch_screens, device.has_capability(input::DeviceCapability::Touch));
+                    let current = state();
+                    if current != previous
+                        && let Some(ui) = hook_window.get().and_then(|weak| weak.upgrade())
+                    {
+                        let launcher = ui.global::<Launcher>();
+                        let keyboard_was_attached = launcher.get_keyboard_attached();
+                        launcher.set_keyboard_attached(current.keyboard);
+                        launcher.set_input_device_attached(current.any());
+                        if current.keyboard && !keyboard_was_attached {
+                            ui.invoke_reset_focus();
+                        }
+                    }
+                }
+                false // don't consume the event
+            })
+            .select()?;
+        Ok(Monitor { window })
+    }
+}
+
+#[cfg(all(
+    target_os = "linux",
+    any(feature = "backend-linuxkms", feature = "backend-linuxkms-noseat")
+))]
+pub use linuxkms::install;
+
+#[cfg(not(all(
+    target_os = "linux",
+    any(feature = "backend-linuxkms", feature = "backend-linuxkms-noseat")
+)))]
+mod noop {
+    pub struct Monitor;
+
+    impl Monitor {
+        pub fn attach(&self, _ui: &crate::LauncherWindow) {}
+    }
+
+    pub fn install() -> Result<Monitor, slint::PlatformError> {
+        Ok(Monitor)
+    }
+}
+
+#[cfg(not(all(
+    target_os = "linux",
+    any(feature = "backend-linuxkms", feature = "backend-linuxkms-noseat")
+)))]
+pub use noop::install;

--- a/demos/launcher/main.rs
+++ b/demos/launcher/main.rs
@@ -1,0 +1,205 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::include_modules!();
+
+mod input_device_monitor;
+
+use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
+use std::path::PathBuf;
+
+struct CatalogEntry {
+    binary: &'static str,
+    title: &'static str,
+    description: &'static str,
+    args: &'static [&'static str],
+}
+
+/// The demos and examples this launcher knows about, by installed binary name.
+/// Only the ones found in PATH (or the extra search directories) are shown.
+const CATALOG: &[CatalogEntry] = &[
+    CatalogEntry {
+        binary: "slint-viewer",
+        title: "Remote Live-Preview",
+        description: "Turn this device into a live-preview target that the Slint IDE integrations connect to over the network.",
+        args: &["--remote"],
+    },
+    CatalogEntry {
+        binary: "printerdemo",
+        title: "Printer Demo",
+        description: "A fictional user interface for the touch screen of a printer.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "energy-monitor",
+        title: "Energy Monitor",
+        description: "A fictional user interface of a device that monitors energy consumption in a building.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "home-automation",
+        title: "Home Automation",
+        description: "A fictional user interface of a device that automates the control of a home.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "usecases",
+        title: "Usecases",
+        description: "Different example use cases in one app.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "weather-demo",
+        title: "Weather Demo",
+        description: "A weather application using real weather data from the OpenWeather API.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "gallery",
+        title: "Widgets Gallery",
+        description: "A gallery of the standard widgets that come with Slint.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "todo",
+        title: "Todo",
+        description: "A simple todo list application.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "memory",
+        title: "Memory Game",
+        description: "The memory game from the Slint tutorial.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "slide_puzzle",
+        title: "Slide Puzzle",
+        description: "A sliding tile puzzle game.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "carousel",
+        title: "Carousel",
+        description: "A custom carousel widget that can be controlled by touch, mouse, and keyboard.",
+        args: &[],
+    },
+    CatalogEntry {
+        binary: "speedometer",
+        title: "Speedometer",
+        description: "A dashboard with an animated speedometer.",
+        args: &[],
+    },
+];
+
+/// Search for `binary` in `search_dirs` and return the first match.
+fn find_binary(binary: &str, search_dirs: &[PathBuf]) -> Option<PathBuf> {
+    let file_name = format!("{binary}{}", std::env::consts::EXE_SUFFIX);
+    search_dirs.iter().map(|dir| dir.join(&file_name)).find(|candidate| {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            candidate.metadata().is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        }
+        #[cfg(not(unix))]
+        {
+            candidate.is_file()
+        }
+    })
+}
+
+/// On LinuxKMS the launcher owns the screen exclusively; there is no windowing
+/// system to hand the display back and forth with a demo running side by side.
+/// The launched demo replaces the launcher instead.
+fn backend_is_linuxkms() -> bool {
+    match std::env::var("SLINT_BACKEND") {
+        Ok(backend) => backend.to_ascii_lowercase().starts_with("linuxkms"),
+        Err(_) => {
+            cfg!(any(feature = "backend-linuxkms", feature = "backend-linuxkms-noseat"))
+                && !cfg!(feature = "default")
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut search_dirs = Vec::new();
+    // In a development build, the demos and examples built from the workspace
+    // land in the same cargo target directory as the launcher itself, so
+    // `cargo run -p launcher` finds them without any configuration.
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        search_dirs.push(dir.to_path_buf());
+    }
+    if let Some(path) = std::env::var_os("PATH") {
+        search_dirs.extend(std::env::split_paths(&path));
+    }
+    let installed: Vec<(&'static CatalogEntry, PathBuf)> = CATALOG
+        .iter()
+        .filter_map(|entry| find_binary(entry.binary, &search_dirs).map(|path| (entry, path)))
+        .collect();
+
+    // On LinuxKMS, only show the focus ring while a keyboard is attached, and
+    // show a hint while no input device is attached at all. The monitor's
+    // libinput hook must be installed before the window is created.
+    let monitor = input_device_monitor::install()?;
+    let ui = LauncherWindow::new()?;
+    monitor.attach(&ui);
+
+    if backend_is_linuxkms() {
+        ui.invoke_default_to_dark_color_scheme();
+    }
+
+    let launcher = ui.global::<Launcher>();
+    launcher.set_entries(ModelRc::new(
+        installed
+            .iter()
+            .map(|(entry, _)| LauncherEntry {
+                title: entry.title.into(),
+                description: entry.description.into(),
+            })
+            .collect::<VecModel<_>>(),
+    ));
+
+    launcher.on_launch({
+        let ui = ui.as_weak();
+        move |index| {
+            let Some((entry, path)) = installed.get(index as usize) else { return };
+            let binary = entry.binary;
+
+            let mut command = std::process::Command::new(path);
+            command.args(entry.args);
+
+            // On LinuxKMS, replace this process with the demo: exec() closes
+            // the DRM device and hands the whole screen over. There is no way
+            // back other than restarting the launcher.
+            #[cfg(unix)]
+            if backend_is_linuxkms() {
+                use std::os::unix::process::CommandExt;
+                let err = command.exec(); // only returns on failure
+                ui.unwrap()
+                    .global::<Launcher>()
+                    .set_status(format!("Failed to start {binary}: {err}").into());
+                return;
+            }
+
+            let ui_handle = ui.clone();
+            let report = move |message: SharedString| {
+                // Reporting fails when the launcher was closed while the demo
+                // was still running; there is nobody left to tell then.
+                let _ = ui_handle.upgrade_in_event_loop(move |ui| {
+                    ui.global::<Launcher>().set_status(message);
+                });
+            };
+
+            std::thread::spawn(move || match command.status() {
+                Ok(status) if status.success() => report(SharedString::default()),
+                Ok(status) => report(format!("{binary} exited with {status}").into()),
+                Err(err) => report(format!("Failed to start {binary}: {err}").into()),
+            });
+        }
+    });
+
+    ui.run()?;
+    Ok(())
+}

--- a/demos/launcher/ui/launcher.slint
+++ b/demos/launcher/ui/launcher.slint
@@ -1,0 +1,253 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Palette } from "std-widgets.slint";
+import "../../home-automation/ui/fonts/Inter-VariableFont.ttf";
+
+export struct LauncherEntry {
+    title: string,
+    description: string,
+}
+
+export global Launcher {
+    in property <[LauncherEntry]> entries;
+    in property <string> status;
+    // Whether a keyboard is available for navigating the list. Only then the
+    // focus ring around the selected entry is shown. On LinuxKMS the host
+    // tracks keyboard hotplug via libinput; elsewhere a keyboard is assumed.
+    in property <bool> keyboard-attached: true;
+    // Whether any input device - keyboard, mouse, or touch screen - is
+    // attached. While none is, a hint is shown. On LinuxKMS the host tracks
+    // this via libinput; elsewhere input devices are assumed.
+    in property <bool> input-device-attached: true;
+    callback launch(int);
+}
+
+global Style {
+    out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
+    // In light mode less transparency: the light gray page background eats
+    // more of the contrast than the dark one does.
+    out property <color> secondary-text: Palette.foreground.transparentize(dark-color-scheme ? 0.4 : 0.3);
+}
+
+component EntryButton inherits Rectangle {
+    in property <string> title;
+    in property <string> description;
+    in property <bool> selected;
+    callback activated;
+
+    border-radius: 12px;
+    // Mostly opaque, so that the decorative lines of the window background
+    // don't shine through the text. In dark mode the cards are lighter than
+    // the page; in light mode they are white on the light gray page, since
+    // gray-on-gray offers too little contrast.
+    background: (touch.pressed ? Palette.background.mix(Palette.foreground, Style.dark-color-scheme ? 0.75 : 0.86)
+        : touch.has-hover ? Palette.background.mix(Palette.foreground, Style.dark-color-scheme ? 0.82 : 0.94)
+        : Style.dark-color-scheme ? Palette.background.mix(Palette.foreground, 0.88)
+        : Palette.background).with-alpha(0.9);
+    animate background { duration: 150ms; }
+    border-width: root.selected ? 2px : 0;
+    border-color: Palette.accent-background;
+
+    touch := TouchArea {
+        mouse-cursor: pointer;
+        clicked => {
+            root.activated();
+        }
+    }
+
+    accessible-role: button;
+    accessible-label: root.title;
+    accessible-action-default => {
+        root.activated();
+    }
+
+    HorizontalLayout {
+        padding: 16px;
+        spacing: 16px;
+
+        VerticalLayout {
+            spacing: 4px;
+            horizontal-stretch: 1;
+            alignment: center;
+
+            Text {
+                text: root.title;
+                font-weight: 500;
+                overflow: elide;
+            }
+
+            Text {
+                text: root.description;
+                font-size: 0.82rem;
+                color: Style.secondary-text;
+                overflow: elide;
+            }
+        }
+
+        Text {
+            text: "›";
+            font-size: 1.41rem;
+            color: Style.secondary-text;
+            vertical-alignment: center;
+        }
+    }
+}
+
+export component LauncherWindow inherits Window {
+    title: @tr("Slint Launcher");
+    preferred-width: 800px;
+    preferred-height: 480px;
+    default-font-family: "Inter";
+
+    property <bool> dark-color-scheme: Style.dark-color-scheme;
+    property <bool> landscape-layout: root.width > root.height;
+
+    // Called by the host on LinuxKMS, where no system color scheme preference
+    // exists that could be followed. On desktops the system preference wins.
+    public function default-to-dark-color-scheme() {
+        Palette.color-scheme = ColorScheme.dark;
+    }
+
+    // Keyboard navigation state: the entry launched with the Return key. The
+    // uniform entry height keeps the scroll-into-view arithmetic simple; it is
+    // in rem so that it grows with the window's default font size.
+    property <int> current-item: 0;
+    property <length> item-height: 6rem;
+    property <length> item-spacing: 8px;
+
+    function select(index: int) {
+        if Launcher.entries.length == 0 {
+            return;
+        }
+        current-item = Math.clamp(index, 0, Launcher.entries.length - 1);
+        // Scroll the selected entry into view.
+        if -flick.viewport-y > item-top(current-item) {
+            flick.viewport-y = -item-top(current-item);
+        } else if item-top(current-item) + item-height + flick.viewport-y > flick.height {
+            flick.viewport-y = flick.height - (item-top(current-item) + item-height);
+        }
+    }
+
+    pure function item-top(index: int) -> length {
+        index * (item-height + item-spacing)
+    }
+
+    forward-focus: key-handler;
+
+    // Called when a keyboard is attached, so that cursor key navigation
+    // works right away.
+    public function reset-focus() {
+        key-handler.focus();
+    }
+
+    key-handler := FocusScope {
+        key-pressed(event) => {
+            if event.text == Key.DownArrow {
+                root.select(root.current-item + 1);
+                return accept;
+            }
+            if event.text == Key.UpArrow {
+                root.select(root.current-item - 1);
+                return accept;
+            }
+            if event.text == Key.Return || event.text == " " {
+                if Launcher.entries.length > 0 {
+                    Launcher.launch(root.current-item);
+                }
+                return accept;
+            }
+            reject
+        }
+    }
+
+    Rectangle {
+        background: root.dark-color-scheme ? @linear-gradient(180deg, #1C1C1C, black) : @linear-gradient(0deg, #D7D9DD, white);
+    }
+
+    if !root.landscape-layout: Image {
+        y: root.height - self.height;
+        width: 100%;
+        source: root.dark-color-scheme
+            ? @image-url("../../../tools/viewer/remote/assets/bg-frame.svg")
+            : @image-url("../../../tools/viewer/remote/assets/bg-frame-light.svg");
+    }
+
+    if root.landscape-layout: Image {
+        x: root.width - self.width;
+        y: root.height - self.height - root.height * 20%;
+        width: min(root.width * 0.36, 360px);
+        source: root.dark-color-scheme
+            ? @image-url("../../../tools/viewer/remote/assets/bg-frame-mark.svg")
+            : @image-url("../../../tools/viewer/remote/assets/bg-frame-mark-light.svg");
+    }
+
+    if root.landscape-layout: Image {
+        x: 0px;
+        y: root.height - self.height;
+        width: root.width;
+        source: root.dark-color-scheme
+            ? @image-url("../../../tools/viewer/remote/assets/bg-frame-lines.svg")
+            : @image-url("../../../tools/viewer/remote/assets/bg-frame-lines-light.svg");
+    }
+
+    VerticalLayout {
+        padding-left: max(root.safe-area-insets.left, 24px);
+        padding-right: max(root.safe-area-insets.right, 24px);
+        padding-top: root.safe-area-insets.top + 24px;
+        padding-bottom: root.safe-area-insets.bottom + 24px;
+        spacing: 16px;
+
+        VerticalLayout {
+            spacing: 8px;
+
+            Text {
+                text: @tr("Welcome to");
+                font-size: 1.41rem;
+                font-weight: 100;
+                opacity: 0.9;
+            }
+
+            Text {
+                text: @tr("Slint Demos & Examples");
+                font-size: 1.41rem;
+                font-weight: 400;
+            }
+        }
+
+        flick := Flickable {
+            vertical-stretch: 1;
+
+            VerticalLayout {
+                alignment: start;
+                spacing: root.item-spacing;
+
+                for entry[index] in Launcher.entries: EntryButton {
+                    height: root.item-height;
+                    title: entry.title;
+                    description: entry.description;
+                    selected: Launcher.keyboard-attached && index == root.current-item;
+                    activated => {
+                        root.select(index);
+                        Launcher.launch(index);
+                    }
+                }
+
+                if Launcher.entries.length == 0: Text {
+                    text: @tr("No demos or examples were found in PATH.");
+                    color: Style.secondary-text;
+                }
+            }
+        }
+
+        // The no-input-device hint takes priority over the last exit status.
+        if !Launcher.input-device-attached || Launcher.status != "": Text {
+            text: !Launcher.input-device-attached
+                ? @tr("Connect a keyboard, mouse, or touch screen to get started.")
+                : Launcher.status;
+            font-size: 0.82rem;
+            color: Style.secondary-text;
+            wrap: word-wrap;
+        }
+    }
+}

--- a/docker/Dockerfile.torizon-demos
+++ b/docker/Dockerfile.torizon-demos
@@ -45,30 +45,36 @@ RUN apt-get update && \
 # Build Demos
 COPY . /slint
 WORKDIR /slint
+# Each cargo invocation whose unified `slint` feature set differs from the
+# previous one recompiles the whole slint stack (i-slint-core and everything
+# above it), so keep the number of invocations minimal and their feature
+# unification identical: build all demos-workspace binaries (including the
+# launcher and home-automation) in a single invocation, and add slint/serde
+# so that the demos build unifies to the same feature set as the examples
+# build and both share the library artifacts via the common target directory.
 RUN mkdir demos_compiled \
-    && cargo build --release --target $RUST_TOOLCHAIN_ARCH --features slint/renderer-skia,slint/backend-linuxkms-noseat \
-        -p printerdemo -p slide_puzzle -p gallery -p opengl_underlay -p carousel -p todo -p energy-monitor -p weather-demo \
+    && if [ "$BUILD_HOME_AUTOMATION_SW_RENDERER" = "true" ]; then \
+        HOME_AUTOMATION_FEATURES=",home-automation/sw-renderer"; \
+    else \
+        HOME_AUTOMATION_FEATURES=""; \
+    fi \
+    && cargo build --release --target $RUST_TOOLCHAIN_ARCH --manifest-path demos/Cargo.toml \
+        --features slint/renderer-skia,slint/backend-linuxkms-noseat,slint/serde,launcher/backend-linuxkms-noseat,launcher/renderer-skia$HOME_AUTOMATION_FEATURES \
+        -p printerdemo -p energy-monitor -p weather-demo -p home-automation -p launcher \
+    && cargo build --release --target $RUST_TOOLCHAIN_ARCH --manifest-path examples/Cargo.toml --features slint/renderer-skia,slint/backend-linuxkms-noseat \
+        -p slide_puzzle -p gallery -p opengl_underlay -p carousel -p todo \
     && cargo build --release --target $RUST_TOOLCHAIN_ARCH --features slint/renderer-skia,slint/backend-linuxkms-noseat \
         -p slint-viewer \
-    && for demo in printerdemo slide_puzzle gallery opengl_underlay carousel todo energy-monitor weather-demo slint-viewer; do \
+    && for demo in printerdemo slide_puzzle gallery opengl_underlay carousel todo energy-monitor weather-demo home-automation slint-demo-launcher slint-viewer; do \
         cp target/$RUST_TOOLCHAIN_ARCH/release/$demo ./demos_compiled/; \
-    done \
-    && if [ "$BUILD_HOME_AUTOMATION_SW_RENDERER" = "true" ]; then \
-        cargo build --release --target $RUST_TOOLCHAIN_ARCH --features slint/renderer-skia,slint/backend-linuxkms-noseat,home-automation/sw-renderer \
-            -p home-automation \
-        && cp target/$RUST_TOOLCHAIN_ARCH/release/home-automation ./demos_compiled/home-automation; \
-    else \
-        cargo build --release --target $RUST_TOOLCHAIN_ARCH --features slint/renderer-skia,slint/backend-linuxkms-noseat \
-            -p home-automation \
-        && cp target/$RUST_TOOLCHAIN_ARCH/release/home-automation ./demos_compiled/home-automation; \
-    fi
+    done
 
 # Create container for target
 FROM --platform=${IMAGE_ARCH} torizon/${BASE_NAME}:${BASE_VERSION} AS deploy
 ARG BUILD_HOME_AUTOMATION_SW_RENDERER
 
 LABEL org.opencontainers.image.source=https://github.com/slint-ui/slint
-LABEL org.opencontainers.image.description="Container image providing Slint demos for use on Torizon. Run with docker run  --user=torizon -v /run/udev:/run/udev -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' --device-cgroup-rule='c 13:* rmw' --device-cgroup-rule='c 4:* rmw'. Available demos: printerdemo slide_puzzle gallery opengl_underlay carousel todo. slint-viewer is included to use the device as a remote live-preview target."
+LABEL org.opencontainers.image.description="Container image providing Slint demos for use on Torizon. Run with docker run  --user=torizon -v /run/udev:/run/udev -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' --device-cgroup-rule='c 13:* rmw' --device-cgroup-rule='c 4:* rmw'. Available demos: printerdemo slide_puzzle gallery opengl_underlay carousel todo energy-monitor weather-demo home-automation. The demo launcher (slint-demo-launcher) shows a menu of the installed demos, and slint-viewer is included for its remote live-preview entry."
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install libfontconfig1 libxkbcommon0 libinput10 fonts-noto-core fonts-noto-cjk fonts-noto-cjk-extra fonts-noto-color-emoji fonts-noto-ui-core fonts-noto-ui-extra \


### PR DESCRIPTION
A little helper app that shows the Slint demos and examples installed on the system and launches them, along with an entry to start slint-viewer --remote to turn the device into a live-preview target.

The launcher checks what's in PATH (for use on devices) or what's in the directly it's installed in (so after `cargo build` in demos it'll be populated when using `cargo run`).

It has a little bit of text at the bottom on linux if no keyboard/mouse/touchscreen is attached, to inform the user what to do.

The look follows the remote viewer's idle screen, reusing its backdrop assets and the Inter font bundled with the home-automation demo.

Obligatory screenshot:

<img width="912" height="624" alt="Bildschirmfoto 2026-07-17 um 16 25 16" src="https://github.com/user-attachments/assets/50bf2102-b9b7-4f8f-bab0-549254727519" />
