### PR TITLE
navigation: experimental declarative `navigator` construct

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -134,6 +134,7 @@ deinit
 delenv
 depfile
 deque
+desugars
 devcode
 devenv
 dfaure
@@ -283,6 +284,7 @@ incididunt
 Inconsolata
 incpath
 inputchip
+interp
 intprop
 intval
 IRAM
@@ -514,6 +516,7 @@ rlib
 Roboto
 RODATA
 rowcol
+rsplit
 rspolib
 rsvg
 rtti
@@ -639,6 +642,7 @@ udivdi
 uintptr
 ullamco
 unfocusable
+ungated
 unhinted
 unicodes
 uninit
@@ -659,6 +663,7 @@ vbus
 vecmodel
 veniam
 venv
+versionable
 verticalbox
 verticallayout
 VGWGPU
@@ -701,9 +706,11 @@ xcent
 xchg
 xcrun
 xfer
+XFILE
 xfixes
 xlib
 xmark
+xmount
 Xrgb
 xshell
 xxaaxx

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -174,6 +174,10 @@ export default defineConfig({
                                         label: "Drag and Drop",
                                         slug: "guide/development/drag-and-drop",
                                     },
+                                    {
+                                        label: "Navigation",
+                                        slug: "guide/development/navigation",
+                                    },
                                     "guide/development/best-practices",
                                     "guide/development/third-party-libraries",
                                 ],

--- a/docs/astro/src/content/docs/guide/development/navigation.mdx
+++ b/docs/astro/src/content/docs/guide/development/navigation.mdx
@@ -1,0 +1,85 @@
+---
+title: Navigation
+description: The convention for moving between screens with an enum route and a current-route property.
+---
+
+Slint has no dedicated navigation element yet. Multi-screen apps are built from a
+small, stable convention: an `enum` of routes, a `current-route` property, and one
+conditional child per route. This page describes that convention.
+
+This is the interim pattern that the visual editor's flow map understands, so
+following it exactly lets tooling read the screens and the transitions between them.
+
+## The convention
+
+The pattern is made of four parts.
+
+1. A user-declared `enum Route` with one value per screen.
+2. A root component with `in-out property <Route> current-route`, set to the initial screen.
+3. One conditional child per route, mapping a route to its screen: `if current-route == Route.Home : HomeScreen { ... }`.
+4. Navigation by assigning the route property: `current-route = Route.Details;`.
+
+```slint
+import { Button, VerticalBox } from "std-widgets.slint";
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits VerticalBox {
+    callback show-details();
+    callback show-settings();
+    Text { text: "Home"; }
+    Button { text: "Go to Details"; clicked => { root.show-details(); } }
+    Button { text: "Open Settings"; clicked => { root.show-settings(); } }
+}
+
+component DetailsScreen inherits VerticalBox {
+    callback back();
+    Text { text: "Details"; }
+    Button { text: "Back to Home"; clicked => { root.back(); } }
+}
+
+component SettingsScreen inherits VerticalBox {
+    callback back();
+    Text { text: "Settings"; }
+    Button { text: "Back to Home"; clicked => { root.back(); } }
+}
+
+export component App inherits Window {
+    // The current screen. Assigning this property navigates.
+    in-out property <Route> current-route: Route.Home;
+
+    // One conditional child per route maps a route to its screen.
+    if current-route == Route.Home : HomeScreen {
+        show-details => { root.current-route = Route.Details; }
+        show-settings => { root.current-route = Route.Settings; }
+    }
+    if current-route == Route.Details : DetailsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+    if current-route == Route.Settings : SettingsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+}
+```
+
+## How it reads
+
+- The `enum Route` is the set of screens.
+- `current-route` is the active screen, and its initializer is the entry screen.
+- Each `if current-route == Route.X : Screen { ... }` is the route-to-screen mapping.
+- Each `current-route = Route.Y;` assignment is a transition from the enclosing screen to `Route.Y`.
+
+Keeping a screen in its own component and wiring its callbacks in the root, next to the
+matching conditional child, keeps each transition close to the screen it starts from.
+
+## Scope
+
+The convention tracks a single `current-route` only. There is no back-stack: returning
+to a previous screen is just another assignment, as in the `back` callbacks above. A
+history stack is a separate concern and is not part of this convention.
+
+A runnable version of this example lives in `examples/navigation` in the Slint repository.

--- a/docs/astro/src/content/docs/guide/development/navigation.mdx
+++ b/docs/astro/src/content/docs/guide/development/navigation.mdx
@@ -1,23 +1,27 @@
 ---
 title: Navigation
-description: The convention for moving between screens with an enum route and a current-route property.
+description: Move between screens with the navigator construct - an enum of routes, a current-route property, and a compiler-checked route table.
 ---
 
-Slint has no dedicated navigation element yet. Multi-screen apps are built from a
-small, stable convention: an `enum` of routes, a `current-route` property, and one
-conditional child per route. This page describes that convention.
+The `navigator` construct declares the screens of a multi-screen app and the
+route between them as one compiler-checked structure. The set of screens is
+static (the compiler resolves it), while the active screen is a value you drive
+at runtime, so tooling can read the whole navigation graph from the source and
+it always matches what runs.
 
-This is the interim pattern that the visual editor's flow map understands, so
-following it exactly lets tooling read the screens and the transitions between them.
+:::caution[Experimental]
+`navigator` is an experimental feature. Build with
+`SLINT_ENABLE_EXPERIMENTAL_FEATURES=1` (or set `enable_experimental` in the
+compiler configuration) to use it.
+:::
 
-## The convention
+## The navigator
 
-The pattern is made of four parts.
+Three pieces make up a navigator:
 
-1. A user-declared `enum Route` with one value per screen.
-2. A root component with `in-out property <Route> current-route`, set to the initial screen.
-3. One conditional child per route, mapping a route to its screen: `if current-route == Route.Home : HomeScreen { ... }`.
-4. Navigation by assigning the route property: `current-route = Route.Details;`.
+1. A user-declared `enum` with one value per screen.
+2. An `in-out property` of that enum type holding the current route.
+3. A `navigator (current-route) { ... }` block that maps each route to its screen.
 
 ```slint
 import { Button, VerticalBox } from "std-widgets.slint";
@@ -37,49 +41,86 @@ component HomeScreen inherits VerticalBox {
 }
 
 component DetailsScreen inherits VerticalBox {
-    callback back();
     Text { text: "Details"; }
-    Button { text: "Back to Home"; clicked => { root.back(); } }
 }
 
 component SettingsScreen inherits VerticalBox {
-    callback back();
     Text { text: "Settings"; }
-    Button { text: "Back to Home"; clicked => { root.back(); } }
 }
 
 export component App inherits Window {
-    // The current screen. Assigning this property navigates.
     in-out property <Route> current-route: Route.Home;
 
-    // One conditional child per route maps a route to its screen.
-    if current-route == Route.Home : HomeScreen {
-        show-details => { root.current-route = Route.Details; }
-        show-settings => { root.current-route = Route.Settings; }
-    }
-    if current-route == Route.Details : DetailsScreen {
-        back => { root.current-route = Route.Home; }
-    }
-    if current-route == Route.Settings : SettingsScreen {
-        back => { root.current-route = Route.Home; }
+    navigator (current-route) {
+        Route.Home: HomeScreen {
+            show-details => { root.navigate(Route.Details); }
+            show-settings => { root.navigate(Route.Settings); }
+        }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
     }
 }
 ```
 
-## How it reads
+{/* cSpell:ignore Detials */}
+The navigator instantiates only the screen for the current route. The route
+enum is a closed set, so `Route.Detials` (a typo) is a compile error rather than
+a screen that silently never shows.
 
-- The `enum Route` is the set of screens.
-- `current-route` is the active screen, and its initializer is the entry screen.
-- Each `if current-route == Route.X : Screen { ... }` is the route-to-screen mapping.
-- Each `current-route = Route.Y;` assignment is a transition from the enclosing screen to `Route.Y`.
+## Navigating
 
-Keeping a screen in its own component and wiring its callbacks in the root, next to the
-matching conditional child, keeps each transition close to the screen it starts from.
+The navigator adds a small history API to the component that declares it:
 
-## Scope
+- `navigate(route)` switches to `route` and pushes the previous one onto a
+  back-stack.
+- `back()` returns to the previous screen, or does nothing at the root.
+- `can-go-back` is `true` while there is somewhere to go back to.
 
-The convention tracks a single `current-route` only. There is no back-stack: returning
-to a previous screen is just another assignment, as in the `back` callbacks above. A
-history stack is a separate concern and is not part of this convention.
+These members belong to the component that declares the `navigator` (`App`
+below), not to the screens. A screen that needs one, such as a Back button that
+disables at the root, takes it as a property that `App` binds when it maps the
+route:
 
-A runnable version of this example lives in `examples/navigation` in the Slint repository.
+```slint
+component DetailsScreen inherits VerticalBox {
+    in property <bool> can-go-back;
+    callback go-back();
+    Text { text: "Details"; }
+    Button {
+        text: "Back";
+        enabled: can-go-back;
+        clicked => { root.go-back(); }
+    }
+}
+
+// ...in App, binding the navigator members next to the route:
+navigator (current-route) {
+    Route.Home: HomeScreen {
+        show-details => { root.navigate(Route.Details); }
+    }
+    Route.Details: DetailsScreen {
+        can-go-back: root.can-go-back;
+        go-back => { root.back(); }
+    }
+}
+```
+
+Assigning `current-route` directly still switches the screen, but it does not
+touch the history. Use `navigate()` and `back()` when you want a back-stack.
+
+For navigation bars that work by position rather than by route (a tab bar, a
+segmented control), the navigator also exposes an integer view: `current-route-index`
+is the ordinal of the active route, and `navigate-index(i)` navigates to the
+route at position `i`. A presentation widget can bind to these without knowing
+the route enum.
+
+## Why a construct
+
+Because the route table is declared structure and the destinations come from a
+compiler-known enum, the navigation graph is fully derivable from source. The
+visual editor's flow map reads the screens and the transitions between them
+straight from the navigator, references are checked at compile time, and the
+tool never disagrees with the running app.
+
+A runnable version of this example lives in `examples/navigation` in the Slint
+repository.

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -9366,6 +9366,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
+name = "navigation"
+version = "1.18.0"
+dependencies = [
+ "slint",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -9373,6 +9373,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "navigation-std"
+version = "1.18.0"
+dependencies = [
+ "slint",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   'mcu-board-support',
   'memory',
   'navigation',
+  'navigation-std',
   'native-gestures',
   'opengl_texture',
   'opengl_underlay',

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   'maps',
   'mcu-board-support',
   'memory',
+  'navigation',
   'native-gestures',
   'opengl_texture',
   'opengl_underlay',

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,7 @@ These examples demonstrate specialized features or integrations:
 | Example | Description |
 | --- | --- |
 | [fancy_demo](./fancy_demo/) | Custom widget implementations built from scratch (buttons, sliders, checkboxes, MDI windows) |
+| [navigation](./navigation/) | Multi-screen navigation using the `enum Route` + `current-route` convention |
 | [fancy-switches](./fancy-switches/) | Fancy toggle switch animations |
 | [dial](./dial/) | Rotary dial control |
 | [speedometer](./speedometer/) | Animated speedometer gauge |

--- a/examples/navigation-std/Cargo.toml
+++ b/examples/navigation-std/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "navigation-std"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+publish = false
+license = "MIT"
+rust-version.workspace = true
+
+[[bin]]
+path = "main.rs"
+name = "navigation-std"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }

--- a/examples/navigation-std/README.md
+++ b/examples/navigation-std/README.md
@@ -1,0 +1,35 @@
+# Navigation (std-widgets)
+
+A multi-screen app whose navigation chrome is built from **std-widgets**, driving
+the experimental `navigator` construct. It pairs with the Material navigation
+example to show one route model behind different widget libraries.
+
+The chrome is a segmented tab bar assembled from a row of std `Button`s (std-widgets
+has no public tab-bar/segmented control). It binds to the navigator's int-index
+adapter:
+
+- the highlighted segment follows `current-route-index`,
+- clicking a segment navigates by ordinal via `navigate-index(index)`.
+
+## Why the wiring lives in `main.rs`
+
+The navigator's int-index adapter (`current-route-index` / `navigate-index`) is
+synthesized *after* expression resolution, so it cannot be referenced from
+`.slint`. The navigator therefore sits on the root `Window`, where its adapter
+members land on the component's public API, and `main.rs` bridges them to the tab
+bar's `current-index` / `selected(int)`.
+
+## Experimental features
+
+`navigator` is experimental. `build.rs` enables it for the `slint!` macro that
+compiles `navigation.slint`:
+
+```rust
+println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+```
+
+Run it with:
+
+```sh
+cargo run -p navigation-std
+```

--- a/examples/navigation-std/build.rs
+++ b/examples/navigation-std/build.rs
@@ -2,7 +2,5 @@
 // SPDX-License-Identifier: MIT
 
 fn main() {
-    // The navigator is experimental; enable it for the `slint!` macro that
-    // compiles navigation.slint at build time.
     println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
 }

--- a/examples/navigation-std/build.rs
+++ b/examples/navigation-std/build.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    // The navigator is experimental; enable it for the `slint!` macro that
+    // compiles navigation.slint at build time.
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+}

--- a/examples/navigation-std/main.rs
+++ b/examples/navigation-std/main.rs
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::slint!(export { App } from "navigation.slint";);
+
+pub fn main() {
+    let app = App::new().unwrap();
+
+    // Bridge the std-widgets tab bar to the navigator's int-index adapter. The
+    // adapter lives on the root's public API (current-route-index /
+    // navigate-index) but is synthesized too late to reference from .slint, so
+    // the wiring happens here instead.
+    let weak = app.as_weak();
+    app.on_nav_select(move |index| {
+        let app = weak.unwrap();
+        // A tab click navigates by ordinal ...
+        app.invoke_navigate_index(index);
+        // ... and the highlight follows the resulting current route.
+        app.set_nav_index(app.get_current_route_index());
+    });
+
+    // Seed the highlight from the initial route.
+    app.set_nav_index(app.get_current_route_index());
+
+    app.run().unwrap();
+}

--- a/examples/navigation-std/main.rs
+++ b/examples/navigation-std/main.rs
@@ -6,20 +6,13 @@ slint::slint!(export { App } from "navigation.slint";);
 pub fn main() {
     let app = App::new().unwrap();
 
-    // Bridge the std-widgets tab bar to the navigator's int-index adapter. The
-    // adapter lives on the root's public API (current-route-index /
-    // navigate-index) but is synthesized too late to reference from .slint, so
-    // the wiring happens here instead.
     let weak = app.as_weak();
     app.on_nav_select(move |index| {
         let app = weak.unwrap();
-        // A tab click navigates by ordinal ...
         app.invoke_navigate_index(index);
-        // ... and the highlight follows the resulting current route.
         app.set_nav_index(app.get_current_route_index());
     });
 
-    // Seed the highlight from the initial route.
     app.set_nav_index(app.get_current_route_index());
 
     app.run().unwrap();

--- a/examples/navigation-std/navigation.slint
+++ b/examples/navigation-std/navigation.slint
@@ -3,17 +3,12 @@
 
 import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
 
-// The navigation convention: one enum value per screen.
 enum Route {
     Home,
     Details,
     Settings,
 }
 
-// A segmented navigation bar built from std-widgets `Button`s. std-widgets has
-// no public tab-bar/segmented control, so this binds a plain Button row to the
-// navigator's int-index adapter: the highlighted segment follows `current-index`
-// and clicking one asks to navigate by ordinal via `selected`.
 component NavBar inherits HorizontalBox {
     in property <[string]> titles;
     in property <int> current-index;
@@ -21,7 +16,6 @@ component NavBar inherits HorizontalBox {
 
     for title[index] in titles: Button {
         text: title;
-        // Highlight the active segment; purely driven by current-index.
         primary: index == root.current-index;
         clicked => { root.selected(index); }
     }
@@ -59,13 +53,8 @@ export component App inherits Window {
     preferred-height: 300px;
     title: "Slint Navigation (std-widgets)";
 
-    // The current screen. Assigning this property navigates.
     in-out property <Route> current-route: Route.Home;
 
-    // The navigator's int-index adapter (current-route-index / navigate-index)
-    // is synthesized after expression resolution, so it cannot be referenced
-    // from .slint. main.rs bridges it to these two members instead: it writes
-    // the highlighted segment here and reacts to a selection by ordinal.
     in property <int> nav-index;
     callback nav-select(index: int);
 
@@ -79,8 +68,6 @@ export component App inherits Window {
         selected(index) => { root.nav-select(index); }
     }
 
-    // The navigator is a direct child of the root Window, so its adapter
-    // members land on the root's public API where main.rs can reach them.
     navigator (current-route) {
         Route.Home: HomeScreen {
             y: 48px;

--- a/examples/navigation-std/navigation.slint
+++ b/examples/navigation-std/navigation.slint
@@ -1,0 +1,101 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+// A segmented navigation bar built from std-widgets `Button`s. std-widgets has
+// no public tab-bar/segmented control, so this binds a plain Button row to the
+// navigator's int-index adapter: the highlighted segment follows `current-index`
+// and clicking one asks to navigate by ordinal via `selected`.
+component NavBar inherits HorizontalBox {
+    in property <[string]> titles;
+    in property <int> current-index;
+    callback selected(index: int);
+
+    for title[index] in titles: Button {
+        text: title;
+        // Highlight the active segment; purely driven by current-index.
+        primary: index == root.current-index;
+        clicked => { root.selected(index); }
+    }
+}
+
+component HomeScreen inherits VerticalBox {
+    Text {
+        text: "Home";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+component DetailsScreen inherits VerticalBox {
+    Text {
+        text: "Details";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+component SettingsScreen inherits VerticalBox {
+    Text {
+        text: "Settings";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+export component App inherits Window {
+    preferred-width: 400px;
+    preferred-height: 300px;
+    title: "Slint Navigation (std-widgets)";
+
+    // The current screen. Assigning this property navigates.
+    in-out property <Route> current-route: Route.Home;
+
+    // The navigator's int-index adapter (current-route-index / navigate-index)
+    // is synthesized after expression resolution, so it cannot be referenced
+    // from .slint. main.rs bridges it to these two members instead: it writes
+    // the highlighted segment here and reacts to a selection by ordinal.
+    in property <int> nav-index;
+    callback nav-select(index: int);
+
+    NavBar {
+        x: 0;
+        y: 0;
+        width: root.width;
+        height: 48px;
+        titles: ["Home", "Details", "Settings"];
+        current-index: root.nav-index;
+        selected(index) => { root.nav-select(index); }
+    }
+
+    // The navigator is a direct child of the root Window, so its adapter
+    // members land on the root's public API where main.rs can reach them.
+    navigator (current-route) {
+        Route.Home: HomeScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+        Route.Details: DetailsScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+        Route.Settings: SettingsScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+    }
+}

--- a/examples/navigation/Cargo.toml
+++ b/examples/navigation/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "navigation"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+publish = false
+license = "MIT"
+rust-version.workspace = true
+
+[[bin]]
+path = "main.rs"
+name = "navigation"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }

--- a/examples/navigation/README.md
+++ b/examples/navigation/README.md
@@ -1,17 +1,32 @@
 # Navigation
 
-A minimal multi-screen app that demonstrates the Slint navigation convention using
-only stable language features.
+A minimal multi-screen app built with the experimental `navigator` construct.
 
-The convention:
+```slint
+navigator (current-route) {
+    Route.Home: HomeScreen { }
+    Route.Details: DetailsScreen { }
+    Route.Settings: SettingsScreen { }
+}
+```
 
-- A user-declared `enum Route`, one value per screen.
-- A root component with `in-out property <Route> current-route`.
-- One conditional child per route: `if current-route == Route.Home : HomeScreen { ... }`.
-- Navigation by assigning the route property: `current-route = Route.Details;`.
+- The set of screens is a compiler-resolved route table; the active screen is the
+  `current-route` property you drive at runtime.
+- The navigator adds a history API to the declaring component: `navigate(route)`,
+  `back()`, and `can-go-back`. This example uses them for the back buttons.
 
-The visual editor's flow map understands this shape. See the docs page
-"Navigation" under Guide > App Development for the full description.
+For the std-widgets and Material presentations of the same route model, see the
+`navigation-std` example. The full description is on the docs page "Navigation"
+under Guide > App Development.
+
+## Experimental features
+
+`navigator` is experimental. `build.rs` enables it for the `slint!` macro that
+compiles `navigation.slint`:
+
+```rust
+println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+```
 
 Run it with:
 

--- a/examples/navigation/README.md
+++ b/examples/navigation/README.md
@@ -1,0 +1,20 @@
+# Navigation
+
+A minimal multi-screen app that demonstrates the Slint navigation convention using
+only stable language features.
+
+The convention:
+
+- A user-declared `enum Route`, one value per screen.
+- A root component with `in-out property <Route> current-route`.
+- One conditional child per route: `if current-route == Route.Home : HomeScreen { ... }`.
+- Navigation by assigning the route property: `current-route = Route.Details;`.
+
+The visual editor's flow map understands this shape. See the docs page
+"Navigation" under Guide > App Development for the full description.
+
+Run it with:
+
+```sh
+cargo run -p navigation
+```

--- a/examples/navigation/build.rs
+++ b/examples/navigation/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+}

--- a/examples/navigation/main.rs
+++ b/examples/navigation/main.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::slint!(export { App } from "navigation.slint";);
+
+pub fn main() {
+    App::new().unwrap().run().unwrap();
+}

--- a/examples/navigation/navigation.slint
+++ b/examples/navigation/navigation.slint
@@ -3,7 +3,6 @@
 
 import { Button, VerticalBox } from "std-widgets.slint";
 
-// The navigation convention: one enum value per screen.
 enum Route {
     Home,
     Details,
@@ -30,7 +29,8 @@ component HomeScreen inherits VerticalBox {
 }
 
 component DetailsScreen inherits VerticalBox {
-    callback back();
+    in property <bool> can-go-back;
+    callback go-back();
 
     Text {
         text: "Details";
@@ -38,13 +38,15 @@ component DetailsScreen inherits VerticalBox {
         horizontal-alignment: center;
     }
     Button {
-        text: "Back to Home";
-        clicked => { root.back(); }
+        text: "Back";
+        enabled: can-go-back;
+        clicked => { root.go-back(); }
     }
 }
 
 component SettingsScreen inherits VerticalBox {
-    callback back();
+    in property <bool> can-go-back;
+    callback go-back();
 
     Text {
         text: "Settings";
@@ -52,8 +54,9 @@ component SettingsScreen inherits VerticalBox {
         horizontal-alignment: center;
     }
     Button {
-        text: "Back to Home";
-        clicked => { root.back(); }
+        text: "Back";
+        enabled: can-go-back;
+        clicked => { root.go-back(); }
     }
 }
 
@@ -62,18 +65,20 @@ export component App inherits Window {
     preferred-height: 240px;
     title: "Slint Navigation";
 
-    // The current screen. Assigning this property navigates.
     in-out property <Route> current-route: Route.Home;
 
-    // One conditional child per route maps a route to its screen.
-    if current-route == Route.Home : HomeScreen {
-        show-details => { root.current-route = Route.Details; }
-        show-settings => { root.current-route = Route.Settings; }
-    }
-    if current-route == Route.Details : DetailsScreen {
-        back => { root.current-route = Route.Home; }
-    }
-    if current-route == Route.Settings : SettingsScreen {
-        back => { root.current-route = Route.Home; }
+    navigator (current-route) {
+        Route.Home: HomeScreen {
+            show-details => { root.navigate(Route.Details); }
+            show-settings => { root.navigate(Route.Settings); }
+        }
+        Route.Details: DetailsScreen {
+            can-go-back: root.can-go-back;
+            go-back => { root.back(); }
+        }
+        Route.Settings: SettingsScreen {
+            can-go-back: root.can-go-back;
+            go-back => { root.back(); }
+        }
     }
 }

--- a/examples/navigation/navigation.slint
+++ b/examples/navigation/navigation.slint
@@ -1,0 +1,79 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Button, VerticalBox } from "std-widgets.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits VerticalBox {
+    callback show-details();
+    callback show-settings();
+
+    Text {
+        text: "Home";
+        font-size: 24px;
+        horizontal-alignment: center;
+    }
+    Button {
+        text: "Go to Details";
+        clicked => { root.show-details(); }
+    }
+    Button {
+        text: "Open Settings";
+        clicked => { root.show-settings(); }
+    }
+}
+
+component DetailsScreen inherits VerticalBox {
+    callback back();
+
+    Text {
+        text: "Details";
+        font-size: 24px;
+        horizontal-alignment: center;
+    }
+    Button {
+        text: "Back to Home";
+        clicked => { root.back(); }
+    }
+}
+
+component SettingsScreen inherits VerticalBox {
+    callback back();
+
+    Text {
+        text: "Settings";
+        font-size: 24px;
+        horizontal-alignment: center;
+    }
+    Button {
+        text: "Back to Home";
+        clicked => { root.back(); }
+    }
+}
+
+export component App inherits Window {
+    preferred-width: 360px;
+    preferred-height: 240px;
+    title: "Slint Navigation";
+
+    // The current screen. Assigning this property navigates.
+    in-out property <Route> current-route: Route.Home;
+
+    // One conditional child per route maps a route to its screen.
+    if current-route == Route.Home : HomeScreen {
+        show-details => { root.current-route = Route.Details; }
+        show-settings => { root.current-route = Route.Settings; }
+    }
+    if current-route == Route.Details : DetailsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+    if current-route == Route.Settings : SettingsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+}

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -875,11 +875,7 @@ pub struct Element {
 
     /// This element is part of a `for <xxx> in <model>`:
     pub repeated: Option<RepeatedElementInfo>,
-    /// The resolved `navigator` route table declared on this element, in
-    /// declaration order. Each route's destination is also present among
-    /// `children` as a conditional element. Kept here so later passes and the
-    /// LSP can recover the route -> component graph. Empty for elements without
-    /// a `navigator`.
+    /// The resolved `navigator` route table, in declaration order (empty if none).
     pub navigator_routes: Vec<NavigatorRoute>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
@@ -1136,23 +1132,15 @@ pub struct RepeatedElementInfo {
 
 #[derive(Debug, Clone)]
 /// One entry of a `navigator` route table: a route enum value mapped to its
-/// resolved destination. Populated by `from_navigator_node` in declaration
-/// order and kept on the enclosing element for later tooling (LSP graph).
+/// resolved destination component.
 pub struct NavigatorRoute {
-    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled so
-    /// tooling can recover its name and source location.
+    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled.
     pub route: syntax_nodes::Expression,
-    /// The resolved destination element. Its `base_type` is the resolved
-    /// component (guaranteed to be an `ElementType::Component`, else a
-    /// diagnostic was reported and this is `ElementType::Error`).
+    /// The resolved destination component (`ElementType::Error` on failure).
     pub component: ElementRc,
 }
 
 impl Element {
-    /// Read-only view of the resolved `navigator` route table declared on this
-    /// element, in declaration order (empty when there is no `navigator`).
-    /// Provided as an accessor so tooling reads the authoritative table without
-    /// touching the lowering in `from_navigator_node`.
     pub fn navigator_routes(&self) -> &[NavigatorRoute] {
         &self.navigator_routes
     }
@@ -2253,14 +2241,9 @@ impl Element {
         cases
     }
 
-    /// Build the object tree for a `navigator` route table. Mirrors
-    /// `from_match_node`: each `Route.X: XScreen { }` becomes a conditional
-    /// child whose model is `<navigator-expr> == <Route.X>`, so `XScreen` is
-    /// instantiated only when the current route equals `Route.X`.
-    ///
-    /// It also resolves each destination to a component (the closed-set check)
-    /// and records the resolved route -> component mapping on `parent` for
-    /// later tooling (see `Element::navigator_routes`).
+    /// Lower a `navigator`: each `Route.X: XScreen {}` becomes a conditional child
+    /// (`<navigator-expr> == Route.X`), resolved to a component and recorded on
+    /// `parent` as `navigator_routes`.
     fn from_navigator_node(
         node: syntax_nodes::Navigator,
         parent: &ElementRc,
@@ -2269,9 +2252,6 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> Vec<ElementRc> {
-        // Experimental gate first, like `from_match_node`. Without it a
-        // non-experimental compile rejects `navigator` and builds nothing, so
-        // the construct stays invisible to non-experimental compiles.
         if !diag.enable_experimental {
             diag.push_error("navigator is an experimental feature".into(), &node);
             return Vec::new();
@@ -2284,8 +2264,6 @@ impl Element {
             let Some(sub_element) = route.SubElement() else {
                 continue;
             };
-            // Conditional child: shown only when the route matches, exactly as
-            // `from_match_node` builds its cases.
             let rei = RepeatedElementInfo {
                 model: Expression::BinaryExpression {
                     lhs: Box::new(Expression::Uncompiled(expr.clone().into())),
@@ -2305,10 +2283,8 @@ impl Element {
                 diag,
                 tr,
             );
-            // Closed-set check: a destination must resolve to a component.
-            // `ElementType::Error` means `from_sub_element_node` already
-            // reported an unknown name, so we don't double-report.
             match &e.borrow().base_type {
+                // Error: already diagnosed by from_sub_element_node.
                 ElementType::Component(_) | ElementType::Error => {}
                 other => {
                     diag.push_error(
@@ -2323,12 +2299,8 @@ impl Element {
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
             cases.push(e);
         }
-        // Declare the navigator's public members now, before expression
-        // resolution, so widget chrome can bind to them from .slint (e.g.
-        // `current-index <- nav.current-route-index`). The lower_navigator pass
-        // fills in their bodies later, once the route table is resolved. Same
-        // shape as an interface function: the declaration is in scope now, the
-        // implementation comes later.
+        // Declare the public members before expression resolution so .slint chrome
+        // can bind them; lower_navigator fills in their bodies later.
         if !routes.is_empty() {
             Self::declare_navigator_members(parent, &routes, tr);
         }
@@ -2336,12 +2308,10 @@ impl Element {
         cases
     }
 
-    /// Declare the navigator's public members (the surface widget chrome binds
-    /// to) up front. Only the signatures are known here; `lower_navigator`
-    /// supplies the bindings/bodies after the route table is resolved.
+    /// Declare the navigator's public members (signatures only; `lower_navigator`
+    /// fills the bodies once the route table is resolved).
     fn declare_navigator_members(elem: &ElementRc, routes: &[NavigatorRoute], tr: &TypeRegister) {
-        // navigate(route) is enum-typed; recover the route enum from a route
-        // case (`Route.X`), whose first path segment names the enum.
+        // Recover the route enum from a route case (`Route.X`) for navigate(route).
         let route_ty = routes.iter().find_map(|r| {
             let name = QualifiedTypeName::from_node(r.route.QualifiedName()?)
                 .members
@@ -2361,12 +2331,8 @@ impl Element {
                 PropertyDeclaration { property_type, visibility, pure, ..Default::default() },
             );
         };
-        // Read surface for chrome: ordinal of the current route and whether the
-        // back-stack has anything to pop.
         declare("current-route-index", Type::Int32, PropertyVisibility::Output, None);
         declare("can-go-back", Type::Bool, PropertyVisibility::Output, None);
-        // Navigation entry points. navigate-index(int) is the index-based surface
-        // chrome (Material's NavigationBar, a std nav bar) drives.
         declare("back", func(vec![], vec![]), PropertyVisibility::Public, Some(false));
         declare(
             "navigate-index",

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2323,8 +2323,63 @@ impl Element {
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
             cases.push(e);
         }
+        // Declare the navigator's public members now, before expression
+        // resolution, so widget chrome can bind to them from .slint (e.g.
+        // `current-index <- nav.current-route-index`). The lower_navigator pass
+        // fills in their bodies later, once the route table is resolved. Same
+        // shape as an interface function: the declaration is in scope now, the
+        // implementation comes later.
+        if !routes.is_empty() {
+            Self::declare_navigator_members(parent, &routes, tr);
+        }
         parent.borrow_mut().navigator_routes = routes;
         cases
+    }
+
+    /// Declare the navigator's public members (the surface widget chrome binds
+    /// to) up front. Only the signatures are known here; `lower_navigator`
+    /// supplies the bindings/bodies after the route table is resolved.
+    fn declare_navigator_members(elem: &ElementRc, routes: &[NavigatorRoute], tr: &TypeRegister) {
+        // navigate(route) is enum-typed; recover the route enum from a route
+        // case (`Route.X`), whose first path segment names the enum.
+        let route_ty = routes.iter().find_map(|r| {
+            let name =
+                QualifiedTypeName::from_node(r.route.QualifiedName()?).members.into_iter().next()?;
+            let ty = tr.lookup(&name);
+            matches!(ty, Type::Enumeration(_)).then_some(ty)
+        });
+        let func = |args: Vec<Type>, arg_names: Vec<SmolStr>| {
+            Type::Function(Rc::new(Function { return_type: Type::Void, args, arg_names }))
+        };
+
+        let mut e = elem.borrow_mut();
+        let mut declare = |name, property_type, visibility, pure| {
+            e.property_declarations.insert(
+                SmolStr::new_static(name),
+                PropertyDeclaration { property_type, visibility, pure, ..Default::default() },
+            );
+        };
+        // Read surface for chrome: ordinal of the current route and whether the
+        // back-stack has anything to pop.
+        declare("current-route-index", Type::Int32, PropertyVisibility::Output, None);
+        declare("can-go-back", Type::Bool, PropertyVisibility::Output, None);
+        // Navigation entry points. navigate-index(int) is the index-based surface
+        // chrome (Material's NavigationBar, a std nav bar) drives.
+        declare("back", func(vec![], vec![]), PropertyVisibility::Public, Some(false));
+        declare(
+            "navigate-index",
+            func(vec![Type::Int32], vec![SmolStr::new_static("index")]),
+            PropertyVisibility::Public,
+            Some(false),
+        );
+        if let Some(route_ty) = route_ty {
+            declare(
+                "navigate",
+                func(vec![route_ty], vec![SmolStr::new_static("route")]),
+                PropertyVisibility::Public,
+                Some(false),
+            );
+        }
     }
 
     /// Return the type of a property in this element or its base, along with the final name, in case

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -875,7 +875,7 @@ pub struct Element {
 
     /// This element is part of a `for <xxx> in <model>`:
     pub repeated: Option<RepeatedElementInfo>,
-    /// The resolved `navigator` route table, in declaration order (empty if none).
+    /// The resolved `navigator` route table, in declaration order.
     pub navigator_routes: Vec<NavigatorRoute>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
@@ -1131,12 +1131,9 @@ pub struct RepeatedElementInfo {
 }
 
 #[derive(Debug, Clone)]
-/// One entry of a `navigator` route table: a route enum value mapped to its
-/// resolved destination component.
+/// One `navigator` route: an uncompiled route enum value and its resolved component.
 pub struct NavigatorRoute {
-    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled.
     pub route: syntax_nodes::Expression,
-    /// The resolved destination component (`ElementType::Error` on failure).
     pub component: ElementRc,
 }
 
@@ -2241,9 +2238,7 @@ impl Element {
         cases
     }
 
-    /// Lower a `navigator`: each `Route.X: XScreen {}` becomes a conditional child
-    /// (`<navigator-expr> == Route.X`), resolved to a component and recorded on
-    /// `parent` as `navigator_routes`.
+    /// Lower a `navigator`: each route becomes a conditional child and is recorded on `parent`.
     fn from_navigator_node(
         node: syntax_nodes::Navigator,
         parent: &ElementRc,
@@ -2284,7 +2279,6 @@ impl Element {
                 tr,
             );
             match &e.borrow().base_type {
-                // Error: already diagnosed by from_sub_element_node.
                 ElementType::Component(_) | ElementType::Error => {}
                 other => {
                     diag.push_error(
@@ -2299,8 +2293,7 @@ impl Element {
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
             cases.push(e);
         }
-        // Declare the public members before expression resolution so .slint chrome
-        // can bind them; lower_navigator fills in their bodies later.
+        // Members must be declared before expression resolution so chrome can bind them.
         if !routes.is_empty() {
             Self::declare_navigator_members(parent, &routes, tr);
         }
@@ -2308,10 +2301,9 @@ impl Element {
         cases
     }
 
-    /// Declare the navigator's public members (signatures only; `lower_navigator`
-    /// fills the bodies once the route table is resolved).
+    /// Declare the navigator's public members; `lower_navigator` fills the bodies later.
     fn declare_navigator_members(elem: &ElementRc, routes: &[NavigatorRoute], tr: &TypeRegister) {
-        // Recover the route enum from a route case (`Route.X`) for navigate(route).
+        // Recover the route enum from a route case for navigate(route).
         let route_ty = routes.iter().find_map(|r| {
             let name = QualifiedTypeName::from_node(r.route.QualifiedName()?)
                 .members

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1148,6 +1148,16 @@ pub struct NavigatorRoute {
     pub component: ElementRc,
 }
 
+impl Element {
+    /// Read-only view of the resolved `navigator` route table declared on this
+    /// element, in declaration order (empty when there is no `navigator`).
+    /// Provided as an accessor so tooling reads the authoritative table without
+    /// touching the lowering in `from_navigator_node`.
+    pub fn navigator_routes(&self) -> &[NavigatorRoute] {
+        &self.navigator_routes
+    }
+}
+
 pub type ElementRc = Rc<RefCell<Element>>;
 pub type ElementWeak = Weak<RefCell<Element>>;
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2343,8 +2343,10 @@ impl Element {
         // navigate(route) is enum-typed; recover the route enum from a route
         // case (`Route.X`), whose first path segment names the enum.
         let route_ty = routes.iter().find_map(|r| {
-            let name =
-                QualifiedTypeName::from_node(r.route.QualifiedName()?).members.into_iter().next()?;
+            let name = QualifiedTypeName::from_node(r.route.QualifiedName()?)
+                .members
+                .into_iter()
+                .next()?;
             let ty = tr.lookup(&name);
             matches!(ty, Type::Enumeration(_)).then_some(ty)
         });

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -875,6 +875,12 @@ pub struct Element {
 
     /// This element is part of a `for <xxx> in <model>`:
     pub repeated: Option<RepeatedElementInfo>,
+    /// The resolved `navigator` route table declared on this element, in
+    /// declaration order. Each route's destination is also present among
+    /// `children` as a conditional element. Kept here so later passes and the
+    /// LSP can recover the route -> component graph. Empty for elements without
+    /// a `navigator`.
+    pub navigator_routes: Vec<NavigatorRoute>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
 
@@ -1126,6 +1132,20 @@ pub struct RepeatedElementInfo {
     pub is_conditional_element: bool,
     /// When the for is the delegate of a ListView
     pub is_listview: Option<ListViewInfo>,
+}
+
+#[derive(Debug, Clone)]
+/// One entry of a `navigator` route table: a route enum value mapped to its
+/// resolved destination. Populated by `from_navigator_node` in declaration
+/// order and kept on the enclosing element for later tooling (LSP graph).
+pub struct NavigatorRoute {
+    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled so
+    /// tooling can recover its name and source location.
+    pub route: syntax_nodes::Expression,
+    /// The resolved destination element. Its `base_type` is the resolved
+    /// component (guaranteed to be an `ElementType::Component`, else a
+    /// diagnostic was reported and this is `ElementType::Error`).
+    pub component: ElementRc,
 }
 
 pub type ElementRc = Rc<RefCell<Element>>;
@@ -1904,6 +1924,23 @@ impl Element {
                     )
                 }
                 r.borrow_mut().children.extend(rep);
+            } else if se.kind() == SyntaxKind::Navigator {
+                let mut sub_child_insertion_point = None;
+                let rep = Element::from_navigator_node(
+                    se.into(),
+                    &r,
+                    &mut sub_child_insertion_point,
+                    is_legacy_syntax,
+                    diag,
+                    tr,
+                );
+                if let Some(ChildrenInsertionPoint { node: se, .. }) = sub_child_insertion_point {
+                    diag.push_error(
+                        "The @children placeholder cannot appear in a navigator".into(),
+                        &se,
+                    )
+                }
+                r.borrow_mut().children.extend(rep);
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
                 #[cfg(feature = "slint-sc")]
                 diag.slint_sc_error("The @children placeholder is", &se);
@@ -2203,6 +2240,80 @@ impl Element {
             e.borrow_mut().repeated = Some(rei);
             cases.push(e);
         }
+        cases
+    }
+
+    /// Build the object tree for a `navigator` route table. Mirrors
+    /// `from_match_node`: each `Route.X: XScreen { }` becomes a conditional
+    /// child whose model is `<navigator-expr> == <Route.X>`, so `XScreen` is
+    /// instantiated only when the current route equals `Route.X`.
+    ///
+    /// It also resolves each destination to a component (the closed-set check)
+    /// and records the resolved route -> component mapping on `parent` for
+    /// later tooling (see `Element::navigator_routes`).
+    fn from_navigator_node(
+        node: syntax_nodes::Navigator,
+        parent: &ElementRc,
+        component_child_insertion_point: &mut Option<ChildrenInsertionPoint>,
+        is_in_legacy_component: bool,
+        diag: &mut BuildDiagnostics,
+        tr: &TypeRegister,
+    ) -> Vec<ElementRc> {
+        // Experimental gate first, like `from_match_node`. Without it a
+        // non-experimental compile rejects `navigator` and builds nothing, so
+        // the construct stays invisible to non-experimental compiles.
+        if !diag.enable_experimental {
+            diag.push_error("navigator is an experimental feature".into(), &node);
+            return Vec::new();
+        }
+        let parent_type = parent.borrow().base_type.clone();
+        let expr = node.Expression();
+        let mut cases: Vec<ElementRc> = Vec::new();
+        let mut routes: Vec<NavigatorRoute> = Vec::new();
+        for route in node.Route() {
+            let Some(sub_element) = route.SubElement() else {
+                continue;
+            };
+            // Conditional child: shown only when the route matches, exactly as
+            // `from_match_node` builds its cases.
+            let rei = RepeatedElementInfo {
+                model: Expression::BinaryExpression {
+                    lhs: Box::new(Expression::Uncompiled(expr.clone().into())),
+                    rhs: Box::new(Expression::Uncompiled(route.Expression().into())),
+                    op: '=',
+                },
+                model_data_id: SmolStr::default(),
+                index_id: SmolStr::default(),
+                is_conditional_element: true,
+                is_listview: None,
+            };
+            let e = Element::from_sub_element_node(
+                sub_element.clone(),
+                parent_type.clone(),
+                component_child_insertion_point,
+                is_in_legacy_component,
+                diag,
+                tr,
+            );
+            // Closed-set check: a destination must resolve to a component.
+            // `ElementType::Error` means `from_sub_element_node` already
+            // reported an unknown name, so we don't double-report.
+            match &e.borrow().base_type {
+                ElementType::Component(_) | ElementType::Error => {}
+                other => {
+                    diag.push_error(
+                        format!(
+                            "navigator route destination must be a component, but '{other}' is not"
+                        ),
+                        &sub_element,
+                    );
+                }
+            }
+            e.borrow_mut().repeated = Some(rei);
+            routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
+            cases.push(e);
+        }
+        parent.borrow_mut().navigator_routes = routes;
         cases
     }
 

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -352,7 +352,7 @@ declare_syntax! {
         /// `id := Element { ... }`
         SubElement -> [ Element ],
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
-                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Function, *SubElement,
+                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
                      *TwoWayBinding, *States, *Transitions, *ImplementStatement, ?ChildrenPlaceholder ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
@@ -364,6 +364,11 @@ declare_syntax! {
         MatchCase -> [ Expression, ?SubElement ],
         /// *: Elem { }
         WildcardMatchCase -> [ ?SubElement ],
+        /// navigator (current-route) { Route.Home: HomeScreen { } }
+        /// The Expression is the current-route binding.
+        Navigator -> [ Expression, *Route ],
+        /// Route.Home: HomeScreen { }
+        Route -> [ Expression, ?SubElement ],
         CallbackDeclaration -> [ DeclaredIdentifier, *CallbackDeclarationParameter, ?ReturnType, ?TwoWayBinding ],
         // `foo: type` or just `type`
         CallbackDeclarationParameter -> [ ?DeclaredIdentifier, Type],

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -365,7 +365,6 @@ declare_syntax! {
         /// *: Elem { }
         WildcardMatchCase -> [ ?SubElement ],
         /// navigator (current-route) { Route.Home: HomeScreen { } }
-        /// The Expression is the current-route binding.
         Navigator -> [ Expression, *Route ],
         /// Route.Home: HomeScreen { }
         Route -> [ Expression, ?SubElement ],

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -54,6 +54,8 @@ pub fn parse_element(p: &mut impl Parser) -> bool {
 /// changed foo => {}
 /// match (foo) { 1: Elem { } }
 /// match bar.property { 1: Elem { } }
+/// navigator (current-route) { Route.Home: Sub { } }
+/// navigator current-route { Route.Home: Sub { } }
 /// ```
 pub fn parse_element_content(p: &mut impl Parser) {
     let mut had_parse_error = false;

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -375,8 +375,7 @@ fn parse_wildcard_case(p: &mut impl Parser) {
 fn parse_navigation(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "navigator");
     let mut p = p.start_node(SyntaxKind::Navigator);
-    p.expect(SyntaxKind::Identifier); // "navigator"
-    // The current-route binding.
+    p.expect(SyntaxKind::Identifier);
     parse_expression(&mut *p);
     if !p.test(SyntaxKind::LBrace) {
         p.error("Expected '{' to start routes");

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -136,8 +136,6 @@ pub fn parse_element_content(p: &mut impl Parser) {
                         }
                     }
                 }
-                // Experimental: parsed unconditionally like `match`; the experimental
-                // gate is applied at object-tree lowering (see from_match_node).
                 SyntaxKind::Identifier | SyntaxKind::LParent
                     if p.peek().as_str() == "navigator" =>
                 {

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -67,7 +67,7 @@ pub fn parse_element_content(p: &mut impl Parser) {
                     had_parse_error |= !parse_sub_element(&mut *p)
                 }
                 SyntaxKind::FatArrow | SyntaxKind::LParent
-                    if !["if", "match"].contains(&p.peek().as_str()) =>
+                    if !["if", "match", "navigator"].contains(&p.peek().as_str()) =>
                 {
                     parse_callback_connection(&mut *p)
                 }
@@ -121,6 +121,33 @@ pub fn parse_element_content(p: &mut impl Parser) {
                             }
                             SyntaxKind::LBrace => {
                                 parse_match_element(&mut *p);
+                                break;
+                            }
+                            SyntaxKind::Eof => {
+                                if !had_parse_error {
+                                    p.error("Error: Expected '{'");
+                                    had_parse_error = true;
+                                }
+                                break;
+                            }
+                            _ => i += 1,
+                        }
+                    }
+                }
+                // Experimental: parsed unconditionally like `match`; the experimental
+                // gate is applied at object-tree lowering (see from_match_node).
+                SyntaxKind::Identifier | SyntaxKind::LParent
+                    if p.peek().as_str() == "navigator" =>
+                {
+                    let mut i = 2;
+                    loop {
+                        match p.nth(i).kind() {
+                            SyntaxKind::FatArrow => {
+                                parse_callback_connection(&mut *p);
+                                break;
+                            }
+                            SyntaxKind::LBrace => {
+                                parse_navigation(&mut *p);
                                 break;
                             }
                             SyntaxKind::Eof => {
@@ -332,6 +359,55 @@ fn parse_wildcard_case(p: &mut impl Parser) {
         if p.peek().kind() == SyntaxKind::Identifier {
             p.error("Remove '{ }' around case element");
             return;
+        }
+        p.expect(SyntaxKind::RBrace);
+        return;
+    }
+    parse_sub_element(&mut *p);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,Navigator
+/// navigator (current-route) { Route.Home: Home { } }
+/// navigator current-route { Route.Home: Home { } Route.Settings: Settings { } }
+/// navigator (current-route) { }
+/// ```
+fn parse_navigation(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "navigator");
+    let mut p = p.start_node(SyntaxKind::Navigator);
+    p.expect(SyntaxKind::Identifier); // "navigator"
+    // The current-route binding.
+    parse_expression(&mut *p);
+    if !p.test(SyntaxKind::LBrace) {
+        p.error("Expected '{' to start routes");
+    }
+    while ![SyntaxKind::RBrace, SyntaxKind::Eof].contains(&p.peek().kind()) {
+        parse_route(&mut *p);
+    }
+    p.expect(SyntaxKind::RBrace);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,Route
+/// Route.Home: Home { }
+/// (Route.Home): Home { }
+/// Route.Home: { }
+/// ```
+fn parse_route(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::Route);
+    parse_expression(&mut *p);
+    if !p.test(SyntaxKind::Colon) {
+        p.error("Expected ':' after route");
+        if p.peek().kind() != SyntaxKind::Identifier {
+            p.consume();
+        }
+    }
+    if p.peek().kind() == SyntaxKind::LBrace {
+        // empty route
+        p.expect(SyntaxKind::LBrace);
+        if p.peek().kind() == SyntaxKind::Identifier {
+            p.error("Remove '{ }' around route component");
+            parse_sub_element(&mut *p);
         }
         p.expect(SyntaxKind::RBrace);
         return;

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -36,6 +36,7 @@ mod lower_accessibility;
 mod lower_component_container;
 mod lower_layout;
 mod lower_menus;
+mod lower_navigator;
 mod lower_platform;
 mod lower_popups;
 mod lower_property_to_element;
@@ -129,6 +130,9 @@ pub async fn run_passes(
     lower_tooltips::lower_tooltips(doc, type_loader, diag).await;
     lower_tabwidget::lower_tabwidget(doc, type_loader, diag).await;
     lower_radiogroup::lower_radiogroup(doc, type_loader, diag).await;
+    // Runs after resolve (route models are typed) and before inlining, so the
+    // synthesized navigate/back/can-go-back propagate like any declared member.
+    lower_navigator::lower_navigator(doc, diag);
     lower_menus::lower_menus(doc, type_loader, diag).await;
     lower_component_container::lower_component_container(doc, type_loader, diag);
     collect_subcomponents::collect_subcomponents(doc);

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -399,6 +399,7 @@ fn duplicate_element_with_mapping(
             .map(|x| duplicate_element_with_mapping(x, mapping, root_component, priority_delta))
             .collect(),
         repeated: elem.repeated.clone(),
+        navigator_routes: elem.navigator_routes.clone(),
         is_component_placeholder: elem.is_component_placeholder,
         debug: elem.debug.clone(),
         enclosing_component: Rc::downgrade(root_component),

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -40,14 +40,18 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         return;
     }
 
-    if !matches!(route_ref, Expression::PropertyReference(_)) {
+    let Expression::PropertyReference(route_nr) = &route_ref else {
         diag.push_error(
             "the navigator route must be a writable property to support navigate() and back()"
                 .into(),
             &*elem.borrow(),
         );
         return;
-    }
+    };
+    // navigate()/back() assign the route, so mark it set. Otherwise a navigator in
+    // a non-root component (where the route is internal) classifies it constant
+    // and panics on the first navigate().
+    route_nr.mark_as_set();
 
     elem.borrow_mut().property_declarations.insert(
         SmolStr::new_static(BACK_STACK),

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,27 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Implement the navigator's public members (declared early by
-//! `from_navigator_node`) and add its private back-stack.
+//! Implement the navigator's public members and add its private back-stack.
 //!
 //! `from_navigator_node` records the resolved route table on the enclosing
 //! element (`Element::navigator_routes`) and declares the public members
 //! (`current-route-index`, `can-go-back`, `navigate`, `navigate-index`, `back`)
-//! up front, so .slint chrome can bind to them. Navigation itself is just
-//! assigning the route property. This pass fills in those members' bodies and
-//! adds, on the same element, the private back-stack that backs them:
+//! up front.
 //!
 //!   navigate(route): push the current route, then switch to `route`
 //!   back():          restore and drop the top of the back-stack (no-op if empty)
 //!   can-go-back:     true while the back-stack is non-empty
-//!
-//! It is expressed entirely by lowering onto the existing property/callback and
-//! `Array*` builtin machinery, so it needs no new `internal/core` items.
-//!
-//! Runs after expression resolution (the route models are typed and the route
-//! property is a resolved reference by then) and before inlining. The construct
-//! is experimental-gated in `from_navigator_node`, so `navigator_routes` is only
-//! ever populated under `enable_experimental`; this pass inherits that gate.
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};
@@ -31,8 +20,6 @@ use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-// Private storage for the back-stack. A single navigator per element is
-// supported, matching the navigation convention.
 const BACK_STACK: &str = "navigator-back-stack";
 
 pub fn lower_navigator(doc: &Document, diag: &mut BuildDiagnostics) {
@@ -46,8 +33,6 @@ pub fn lower_navigator(doc: &Document, diag: &mut BuildDiagnostics) {
 }
 
 fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
-    // The route property and its enum type both come from a route case's model:
-    // resolve turned each case into `<route-property> == Route.X`.
     let model = elem
         .borrow()
         .navigator_routes
@@ -61,8 +46,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
     if !matches!(route_ty, Type::Enumeration(_)) {
         return;
     }
-    // navigate()/back() write the route back, so it must be an assignable
-    // property reference. The convention uses `in-out property <Route>`.
+
     if !matches!(route_ref, Expression::PropertyReference(_)) {
         diag.push_error(
             "the navigator route must be a writable property to support navigate() and back()"
@@ -80,8 +64,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
             ..Default::default()
         },
     );
-    // Initialize to an empty array: an unbound model property is a null model
-    // whose push/remove are silently no-ops.
+
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static(BACK_STACK),
         RefCell::new(Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into()),
@@ -93,7 +76,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         arguments: vec![back_stack()],
         source_location: None,
     };
-    // Index of the top of the stack: `length - 1`.
     let top_index = || Expression::BinaryExpression {
         lhs: Box::new(length()),
         rhs: Box::new(Expression::NumberLiteral(1., Unit::None)),
@@ -111,7 +93,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         node: None,
     };
 
-    // navigate(route): remember the current route, then switch to the argument.
     let navigate_body = Expression::CodeBlock(vec![
         Expression::FunctionCall {
             function: Callable::Builtin(BuiltinFunction::ArrayPush),
@@ -121,8 +102,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         assign_route(Expression::FunctionParameterReference { index: 0, ty: route_ty.clone() }),
     ]);
 
-    // back(): restore the top route, then drop it. The restore reads the top
-    // before the remove, so both use the pre-pop length.
     let back_body = Expression::Condition {
         condition: Box::new(non_empty()),
         true_expr: Box::new(Expression::CodeBlock(vec![
@@ -141,10 +120,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
 
     let can_go_back = non_empty();
 
-    // Int-index adapter for chrome that speaks `current_index: int` /
-    // `index_changed(int)` rather than the route enum. Each route case's
-    // resolved model is `route_ref == Route.X`, so its rhs is that route's enum
-    // value; collected in declaration order these map ordinal <-> route.
     let route_values: Vec<Expression> = elem
         .borrow()
         .navigator_routes
@@ -155,8 +130,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         })
         .collect();
 
-    // current-route-index: ordinal of the current route, else -1. Lowered as an
-    // if-chain `current == route0 ? 0 : current == route1 ? 1 : ... : -1`.
     let current_route_index = route_values.iter().enumerate().rev().fold(
         Expression::NumberLiteral(-1., Unit::None),
         |otherwise, (i, route_value)| Expression::Condition {
@@ -170,8 +143,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
 
-    // navigate-index(index): navigate to the route at that ordinal using the same
-    // push-then-set logic as navigate(); an out-of-range index is a no-op.
     let index_param = || Expression::FunctionParameterReference { index: 0, ty: Type::Int32 };
     let navigate_index_body = route_values.iter().enumerate().rev().fold(
         Expression::CodeBlock(vec![]),
@@ -193,9 +164,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
 
-    // The public members were declared early (before resolve) by
-    // `from_navigator_node` so .slint chrome can bind to them; here we only fill
-    // in their bodies/bindings, now that the route table is resolved.
     let mut e = elem.borrow_mut();
     e.bindings.insert(SmolStr::new_static("navigate"), RefCell::new(navigate_body.into()));
     e.bindings.insert(SmolStr::new_static("back"), RefCell::new(back_body.into()));

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,16 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Implement the navigator's public members and add its private back-stack.
+//! Fill in the navigator's public member bodies and add its private back-stack.
 //!
-//! `from_navigator_node` records the resolved route table on the enclosing
-//! element (`Element::navigator_routes`) and declares the public members
-//! (`current-route-index`, `can-go-back`, `navigate`, `navigate-index`, `back`)
-//! up front.
-//!
-//!   navigate(route): push the current route, then switch to `route`
-//!   back():          restore and drop the top of the back-stack (no-op if empty)
-//!   can-go-back:     true while the back-stack is non-empty
+//! Runs after the route table and member signatures are set up by `from_navigator_node`.
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,12 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Synthesize the navigator back-stack.
+//! Implement the navigator's public members (declared early by
+//! `from_navigator_node`) and add its private back-stack.
 //!
 //! `from_navigator_node` records the resolved route table on the enclosing
-//! element (`Element::navigator_routes`); navigation itself is just assigning
-//! the route property. This pass adds, on that same element, a back-stack plus
-//! the surface for going back:
+//! element (`Element::navigator_routes`) and declares the public members
+//! (`current-route-index`, `can-go-back`, `navigate`, `navigate-index`, `back`)
+//! up front, so .slint chrome can bind to them. Navigation itself is just
+//! assigning the route property. This pass fills in those members' bodies and
+//! adds, on the same element, the private back-stack that backs them:
 //!
 //!   navigate(route): push the current route, then switch to `route`
 //!   back():          restore and drop the top of the back-stack (no-op if empty)
@@ -22,7 +25,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};
-use crate::langtype::{Function, Type};
+use crate::langtype::Type;
 use crate::object_tree::*;
 use smol_str::SmolStr;
 use std::cell::RefCell;
@@ -194,79 +197,16 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
 
+    // The public members were declared early (before resolve) by
+    // `from_navigator_node` so .slint chrome can bind to them; here we only fill
+    // in their bodies/bindings, now that the route table is resolved.
     let mut e = elem.borrow_mut();
-    e.property_declarations.insert(
-        SmolStr::new_static("navigate"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![route_ty.clone()],
-                arg_names: vec![SmolStr::new_static("route")],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            // Synthesized after check_public_api; opt into the public surface so
-            // callers can invoke it and remove_unused_properties keeps it.
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("navigate"), RefCell::new(navigate_body.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("back"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![],
-                arg_names: vec![],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("back"), RefCell::new(back_body.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("can-go-back"),
-        PropertyDeclaration {
-            property_type: Type::Bool,
-            visibility: PropertyVisibility::Output,
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("current-route-index"),
-        PropertyDeclaration {
-            property_type: Type::Int32,
-            visibility: PropertyVisibility::Output,
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(
         SmolStr::new_static("current-route-index"),
         RefCell::new(current_route_index.into()),
-    );
-
-    e.property_declarations.insert(
-        SmolStr::new_static("navigate-index"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![Type::Int32],
-                arg_names: vec![SmolStr::new_static("index")],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            expose_in_public_api: true,
-            ..Default::default()
-        },
     );
     e.bindings
         .insert(SmolStr::new_static("navigate-index"), RefCell::new(navigate_index_body.into()));

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,0 +1,188 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Synthesize the navigator back-stack.
+//!
+//! `from_navigator_node` records the resolved route table on the enclosing
+//! element (`Element::navigator_routes`); navigation itself is just assigning
+//! the route property. This pass adds, on that same element, a back-stack plus
+//! the surface for going back:
+//!
+//!   navigate(route): push the current route, then switch to `route`
+//!   back():          restore and drop the top of the back-stack (no-op if empty)
+//!   can-go-back:     true while the back-stack is non-empty
+//!
+//! It is expressed entirely by lowering onto the existing property/callback and
+//! `Array*` builtin machinery, so it needs no new `internal/core` items.
+//!
+//! Runs after expression resolution (the route models are typed and the route
+//! property is a resolved reference by then) and before inlining. The construct
+//! is experimental-gated in `from_navigator_node`, so `navigator_routes` is only
+//! ever populated under `enable_experimental`; this pass inherits that gate.
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};
+use crate::langtype::{Function, Type};
+use crate::object_tree::*;
+use smol_str::SmolStr;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// Private storage for the back-stack. A single navigator per element is
+// supported, matching the navigation convention.
+const BACK_STACK: &str = "navigator-back-stack";
+
+pub fn lower_navigator(doc: &Document, diag: &mut BuildDiagnostics) {
+    doc.visit_all_used_components(|component| {
+        recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+            if !elem.borrow().navigator_routes.is_empty() {
+                lower_one(elem, diag);
+            }
+        })
+    });
+}
+
+fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
+    // The route property and its enum type both come from a route case's model:
+    // resolve turned each case into `<route-property> == Route.X`.
+    let model = elem
+        .borrow()
+        .navigator_routes
+        .first()
+        .and_then(|r| r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()));
+    let Some(Expression::BinaryExpression { lhs: route_ref, .. }) = model else {
+        return;
+    };
+    let route_ref = *route_ref;
+    let route_ty = route_ref.ty();
+    if !matches!(route_ty, Type::Enumeration(_)) {
+        return;
+    }
+    // navigate()/back() write the route back, so it must be an assignable
+    // property reference. The convention uses `in-out property <Route>`.
+    if !matches!(route_ref, Expression::PropertyReference(_)) {
+        diag.push_error(
+            "the navigator route must be a writable property to support navigate() and back()"
+                .into(),
+            &*elem.borrow(),
+        );
+        return;
+    }
+
+    elem.borrow_mut().property_declarations.insert(
+        SmolStr::new_static(BACK_STACK),
+        PropertyDeclaration {
+            property_type: Type::Array(Rc::new(route_ty.clone())),
+            visibility: PropertyVisibility::Private,
+            ..Default::default()
+        },
+    );
+    // Initialize to an empty array: an unbound model property is a null model
+    // whose push/remove are silently no-ops.
+    elem.borrow_mut().bindings.insert(
+        SmolStr::new_static(BACK_STACK),
+        RefCell::new(
+            Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into(),
+        ),
+    );
+
+    let back_stack = || Expression::PropertyReference(NamedReference::new(elem, BACK_STACK.into()));
+    let length = || Expression::FunctionCall {
+        function: Callable::Builtin(BuiltinFunction::ArrayLength),
+        arguments: vec![back_stack()],
+        source_location: None,
+    };
+    // Index of the top of the stack: `length - 1`.
+    let top_index = || Expression::BinaryExpression {
+        lhs: Box::new(length()),
+        rhs: Box::new(Expression::NumberLiteral(1., Unit::None)),
+        op: '-',
+    };
+    let non_empty = || Expression::BinaryExpression {
+        lhs: Box::new(length()),
+        rhs: Box::new(Expression::NumberLiteral(0., Unit::None)),
+        op: '>',
+    };
+    let assign_route = |rhs: Expression| Expression::SelfAssignment {
+        lhs: Box::new(route_ref.clone()),
+        rhs: Box::new(rhs),
+        op: '=',
+        node: None,
+    };
+
+    // navigate(route): remember the current route, then switch to the argument.
+    let navigate_body = Expression::CodeBlock(vec![
+        Expression::FunctionCall {
+            function: Callable::Builtin(BuiltinFunction::ArrayPush),
+            arguments: vec![back_stack(), route_ref.clone()],
+            source_location: None,
+        },
+        assign_route(Expression::FunctionParameterReference { index: 0, ty: route_ty.clone() }),
+    ]);
+
+    // back(): restore the top route, then drop it. The restore reads the top
+    // before the remove, so both use the pre-pop length.
+    let back_body = Expression::Condition {
+        condition: Box::new(non_empty()),
+        true_expr: Box::new(Expression::CodeBlock(vec![
+            assign_route(Expression::ArrayIndex {
+                array: Box::new(back_stack()),
+                index: Box::new(top_index()),
+            }),
+            Expression::FunctionCall {
+                function: Callable::Builtin(BuiltinFunction::ArrayRemove),
+                arguments: vec![back_stack(), top_index()],
+                source_location: None,
+            },
+        ])),
+        false_expr: Box::new(Expression::CodeBlock(vec![])),
+    };
+
+    let can_go_back = non_empty();
+
+    let mut e = elem.borrow_mut();
+    e.property_declarations.insert(
+        SmolStr::new_static("navigate"),
+        PropertyDeclaration {
+            property_type: Type::Function(Rc::new(Function {
+                return_type: Type::Void,
+                args: vec![route_ty.clone()],
+                arg_names: vec![SmolStr::new_static("route")],
+            })),
+            visibility: PropertyVisibility::Public,
+            pure: Some(false),
+            // Synthesized after check_public_api; opt into the public surface so
+            // callers can invoke it and remove_unused_properties keeps it.
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(SmolStr::new_static("navigate"), RefCell::new(navigate_body.into()));
+
+    e.property_declarations.insert(
+        SmolStr::new_static("back"),
+        PropertyDeclaration {
+            property_type: Type::Function(Rc::new(Function {
+                return_type: Type::Void,
+                args: vec![],
+                arg_names: vec![],
+            })),
+            visibility: PropertyVisibility::Public,
+            pure: Some(false),
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(SmolStr::new_static("back"), RefCell::new(back_body.into()));
+
+    e.property_declarations.insert(
+        SmolStr::new_static("can-go-back"),
+        PropertyDeclaration {
+            property_type: Type::Bool,
+            visibility: PropertyVisibility::Output,
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
+}

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -140,6 +140,60 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
 
     let can_go_back = non_empty();
 
+    // Int-index adapter for chrome that speaks `current_index: int` /
+    // `index_changed(int)` rather than the route enum. Each route case's
+    // resolved model is `route_ref == Route.X`, so its rhs is that route's enum
+    // value; collected in declaration order these map ordinal <-> route.
+    let route_values: Vec<Expression> = elem
+        .borrow()
+        .navigator_routes
+        .iter()
+        .filter_map(|r| {
+            match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
+                Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
+                _ => None,
+            }
+        })
+        .collect();
+
+    // current-route-index: ordinal of the current route, else -1. Lowered as an
+    // if-chain `current == route0 ? 0 : current == route1 ? 1 : ... : -1`.
+    let current_route_index = route_values.iter().enumerate().rev().fold(
+        Expression::NumberLiteral(-1., Unit::None),
+        |otherwise, (i, route_value)| Expression::Condition {
+            condition: Box::new(Expression::BinaryExpression {
+                lhs: Box::new(route_ref.clone()),
+                rhs: Box::new(route_value.clone()),
+                op: '=',
+            }),
+            true_expr: Box::new(Expression::NumberLiteral(i as f64, Unit::None)),
+            false_expr: Box::new(otherwise),
+        },
+    );
+
+    // navigate-index(index): navigate to the route at that ordinal using the same
+    // push-then-set logic as navigate(); an out-of-range index is a no-op.
+    let index_param = || Expression::FunctionParameterReference { index: 0, ty: Type::Int32 };
+    let navigate_index_body = route_values.iter().enumerate().rev().fold(
+        Expression::CodeBlock(vec![]),
+        |otherwise, (i, route_value)| Expression::Condition {
+            condition: Box::new(Expression::BinaryExpression {
+                lhs: Box::new(index_param()),
+                rhs: Box::new(Expression::NumberLiteral(i as f64, Unit::None)),
+                op: '=',
+            }),
+            true_expr: Box::new(Expression::CodeBlock(vec![
+                Expression::FunctionCall {
+                    function: Callable::Builtin(BuiltinFunction::ArrayPush),
+                    arguments: vec![back_stack(), route_ref.clone()],
+                    source_location: None,
+                },
+                assign_route(route_value.clone()),
+            ])),
+            false_expr: Box::new(otherwise),
+        },
+    );
+
     let mut e = elem.borrow_mut();
     e.property_declarations.insert(
         SmolStr::new_static("navigate"),
@@ -185,4 +239,35 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
     e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
+
+    e.property_declarations.insert(
+        SmolStr::new_static("current-route-index"),
+        PropertyDeclaration {
+            property_type: Type::Int32,
+            visibility: PropertyVisibility::Output,
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(
+        SmolStr::new_static("current-route-index"),
+        RefCell::new(current_route_index.into()),
+    );
+
+    e.property_declarations.insert(
+        SmolStr::new_static("navigate-index"),
+        PropertyDeclaration {
+            property_type: Type::Function(Rc::new(Function {
+                return_type: Type::Void,
+                args: vec![Type::Int32],
+                arg_names: vec![SmolStr::new_static("index")],
+            })),
+            visibility: PropertyVisibility::Public,
+            pure: Some(false),
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings
+        .insert(SmolStr::new_static("navigate-index"), RefCell::new(navigate_index_body.into()));
 }

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -84,9 +84,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
     // whose push/remove are silently no-ops.
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static(BACK_STACK),
-        RefCell::new(
-            Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into(),
-        ),
+        RefCell::new(Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into()),
     );
 
     let back_stack = || Expression::PropertyReference(NamedReference::new(elem, BACK_STACK.into()));
@@ -151,11 +149,9 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         .borrow()
         .navigator_routes
         .iter()
-        .filter_map(|r| {
-            match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
-                Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
-                _ => None,
-            }
+        .filter_map(|r| match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
+            Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
+            _ => None,
         })
         .collect();
 

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -47,6 +47,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 property_declarations: std::mem::take(&mut original_elem.property_declarations),
                 named_references: Default::default(),
                 repeated: None,
+                navigator_routes: Default::default(),
                 is_component_placeholder: false,
                 debug: original_elem.debug.clone(),
                 enclosing_component: Default::default(),

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -50,6 +50,7 @@ pub fn ensure_window(
         property_declarations: Default::default(),
         named_references: Default::default(),
         repeated: Default::default(),
+        navigator_routes: Default::default(),
         states: Default::default(),
         transitions: Default::default(),
         child_of_layout: false,

--- a/internal/compiler/tests/syntax/navigation/assignment.slint
+++ b/internal/compiler/tests/syntax/navigation/assignment.slint
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigation edge is an assignment to current-route inside a callback.
+// Several assignment forms are exercised here and all compile cleanly.
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+export component App {
+    in-out property <Route> current-route: Route.Home;
+
+    // Assignment triggered by an element callback.
+    TouchArea {
+        clicked => { root.current-route = Route.Details; }
+    }
+
+    // Assignment inside a declared callback handler.
+    callback open-settings();
+    open-settings => { current-route = Route.Settings; }
+
+    // Assignment inside a function.
+    function go-home() {
+        current-route = Route.Home;
+    }
+}

--- a/internal/compiler/tests/syntax/navigation/basic.slint
+++ b/internal/compiler/tests/syntax/navigation/basic.slint
@@ -1,0 +1,40 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigation convention: enum Route + current-route + conditional
+// children + assignment. This shape is expected to compile cleanly.
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle {
+    callback show-details();
+    TouchArea { clicked => { root.show-details(); } }
+}
+
+component DetailsScreen inherits Rectangle {
+    callback back();
+    TouchArea { clicked => { root.back(); } }
+}
+
+component SettingsScreen inherits Rectangle {
+    callback back();
+    TouchArea { clicked => { root.back(); } }
+}
+
+export component App {
+    in-out property <Route> current-route: Route.Home;
+
+    if current-route == Route.Home : HomeScreen {
+        show-details => { root.current-route = Route.Details; }
+    }
+    if current-route == Route.Details : DetailsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+    if current-route == Route.Settings : SettingsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+}

--- a/internal/compiler/tests/syntax/navigation/initial_route.slint
+++ b/internal/compiler/tests/syntax/navigation/initial_route.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // The current-route initializer picks the entry screen. Any enum value is a
-// valid initial route, and the conditional mapping stays the same.
+// valid initial route; the navigator maps the same set of routes either way.
 
 enum Route {
     Home,
@@ -15,15 +15,19 @@ component Screen inherits Rectangle { }
 export component StartOnDetails {
     in-out property <Route> current-route: Route.Details;
 
-    if current-route == Route.Home : Screen { }
-    if current-route == Route.Details : Screen { }
-    if current-route == Route.Settings : Screen { }
+    navigator (current-route) {
+        Route.Home: Screen { }
+        Route.Details: Screen { }
+        Route.Settings: Screen { }
+    }
 }
 
 export component StartOnSettings {
     in-out property <Route> current-route: Route.Settings;
 
-    if current-route == Route.Home : Screen { }
-    if current-route == Route.Details : Screen { }
-    if current-route == Route.Settings : Screen { }
+    navigator (current-route) {
+        Route.Home: Screen { }
+        Route.Details: Screen { }
+        Route.Settings: Screen { }
+    }
 }

--- a/internal/compiler/tests/syntax/navigation/initial_route.slint
+++ b/internal/compiler/tests/syntax/navigation/initial_route.slint
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The current-route initializer picks the entry screen. Any enum value is a
+// valid initial route, and the conditional mapping stays the same.
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component Screen inherits Rectangle { }
+
+export component StartOnDetails {
+    in-out property <Route> current-route: Route.Details;
+
+    if current-route == Route.Home : Screen { }
+    if current-route == Route.Details : Screen { }
+    if current-route == Route.Settings : Screen { }
+}
+
+export component StartOnSettings {
+    in-out property <Route> current-route: Route.Settings;
+
+    if current-route == Route.Home : Screen { }
+    if current-route == Route.Details : Screen { }
+    if current-route == Route.Settings : Screen { }
+}

--- a/internal/compiler/tests/syntax/navigator/destination_resolution.slint
+++ b/internal/compiler/tests/syntax/navigator/destination_resolution.slint
@@ -1,0 +1,32 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigator destinations form a compiler-checked closed set: each route
+// must resolve to a component.
+
+enum Route {
+    Home,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle { }
+
+export component App inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        // A user-defined component is a valid destination.
+        Route.Home: HomeScreen { }
+        // An unknown name is rejected.
+        Route.Settings: DoesNotExist { }
+//                      >           <error{Unknown element 'DoesNotExist'}
+    }
+}
+
+export component App2 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        // A builtin element is not a component, so it is rejected.
+        Route.Home: Rectangle { }
+//                  >           <error{navigator route destination must be a component, but 'Rectangle' is not}
+    }
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1587,6 +1587,13 @@ impl TypeLoader {
         is_builtin: bool,
         import_stack: &HashSet<PathBuf>,
     ) -> (PathBuf, Document) {
+        // Mirror lib.rs `prepare_for_compile`: the main compile path sets this on the
+        // diagnostics up front, but LSP/live-editor loads reach the type loader with a
+        // fresh BuildDiagnostics that never got the flag. This is the single funnel every
+        // load entry point flows through, so propagate the config here.
+        let enable_experimental = state.borrow().tl.compiler_config.enable_experimental;
+        state.borrow_mut().diag.enable_experimental = enable_experimental;
+
         let dependency_registry =
             Rc::new(RefCell::new(TypeRegister::new(&state.borrow().tl.global_type_registry)));
         dependency_registry.borrow_mut().expose_internal_types =
@@ -1983,6 +1990,59 @@ fn test_dependency_loading() {
     for file in imported_files {
         assert!(loader.get_document(&file).is_none(), "{} is still loaded", file.display());
     }
+}
+
+// The experimental `navigator` compiles through the normal type-loader load
+// path only when the config enables experimental, and is rejected otherwise.
+// Guards the LSP/live-editor load path, which reaches the loader with a fresh
+// BuildDiagnostics that never got the flag from the config.
+#[test]
+fn test_load_navigator_experimental_from_config() {
+    let source = r#"
+enum Route { A, B }
+component A inherits Rectangle { }
+component B inherits Rectangle { }
+export component App inherits Window {
+    in-out property <Route> current-route: Route.A;
+    navigator (current-route) {
+        Route.A: A { }
+        Route.B: B { }
+    }
+}
+"#;
+
+    let load = |enable_experimental: bool| {
+        let mut compiler_config =
+            CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        compiler_config.style = Some("fluent".into());
+        compiler_config.enable_experimental = enable_experimental;
+
+        let mut build_diagnostics = BuildDiagnostics::default();
+        let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+        assert!(!build_diagnostics.has_errors());
+
+        // The caller-provided diagnostics start without the flag, exactly like
+        // the LSP load path; the loader must derive it from the config.
+        let mut diag = BuildDiagnostics::default();
+        assert!(!diag.enable_experimental);
+        let path = PathBuf::from("/foo/nav.slint");
+        spin_on::spin_on(loader.load_file(&path, &path, source.into(), false, &mut diag));
+        diag
+    };
+
+    let diag = load(true);
+    assert!(diag.enable_experimental, "the config flag must reach the diagnostics");
+    assert!(
+        !diag.iter().any(|d| d.message().contains("experimental")),
+        "navigator rejected with experimental enabled: {:?}",
+        diag.iter().map(|d| d.message().to_string()).collect::<Vec<_>>()
+    );
+
+    let diag = load(false);
+    assert!(
+        diag.iter().any(|d| d.message().contains("navigator is an experimental feature")),
+        "navigator should be rejected when experimental is disabled"
+    );
 }
 
 #[test]

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -281,11 +281,8 @@ export component TestCase {
     assert_eq!(instance.get_property("a-open").unwrap(), Value::from(false), "a after close");
 }
 
-// A `navigator` renders the destination component for the
-// current route, and re-renders when the route changes. Each destination
-// records its name in a global on `init`, so the observed value tells us which
-// route's screen is currently instantiated. Requires `enable_experimental`,
-// which is only reachable through the `internal` compiler configuration API.
+// Each destination records its name in `NavProbe.active` on `init`, so `active`
+// tells us which route's screen is currently instantiated.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_shows_current_route() {
@@ -318,7 +315,6 @@ export component TestCase inherits Window {
 
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
 
-    // The initial route renders its screen.
     i_slint_backend_testing::mock_elapsed_time(100);
     assert_eq!(
         instance.get_property("active").unwrap(),
@@ -326,7 +322,6 @@ export component TestCase inherits Window {
         "Route.Home renders HomeScreen"
     );
 
-    // Switching the current route renders the other screen.
     instance.set_property("current-route", route("Settings")).unwrap();
     i_slint_backend_testing::mock_elapsed_time(100);
     assert_eq!(
@@ -335,7 +330,6 @@ export component TestCase inherits Window {
         "Route.Settings renders SettingsScreen"
     );
 
-    // And back to the first route.
     instance.set_property("current-route", route("Home")).unwrap();
     i_slint_backend_testing::mock_elapsed_time(100);
     assert_eq!(
@@ -345,9 +339,6 @@ export component TestCase inherits Window {
     );
 }
 
-// Without `enable_experimental`, `navigator` is rejected at object-tree
-// lowering with the experimental-feature diagnostic. `Compiler::default()`
-// does not enable experimental features.
 #[test]
 fn navigator_requires_experimental() {
     i_slint_backend_testing::init_no_event_loop();
@@ -372,10 +363,6 @@ export component TestCase inherits Window {
     );
 }
 
-// The back-stack: `navigate(route)` pushes the current route before switching,
-// `back()` restores the previous route (no-op at the root), and `can-go-back`
-// reflects whether the stack is non-empty. The `active` global still tells us
-// which screen is instantiated, so we assert on the rendered route.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_back_stack() {
@@ -414,11 +401,9 @@ export component TestCase inherits Window {
         instance.get_property("active").unwrap()
     };
 
-    // Root: nothing to go back to.
     assert_eq!(rendered(&instance), Value::from(SharedString::from("home")));
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "root");
 
-    // navigate(Home -> Details -> Settings): the stack fills up.
     instance.invoke("navigate", &[route("Details")]).unwrap();
     assert_eq!(rendered(&instance), Value::from(SharedString::from("details")));
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Details");
@@ -427,7 +412,6 @@ export component TestCase inherits Window {
     assert_eq!(rendered(&instance), Value::from(SharedString::from("settings")));
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Settings");
 
-    // back() twice unwinds Settings -> Details -> Home.
     instance.invoke("back", &[]).unwrap();
     assert_eq!(rendered(&instance), Value::from(SharedString::from("details")), "back to Details");
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "one left");
@@ -440,16 +424,13 @@ export component TestCase inherits Window {
         "back at the root"
     );
 
-    // back() at the root is a no-op.
     instance.invoke("back", &[]).unwrap();
     assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "no-op at root");
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "still root");
 }
 
-// The int-index adapter: `current-route-index` reports the ordinal of the
-// current route in declaration order, and `navigate-index(i)` navigates to the
-// route at that ordinal. This is what int-index chrome (current_index /
-// index_changed) binds to, so it must agree with the route enum both ways.
+// The int-index adapter (`current-route-index` / `navigate-index`) must agree
+// with the route enum both ways.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_index_adapter() {
@@ -488,14 +469,12 @@ export component TestCase inherits Window {
         instance.get_property("current-route-index").unwrap()
     };
 
-    // Setting the route enum drives current-route-index to the declared ordinal.
     assert_eq!(index(&instance), Value::from(0.), "Home is ordinal 0");
     instance.set_property("current-route", route("Details")).unwrap();
     assert_eq!(index(&instance), Value::from(1.), "Details is ordinal 1");
     instance.set_property("current-route", route("Settings")).unwrap();
     assert_eq!(index(&instance), Value::from(2.), "Settings is ordinal 2");
 
-    // navigate-index(i) drives the route enum the other way (and the index with it).
     instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
     assert_eq!(
         instance.get_property("current-route").unwrap(),
@@ -512,7 +491,6 @@ export component TestCase inherits Window {
     );
     assert_eq!(index(&instance), Value::from(0.));
 
-    // Out-of-range is a no-op: the route (and index) stay put.
     instance.invoke("navigate-index", &[Value::from(9.)]).unwrap();
     assert_eq!(
         instance.get_property("current-route").unwrap(),
@@ -522,14 +500,9 @@ export component TestCase inherits Window {
     assert_eq!(index(&instance), Value::from(0.));
 }
 
-// A std-widgets navigation presentation (a Button-row tab bar) driving
-// the navigator through its int-index adapter. The tab bar is a plain std
-// `Button` row that exposes `current-index` / `selected(int)`; the host bridges
-// those to the navigator's `current-route-index` / `navigate-index` (the adapter
-// is synthesized after resolve, so it is reachable from the host rather than
-// from .slint). This guards that the std presentation compiles with the
-// navigator and that both directions of the binding hold: the highlight source
-// follows the current route, and activating a tab moves the current route.
+// A std-widgets Button-row tab bar driving the navigator through its int-index
+// adapter. The adapter is synthesized after resolve, so the host bridges it to
+// the tab bar's `current-index` / `selected(int)`.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_std_chrome_index_binding() {
@@ -589,9 +562,6 @@ export component TestCase inherits Window {
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
     let settle = || i_slint_backend_testing::mock_elapsed_time(100);
 
-    // The host feeds the tab bar's highlight from the adapter. Setting the route
-    // (as an in-screen action would) moves current-route-index, which is what
-    // the chrome's current-index binds to.
     settle();
     instance.set_property("current-route", route("Details")).unwrap();
     settle();
@@ -610,8 +580,6 @@ export component TestCase inherits Window {
         "the navigator renders the Details screen"
     );
 
-    // Activating a tab: the chrome's `selected(int)` is routed to navigate-index,
-    // which moves the current route (and its rendered screen).
     instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
     settle();
     assert_eq!(
@@ -631,16 +599,8 @@ export component TestCase inherits Window {
     );
 }
 
-// The presentation-agnostic proof: an int-index chrome that mimics Material's
-// `BaseNavigation` (`items` / `current_index` / `index_changed` / `select`)
-// drives the enum-typed navigator through the int-index adapter, both ways.
-// `IntChrome` copies that contract verbatim (only `select` is public so the test
-// can trigger a "tap"; Material's is protected and fired by item clicks). The
-// two adapter members are consumed exactly as native Material wiring would:
-//   current_index  <- current-route-index   (the bar reflects the route)
-//   index_changed(i) => navigate-index(i)    (a tap navigates)
-// Nothing about the `navigator { Route... }` block is chrome-specific, so std
-// chrome binds the same two members with zero change to the routes.
+// An int-index chrome mimicking Material's `BaseNavigation` drives the navigator
+// through the adapter, both ways, bound from the host.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_int_chrome_binding() {
@@ -707,8 +667,7 @@ export component TestCase inherits Window {
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
     let settle = || i_slint_backend_testing::mock_elapsed_time(100);
 
-    // The tap binding: index_changed(i) => navigate-index(i). Wired once, exactly
-    // as native Material code binds NavigationBar.index_changed to the adapter.
+    // index_changed(i) => navigate-index(i), wired as native Material code would.
     let weak = instance.as_weak();
     instance
         .set_callback("chrome-index-changed", move |args| {
@@ -718,15 +677,13 @@ export component TestCase inherits Window {
         })
         .unwrap();
 
-    // The display binding: current_index <- current-route-index. Pushed after each
-    // route change (native code does the same via set_bar_index).
+    // current_index <- current-route-index, pushed after each route change.
     let mirror = |instance: &crate::ComponentInstance| {
         let idx = instance.get_property("current-route-index").unwrap();
         instance.set_property("chrome-index", idx).unwrap();
         settle();
     };
 
-    // Display side: moving the route moves the chrome's current_index.
     mirror(&instance);
     assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "Home -> 0");
     instance.set_property("current-route", route("Details")).unwrap();
@@ -740,7 +697,6 @@ export component TestCase inherits Window {
         "Settings -> 2"
     );
 
-    // Tap side: chrome.select(i) fires index_changed -> navigate-index(i) -> route.
     instance.invoke("tap", &[Value::from(0.)]).unwrap();
     mirror(&instance);
     assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
@@ -759,7 +715,6 @@ export component TestCase inherits Window {
         Value::from(SharedString::from("settings"))
     );
 
-    // Out-of-range tap is a no-op in the mimic's guard (same as BaseNavigation.select).
     instance.invoke("tap", &[Value::from(9.)]).unwrap();
     mirror(&instance);
     assert_eq!(
@@ -769,15 +724,9 @@ export component TestCase inherits Window {
     );
 }
 
-// The navigator's public members are declared before expression
-// resolution, so widget chrome binds to them INLINE in .slint (not from the
-// host language). This is the same IntChrome contract as
-// navigator_int_chrome_binding, but the two adapter members are wired in .slint:
-//   current-index: root.current-route-index       (the bar reflects the route)
-//   index-changed(i) => root.navigate-index(i)     (a tap navigates)
-// and can-go-back is read in a .slint binding too. If these members did
-// not exist at resolve time, so this binding failed with "does not have a
-// property 'current-route-index'" and had to be done from Rust.
+// The navigator's public members are declared before expression resolution, so
+// chrome can bind them INLINE in .slint (current-route-index, navigate-index,
+// can-go-back) rather than from the host, as navigator_int_chrome_binding does.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_inline_chrome_binding() {
@@ -841,7 +790,6 @@ export component TestCase inherits Window {
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
     let settle = || i_slint_backend_testing::mock_elapsed_time(100);
 
-    // Read side, all in .slint: the bar's current-index follows current-route-index.
     settle();
     assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "Home -> 0");
     assert_eq!(instance.get_property("chrome-can-back").unwrap(), Value::from(false), "root");
@@ -858,7 +806,6 @@ export component TestCase inherits Window {
         Value::from(SharedString::from("details"))
     );
 
-    // Write side, all in .slint: tap -> select -> index-changed -> navigate-index.
     instance.invoke("tap", &[Value::from(2.)]).unwrap();
     settle();
     assert_eq!(
@@ -871,20 +818,17 @@ export component TestCase inherits Window {
         instance.get_property("active").unwrap(),
         Value::from(SharedString::from("settings"))
     );
-    // navigate-index pushed the previous route, so can-go-back (bound in .slint) is true.
     assert_eq!(
         instance.get_property("chrome-can-back").unwrap(),
         Value::from(true),
         "can-go-back reflects the push, read in a .slint binding"
     );
 
-    // Another tap moves it back to the first route.
     instance.invoke("tap", &[Value::from(0.)]).unwrap();
     settle();
     assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
     assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "bar shows 0");
 
-    // Out-of-range tap is a no-op (the chrome's own guard).
     instance.invoke("tap", &[Value::from(9.)]).unwrap();
     settle();
     assert_eq!(

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -281,7 +281,7 @@ export component TestCase {
     assert_eq!(instance.get_property("a-open").unwrap(), Value::from(false), "a after close");
 }
 
-// The milestone test: a `navigator` renders the destination component for the
+// A `navigator` renders the destination component for the
 // current route, and re-renders when the route changes. Each destination
 // records its name in a global on `init`, so the observed value tells us which
 // route's screen is currently instantiated. Requires `enable_experimental`,
@@ -522,7 +522,7 @@ export component TestCase inherits Window {
     assert_eq!(index(&instance), Value::from(0.));
 }
 
-// PR A8: a std-widgets navigation presentation (a Button-row tab bar) driving
+// A std-widgets navigation presentation (a Button-row tab bar) driving
 // the navigator through its int-index adapter. The tab bar is a plain std
 // `Button` row that exposes `current-index` / `selected(int)`; the host bridges
 // those to the navigator's `current-route-index` / `navigate-index` (the adapter
@@ -640,7 +640,7 @@ export component TestCase inherits Window {
 //   current_index  <- current-route-index   (the bar reflects the route)
 //   index_changed(i) => navigate-index(i)    (a tap navigates)
 // Nothing about the `navigator { Route... }` block is chrome-specific, so std
-// chrome (PR A8) binds the same two members with zero change to the routes.
+// chrome binds the same two members with zero change to the routes.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_int_chrome_binding() {
@@ -769,13 +769,13 @@ export component TestCase inherits Window {
     );
 }
 
-// PR #13: the navigator's public members are declared before expression
+// The navigator's public members are declared before expression
 // resolution, so widget chrome binds to them INLINE in .slint (not from the
 // host language). This is the same IntChrome contract as
 // navigator_int_chrome_binding, but the two adapter members are wired in .slint:
 //   current-index: root.current-route-index       (the bar reflects the route)
 //   index-changed(i) => root.navigate-index(i)     (a tap navigates)
-// and can-go-back is read in a .slint binding too. Before #13 these members did
+// and can-go-back is read in a .slint binding too. If these members did
 // not exist at resolve time, so this binding failed with "does not have a
 // property 'current-route-index'" and had to be done from Rust.
 #[cfg(feature = "internal")]
@@ -810,7 +810,7 @@ export component TestCase inherits Window {
     in-out property <Route> current-route: Route.Home;
     out property <string> active: NavProbe.active;
 
-    // The #13 proof: the chrome binds the navigator's synthesized members
+    // The chrome binds the navigator's synthesized members
     // directly in .slint. These mirrors let the test observe the bound values.
     out property <int> chrome-index: chrome.current-index;
     out property <bool> chrome-can-back: root.can-go-back;

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -280,3 +280,94 @@ export component TestCase {
     instance.invoke("close-a", &[]).unwrap();
     assert_eq!(instance.get_property("a-open").unwrap(), Value::from(false), "a after close");
 }
+
+// The milestone test: a `navigator` renders the destination component for the
+// current route, and re-renders when the route changes. Each destination
+// records its name in a global on `init`, so the observed value tells us which
+// route's screen is currently instantiated. Requires `enable_experimental`,
+// which is only reachable through the `internal` compiler configuration API.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_shows_current_route() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+
+    // The initial route renders its screen.
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("home")),
+        "Route.Home renders HomeScreen"
+    );
+
+    // Switching the current route renders the other screen.
+    instance.set_property("current-route", route("Settings")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings")),
+        "Route.Settings renders SettingsScreen"
+    );
+
+    // And back to the first route.
+    instance.set_property("current-route", route("Home")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("home")),
+        "Route.Home renders HomeScreen again"
+    );
+}
+
+// Without `enable_experimental`, `navigator` is rejected at object-tree
+// lowering with the experimental-feature diagnostic. `Compiler::default()`
+// does not enable experimental features.
+#[test]
+fn navigator_requires_experimental() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::Compiler;
+    let code = r#"
+enum Route { Home }
+component HomeScreen inherits Rectangle { }
+export component TestCase inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+    }
+}
+"#;
+    let compiler = Compiler::default();
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(result.has_errors(), "navigator must be rejected without experimental");
+    assert!(
+        result.diagnostics().any(|d| d.message().contains("navigator is an experimental feature")),
+        "expected the experimental-feature diagnostic, got: {:?}",
+        result.diagnostics().map(|d| d.message().to_owned()).collect::<Vec<_>>()
+    );
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -445,3 +445,79 @@ export component TestCase inherits Window {
     assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "no-op at root");
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "still root");
 }
+
+// The int-index adapter: `current-route-index` reports the ordinal of the
+// current route in declaration order, and `navigate-index(i)` navigates to the
+// route at that ordinal. This is what int-index chrome (current_index /
+// index_changed) binds to, so it must agree with the route enum both ways.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_index_adapter() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let index = |instance: &crate::ComponentInstance| {
+        i_slint_backend_testing::mock_elapsed_time(100);
+        instance.get_property("current-route-index").unwrap()
+    };
+
+    // Setting the route enum drives current-route-index to the declared ordinal.
+    assert_eq!(index(&instance), Value::from(0.), "Home is ordinal 0");
+    instance.set_property("current-route", route("Details")).unwrap();
+    assert_eq!(index(&instance), Value::from(1.), "Details is ordinal 1");
+    instance.set_property("current-route", route("Settings")).unwrap();
+    assert_eq!(index(&instance), Value::from(2.), "Settings is ordinal 2");
+
+    // navigate-index(i) drives the route enum the other way (and the index with it).
+    instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "navigate-index(2) selects Settings"
+    );
+    assert_eq!(index(&instance), Value::from(2.));
+
+    instance.invoke("navigate-index", &[Value::from(0.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "navigate-index(0) selects Home"
+    );
+    assert_eq!(index(&instance), Value::from(0.));
+
+    // Out-of-range is a no-op: the route (and index) stay put.
+    instance.invoke("navigate-index", &[Value::from(9.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "out-of-range navigate-index is a no-op"
+    );
+    assert_eq!(index(&instance), Value::from(0.));
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -371,3 +371,77 @@ export component TestCase inherits Window {
         result.diagnostics().map(|d| d.message().to_owned()).collect::<Vec<_>>()
     );
 }
+
+// The back-stack: `navigate(route)` pushes the current route before switching,
+// `back()` restores the previous route (no-op at the root), and `can-go-back`
+// reflects whether the stack is non-empty. The `active` global still tells us
+// which screen is instantiated, so we assert on the rendered route.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_back_stack() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let rendered = |instance: &crate::ComponentInstance| {
+        i_slint_backend_testing::mock_elapsed_time(100);
+        instance.get_property("active").unwrap()
+    };
+
+    // Root: nothing to go back to.
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("home")));
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "root");
+
+    // navigate(Home -> Details -> Settings): the stack fills up.
+    instance.invoke("navigate", &[route("Details")]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("details")));
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Details");
+
+    instance.invoke("navigate", &[route("Settings")]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("settings")));
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Settings");
+
+    // back() twice unwinds Settings -> Details -> Home.
+    instance.invoke("back", &[]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("details")), "back to Details");
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "one left");
+
+    instance.invoke("back", &[]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "back to Home");
+    assert_eq!(
+        instance.get_property("can-go-back").unwrap(),
+        Value::from(false),
+        "back at the root"
+    );
+
+    // back() at the root is a no-op.
+    instance.invoke("back", &[]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "no-op at root");
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "still root");
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -768,3 +768,128 @@ export component TestCase inherits Window {
         "out-of-range tap is a no-op"
     );
 }
+
+// PR #13: the navigator's public members are declared before expression
+// resolution, so widget chrome binds to them INLINE in .slint (not from the
+// host language). This is the same IntChrome contract as
+// navigator_int_chrome_binding, but the two adapter members are wired in .slint:
+//   current-index: root.current-route-index       (the bar reflects the route)
+//   index-changed(i) => root.navigate-index(i)     (a tap navigates)
+// and can-go-back is read in a .slint binding too. Before #13 these members did
+// not exist at resolve time, so this binding failed with "does not have a
+// property 'current-route-index'" and had to be done from Rust.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_inline_chrome_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// Int-index chrome, same contract as Material's BaseNavigation: the host feeds
+// the highlighted index in, a tap fires index-changed out.
+component IntChrome {
+    in property <[string]> items;
+    in property <int> current-index;
+    callback index-changed(index: int);
+    public function select(index: int) {
+        if (index < 0 || index >= root.items.length) {
+            return;
+        }
+        root.index-changed(index);
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+
+    // The #13 proof: the chrome binds the navigator's synthesized members
+    // directly in .slint. These mirrors let the test observe the bound values.
+    out property <int> chrome-index: chrome.current-index;
+    out property <bool> chrome-can-back: root.can-go-back;
+
+    chrome := IntChrome {
+        items: ["Home", "Details", "Settings"];
+        current-index: root.current-route-index;            // display <- current-route-index
+        index-changed(i) => { root.navigate-index(i); }     // tap -> navigate-index
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+    // Simulate an item tap (Material fires select() from a NavigationItem click).
+    public function tap(index: int) { chrome.select(index); }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // Read side, all in .slint: the bar's current-index follows current-route-index.
+    settle();
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "Home -> 0");
+    assert_eq!(instance.get_property("chrome-can-back").unwrap(), Value::from(false), "root");
+
+    instance.set_property("current-route", route("Details")).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("chrome-index").unwrap(),
+        Value::from(1.),
+        "the bar's current-index reflects the route, bound in .slint"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("details"))
+    );
+
+    // Write side, all in .slint: tap -> select -> index-changed -> navigate-index.
+    instance.invoke("tap", &[Value::from(2.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "a .slint-wired tap navigates by ordinal"
+    );
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(2.), "bar shows 2");
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings"))
+    );
+    // navigate-index pushed the previous route, so can-go-back (bound in .slint) is true.
+    assert_eq!(
+        instance.get_property("chrome-can-back").unwrap(),
+        Value::from(true),
+        "can-go-back reflects the push, read in a .slint binding"
+    );
+
+    // Another tap moves it back to the first route.
+    instance.invoke("tap", &[Value::from(0.)]).unwrap();
+    settle();
+    assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "bar shows 0");
+
+    // Out-of-range tap is a no-op (the chrome's own guard).
+    instance.invoke("tap", &[Value::from(9.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "out-of-range tap is a no-op"
+    );
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -521,3 +521,112 @@ export component TestCase inherits Window {
     );
     assert_eq!(index(&instance), Value::from(0.));
 }
+
+// PR A8: a std-widgets navigation presentation (a Button-row tab bar) driving
+// the navigator through its int-index adapter. The tab bar is a plain std
+// `Button` row that exposes `current-index` / `selected(int)`; the host bridges
+// those to the navigator's `current-route-index` / `navigate-index` (the adapter
+// is synthesized after resolve, so it is reachable from the host rather than
+// from .slint). This guards that the std presentation compiles with the
+// navigator and that both directions of the binding hold: the highlight source
+// follows the current route, and activating a tab moves the current route.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_std_chrome_index_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// The std presentation: a Button row whose active segment follows current-index.
+component NavBar inherits HorizontalBox {
+    in property <[string]> titles;
+    in property <int> current-index;
+    callback selected(index: int);
+    for title[index] in titles: Button {
+        text: title;
+        primary: index == root.current-index;
+        clicked => { root.selected(index); }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    // The chrome inputs the host bridges to the navigator adapter.
+    in property <int> nav-index;
+    callback nav-select(index: int);
+
+    NavBar {
+        titles: ["Home", "Details", "Settings"];
+        current-index: root.nav-index;
+        selected(index) => { root.nav-select(index); }
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // The host feeds the tab bar's highlight from the adapter. Setting the route
+    // (as an in-screen action would) moves current-route-index, which is what
+    // the chrome's current-index binds to.
+    settle();
+    instance.set_property("current-route", route("Details")).unwrap();
+    settle();
+    let highlight = instance.get_property("current-route-index").unwrap();
+    assert_eq!(highlight, Value::from(1.), "highlight source follows the current route");
+    instance.set_property("nav-index", highlight).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("nav-index").unwrap(),
+        Value::from(1.),
+        "the tab bar's current-index reflects the current route"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("details")),
+        "the navigator renders the Details screen"
+    );
+
+    // Activating a tab: the chrome's `selected(int)` is routed to navigate-index,
+    // which moves the current route (and its rendered screen).
+    instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "activating the Settings tab navigates by ordinal"
+    );
+    assert_eq!(
+        instance.get_property("current-route-index").unwrap(),
+        Value::from(2.),
+        "the highlight source moves with the activated tab"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings")),
+        "the navigator renders the Settings screen"
+    );
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -630,3 +630,141 @@ export component TestCase inherits Window {
         "the navigator renders the Settings screen"
     );
 }
+
+// The presentation-agnostic proof: an int-index chrome that mimics Material's
+// `BaseNavigation` (`items` / `current_index` / `index_changed` / `select`)
+// drives the enum-typed navigator through the int-index adapter, both ways.
+// `IntChrome` copies that contract verbatim (only `select` is public so the test
+// can trigger a "tap"; Material's is protected and fired by item clicks). The
+// two adapter members are consumed exactly as native Material wiring would:
+//   current_index  <- current-route-index   (the bar reflects the route)
+//   index_changed(i) => navigate-index(i)    (a tap navigates)
+// Nothing about the `navigator { Route... }` block is chrome-specific, so std
+// chrome (PR A8) binds the same two members with zero change to the routes.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_int_chrome_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// Mirrors Material's BaseNavigation int API (items/current_index/index_changed/select).
+component IntChrome {
+    in property <[string]> items;
+    in-out property <int> current_index;
+    callback index_changed(index: int);
+    public function select(index: int) {
+        if (index < 0 || index >= root.items.length) {
+            return;
+        }
+        root.current_index = index;
+        root.index_changed(index);
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+
+    // Adapter members are synthesized after expression resolution, so they are a
+    // native/runtime surface, not source-referenceable. The test copies
+    // current-route-index into `chrome-index` and forwards index_changed out, then
+    // binds both to the adapter through the runtime API, as native code does.
+    in property <int> chrome-index;
+    out property <int> chrome-index-out: chrome.current_index;
+    callback chrome-index-changed(index: int);
+
+    chrome := IntChrome {
+        items: ["Home", "Details", "Settings"];
+        current_index: root.chrome-index;              // display <- current-route-index
+        index_changed(i) => { root.chrome-index-changed(i); }  // tap forwarded out
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+    // Simulate an item tap (Material fires select() from a NavigationItem click).
+    public function tap(index: int) { chrome.select(index); }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // The tap binding: index_changed(i) => navigate-index(i). Wired once, exactly
+    // as native Material code binds NavigationBar.index_changed to the adapter.
+    let weak = instance.as_weak();
+    instance
+        .set_callback("chrome-index-changed", move |args| {
+            let i: i32 = args[0].clone().try_into().unwrap();
+            weak.unwrap().invoke("navigate-index", &[Value::from(i as f64)]).unwrap();
+            Value::Void
+        })
+        .unwrap();
+
+    // The display binding: current_index <- current-route-index. Pushed after each
+    // route change (native code does the same via set_bar_index).
+    let mirror = |instance: &crate::ComponentInstance| {
+        let idx = instance.get_property("current-route-index").unwrap();
+        instance.set_property("chrome-index", idx).unwrap();
+        settle();
+    };
+
+    // Display side: moving the route moves the chrome's current_index.
+    mirror(&instance);
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "Home -> 0");
+    instance.set_property("current-route", route("Details")).unwrap();
+    mirror(&instance);
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(1.), "Details -> 1");
+    instance.set_property("current-route", route("Settings")).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("chrome-index-out").unwrap(),
+        Value::from(2.),
+        "Settings -> 2"
+    );
+
+    // Tap side: chrome.select(i) fires index_changed -> navigate-index(i) -> route.
+    instance.invoke("tap", &[Value::from(0.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "bar shows 0");
+
+    instance.invoke("tap", &[Value::from(2.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "tap 2 -> Settings"
+    );
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(2.), "bar shows 2");
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings"))
+    );
+
+    // Out-of-range tap is a no-op in the mimic's guard (same as BaseNavigation.select).
+    instance.invoke("tap", &[Value::from(9.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "out-of-range tap is a no-op"
+    );
+}

--- a/tests/cases/navigation/basic.slint
+++ b/tests/cases/navigation/basic.slint
@@ -1,0 +1,129 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigator's public members (navigate, back, can-go-back, navigate-index,
+// current-route-index) are exercised from every language binding. Driving by the
+// integer adapter keeps the assertions int/bool; one navigate(enum) call checks
+// the enum-argument path.
+
+export enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle { }
+component DetailsScreen inherits Rectangle { }
+component SettingsScreen inherits Rectangle { }
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    in-out property <Route> current-route: Route.Home;
+
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_current_route_index(), 0);
+assert!(!instance.get_can_go_back());
+
+instance.invoke_navigate_index(1);
+assert_eq!(instance.get_current_route_index(), 1);
+assert!(instance.get_can_go_back());
+
+instance.invoke_navigate_index(2);
+assert_eq!(instance.get_current_route_index(), 2);
+
+instance.invoke_back();
+assert_eq!(instance.get_current_route_index(), 1);
+
+instance.invoke_back();
+assert_eq!(instance.get_current_route_index(), 0);
+assert!(!instance.get_can_go_back());
+
+instance.invoke_navigate(Route::Settings);
+assert_eq!(instance.get_current_route_index(), 2);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_current_route_index(), 0);
+assert(!instance.get_can_go_back());
+
+instance.invoke_navigate_index(1);
+assert_eq(instance.get_current_route_index(), 1);
+assert(instance.get_can_go_back());
+
+instance.invoke_navigate_index(2);
+assert_eq(instance.get_current_route_index(), 2);
+
+instance.invoke_back();
+assert_eq(instance.get_current_route_index(), 1);
+
+instance.invoke_back();
+assert_eq(instance.get_current_route_index(), 0);
+assert(!instance.get_can_go_back());
+
+instance.invoke_navigate(Route::Settings);
+assert_eq(instance.get_current_route_index(), 2);
+```
+
+```js
+var instance = new slint.TestCase();
+
+assert.equal(instance.current_route_index, 0);
+assert(!instance.can_go_back);
+
+instance.navigate_index(1);
+assert.equal(instance.current_route_index, 1);
+assert(instance.can_go_back);
+
+instance.navigate_index(2);
+assert.equal(instance.current_route_index, 2);
+
+instance.back();
+assert.equal(instance.current_route_index, 1);
+
+instance.back();
+assert.equal(instance.current_route_index, 0);
+assert(!instance.can_go_back);
+
+instance.navigate("Settings");
+assert.equal(instance.current_route_index, 2);
+```
+
+```python
+instance = TestCase()
+
+assert instance.current_route_index == 0
+assert not instance.can_go_back
+
+instance.navigate_index(1)
+assert instance.current_route_index == 1
+assert instance.can_go_back
+
+instance.navigate_index(2)
+assert instance.current_route_index == 2
+
+instance.back()
+assert instance.current_route_index == 1
+
+instance.back()
+assert instance.current_route_index == 0
+assert not instance.can_go_back
+
+instance.navigate(Route.Settings)
+assert instance.current_route_index == 2
+```
+*/

--- a/tests/cases/navigation/basic.slint
+++ b/tests/cases/navigation/basic.slint
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// The navigator's public members (navigate, back, can-go-back, navigate-index,
-// current-route-index) are exercised from every language binding. Driving by the
-// integer adapter keeps the assertions int/bool; one navigate(enum) call checks
-// the enum-argument path.
-
 export enum Route {
     Home,
     Details,

--- a/tests/cases/navigation/internal_route.slint
+++ b/tests/cases/navigation/internal_route.slint
@@ -1,0 +1,72 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A navigator inside a non-root component: its route property is internal, and
+// navigate()/back() must still be able to write it. Regression for the route
+// being wrongly classified constant (which panicked "Constant property being
+// changed" the first time navigate() ran).
+
+enum Route { Main, Detail }
+
+component Screen inherits Rectangle { }
+
+component Feature inherits Rectangle {
+    in-out property <Route> route: Route.Main;
+    public function push() { root.navigate(Route.Detail); }
+    public function pop() { root.back(); }
+    navigator (route) {
+        Route.Main: Screen { }
+        Route.Detail: Screen { }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    feature := Feature { }
+
+    out property <int> index: feature.current-route-index;
+
+    public function push() { feature.push(); }
+    public function pop() { feature.pop(); }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_index(), 0);
+instance.invoke_push();
+assert_eq!(instance.get_index(), 1);
+instance.invoke_pop();
+assert_eq!(instance.get_index(), 0);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_index(), 0);
+instance.invoke_push();
+assert_eq(instance.get_index(), 1);
+instance.invoke_pop();
+assert_eq(instance.get_index(), 0);
+```
+
+```js
+var instance = new slint.TestCase();
+assert.equal(instance.index, 0);
+instance.push();
+assert.equal(instance.index, 1);
+instance.pop();
+assert.equal(instance.index, 0);
+```
+
+```python
+instance = TestCase()
+assert instance.index == 0
+instance.push()
+assert instance.index == 1
+instance.pop()
+assert instance.index == 0
+```
+*/

--- a/tests/driver/rust/tests/navigation.rs
+++ b/tests/driver/rust/tests/navigation.rs
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// NOTE: The files under tests/driver/rust/tests/ are generated and validated against this template.
+// Do not edit them directly, instead edit the template.rs file!
+
+// needs to be crate-level
+#![deny(rust_2024_compatibility)]
+
+include!(concat!(env!("OUT_DIR"), "/navigation.rs"));

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -708,12 +708,14 @@ export component App inherits Window {
             if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
         let url = Url::from_file_path(path).unwrap();
 
-        // The type-loader load path does not derive the experimental flag from
-        // the compiler config, so set it on the diagnostics to compile the
-        // experimental `navigator`.
+        // The normal load path derives the experimental flag from the compiler
+        // config (enabled by empty_document_cache_experimental), so a default
+        // BuildDiagnostics is enough to compile the experimental `navigator`.
         let mut diag = BuildDiagnostics::default();
-        diag.enable_experimental = true;
+        assert!(!diag.enable_experimental, "the diag must start without the flag");
         let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
+        // Proof the load path propagated the config flag onto the diagnostics.
+        assert!(diag.enable_experimental, "load path did not propagate enable_experimental");
         assert!(
             !diag.has_errors(),
             "unexpected errors: {:?}",

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -4,7 +4,8 @@
 //! Data structures common between LSP and previewer
 
 use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile};
-use i_slint_compiler::object_tree::Document;
+use i_slint_compiler::langtype::ElementType;
+use i_slint_compiler::object_tree::{Document, ElementRc};
 use i_slint_compiler::parser::{TextSize, syntax_nodes};
 use i_slint_compiler::typeloader::TypeLoader;
 use i_slint_compiler::typeregister::TypeRegister;
@@ -79,6 +80,38 @@ impl CompilerConfiguration {
 
         (result, self.open_import_callback)
     }
+}
+
+/// One resolved entry of a `navigator` route table: which destination
+/// component a route enum value maps to, plus where that component is declared.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavigatorRouteEntry {
+    /// The route enum value name, e.g. `Home` for `Route.Home`.
+    pub route_name: String,
+    /// The destination component's name. Empty when the destination did not
+    /// resolve to a component (a diagnostic was already reported).
+    pub destination_component: String,
+    /// Where the destination component is declared. `None` when it did not
+    /// resolve or has no source node.
+    pub destination_uri: Option<Url>,
+    /// Byte offset of the destination component's declaration.
+    pub destination_offset: Option<TextSize>,
+}
+
+/// The authoritative route table for one `navigator`: the component that
+/// declares it (the entry/root) and its resolved routes, in declaration order.
+/// This is the compiler-resolved route -> destination mapping. It is not the
+/// screen-to-screen edge graph, which the flow-map derives separately.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavigatorTable {
+    /// The component that declares the `navigator`.
+    pub entry_component: String,
+    /// Where that component is declared.
+    pub entry_uri: Option<Url>,
+    /// Byte offset of the entry component's declaration.
+    pub entry_offset: Option<TextSize>,
+    /// The resolved routes, in declaration order.
+    pub routes: Vec<NavigatorRouteEntry>,
 }
 
 /// A cache of loaded documents
@@ -480,6 +513,96 @@ impl DocumentCache {
     pub fn all_paths_to_watch(&self) -> HashSet<PathBuf> {
         self.type_loader.all_files_to_watch()
     }
+
+    /// Return the navigator route tables declared in `text_document_uri`.
+    ///
+    /// For every component that contains a `navigator`, this yields its
+    /// entry/root and the compiler-resolved route table: each route enum value
+    /// mapped to its destination component and that component's location. This
+    /// is the authoritative route -> screen mapping only. It is not the
+    /// screen-to-screen edge graph, which the flow-map derives separately from
+    /// assignment detection.
+    ///
+    /// Reuses the `inner_components` walk that `element_at_document_and_offset`
+    /// relies on, so it sees the same un-inlined object tree.
+    pub fn navigator_tables(&self, text_document_uri: &Url) -> Vec<NavigatorTable> {
+        // Location of a component's declaration, from its source node.
+        fn component_location(
+            node: &Option<syntax_nodes::Component>,
+        ) -> (Option<Url>, Option<TextSize>) {
+            let Some(node) = node else { return (None, None) };
+            match file_to_uri(node.source_file.path()) {
+                Some(uri) => (Some(uri), Some(node.text_range().start())),
+                None => (None, None),
+            }
+        }
+
+        // Collect elements holding a navigator route table. A navigator is
+        // usually on the root element, but may be nested, so walk children too.
+        fn collect(element: &ElementRc, out: &mut Vec<ElementRc>) {
+            let elem = element.borrow();
+            if !elem.navigator_routes().is_empty() {
+                out.push(element.clone());
+            }
+            for child in &elem.children {
+                collect(child, out);
+            }
+        }
+
+        let Some(document) = self.get_document(text_document_uri) else {
+            return Vec::new();
+        };
+
+        let mut tables = Vec::new();
+        for component in &document.inner_components {
+            let mut navigator_elements = Vec::new();
+            collect(&component.root_element, &mut navigator_elements);
+            if navigator_elements.is_empty() {
+                continue;
+            }
+
+            let (entry_uri, entry_offset) = component_location(&component.node);
+            for element in &navigator_elements {
+                let element = element.borrow();
+                let routes = element
+                    .navigator_routes()
+                    .iter()
+                    .map(|route| {
+                        // The last segment of the qualified enum value, e.g.
+                        // `Home` from `Route.Home`.
+                        let route_name = route
+                            .route
+                            .text()
+                            .to_string()
+                            .rsplit('.')
+                            .next()
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string();
+                        let destination = route.component.borrow();
+                        let (destination_component, dest_node) = match &destination.base_type {
+                            ElementType::Component(c) => (c.id.to_string(), c.node.clone()),
+                            _ => (String::new(), None),
+                        };
+                        let (destination_uri, destination_offset) = component_location(&dest_node);
+                        NavigatorRouteEntry {
+                            route_name,
+                            destination_component,
+                            destination_uri,
+                            destination_offset,
+                        }
+                    })
+                    .collect();
+                tables.push(NavigatorTable {
+                    entry_component: component.id.to_string(),
+                    entry_uri: entry_uri.clone(),
+                    entry_offset,
+                    routes,
+                });
+            }
+        }
+        tables
+    }
 }
 
 #[cfg(test)]
@@ -558,5 +681,63 @@ mod tests {
         assert_eq!(base_type_at_position(&dc, &url, 27, 4), Some("VerticalBox".to_string()));
         assert_eq!(base_type_at_position(&dc, &url, 28, 8), Some("Text".to_string()));
         assert_eq!(base_type_at_position(&dc, &url, 51, 4), Some("VerticalBox".to_string()));
+    }
+
+    #[test]
+    fn test_navigator_tables() {
+        use i_slint_compiler::diagnostics::BuildDiagnostics;
+
+        // A component that declares a navigator over two routes, each resolving
+        // to a component in the same document.
+        let content = r#"
+enum Route { A, B }
+component A inherits Rectangle { }
+component B inherits Rectangle { }
+export component App inherits Window {
+    in-out property <Route> current-route: Route.A;
+    navigator (current-route) {
+        Route.A: A { }
+        Route.B: B { }
+    }
+}
+"#;
+
+        let mut dc = crate::language::test::empty_document_cache_with_experimental();
+        spin_on::spin_on(dc.preload_builtins());
+        let path =
+            if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
+        let url = Url::from_file_path(path).unwrap();
+
+        // The type-loader load path does not derive the experimental flag from
+        // the compiler config, so set it on the diagnostics to compile the
+        // experimental `navigator`.
+        let mut diag = BuildDiagnostics::default();
+        diag.enable_experimental = true;
+        let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
+        assert!(
+            !diag.has_errors(),
+            "unexpected errors: {:?}",
+            diag.iter().map(|d| d.message().to_string()).collect::<Vec<_>>()
+        );
+
+        let tables = dc.navigator_tables(&url);
+        assert_eq!(tables.len(), 1, "expected exactly one navigator table");
+        let table = &tables[0];
+        assert_eq!(table.entry_component, "App");
+        assert_eq!(table.entry_uri.as_ref(), Some(&url));
+
+        // The authoritative route table: Route.A -> A, Route.B -> B, in order.
+        let routes: Vec<(&str, &str)> = table
+            .routes
+            .iter()
+            .map(|r| (r.route_name.as_str(), r.destination_component.as_str()))
+            .collect();
+        assert_eq!(routes, vec![("A", "A"), ("B", "B")]);
+
+        // Destinations point at real declarations in this document.
+        for route in &table.routes {
+            assert_eq!(route.destination_uri.as_ref(), Some(&url));
+            assert!(route.destination_offset.is_some(), "missing offset for {}", route.route_name);
+        }
     }
 }

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -82,33 +82,22 @@ impl CompilerConfiguration {
     }
 }
 
-/// One resolved entry of a `navigator` route table: which destination
-/// component a route enum value maps to, plus where that component is declared.
+/// One resolved entry of a `navigator` route table.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NavigatorRouteEntry {
     /// The route enum value name, e.g. `Home` for `Route.Home`.
     pub route_name: String,
-    /// The destination component's name. Empty when the destination did not
-    /// resolve to a component (a diagnostic was already reported).
+    /// Empty when the destination did not resolve to a component.
     pub destination_component: String,
-    /// Where the destination component is declared. `None` when it did not
-    /// resolve or has no source node.
     pub destination_uri: Option<Url>,
-    /// Byte offset of the destination component's declaration.
     pub destination_offset: Option<TextSize>,
 }
 
-/// The authoritative route table for one `navigator`: the component that
-/// declares it (the entry/root) and its resolved routes, in declaration order.
-/// This is the compiler-resolved route -> destination mapping. It is not the
-/// screen-to-screen edge graph, which the flow-map derives separately.
+/// The resolved route table for one `navigator`: the declaring component and its routes.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NavigatorTable {
-    /// The component that declares the `navigator`.
     pub entry_component: String,
-    /// Where that component is declared.
     pub entry_uri: Option<Url>,
-    /// Byte offset of the entry component's declaration.
     pub entry_offset: Option<TextSize>,
     /// The resolved routes, in declaration order.
     pub routes: Vec<NavigatorRouteEntry>,
@@ -514,19 +503,11 @@ impl DocumentCache {
         self.type_loader.all_files_to_watch()
     }
 
-    /// Return the navigator route tables declared in `text_document_uri`.
+    /// Return the resolved navigator route tables declared in `text_document_uri`.
     ///
-    /// For every component that contains a `navigator`, this yields its
-    /// entry/root and the compiler-resolved route table: each route enum value
-    /// mapped to its destination component and that component's location. This
-    /// is the authoritative route -> screen mapping only. It is not the
-    /// screen-to-screen edge graph, which the flow-map derives separately from
-    /// assignment detection.
-    ///
-    /// Reuses the `inner_components` walk that `element_at_document_and_offset`
-    /// relies on, so it sees the same un-inlined object tree.
+    /// Walks `inner_components` so it sees the same un-inlined object tree as
+    /// `element_at_document_and_offset`.
     pub fn navigator_tables(&self, text_document_uri: &Url) -> Vec<NavigatorTable> {
-        // Location of a component's declaration, from its source node.
         fn component_location(
             node: &Option<syntax_nodes::Component>,
         ) -> (Option<Url>, Option<TextSize>) {
@@ -537,8 +518,7 @@ impl DocumentCache {
             }
         }
 
-        // Collect elements holding a navigator route table. A navigator is
-        // usually on the root element, but may be nested, so walk children too.
+        // A navigator may be nested below the root, so walk children too.
         fn collect(element: &ElementRc, out: &mut Vec<ElementRc>) {
             let elem = element.borrow();
             if !elem.navigator_routes().is_empty() {
@@ -568,8 +548,6 @@ impl DocumentCache {
                     .navigator_routes()
                     .iter()
                     .map(|route| {
-                        // The last segment of the qualified enum value, e.g.
-                        // `Home` from `Route.Home`.
                         let route_name = route
                             .route
                             .text()
@@ -687,8 +665,6 @@ mod tests {
     fn test_navigator_tables() {
         use i_slint_compiler::diagnostics::BuildDiagnostics;
 
-        // A component that declares a navigator over two routes, each resolving
-        // to a component in the same document.
         let content = r#"
 enum Route { A, B }
 component A inherits Rectangle { }
@@ -708,13 +684,11 @@ export component App inherits Window {
             if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
         let url = Url::from_file_path(path).unwrap();
 
-        // The normal load path derives the experimental flag from the compiler
-        // config (enabled by empty_document_cache_experimental), so a default
-        // BuildDiagnostics is enough to compile the experimental `navigator`.
+        // The load path derives the experimental flag from the compiler config,
+        // so a default BuildDiagnostics compiles the experimental `navigator`.
         let mut diag = BuildDiagnostics::default();
         assert!(!diag.enable_experimental, "the diag must start without the flag");
         let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
-        // Proof the load path propagated the config flag onto the diagnostics.
         assert!(diag.enable_experimental, "load path did not propagate enable_experimental");
         assert!(
             !diag.has_errors(),
@@ -728,7 +702,6 @@ export component App inherits Window {
         assert_eq!(table.entry_component, "App");
         assert_eq!(table.entry_uri.as_ref(), Some(&url));
 
-        // The authoritative route table: Route.A -> A, Route.B -> B, in order.
         let routes: Vec<(&str, &str)> = table
             .routes
             .iter()
@@ -736,7 +709,6 @@ export component App inherits Window {
             .collect();
         assert_eq!(routes, vec![("A", "A"), ("B", "B")]);
 
-        // Destinations point at real declarations in this document.
         for route in &table.routes {
             assert_eq!(route.destination_uri.as_ref(), Some(&url));
             assert!(route.destination_offset.is_some(), "missing offset for {}", route.route_name);

--- a/ui-libraries/material/Cargo.toml
+++ b/ui-libraries/material/Cargo.toml
@@ -11,7 +11,7 @@
 # artifacts are reused. Developers working on the material library can load
 # both workspaces at once via `rust-analyzer.linkedProjects`.
 [workspace]
-members = ['examples/gallery']
+members = ['examples/gallery', 'examples/navigation']
 
 resolver = "3"
 

--- a/ui-libraries/material/examples/navigation/Cargo.toml
+++ b/ui-libraries/material/examples/navigation/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+# PR A8b: proves Material's navigation chrome binds to the experimental
+# `navigator` construct. `navigator` is experimental, so the compile is enabled
+# via build.rs (see there); no change to Material's int-based API is required.
+[package]
+name = "material-navigation"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+publish = false
+license.workspace = true
+
+[[bin]]
+path = "src/main.rs"
+name = "material-navigation"
+
+[dependencies]
+slint = { path = "../../../../api/rs/slint", features = ["renderer-skia"] }
+
+[build-dependencies]
+slint-build = { path = "../../../../api/rs/build" }

--- a/ui-libraries/material/examples/navigation/Cargo.toml
+++ b/ui-libraries/material/examples/navigation/Cargo.toml
@@ -1,9 +1,6 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: MIT
 
-# PR A8b: proves Material's navigation chrome binds to the experimental
-# `navigator` construct. `navigator` is experimental, so the compile is enabled
-# via build.rs (see there); no change to Material's int-based API is required.
 [package]
 name = "material-navigation"
 version.workspace = true

--- a/ui-libraries/material/examples/navigation/build.rs
+++ b/ui-libraries/material/examples/navigation/build.rs
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    // The `navigator` construct is experimental. slint-build has no typed setter
+    // for it, but `CompilerConfiguration::new()` reads this env var, and the
+    // compile runs in this same build-script process, so setting it here enables
+    // experimental for exactly this crate's `.slint` compile. Edition 2024 makes
+    // `set_var` unsafe; it is sound here because the build script is still
+    // single-threaded when this runs.
+    unsafe {
+        std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
+    }
+    slint_build::compile("ui/app.slint").expect("Slint build failed");
+}

--- a/ui-libraries/material/examples/navigation/build.rs
+++ b/ui-libraries/material/examples/navigation/build.rs
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 fn main() {
-    // The `navigator` construct is experimental. slint-build has no typed setter
-    // for it, but `CompilerConfiguration::new()` reads this env var, and the
-    // compile runs in this same build-script process, so setting it here enables
-    // experimental for exactly this crate's `.slint` compile. Edition 2024 makes
-    // `set_var` unsafe; it is sound here because the build script is still
-    // single-threaded when this runs.
     unsafe {
         std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
     }

--- a/ui-libraries/material/examples/navigation/src/main.rs
+++ b/ui-libraries/material/examples/navigation/src/main.rs
@@ -1,21 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-// PR A8b acceptance: ONE route model (the `navigator { Route... }` block in
-// app.slint) drives Material's int-index chrome through the adapter. Material's
-// `BaseNavigation` int API is untouched; the binding lives here, in the two
-// lines that connect the bar to `navigate-index` / `current-route-index`.
-
 slint::include_modules!();
 
 fn main() -> Result<(), slint::PlatformError> {
     let app = App::new()?;
 
-    // Bind Material's chrome to the navigator adapter:
-    //   index_changed(i) => navigate-index(i)   (the tap navigates)
-    //   current_index    <- current-route-index (the bar reflects the route)
-    // Both bar taps and in-screen buttons funnel through `request-index`, so
-    // every navigation goes through the adapter and the bar stays in sync.
     let weak = app.as_weak();
     app.on_request_index(move |index| {
         let app = weak.unwrap();
@@ -23,7 +13,6 @@ fn main() -> Result<(), slint::PlatformError> {
         app.set_bar_index(app.get_current_route_index());
     });
 
-    // Initial sync: the bar starts on whatever route the navigator starts on.
     app.set_bar_index(app.get_current_route_index());
 
     app.run()

--- a/ui-libraries/material/examples/navigation/src/main.rs
+++ b/ui-libraries/material/examples/navigation/src/main.rs
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// PR A8b acceptance: ONE route model (the `navigator { Route... }` block in
+// app.slint) drives Material's int-index chrome through the adapter. Material's
+// `BaseNavigation` int API is untouched; the binding lives here, in the two
+// lines that connect the bar to `navigate-index` / `current-route-index`.
+
+slint::include_modules!();
+
+fn main() -> Result<(), slint::PlatformError> {
+    let app = App::new()?;
+
+    // Bind Material's chrome to the navigator adapter:
+    //   index_changed(i) => navigate-index(i)   (the tap navigates)
+    //   current_index    <- current-route-index (the bar reflects the route)
+    // Both bar taps and in-screen buttons funnel through `request-index`, so
+    // every navigation goes through the adapter and the bar stays in sync.
+    let weak = app.as_weak();
+    app.on_request_index(move |index| {
+        let app = weak.unwrap();
+        app.invoke_navigate_index(index);
+        app.set_bar_index(app.get_current_route_index());
+    });
+
+    // Initial sync: the bar starts on whatever route the navigator starts on.
+    app.set_bar_index(app.get_current_route_index());
+
+    app.run()
+}

--- a/ui-libraries/material/examples/navigation/ui/app.slint
+++ b/ui-libraries/material/examples/navigation/ui/app.slint
@@ -1,0 +1,92 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// PR A8b: bind Material's int-index navigation chrome to the `navigator`
+// construct through its adapter. Material's `NavigationBar` (int `current_index`
+// / `index_changed`) is unchanged; only what feeds it changes. The SAME
+// `navigator { Route... }` block would drive std-widgets chrome (PR A8) with no
+// change to the route declarations, because both bind the same two adapter
+// members: `current-route-index` and `navigate-index`.
+
+import { MaterialWindow, NavigationBar, FilledButton, MaterialText } from "../../../src/material.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px; // leave room for the pinned NavigationBar
+        MaterialText { text: "Home"; horizontal-alignment: center; }
+        FilledButton { text: "Go to Details"; clicked => { root.go(1); } }
+        FilledButton { text: "Open Settings"; clicked => { root.go(2); } }
+    }
+}
+
+component DetailsScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px;
+        MaterialText { text: "Details"; horizontal-alignment: center; }
+        FilledButton { text: "Back to Home"; clicked => { root.go(0); } }
+    }
+}
+
+component SettingsScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px;
+        MaterialText { text: "Settings"; horizontal-alignment: center; }
+        FilledButton { text: "Back to Home"; clicked => { root.go(0); } }
+    }
+}
+
+export component App inherits MaterialWindow {
+    preferred-width: 400px;
+    preferred-height: 640px;
+    title: "Slint Navigation - Material";
+
+    // The navigator's route property (the adapter's enum target).
+    in-out property <Route> current-route: Route.Home;
+
+    // Mirror of the adapter's `current-route-index`. Rust keeps this in sync
+    // after every navigation; the bar's `current_index` binds to it below.
+    in-out property <int> bar-index;
+
+    // Every navigation request funnels here so Rust routes it through the
+    // adapter's `navigate-index`. Bar taps and in-screen buttons both call it.
+    callback request-index(index: int);
+
+    // The route model: one destination per route, in declaration order. This is
+    // the presentation-agnostic surface; swapping the chrome below never touches it.
+    navigator (current-route) {
+        Route.Home: HomeScreen { go(i) => { root.request-index(i); } }
+        Route.Details: DetailsScreen { go(i) => { root.request-index(i); } }
+        Route.Settings: SettingsScreen { go(i) => { root.request-index(i); } }
+    }
+
+    // Material's int-index chrome, one item per route in declaration order.
+    NavigationBar {
+        y: root.height - self.height;
+        width: 100%;
+        items: [
+            { text: "Home" },
+            { text: "Details" },
+            { text: "Settings" },
+        ];
+        // Display: the bar reflects the current route (via current-route-index).
+        current_index: root.bar-index;
+        // Tap: navigating the bar navigates the route (via navigate-index).
+        index_changed(i) => { root.request-index(i); }
+    }
+}

--- a/ui-libraries/material/examples/navigation/ui/app.slint
+++ b/ui-libraries/material/examples/navigation/ui/app.slint
@@ -1,16 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-// PR A8b: bind Material's int-index navigation chrome to the `navigator`
-// construct through its adapter. Material's `NavigationBar` (int `current_index`
-// / `index_changed`) is unchanged; only what feeds it changes. The SAME
-// `navigator { Route... }` block would drive std-widgets chrome (PR A8) with no
-// change to the route declarations, because both bind the same two adapter
-// members: `current-route-index` and `navigate-index`.
-
 import { MaterialWindow, NavigationBar, FilledButton, MaterialText } from "../../../src/material.slint";
 
-// The navigation convention: one enum value per screen.
 enum Route {
     Home,
     Details,
@@ -22,7 +14,7 @@ component HomeScreen inherits Rectangle {
     VerticalLayout {
         alignment: center;
         spacing: 12px;
-        padding-bottom: 96px; // leave room for the pinned NavigationBar
+        padding-bottom: 96px;
         MaterialText { text: "Home"; horizontal-alignment: center; }
         FilledButton { text: "Go to Details"; clicked => { root.go(1); } }
         FilledButton { text: "Open Settings"; clicked => { root.go(2); } }
@@ -56,26 +48,18 @@ export component App inherits MaterialWindow {
     preferred-height: 640px;
     title: "Slint Navigation - Material";
 
-    // The navigator's route property (the adapter's enum target).
     in-out property <Route> current-route: Route.Home;
 
-    // Mirror of the adapter's `current-route-index`. Rust keeps this in sync
-    // after every navigation; the bar's `current_index` binds to it below.
     in-out property <int> bar-index;
 
-    // Every navigation request funnels here so Rust routes it through the
-    // adapter's `navigate-index`. Bar taps and in-screen buttons both call it.
     callback request-index(index: int);
 
-    // The route model: one destination per route, in declaration order. This is
-    // the presentation-agnostic surface; swapping the chrome below never touches it.
     navigator (current-route) {
         Route.Home: HomeScreen { go(i) => { root.request-index(i); } }
         Route.Details: DetailsScreen { go(i) => { root.request-index(i); } }
         Route.Settings: SettingsScreen { go(i) => { root.request-index(i); } }
     }
 
-    // Material's int-index chrome, one item per route in declaration order.
     NavigationBar {
         y: root.height - self.height;
         width: 100%;
@@ -84,9 +68,7 @@ export component App inherits MaterialWindow {
             { text: "Details" },
             { text: "Settings" },
         ];
-        // Display: the bar reflects the current route (via current-route-index).
         current_index: root.bar-index;
-        // Tap: navigating the bar navigates the route (via navigate-index).
         index_changed(i) => { root.request-index(i); }
     }
 }


### PR DESCRIPTION
An experimental, declarative **`navigator`** construct: model a multi-screen app
as a compiler-resolved route table, with a history API and an integer adapter for
position-based chrome. Behind the experimental-features gate.

## Basic navigation

An `enum` of screens, a `current-route` property, and a `navigator` block that
maps each route to its screen. The navigator adds `navigate(route)`, `back()`,
and `can-go-back` to the declaring component.

```slint
enum Route { Home, Details }

component HomeScreen inherits VerticalBox {
    callback open-details();
    Button { text: "Details"; clicked => { root.open-details(); } }
}

component DetailsScreen inherits VerticalBox {
    in property <bool> can-go-back;
    callback go-back();
    Button { text: "Back"; enabled: can-go-back; clicked => { root.go-back(); } }
}

export component App inherits Window {
    in-out property <Route> current-route: Route.Home;

    navigator (current-route) {
        Route.Home: HomeScreen {
            open-details => { root.navigate(Route.Details); }
        }
        Route.Details: DetailsScreen {
            can-go-back: root.can-go-back;
            go-back => { root.back(); }
        }
    }
}
```

The route enum is a closed set, so a mistyped route is a compile error. Only the
current route's screen is instantiated.

## Position-based chrome (tab bars, segmented controls)

The same `navigator` also exposes an integer view, so presentation that works by
position drives it without knowing the route enum:

```slint
// bind a tab bar to the adapter:
//   current_index : current-route-index
//   selected(i)   => navigate-index(i)
```

Runnable: `examples/navigation-std` (std-widgets) and the Material example bind a
tab bar to this adapter with no change to the route declarations.

## Tooling

The compiler-resolved route table is exposed through the LSP document cache, so a
tool (for example a screen-flow map) can read the navigation graph straight from
source, checked at compile time.

## Notes

- **Experimental:** build with `SLINT_ENABLE_EXPERIMENTAL_FEATURES=1`.
- **Docs:** guide page *Navigation* (Guide > App Development); runnable
  `examples/navigation` and `examples/navigation-std`.
- **Language bindings:** `tests/cases/navigation` exercises the navigator members
  and is green in the Rust, C++, JavaScript, and Python drivers.
- **Tests:** parser + syntax fixtures, and interpreter tests for render-by-route,
  the back-stack, the index adapter, and presentation binding.
