### PR TITLE
Import wgpu textures into the FemtoVG WGPU renderer on wasm

### DIFF
--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -188,7 +188,7 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                     )
                     .unwrap()
             }
-            #[cfg(all(not(target_arch = "wasm32"), feature = "unstable-wgpu-29"))]
+            #[cfg(feature = "unstable-wgpu-29")]
             ImageInner::WGPUTexture(i_slint_core::graphics::WGPUTexture::WGPU29Texture(
                 texture,
             )) => {


### PR DESCRIPTION
Fixes #12538.

The match arm in `internal/renderers/femtovg/images.rs` that hands an `ImageInner::WGPUTexture` to FemtoVG is still gated on `not(target_arch = "wasm32")`, left over from when the WGPU renderer did not exist on wasm. #11580 lifted the equivalent gate on `impl TextureImporter`; this relaxes the arm to match.

**Why not teach `render_to_buffer()` about the variant.** That is where the texture ends up today, so a case there would also make something appear — but at the cost of a readback into `SharedImageBuffer` every frame, which defeats sharing a wgpu device, and the readback is async on WebGPU while the function is not.

**Hazard this exposes.** With `renderer-femtovg` selected but `unstable-wgpu-29` enabled, the arm now reaches `OpenGl::convert_wgpu_29_texture`, which is `unimplemented!()`. Same panic as on desktop today, but newly reachable in the browser. Happy to add a graceful path here if you want one.

**Verified** in Chrome 150 on Linux/Wayland, WebGPU on an NVIDIA adapter, `wasm32-unknown-unknown` with `renderer-femtovg-wgpu` + `unstable-wgpu-29`, rendering into a texture on a device shared through `WGPUConfiguration::Manual`. Empty before, drawn after. I did not run Slint's test suite locally.
