### PR TITLE
Skip the hidpi SVG upscale for the FemtoVG WGPU renderer on wasm

### DIFF
--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -150,8 +150,8 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                     // pre-multiplied alpha. It's possible that this is not generally applicable, but it
                     // is the case for SVGs.
                     let image_flags = if html_image.is_svg() {
-                        if let Some(target_size) = target_size_for_scalable_source
-                            .filter(|_| R::SUPPORTS_HTML_SVG_UPSCALE)
+                        if let Some(target_size) =
+                            target_size_for_scalable_source.filter(|_| R::SUPPORTS_HTML_SVG_UPSCALE)
                         {
                             let dom_element = &html_image.dom_element;
                             dom_element.set_width(target_size.width);

--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -18,6 +18,9 @@ pub trait TextureImporter
 where
     Self: femtovg::Renderer + Sized,
 {
+    /// Whether enlarging an SVG HTMLImageElement affects what gets uploaded (wasm only).
+    const SUPPORTS_HTML_SVG_UPSCALE: bool = true;
+
     #[cfg(not(target_family = "wasm"))]
     fn convert_opengl_texture(opengl_texture: std::num::NonZero<u32>) -> Self::NativeTexture;
 
@@ -39,6 +42,8 @@ impl TextureImporter for femtovg::renderer::OpenGl {
 
 #[cfg(feature = "wgpu-29")]
 impl TextureImporter for femtovg::renderer::WGPURenderer {
+    const SUPPORTS_HTML_SVG_UPSCALE: bool = false;
+
     #[cfg(not(target_family = "wasm"))]
     fn convert_opengl_texture(_opengl_texture: std::num::NonZero<u32>) -> Self::NativeTexture {
         todo!()
@@ -145,7 +150,9 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                     // pre-multiplied alpha. It's possible that this is not generally applicable, but it
                     // is the case for SVGs.
                     let image_flags = if html_image.is_svg() {
-                        if let Some(target_size) = target_size_for_scalable_source {
+                        if let Some(target_size) = target_size_for_scalable_source
+                            .filter(|_| R::SUPPORTS_HTML_SVG_UPSCALE)
+                        {
                             let dom_element = &html_image.dom_element;
                             dom_element.set_width(target_size.width);
                             dom_element.set_height(target_size.height);


### PR DESCRIPTION
Fixes #12540.

On wasm with the FemtoVG WGPU renderer, any SVG image on a display with a scale factor above 1 kills the application: one frame renders, then `copyExternalImageToTexture` fails validation and wgpu's `unwrap()` panics, taking the wasm instance with it. A `std-widgets` `LineEdit` triggers it, because its clear icon is an SVG.

`images.rs` enlarges SVG-backed `HTMLImageElement`s for hidpi by setting the element's width/height attributes, and femtovg derives the copy extent from those attributes. WebGL rasterizes an SVG at the attribute size, so this has been correct since 6d968aa32 introduced it in 2023. WebGPU takes the source size of an `HTMLImageElement` from its natural size and bounds-checks against that, so the enlarged extent is out of bounds. #11580 made this path reachable in the browser.

This gates the enlargement on a `TextureImporter` associated const, defaulting to `true` so the OpenGL renderer is unaffected, and set to `false` for `WGPURenderer`.

**Why not preserve the resolution instead**

The attributes buy no resolution on this backend. The issue has a self-contained page measuring it: with a 16x16 SVG whose attributes are set to 20x20, a 20x20 copy fails as out of bounds and a 16x16 copy succeeds, so WebGPU is reading the natural-size rasterization either way. Setting the attributes produces an invalid extent and nothing else.

Re-rasterizing through a 2D canvas does preserve resolution and does upload cleanly, which I also measured. Reaching it from Slint needs a canvas or `ImageBitmap` variant in femtovg's `ImageSource`, which only carries `HtmlImageElement` on wasm. I kept that out of this PR since it is a feature rather than a fix for the panic, and I am happy to follow up if you want that route.

**What this does not cover**

Icons now upload at their natural size and are stretched to the target size by the renderer, so they are softer on hidpi than under WebGL. That is the trade for the app staying alive.

femtovg's WGPU renderer still uses `ImageSource::dimensions()` as the copy extent, so a consumer that enlarges an `HTMLImageElement` the way Slint did will hit the same panic. Clamping the extent to the element's natural size there would be a useful second line of defence, but it belongs in femtovg rather than here.

**Testing**

Verified in Chrome 150.0.7871.114 on Linux/Wayland at `devicePixelRatio` 1.25, with a wasm build using `backend-winit`, `renderer-femtovg-wgpu` and `unstable-wgpu-29`. Without the patch, opening a page containing a `LineEdit` panics with the error above after one frame. With it, the page renders and stays interactive, and the console is clean.

Note that a scale factor of exactly 1 makes the attribute size and natural size coincide, so this does not reproduce under emulated viewports that pin dpr to 1.0. I did not run the Slint test suite locally and left that to CI.
