### PR TITLE
winit: probe for NSColor.controlAccentColor before calling it

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -887,7 +887,14 @@ impl WinitWindowAdapter {
                 let b = ((colorref >> 16) & 0xFF) as u8;
                 Color::from_argb_u8(255, r, g, b)
             } else if #[cfg(target_os = "macos")] {
+                use objc2::ClassType;
                 use objc2_app_kit::{NSColor, NSColorType};
+                // controlAccentColor is only available on macOS 10.14 and later.
+                // Probe for it so that older systems fall back to the default palette
+                // instead of aborting with an unrecognized-selector exception.
+                if !NSColor::class().responds_to(objc2::sel!(controlAccentColor)) {
+                    return Color::default();
+                }
                 let color = NSColor::controlAccentColor();
                 color.colorUsingType(NSColorType::ComponentBased).map(|c| {
                     let r = c.redComponent() as f32;


### PR DESCRIPTION
`NSColor.controlAccentColor` is only available since macOS 10.14. On older systems the unconditional call raises an `unrecognized selector` exception, which unwinds through the FFI boundary and aborts the process during startup.

This isn't a request to support macOS 10.13 — it just makes the failure graceful: probe with `respondsToSelector`: and fall back to `Color::default()`, which callers already treat as "accent color unavailable" (the same path other platforms take). This mirrors the dynamic-lookup approach the neighboring `prefers_non_blinking_text_insertion_indicator()` already uses for the same reason. Happy to switch to a version check if you prefer that style.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
