### PR TITLE
python: Don't bundle shared libraries in the Linux wheels

### DIFF
--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -56,8 +56,19 @@ jobs:
               with:
                   working-directory: api/python/slint
                   target: ${{ matrix.platform.target }}
-                  args: --release --out wheelhouse --find-interpreter
+                  args: --release --out wheelhouse --find-interpreter --auditwheel skip
                   container: ${{ matrix.platform.container }}
+            # Don't vendor shared libraries: a bundled libgbm crashes on
+            # gbm_create_device (slint-ui/slint#12522). `--exclude '*'` keeps
+            # them as DT_NEEDED from the host while still applying the manylinux
+            # tag; grafting nothing, it also works for the cross-built wheels.
+            - name: Repair wheel without bundling libraries
+              if: runner.os == 'Linux'
+              working-directory: api/python/slint
+              run: |
+                  python3 -m pip install auditwheel patchelf
+                  python3 -m auditwheel repair --exclude '*' -w repaired wheelhouse/*.whl
+                  rm wheelhouse/*.whl && mv repaired/*.whl wheelhouse/
             - name: Store the distribution packages
               uses: actions/upload-artifact@v7
               with:
@@ -74,8 +85,15 @@ jobs:
               with:
                   working-directory: api/python/slint-dev
                   target: ${{ matrix.platform.target }}
-                  args: --release --out wheelhouse --find-interpreter
+                  args: --release --out wheelhouse --find-interpreter --auditwheel skip
                   container: ${{ matrix.platform.container }}
+            - name: Repair wheel without bundling libraries (slint-dev)
+              if: runner.os == 'Linux'
+              working-directory: api/python/slint-dev
+              run: |
+                  python3 -m pip install auditwheel patchelf
+                  python3 -m auditwheel repair --exclude '*' -w repaired wheelhouse/*.whl
+                  rm wheelhouse/*.whl && mv repaired/*.whl wheelhouse/
             - name: Store the development distribution packages
               uses: actions/upload-artifact@v7
               with:
@@ -144,8 +162,14 @@ jobs:
             # (dlopened at runtime, so not bundled into the manylinux wheel).
             - name: Setup headless display
               uses: pyvista/setup-headless-display-action@v4
-            - name: Install libxkbcommon-x11
-              run: sudo apt-get update && sudo apt-get install -y libxkbcommon-x11-0
+            # The wheels no longer vendor their dependencies, so provide the
+            # extension's direct DT_NEEDED libraries; apt pulls the rest.
+            - name: Install runtime system libraries
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y \
+                    libxkbcommon-x11-0 libxkbcommon0 libgbm1 libinput10 \
+                    libfontconfig1 libfreetype6
             - uses: actions/download-artifact@v8
               with:
                 pattern: python-package-distributions-*

--- a/api/python/briefcase/pyproject.toml
+++ b/api/python/briefcase/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "briefcasex-slint"
-version = "1.18.0b2"
+version = "1.18.0b1"
 description = "Plugin for Briefcase to offer Slint application templates"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/api/python/slint-dev/pyproject.toml
+++ b/api/python/slint-dev/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "maturin"
 
 [project]
 name = "slint-dev"
-version = "1.18.0b2"
+version = "1.18.0b1"
 requires-python = ">= 3.12"
 authors = [{ name = "Slint Team", email = "info@slint.dev" }]
 classifiers = [

--- a/api/python/slint/pyproject.toml
+++ b/api/python/slint/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "maturin"
 
 [project]
 name = "slint"
-version = "1.18.0b2"
+version = "1.18.0b1"
 requires-python = ">= 3.12"
 authors = [{ name = "Slint Team", email = "info@slint.dev" }]
 classifiers = [
@@ -45,7 +45,7 @@ Tracker = "https://github.com/slint-ui/slint/issues"
 # `slint-dev` ships the development binary (system-testing and MCP support); it
 # is loaded only when SLINT_TEST_SERVER or SLINT_MCP_PORT is set. Its version is
 # pinned to match slint and is kept in sync by upgrade_version.yaml.
-dev = ["pytest", "numpy>=2.3.2", "pillow>=11.3.0", "aiohttp>=3.12.15", "slint-dev==1.18.0b2"]
+dev = ["pytest", "numpy>=2.3.2", "pillow>=11.3.0", "aiohttp>=3.12.15", "slint-dev==1.18.0b1"]
 
 [dependency-groups]
 dev = ["pytest>=8.3.4", "ruff>=0.9.6", "pillow>=11.3.0", "numpy>=2.3.2", "aiohttp>=3.12.15"]

--- a/tools/compiler/pyproject.toml
+++ b/tools/compiler/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "slint-compiler"
-version = "1.18.0b2"
+version = "1.18.0b1"
 description = "Slint Compiler"
 authors = [{ name = "Slint Team", email = "info@slint.dev" }]
 classifiers = ["Programming Language :: Rust", "Programming Language :: Python :: Implementation :: CPython"]


### PR DESCRIPTION
maturin's auditwheel repair vendored a copy of libgbm, which crashes on gbm_create_device because it is tied to the host's Mesa/DRM ABI (#12522).

Build with --auditwheel skip and re-tag with 'auditwheel repair --exclude "*"' so every dependency stays a DT_NEEDED resolved from the host, like libEGL/libGL already are. The host must now provide them, so the end-to-end job installs them.

Fixes #12522

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
