### PR TITLE
Feature: Named Slots (@children extension) Initial Implementation

### DIFF
--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -114,7 +114,16 @@ fn fill_token_vec(stream: impl Iterator<Item = TokenTree>, vec: &mut Vec<parser:
                     }
                     '*' => SyntaxKind::Star,
                     '/' => SyntaxKind::Div,
-                    '<' => SyntaxKind::LAngle,
+                    '<' => {
+                        if let Some(last) = vec.last_mut() {
+                            if last.kind == SyntaxKind::LAngle && prev_spacing == Spacing::Joint {
+                                last.kind = SyntaxKind::DoubleLess;
+                                last.text = "<<".into();
+                                continue;
+                            }
+                        }
+                        SyntaxKind::LAngle
+                    }
                     '>' => {
                         if let Some(last) = vec.last_mut() {
                             if last.kind == SyntaxKind::LessEqual && prev_spacing == Spacing::Joint

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -115,12 +115,13 @@ fn fill_token_vec(stream: impl Iterator<Item = TokenTree>, vec: &mut Vec<parser:
                     '*' => SyntaxKind::Star,
                     '/' => SyntaxKind::Div,
                     '<' => {
-                        if let Some(last) = vec.last_mut() {
-                            if last.kind == SyntaxKind::LAngle && prev_spacing == Spacing::Joint {
-                                last.kind = SyntaxKind::DoubleLess;
-                                last.text = "<<".into();
-                                continue;
-                            }
+                        if let Some(last) = vec.last_mut()
+                            && last.kind == SyntaxKind::LAngle
+                            && prev_spacing == Spacing::Joint
+                        {
+                            last.kind = SyntaxKind::DoubleLess;
+                            last.text = "<<".into();
+                            continue;
                         }
                         SyntaxKind::LAngle
                     }

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -264,6 +264,10 @@ export default defineConfig({
                                                   slug: "guide/experimental/match-elements",
                                               },
                                               {
+                                                  label: "Named Slots",
+                                                  slug: "guide/experimental/named-slots",
+                                              },
+                                              {
                                                   label: "Deprecated Properties",
                                                   slug: "guide/experimental/deprecated",
                                               },

--- a/docs/astro/src/content/docs/guide/experimental/named-slots.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/named-slots.mdx
@@ -1,0 +1,119 @@
+---
+title: Named Slots
+description: Experimental named slots for multiple content insertion points.
+---
+
+A `slot` is a named insertion point where a component renders content supplied by its user.
+It generalizes the built-in `@children` placeholder: instead of a single anonymous block of children, a component can declare several slots and place each one at a distinct location in its own layout.
+
+> **Note**: named slots are experimental and subject to change.
+> Tracking issue: [slint-ui/slint#6258](https://github.com/slint-ui/slint/issues/6258).
+
+## Declaring a slot
+
+Use the `slot` keyword inside a component to declare a slot, then render it at the desired location by writing the slot's name as an empty element.
+
+```slint no-test
+export component Base inherits Rectangle {
+    slot header;
+    slot footer;
+
+    VerticalLayout {
+        header {}      // render site for the `header` slot
+        @children      // the default slot
+        footer {}      // render site for the `footer` slot
+    }
+}
+```
+
+A declared slot must be rendered exactly once.
+`@children` continues to work as before and represents the default, unnamed slot.
+
+## Assigning a slot
+
+The user of a component fills a slot with the `<<` operator, naming the slot on the left and the content on the right.
+Content that is not assigned to a named slot goes to `@children`, as usual.
+
+```slint no-test
+export component App inherits Rectangle {
+    Base {
+        header << Rectangle { background: blue; }
+        Text { text: "Main Content"; }   // goes to @children
+        footer << Rectangle { background: gray; }
+    }
+}
+```
+
+Assigning a slot is optional.
+An unassigned slot renders nothing.
+
+## Referencing a slot
+
+The name bound to a slot is a regular element reference, so its properties can be read like any other element.
+
+```slint no-test
+export component App inherits Rectangle {
+    Base {
+        header << Rectangle { height: 8px; }
+        out property <length> header-y: header.absolute-position.y;
+    }
+}
+```
+
+## Forwarding a slot
+
+A component can forward one of its own slots to a slot of a child component, again with the `<<` operator.
+This lets a wrapper expose a nested component's slots as its own.
+
+```slint no-test
+export component SlotHost inherits Rectangle {
+    slot host-header;
+    VerticalLayout {
+        host-header {}
+        @children
+    }
+}
+
+export component Outer inherits Rectangle {
+    slot header;
+    SlotHost {
+        host-header << header;   // forward Outer's `header` into SlotHost's `host-header`
+        @children
+    }
+}
+```
+
+## Full example
+
+```slint no-test
+export component Card inherits Rectangle {
+    slot header;
+    slot footer;
+
+    VerticalLayout {
+        header {}
+        @children
+        footer {}
+    }
+}
+
+export component App inherits Window {
+    Card {
+        header << Text { text: "Title"; }
+        Text { text: "Body content"; }
+        footer << Text { text: "Footer"; }
+    }
+}
+```
+
+## Current limitations
+
+The named slot feature is in its early stages. The following restrictions apply:
+
+- The name `children` is reserved for the default slot. Use `@children` to render it.
+
+- A declared slot must be rendered exactly once, and it may not be placed inside a `for`, `if`, or `match` element.
+
+- A slot cannot be placed inside a `PopupWindow` or a `ComponentContainer`.
+
+- Slot assignment and forwarding are only valid on components, and each slot may be assigned at most once.

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -16,6 +16,10 @@ module.exports = grammar({
 
   externals: ($) => [$.block_comment],
 
+  // Substituted into their call sites: as rules of their own they would add a
+  // reduction that conflicts with $.anon_struct_assignment.
+  inline: ($) => [$._statement_identifier, $._statement_type_identifier],
+
   rules: {
     sourcefile: ($) => repeat($._definition),
 
@@ -72,8 +76,8 @@ module.exports = grammar({
 
     component: ($) =>
       seq(
-        optional(seq(field("id", $.simple_identifier), ":=")),
-        field("type", $.user_type_identifier),
+        optional(seq(field("id", $._statement_identifier), ":=")),
+        field("type", $._statement_type_identifier),
         $.block,
       ),
 
@@ -156,7 +160,7 @@ module.exports = grammar({
         field("deprecation", optional($.property_deprecation)),
         field("visibility", optional($.property_visibility)),
         optional("property"),
-        field("name", $.simple_identifier),
+        field("name", $._statement_identifier),
         "<=>",
         field("alias", $.expression),
         ";",
@@ -288,15 +292,26 @@ module.exports = grammar({
     slot_declaration: ($) =>
       seq("slot", field("name", $.simple_identifier), ";"),
 
+    // `slot` is a contextual keyword: it only introduces a slot declaration when a
+    // name follows it, so it stays a valid identifier everywhere else. As with
+    // "changed" in $.callback_event, the lexer would otherwise always prefer the
+    // "slot" keyword over the identifier regex, so alias it back to an identifier
+    // in every statement that may start with one.
+    _statement_identifier: ($) =>
+      choice($.simple_identifier, alias("slot", $.simple_identifier)),
+
+    _statement_type_identifier: ($) =>
+      choice($.user_type_identifier, alias("slot", $.user_type_identifier)),
+
     slot_assignment: ($) =>
-      seq(field("name", $.simple_identifier), "<<", $.component),
+      seq(field("name", $._statement_identifier), "<<", $.component),
 
     slot_forwarding: ($) =>
-      seq(field("name", $.simple_identifier), "<<", field("value", $.expression), ";"),
+      seq(field("name", $._statement_identifier), "<<", field("value", $.expression), ";"),
 
     property_assignment: ($) =>
       seq(
-        field("property", $.simple_identifier),
+        field("property", $._statement_identifier),
         ":",
         field(
           "value",
@@ -657,7 +672,7 @@ module.exports = grammar({
     // By using the alias here we can force Tree-sitter to treat it also as an identifier.
     callback_event: ($) =>
       seq(
-        field("name", choice($.simple_identifier, alias("changed", $.simple_identifier))),
+        field("name", choice($._statement_identifier, alias("changed", $.simple_identifier))),
         optional(field("arguments", $.arguments)),
         "=>",
         field("action", $._binding),

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -278,9 +278,21 @@ module.exports = grammar({
         $.match_statement,
         $.property,
         $.property_assignment,
+        $.slot_declaration,
+        $.slot_assignment,
+        $.slot_forwarding,
         $.states_definition,
         $.transitions_definition,
       ),
+
+    slot_declaration: ($) =>
+      seq("slot", field("name", $.simple_identifier), ";"),
+
+    slot_assignment: ($) =>
+      seq(field("name", $.simple_identifier), "<<", $.component),
+
+    slot_forwarding: ($) =>
+      seq(field("name", $.simple_identifier), "<<", field("value", $.expression), ";"),
 
     property_assignment: ($) =>
       seq(

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use smol_str::SmolStr;
 
 use crate::expression_tree::{BuiltinFunction, Expression, Unit};
-use crate::object_tree::{Component, PropertyVisibility};
+use crate::object_tree::{Component, DEFAULT_SLOT_NAME, PropertyVisibility};
 use crate::typeregister::TypeRegister;
 
 #[derive(Debug, Clone, Default)]
@@ -561,7 +561,7 @@ impl ElementType {
     ) -> Result<ElementType, String> {
         match self {
             Self::Component(component) => {
-                let base_type = match component.child_insertion_points.borrow().get("_children") {
+                let base_type = match component.child_insertion_points.borrow().get(DEFAULT_SLOT_NAME) {
                     Some(insert_in) => insert_in.parent.borrow().base_type.clone(),
                     None => {
                         let base_type = component.root_element.borrow().base_type.clone();

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -561,7 +561,7 @@ impl ElementType {
     ) -> Result<ElementType, String> {
         match self {
             Self::Component(component) => {
-                let base_type = match &*component.child_insertion_point.borrow() {
+                let base_type = match component.child_insertion_points.borrow().get("_children") {
                     Some(insert_in) => insert_in.parent.borrow().base_type.clone(),
                     None => {
                         let base_type = component.root_element.borrow().base_type.clone();

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -5,7 +5,7 @@
     Parse the contents of builtins.slint and fill the builtin type registry
 */
 
-use smol_str::{SmolStr, ToSmolStr};
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2118,6 +2118,7 @@ impl Element {
                         &r,
                         component_child_insertion_points,
                         diag,
+                        tr,
                     );
                     continue;
                 }
@@ -2427,6 +2428,7 @@ impl Element {
         parent: &ElementRc,
         component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
         diagnostics: &mut BuildDiagnostics,
+        type_register: &TypeRegister,
     ) {
         Self::assert_experimental_slots(diagnostics, node, "named slots");
         if let Some(existing) = component_child_insertion_points.get(slot_name.as_str()) {
@@ -2447,6 +2449,15 @@ impl Element {
                 );
             }
             return;
+        }
+        if type_register.lookup_element(slot_name.as_str()).is_ok() {
+            diagnostics.push_warning(
+                format!(
+                    "{} shadows an element type of the same name. This element is a slot placeholder, not an instance of '{slot_name}'",
+                    slot_error_subject(&slot_name)
+                ),
+                node,
+            );
         }
         let insertion_index = parent.borrow().children.len();
         component_child_insertion_points.insert(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -371,6 +371,14 @@ pub struct Timer {
 /// Not a valid Slint identifier, so it can never collide with a user-declared slot name.
 pub const DEFAULT_SLOT_NAME: &str = "@children";
 
+pub fn slot_error_subject(name: &str) -> String {
+    if name == DEFAULT_SLOT_NAME {
+        "The @children placeholder".into()
+    } else {
+        format!("The slot '{name}'")
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ChildrenInsertionPoint {
     pub parent: ElementRc,
@@ -2119,9 +2127,12 @@ impl Element {
                     diag,
                     tr,
                 );
-                for (_, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
+                for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
                     diag.push_error(
-                        "The @children placeholder cannot appear in a repeated element".into(),
+                        format!(
+                            "{} cannot appear in a repeated element",
+                            slot_error_subject(&name)
+                        ),
                         &se,
                     )
                 }
@@ -2137,9 +2148,12 @@ impl Element {
                     diag,
                     tr,
                 );
-                for (_, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
+                for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
                     diag.push_error(
-                        "The @children placeholder cannot appear in a conditional element".into(),
+                        format!(
+                            "{} cannot appear in a conditional element",
+                            slot_error_subject(&name)
+                        ),
                         &se,
                     )
                 }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2082,7 +2082,10 @@ impl Element {
                     );
                 } else {
                     diag.push_error(
-                        format!("The slot '{source}' can only appear once in an element"),
+                        format!(
+                            "{} can only appear once in an element",
+                            slot_error_subject(&source)
+                        ),
                         &forwarding.node,
                     );
                 }
@@ -2191,7 +2194,10 @@ impl Element {
                 diag.slint_sc_error("The @children placeholder is", &se);
                 if component_child_insertion_points.contains_key(DEFAULT_SLOT_NAME) {
                     diag.push_error(
-                        "The @children placeholder can only appear once in an element".into(),
+                        format!(
+                            "{} can only appear once in an element",
+                            slot_error_subject(DEFAULT_SLOT_NAME)
+                        ),
                         &se,
                     );
                 } else {
@@ -2422,7 +2428,10 @@ impl Element {
                 );
             } else {
                 diagnostics.push_error(
-                    format!("The slot '{slot_name}' can only appear once in an element"),
+                    format!(
+                        "{} can only appear once in an element",
+                        slot_error_subject(&slot_name)
+                    ),
                     node,
                 );
             }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1979,8 +1979,7 @@ impl Element {
             if se.kind() != SyntaxKind::SlotForwarding {
                 continue;
             }
-            if !diag.enable_experimental {
-                diag.push_error("'slot forwarding' is an experimental feature".into(), &se);
+            if !Self::assert_experimental_slots(diag, &se, "slot forwarding") {
                 continue;
             }
 
@@ -2182,16 +2181,13 @@ impl Element {
                     );
                 }
             } else if se.kind() == SyntaxKind::SlotDeclaration {
-                if !diag.enable_experimental {
-                    diag.push_error("'named slots' is an experimental feature".into(), &se);
-                }
+                Self::assert_experimental_slots(diag, &se, "named slots");
                 let decl: syntax_nodes::SlotDeclaration = se.into();
                 let name_ident = decl.DeclaredIdentifier();
                 let name = parser::identifier_text(&name_ident).unwrap_or_default();
                 declared_slots.push(DeclaredSlot { name, name_ident: name_ident.into() });
             } else if se.kind() == SyntaxKind::SlotAssignment {
-                if !diag.enable_experimental {
-                    diag.push_error("'named slots' is an experimental feature".into(), &se);
+                if !Self::assert_experimental_slots(diag, &se, "named slots") {
                     continue;
                 }
                 let name = parser::identifier_text(
@@ -2348,6 +2344,18 @@ impl Element {
         )
     }
 
+    fn assert_experimental_slots(
+        diagnostics: &mut BuildDiagnostics,
+        node: &SyntaxNode,
+        what: &str,
+    ) -> bool {
+        if diagnostics.enable_experimental {
+            return true;
+        }
+        diagnostics.push_error(format!("'{what}' is an experimental feature"), node);
+        false
+    }
+
     fn sub_element_slot_placeholder_name(
         node: &SyntaxNode,
         declared_slots: &[DeclaredSlot],
@@ -2374,9 +2382,7 @@ impl Element {
         component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
         diagnostics: &mut BuildDiagnostics,
     ) {
-        if !diagnostics.enable_experimental {
-            diagnostics.push_error("'named slots' is an experimental feature".into(), node);
-        }
+        Self::assert_experimental_slots(diagnostics, node, "named slots");
         if let Some(existing) = component_child_insertion_points.get(slot_name.as_str()) {
             if existing.node.kind() == SyntaxKind::Expression {
                 diagnostics.push_error(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -581,6 +581,9 @@ impl Component {
         if !diagnostics.enable_experimental {
             return;
         }
+        if self.is_global() || self.is_interface() {
+            return;
+        }
         let mut declared_slot_nodes = BTreeMap::<SmolStr, SyntaxNode>::new();
         for slot in self.declared_slots.borrow().iter() {
             if slot.name == "children" {
@@ -1315,6 +1318,7 @@ impl Element {
                 }
             });
             node.MatchElement().for_each(|n| error_on(&n, "match statements"));
+            node.SlotDeclaration().for_each(|n| error_on(&n, "slots"));
 
             if parent_type == ElementType::Interface {
                 node.Binding().for_each(|n| error_on(&n, "bindings"));

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2190,25 +2190,23 @@ impl Element {
                 if !Self::assert_experimental_slots(diag, &se, "named slots") {
                     continue;
                 }
-                let name = parser::identifier_text(
-                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap(),
-                )
-                .unwrap_or_default();
+                let name_node = se.child_node(SyntaxKind::DeclaredIdentifier).unwrap();
+                let name = parser::identifier_text(&name_node).unwrap_or_default();
                 if name == "children" {
                     diag.push_error(
                         format!(
                             "The name '{name}' is reserved for the default slot. Use @children instead"
                         ),
-                        &se,
+                        &name_node,
                     );
                 }
                 if !assigned_slots.insert(name.clone()) {
-                    diag.push_error(format!("Duplicate assignment to slot '{name}'"), &se);
+                    diag.push_error(format!("Duplicate assignment to slot '{name}'"), &name_node);
                 }
                 if r.borrow().forwarded_slots.iter().any(|f| f.target == name) {
                     diag.push_error(
                         format!("Slot '{name}' cannot be both forwarded and assigned"),
-                        &se,
+                        &name_node,
                     );
                 }
                 let sub_element_node = se.child_node(SyntaxKind::SubElement).unwrap();
@@ -2223,7 +2221,7 @@ impl Element {
                     {
                         diag.push_error(
                             format!("Unknown slot '{name}' in '{}'", component.id),
-                            &se,
+                            &name_node,
                         );
                     }
                     ElementType::Component(_) => {}

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2138,16 +2138,12 @@ impl Element {
                     diag,
                     tr,
                 );
-                for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
-                    Self::mark_placeholder_rejected(declared_slots, &name);
-                    diag.push_error(
-                        format!(
-                            "{} cannot appear in a repeated element",
-                            slot_error_subject(&name)
-                        ),
-                        &se,
-                    )
-                }
+                Self::reject_slot_placeholders(
+                    diag,
+                    declared_slots,
+                    sub_child_insertion_points,
+                    "a repeated element",
+                );
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::ConditionalElement {
                 let mut sub_child_insertion_points = BTreeMap::new();
@@ -2160,16 +2156,12 @@ impl Element {
                     diag,
                     tr,
                 );
-                for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
-                    Self::mark_placeholder_rejected(declared_slots, &name);
-                    diag.push_error(
-                        format!(
-                            "{} cannot appear in a conditional element",
-                            slot_error_subject(&name)
-                        ),
-                        &se,
-                    )
-                }
+                Self::reject_slot_placeholders(
+                    diag,
+                    declared_slots,
+                    sub_child_insertion_points,
+                    "a conditional element",
+                );
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::MatchElement {
                 let mut sub_child_insertion_points = BTreeMap::new();
@@ -2182,13 +2174,12 @@ impl Element {
                     diag,
                     tr,
                 );
-                for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
-                    Self::mark_placeholder_rejected(declared_slots, &name);
-                    diag.push_error(
-                        format!("{} cannot appear in a match element", slot_error_subject(&name)),
-                        &se,
-                    )
-                }
+                Self::reject_slot_placeholders(
+                    diag,
+                    declared_slots,
+                    sub_child_insertion_points,
+                    "a match element",
+                );
                 r.borrow_mut().children.extend(rep);
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
                 #[cfg(feature = "slint-sc")]
@@ -2408,6 +2399,21 @@ impl Element {
     fn mark_placeholder_rejected(declared_slots: &mut [DeclaredSlot], name: &str) {
         if let Some(slot) = declared_slots.iter_mut().find(|slot| slot.name.as_str() == name) {
             slot.has_rejected_placeholder = true;
+        }
+    }
+
+    fn reject_slot_placeholders(
+        diagnostics: &mut BuildDiagnostics,
+        declared_slots: &mut [DeclaredSlot],
+        insertion_points: BTreeMap<String, ChildrenInsertionPoint>,
+        context: &str,
+    ) {
+        for (name, ChildrenInsertionPoint { node, .. }) in insertion_points {
+            Self::mark_placeholder_rejected(declared_slots, &name);
+            diagnostics.push_error(
+                format!("{} cannot appear in {context}", slot_error_subject(&name)),
+                &node,
+            );
         }
     }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2082,7 +2082,7 @@ impl Element {
                     );
                 } else {
                     diag.push_error(
-                        format!("The slot '{source}' can only appear once in an element hierarchy"),
+                        format!("The slot '{source}' can only appear once in an element"),
                         &forwarding.node,
                     );
                 }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1997,7 +1997,7 @@ impl Element {
             }
 
             if r.borrow().forwarded_slots.iter().any(|f| f.target == target) {
-                diag.push_error(format!("Duplicate forwarding to slot '{target}'"), &target_node);
+                diag.push_error(format!("Duplicate assignment to slot '{target}'"), &target_node);
                 continue;
             }
 
@@ -2204,10 +2204,7 @@ impl Element {
                     diag.push_error(format!("Duplicate assignment to slot '{name}'"), &name_node);
                 }
                 if r.borrow().forwarded_slots.iter().any(|f| f.target == name) {
-                    diag.push_error(
-                        format!("Slot '{name}' cannot be both forwarded and assigned"),
-                        &name_node,
-                    );
+                    diag.push_error(format!("Duplicate assignment to slot '{name}'"), &name_node);
                 }
                 let sub_element_node = se.child_node(SyntaxKind::SubElement).unwrap();
                 let parent_type = r.borrow().base_type.clone();

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2422,7 +2422,7 @@ impl Element {
                 );
             } else {
                 diagnostics.push_error(
-                    format!("The slot '{slot_name}' can only appear once in an element hierarchy"),
+                    format!("The slot '{slot_name}' can only appear once in an element"),
                     node,
                 );
             }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -390,6 +390,7 @@ pub struct ChildrenInsertionPoint {
 pub struct DeclaredSlot {
     pub name: SmolStr,
     pub name_ident: SyntaxNode,
+    has_rejected_placeholder: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -609,7 +610,14 @@ impl Component {
             }
         }
         for (name, node) in declared_slot_nodes.iter() {
-            if !self.child_insertion_points.borrow().contains_key(name.as_str()) {
+            let has_rejected_placeholder = self
+                .declared_slots
+                .borrow()
+                .iter()
+                .any(|slot| slot.has_rejected_placeholder && &slot.name == name);
+            if !self.child_insertion_points.borrow().contains_key(name.as_str())
+                && !has_rejected_placeholder
+            {
                 diagnostics.push_error(format!("The slot '{name}' is declared but not used"), node);
             }
         }
@@ -2128,6 +2136,7 @@ impl Element {
                     tr,
                 );
                 for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
+                    Self::mark_placeholder_rejected(declared_slots, &name);
                     diag.push_error(
                         format!(
                             "{} cannot appear in a repeated element",
@@ -2149,6 +2158,7 @@ impl Element {
                     tr,
                 );
                 for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
+                    Self::mark_placeholder_rejected(declared_slots, &name);
                     diag.push_error(
                         format!(
                             "{} cannot appear in a conditional element",
@@ -2199,7 +2209,11 @@ impl Element {
                 let decl: syntax_nodes::SlotDeclaration = se.into();
                 let name_ident = decl.DeclaredIdentifier();
                 let name = parser::identifier_text(&name_ident).unwrap_or_default();
-                declared_slots.push(DeclaredSlot { name, name_ident: name_ident.into() });
+                declared_slots.push(DeclaredSlot {
+                    name,
+                    name_ident: name_ident.into(),
+                    has_rejected_placeholder: false,
+                });
             } else if se.kind() == SyntaxKind::SlotAssignment {
                 if !Self::assert_experimental_slots(diag, &se, "named slots") {
                     continue;
@@ -2382,6 +2396,12 @@ impl Element {
         }
         let name = parser::identifier_text(&qualified_name)?;
         declared_slots.iter().any(|slot| slot.name == name).then_some(name)
+    }
+
+    fn mark_placeholder_rejected(declared_slots: &mut [DeclaredSlot], name: &str) {
+        if let Some(slot) = declared_slots.iter_mut().find(|slot| slot.name.as_str() == name) {
+            slot.has_rejected_placeholder = true;
+        }
     }
 
     fn register_slot_placeholder(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2182,9 +2182,10 @@ impl Element {
                     diag,
                     tr,
                 );
-                for (_, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
+                for (name, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
+                    Self::mark_placeholder_rejected(declared_slots, &name);
                     diag.push_error(
-                        "The @children placeholder cannot appear in a match element".into(),
+                        format!("{} cannot appear in a match element", slot_error_subject(&name)),
                         &se,
                     )
                 }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1579,14 +1579,12 @@ impl Element {
             node.Binding().filter_map(|b| {
                 Some((b.child_token(SyntaxKind::Identifier)?, b.BindingExpression().into()))
             }),
-            true,
             is_legacy_syntax,
             diag,
         );
         r.parse_bindings(
             node.TwoWayBinding()
                 .filter_map(|b| Some((b.child_token(SyntaxKind::Identifier)?, b.into()))),
-            false,
             is_legacy_syntax,
             diag,
         );
@@ -2698,7 +2696,6 @@ impl Element {
     fn parse_bindings(
         &mut self,
         bindings: impl Iterator<Item = (crate::parser::SyntaxToken, SyntaxNode)>,
-        _allow_slot_forwarding: bool,
         is_in_legacy_component: bool,
         diag: &mut BuildDiagnostics,
     ) {
@@ -3377,7 +3374,6 @@ fn animation_element_from_node(
             anim.Binding().filter_map(|b| {
                 Some((b.child_token(SyntaxKind::Identifier)?, b.BindingExpression().into()))
             }),
-            false,
             false,
             diag,
         );

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -367,6 +367,10 @@ pub struct Timer {
     pub element: ElementWeak,
 }
 
+/// Key used for the default slot's insertion point and slot-target maps.
+/// Not a valid Slint identifier, so it can never collide with a user-declared slot name.
+pub const DEFAULT_SLOT_NAME: &str = "@children";
+
 #[derive(Clone, Debug)]
 pub struct ChildrenInsertionPoint {
     pub parent: ElementRc,
@@ -570,7 +574,7 @@ impl Component {
         }
         let mut declared_slot_nodes = BTreeMap::<SmolStr, SyntaxNode>::new();
         for slot in self.declared_slots.borrow().iter() {
-            if slot.name == "children" || slot.name == "_children" {
+            if slot.name == "children" {
                 diagnostics.push_error(
                     format!(
                         "The name '{}' is reserved for the default slot. Use @children instead",
@@ -588,7 +592,7 @@ impl Component {
             }
         }
         for (name, cip) in self.child_insertion_points.borrow().iter() {
-            if name == "_children" {
+            if name == DEFAULT_SLOT_NAME {
                 continue;
             }
             if !declared_slot_nodes.contains_key(name.as_str()) {
@@ -1983,7 +1987,7 @@ impl Element {
             let target_node = se.child_node(SyntaxKind::DeclaredIdentifier).unwrap();
             let target = parser::identifier_text(&target_node.clone()).unwrap_or_default();
 
-            if target == "children" || target == "_children" {
+            if target == "children" {
                 diag.push_error(
                     format!(
                         "The name '{target}' is reserved for the default slot. Use @children instead"
@@ -2034,7 +2038,7 @@ impl Element {
                 continue;
             };
 
-            if source == "children" || source == "_children" {
+            if source == "children" {
                 diag.push_error(
                     format!(
                         "The name '{source}' is reserved for the default slot. Use @children instead"
@@ -2162,14 +2166,14 @@ impl Element {
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
                 #[cfg(feature = "slint-sc")]
                 diag.slint_sc_error("The @children placeholder is", &se);
-                if component_child_insertion_points.contains_key("_children") {
+                if component_child_insertion_points.contains_key(DEFAULT_SLOT_NAME) {
                     diag.push_error(
                         "The @children placeholder can only appear once in an element".into(),
                         &se,
                     );
                 } else {
                     component_child_insertion_points.insert(
-                        "_children".into(),
+                        DEFAULT_SLOT_NAME.into(),
                         ChildrenInsertionPoint {
                             parent: r.clone(),
                             insertion_index: r.borrow().children.len(),
@@ -2194,7 +2198,7 @@ impl Element {
                     &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap(),
                 )
                 .unwrap_or_default();
-                if name == "children" || name == "_children" {
+                if name == "children" {
                     diag.push_error(
                         format!(
                             "The name '{name}' is reserved for the default slot. Use @children instead"

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -371,7 +371,20 @@ pub struct Timer {
 pub struct ChildrenInsertionPoint {
     pub parent: ElementRc,
     pub insertion_index: usize,
-    pub node: syntax_nodes::ChildrenPlaceholder,
+    pub node: SyntaxNode,
+}
+
+#[derive(Clone, Debug)]
+pub struct DeclaredSlot {
+    pub name: SmolStr,
+    pub name_ident: SyntaxNode,
+}
+
+#[derive(Clone, Debug)]
+pub struct SlotForwarding {
+    pub target: SmolStr,
+    pub source: SmolStr,
+    pub node: SyntaxNode,
 }
 
 /// Used sub types for a root component
@@ -446,7 +459,10 @@ pub struct Component {
 
     /// When creating this component and inserting "children", append them to the children of
     /// the element pointer to by this field.
-    pub child_insertion_point: RefCell<Option<ChildrenInsertionPoint>>,
+    pub child_insertion_points: RefCell<BTreeMap<String, ChildrenInsertionPoint>>,
+
+    /// Slots declared in this component, in source order.
+    pub declared_slots: RefCell<Vec<DeclaredSlot>>,
 
     pub init_code: RefCell<InitCode>,
 
@@ -478,7 +494,8 @@ impl Component {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> Rc<Self> {
-        let mut child_insertion_point = None;
+        let mut child_insertion_points = BTreeMap::new();
+        let mut declared_slots = Vec::new();
         let is_legacy_syntax = node.child_token(SyntaxKind::ColonEqual).is_some();
         let c = Component {
             node: Some(node.clone()),
@@ -501,14 +518,48 @@ impl Component {
                     }
                     _ => ElementType::Error,
                 },
-                &mut child_insertion_point,
+                &mut child_insertion_points,
+                &mut declared_slots,
                 is_legacy_syntax,
                 diag,
                 tr,
             ),
-            child_insertion_point: RefCell::new(child_insertion_point),
+            child_insertion_points: RefCell::new(child_insertion_points),
+            declared_slots: RefCell::new(declared_slots),
             ..Default::default()
         };
+        let mut declared_slot_nodes = BTreeMap::<SmolStr, SyntaxNode>::new();
+        for slot in c.declared_slots.borrow().iter() {
+            if slot.name == "children" || slot.name == "_children" {
+                diag.push_error(
+                    format!(
+                        "The name '{}' is reserved for the default slot. Use @children instead",
+                        slot.name
+                    ),
+                    &slot.name_ident,
+                );
+                continue;
+            }
+            if declared_slot_nodes.insert(slot.name.clone(), slot.name_ident.clone()).is_some() {
+                diag.push_error(
+                    format!("Duplicate slot declaration '{}'", slot.name),
+                    &slot.name_ident,
+                );
+            }
+        }
+        for (name, cip) in c.child_insertion_points.borrow().iter() {
+            if name == "_children" {
+                continue;
+            }
+            if !declared_slot_nodes.contains_key(name.as_str()) {
+                diag.push_error(format!("The slot '{name}' is used but not declared"), &cip.node);
+            }
+        }
+        for (name, node) in declared_slot_nodes.iter() {
+            if !c.child_insertion_points.borrow().contains_key(name.as_str()) {
+                diag.push_error(format!("The slot '{name}' is declared but not used"), node);
+            }
+        }
         let c = Rc::new(c);
         // x and y on a Window are meaningless
         if c.root_element
@@ -942,6 +993,12 @@ pub struct Element {
     /// How many times the element was inlined
     pub inline_depth: i32,
 
+    /// If this element is assigned to a specific slot in its parent component (e.g., `name << ...`)
+    pub slot_target: Option<SmolStr>,
+
+    /// Slot forwarding mappings declared on this element: `target: source;`
+    pub forwarded_slots: Vec<SlotForwarding>,
+
     /// Information about the grid cell containing this element, if applicable
     pub grid_layout_cell: Option<Rc<RefCell<crate::layout::GridLayoutCell>>>,
 
@@ -1160,7 +1217,8 @@ impl Element {
         node: syntax_nodes::Element,
         id: SmolStr,
         parent_type: ElementType,
-        component_child_insertion_point: &mut Option<ChildrenInsertionPoint>,
+        component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
+        declared_slots: &mut Vec<DeclaredSlot>,
         is_legacy_syntax: bool,
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
@@ -1489,12 +1547,14 @@ impl Element {
             node.Binding().filter_map(|b| {
                 Some((b.child_token(SyntaxKind::Identifier)?, b.BindingExpression().into()))
             }),
+            true,
             is_legacy_syntax,
             diag,
         );
         r.parse_bindings(
             node.TwoWayBinding()
                 .filter_map(|b| Some((b.child_token(SyntaxKind::Identifier)?, b.into()))),
+            false,
             is_legacy_syntax,
             diag,
         );
@@ -1901,8 +1961,117 @@ impl Element {
             }
         }
 
-        let mut children_placeholder = None;
         let r = r.make_rc();
+
+        for se in node.children() {
+            if se.kind() != SyntaxKind::SlotForwarding {
+                continue;
+            }
+            if !diag.enable_experimental {
+                diag.push_error("'slot forwarding' is an experimental feature".into(), &se);
+                continue;
+            }
+
+            let target_node = se.child_node(SyntaxKind::DeclaredIdentifier).unwrap();
+            let target = parser::identifier_text(&target_node.clone().into()).unwrap_or_default();
+
+            if target == "children" || target == "_children" {
+                diag.push_error(
+                    format!(
+                        "The name '{target}' is reserved for the default slot. Use @children instead"
+                    ),
+                    &target_node,
+                );
+                continue;
+            }
+
+            if r.borrow().forwarded_slots.iter().any(|f| f.target == target) {
+                diag.push_error(format!("Duplicate forwarding to slot '{target}'"), &target_node);
+                continue;
+            }
+
+            match &r.borrow().base_type {
+                ElementType::Component(component)
+                    if !component
+                        .declared_slots
+                        .borrow()
+                        .iter()
+                        .any(|slot| slot.name == target) =>
+                {
+                    diag.push_error(
+                        format!("Unknown slot '{target}' in '{}'", component.id),
+                        &target_node,
+                    );
+                    continue;
+                }
+                ElementType::Component(_) => {}
+                _ => {
+                    diag.push_error("Slot forwarding can only be used on components".into(), &se);
+                    continue;
+                }
+            }
+
+            let Some(expr_node) = se.child_node(SyntaxKind::Expression) else {
+                diag.push_error(
+                    "Slot forwarding requires a slot identifier on the right-hand side".into(),
+                    &se,
+                );
+                continue;
+            };
+            let Some(source) = Self::slot_forwarding_expr_identifier(&expr_node) else {
+                diag.push_error(
+                    "Slot forwarding requires a slot identifier on the right-hand side".into(),
+                    &expr_node,
+                );
+                continue;
+            };
+
+            if source == "children" || source == "_children" {
+                diag.push_error(
+                    format!(
+                        "The name '{source}' is reserved for the default slot. Use @children instead"
+                    ),
+                    &expr_node,
+                );
+                continue;
+            }
+
+            r.borrow_mut().forwarded_slots.push(SlotForwarding {
+                target,
+                source,
+                node: expr_node.clone(),
+            });
+        }
+
+        for forwarding in r.borrow().forwarded_slots.clone() {
+            let source = forwarding.source.clone();
+            if let Some(existing_cip) = component_child_insertion_points.get(source.as_str()) {
+                if matches!(existing_cip.node.kind(), SyntaxKind::SlotPlaceholder) {
+                    diag.push_error(
+                        format!(
+                            "The slot '{source}' cannot be forwarded and used as a placeholder in the same component"
+                        ),
+                        &forwarding.node,
+                    );
+                } else {
+                    diag.push_error(
+                        format!("The slot '{source}' can only appear once in an element hierarchy"),
+                        &forwarding.node,
+                    );
+                }
+                continue;
+            }
+            component_child_insertion_points.insert(
+                source.to_string(),
+                ChildrenInsertionPoint {
+                    parent: r.clone(),
+                    insertion_index: 0,
+                    node: forwarding.node.clone(),
+                },
+            );
+        }
+
+        let mut assigned_slots = HashSet::new();
 
         for se in node.children() {
             if se.kind() == SyntaxKind::SubElement {
@@ -1910,22 +2079,24 @@ impl Element {
                 r.borrow_mut().children.push(Element::from_sub_element_node(
                     se.into(),
                     parent_type,
-                    component_child_insertion_point,
+                    component_child_insertion_points,
+                    declared_slots,
                     is_legacy_syntax,
                     diag,
                     tr,
                 ));
             } else if se.kind() == SyntaxKind::RepeatedElement {
-                let mut sub_child_insertion_point = None;
+                let mut sub_child_insertion_points = BTreeMap::new();
                 let rep = Element::from_repeated_node(
                     se.into(),
                     &r,
-                    &mut sub_child_insertion_point,
+                    &mut sub_child_insertion_points,
+                    declared_slots,
                     is_legacy_syntax,
                     diag,
                     tr,
                 );
-                if let Some(ChildrenInsertionPoint { node: se, .. }) = sub_child_insertion_point {
+                for (_, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
                     diag.push_error(
                         "The @children placeholder cannot appear in a repeated element".into(),
                         &se,
@@ -1933,16 +2104,17 @@ impl Element {
                 }
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::ConditionalElement {
-                let mut sub_child_insertion_point = None;
+                let mut sub_child_insertion_points = BTreeMap::new();
                 let rep = Element::from_conditional_node(
                     se.into(),
                     r.borrow().base_type.clone(),
-                    &mut sub_child_insertion_point,
+                    &mut sub_child_insertion_points,
+                    declared_slots,
                     is_legacy_syntax,
                     diag,
                     tr,
                 );
-                if let Some(ChildrenInsertionPoint { node: se, .. }) = sub_child_insertion_point {
+                for (_, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
                     diag.push_error(
                         "The @children placeholder cannot appear in a conditional element".into(),
                         &se,
@@ -1950,16 +2122,17 @@ impl Element {
                 }
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::MatchElement {
-                let mut sub_child_insertion_point = None;
+                let mut sub_child_insertion_points = BTreeMap::new();
                 let rep = Element::from_match_node(
                     se.into(),
                     r.borrow().base_type.clone(),
-                    &mut sub_child_insertion_point,
+                    &mut sub_child_insertion_points,
+                    declared_slots,
                     is_legacy_syntax,
                     diag,
                     tr,
                 );
-                if let Some(ChildrenInsertionPoint { node: se, .. }) = sub_child_insertion_point {
+                for (_, ChildrenInsertionPoint { node: se, .. }) in sub_child_insertion_points {
                     diag.push_error(
                         "The @children placeholder cannot appear in a match element".into(),
                         &se,
@@ -1969,29 +2142,136 @@ impl Element {
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
                 #[cfg(feature = "slint-sc")]
                 diag.slint_sc_error("The @children placeholder is", &se);
-                if children_placeholder.is_some() {
+                if component_child_insertion_points.contains_key("_children") {
                     diag.push_error(
                         "The @children placeholder can only appear once in an element".into(),
                         &se,
-                    )
+                    );
                 } else {
-                    children_placeholder = Some((se.clone().into(), r.borrow().children.len()));
+                    component_child_insertion_points.insert(
+                        "_children".into(),
+                        ChildrenInsertionPoint {
+                            parent: r.clone(),
+                            insertion_index: r.borrow().children.len(),
+                            node: se.into(),
+                        },
+                    );
                 }
-            }
-        }
-
-        if let Some((children_placeholder, index)) = children_placeholder {
-            if component_child_insertion_point.is_some() {
-                diag.push_error(
-                    "The @children placeholder can only appear once in an element hierarchy".into(),
-                    &children_placeholder,
+            } else if se.kind() == SyntaxKind::SlotDeclaration {
+                if !diag.enable_experimental {
+                    diag.push_error("'named slots' is an experimental feature".into(), &se);
+                    continue;
+                }
+                let decl: syntax_nodes::SlotDeclaration = se.into();
+                let name_ident = decl.DeclaredIdentifier();
+                let name = parser::identifier_text(&name_ident).unwrap_or_default();
+                declared_slots.push(DeclaredSlot { name, name_ident: name_ident.into() });
+            } else if se.kind() == SyntaxKind::SlotPlaceholder {
+                if !diag.enable_experimental {
+                    diag.push_error("'named slots' is an experimental feature".into(), &se);
+                    continue;
+                }
+                let name = parser::identifier_text(
+                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap().into(),
                 )
-            } else {
-                *component_child_insertion_point = Some(ChildrenInsertionPoint {
-                    parent: r.clone(),
-                    insertion_index: index,
-                    node: children_placeholder,
-                });
+                .unwrap_or_default();
+                if name == "children" || name == "_children" {
+                    diag.push_error(
+                        format!("The name '{name}' is reserved for the default slot. Use @children instead"),
+                        &se,
+                    );
+                } else if component_child_insertion_points.contains_key(name.as_str()) {
+                    let existing = component_child_insertion_points.get(name.as_str()).unwrap();
+                    if matches!(
+                        existing.node.kind(),
+                        SyntaxKind::BindingExpression
+                            | SyntaxKind::SlotForwarding
+                            | SyntaxKind::Expression
+                    ) {
+                        diag.push_error(
+                            format!(
+                                "The slot '{name}' cannot be forwarded and used as a placeholder in the same component"
+                            ),
+                            &se,
+                        );
+                    } else {
+                        diag.push_error(
+                            format!(
+                                "The slot '{name}' can only appear once in an element hierarchy"
+                            ),
+                            &se,
+                        );
+                    }
+                } else {
+                    component_child_insertion_points.insert(
+                        name.into(),
+                        ChildrenInsertionPoint {
+                            parent: r.clone(),
+                            insertion_index: r.borrow().children.len(),
+                            node: se.into(),
+                        },
+                    );
+                }
+            } else if se.kind() == SyntaxKind::SlotAssignment {
+                if !diag.enable_experimental {
+                    diag.push_error("'named slots' is an experimental feature".into(), &se);
+                    continue;
+                }
+                let name = parser::identifier_text(
+                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap().into(),
+                )
+                .unwrap_or_default();
+                if name == "children" || name == "_children" {
+                    diag.push_error(
+                        format!(
+                            "The name '{name}' is reserved for the default slot. Use @children instead"
+                        ),
+                        &se,
+                    );
+                }
+                if !assigned_slots.insert(name.clone()) {
+                    diag.push_error(format!("Duplicate assignment to slot '{name}'"), &se);
+                }
+                if r.borrow().forwarded_slots.iter().any(|f| f.target == name) {
+                    diag.push_error(
+                        format!("Slot '{name}' cannot be both forwarded and assigned"),
+                        &se,
+                    );
+                }
+                let sub_element_node = se.child_node(SyntaxKind::SubElement).unwrap();
+                let parent_type = r.borrow().base_type.clone();
+                match &parent_type {
+                    ElementType::Component(component)
+                        if !component
+                            .declared_slots
+                            .borrow()
+                            .iter()
+                            .any(|slot| slot.name == name) =>
+                    {
+                        diag.push_error(
+                            format!("Unknown slot '{name}' in '{}'", component.id),
+                            &se,
+                        );
+                    }
+                    ElementType::Component(_) => {}
+                    _ => {
+                        diag.push_error(
+                            format!("Slot assignments can only be used on components"),
+                            &se,
+                        );
+                    }
+                }
+                let element = Element::from_sub_element_node(
+                    sub_element_node.into(),
+                    parent_type,
+                    component_child_insertion_points,
+                    declared_slots,
+                    is_legacy_syntax,
+                    diag,
+                    tr,
+                );
+                element.borrow_mut().slot_target = Some(name);
+                r.borrow_mut().children.push(element);
             }
         }
 
@@ -2065,7 +2345,8 @@ impl Element {
     fn from_sub_element_node(
         node: syntax_nodes::SubElement,
         parent_type: ElementType,
-        component_child_insertion_point: &mut Option<ChildrenInsertionPoint>,
+        component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
+        declared_slots: &mut Vec<DeclaredSlot>,
         is_in_legacy_component: bool,
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
@@ -2082,7 +2363,8 @@ impl Element {
             node.Element(),
             id,
             parent_type,
-            component_child_insertion_point,
+            component_child_insertion_points,
+            declared_slots,
             is_in_legacy_component,
             diag,
             tr,
@@ -2092,7 +2374,8 @@ impl Element {
     fn from_repeated_node(
         node: syntax_nodes::RepeatedElement,
         parent: &ElementRc,
-        component_child_insertion_point: &mut Option<ChildrenInsertionPoint>,
+        component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
+        declared_slots: &mut Vec<DeclaredSlot>,
         is_in_legacy_component: bool,
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
@@ -2102,7 +2385,8 @@ impl Element {
         let e = Element::from_sub_element_node(
             node.SubElement(),
             parent.borrow().base_type.clone(),
-            component_child_insertion_point,
+            component_child_insertion_points,
+            declared_slots,
             is_in_legacy_component,
             diag,
             tr,
@@ -2178,7 +2462,8 @@ impl Element {
     fn from_conditional_node(
         node: syntax_nodes::ConditionalElement,
         parent_type: ElementType,
-        component_child_insertion_point: &mut Option<ChildrenInsertionPoint>,
+        component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
+        declared_slots: &mut Vec<DeclaredSlot>,
         is_in_legacy_component: bool,
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
@@ -2195,7 +2480,8 @@ impl Element {
         let e = Element::from_sub_element_node(
             node.SubElement(),
             parent_type,
-            component_child_insertion_point,
+            component_child_insertion_points,
+            declared_slots,
             is_in_legacy_component,
             diag,
             tr,
@@ -2207,7 +2493,8 @@ impl Element {
     fn from_match_node(
         node: syntax_nodes::MatchElement,
         parent_type: ElementType,
-        component_child_insertion_point: &mut Option<ChildrenInsertionPoint>,
+        component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
+        declared_slots: &mut Vec<DeclaredSlot>,
         is_in_legacy_component: bool,
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
@@ -2235,7 +2522,8 @@ impl Element {
             let e: Rc<RefCell<Element>> = Element::from_sub_element_node(
                 sub_element,
                 parent_type.clone(),
-                component_child_insertion_point,
+                component_child_insertion_points,
+                declared_slots,
                 is_in_legacy_component,
                 diag,
                 tr,
@@ -2273,7 +2561,8 @@ impl Element {
             let e = Element::from_sub_element_node(
                 sub_element,
                 parent_type.clone(),
-                component_child_insertion_point,
+                component_child_insertion_points,
+                declared_slots,
                 is_in_legacy_component,
                 diag,
                 tr,
@@ -2314,6 +2603,7 @@ impl Element {
     fn parse_bindings(
         &mut self,
         bindings: impl Iterator<Item = (crate::parser::SyntaxToken, SyntaxNode)>,
+        _allow_slot_forwarding: bool,
         is_in_legacy_component: bool,
         diag: &mut BuildDiagnostics,
     ) {
@@ -2395,6 +2685,29 @@ impl Element {
                 }
             };
         }
+    }
+
+    fn slot_forwarding_expr_identifier(expression: &SyntaxNode) -> Option<SmolStr> {
+        if expression.kind() != SyntaxKind::Expression {
+            return None;
+        }
+
+        let mut expr_children = expression.children();
+        let qualified_name = expr_children.find(|n| n.kind() == SyntaxKind::QualifiedName)?;
+        if expr_children.next().is_some() {
+            return None;
+        }
+
+        let mut identifiers = qualified_name
+            .children_with_tokens()
+            .filter(|n| n.kind() == SyntaxKind::Identifier)
+            .filter_map(|n| n.into_token());
+        let identifier = identifiers.next()?;
+        if identifiers.next().is_some() {
+            return None;
+        }
+
+        Some(crate::parser::normalize_identifier(identifier.text()))
     }
 
     /// Return the alias node of a `callback foo <=> ...;` declaration, if `name` is one.
@@ -2970,6 +3283,7 @@ fn animation_element_from_node(
                 Some((b.child_token(SyntaxKind::Identifier)?, b.BindingExpression().into()))
             }),
             false,
+            false,
             diag,
         );
 
@@ -2993,6 +3307,10 @@ impl QualifiedTypeName {
             .filter_map(|x| x.as_token().map(|x| crate::parser::normalize_identifier(x.text())))
             .collect();
         Self { members }
+    }
+
+    pub fn to_smolstr(&self) -> SmolStr {
+        self.members.join(".").into()
     }
 }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -380,16 +380,45 @@ pub fn slot_error_subject(name: &str) -> String {
 }
 
 #[derive(Clone, Debug)]
+pub enum ChildInsertionPointNode {
+    DefaultChildrenPlaceHolder(SyntaxNode),
+    ChildrenPlaceHolder(syntax_nodes::ChildrenPlaceholder),
+    SlotPlaceholder(syntax_nodes::SubElement),
+    SlotForwarding(syntax_nodes::Expression),
+}
+
+impl ChildInsertionPointNode {
+    pub fn syntax_node(&self) -> &SyntaxNode {
+        match self {
+            Self::DefaultChildrenPlaceHolder(node) => node,
+            Self::ChildrenPlaceHolder(node) => node,
+            Self::SlotPlaceholder(node) => node,
+            Self::SlotForwarding(node) => node,
+        }
+    }
+}
+
+impl Spanned for ChildInsertionPointNode {
+    fn span(&self) -> crate::diagnostics::Span {
+        self.syntax_node().span()
+    }
+
+    fn source_file(&self) -> Option<&crate::diagnostics::SourceFile> {
+        self.syntax_node().source_file()
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct ChildrenInsertionPoint {
     pub parent: ElementRc,
     pub insertion_index: usize,
-    pub node: SyntaxNode,
+    pub node: ChildInsertionPointNode,
 }
 
 #[derive(Clone, Debug)]
 pub struct DeclaredSlot {
     pub name: SmolStr,
-    pub name_ident: SyntaxNode,
+    pub name_node: syntax_nodes::DeclaredIdentifier,
     has_rejected_placeholder: bool,
 }
 
@@ -397,7 +426,7 @@ pub struct DeclaredSlot {
 pub struct SlotForwarding {
     pub target: SmolStr,
     pub source: SmolStr,
-    pub node: SyntaxNode,
+    pub expression_node: syntax_nodes::Expression,
 }
 
 /// Used sub types for a root component
@@ -584,7 +613,7 @@ impl Component {
         if self.is_global() || self.is_interface() {
             return;
         }
-        let mut declared_slot_nodes = BTreeMap::<SmolStr, SyntaxNode>::new();
+        let mut declared_slot_nodes = BTreeMap::<SmolStr, syntax_nodes::DeclaredIdentifier>::new();
         for slot in self.declared_slots.borrow().iter() {
             if slot.name == "children" {
                 diagnostics.push_error(
@@ -592,14 +621,14 @@ impl Component {
                         "The name '{}' is reserved for the default slot. Use @children instead",
                         slot.name
                     ),
-                    &slot.name_ident,
+                    &slot.name_node,
                 );
                 continue;
             }
-            if declared_slot_nodes.insert(slot.name.clone(), slot.name_ident.clone()).is_some() {
+            if declared_slot_nodes.insert(slot.name.clone(), slot.name_node.clone()).is_some() {
                 diagnostics.push_error(
                     format!("Duplicate slot declaration '{}'", slot.name),
-                    &slot.name_ident,
+                    &slot.name_node,
                 );
             }
         }
@@ -2040,17 +2069,17 @@ impl Element {
                 }
             }
 
-            let Some(expr_node) = se.child_node(SyntaxKind::Expression) else {
+            let Some(expression_node) = se.child_node(SyntaxKind::Expression) else {
                 diag.push_error(
                     "Slot forwarding requires a slot identifier on the right-hand side".into(),
                     &se,
                 );
                 continue;
             };
-            let Some(source) = Self::slot_forwarding_expr_identifier(&expr_node) else {
+            let Some(source) = Self::slot_forwarding_expr_identifier(&expression_node) else {
                 diag.push_error(
                     "Slot forwarding requires a slot identifier on the right-hand side".into(),
-                    &expr_node,
+                    &expression_node,
                 );
                 continue;
             };
@@ -2060,7 +2089,7 @@ impl Element {
                     format!(
                         "The name '{source}' is reserved for the default slot. Use @children instead"
                     ),
-                    &expr_node,
+                    &expression_node,
                 );
                 continue;
             }
@@ -2068,19 +2097,19 @@ impl Element {
             r.borrow_mut().forwarded_slots.push(SlotForwarding {
                 target,
                 source,
-                node: expr_node.clone(),
+                expression_node: expression_node.into(),
             });
         }
 
         for forwarding in r.borrow().forwarded_slots.clone() {
             let source = forwarding.source.clone();
             if let Some(existing_cip) = component_child_insertion_points.get(source.as_str()) {
-                if matches!(existing_cip.node.kind(), SyntaxKind::SubElement) {
+                if matches!(existing_cip.node, ChildInsertionPointNode::SlotPlaceholder(_)) {
                     diag.push_error(
                         format!(
                             "The slot '{source}' cannot be forwarded and used as a placeholder in the same component"
                         ),
-                        &forwarding.node,
+                        &forwarding.expression_node,
                     );
                 } else {
                     diag.push_error(
@@ -2088,7 +2117,7 @@ impl Element {
                             "{} can only appear once in an element",
                             slot_error_subject(&source)
                         ),
-                        &forwarding.node,
+                        &forwarding.expression_node,
                     );
                 }
                 continue;
@@ -2098,7 +2127,7 @@ impl Element {
                 ChildrenInsertionPoint {
                     parent: r.clone(),
                     insertion_index: 0,
-                    node: forwarding.node.clone(),
+                    node: ChildInsertionPointNode::SlotForwarding(forwarding.expression_node),
                 },
             );
         }
@@ -2201,18 +2230,18 @@ impl Element {
                         ChildrenInsertionPoint {
                             parent: r.clone(),
                             insertion_index: r.borrow().children.len(),
-                            node: se,
+                            node: ChildInsertionPointNode::ChildrenPlaceHolder(se.into()),
                         },
                     );
                 }
             } else if se.kind() == SyntaxKind::SlotDeclaration {
                 Self::assert_experimental_slots(diag, &se, "named slots");
                 let decl: syntax_nodes::SlotDeclaration = se.into();
-                let name_ident = decl.DeclaredIdentifier();
-                let name = parser::identifier_text(&name_ident).unwrap_or_default();
+                let name_node = decl.DeclaredIdentifier();
+                let name = parser::identifier_text(&name_node).unwrap_or_default();
                 declared_slots.push(DeclaredSlot {
                     name,
-                    name_ident: name_ident.into(),
+                    name_node,
                     has_rejected_placeholder: false,
                 });
             } else if se.kind() == SyntaxKind::SlotAssignment {
@@ -2430,7 +2459,7 @@ impl Element {
     ) {
         Self::assert_experimental_slots(diagnostics, node, "named slots");
         if let Some(existing) = component_child_insertion_points.get(slot_name.as_str()) {
-            if existing.node.kind() == SyntaxKind::Expression {
+            if matches!(existing.node, ChildInsertionPointNode::SlotForwarding(_)) {
                 diagnostics.push_error(
                     format!(
                         "The slot '{slot_name}' cannot be forwarded and used as a placeholder in the same component"
@@ -2460,7 +2489,11 @@ impl Element {
         let insertion_index = parent.borrow().children.len();
         component_child_insertion_points.insert(
             slot_name.to_string(),
-            ChildrenInsertionPoint { parent: parent.clone(), insertion_index, node: node.clone() },
+            ChildrenInsertionPoint {
+                parent: parent.clone(),
+                insertion_index,
+                node: ChildInsertionPointNode::SlotPlaceholder(node.clone().into()),
+            },
         );
     }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -528,38 +528,7 @@ impl Component {
             declared_slots: RefCell::new(declared_slots),
             ..Default::default()
         };
-        let mut declared_slot_nodes = BTreeMap::<SmolStr, SyntaxNode>::new();
-        for slot in c.declared_slots.borrow().iter() {
-            if slot.name == "children" || slot.name == "_children" {
-                diag.push_error(
-                    format!(
-                        "The name '{}' is reserved for the default slot. Use @children instead",
-                        slot.name
-                    ),
-                    &slot.name_ident,
-                );
-                continue;
-            }
-            if declared_slot_nodes.insert(slot.name.clone(), slot.name_ident.clone()).is_some() {
-                diag.push_error(
-                    format!("Duplicate slot declaration '{}'", slot.name),
-                    &slot.name_ident,
-                );
-            }
-        }
-        for (name, cip) in c.child_insertion_points.borrow().iter() {
-            if name == "_children" {
-                continue;
-            }
-            if !declared_slot_nodes.contains_key(name.as_str()) {
-                diag.push_error(format!("The slot '{name}' is used but not declared"), &cip.node);
-            }
-        }
-        for (name, node) in declared_slot_nodes.iter() {
-            if !c.child_insertion_points.borrow().contains_key(name.as_str()) {
-                diag.push_error(format!("The slot '{name}' is declared but not used"), node);
-            }
-        }
+        c.check_slot_validity(diag);
         let c = Rc::new(c);
         // x and y on a Window are meaningless
         if c.root_element
@@ -593,6 +562,45 @@ impl Component {
             }
         });
         c
+    }
+
+    fn check_slot_validity(&self, diagnostics: &mut BuildDiagnostics) {
+        if !diagnostics.enable_experimental {
+            return;
+        }
+        let mut declared_slot_nodes = BTreeMap::<SmolStr, SyntaxNode>::new();
+        for slot in self.declared_slots.borrow().iter() {
+            if slot.name == "children" || slot.name == "_children" {
+                diagnostics.push_error(
+                    format!(
+                        "The name '{}' is reserved for the default slot. Use @children instead",
+                        slot.name
+                    ),
+                    &slot.name_ident,
+                );
+                continue;
+            }
+            if declared_slot_nodes.insert(slot.name.clone(), slot.name_ident.clone()).is_some() {
+                diagnostics.push_error(
+                    format!("Duplicate slot declaration '{}'", slot.name),
+                    &slot.name_ident,
+                );
+            }
+        }
+        for (name, cip) in self.child_insertion_points.borrow().iter() {
+            if name == "_children" {
+                continue;
+            }
+            if !declared_slot_nodes.contains_key(name.as_str()) {
+                diagnostics
+                    .push_error(format!("The slot '{name}' is used but not declared"), &cip.node);
+            }
+        }
+        for (name, node) in declared_slot_nodes.iter() {
+            if !self.child_insertion_points.borrow().contains_key(name.as_str()) {
+                diagnostics.push_error(format!("The slot '{name}' is declared but not used"), node);
+            }
+        }
     }
 
     /// This component is a global component introduced with the "global" keyword
@@ -2046,7 +2054,7 @@ impl Element {
         for forwarding in r.borrow().forwarded_slots.clone() {
             let source = forwarding.source.clone();
             if let Some(existing_cip) = component_child_insertion_points.get(source.as_str()) {
-                if matches!(existing_cip.node.kind(), SyntaxKind::SlotPlaceholder) {
+                if matches!(existing_cip.node.kind(), SyntaxKind::SubElement) {
                     diag.push_error(
                         format!(
                             "The slot '{source}' cannot be forwarded and used as a placeholder in the same component"
@@ -2075,6 +2083,18 @@ impl Element {
 
         for se in node.children() {
             if se.kind() == SyntaxKind::SubElement {
+                if let Some(slot_name) =
+                    Self::sub_element_slot_placeholder_name(&se, declared_slots)
+                {
+                    Self::register_slot_placeholder(
+                        &se,
+                        slot_name,
+                        &r,
+                        component_child_insertion_points,
+                        diag,
+                    );
+                    continue;
+                }
                 let parent_type = r.borrow().base_type.clone();
                 r.borrow_mut().children.push(Element::from_sub_element_node(
                     se.into(),
@@ -2160,58 +2180,11 @@ impl Element {
             } else if se.kind() == SyntaxKind::SlotDeclaration {
                 if !diag.enable_experimental {
                     diag.push_error("'named slots' is an experimental feature".into(), &se);
-                    continue;
                 }
                 let decl: syntax_nodes::SlotDeclaration = se.into();
                 let name_ident = decl.DeclaredIdentifier();
                 let name = parser::identifier_text(&name_ident).unwrap_or_default();
                 declared_slots.push(DeclaredSlot { name, name_ident: name_ident.into() });
-            } else if se.kind() == SyntaxKind::SlotPlaceholder {
-                if !diag.enable_experimental {
-                    diag.push_error("'named slots' is an experimental feature".into(), &se);
-                    continue;
-                }
-                let name = parser::identifier_text(
-                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap(),
-                )
-                .unwrap_or_default();
-                if name == "children" || name == "_children" {
-                    diag.push_error(
-                        format!("The name '{name}' is reserved for the default slot. Use @children instead"),
-                        &se,
-                    );
-                } else if component_child_insertion_points.contains_key(name.as_str()) {
-                    let existing = component_child_insertion_points.get(name.as_str()).unwrap();
-                    if matches!(
-                        existing.node.kind(),
-                        SyntaxKind::BindingExpression
-                            | SyntaxKind::SlotForwarding
-                            | SyntaxKind::Expression
-                    ) {
-                        diag.push_error(
-                            format!(
-                                "The slot '{name}' cannot be forwarded and used as a placeholder in the same component"
-                            ),
-                            &se,
-                        );
-                    } else {
-                        diag.push_error(
-                            format!(
-                                "The slot '{name}' can only appear once in an element hierarchy"
-                            ),
-                            &se,
-                        );
-                    }
-                } else {
-                    component_child_insertion_points.insert(
-                        name.into(),
-                        ChildrenInsertionPoint {
-                            parent: r.clone(),
-                            insertion_index: r.borrow().children.len(),
-                            node: se,
-                        },
-                    );
-                }
             } else if se.kind() == SyntaxKind::SlotAssignment {
                 if !diag.enable_experimental {
                     diag.push_error("'named slots' is an experimental feature".into(), &se);
@@ -2369,6 +2342,58 @@ impl Element {
             diag,
             tr,
         )
+    }
+
+    fn sub_element_slot_placeholder_name(
+        node: &SyntaxNode,
+        declared_slots: &[DeclaredSlot],
+    ) -> Option<SmolStr> {
+        if node.child_token(SyntaxKind::ColonEqual).is_some() {
+            return None;
+        }
+        let element = node.child_node(SyntaxKind::Element)?;
+        if element.children().any(|c| c.kind() != SyntaxKind::QualifiedName) {
+            return None;
+        }
+        let qualified_name = element.child_node(SyntaxKind::QualifiedName)?;
+        if qualified_name.child_token(SyntaxKind::Dot).is_some() {
+            return None;
+        }
+        let name = parser::identifier_text(&qualified_name)?;
+        declared_slots.iter().any(|slot| slot.name == name).then_some(name)
+    }
+
+    fn register_slot_placeholder(
+        node: &SyntaxNode,
+        slot_name: SmolStr,
+        parent: &ElementRc,
+        component_child_insertion_points: &mut BTreeMap<String, ChildrenInsertionPoint>,
+        diagnostics: &mut BuildDiagnostics,
+    ) {
+        if !diagnostics.enable_experimental {
+            diagnostics.push_error("'named slots' is an experimental feature".into(), node);
+        }
+        if let Some(existing) = component_child_insertion_points.get(slot_name.as_str()) {
+            if existing.node.kind() == SyntaxKind::Expression {
+                diagnostics.push_error(
+                    format!(
+                        "The slot '{slot_name}' cannot be forwarded and used as a placeholder in the same component"
+                    ),
+                    node,
+                );
+            } else {
+                diagnostics.push_error(
+                    format!("The slot '{slot_name}' can only appear once in an element hierarchy"),
+                    node,
+                );
+            }
+            return;
+        }
+        let insertion_index = parent.borrow().children.len();
+        component_child_insertion_points.insert(
+            slot_name.to_string(),
+            ChildrenInsertionPoint { parent: parent.clone(), insertion_index, node: node.clone() },
+        );
     }
 
     fn from_repeated_node(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1973,7 +1973,7 @@ impl Element {
             }
 
             let target_node = se.child_node(SyntaxKind::DeclaredIdentifier).unwrap();
-            let target = parser::identifier_text(&target_node.clone().into()).unwrap_or_default();
+            let target = parser::identifier_text(&target_node.clone()).unwrap_or_default();
 
             if target == "children" || target == "_children" {
                 diag.push_error(
@@ -2153,7 +2153,7 @@ impl Element {
                         ChildrenInsertionPoint {
                             parent: r.clone(),
                             insertion_index: r.borrow().children.len(),
-                            node: se.into(),
+                            node: se,
                         },
                     );
                 }
@@ -2172,7 +2172,7 @@ impl Element {
                     continue;
                 }
                 let name = parser::identifier_text(
-                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap().into(),
+                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap(),
                 )
                 .unwrap_or_default();
                 if name == "children" || name == "_children" {
@@ -2208,7 +2208,7 @@ impl Element {
                         ChildrenInsertionPoint {
                             parent: r.clone(),
                             insertion_index: r.borrow().children.len(),
-                            node: se.into(),
+                            node: se,
                         },
                     );
                 }
@@ -2218,7 +2218,7 @@ impl Element {
                     continue;
                 }
                 let name = parser::identifier_text(
-                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap().into(),
+                    &se.child_node(SyntaxKind::DeclaredIdentifier).unwrap(),
                 )
                 .unwrap_or_default();
                 if name == "children" || name == "_children" {
@@ -2256,7 +2256,7 @@ impl Element {
                     ElementType::Component(_) => {}
                     _ => {
                         diag.push_error(
-                            format!("Slot assignments can only be used on components"),
+                            "Slot assignments can only be used on components".to_string(),
                             &se,
                         );
                     }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use smol_str::{SmolStr, ToSmolStr};
+use smol_str::SmolStr;
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BindingExpression, Callable, Expression};

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -738,14 +738,12 @@ impl<'a> DefaultParser<'a> {
                 SyntaxKind::LBrace => depth += 1,
                 SyntaxKind::RBrace => depth -= 1,
                 SyntaxKind::Identifier if depth == 1 && self.tokens[idx].as_str() == "slot" => {
-                    if let Some(name_idx) = self.next_non_trivia_token(idx + 1) {
-                        if self.tokens[name_idx].kind == SyntaxKind::Identifier {
-                            if let Some(semi_idx) = self.next_non_trivia_token(name_idx + 1) {
-                                if self.tokens[semi_idx].kind == SyntaxKind::Semicolon {
-                                    slots.insert(self.tokens[name_idx].text.clone());
-                                }
-                            }
-                        }
+                    if let Some(name_idx) = self.next_non_trivia_token(idx + 1)
+                        && self.tokens[name_idx].kind == SyntaxKind::Identifier
+                        && let Some(semi_idx) = self.next_non_trivia_token(name_idx + 1)
+                        && self.tokens[semi_idx].kind == SyntaxKind::Semicolon
+                    {
+                        slots.insert(self.tokens[name_idx].text.clone());
                     }
                 }
                 _ => {}

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -405,7 +405,7 @@ declare_syntax! {
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
-                       ?MemberAccess, ?AtKeys, ?SlotReference ],
+                       ?MemberAccess, ?AtKeys ],
         /// Concatenate the children Expressions and StringLiteral to make a string
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
@@ -415,8 +415,6 @@ declare_syntax! {
         /// `@tr("foo", ...)`  // the string is a StringLiteral
         AtTr -> [?TrContext, ?TrPlural, *Expression],
         AtMarkdown -> [*Expression],
-        /// slot reference in expressions
-        SlotReference -> [ DeclaredIdentifier ],
         /// `slot header;`
         SlotDeclaration -> [ DeclaredIdentifier ],
         /// `"foo" =>`  in a `AtTr` node

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -15,7 +15,6 @@ This module has different sub modules with the actual parser functions
 
 use crate::diagnostics::{BuildDiagnostics, SourceFile, Spanned};
 use smol_str::SmolStr;
-use std::collections::HashSet;
 use std::fmt::Display;
 
 mod document;
@@ -357,7 +356,7 @@ declare_syntax! {
                      *CallbackDeclaration, *ConditionalElement, *MatchElement, *Function, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
                      *TwoWayBinding, *States, *Transitions, *ImplementStatement, ?ChildrenPlaceholder,
-                     *SlotDeclaration, *SlotPlaceholder, *SlotAssignment, *SlotForwarding ],
+                     *SlotDeclaration, *SlotAssignment, *SlotForwarding ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],
         ConditionalElement -> [ Expression , SubElement],
@@ -389,7 +388,6 @@ declare_syntax! {
         /// Wraps single identifier (to disambiguate when there are other identifier in the production)
         DeclaredIdentifier -> [],
         ChildrenPlaceholder -> [],
-        SlotPlaceholder -> [ DeclaredIdentifier ],
         SlotAssignment -> [ DeclaredIdentifier, SubElement ],
         SlotForwarding -> [ DeclaredIdentifier, ?Expression ],
         Binding-> [ BindingExpression ],
@@ -581,15 +579,6 @@ mod parser_trait {
         fn error(&mut self, e: impl Into<String>);
         fn warning(&mut self, e: impl Into<String>);
 
-        /// Called before parsing a component's element to collect slot declarations.
-        fn enter_component_slot_scope(&mut self) {}
-        /// Called after parsing a component's element to pop slot declarations.
-        fn exit_component_slot_scope(&mut self) {}
-        /// Returns true if the slot name is declared in the current component scope.
-        fn is_slot_declared(&self, _name: &str) -> bool {
-            false
-        }
-
         /// Consume the token if it has the right kind, otherwise report a syntax error.
         /// Returns true if the token was consumed.
         fn expect(&mut self, kind: SyntaxKind) -> bool {
@@ -665,7 +654,6 @@ pub struct DefaultParser<'a> {
     tokens: Vec<Token>,
     /// points on the current token of the token list
     cursor: usize,
-    component_slot_declarations: Vec<HashSet<SmolStr>>,
     diags: &'a mut BuildDiagnostics,
     source_file: SourceFile,
 }
@@ -676,7 +664,6 @@ impl<'a> DefaultParser<'a> {
             builder: Default::default(),
             tokens,
             cursor: 0,
-            component_slot_declarations: Vec::new(),
             diags,
             source_file: Default::default(),
         }
@@ -697,61 +684,6 @@ impl<'a> DefaultParser<'a> {
         while matches!(self.current_token().kind, SyntaxKind::Whitespace | SyntaxKind::Comment) {
             self.consume()
         }
-    }
-
-    fn next_non_trivia_token(&self, mut idx: usize) -> Option<usize> {
-        while idx < self.tokens.len()
-            && matches!(self.tokens[idx].kind, SyntaxKind::Whitespace | SyntaxKind::Comment)
-        {
-            idx += 1;
-        }
-        if idx < self.tokens.len() { Some(idx) } else { None }
-    }
-
-    fn scan_component_slot_declarations(&self) -> HashSet<SmolStr> {
-        let mut slots = HashSet::new();
-        let mut idx = self.cursor;
-        let mut depth = 0usize;
-
-        // Find the opening brace of the component's root element.
-        while idx < self.tokens.len() {
-            let kind = self.tokens[idx].kind;
-            if matches!(kind, SyntaxKind::Whitespace | SyntaxKind::Comment) {
-                idx += 1;
-                continue;
-            }
-            if kind == SyntaxKind::LBrace {
-                depth = 1;
-                idx += 1;
-                break;
-            }
-            idx += 1;
-        }
-
-        if depth == 0 {
-            return slots;
-        }
-
-        while idx < self.tokens.len() && depth > 0 {
-            let kind = self.tokens[idx].kind;
-            match kind {
-                SyntaxKind::LBrace => depth += 1,
-                SyntaxKind::RBrace => depth -= 1,
-                SyntaxKind::Identifier if depth == 1 && self.tokens[idx].as_str() == "slot" => {
-                    if let Some(name_idx) = self.next_non_trivia_token(idx + 1)
-                        && self.tokens[name_idx].kind == SyntaxKind::Identifier
-                        && let Some(semi_idx) = self.next_non_trivia_token(name_idx + 1)
-                        && self.tokens[semi_idx].kind == SyntaxKind::Semicolon
-                    {
-                        slots.insert(self.tokens[name_idx].text.clone());
-                    }
-                }
-                _ => {}
-            }
-            idx += 1;
-        }
-
-        slots
     }
 }
 
@@ -842,19 +774,6 @@ impl Parser for DefaultParser<'_> {
                 span,
             },
         );
-    }
-
-    fn enter_component_slot_scope(&mut self) {
-        let slots = self.scan_component_slot_declarations();
-        self.component_slot_declarations.push(slots);
-    }
-
-    fn exit_component_slot_scope(&mut self) {
-        self.component_slot_declarations.pop();
-    }
-
-    fn is_slot_declared(&self, name: &str) -> bool {
-        self.component_slot_declarations.last().is_some_and(|slots| slots.contains(name))
     }
 
     type Checkpoint = rowan::Checkpoint;

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -15,6 +15,7 @@ This module has different sub modules with the actual parser functions
 
 use crate::diagnostics::{BuildDiagnostics, SourceFile, Spanned};
 use smol_str::SmolStr;
+use std::collections::HashSet;
 use std::fmt::Display;
 
 mod document;
@@ -306,6 +307,7 @@ declare_syntax! {
         ColorLiteral -> &crate::lexer::lex_color,
         Identifier -> &crate::lexer::lex_identifier,
         DoubleArrow -> "<=>",
+        DoubleLess -> "<<",
         PlusEqual -> "+=",
         MinusEqual -> "-=",
         StarEqual -> "*=",
@@ -354,7 +356,8 @@ declare_syntax! {
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
                      *CallbackDeclaration, *ConditionalElement, *MatchElement, *Function, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
-                     *TwoWayBinding, *States, *Transitions, *ImplementStatement, ?ChildrenPlaceholder ],
+                     *TwoWayBinding, *States, *Transitions, *ImplementStatement, ?ChildrenPlaceholder,
+                     *SlotDeclaration, *SlotPlaceholder, *SlotAssignment, *SlotForwarding ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],
         ConditionalElement -> [ Expression , SubElement],
@@ -386,6 +389,9 @@ declare_syntax! {
         /// Wraps single identifier (to disambiguate when there are other identifier in the production)
         DeclaredIdentifier -> [],
         ChildrenPlaceholder -> [],
+        SlotPlaceholder -> [ DeclaredIdentifier ],
+        SlotAssignment -> [ DeclaredIdentifier, SubElement ],
+        SlotForwarding -> [ DeclaredIdentifier, ?Expression ],
         Binding-> [ BindingExpression ],
         /// `xxx <=> something`
         TwoWayBinding -> [ Expression ],
@@ -401,7 +407,7 @@ declare_syntax! {
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
-                       ?MemberAccess, ?AtKeys ],
+                       ?MemberAccess, ?AtKeys, ?SlotReference ],
         /// Concatenate the children Expressions and StringLiteral to make a string
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
@@ -411,6 +417,10 @@ declare_syntax! {
         /// `@tr("foo", ...)`  // the string is a StringLiteral
         AtTr -> [?TrContext, ?TrPlural, *Expression],
         AtMarkdown -> [*Expression],
+        /// slot reference in expressions
+        SlotReference -> [ DeclaredIdentifier ],
+        /// `slot header;`
+        SlotDeclaration -> [ DeclaredIdentifier ],
         /// `"foo" =>`  in a `AtTr` node
         TrContext -> [],
         /// `| "foo" % n`  in a `AtTr` node
@@ -571,6 +581,15 @@ mod parser_trait {
         fn error(&mut self, e: impl Into<String>);
         fn warning(&mut self, e: impl Into<String>);
 
+        /// Called before parsing a component's element to collect slot declarations.
+        fn enter_component_slot_scope(&mut self) {}
+        /// Called after parsing a component's element to pop slot declarations.
+        fn exit_component_slot_scope(&mut self) {}
+        /// Returns true if the slot name is declared in the current component scope.
+        fn is_slot_declared(&self, _name: &str) -> bool {
+            false
+        }
+
         /// Consume the token if it has the right kind, otherwise report a syntax error.
         /// Returns true if the token was consumed.
         fn expect(&mut self, kind: SyntaxKind) -> bool {
@@ -646,6 +665,7 @@ pub struct DefaultParser<'a> {
     tokens: Vec<Token>,
     /// points on the current token of the token list
     cursor: usize,
+    component_slot_declarations: Vec<HashSet<SmolStr>>,
     diags: &'a mut BuildDiagnostics,
     source_file: SourceFile,
 }
@@ -656,6 +676,7 @@ impl<'a> DefaultParser<'a> {
             builder: Default::default(),
             tokens,
             cursor: 0,
+            component_slot_declarations: Vec::new(),
             diags,
             source_file: Default::default(),
         }
@@ -676,6 +697,63 @@ impl<'a> DefaultParser<'a> {
         while matches!(self.current_token().kind, SyntaxKind::Whitespace | SyntaxKind::Comment) {
             self.consume()
         }
+    }
+
+    fn next_non_trivia_token(&self, mut idx: usize) -> Option<usize> {
+        while idx < self.tokens.len()
+            && matches!(self.tokens[idx].kind, SyntaxKind::Whitespace | SyntaxKind::Comment)
+        {
+            idx += 1;
+        }
+        if idx < self.tokens.len() { Some(idx) } else { None }
+    }
+
+    fn scan_component_slot_declarations(&self) -> HashSet<SmolStr> {
+        let mut slots = HashSet::new();
+        let mut idx = self.cursor;
+        let mut depth = 0usize;
+
+        // Find the opening brace of the component's root element.
+        while idx < self.tokens.len() {
+            let kind = self.tokens[idx].kind;
+            if matches!(kind, SyntaxKind::Whitespace | SyntaxKind::Comment) {
+                idx += 1;
+                continue;
+            }
+            if kind == SyntaxKind::LBrace {
+                depth = 1;
+                idx += 1;
+                break;
+            }
+            idx += 1;
+        }
+
+        if depth == 0 {
+            return slots;
+        }
+
+        while idx < self.tokens.len() && depth > 0 {
+            let kind = self.tokens[idx].kind;
+            match kind {
+                SyntaxKind::LBrace => depth += 1,
+                SyntaxKind::RBrace => depth -= 1,
+                SyntaxKind::Identifier if depth == 1 && self.tokens[idx].as_str() == "slot" => {
+                    if let Some(name_idx) = self.next_non_trivia_token(idx + 1) {
+                        if self.tokens[name_idx].kind == SyntaxKind::Identifier {
+                            if let Some(semi_idx) = self.next_non_trivia_token(name_idx + 1) {
+                                if self.tokens[semi_idx].kind == SyntaxKind::Semicolon {
+                                    slots.insert(self.tokens[name_idx].text.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+            idx += 1;
+        }
+
+        slots
     }
 }
 
@@ -728,7 +806,10 @@ impl Parser for DefaultParser<'_> {
     fn error(&mut self, e: impl Into<String>) {
         let current_token = self.current_token();
         #[allow(unused_mut)]
-        let mut span = crate::diagnostics::Span::new(current_token.offset, current_token.length);
+        let mut span = crate::diagnostics::Span::new(
+            current_token.offset,
+            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.length },
+        );
         #[cfg(feature = "proc_macro_span")]
         {
             span.span = current_token.span;
@@ -747,7 +828,10 @@ impl Parser for DefaultParser<'_> {
     fn warning(&mut self, e: impl Into<String>) {
         let current_token = self.current_token();
         #[allow(unused_mut)]
-        let mut span = crate::diagnostics::Span::new(current_token.offset, current_token.length);
+        let mut span = crate::diagnostics::Span::new(
+            current_token.offset,
+            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.length },
+        );
         #[cfg(feature = "proc_macro_span")]
         {
             span.span = current_token.span;
@@ -760,6 +844,19 @@ impl Parser for DefaultParser<'_> {
                 span,
             },
         );
+    }
+
+    fn enter_component_slot_scope(&mut self) {
+        let slots = self.scan_component_slot_declarations();
+        self.component_slot_declarations.push(slots);
+    }
+
+    fn exit_component_slot_scope(&mut self) {
+        self.component_slot_declarations.pop();
+    }
+
+    fn is_slot_declared(&self, name: &str) -> bool {
+        self.component_slot_declarations.last().is_some_and(|slots| slots.contains(name))
     }
 
     type Checkpoint = rowan::Checkpoint;

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -110,7 +110,6 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
     let is_global = !simple_component && p.peek().as_str() == "global";
     let is_interface = !simple_component && p.peek().as_str() == "interface";
     let is_new_component = !simple_component && p.peek().as_str() == "component";
-    let is_component_item = !is_global && !is_interface;
     if !is_global && !simple_component && !is_new_component && !is_interface {
         p.error(
             "Parse error: expected a top-level item such as a component, a struct, or a global",
@@ -151,17 +150,10 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
     } else if p.peek().as_str() == "inherits" {
         p.consume();
     } else if p.peek().kind() == SyntaxKind::LBrace {
-        if is_component_item {
-            p.enter_component_slot_scope();
-        }
         let mut p = p.start_node(SyntaxKind::Element);
         p.consume();
         parse_element_content(&mut *p);
-        let result = p.expect(SyntaxKind::RBrace);
-        if is_component_item {
-            p.exit_component_slot_scope();
-        }
-        return result;
+        return p.expect(SyntaxKind::RBrace);
     } else {
         p.error("Expected '{' or keyword 'inherits'");
         drop(p.start_node(SyntaxKind::Element));
@@ -175,14 +167,7 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
         return p.expect(SyntaxKind::RBrace);
     }
 
-    if is_component_item {
-        p.enter_component_slot_scope();
-    }
-    let result = parse_element(&mut *p);
-    if is_component_item {
-        p.exit_component_slot_scope();
-    }
-    result
+    parse_element(&mut *p)
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -110,6 +110,7 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
     let is_global = !simple_component && p.peek().as_str() == "global";
     let is_interface = !simple_component && p.peek().as_str() == "interface";
     let is_new_component = !simple_component && p.peek().as_str() == "component";
+    let is_component_item = !is_global && !is_interface;
     if !is_global && !simple_component && !is_new_component && !is_interface {
         p.error(
             "Parse error: expected a top-level item such as a component, a struct, or a global",
@@ -150,10 +151,17 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
     } else if p.peek().as_str() == "inherits" {
         p.consume();
     } else if p.peek().kind() == SyntaxKind::LBrace {
+        if is_component_item {
+            p.enter_component_slot_scope();
+        }
         let mut p = p.start_node(SyntaxKind::Element);
         p.consume();
         parse_element_content(&mut *p);
-        return p.expect(SyntaxKind::RBrace);
+        let result = p.expect(SyntaxKind::RBrace);
+        if is_component_item {
+            p.exit_component_slot_scope();
+        }
+        return result;
     } else {
         p.error("Expected '{' or keyword 'inherits'");
         drop(p.start_node(SyntaxKind::Element));
@@ -167,7 +175,14 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
         return p.expect(SyntaxKind::RBrace);
     }
 
-    parse_element(&mut *p)
+    if is_component_item {
+        p.enter_component_slot_scope();
+    }
+    let result = parse_element(&mut *p);
+    if is_component_item {
+        p.exit_component_slot_scope();
+    }
+    result
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -73,15 +73,7 @@ pub fn parse_element_content(p: &mut impl Parser) {
                     had_parse_error |= !parse_slot_assignment_or_forwarding(&mut *p)
                 }
                 SyntaxKind::ColonEqual | SyntaxKind::LBrace => {
-                    let identifier = p.peek().text.clone();
-                    if p.nth(1).kind() == SyntaxKind::LBrace
-                        && p.nth(2).kind() == SyntaxKind::RBrace
-                        && p.is_slot_declared(identifier.as_str())
-                    {
-                        parse_slot_placeholder(&mut *p);
-                    } else {
-                        had_parse_error |= !parse_sub_element(&mut *p);
-                    }
+                    had_parse_error |= !parse_sub_element(&mut *p);
                 }
                 SyntaxKind::FatArrow | SyntaxKind::LParent
                     if !["if", "match"].contains(&p.peek().as_str()) =>
@@ -229,20 +221,6 @@ fn parse_slot_declaration(p: &mut impl Parser) {
         p.expect(SyntaxKind::Identifier);
     }
     p.expect(SyntaxKind::Semicolon);
-}
-
-#[cfg_attr(test, parser_test)]
-/// ```test,SlotPlaceholder
-/// header {}
-/// ```
-fn parse_slot_placeholder(p: &mut impl Parser) {
-    let mut p = p.start_node(SyntaxKind::SlotPlaceholder);
-    {
-        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
-        p.expect(SyntaxKind::Identifier);
-    }
-    p.expect(SyntaxKind::LBrace);
-    p.expect(SyntaxKind::RBrace);
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -55,6 +55,10 @@ pub fn parse_element(p: &mut impl Parser) -> bool {
 /// changed foo => {}
 /// match (foo) { 1: Elem { } }
 /// match bar.property { 1: Elem { } }
+/// slot header;
+/// header {}
+/// header << HeaderComponent {}
+/// header << parentHeader;
 /// ```
 pub fn parse_element_content(p: &mut impl Parser) {
     let mut had_parse_error = false;
@@ -63,9 +67,21 @@ pub fn parse_element_content(p: &mut impl Parser) {
             SyntaxKind::RBrace => return,
             SyntaxKind::Eof => return,
             SyntaxKind::Identifier => match p.nth(1).kind() {
+                _ if p.peek().as_str() == "slot" => parse_slot_declaration(&mut *p),
                 SyntaxKind::Colon => parse_property_binding(&mut *p),
+                SyntaxKind::DoubleLess => {
+                    had_parse_error |= !parse_slot_assignment_or_forwarding(&mut *p)
+                }
                 SyntaxKind::ColonEqual | SyntaxKind::LBrace => {
-                    had_parse_error |= !parse_sub_element(&mut *p)
+                    let identifier = p.peek().text.clone();
+                    if p.nth(1).kind() == SyntaxKind::LBrace
+                        && p.nth(2).kind() == SyntaxKind::RBrace
+                        && p.is_slot_declared(identifier.as_str())
+                    {
+                        parse_slot_placeholder(&mut *p);
+                    } else {
+                        had_parse_error |= !parse_sub_element(&mut *p);
+                    }
                 }
                 SyntaxKind::FatArrow | SyntaxKind::LParent
                     if !["if", "match"].contains(&p.peek().as_str()) =>
@@ -198,6 +214,82 @@ fn parse_sub_element(p: &mut impl Parser) -> bool {
         p.expect(SyntaxKind::ColonEqual);
     }
     parse_element(&mut *p)
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,SlotDeclaration
+/// slot header;
+/// ```
+fn parse_slot_declaration(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "slot");
+    let mut p = p.start_node(SyntaxKind::SlotDeclaration);
+    p.expect(SyntaxKind::Identifier); // "slot"
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+    p.expect(SyntaxKind::Semicolon);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,SlotPlaceholder
+/// header {}
+/// ```
+fn parse_slot_placeholder(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::SlotPlaceholder);
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+    p.expect(SyntaxKind::LBrace);
+    p.expect(SyntaxKind::RBrace);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,SlotAssignment
+/// header << HeaderComponent {}
+/// ```
+fn parse_slot_assignment(p: &mut impl Parser) -> bool {
+    let mut p = p.start_node(SyntaxKind::SlotAssignment);
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+    p.expect(SyntaxKind::DoubleLess);
+    if !parse_sub_element(&mut *p) {
+        p.error("Expected element after '<<'");
+        return false;
+    }
+    true
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,SlotForwarding
+/// hostHeader << header;
+/// hostHeader << header + 1;
+/// ```
+fn parse_slot_forwarding(p: &mut impl Parser) -> bool {
+    let mut p = p.start_node(SyntaxKind::SlotForwarding);
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+    p.expect(SyntaxKind::DoubleLess);
+    if !parse_expression(&mut *p) {
+        return false;
+    }
+    p.expect(SyntaxKind::Semicolon)
+}
+
+fn parse_slot_assignment_or_forwarding(p: &mut impl Parser) -> bool {
+    debug_assert_eq!(p.nth(1).kind(), SyntaxKind::DoubleLess);
+    let rhs_first = p.nth(2).kind();
+    let rhs_second = p.nth(3).kind();
+
+    let is_slot_assignment = rhs_first == SyntaxKind::Identifier
+        && matches!(rhs_second, SyntaxKind::LBrace | SyntaxKind::ColonEqual);
+
+    if is_slot_assignment { parse_slot_assignment(p) } else { parse_slot_forwarding(p) }
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -67,7 +67,9 @@ pub fn parse_element_content(p: &mut impl Parser) {
             SyntaxKind::RBrace => return,
             SyntaxKind::Eof => return,
             SyntaxKind::Identifier => match p.nth(1).kind() {
-                _ if p.peek().as_str() == "slot" => parse_slot_declaration(&mut *p),
+                SyntaxKind::Identifier | SyntaxKind::Semicolon if p.peek().as_str() == "slot" => {
+                    parse_slot_declaration(&mut *p)
+                }
                 SyntaxKind::Colon => parse_property_binding(&mut *p),
                 SyntaxKind::DoubleLess => {
                     had_parse_error |= !parse_slot_assignment_or_forwarding(&mut *p)

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -121,10 +121,10 @@ fn create_content_element(flickable: &ElementRc, native_empty: &Arc<NativeClass>
         .is_set_externally = true;
 
     let enclosing_component = flickable.borrow().enclosing_component.upgrade().unwrap();
-    if let Some(insertion_point) = &mut *enclosing_component.child_insertion_point.borrow_mut()
-        && std::rc::Rc::ptr_eq(&insertion_point.parent, flickable)
-    {
-        insertion_point.parent = content.clone()
+    for insertion_point in enclosing_component.child_insertion_points.borrow_mut().values_mut() {
+        if std::rc::Rc::ptr_eq(&insertion_point.parent, flickable) {
+            insertion_point.parent = content.clone()
+        }
     }
 
     flickable.borrow_mut().children.push(content);

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -133,35 +133,35 @@ fn inline_element(
 
     // Ensure @children CIP exists if it's missing but the component is a builtin that accepts children.
     // This preserves the implicit-children behavior for builtins without explicit placeholders.
-    if !inlined_insertion_points.contains_key("_children") {
-        if let Some(builtin) = inlined_component.root_element.borrow().builtin_type() {
-            if !builtin.is_non_item_type && !builtin.disallow_global_types_as_child_elements {
-                let cip_node = inlined_component
-                    .node
-                    .as_ref()
-                    .map(|n| n.clone().into())
-                    .or_else(|| {
-                        inlined_component
-                            .root_element
-                            .borrow()
-                            .debug
-                            .first()
-                            .map(|debug| debug.node.clone().into())
-                    })
-                    .or_else(|| elem_mut.debug.first().map(|debug| debug.node.clone().into()))
-                    .or_else(|| root_component.node.as_ref().map(|n| n.clone().into()))
-                    .expect("Missing syntax node for implicit @children insertion point");
+    if !inlined_insertion_points.contains_key("_children")
+        && let Some(builtin) = inlined_component.root_element.borrow().builtin_type()
+        && !builtin.is_non_item_type
+        && !builtin.disallow_global_types_as_child_elements
+    {
+        let cip_node = inlined_component
+            .node
+            .as_ref()
+            .map(|n| n.clone().into())
+            .or_else(|| {
+                inlined_component
+                    .root_element
+                    .borrow()
+                    .debug
+                    .first()
+                    .map(|debug| debug.node.clone().into())
+            })
+            .or_else(|| elem_mut.debug.first().map(|debug| debug.node.clone().into()))
+            .or_else(|| root_component.node.as_ref().map(|n| n.clone().into()))
+            .expect("Missing syntax node for implicit @children insertion point");
 
-                inlined_insertion_points.insert(
-                    "_children".into(),
-                    ChildrenInsertionPoint {
-                        parent: inlined_component.root_element.clone(),
-                        insertion_index: inlined_component.root_element.borrow().children.len(),
-                        node: cip_node,
-                    },
-                );
-            }
-        }
+        inlined_insertion_points.insert(
+            "_children".into(),
+            ChildrenInsertionPoint {
+                parent: inlined_component.root_element.clone(),
+                insertion_index: inlined_component.root_element.borrow().children.len(),
+                node: cip_node,
+            },
+        );
     }
 
     // Group instance children by slot target (named slot or default _children).

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -167,7 +167,6 @@ fn inline_element(
     // Group instance children by slot target (named slot or default _children).
     // This preserves relative order within each slot and allows named slot validation.
     let mut children_by_slot: HashMap<SmolStr, Vec<ElementRc>> = HashMap::new();
-    let mut seen_slots: HashSet<SmolStr> = HashSet::new();
     for child in std::mem::take(&mut elem_mut.children) {
         let slot = child
             .borrow()
@@ -175,17 +174,6 @@ fn inline_element(
             .as_ref()
             .map(|s| crate::parser::normalize_identifier(s))
             .unwrap_or_else(|| "_children".into());
-
-        // Only named slots are single-assignment; default _children can appear multiple times.
-        if let Some(target) = &child.borrow().slot_target {
-            let normalized = crate::parser::normalize_identifier(target);
-            if normalized != "_children" && !seen_slots.insert(normalized.clone()) {
-                diag.push_error(
-                    format!("Duplicate assignment to slot '{target}'"),
-                    &*child.borrow(),
-                );
-            }
-        }
 
         children_by_slot.entry(slot).or_default().push(child);
     }

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -128,12 +128,12 @@ fn inline_element(
     );
 
     // Copy insertion points so we can extend/adjust without mutating the source component.
-    let inlined_cips_orig = inlined_component.child_insertion_points.borrow();
-    let mut inlined_cips = inlined_cips_orig.clone();
+    let inlined_insertion_points_orig = inlined_component.child_insertion_points.borrow();
+    let mut inlined_insertion_points = inlined_insertion_points_orig.clone();
 
     // Ensure @children CIP exists if it's missing but the component is a builtin that accepts children.
     // This preserves the implicit-children behavior for builtins without explicit placeholders.
-    if !inlined_cips.contains_key("_children") {
+    if !inlined_insertion_points.contains_key("_children") {
         if let Some(builtin) = inlined_component.root_element.borrow().builtin_type() {
             if !builtin.is_non_item_type && !builtin.disallow_global_types_as_child_elements {
                 let cip_node = inlined_component
@@ -152,7 +152,7 @@ fn inline_element(
                     .or_else(|| root_component.node.as_ref().map(|n| n.clone().into()))
                     .expect("Missing syntax node for implicit @children insertion point");
 
-                inlined_cips.insert(
+                inlined_insertion_points.insert(
                     "_children".into(),
                     ChildrenInsertionPoint {
                         parent: inlined_component.root_element.clone(),
@@ -198,7 +198,7 @@ fn inline_element(
             // Keep the existing behavior and avoid reporting "_children" as an unknown named slot here.
             continue;
         }
-        if !inlined_cips.contains_key(slot_name.as_str()) {
+        if !inlined_insertion_points.contains_key(slot_name.as_str()) {
             for child in children {
                 diag.push_error(
                     format!("Unknown slot '{slot_name}' in '{}'", inlined_component.id),
@@ -233,7 +233,7 @@ fn inline_element(
     let mut insertions_by_parent: HashMap<ByAddress<ElementRc>, (ElementRc, Vec<SlotInsertion>)> =
         HashMap::new();
 
-    for (slot_name, inlined_cip) in inlined_cips.iter() {
+    for (slot_name, inlined_cip) in inlined_insertion_points.iter() {
         let children = children_by_slot.remove(slot_name.as_str()).unwrap_or_default();
         if let Some(insertion_element) = mapping.get(&element_key(inlined_cip.parent.clone())) {
             insertions_by_parent
@@ -284,8 +284,9 @@ fn inline_element(
                         new_children.splice(adjusted_index..adjusted_index, insertion.children);
                     }
 
-                    let mut root_cips = root_component.child_insertion_points.borrow_mut();
-                    for (root_slot_name, cip) in root_cips.iter_mut() {
+                    let mut root_insertion_points =
+                        root_component.child_insertion_points.borrow_mut();
+                    for (root_slot_name, cip) in root_insertion_points.iter_mut() {
                         let forwarded_match = forwarded_sources_by_target
                             .get(insertion.slot_name.as_str())
                             .is_some_and(|sources| {
@@ -302,11 +303,11 @@ fn inline_element(
                             };
                         }
                     }
-                    if root_cips.is_empty()
+                    if root_insertion_points.is_empty()
                         && Rc::ptr_eq(elem, &root_component.root_element)
                         && insertion.slot_name == "_children"
                     {
-                        root_cips.insert(
+                        root_insertion_points.insert(
                             "_children".into(),
                             ChildrenInsertionPoint {
                                 parent: insertion.insertion_element.clone(),
@@ -330,8 +331,9 @@ fn inline_element(
                             .splice(adjusted_index..adjusted_index, insertion.children);
                     }
 
-                    let mut root_cips = root_component.child_insertion_points.borrow_mut();
-                    for (root_slot_name, cip) in root_cips.iter_mut() {
+                    let mut root_insertion_points =
+                        root_component.child_insertion_points.borrow_mut();
+                    for (root_slot_name, cip) in root_insertion_points.iter_mut() {
                         let forwarded_match = forwarded_sources_by_target
                             .get(insertion.slot_name.as_str())
                             .is_some_and(|sources| {
@@ -348,11 +350,11 @@ fn inline_element(
                             };
                         }
                     }
-                    if root_cips.is_empty()
+                    if root_insertion_points.is_empty()
                         && Rc::ptr_eq(elem, &root_component.root_element)
                         && insertion.slot_name == "_children"
                     {
-                        root_cips.insert(
+                        root_insertion_points.insert(
                             "_children".into(),
                             ChildrenInsertionPoint {
                                 parent: insertion.insertion_element.clone(),
@@ -410,8 +412,8 @@ fn inline_element(
 
     let mut moved_into_popup = HashSet::new();
     if let Some(children) = move_children_into_popup {
-        let inlined_cips = inlined_component.child_insertion_points.borrow();
-        let inlined_cip = inlined_cips.get("_children").unwrap();
+        let inlined_insertion_points = inlined_component.child_insertion_points.borrow();
+        let inlined_cip = inlined_insertion_points.get("_children").unwrap();
 
         let insertion_element = mapping.get(&element_key(inlined_cip.parent.clone())).unwrap();
         debug_assert!(!std::rc::Weak::ptr_eq(
@@ -433,8 +435,8 @@ fn inline_element(
             .borrow_mut()
             .children
             .splice(inlined_cip.insertion_index..inlined_cip.insertion_index, children);
-        let mut root_cips = root_component.child_insertion_points.borrow_mut();
-        for cip in root_cips.values_mut() {
+        let mut root_insertion_points = root_component.child_insertion_points.borrow_mut();
+        for cip in root_insertion_points.values_mut() {
             if Rc::ptr_eq(&cip.parent, elem) {
                 *cip = ChildrenInsertionPoint {
                     parent: insertion_element.clone(),
@@ -443,8 +445,8 @@ fn inline_element(
                 };
             }
         }
-        if root_cips.is_empty() {
-            root_cips.insert(
+        if root_insertion_points.is_empty() {
+            root_insertion_points.insert(
                 "_children".into(),
                 ChildrenInsertionPoint {
                     parent: insertion_element.clone(),

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -245,7 +245,7 @@ fn inline_element(
                 move_children_into_popup = Some(children);
             } else {
                 diag.push_error(
-                    format!("Slot '{slot_name}' is inside a PopupWindow, which is not supported"),
+                    format!("The slot '{slot_name}' cannot appear in a PopupWindow"),
                     &inlined_cip.node,
                 );
             }

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -133,7 +133,7 @@ fn inline_element(
 
     // Ensure @children CIP exists if it's missing but the component is a builtin that accepts children.
     // This preserves the implicit-children behavior for builtins without explicit placeholders.
-    if !inlined_insertion_points.contains_key("_children")
+    if !inlined_insertion_points.contains_key(DEFAULT_SLOT_NAME)
         && let Some(builtin) = inlined_component.root_element.borrow().builtin_type()
         && !builtin.is_non_item_type
         && !builtin.disallow_global_types_as_child_elements
@@ -155,7 +155,7 @@ fn inline_element(
             .expect("Missing syntax node for implicit @children insertion point");
 
         inlined_insertion_points.insert(
-            "_children".into(),
+            DEFAULT_SLOT_NAME.into(),
             ChildrenInsertionPoint {
                 parent: inlined_component.root_element.clone(),
                 insertion_index: inlined_component.root_element.borrow().children.len(),
@@ -164,7 +164,7 @@ fn inline_element(
         );
     }
 
-    // Group instance children by slot target (named slot or default _children).
+    // Group instance children by slot target (named slot or the default slot).
     // This preserves relative order within each slot and allows named slot validation.
     let mut children_by_slot: HashMap<SmolStr, Vec<ElementRc>> = HashMap::new();
     for child in std::mem::take(&mut elem_mut.children) {
@@ -173,7 +173,7 @@ fn inline_element(
             .slot_target
             .as_ref()
             .map(|s| crate::parser::normalize_identifier(s))
-            .unwrap_or_else(|| "_children".into());
+            .unwrap_or_else(|| DEFAULT_SLOT_NAME.into());
 
         children_by_slot.entry(slot).or_default().push(child);
     }
@@ -181,9 +181,9 @@ fn inline_element(
     // Validate that all referenced slots exist on the inlined component.
     let mut unknown_slots = Vec::new();
     for (slot_name, children) in &children_by_slot {
-        if slot_name == "_children" {
+        if slot_name == DEFAULT_SLOT_NAME {
             // Missing default slot diagnostics are emitted earlier while constructing the object tree.
-            // Keep the existing behavior and avoid reporting "_children" as an unknown named slot here.
+            // Keep the existing behavior and avoid reporting the default slot as an unknown named slot here.
             continue;
         }
         if !inlined_insertion_points.contains_key(slot_name.as_str()) {
@@ -241,7 +241,7 @@ fn inline_element(
                 &p.component,
                 &inlined_cip.parent.borrow().enclosing_component.upgrade().unwrap()
             )));
-            if slot_name == "_children" {
+            if slot_name == DEFAULT_SLOT_NAME {
                 move_children_into_popup = Some(children);
             } else {
                 diag.push_error(
@@ -293,10 +293,10 @@ fn inline_element(
                     }
                     if root_insertion_points.is_empty()
                         && Rc::ptr_eq(elem, &root_component.root_element)
-                        && insertion.slot_name == "_children"
+                        && insertion.slot_name == DEFAULT_SLOT_NAME
                     {
                         root_insertion_points.insert(
-                            "_children".into(),
+                            DEFAULT_SLOT_NAME.into(),
                             ChildrenInsertionPoint {
                                 parent: insertion.insertion_element.clone(),
                                 insertion_index: adjusted_index + inserted_len,
@@ -340,10 +340,10 @@ fn inline_element(
                     }
                     if root_insertion_points.is_empty()
                         && Rc::ptr_eq(elem, &root_component.root_element)
-                        && insertion.slot_name == "_children"
+                        && insertion.slot_name == DEFAULT_SLOT_NAME
                     {
                         root_insertion_points.insert(
-                            "_children".into(),
+                            DEFAULT_SLOT_NAME.into(),
                             ChildrenInsertionPoint {
                                 parent: insertion.insertion_element.clone(),
                                 insertion_index: adjusted_index + inserted_len,
@@ -401,7 +401,7 @@ fn inline_element(
     let mut moved_into_popup = HashSet::new();
     if let Some(children) = move_children_into_popup {
         let inlined_insertion_points = inlined_component.child_insertion_points.borrow();
-        let inlined_cip = inlined_insertion_points.get("_children").unwrap();
+        let inlined_cip = inlined_insertion_points.get(DEFAULT_SLOT_NAME).unwrap();
 
         let insertion_element = mapping.get(&element_key(inlined_cip.parent.clone())).unwrap();
         debug_assert!(!std::rc::Weak::ptr_eq(
@@ -435,7 +435,7 @@ fn inline_element(
         }
         if root_insertion_points.is_empty() {
             root_insertion_points.insert(
-                "_children".into(),
+                DEFAULT_SLOT_NAME.into(),
                 ChildrenInsertionPoint {
                     parent: insertion_element.clone(),
                     insertion_index: inlined_cip.insertion_index,

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -9,6 +9,7 @@ use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
+use crate::parser::SyntaxNode;
 use by_address::ByAddress;
 use smol_str::SmolStr;
 use std::cell::RefCell;
@@ -126,58 +127,248 @@ fn inline_element(
         }),
     );
 
-    let mut move_children_into_popup = None;
+    // Copy insertion points so we can extend/adjust without mutating the source component.
+    let inlined_cips_orig = inlined_component.child_insertion_points.borrow();
+    let mut inlined_cips = inlined_cips_orig.clone();
 
-    match inlined_component.child_insertion_point.borrow().as_ref() {
-        Some(inlined_cip) => {
-            let children = std::mem::take(&mut elem_mut.children);
-            let old_count = children.len();
-            if let Some(insertion_element) = mapping.get(&element_key(inlined_cip.parent.clone())) {
-                if old_count > 0 {
-                    if !Rc::ptr_eq(elem, insertion_element) {
-                        debug_assert!(std::rc::Weak::ptr_eq(
-                            &insertion_element.borrow().enclosing_component,
-                            &elem_mut.enclosing_component,
-                        ));
-                        insertion_element.borrow_mut().children.splice(
-                            inlined_cip.insertion_index..inlined_cip.insertion_index,
-                            children,
-                        );
-                    } else {
-                        new_children.splice(
-                            inlined_cip.insertion_index..inlined_cip.insertion_index,
-                            children,
-                        );
-                    }
-                }
-                let mut cip = root_component.child_insertion_point.borrow_mut();
-                if let Some(cip) = cip.as_mut() {
-                    if Rc::ptr_eq(&cip.parent, elem) {
-                        *cip = ChildrenInsertionPoint {
-                            parent: insertion_element.clone(),
-                            insertion_index: inlined_cip.insertion_index + cip.insertion_index,
-                            node: inlined_cip.node.clone(),
-                        };
-                    }
-                } else if Rc::ptr_eq(elem, &root_component.root_element) {
-                    *cip = Some(ChildrenInsertionPoint {
-                        parent: insertion_element.clone(),
-                        insertion_index: inlined_cip.insertion_index + old_count,
-                        node: inlined_cip.node.clone(),
-                    });
-                };
-            } else if old_count > 0 {
-                // @children was into a PopupWindow
-                debug_assert!(inlined_component.popup_windows.borrow().iter().any(|p| Rc::ptr_eq(
-                    &p.component,
-                    &inlined_cip.parent.borrow().enclosing_component.upgrade().unwrap()
-                )));
+    // Ensure @children CIP exists if it's missing but the component is a builtin that accepts children.
+    // This preserves the implicit-children behavior for builtins without explicit placeholders.
+    if !inlined_cips.contains_key("_children") {
+        if let Some(builtin) = inlined_component.root_element.borrow().builtin_type() {
+            if !builtin.is_non_item_type && !builtin.disallow_global_types_as_child_elements {
+                let cip_node = inlined_component
+                    .node
+                    .as_ref()
+                    .map(|n| n.clone().into())
+                    .or_else(|| {
+                        inlined_component
+                            .root_element
+                            .borrow()
+                            .debug
+                            .first()
+                            .map(|debug| debug.node.clone().into())
+                    })
+                    .or_else(|| elem_mut.debug.first().map(|debug| debug.node.clone().into()))
+                    .or_else(|| root_component.node.as_ref().map(|n| n.clone().into()))
+                    .expect("Missing syntax node for implicit @children insertion point");
+
+                inlined_cips.insert(
+                    "_children".into(),
+                    ChildrenInsertionPoint {
+                        parent: inlined_component.root_element.clone(),
+                        insertion_index: inlined_component.root_element.borrow().children.len(),
+                        node: cip_node,
+                    },
+                );
+            }
+        }
+    }
+
+    // Group instance children by slot target (named slot or default _children).
+    // This preserves relative order within each slot and allows named slot validation.
+    let mut children_by_slot: HashMap<SmolStr, Vec<ElementRc>> = HashMap::new();
+    let mut seen_slots: HashSet<SmolStr> = HashSet::new();
+    for child in std::mem::take(&mut elem_mut.children) {
+        let slot = child
+            .borrow()
+            .slot_target
+            .as_ref()
+            .map(|s| crate::parser::normalize_identifier(s))
+            .unwrap_or_else(|| "_children".into());
+
+        // Only named slots are single-assignment; default _children can appear multiple times.
+        if let Some(target) = &child.borrow().slot_target {
+            let normalized = crate::parser::normalize_identifier(target);
+            if normalized != "_children" && !seen_slots.insert(normalized.clone()) {
+                diag.push_error(
+                    format!("Duplicate assignment to slot '{target}'"),
+                    &*child.borrow(),
+                );
+            }
+        }
+
+        children_by_slot.entry(slot).or_default().push(child);
+    }
+
+    // Validate that all referenced slots exist on the inlined component.
+    let mut unknown_slots = Vec::new();
+    for (slot_name, children) in &children_by_slot {
+        if slot_name == "_children" {
+            // Missing default slot diagnostics are emitted earlier while constructing the object tree.
+            // Keep the existing behavior and avoid reporting "_children" as an unknown named slot here.
+            continue;
+        }
+        if !inlined_cips.contains_key(slot_name.as_str()) {
+            for child in children {
+                diag.push_error(
+                    format!("Unknown slot '{slot_name}' in '{}'", inlined_component.id),
+                    &*child.borrow(),
+                );
+            }
+            unknown_slots.push(slot_name.clone());
+        }
+    }
+    for slot_name in unknown_slots {
+        children_by_slot.remove(&slot_name);
+    }
+
+    let mut move_children_into_popup = None;
+    let forwarded_sources_by_target: HashMap<SmolStr, Vec<SmolStr>> =
+        elem_mut.forwarded_slots.iter().fold(HashMap::new(), |mut map, forwarding| {
+            map.entry(crate::parser::normalize_identifier(forwarding.target.as_str()))
+                .or_default()
+                .push(crate::parser::normalize_identifier(forwarding.source.as_str()));
+            map
+        });
+
+    struct SlotInsertion {
+        slot_name: SmolStr,
+        insertion_index: usize,
+        node: SyntaxNode,
+        insertion_element: ElementRc,
+        children: Vec<ElementRc>,
+    }
+
+    // Collect all insertions per parent element so we can insert in a stable order.
+    let mut insertions_by_parent: HashMap<ByAddress<ElementRc>, (ElementRc, Vec<SlotInsertion>)> =
+        HashMap::new();
+
+    for (slot_name, inlined_cip) in inlined_cips.iter() {
+        let children = children_by_slot.remove(slot_name.as_str()).unwrap_or_default();
+        if let Some(insertion_element) = mapping.get(&element_key(inlined_cip.parent.clone())) {
+            insertions_by_parent
+                .entry(element_key(insertion_element.clone()))
+                .or_insert_with(|| (insertion_element.clone(), Vec::new()))
+                .1
+                .push(SlotInsertion {
+                    slot_name: slot_name.as_str().into(),
+                    insertion_index: inlined_cip.insertion_index,
+                    node: inlined_cip.node.clone(),
+                    insertion_element: insertion_element.clone(),
+                    children,
+                });
+        } else if !children.is_empty() {
+            // @children was into a PopupWindow (named slots inside popups are not supported).
+            debug_assert!(inlined_component.popup_windows.borrow().iter().any(|p| Rc::ptr_eq(
+                &p.component,
+                &inlined_cip.parent.borrow().enclosing_component.upgrade().unwrap()
+            )));
+            if slot_name == "_children" {
                 move_children_into_popup = Some(children);
-            };
+            } else {
+                diag.push_error(
+                    format!("Slot '{slot_name}' is inside a PopupWindow, which is not supported"),
+                    &inlined_cip.node,
+                );
+            }
         }
-        _ => {
-            new_children.append(&mut elem_mut.children);
-        }
+    }
+
+    // Insert slot children and keep root insertion points in sync.
+    let mut insertions_for_parent =
+        |insertion_element: &ElementRc, insertions: &mut Vec<SlotInsertion>| {
+            insertions.sort_by(|a, b| {
+                a.insertion_index
+                    .cmp(&b.insertion_index)
+                    .then_with(|| a.node.span().offset.cmp(&b.node.span().offset))
+                    .then_with(|| a.slot_name.cmp(&b.slot_name))
+            });
+
+            let mut offset = 0usize;
+            if Rc::ptr_eq(elem, insertion_element) {
+                // Insert into the new inlined root children vector.
+                for insertion in insertions.drain(..) {
+                    let adjusted_index = insertion.insertion_index + offset;
+                    let inserted_len = insertion.children.len();
+                    if inserted_len > 0 {
+                        new_children.splice(adjusted_index..adjusted_index, insertion.children);
+                    }
+
+                    let mut root_cips = root_component.child_insertion_points.borrow_mut();
+                    for (root_slot_name, cip) in root_cips.iter_mut() {
+                        let forwarded_match = forwarded_sources_by_target
+                            .get(insertion.slot_name.as_str())
+                            .is_some_and(|sources| {
+                                sources.iter().any(|source| source == root_slot_name)
+                            });
+                        if Rc::ptr_eq(&cip.parent, elem)
+                            && (root_slot_name.as_str() == insertion.slot_name.as_str()
+                                || forwarded_match)
+                        {
+                            *cip = ChildrenInsertionPoint {
+                                parent: insertion.insertion_element.clone(),
+                                insertion_index: adjusted_index + cip.insertion_index,
+                                node: insertion.node.clone(),
+                            };
+                        }
+                    }
+                    if root_cips.is_empty()
+                        && Rc::ptr_eq(elem, &root_component.root_element)
+                        && insertion.slot_name == "_children"
+                    {
+                        root_cips.insert(
+                            "_children".into(),
+                            ChildrenInsertionPoint {
+                                parent: insertion.insertion_element.clone(),
+                                insertion_index: adjusted_index + inserted_len,
+                                node: insertion.node.clone(),
+                            },
+                        );
+                    }
+
+                    offset += inserted_len;
+                }
+            } else {
+                // Insert into a mapped child element (not the inlined root).
+                let mut insertion_element_mut = insertion_element.borrow_mut();
+                for insertion in insertions.drain(..) {
+                    let adjusted_index = insertion.insertion_index + offset;
+                    let inserted_len = insertion.children.len();
+                    if inserted_len > 0 {
+                        insertion_element_mut
+                            .children
+                            .splice(adjusted_index..adjusted_index, insertion.children);
+                    }
+
+                    let mut root_cips = root_component.child_insertion_points.borrow_mut();
+                    for (root_slot_name, cip) in root_cips.iter_mut() {
+                        let forwarded_match = forwarded_sources_by_target
+                            .get(insertion.slot_name.as_str())
+                            .is_some_and(|sources| {
+                                sources.iter().any(|source| source == root_slot_name)
+                            });
+                        if Rc::ptr_eq(&cip.parent, elem)
+                            && (root_slot_name.as_str() == insertion.slot_name.as_str()
+                                || forwarded_match)
+                        {
+                            *cip = ChildrenInsertionPoint {
+                                parent: insertion.insertion_element.clone(),
+                                insertion_index: adjusted_index + cip.insertion_index,
+                                node: insertion.node.clone(),
+                            };
+                        }
+                    }
+                    if root_cips.is_empty()
+                        && Rc::ptr_eq(elem, &root_component.root_element)
+                        && insertion.slot_name == "_children"
+                    {
+                        root_cips.insert(
+                            "_children".into(),
+                            ChildrenInsertionPoint {
+                                parent: insertion.insertion_element.clone(),
+                                insertion_index: adjusted_index + inserted_len,
+                                node: insertion.node.clone(),
+                            },
+                        );
+                    }
+
+                    offset += inserted_len;
+                }
+            }
+        };
+
+    for (insertion_element, mut insertions) in insertions_by_parent.into_values() {
+        insertions_for_parent(&insertion_element, &mut insertions);
     }
 
     elem_mut.children = new_children;
@@ -219,8 +410,8 @@ fn inline_element(
 
     let mut moved_into_popup = HashSet::new();
     if let Some(children) = move_children_into_popup {
-        let child_insertion_point = inlined_component.child_insertion_point.borrow();
-        let inlined_cip = child_insertion_point.as_ref().unwrap();
+        let inlined_cips = inlined_component.child_insertion_points.borrow();
+        let inlined_cip = inlined_cips.get("_children").unwrap();
 
         let insertion_element = mapping.get(&element_key(inlined_cip.parent.clone())).unwrap();
         debug_assert!(!std::rc::Weak::ptr_eq(
@@ -242,8 +433,8 @@ fn inline_element(
             .borrow_mut()
             .children
             .splice(inlined_cip.insertion_index..inlined_cip.insertion_index, children);
-        let mut cip = root_component.child_insertion_point.borrow_mut();
-        if let Some(cip) = cip.as_mut() {
+        let mut root_cips = root_component.child_insertion_points.borrow_mut();
+        for cip in root_cips.values_mut() {
             if Rc::ptr_eq(&cip.parent, elem) {
                 *cip = ChildrenInsertionPoint {
                     parent: insertion_element.clone(),
@@ -251,12 +442,16 @@ fn inline_element(
                     node: inlined_cip.node.clone(),
                 };
             }
-        } else {
-            *cip = Some(ChildrenInsertionPoint {
-                parent: insertion_element.clone(),
-                insertion_index: inlined_cip.insertion_index,
-                node: inlined_cip.node.clone(),
-            });
+        }
+        if root_cips.is_empty() {
+            root_cips.insert(
+                "_children".into(),
+                ChildrenInsertionPoint {
+                    parent: insertion_element.clone(),
+                    insertion_index: inlined_cip.insertion_index,
+                    node: inlined_cip.node.clone(),
+                },
+            );
         };
     }
 
@@ -424,6 +619,8 @@ fn duplicate_element_with_mapping(
         is_tooltip: elem.is_tooltip,
         is_legacy_syntax: elem.is_legacy_syntax,
         inline_depth: elem.inline_depth + 1,
+        slot_target: elem.slot_target.clone(),
+        forwarded_slots: elem.forwarded_slots.clone(),
         // Deep-clone grid_layout_cell to avoid sharing between original and inlined copies.
         // This is important because children_constraints contain NamedReferences that need
         // to be fixed up independently for each inlined copy.
@@ -477,7 +674,8 @@ fn duplicate_sub_component(
                 .collect(),
         ),
         root_constraints: component_to_duplicate.root_constraints.clone(),
-        child_insertion_point: component_to_duplicate.child_insertion_point.clone(),
+        child_insertion_points: component_to_duplicate.child_insertion_points.clone(),
+        declared_slots: component_to_duplicate.declared_slots.clone(),
         init_code: component_to_duplicate.init_code.clone(),
         popup_windows: Default::default(),
         timers: component_to_duplicate.timers.clone(),
@@ -760,6 +958,12 @@ fn component_requires_inlining(component: &Rc<Component>) -> bool {
 fn element_require_inlining(elem: &ElementRc) -> bool {
     if !elem.borrow().children.is_empty() {
         // the generators assume that the children list is complete, which sub-components may break
+        return true;
+    }
+
+    if !elem.borrow().forwarded_slots.is_empty() {
+        // Slot forwarding relies on slot insertion points being materialized in this element's
+        // subtree, which currently only happens through inlining.
         return true;
     }
 

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -9,7 +9,6 @@ use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
-use crate::parser::SyntaxNode;
 use by_address::ByAddress;
 use smol_str::SmolStr;
 use std::cell::RefCell;
@@ -159,7 +158,7 @@ fn inline_element(
             ChildrenInsertionPoint {
                 parent: inlined_component.root_element.clone(),
                 insertion_index: inlined_component.root_element.borrow().children.len(),
-                node: cip_node,
+                node: ChildInsertionPointNode::DefaultChildrenPlaceHolder(cip_node),
             },
         );
     }
@@ -212,7 +211,7 @@ fn inline_element(
     struct SlotInsertion {
         slot_name: SmolStr,
         insertion_index: usize,
-        node: SyntaxNode,
+        node: ChildInsertionPointNode,
         insertion_element: ElementRc,
         children: Vec<ElementRc>,
     }

--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -50,14 +50,19 @@ fn diagnose_component_container(element: &ElementRc, diag: &mut BuildDiagnostics
     if !elem.children.is_empty() {
         diag.push_error("ComponentContainers may not have children".into(), &*element.borrow());
     }
-    if let Some(cip) =
-        elem.enclosing_component.upgrade().unwrap().child_insertion_point.borrow().clone()
-        && Rc::ptr_eq(&cip.parent, element)
+    for (name, cip) in &*elem.enclosing_component.upgrade().unwrap().child_insertion_points.borrow()
     {
-        diag.push_error(
-            "The @children placeholder cannot appear in a ComponentContainer".into(),
-            &*element.borrow(),
-        );
+        if Rc::ptr_eq(&cip.parent, element) {
+            let slot_name = if name == "_children" {
+                "The @children placeholder".into()
+            } else {
+                format!("the slot '{name}'")
+            };
+            diag.push_error(
+                format!("{} cannot appear in a ComponentContainer", slot_name),
+                &*element.borrow(),
+            );
+        }
     }
 }
 

--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -53,13 +53,8 @@ fn diagnose_component_container(element: &ElementRc, diag: &mut BuildDiagnostics
     for (name, cip) in &*elem.enclosing_component.upgrade().unwrap().child_insertion_points.borrow()
     {
         if Rc::ptr_eq(&cip.parent, element) {
-            let slot_name = if name == DEFAULT_SLOT_NAME {
-                "The @children placeholder".into()
-            } else {
-                format!("The slot '{name}'")
-            };
             diag.push_error(
-                format!("{} cannot appear in a ComponentContainer", slot_name),
+                format!("{} cannot appear in a ComponentContainer", slot_error_subject(name)),
                 &*element.borrow(),
             );
         }

--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -53,7 +53,7 @@ fn diagnose_component_container(element: &ElementRc, diag: &mut BuildDiagnostics
     for (name, cip) in &*elem.enclosing_component.upgrade().unwrap().child_insertion_points.borrow()
     {
         if Rc::ptr_eq(&cip.parent, element) {
-            let slot_name = if name == "_children" {
+            let slot_name = if name == DEFAULT_SLOT_NAME {
                 "The @children placeholder".into()
             } else {
                 format!("the slot '{name}'")

--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -56,7 +56,7 @@ fn diagnose_component_container(element: &ElementRc, diag: &mut BuildDiagnostics
             let slot_name = if name == DEFAULT_SLOT_NAME {
                 "The @children placeholder".into()
             } else {
-                format!("the slot '{name}'")
+                format!("The slot '{name}'")
             };
             diag.push_error(
                 format!("{} cannot appear in a ComponentContainer", slot_name),

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -106,11 +106,10 @@ fn lower_popup_window(
     parent_element_borrowed.children.remove(index);
     parent_element_borrowed.has_popup_child = true;
     drop(parent_element_borrowed);
-    if let Some(parent_cip) = &mut *parent_component.child_insertion_point.borrow_mut()
-        && Rc::ptr_eq(&parent_cip.parent, parent_element)
-        && parent_cip.insertion_index > index
-    {
-        parent_cip.insertion_index -= 1;
+    for parent_cip in parent_component.child_insertion_points.borrow_mut().values_mut() {
+        if Rc::ptr_eq(&parent_cip.parent, parent_element) && parent_cip.insertion_index > index {
+            parent_cip.insertion_index -= 1;
+        }
     }
 
     let map_close_on_click_value = |b: &BindingExpression| {

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -86,11 +86,10 @@ fn lower_timer(
     let removed = parent_element_borrowed.children.remove(index);
     parent_component.optimized_elements.borrow_mut().push(removed);
     drop(parent_element_borrowed);
-    if let Some(parent_cip) = &mut *parent_component.child_insertion_point.borrow_mut()
-        && Rc::ptr_eq(&parent_cip.parent, parent_element)
-        && parent_cip.insertion_index > index
-    {
-        parent_cip.insertion_index -= 1;
+    for parent_cip in parent_component.child_insertion_points.borrow_mut().values_mut() {
+        if Rc::ptr_eq(&parent_cip.parent, parent_element) && parent_cip.insertion_index > index {
+            parent_cip.insertion_index -= 1;
+        }
     }
 
     let running = NamedReference::new(timer_element, SmolStr::new_static("running"));

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -67,6 +67,8 @@ fn create_repeater_components(component: &Rc<Component>) {
                 item_index_of_first_children: Default::default(),
                 is_legacy_syntax: original_elem.is_legacy_syntax,
                 inline_depth: 0,
+                slot_target: original_elem.slot_target.clone(),
+                forwarded_slots: original_elem.forwarded_slots.clone(),
                 grid_layout_cell: original_elem.grid_layout_cell.clone(),
             })),
             parent_element: RefCell::new(Weak::clone(&original_elem_as_weak)),

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2277,7 +2277,7 @@ fn resolve_slot_reference_element(
     node: &dyn Spanned,
     report_unknown: bool,
 ) -> Option<ElementRc> {
-    if name == "children" || name == "_children" {
+    if name == "children" {
         ctx.diag.push_error(
             "The default slot '@children' cannot be referenced in expressions".into(),
             node,

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -482,11 +482,6 @@ impl Expression {
                         ctx.diag.slint_sc_error("@keys() expressions are", &node);
                         return Self::from_at_keys_node(node.into(), ctx);
                     }
-                    SyntaxKind::SlotReference => {
-                        #[cfg(feature = "slint-sc")]
-                        ctx.diag.slint_sc_error("Slot references are", &node);
-                        return Self::from_slot_reference_node(node.into(), ctx);
-                    }
                     SyntaxKind::QualifiedName => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Identifier references are", &node);
@@ -690,14 +685,6 @@ impl Expression {
             source_location: Some(node.to_source_location()),
             nine_slice,
         }
-    }
-
-    fn from_slot_reference_node(node: syntax_nodes::SlotReference, ctx: &mut LookupCtx) -> Self {
-        let name = identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
-        resolve_slot_reference_element(name.as_str(), ctx, &node, true)
-            .map_or(Expression::Invalid, |element| {
-                Expression::ElementReference(Rc::downgrade(&element))
-            })
     }
 
     pub fn from_at_gradient(node: syntax_nodes::AtGradient, ctx: &mut LookupCtx) -> Self {
@@ -2197,7 +2184,7 @@ fn lookup_qualified_name_node(
     let result = match global_lookup.lookup(ctx, &first_str) {
         None => {
             if let Some(slot_element) =
-                resolve_slot_reference_element(first_str.as_str(), ctx, &node, false)
+                resolve_slot_reference_element(first_str.as_str(), ctx, &node)
             {
                 return continue_lookup_within_element(&slot_element, &mut it, node, ctx);
             }
@@ -2275,7 +2262,6 @@ fn resolve_slot_reference_element(
     name: &str,
     ctx: &mut LookupCtx,
     node: &dyn Spanned,
-    report_unknown: bool,
 ) -> Option<ElementRc> {
     if name == "children" {
         ctx.diag.push_error(
@@ -2316,9 +2302,6 @@ fn resolve_slot_reference_element(
         return None;
     }
 
-    if report_unknown {
-        ctx.diag.push_error(format!("Unknown slot '{name}'"), node);
-    }
     None
 }
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -482,6 +482,11 @@ impl Expression {
                         ctx.diag.slint_sc_error("@keys() expressions are", &node);
                         return Self::from_at_keys_node(node.into(), ctx);
                     }
+                    SyntaxKind::SlotReference => {
+                        #[cfg(feature = "slint-sc")]
+                        ctx.diag.slint_sc_error("Slot references are", &node);
+                        return Self::from_slot_reference_node(node.into(), ctx);
+                    }
                     SyntaxKind::QualifiedName => {
                         #[cfg(feature = "slint-sc")]
                         ctx.diag.slint_sc_error("Identifier references are", &node);
@@ -685,6 +690,14 @@ impl Expression {
             source_location: Some(node.to_source_location()),
             nine_slice,
         }
+    }
+
+    fn from_slot_reference_node(node: syntax_nodes::SlotReference, ctx: &mut LookupCtx) -> Self {
+        let name = identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
+        resolve_slot_reference_element(name.as_str(), ctx, &node, true)
+            .map_or(Expression::Invalid, |element| {
+                Expression::ElementReference(Rc::downgrade(&element))
+            })
     }
 
     pub fn from_at_gradient(node: syntax_nodes::AtGradient, ctx: &mut LookupCtx) -> Self {
@@ -2183,6 +2196,16 @@ fn lookup_qualified_name_node(
     let global_lookup = crate::lookup::global_lookup();
     let result = match global_lookup.lookup(ctx, &first_str) {
         None => {
+            if let Some(slot_element) =
+                resolve_slot_reference_element(first_str.as_str(), ctx, &node, false)
+            {
+                return continue_lookup_within_element(&slot_element, &mut it, node, ctx);
+            }
+            if is_declared_slot_in_scope(first_str.as_str(), ctx) {
+                // resolve_slot_reference_element() already emitted a slot-specific diagnostic.
+                return None;
+            }
+
             if let Some(minus_pos) = first.text().find('-') {
                 // Attempt to recover if the user wanted to write "-" for minus
                 let first_str = &first.text()[0..minus_pos];
@@ -2246,6 +2269,67 @@ fn lookup_qualified_name_node(
         }
         result => maybe_lookup_object(result, it, ctx),
     }
+}
+
+fn resolve_slot_reference_element(
+    name: &str,
+    ctx: &mut LookupCtx,
+    node: &dyn Spanned,
+    report_unknown: bool,
+) -> Option<ElementRc> {
+    if name == "children" || name == "_children" {
+        ctx.diag.push_error(
+            "The default slot '@children' cannot be referenced in expressions".into(),
+            node,
+        );
+        return None;
+    }
+
+    for scope_elem in ctx.component_scope.iter().rev() {
+        let scope_elem_ref = scope_elem.borrow();
+        let repeated = scope_elem_ref.repeated.is_some();
+        let mut matches = scope_elem_ref.children.iter().filter(|child| {
+            child.borrow().slot_target.as_ref().is_some_and(|slot| slot.as_str() == name)
+        });
+        if let Some(found) = matches.next() {
+            if matches.next().is_some() {
+                ctx.diag.push_error(format!("Duplicate assignment to slot '{name}'"), node);
+                return None;
+            }
+
+            if repeated {
+                ctx.diag.push_error(
+                    format!(
+                        "Slot '{name}' cannot be referenced inside repeated or conditional elements"
+                    ),
+                    node,
+                );
+                return None;
+            }
+
+            return Some(found.clone());
+        }
+    }
+
+    if is_declared_slot_in_scope(name, ctx) {
+        ctx.diag.push_error(format!("Slot '{name}' is not assigned in this instance"), node);
+        return None;
+    }
+
+    if report_unknown {
+        ctx.diag.push_error(format!("Unknown slot '{name}'"), node);
+    }
+    None
+}
+
+fn is_declared_slot_in_scope(name: &str, ctx: &LookupCtx) -> bool {
+    ctx.component_scope.iter().rev().any(|scope_elem| {
+        let scope_elem_ref = scope_elem.borrow();
+        let ElementType::Component(component) = &scope_elem_ref.base_type else {
+            return false;
+        };
+        component.declared_slots.borrow().iter().any(|slot| slot.name == name)
+    })
 }
 
 fn continue_lookup_within_element(

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2201,7 +2201,7 @@ fn lookup_qualified_name_node(
             {
                 return continue_lookup_within_element(&slot_element, &mut it, node, ctx);
             }
-            if is_declared_slot_in_scope(first_str.as_str(), ctx) {
+            if first_str == "children" || is_declared_slot_in_scope(first_str.as_str(), ctx) {
                 // resolve_slot_reference_element() already emitted a slot-specific diagnostic.
                 return None;
             }

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -70,6 +70,8 @@ pub fn ensure_window(
 
         inline_depth: 0,
         is_legacy_syntax: false,
+        slot_target: None,
+        forwarded_slots: Vec::new(),
     };
     let new_root = new_root.make_rc();
     win_elem_mut.children.push(new_root.clone());

--- a/internal/compiler/tests/syntax/basic/children_placeholder.slint
+++ b/internal/compiler/tests/syntax/basic/children_placeholder.slint
@@ -34,7 +34,7 @@ export TestBox2 := Rectangle {
         @children
     }
     @children
-//  >       <error{The @children placeholder can only appear once in an element hierarchy}
+//  >       <error{The @children placeholder can only appear once in an element}
 }
 
 export Final := TestBox {

--- a/internal/compiler/tests/syntax/component_slots/component_slots.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots.slint
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Base inherits Rectangle {
+    slot header;
+    slot footer;
+
+    VerticalLayout {
+        header {}
+        @children
+        footer {}
+    }
+}
+
+export component Test inherits Rectangle {
+    Base {
+        header << Rectangle {
+            background: blue;
+        }
+        Text { text: "Main Content"; }
+        footer << Rectangle {
+            background: gray;
+        }
+    }
+}
+
+export component FailDuplicateUse inherits Rectangle {
+    slot header;
+    header {}
+    header {}
+//  >       <error{The slot 'header' can only appear once in an element hierarchy}
+}
+
+export component FailDuplicateUse2 inherits Rectangle {
+    slot header;
+    header {}
+    Rectangle {
+        header {}
+//      >       <error{The slot 'header' can only appear once in an element hierarchy}
+    }
+}
+
+export component FailReservedSlotName inherits Rectangle {
+    slot _children;
+//       >       <error{The name '_children' is reserved for the default slot. Use @children instead}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots.slint
@@ -24,22 +24,6 @@ export component Test inherits Rectangle {
     }
 }
 
-export component FailDuplicateUse inherits Rectangle {
-    slot header;
-    header {}
-    header {}
-//  >       <error{The slot 'header' can only appear once in an element hierarchy}
-}
-
-export component FailDuplicateUse2 inherits Rectangle {
-    slot header;
-    header {}
-    Rectangle {
-        header {}
-//      >       <error{The slot 'header' can only appear once in an element hierarchy}
-    }
-}
-
 export component FailReservedSlotName inherits Rectangle {
     slot children;
 //       >      <error{The name 'children' is reserved for the default slot. Use @children instead}

--- a/internal/compiler/tests/syntax/component_slots/component_slots.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots.slint
@@ -41,6 +41,6 @@ export component FailDuplicateUse2 inherits Rectangle {
 }
 
 export component FailReservedSlotName inherits Rectangle {
-    slot _children;
-//       >       <error{The name '_children' is reserved for the default slot. Use @children instead}
+    slot children;
+//       >      <error{The name 'children' is reserved for the default slot. Use @children instead}
 }

--- a/internal/compiler/tests/syntax/component_slots/component_slots.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots.slint
@@ -44,3 +44,16 @@ export component FailReservedSlotName inherits Rectangle {
     slot children;
 //       >      <error{The name 'children' is reserved for the default slot. Use @children instead}
 }
+
+export component FailDuplicateSlotDeclaration inherits Rectangle {
+    slot header;
+    slot header;
+//       >    <error{Duplicate slot declaration 'header'}
+
+    header {}
+}
+
+export component FailUnusedSlotDeclaration inherits Rectangle {
+    slot header;
+//       >    <error{The slot 'header' is declared but not used}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots.slint
@@ -41,3 +41,19 @@ export component FailUnusedSlotDeclaration inherits Rectangle {
     slot header;
 //       >    <error{The slot 'header' is declared but not used}
 }
+
+export interface InterfacesCannotHaveSlots {
+    slot header;
+//  >          <error{An interface cannot have slots}
+
+    header {}
+//  >       <error{An interface cannot have sub elements}
+}
+
+export global GlobalsCannotHaveSlots {
+    slot header;
+//  >          <error{A global component cannot have slots}
+
+    header {}
+//  >       <error{A global component cannot have sub elements}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -1,0 +1,108 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot header;
+
+    VerticalLayout {
+        header {}
+    }
+}
+
+export component UseOk inherits Rectangle {
+    SlotHost {
+        header << Rectangle {
+            background: blue;
+        }
+    }
+}
+
+export component FailDuplicateAssignment inherits Rectangle {
+    SlotHost {
+        header << Rectangle { background: red; }
+        header << Rectangle { background: green; }
+//      >                                        <error{Duplicate assignment to slot 'header'}
+    }
+}
+
+export component FailUnknownSlot inherits Rectangle {
+    SlotHost {
+        footer << Rectangle { }
+//      >                     <error{Unknown slot 'footer' in 'SlotHost'}
+    }
+}
+
+export component ForwardTargetHost inherits Rectangle {
+    slot hostHeader;
+
+    Rectangle {
+        hostHeader {}
+    }
+}
+
+export component FailUnknownForwardTarget inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        footer << header;
+//      >    <error{Unknown slot 'footer' in 'ForwardTargetHost'}
+    }
+
+    header {}
+}
+
+export component FailDuplicateForwardingTarget inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header;
+        hostHeader << header;
+//      >        <error{Duplicate forwarding to slot 'hostHeader'}
+    }
+}
+
+export component FailForwardAndAssignConflict inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header;
+        hostHeader << Rectangle { }
+//      >                         <error{Slot 'hostHeader' cannot be both forwarded and assigned}
+    }
+}
+
+export component FailForwardAndPlaceholderConflict inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header;
+    }
+
+    header {}
+//  >       <error{The slot 'header' cannot be forwarded and used as a placeholder in the same component}
+}
+
+export component FailForwardUnknownSource inherits Rectangle {
+    ForwardTargetHost {
+        hostHeader << header;
+//                    >    <error{The slot 'header' is used but not declared}
+    }
+}
+
+export component FailForwardInvalidRhs inherits Rectangle {
+    slot header;
+
+    ForwardTargetHost {
+        hostHeader << header + 1;
+//                    >        <error{Slot forwarding requires a slot identifier on the right-hand side}
+    }
+
+    header {}
+}
+
+export component FailUnassignedSlotReference inherits Rectangle {
+    SlotHost {
+        out property <length> header_y: header.absolute-position.y;
+//                                      >                        <error{Slot 'header' is not assigned in this instance}
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -124,3 +124,8 @@ export component FailForwardingOnNonComponent inherits Rectangle {
 
     header {}
 }
+
+export component FailChildrenReference inherits Rectangle {
+    out property <length> header_y: children.absolute-position.y;
+//                                  >                          <error{The default slot '@children' cannot be referenced in expressions}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -57,7 +57,7 @@ export component FailDuplicateForwardingTarget inherits Rectangle {
     ForwardTargetHost {
         hostHeader << header;
         hostHeader << header;
-//      >        <error{Duplicate forwarding to slot 'hostHeader'}
+//      >        <error{Duplicate assignment to slot 'hostHeader'}
     }
 }
 
@@ -67,7 +67,7 @@ export component FailForwardAndAssignConflict inherits Rectangle {
     ForwardTargetHost {
         hostHeader << header;
         hostHeader << Rectangle { }
-//      >        <error{Slot 'hostHeader' cannot be both forwarded and assigned}
+//      >        <error{Duplicate assignment to slot 'hostHeader'}
     }
 }
 

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -106,3 +106,21 @@ export component FailUnassignedSlotReference inherits Rectangle {
 //                                      >                        <error{Slot 'header' is not assigned in this instance}
     }
 }
+
+export component FailAssignmentOnNonComponent inherits Rectangle {
+    Rectangle {
+        header << Rectangle { }
+//      >                     <error{Slot assignments can only be used on components}
+    }
+}
+
+export component FailForwardingOnNonComponent inherits Rectangle {
+    slot header;
+
+    Rectangle {
+        hostHeader << header;
+//      >                   <error{Slot forwarding can only be used on components}
+    }
+
+    header {}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -21,14 +21,14 @@ export component FailDuplicateAssignment inherits Rectangle {
     SlotHost {
         header << Rectangle { background: red; }
         header << Rectangle { background: green; }
-//      >                                        <error{Duplicate assignment to slot 'header'}
+//      >    <error{Duplicate assignment to slot 'header'}
     }
 }
 
 export component FailUnknownSlot inherits Rectangle {
     SlotHost {
         footer << Rectangle { }
-//      >                     <error{Unknown slot 'footer' in 'SlotHost'}
+//      >    <error{Unknown slot 'footer' in 'SlotHost'}
     }
 }
 
@@ -67,7 +67,7 @@ export component FailForwardAndAssignConflict inherits Rectangle {
     ForwardTargetHost {
         hostHeader << header;
         hostHeader << Rectangle { }
-//      >                         <error{Slot 'hostHeader' cannot be both forwarded and assigned}
+//      >        <error{Slot 'hostHeader' cannot be both forwarded and assigned}
     }
 }
 

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -149,3 +149,19 @@ export component FailChildrenReference inherits Rectangle {
     out property <length> header_y: children.absolute-position.y;
 //                                  >                          <error{The default slot '@children' cannot be referenced in expressions}
 }
+
+export component FailReferenceInRepeated inherits Rectangle {
+    for i in [0, 1]: SlotHost {
+        header << Rectangle { }
+        x: header.absolute-position.x;
+//         >                        <error{Slot 'header' cannot be referenced inside repeated or conditional elements}
+    }
+}
+
+export component FailReferenceInConditional inherits Rectangle {
+    if true: SlotHost {
+        header << Rectangle { }
+        x: header.absolute-position.x;
+//         >                        <error{Slot 'header' cannot be referenced inside repeated or conditional elements}
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_binding_errors.slint
@@ -71,6 +71,26 @@ export component FailForwardAndAssignConflict inherits Rectangle {
     }
 }
 
+export component TwoTargetHost inherits Rectangle {
+    slot hostHeader;
+    slot hostFooter;
+
+    VerticalLayout {
+        hostHeader {}
+        hostFooter {}
+    }
+}
+
+export component FailDuplicateForwardSource inherits Rectangle {
+    slot header;
+
+    TwoTargetHost {
+        hostHeader << header;
+        hostFooter << header;
+//                    >    <error{The slot 'header' can only appear once in an element}
+    }
+}
+
 export component FailForwardAndPlaceholderConflict inherits Rectangle {
     slot header;
 

--- a/internal/compiler/tests/syntax/component_slots/component_slots_component_container_restriction.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_component_container_restriction.slint
@@ -1,0 +1,17 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component ComponentContainerSlotHost inherits Rectangle {
+    slot header;
+
+    ComponentContainer {
+//  >                 <error{The slot 'header' cannot appear in a ComponentContainer}
+        header {}
+    }
+}
+
+export component FailSlotInComponentContainer inherits Rectangle {
+    ComponentContainerSlotHost {
+        header << Rectangle { }
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_keywords.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_keywords.slint
@@ -1,0 +1,65 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>, Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component PropertyNamedSlot {
+    in property <int> slot;
+}
+
+component CallbackNamedSlot {
+    callback slot;
+}
+
+component CallbackWithArgumentNamedSlot {
+    callback slot(int);
+    in-out property <int> received;
+}
+
+component FunctionNamedSlot {
+    public function slot() {}
+}
+
+component TwoWayNamedSlot {
+    in-out property <int> slot;
+}
+
+component slot { }
+
+export component InstantiateComponentNamedSlot {
+    slot { }
+}
+
+export component ChildIdentifierSlot {
+    slot := PropertyNamedSlot {
+        slot: 42;
+    }
+
+    CallbackNamedSlot {
+        slot => {}
+    }
+
+    CallbackWithArgumentNamedSlot {
+        slot(value) => { self.received = value; }
+    }
+
+    function-component := FunctionNamedSlot { }
+
+    init => function-component.slot();
+}
+
+// `slot` as a property of the element declaring it, and as a loop variable
+export component SelfPropertyNamedSlot inherits Rectangle {
+    in-out property <int> slot;
+    in-out property <int> mirror;
+    in-out property <int> change-count;
+
+    animate slot { duration: 100ms; }
+    changed slot => { self.change-count += 1; }
+
+    TwoWayNamedSlot {
+        slot <=> root.mirror;
+    }
+
+    for slot in [1, 2, 3]: Rectangle {
+        width: slot * 1px;
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_keywords.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_keywords.slint
@@ -28,6 +28,16 @@ export component InstantiateComponentNamedSlot {
     slot { }
 }
 
+export component Header { }
+
+export component WarnThatSlotShadowsComponent inherits Rectangle {
+    slot Header;
+    VerticalLayout {
+        Header { }
+//      >        <warning{The slot 'Header' shadows an element type of the same name. This element is a slot placeholder, not an instance of 'Header'}
+    }
+}
+
 export component ChildIdentifierSlot {
     slot := PropertyNamedSlot {
         slot: 42;

--- a/internal/compiler/tests/syntax/component_slots/component_slots_parse_error.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_parse_error.slint
@@ -1,0 +1,7 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Fail inherits Rectangle {
+    header << ;
+//            ^error{invalid expression}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_parse_error.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_parse_error.slint
@@ -5,3 +5,8 @@ export component Fail inherits Rectangle {
     header << ;
 //            ^error{invalid expression}
 }
+
+export component FailMissingSlotName inherits Rectangle {
+    slot;
+//      ^error{Syntax error: expected Identifier}
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
@@ -43,3 +43,14 @@ export component NestedPlaceholder inherits Rectangle {
         header {}
     }
 }
+
+export component NotInMatch inherits Rectangle {
+    slot header;
+    in-out property <int> value;
+    match value {
+        0: Rectangle {
+            header {}
+//          >       <error{The slot 'header' cannot appear in a match element}
+        }
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
@@ -21,6 +21,22 @@ export component NotInFor inherits Rectangle {
     }
 }
 
+export component FailDuplicateUse inherits Rectangle {
+    slot header;
+    header {}
+    header {}
+//  >       <error{The slot 'header' can only appear once in an element}
+}
+
+export component FailDuplicateUse2 inherits Rectangle {
+    slot header;
+    Rectangle {
+        header {}
+    }
+    header {}
+//  >       <error{The slot 'header' can only appear once in an element}
+}
+
 export component NestedPlaceholder inherits Rectangle {
     slot header;
     Rectangle {

--- a/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>, Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component NotInIf inherits Rectangle {
+    slot header;
+    if true: Rectangle {
+        header {}
+//      >       <error{The slot 'header' cannot appear in a conditional element}
+    }
+}
+
+export component NotInFor inherits Rectangle {
+    slot header;
+    HorizontalLayout {
+        for xxx in 12: Rectangle {
+            VerticalLayout {
+                header {}
+//              >       <error{The slot 'header' cannot appear in a repeated element}
+            }
+        }
+    }
+}
+
+export component NestedPlaceholder inherits Rectangle {
+    slot header;
+    Rectangle {
+        header {}
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/component_slots_popup_restriction.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_popup_restriction.slint
@@ -1,0 +1,17 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component PopupSlotHost inherits Rectangle {
+    slot header;
+
+    PopupWindow {
+        header {}
+//      >       <error{The slot 'header' cannot appear in a PopupWindow}
+    }
+}
+
+export component FailSlotInPopup inherits Rectangle {
+    PopupSlotHost {
+        header << Rectangle { }
+    }
+}

--- a/internal/compiler/tests/syntax/component_slots/global_called_slot.slint
+++ b/internal/compiler/tests/syntax/component_slots/global_called_slot.slint
@@ -1,0 +1,10 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+global slot {
+    pure public function slot() -> int { 42 }
+}
+
+export component ImplementInterfaceNamedSlot {
+    out property <int> v: slot.slot();
+}

--- a/internal/compiler/tests/syntax/component_slots/interface_called_slot.slint
+++ b/internal/compiler/tests/syntax/component_slots/interface_called_slot.slint
@@ -1,0 +1,14 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface slot {
+    in-out property <int> slot;
+}
+
+export component ImplementInterfaceNamedSlot {
+    implement slot <=> slot;
+
+    slot := Rectangle {
+        in-out property <int> slot: 42;
+    }
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -348,8 +348,9 @@ impl Snapshotter {
                     .collect(),
             );
 
-            let child_insertion_point =
-                RefCell::new(component.child_insertion_point.borrow().clone());
+            let child_insertion_points =
+                RefCell::new(component.child_insertion_points.borrow().clone());
+            let declared_slots = component.declared_slots.clone();
 
             let popup_windows = RefCell::new(
                 component
@@ -375,7 +376,8 @@ impl Snapshotter {
             object_tree::Component {
                 node: component.node.clone(),
                 id: component.id.clone(),
-                child_insertion_point,
+                child_insertion_points,
+                declared_slots,
                 exported_global_names: RefCell::new(
                     component.exported_global_names.borrow().clone(),
                 ),

--- a/tests/cases/component_slots/component_slots_basic.slint
+++ b/tests/cases/component_slots/component_slots_basic.slint
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotContent inherits Rectangle {
+    in-out property <int> value;
+    width: 10px;
+    height: 10px;
+    background: red;
+}
+
+export component Host inherits Rectangle {
+    slot header;
+    VerticalLayout {
+        header {}
+
+
+    }
+}
+
+export component TestCase inherits Rectangle {
+    host := Host {
+        header << SlotContent {
+            value: 42;
+        }
+
+        out property <int> header_value: header.value;
+    }
+
+    out property <int> header_value: host.header_value;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_header_value(), 42);
+```
+*/

--- a/tests/cases/component_slots/component_slots_basic.slint
+++ b/tests/cases/component_slots/component_slots_basic.slint
@@ -11,7 +11,7 @@ export component SlotContent inherits Rectangle {
 export component Host inherits Rectangle {
     slot header;
     VerticalLayout {
-        header {}
+        header { }
     }
 }
 

--- a/tests/cases/component_slots/component_slots_basic.slint
+++ b/tests/cases/component_slots/component_slots_basic.slint
@@ -12,8 +12,6 @@ export component Host inherits Rectangle {
     slot header;
     VerticalLayout {
         header {}
-
-
     }
 }
 

--- a/tests/cases/component_slots/component_slots_branching_children.slint
+++ b/tests/cases/component_slots/component_slots_branching_children.slint
@@ -1,0 +1,123 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component HeaderComponent inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 1px;
+        }
+
+        @children
+        Rectangle {
+            height: 2px;
+        }
+    }
+}
+
+export component ContentBlock inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 1px;
+        }
+
+        @children
+        Rectangle {
+            height: 2px;
+        }
+    }
+}
+
+export component FooterComponent inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 1px;
+        }
+
+        @children
+        Rectangle {
+            height: 2px;
+        }
+    }
+}
+
+export component Panel inherits Rectangle {
+    slot header;
+    slot footer;
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+        @children
+        footer {}
+
+
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 160px;
+
+    panel := Panel {
+        width: 200px;
+        height: 160px;
+
+        header << HeaderComponent {
+            h1 := Rectangle {
+                height: 5px;
+            }
+
+            h2 := Rectangle {
+                height: 7px;
+            }
+        }
+
+        ContentBlock {
+            b1 := Rectangle {
+                height: 11px;
+            }
+        }
+
+        ContentBlock {
+            b2 := Rectangle {
+                height: 13px;
+            }
+        }
+
+        ContentBlock {
+            b3 := Rectangle {
+                height: 17px;
+            }
+        }
+
+        footer << FooterComponent {
+            f1 := Rectangle {
+                height: 19px;
+            }
+
+            f2 := Rectangle {
+                height: 23px;
+            }
+        }
+
+        out property <length> h1y: h1.absolute-position.y;
+        out property <length> h2y: h2.absolute-position.y;
+        out property <length> b1y: b1.absolute-position.y;
+        out property <length> b2y: b2.absolute-position.y;
+        out property <length> b3y: b3.absolute-position.y;
+        out property <length> f1y: f1.absolute-position.y;
+        out property <length> f2y: f2.absolute-position.y;
+    }
+
+    out property <bool> test:
+        panel.h1y == 1px && panel.h2y == 6px && panel.b1y == 16px && panel.b2y == 30px && panel.b3y == 46px && panel.f1y == 66px && panel.f2y == 85px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_branching_children.slint
+++ b/tests/cases/component_slots/component_slots_branching_children.slint
@@ -51,8 +51,6 @@ export component Panel inherits Rectangle {
         header {}
         @children
         footer {}
-
-
     }
 }
 

--- a/tests/cases/component_slots/component_slots_branching_children.slint
+++ b/tests/cases/component_slots/component_slots_branching_children.slint
@@ -48,9 +48,10 @@ export component Panel inherits Rectangle {
     slot footer;
     VerticalLayout {
         spacing: 0px;
-        header {}
+        header { }
+
         @children
-        footer {}
+        footer { }
     }
 }
 

--- a/tests/cases/component_slots/component_slots_keywords_tree_sitter.slint
+++ b/tests/cases/component_slots/component_slots_keywords_tree_sitter.slint
@@ -1,0 +1,76 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+component PropertyNamedSlot {
+    in property <int> slot;
+}
+
+component CallbackNamedSlot {
+    callback slot;
+}
+
+component CallbackWithArgumentNamedSlot {
+    callback slot(int);
+    in-out property <int> received;
+}
+
+component FunctionNamedSlot {
+    public function slot() {}
+}
+
+component ChildIdentifierSlot {
+    slot := PropertyNamedSlot {
+        slot: 42;
+    }
+
+    CallbackNamedSlot {
+        slot => {}
+    }
+
+    CallbackWithArgumentNamedSlot {
+        slot(value) => { self.received = value; }
+    }
+
+    function-component := FunctionNamedSlot { }
+
+    init => function-component.slot();
+}
+
+component TwoWayNamedSlot {
+    in-out property <int> slot;
+}
+
+component SelfPropertyNamedSlot inherits Rectangle {
+    in-out property <int> slot;
+    in-out property <int> mirror;
+    in-out property <int> change-count;
+
+    animate slot { duration: 100ms; }
+    changed slot => { self.change-count += 1; }
+
+    TwoWayNamedSlot {
+        slot <=> root.mirror;
+    }
+
+    for slot in [1, 2, 3]: Rectangle {
+        width: slot * 1px;
+    }
+}
+
+component slot { }
+
+
+export component TestCase inherits Rectangle {
+    ChildIdentifierSlot { }
+
+    SelfPropertyNamedSlot { }
+
+    slot { }
+}
+
+/*
+```rust
+let _instance = TestCase::new().unwrap();
+```
+*/

--- a/tests/cases/component_slots/component_slots_layout.slint
+++ b/tests/cases/component_slots/component_slots_layout.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot header;
+    slot footer;
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+        @children
+        footer {}
+
+
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 60px;
+
+    host := SlotHost {
+        width: 200px;
+        height: 60px;
+
+        header << Rectangle {
+            height: 10px;
+        }
+
+        body_rect := Rectangle {
+            height: 20px;
+        }
+
+        footer << Rectangle {
+            height: 30px;
+        }
+
+        out property <length> header_y: header.absolute-position.y;
+        out property <length> body_y: body_rect.absolute-position.y;
+        out property <length> footer_y: footer.absolute-position.y;
+    }
+
+    out property <bool> test: host.header_y == 0px && host.body_y == 10px && host.footer_y == 30px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_layout.slint
+++ b/tests/cases/component_slots/component_slots_layout.slint
@@ -9,8 +9,6 @@ export component SlotHost inherits Rectangle {
         header {}
         @children
         footer {}
-
-
     }
 }
 

--- a/tests/cases/component_slots/component_slots_layout.slint
+++ b/tests/cases/component_slots/component_slots_layout.slint
@@ -6,9 +6,10 @@ export component SlotHost inherits Rectangle {
     slot footer;
     VerticalLayout {
         spacing: 0px;
-        header {}
+        header { }
+
         @children
-        footer {}
+        footer { }
     }
 }
 

--- a/tests/cases/component_slots/component_slots_optional_header.slint
+++ b/tests/cases/component_slots/component_slots_optional_header.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot header;
+
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+        @children
+    }
+}
+
+export component TestCase inherits Window {
+    width: 120px;
+    height: 30px;
+
+    host := SlotHost {
+        width: 120px;
+        height: 30px;
+
+        body_rect := Rectangle {
+            height: 30px;
+        }
+    }
+
+    out property <length> body_y: body_rect.absolute-position.y;
+    out property <bool> test: body_y == 0px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_optional_header.slint
+++ b/tests/cases/component_slots/component_slots_optional_header.slint
@@ -6,7 +6,8 @@ export component SlotHost inherits Rectangle {
 
     VerticalLayout {
         spacing: 0px;
-        header {}
+        header { }
+
         @children
     }
 }

--- a/tests/cases/component_slots/component_slots_slot_assignment_children.slint
+++ b/tests/cases/component_slots/component_slots_slot_assignment_children.slint
@@ -1,0 +1,63 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component NestedHost inherits Rectangle {
+    VerticalLayout {
+        spacing: 0px;
+        Rectangle {
+            height: 2px;
+        }
+
+        @children
+        Rectangle {
+            height: 3px;
+        }
+    }
+}
+
+export component SlotHost inherits Rectangle {
+    slot header;
+    VerticalLayout {
+        spacing: 0px;
+        header {}
+
+
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 60px;
+
+    host := SlotHost {
+        width: 100px;
+        height: 60px;
+
+        header << NestedHost {
+            a := Rectangle {
+                height: 5px;
+            }
+
+            b := Rectangle {
+                height: 7px;
+            }
+
+            c := Rectangle {
+                height: 11px;
+            }
+        }
+
+        out property <length> ay: a.absolute-position.y;
+        out property <length> by: b.absolute-position.y;
+        out property <length> cy: c.absolute-position.y;
+    }
+
+    out property <bool> test: host.ay == 2px && host.by == 7px && host.cy == 14px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_slot_assignment_children.slint
+++ b/tests/cases/component_slots/component_slots_slot_assignment_children.slint
@@ -19,7 +19,7 @@ export component SlotHost inherits Rectangle {
     slot header;
     VerticalLayout {
         spacing: 0px;
-        header {}
+        header { }
     }
 }
 

--- a/tests/cases/component_slots/component_slots_slot_assignment_children.slint
+++ b/tests/cases/component_slots/component_slots_slot_assignment_children.slint
@@ -20,8 +20,6 @@ export component SlotHost inherits Rectangle {
     VerticalLayout {
         spacing: 0px;
         header {}
-
-
     }
 }
 

--- a/tests/cases/component_slots/component_slots_two_levels.slint
+++ b/tests/cases/component_slots/component_slots_two_levels.slint
@@ -1,0 +1,58 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SlotHost inherits Rectangle {
+    slot hostHeader;
+
+    VerticalLayout {
+        spacing: 0px;
+        hostHeader {}
+        @children
+    }
+}
+
+export component Outer inherits Rectangle {
+    slot header;
+
+    SlotHost {
+        hostHeader << header;
+        @children
+    }
+}
+
+export component TestCase inherits Window {
+    width: 120px;
+    height: 20px;
+
+    outer := Outer {
+        width: 120px;
+        height: 20px;
+
+        header << Rectangle {
+            height: 8px;
+        }
+
+        body_rect := Rectangle {
+            height: 12px;
+        }
+
+        out property <length> header_y: header.absolute-position.y;
+        out property <length> body_y: body_rect.absolute-position.y;
+    }
+
+    out property <bool> test: outer.header_y == 0px && outer.body_y == 8px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/component_slots/component_slots_two_levels.slint
+++ b/tests/cases/component_slots/component_slots_two_levels.slint
@@ -6,7 +6,8 @@ export component SlotHost inherits Rectangle {
 
     VerticalLayout {
         spacing: 0px;
-        hostHeader {}
+        hostHeader { }
+
         @children
     }
 }

--- a/tests/driver/rust/tests/component_slots.rs
+++ b/tests/driver/rust/tests/component_slots.rs
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// NOTE: The files under tests/driver/rust/tests/ are generated and validated against this template.
+// Do not edit them directly, instead edit the template.rs file!
+
+// needs to be crate-level
+#![deny(rust_2024_compatibility)]
+
+include!(concat!(env!("OUT_DIR"), "/component_slots.rs"));

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -149,6 +149,12 @@ fn format_node(
         SyntaxKind::ChildrenPlaceholder => {
             return format_children_placeholder(node, writer, state);
         }
+        SyntaxKind::SlotDeclaration => {
+            return format_slot_declaration(node, writer, state);
+        }
+        SyntaxKind::SlotPlaceholder => {
+            return format_slot_placeholder(node, writer, state);
+        }
         SyntaxKind::RepeatedElement => {
             return format_repeated_element(node, writer, state);
         }
@@ -1249,6 +1255,34 @@ fn format_children_placeholder(
     for n in node.children_with_tokens() {
         fold(n, writer, state)?;
     }
+    state.new_line();
+    Ok(())
+}
+
+fn format_slot_declaration(
+    node: &SyntaxNode,
+    writer: &mut impl TokenWriter,
+    state: &mut FormatState,
+) -> Result<(), std::io::Error> {
+    let mut sub = node.children_with_tokens();
+    let _ok = whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?
+        && whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, " ")?
+        && whitespace_to(&mut sub, SyntaxKind::Semicolon, writer, state, "")?;
+    finish_node(sub, writer, state)?;
+    state.new_line();
+    Ok(())
+}
+
+fn format_slot_placeholder(
+    node: &SyntaxNode,
+    writer: &mut impl TokenWriter,
+    state: &mut FormatState,
+) -> Result<(), std::io::Error> {
+    let mut sub = node.children_with_tokens();
+    let _ok = whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, "")?
+        && whitespace_to(&mut sub, SyntaxKind::LBrace, writer, state, " ")?
+        && whitespace_to(&mut sub, SyntaxKind::RBrace, writer, state, "")?;
+    finish_node(sub, writer, state)?;
     state.new_line();
     Ok(())
 }

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -152,9 +152,6 @@ fn format_node(
         SyntaxKind::SlotDeclaration => {
             return format_slot_declaration(node, writer, state);
         }
-        SyntaxKind::SlotPlaceholder => {
-            return format_slot_placeholder(node, writer, state);
-        }
         SyntaxKind::RepeatedElement => {
             return format_repeated_element(node, writer, state);
         }
@@ -1268,20 +1265,6 @@ fn format_slot_declaration(
     let _ok = whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?
         && whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, " ")?
         && whitespace_to(&mut sub, SyntaxKind::Semicolon, writer, state, "")?;
-    finish_node(sub, writer, state)?;
-    state.new_line();
-    Ok(())
-}
-
-fn format_slot_placeholder(
-    node: &SyntaxNode,
-    writer: &mut impl TokenWriter,
-    state: &mut FormatState,
-) -> Result<(), std::io::Error> {
-    let mut sub = node.children_with_tokens();
-    let _ok = whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, "")?
-        && whitespace_to(&mut sub, SyntaxKind::LBrace, writer, state, " ")?
-        && whitespace_to(&mut sub, SyntaxKind::RBrace, writer, state, "")?;
     finish_node(sub, writer, state)?;
     state.new_line();
     Ok(())

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -712,7 +712,8 @@ fn resolve_element_scope(
         ) -> (bool, bool, Vec<SmolStr>) {
             match element_type {
                 ElementType::Component(component) => {
-                    let base_type = match &*component.child_insertion_point.borrow() {
+                    let base_type = match component.child_insertion_points.borrow().get("_children")
+                    {
                         Some(insert_in) => insert_in.parent.borrow().base_type.clone(),
                         None => {
                             let base_type = component.root_element.borrow().base_type.clone();

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -712,7 +712,10 @@ fn resolve_element_scope(
         ) -> (bool, bool, Vec<SmolStr>) {
             match element_type {
                 ElementType::Component(component) => {
-                    let base_type = match component.child_insertion_points.borrow().get("_children")
+                    let base_type = match component
+                        .child_insertion_points
+                        .borrow()
+                        .get(i_slint_compiler::object_tree::DEFAULT_SLOT_NAME)
                     {
                         Some(insert_in) => insert_in.parent.borrow().base_type.clone(),
                         None => {


### PR DESCRIPTION
This PR rebases the original PR by @ThePartyPinguin (Closes #10738) and applies review feedback
Initial implementation for #6258.

---

## Overview

This PR adds named slots to Slint, generalizing the existing `@children` mechanism. Today a component can accept exactly one anonymous block of child content via `@children`. Named slots let a component declare multiple, individually-addressable insertion points, so a container can place caller-supplied content at several distinct locations in its own layout.

## The feature

A component declares slots with the new `slot` keyword and renders each one at a chosen location by writing the slot name as an empty element (`header {}`). The caller fills a slot with the `<<` operator:

```slint
export component Base inherits Rectangle {
    slot header;
    slot footer;

    VerticalLayout {
        header {}      // render site for the `header` slot
        @children      // the default slot, unchanged
        footer {}      // render site for the `footer` slot
    }
}

export component App inherits Rectangle {
    Base {
        header << Rectangle { background: blue; }
        Text { text: "Main Content"; }   // still goes to @children
        footer << Rectangle { background: gray; }
    }
}
```

**Referencing a slot.** The name bound to a slot is a first-class element reference, so its properties can be read like any other element:

```slint
Base {
    header << Rectangle { height: 8px; }
    out property <length> header_y: header.absolute-position.y;
}
```

**Forwarding.** A slot can be forwarded to a slot of a nested component with the same `<<` operator, letting a wrapper expose an inner component's slots as its own:

```slint
export component Outer inherits Rectangle {
    slot header;
    SlotHost {
        hostHeader << header;   // forward Outer's `header` into SlotHost's `hostHeader`
        @children
    }
}
```

**Optional assignment.** Declaring and rendering a slot does not force the caller to fill it; an unassigned slot simply renders nothing.

### Rules and diagnostics

- A declared slot must be rendered exactly once, and it may not be placed inside a for, if, or match element (these are conditional/repeated contexts).
- The name `children` is reserved for the default slot; use `@children`.
- Slots cannot appear inside a `PopupWindow` or a `ComponentContainer`.
- Assignment/forwarding is only valid on components, and each slot may only be assigned once.

Each of these paths has a dedicated syntax test with an exact expected message and span.

The feature is gated behind the experimental-features flag.

---

## High-level review comments addressed from the previous PR (#10738)

The original PR's review threads were written against an earlier syntax (`@header := Rectangle{}`). The feature was subsequently redesigned to the `slot` / `<<` form shown above (no sigil, `<<` as the operator), which itself resolves several threads. This PR then works through the remaining substantive feedback:

### Architecture — move semantics out of the parser (ogoffart)
- `SlotPlaceholder` is no longer its own grammar node. `name {}` now parses as an ordinary `SubElement` and is recognised as a placeholder during object-tree conversion. The parser is now permissive — it no longer tracks slot scope, declaration order, or duplicate names.
- The duplicate-slot-name check was consolidated: it lives at object-tree construction / resolving time, and the redundant copy in the inlining pass was removed.
- `@children` inlining was generalised so named slots and the default slot flow through a single code path.

### Cleanups
- Introduced a `DEFAULT_SLOT_NAME` constant (`"@children"`) replacing the scattered `"_children"` string literals. Because `"@children"` is not a valid identifier it can never collide with a user slot name, which let the `_children` special-casing in the reservation checks be dropped.
- Extracted the four duplicated experimental-feature gate blocks into a single `assert_experimental_slots` helper.

### Diagnostics (ogoffart / Murmele)
- Tightened slot-assignment error spans to point at the slot identifier rather than the whole sub-element, matching the forwarding diagnostics.
- Unified the duplicate-assignment, duplicate-forwarding, and forward-and-assign-conflict cases to a single consistent "Duplicate assignment to slot 'X'" message, and deduplicated the three "can only appear once" messages.
- Fixed two double-diagnostic bugs: referencing `children` in an expression, and placing a named slot inside a `for` / `if`, each now emit exactly one error.
- Repeated/conditional placement errors now name the actual slot instead of always saying `@children`.

### Tests (ogoffart)
- Added a syntax test for every reachable slot diagnostic (duplicate declaration, unused declaration, assignment/forwarding on a non-component, `PopupWindow` and `ComponentContainer` restrictions, reference-in-repeated/conditional, and the reserved-name and children-in-expression cases).
- Mirrored the existing `@children` placeholder parity tests for named slots.

### Dead-code removal
- Removed the unreachable `SlotReference` grammar node and its associated parsing and the never-fired `Unknown slot 'X'` diagnostic (the parser never constructed that node).

### Deferred (per ogoffart: "get the compiler working first")
- Broader LSP support beyond formatter idempotency, and info-level diagnostic hints, are intentionally out of scope for this PR.

### Editor support
- Added tree-sitter grammar support for the named-slot syntax.

A design point left deliberately open: `SlotAssignment` is single-element today but the grammar is not foreclosed against a future list form (`slot <[Interface]> names;`), per the team design discussion.