### PR TITLE
python: Handle Ctrl-C (SIGINT) in the event loop

### DIFF
--- a/api/python/slint/slint/__init__.py
+++ b/api/python/slint/slint/__init__.py
@@ -21,6 +21,8 @@ from .loop import SlintEventLoop
 from pathlib import Path
 from collections.abc import Coroutine
 import asyncio
+import signal
+import threading
 import gettext
 import gzip
 import base64
@@ -578,6 +580,20 @@ def run_event_loop(
 
     """
 
+    # Decide whether to install our own SIGINT handler *before* asyncio.run()
+    # installs its own: only claim SIGINT on the main thread and only if the
+    # application hasn't set its own handler. asyncio.run()'s built-in Ctrl-C
+    # handling can't help here — it relies on a Python-level signal.signal()
+    # callback that never runs while we are blocked in the native event loop
+    # with the GIL released. Arming it through loop.add_signal_handler() instead
+    # wires up the self-pipe wakeup, so the native loop wakes on Ctrl-C even when
+    # idle (see #11507 for the underlying machinery).
+    interrupted = [False]
+    install_sigint = (
+        threading.current_thread() is threading.main_thread()
+        and signal.getsignal(signal.SIGINT) is signal.default_int_handler
+    )
+
     async def run_inner() -> None:
         global quit_event
         loop = typing.cast(SlintEventLoop, asyncio.get_event_loop())
@@ -591,6 +607,20 @@ def run_event_loop(
             main_task = loop.create_task(main_coro)
             tasks.append(main_task)
 
+        if install_sigint:
+
+            def _on_sigint() -> None:
+                # Preserve Python semantics: stop the loop and re-raise
+                # KeyboardInterrupt out of run_event_loop() below.
+                interrupted[0] = True
+                quit_event.set()
+
+            try:
+                loop.add_signal_handler(signal.SIGINT, _on_sigint)
+            except (NotImplementedError, RuntimeError, ValueError):
+                # add_signal_handler is Unix and main-thread only.
+                pass
+
         done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
         if main_task is not None and main_task in done:
@@ -601,6 +631,8 @@ def run_event_loop(
     global quit_event
     quit_event = asyncio.Event()
     asyncio.run(run_inner(), debug=False, loop_factory=SlintEventLoop)
+    if interrupted[0]:
+        raise KeyboardInterrupt
 
 
 def quit_event_loop() -> None:

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -298,3 +298,30 @@ if sys.platform != "win32":
 
         slint.run_event_loop(run())
         assert handler_called[0]
+
+    def test_sigint_raises_keyboard_interrupt() -> None:
+        # Without any explicit add_signal_handler, Ctrl-C (SIGINT) delivered
+        # while the loop is parked idle in the native wait must be turned into a
+        # KeyboardInterrupt that propagates out of run_event_loop(), rather than
+        # being swallowed (which forces callers/harnesses to escalate to
+        # SIGQUIT and crash the process).
+        import os
+        import signal
+        import threading
+        import time
+
+        def deliver_sigint_later() -> None:
+            time.sleep(0.2)
+            os.kill(os.getpid(), signal.SIGINT)
+
+        def watchdog() -> None:
+            time.sleep(5)
+            native.invoke_from_event_loop(slint.quit_event_loop)
+
+        async def run() -> None:
+            threading.Thread(target=deliver_sigint_later, daemon=True).start()
+            threading.Thread(target=watchdog, daemon=True).start()
+            await asyncio.Event().wait()
+
+        with pytest.raises(KeyboardInterrupt):
+            slint.run_event_loop(run())


### PR DESCRIPTION
While blocked in the native event loop with the GIL released, Python's
default SIGINT handler never runs, so Ctrl-C was ignored on an idle loop
and callers had to escalate to SIGQUIT (which macOS records as a crash).

Arm SIGINT via loop.add_signal_handler() in run_event_loop(), reusing the
self-pipe wakeup wired up for asyncio signal handling (#11507): the native
loop now wakes on Ctrl-C even when idle and raises KeyboardInterrupt out
of run_event_loop(), preserving normal Python semantics. Only claim SIGINT
on the main thread when the application hasn't installed its own handler.

ChangeLog: Python: Ctrl-C (SIGINT) now interrupts a running event loop and raises KeyboardInterrupt