### PR TITLE
winit: Support dragging and dropping images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "image",
  "imgref",
  "lyon_path",
  "muda",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2490,6 +2490,7 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "image",
  "imgref",
  "lyon_path",
  "muda",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -7120,6 +7120,7 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "image",
  "imgref",
  "lyon_path",
  "muda",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -112,6 +112,8 @@ accesskit = { version = "0.24", optional = true }
 accesskit_winit = { version = "0.33", optional = true, default-features = false, features = ["accesskit_unix", "async-io", "rwh_06"] }
 # The browser decodes images on the web; decode with the image and resvg crates elsewhere.
 i-slint-core = { workspace = true, features = ["image-decoders", "svg"] }
+# For encoding drag-and-drop image payloads
+image = { workspace = true }
 
 [target.'cfg(not(any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32", target_os = "android")))'.dependencies]
 winit-wayland = { git = "https://github.com/rust-windowing/winit.git", rev = "156433eb912a62a1a07da0f9bbaa2d775270c788", optional = true }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -230,6 +230,18 @@ impl EventLoopState {
     }
 }
 
+/// Decode the encoded image bytes of an incoming drag, without going through the
+/// image cache.
+fn decode_dropped_image(
+    bytes: &[u8],
+    extension_hint: Option<&str>,
+) -> Option<corelib::graphics::Image> {
+    corelib::graphics::load_image_from_dynamic_data(
+        bytes.into(),
+        extension_hint.unwrap_or_default().as_bytes().into(),
+    )
+}
+
 /// Map a winit drag action to Slint's `DragAction`. A `None` (e.g. unknown) action becomes
 /// `DragAction::None`.
 fn dnd_action_to_slint(action: Option<winit::event_loop::DndAction>) -> corelib::items::DragAction {
@@ -698,6 +710,10 @@ impl winit::application::ApplicationHandler for EventLoopState {
                 // the valid actions to the OS, once it arrives (in `DataTransferReceived` below).
                 let _ =
                     event_loop.fetch_data_transfer(id, &winit::data_transfer::TypeHint::Plaintext);
+                let _ = event_loop.fetch_data_transfer(
+                    id,
+                    &winit::data_transfer::TypeHint::Image { extension_hint: None },
+                );
                 if let Some(position) = position {
                     let pos = position.to_logical(runtime_window.scale_factor() as f64);
                     self.cursor_pos = euclid::point2(pos.x, pos.y);
@@ -722,13 +738,47 @@ impl winit::application::ApplicationHandler for EventLoopState {
                 self.shared_backend_data.incoming_transfers.borrow_mut().remove(&id);
             }
             WindowEvent::DataTransferReceived { id, value, .. } => {
-                if let Ok(text) = value.try_as_string() {
-                    self.shared_backend_data
-                        .incoming_transfers
-                        .borrow_mut()
-                        .entry(id)
-                        .or_default()
-                        .set_plain_text(text.into());
+                // Every type fetched in `DragEntered` arrives in its own event and
+                // accumulates on the same transfer, so a drag offering several
+                // representations delivers them all. Dispatch on the value's type rather
+                // than probing each `try_as_*` accessor: those don't all check the type,
+                // e.g. on X11 `try_as_string` on a URI list returns the raw `file://` lines.
+                let received = match value.type_().hint() {
+                    Some(winit::data_transfer::TypeHint::Plaintext) => {
+                        match value.try_as_string() {
+                            Ok(text) => {
+                                self.shared_backend_data
+                                    .incoming_transfers
+                                    .borrow_mut()
+                                    .entry(id)
+                                    .or_default()
+                                    .set_plain_text(text.into());
+                                true
+                            }
+                            Err(_) => false,
+                        }
+                    }
+                    Some(winit::data_transfer::TypeHint::Image { extension_hint }) => {
+                        match value
+                            .try_as_bytes()
+                            .ok()
+                            .and_then(|bytes| decode_dropped_image(&bytes, extension_hint))
+                        {
+                            Some(image) => {
+                                self.shared_backend_data
+                                    .incoming_transfers
+                                    .borrow_mut()
+                                    .entry(id)
+                                    .or_default()
+                                    .set_image(image);
+                                true
+                            }
+                            None => false,
+                        }
+                    }
+                    _ => false,
+                };
+                if received {
                     // The payload is now available: evaluate the DropAreas at the current
                     // position and report the valid actions to the OS.
                     self.dispatch_and_report_incoming(

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1470,26 +1470,16 @@ impl WindowAdapterInternal for WinitWindowAdapter {
         if text.is_none() && image.is_none() {
             return false;
         }
-        /// The source of truth for the outgoing drag, converted on demand to the
-        /// type the receiving application picks.
-        #[derive(Debug)]
-        struct SendState {
-            text: Option<String>,
-            image: Option<corelib::graphics::SharedPixelBuffer<corelib::graphics::Rgba8Pixel>>,
-        }
-        let has_text = text.is_some();
-        let has_image = image.is_some();
-        let mut builder =
-            winit::data_transfer::DataTransferSendBuilder::new(SendState { text, image });
-        if has_text {
-            builder.add_type(winit::data_transfer::TypeHint::Plaintext, |state: &SendState, _| {
-                state.text.clone()
+        let mut builder = winit::data_transfer::DataTransferSendBuilder::new(());
+        if let Some(text) = text {
+            builder.add_type(winit::data_transfer::TypeHint::Plaintext, move |_, _| {
+                Some(text.clone())
             });
         }
-        if has_image {
+        if let Some(image) = image {
             builder.add_type(
                 winit::data_transfer::TypeHint::Image { extension_hint: Some("png") },
-                |state: &SendState, _| encode_png(state.image.as_ref()?),
+                move |_, _| encode_png(&image),
             );
         }
         let data = builder.build();

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -115,36 +115,58 @@ fn icon_to_winit(
     icon: corelib::graphics::Image,
     size: euclid::Size2D<Coord, PhysicalPx>,
 ) -> Option<winit::icon::Icon> {
-    let image_inner: &ImageInner = (&icon).into();
-
-    let pixel_buffer = image_inner.render_to_buffer(Some(size.cast()))?;
-
-    // This could become a method in SharedPixelBuffer...
-    let rgba_pixels: Vec<u8> = match &pixel_buffer {
-        SharedImageBuffer::RGB8(pixels) => pixels
-            .as_bytes()
-            .chunks(3)
-            .flat_map(|rgb| IntoIterator::into_iter([rgb[0], rgb[1], rgb[2], 255]))
-            .collect(),
-        SharedImageBuffer::RGBA8(pixels) => pixels.as_bytes().to_vec(),
-        SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels
-            .as_bytes()
-            .chunks(4)
-            .flat_map(|rgba| {
-                let alpha = rgba[3] as u32;
-                IntoIterator::into_iter(rgba)
-                    .take(3)
-                    .map(move |component| (*component as u32 * alpha / 255) as u8)
-                    .chain(std::iter::once(alpha as u8))
-            })
-            .collect(),
-    };
+    let pixel_buffer = icon.to_rgba8_with_target_size(corelib::graphics::IntSize::new(
+        size.width as u32,
+        size.height as u32,
+    ))?;
 
     Some(
-        winit::icon::RgbaIcon::new(rgba_pixels, pixel_buffer.width(), pixel_buffer.height())
-            .ok()?
-            .into(),
+        winit::icon::RgbaIcon::new(
+            pixel_buffer.as_bytes().to_vec(),
+            pixel_buffer.width(),
+            pixel_buffer.height(),
+        )
+        .ok()?
+        .into(),
     )
+}
+
+/// The image of an outgoing drag, rendered to RGBA pixels ready for PNG encoding.
+/// Not available on wasm, where winit has no drag-and-drop and the PNG encoder
+/// would only grow the binary.
+#[cfg(not(target_arch = "wasm32"))]
+fn drag_image_payload(
+    request: &DragRequest,
+) -> Option<corelib::graphics::SharedPixelBuffer<corelib::graphics::Rgba8Pixel>> {
+    request.data().image().ok()?.to_rgba8()
+}
+#[cfg(target_arch = "wasm32")]
+fn drag_image_payload(
+    _request: &DragRequest,
+) -> Option<corelib::graphics::SharedPixelBuffer<corelib::graphics::Rgba8Pixel>> {
+    None
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn encode_png(
+    pixel_buffer: &corelib::graphics::SharedPixelBuffer<corelib::graphics::Rgba8Pixel>,
+) -> Option<Vec<u8>> {
+    let mut png = Vec::new();
+    image::ImageEncoder::write_image(
+        image::codecs::png::PngEncoder::new(&mut png),
+        pixel_buffer.as_bytes(),
+        pixel_buffer.width(),
+        pixel_buffer.height(),
+        image::ExtendedColorType::Rgba8,
+    )
+    .ok()?;
+    Some(png)
+}
+#[cfg(target_arch = "wasm32")]
+fn encode_png(
+    _pixel_buffer: &corelib::graphics::SharedPixelBuffer<corelib::graphics::Rgba8Pixel>,
+) -> Option<Vec<u8>> {
+    None
 }
 
 fn window_is_resizable(
@@ -1441,15 +1463,36 @@ impl WindowAdapterInternal for WinitWindowAdapter {
         let Some(winit_window) = self.winit_window() else {
             return false;
         };
-        // Only plain text is sent natively for now; without it, fall back to the in-window drag.
-        let Some(text) = request.data().plain_text().ok().filter(|t| !t.is_empty()) else {
+        // Plain text and images are sent natively for now; without either, fall back
+        // to the in-window drag.
+        let text = request.data().plain_text().ok().filter(|t| !t.is_empty()).map(String::from);
+        let image = drag_image_payload(request);
+        if text.is_none() && image.is_none() {
             return false;
-        };
-        let data = winit::data_transfer::DataTransferSendBuilder::new(text.to_string())
-            .with_type(winit::data_transfer::TypeHint::Plaintext, |text: &String, _| {
-                Some(text.clone())
-            })
-            .build();
+        }
+        /// The source of truth for the outgoing drag, converted on demand to the
+        /// type the receiving application picks.
+        #[derive(Debug)]
+        struct SendState {
+            text: Option<String>,
+            image: Option<corelib::graphics::SharedPixelBuffer<corelib::graphics::Rgba8Pixel>>,
+        }
+        let has_text = text.is_some();
+        let has_image = image.is_some();
+        let mut builder =
+            winit::data_transfer::DataTransferSendBuilder::new(SendState { text, image });
+        if has_text {
+            builder.add_type(winit::data_transfer::TypeHint::Plaintext, |state: &SendState, _| {
+                state.text.clone()
+            });
+        }
+        if has_image {
+            builder.add_type(
+                winit::data_transfer::TypeHint::Image { extension_hint: Some("png") },
+                |state: &SendState, _| encode_png(state.image.as_ref()?),
+            );
+        }
+        let data = builder.build();
         let allowed = request.allowed_actions();
         let mut actions = Vec::new();
         if allowed.move_ {

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1219,6 +1219,35 @@ pub fn load_image_from_embedded_data(data: Slice<'static, u8>, format: Slice<'_,
     })
 }
 
+/// Load an image from encoded data that only lives temporarily, such as the payload
+/// of a drag-and-drop operation. Unlike [`load_image_from_embedded_data`], the image
+/// is not added to the image cache.
+#[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]
+pub fn load_image_from_dynamic_data(data: Slice<'_, u8>, format: Slice<'_, u8>) -> Option<Image> {
+    ImageInner::load_from_data_with_cache_key(ImageCacheKey::Invalid, data, format).map(Image)
+}
+
+#[cfg(all(feature = "image-decoders", not(target_arch = "wasm32")))]
+#[test]
+fn test_load_image_from_dynamic_data() {
+    // A 1x1 red PNG
+    let png: &[u8] = &[
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 2,
+        0, 0, 0, 144, 119, 83, 222, 0, 0, 0, 12, 73, 68, 65, 84, 120, 156, 99, 248, 207, 192, 0, 0,
+        3, 1, 1, 0, 201, 254, 146, 239, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ];
+    let image = load_image_from_dynamic_data(png.into(), Slice::from_slice(b"png")).unwrap();
+    assert_eq!(image.size(), IntSize::new(1, 1));
+    assert_eq!(image.to_rgb8().unwrap().as_slice(), &[Rgb8Pixel::new(255, 0, 0)]);
+    // The format is sniffed from the data when no format hint is supplied.
+    let image = load_image_from_dynamic_data(png.into(), Slice::from_slice(b"")).unwrap();
+    assert_eq!(image.size(), IntSize::new(1, 1));
+    assert!(
+        load_image_from_dynamic_data(Slice::from_slice(b"not an image"), Slice::from_slice(b""))
+            .is_none()
+    );
+}
+
 #[test]
 fn test_image_size_from_buffer_without_backend() {
     {

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2284,6 +2284,7 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "image",
  "imgref",
  "lyon_path",
  "muda",


### PR DESCRIPTION
Decode the image data of incoming drags into the DataTransfer's image with a new load_image_from_dynamic_data function that bypasses the image cache, and send the image of an outgoing drag as PNG, encoded on demand. The PNG encoder is not compiled on wasm, where winit has no drag-and-drop.

The drag icon conversion now uses Image::to_rgba8_with_target_size, which also fixes translucent icon pixels being darkened by a second alpha pre-multiplication.
