### PR TITLE
Persist the box shadow cache across frames in the FemtoVG and Skia re…

### DIFF
--- a/internal/core/graphics/boxshadowcache.rs
+++ b/internal/core/graphics/boxshadowcache.rs
@@ -5,7 +5,11 @@
 This module contains a cache helper for caching box shadow textures.
 */
 
-use std::{cell::RefCell, collections::BTreeMap};
+use alloc::boxed::Box;
+use std::{
+    cell::{Cell, RefCell},
+    collections::BTreeMap,
+};
 
 use crate::items::ItemRc;
 use crate::{
@@ -126,12 +130,48 @@ impl BoxShadowOptions {
     }
 }
 
+/// Upper bound on the number of shadow textures kept alive by a [`BoxShadowCache`].
+const MAX_CACHED_SHADOWS: usize = 16;
+
+struct CacheEntry<ImageType> {
+    image: Option<ImageType>,
+    /// Value of the cache's access counter when this entry was last returned, for LRU eviction.
+    last_used: u64,
+}
+
 /// Cache to hold box textures for given box shadow options.
-pub struct BoxShadowCache<ImageType>(RefCell<BTreeMap<BoxShadowOptions, Option<ImageType>>>);
+pub struct BoxShadowCache<ImageType> {
+    entries: RefCell<BTreeMap<BoxShadowOptions, CacheEntry<ImageType>>>,
+    access_counter: Cell<u64>,
+    /// Track if the window scale factor changes; used to clear the cache if necessary.
+    window_scale_factor_tracker: core::pin::Pin<Box<crate::properties::PropertyTracker>>,
+}
 
 impl<ImageType> Default for BoxShadowCache<ImageType> {
     fn default() -> Self {
-        Self(Default::default())
+        Self {
+            entries: Default::default(),
+            access_counter: Default::default(),
+            window_scale_factor_tracker: Box::pin(Default::default()),
+        }
+    }
+}
+
+impl<ImageType> BoxShadowCache<ImageType> {
+    /// Removes all cached box shadow textures.
+    pub fn clear(&self) {
+        self.entries.borrow_mut().clear();
+    }
+
+    /// Clears the cache if the window's scale factor has changed since the last call, as the
+    /// cached textures are rendered in physical pixels.
+    pub fn clear_cache_if_scale_factor_changed(&self, window: &crate::api::Window) {
+        if self.window_scale_factor_tracker.is_dirty() {
+            self.window_scale_factor_tracker
+                .as_ref()
+                .evaluate_as_dependency_root(|| window.scale_factor());
+            self.clear();
+        }
     }
 }
 
@@ -147,11 +187,28 @@ impl<ImageType: Clone> BoxShadowCache<ImageType> {
     ) -> Option<ImageType> {
         item_cache.get_or_update_cache_entry(item_rc, || {
             let shadow_options = BoxShadowOptions::new(item_rc, box_shadow, scale_factor)?;
-            self.0
-                .borrow_mut()
-                .entry(shadow_options.clone())
-                .or_insert_with(|| shadow_render_fn(&shadow_options))
-                .clone()
+            let mut entries = self.entries.borrow_mut();
+            // Shadow options that change on every frame (an animated blur for example) would grow
+            // the cache without bounds, so evict the least recently used entry when it gets too big.
+            // Note that evicted images may still be alive through the per-item cache; eviction only
+            // means that the shadow has to be re-rendered on the next per-item cache miss.
+            if entries.len() >= MAX_CACHED_SHADOWS
+                && !entries.contains_key(&shadow_options)
+                && let Some(least_recently_used) = entries
+                    .iter()
+                    .min_by_key(|(_, entry)| entry.last_used)
+                    .map(|(options, _)| options.clone())
+            {
+                entries.remove(&least_recently_used);
+            }
+            let stamp = self.access_counter.get() + 1;
+            self.access_counter.set(stamp);
+            let entry = entries.entry(shadow_options.clone()).or_insert_with(|| CacheEntry {
+                image: shadow_render_fn(&shadow_options),
+                last_used: stamp,
+            });
+            entry.last_used = stamp;
+            entry.image.clone()
         })
     }
 }

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -33,7 +33,7 @@ use super::PhysicalSize;
 use super::images::{Texture, TextureCacheKey};
 use super::{PhysicalBorderRadius, PhysicalLength, PhysicalPoint, PhysicalRect, font_cache};
 
-type FemtovgBoxShadowCache<R> = BoxShadowCache<ItemGraphicsCacheEntry<R>>;
+pub(super) type FemtovgBoxShadowCache<R> = BoxShadowCache<ItemGraphicsCacheEntry<R>>;
 
 pub use femtovg::Canvas;
 pub type CanvasRc<R> = Rc<RefCell<Canvas<R>>>;
@@ -88,7 +88,7 @@ pub struct GLItemRenderer<'a, R: femtovg::Renderer + TextureImporter> {
     graphics_cache: &'a ItemGraphicsCache<R>,
     layer_cache: &'a LayerCache<R>,
     texture_cache: &'a RefCell<super::images::TextureCache<R>>,
-    box_shadow_cache: FemtovgBoxShadowCache<R>,
+    box_shadow_cache: &'a FemtovgBoxShadowCache<R>,
     canvas: CanvasRc<R>,
     // Textures from layering or tiling that were scheduled for rendering where we can't delete the femtovg::ImageId yet
     // because that can only happen after calling `flush`. Otherwise femtovg ends up processing
@@ -1153,6 +1153,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         graphics_cache: &'a ItemGraphicsCache<R>,
         layer_cache: &'a LayerCache<R>,
         texture_cache: &'a RefCell<super::images::TextureCache<R>>,
+        box_shadow_cache: &'a FemtovgBoxShadowCache<R>,
         text_layout_cache: &'a sharedparley::TextLayoutCache,
         window: &'a i_slint_core::api::Window,
         width: u32,
@@ -1163,7 +1164,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
             graphics_cache,
             layer_cache,
             texture_cache,
-            box_shadow_cache: Default::default(),
+            box_shadow_cache,
             canvas: canvas.clone(),
             textures_to_delete_after_flush: Default::default(),
             window,

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -108,6 +108,7 @@ pub struct FemtoVGRenderer<B: GraphicsBackend> {
     graphics_cache: itemrenderer::ItemGraphicsCache<B::Renderer>,
     layer_cache: itemrenderer::LayerCache<B::Renderer>,
     texture_cache: RefCell<images::TextureCache<B::Renderer>>,
+    box_shadow_cache: itemrenderer::FemtovgBoxShadowCache<B::Renderer>,
     text_layout_cache: sharedparley::TextLayoutCache,
     rendering_metrics_collector: RefCell<Option<Rc<RenderingMetricsCollector>>>,
     rendering_first_time: Cell<bool>,
@@ -125,6 +126,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
             graphics_cache: Default::default(),
             layer_cache: Default::default(),
             texture_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Cell::new(true),
@@ -239,6 +241,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
 
                 self.graphics_cache.clear_cache_if_scale_factor_changed(window);
                 self.layer_cache.clear_cache_if_scale_factor_changed(window);
+                self.box_shadow_cache.clear_cache_if_scale_factor_changed(window);
                 self.text_layout_cache.clear_cache_if_scale_factor_changed(window);
 
                 let mut item_renderer = self::itemrenderer::GLItemRenderer::new(
@@ -246,6 +249,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     &self.graphics_cache,
                     &self.layer_cache,
                     &self.texture_cache,
+                    &self.box_shadow_cache,
                     &self.text_layout_cache,
                     window,
                     width.get(),
@@ -450,6 +454,7 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
                 self.graphics_cache.clear_all();
                 self.layer_cache.clear_all();
                 self.texture_cache.borrow_mut().clear();
+                self.box_shadow_cache.clear();
             })
             .ok();
     }
@@ -533,6 +538,7 @@ impl<B: GraphicsBackend> FemtoVGRendererExt for FemtoVGRenderer<B> {
             graphics_cache: Default::default(),
             layer_cache: Default::default(),
             texture_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Cell::new(true),
@@ -557,6 +563,7 @@ impl<B: GraphicsBackend> FemtoVGRendererExt for FemtoVGRenderer<B> {
             self.graphics_cache.clear_all();
             self.layer_cache.clear_all();
             self.texture_cache.borrow_mut().clear();
+            self.box_shadow_cache.clear();
         })?;
 
         self.text_layout_cache.clear_all();

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -43,7 +43,7 @@ pub struct SkiaItemRenderer<'a> {
     layer_cache: &'a ItemCache<Option<(PhysicalPoint, skia_safe::Image)>>,
     path_cache: &'a ItemCache<Option<(Vector2D<f32, PhysicalPx>, skia_safe::Path)>>,
     text_layout_cache: &'a sharedparley::TextLayoutCache,
-    box_shadow_cache: &'a mut SkiaBoxShadowCache,
+    box_shadow_cache: &'a SkiaBoxShadowCache,
 }
 
 impl<'a> SkiaItemRenderer<'a> {
@@ -55,7 +55,7 @@ impl<'a> SkiaItemRenderer<'a> {
         layer_cache: &'a ItemCache<Option<(PhysicalPoint, skia_safe::Image)>>,
         path_cache: &'a ItemCache<Option<(Vector2D<f32, PhysicalPx>, skia_safe::Path)>>,
         text_layout_cache: &'a sharedparley::TextLayoutCache,
-        box_shadow_cache: &'a mut SkiaBoxShadowCache,
+        box_shadow_cache: &'a SkiaBoxShadowCache,
     ) -> Self {
         Self {
             canvas,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -171,6 +171,7 @@ pub struct SkiaRenderer {
     image_cache: ItemCache<Option<skia_safe::Image>>,
     layer_cache: ItemCache<Option<(PhysicalPoint, skia_safe::Image)>>,
     path_cache: ItemCache<Option<(Vector2D<f32, PhysicalPx>, skia_safe::Path)>>,
+    box_shadow_cache: itemrenderer::SkiaBoxShadowCache,
     text_layout_cache: sharedparley::TextLayoutCache,
     rendering_metrics_collector: RefCell<Option<Rc<RenderingMetricsCollector>>>,
     rendering_first_time: Cell<bool>,
@@ -199,6 +200,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -221,6 +223,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -256,6 +259,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -291,6 +295,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -326,6 +331,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -361,6 +367,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -396,6 +403,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -431,6 +439,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
@@ -482,6 +491,7 @@ impl SkiaRenderer {
             image_cache: Default::default(),
             layer_cache: Default::default(),
             path_cache: Default::default(),
+            box_shadow_cache: Default::default(),
             text_layout_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Cell::new(true),
@@ -501,6 +511,7 @@ impl SkiaRenderer {
     pub fn set_surface(&self, surface: Box<dyn Surface + 'static>) {
         self.image_cache.clear_all();
         self.path_cache.clear_all();
+        self.box_shadow_cache.clear();
         self.text_layout_cache.clear_all();
         self.rendering_first_time.set(true);
         *self.surface.borrow_mut() = Some(surface);
@@ -533,6 +544,7 @@ impl SkiaRenderer {
     pub fn suspend(&self) -> Result<(), PlatformError> {
         self.image_cache.clear_all();
         self.path_cache.clear_all();
+        self.box_shadow_cache.clear();
         self.text_layout_cache.clear_all();
         // Destroy the old surface before allocating the new one, to work around
         // the vivante drivers using zwp_linux_explicit_synchronization_v1 and
@@ -678,10 +690,9 @@ impl SkiaRenderer {
         let window_inner = WindowInner::from_pub(window);
         let window_adapter = window_inner.window_adapter();
 
-        let mut box_shadow_cache = Default::default();
-
         self.image_cache.clear_cache_if_scale_factor_changed(window);
         self.path_cache.clear_cache_if_scale_factor_changed(window);
+        self.box_shadow_cache.clear_cache_if_scale_factor_changed(window);
         self.text_layout_cache.clear_cache_if_scale_factor_changed(window);
 
         let mut skia_item_renderer = itemrenderer::SkiaItemRenderer::new(
@@ -692,7 +703,7 @@ impl SkiaRenderer {
             &self.layer_cache,
             &self.path_cache,
             &self.text_layout_cache,
-            &mut box_shadow_cache,
+            &self.box_shadow_cache,
         );
 
         let scale_factor = ScaleFactor::new(window_inner.scale_factor());
@@ -979,6 +990,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
         self.image_cache.clear_all();
         self.path_cache.clear_all();
+        self.box_shadow_cache.clear();
         self.text_layout_cache.clear_all();
 
         if let Some(partial_rendering_state) = self.partial_rendering_state() {


### PR DESCRIPTION
…nderers

The BoxShadowCache was owned by the per-render-pass item renderer in both renderers, making it frame-scoped: every redraw re-blurred and re-uploaded shadow textures even when the shadow options were unchanged. Move the cache into the persistent renderer structs, pass it by reference into the item renderers, and clear it together with the other graphics caches on renderer teardown and when the scale factor changes.

Since the cache now outlives the frame, bound its size: entries carry a last-used stamp and the least recently used entry is evicted when the cache is full. Evicted images may still be alive through the per-item cache, so eviction only means a re-render on the next per-item cache miss.

Fixes #12545

changelog: Fixed box shadows being re-rendered on every frame in the FemtoVG and Skia renderers when the shadow itself was unchanged (#12545)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
