### PR TITLE
tests: tolerate rounding differences in language-independent results

### DIFF
--- a/tests/cases/expr/acos.slint
+++ b/tests/cases/expr/acos.slint
@@ -24,8 +24,8 @@ assert!(instance.get_t3().abs() < 0.0001);
 
 ```js
 var instance = new slint.TestCase({});
-assert.equal(instance.t1, 90);
-assert.equal(instance.t2, 60);
-assert.equal(instance.t3, 0);
+assert(Math.abs(instance.t1 - 90) < 0.0001);
+assert(Math.abs(instance.t2 - 60) < 0.0001);
+assert(Math.abs(instance.t3) < 0.0001);
 ```
 */

--- a/tests/cases/expr/asin.slint
+++ b/tests/cases/expr/asin.slint
@@ -24,8 +24,8 @@ assert!((instance.get_t3() - 90.0).abs() < 0.0001);
 
 ```js
 var instance = new slint.TestCase({});
-assert.equal(instance.t1, 0);
-assert.equal(instance.t2, 30);
-assert.equal(instance.t3, 90);
+assert(Math.abs(instance.t1) < 0.0001);
+assert(Math.abs(instance.t2 - 30) < 0.0001);
+assert(Math.abs(instance.t3 - 90) < 0.0001);
 ```
 */

--- a/tests/cases/expr/atan.slint
+++ b/tests/cases/expr/atan.slint
@@ -27,9 +27,9 @@ assert!((instance.get_t4() - 60.0).abs() < 0.0001);
 
 ```js
 var instance = new slint.TestCase({});
-assert.equal(instance.t1, 0);
-assert.equal(instance.t2, 30);
-assert.equal(instance.t3, 45);
-assert.equal(instance.t4, 60);
+assert(Math.abs(instance.t1) < 0.0001);
+assert(Math.abs(instance.t2 - 30) < 0.0001);
+assert(Math.abs(instance.t3 - 45) < 0.0001);
+assert(Math.abs(instance.t4 - 60) < 0.0001);
 ```
 */

--- a/tests/cases/expr/mod.slint
+++ b/tests/cases/expr/mod.slint
@@ -44,14 +44,15 @@ assert!(instance.get_test());
 
 ```js
 var instance = new slint.TestCase({});
-assert.equal(instance.t1, 0);
-assert.equal(instance.t2, 8.5);
-assert.equal(instance.t3, 3);
-assert.equal(instance.t4, 432);
+assert(Math.abs(instance.t1) < 0.0001);
+assert(Math.abs(instance.t2 - 8.5) < 0.0001);
+assert(Math.abs(instance.t3 - 3) < 0.0001);
+assert(Math.abs(instance.t4 - 432) < 0.0001);
 assert.equal(Math.round(instance.t5 * 1000), 1800);
-assert.equal(instance.t6, 2.);
-assert.equal(instance.t7, 3.5);
-assert.equal(instance.t8, 0);
+assert(Math.abs(instance.t6 - 2.) < 0.0001);
+assert(Math.abs(instance.t7 - 3.5) < 0.0001);
+// `(-42) % 2` is `-0` in IEEE-754; compare absolute value so `-0 === 0`.
+assert(Math.abs(instance.t8) < 0.0001);
 assert(instance.test);
 ```
 */

--- a/tests/cases/properties/property_animation_restart.slint
+++ b/tests/cases/properties/property_animation_restart.slint
@@ -30,7 +30,9 @@ assert_eq!(instance.get_yy(), 7500 - 2500/2); // even if time has passed, since 
 slint_testing::mock_elapsed_time(500);
 instance.set_xx(1000);
 slint_testing::mock_elapsed_time(250);
-assert_eq!(instance.get_yy(), 9063);
+// Tolerate ±1 rounding: rust uses Property<i32>::interpolate, which rounds
+// the delta; other code generators interpolate in floats and truncate.
+assert!((instance.get_yy() - 9063).abs() <= 1);
 slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_yy(), 10000);
 ```


### PR DESCRIPTION
The JS blocks compared trigonometry and modulo results with exact floating point equality, and the animation restart test pinned one interpolation step to an exact integer. Compare with a tolerance so the assertions hold regardless of whether an implementation computes in f32 or f64, or rounds versus truncates when interpolating integers. The assertions only get weaker; every implementation that passed before still passes.
