### PR TITLE
python: Fix wheel repair failing on root-owned containerized builds

### DIFF
--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -68,7 +68,9 @@ jobs:
               run: |
                   python3 -m pip install auditwheel patchelf
                   python3 -m auditwheel repair --exclude '*' -w repaired wheelhouse/*.whl
-                  rm wheelhouse/*.whl && mv repaired/*.whl wheelhouse/
+                  # The aarch64/armv7 wheels are built by maturin in a container
+                  # as root, so the wheelhouse is root-owned; swap as root.
+                  sudo rm wheelhouse/*.whl && sudo mv repaired/*.whl wheelhouse/
             - name: Store the distribution packages
               uses: actions/upload-artifact@v7
               with:
@@ -93,7 +95,9 @@ jobs:
               run: |
                   python3 -m pip install auditwheel patchelf
                   python3 -m auditwheel repair --exclude '*' -w repaired wheelhouse/*.whl
-                  rm wheelhouse/*.whl && mv repaired/*.whl wheelhouse/
+                  # The aarch64/armv7 wheels are built by maturin in a container
+                  # as root, so the wheelhouse is root-owned; swap as root.
+                  sudo rm wheelhouse/*.whl && sudo mv repaired/*.whl wheelhouse/
             - name: Store the development distribution packages
               uses: actions/upload-artifact@v7
               with:


### PR DESCRIPTION
The aarch64/armv7 wheels are built by maturin inside a container as root, so the wheelhouse is root-owned and the host-side repair step (uid 1001) could not replace the wheel. Swap it as root.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
