### PR TITLE
navigation: expose the route table to tooling + a route/int-index adapter

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1150,6 +1150,16 @@ pub struct NavigatorRoute {
     pub component: ElementRc,
 }
 
+impl Element {
+    /// Read-only view of the resolved `navigator` route table declared on this
+    /// element, in declaration order (empty when there is no `navigator`).
+    /// Provided as an accessor so tooling reads the authoritative table without
+    /// touching the lowering in `from_navigator_node`.
+    pub fn navigator_routes(&self) -> &[NavigatorRoute] {
+        &self.navigator_routes
+    }
+}
+
 pub type ElementRc = Rc<RefCell<Element>>;
 pub type ElementWeak = Weak<RefCell<Element>>;
 

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -140,6 +140,60 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
 
     let can_go_back = non_empty();
 
+    // Int-index adapter for chrome that speaks `current_index: int` /
+    // `index_changed(int)` rather than the route enum. Each route case's
+    // resolved model is `route_ref == Route.X`, so its rhs is that route's enum
+    // value; collected in declaration order these map ordinal <-> route.
+    let route_values: Vec<Expression> = elem
+        .borrow()
+        .navigator_routes
+        .iter()
+        .filter_map(|r| {
+            match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
+                Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
+                _ => None,
+            }
+        })
+        .collect();
+
+    // current-route-index: ordinal of the current route, else -1. Lowered as an
+    // if-chain `current == route0 ? 0 : current == route1 ? 1 : ... : -1`.
+    let current_route_index = route_values.iter().enumerate().rev().fold(
+        Expression::NumberLiteral(-1., Unit::None),
+        |otherwise, (i, route_value)| Expression::Condition {
+            condition: Box::new(Expression::BinaryExpression {
+                lhs: Box::new(route_ref.clone()),
+                rhs: Box::new(route_value.clone()),
+                op: '=',
+            }),
+            true_expr: Box::new(Expression::NumberLiteral(i as f64, Unit::None)),
+            false_expr: Box::new(otherwise),
+        },
+    );
+
+    // navigate-index(index): navigate to the route at that ordinal using the same
+    // push-then-set logic as navigate(); an out-of-range index is a no-op.
+    let index_param = || Expression::FunctionParameterReference { index: 0, ty: Type::Int32 };
+    let navigate_index_body = route_values.iter().enumerate().rev().fold(
+        Expression::CodeBlock(vec![]),
+        |otherwise, (i, route_value)| Expression::Condition {
+            condition: Box::new(Expression::BinaryExpression {
+                lhs: Box::new(index_param()),
+                rhs: Box::new(Expression::NumberLiteral(i as f64, Unit::None)),
+                op: '=',
+            }),
+            true_expr: Box::new(Expression::CodeBlock(vec![
+                Expression::FunctionCall {
+                    function: Callable::Builtin(BuiltinFunction::ArrayPush),
+                    arguments: vec![back_stack(), route_ref.clone()],
+                    source_location: None,
+                },
+                assign_route(route_value.clone()),
+            ])),
+            false_expr: Box::new(otherwise),
+        },
+    );
+
     let mut e = elem.borrow_mut();
     e.property_declarations.insert(
         SmolStr::new_static("navigate"),
@@ -185,4 +239,35 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
     e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
+
+    e.property_declarations.insert(
+        SmolStr::new_static("current-route-index"),
+        PropertyDeclaration {
+            property_type: Type::Int32,
+            visibility: PropertyVisibility::Output,
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(
+        SmolStr::new_static("current-route-index"),
+        RefCell::new(current_route_index.into()),
+    );
+
+    e.property_declarations.insert(
+        SmolStr::new_static("navigate-index"),
+        PropertyDeclaration {
+            property_type: Type::Function(Rc::new(Function {
+                return_type: Type::Void,
+                args: vec![Type::Int32],
+                arg_names: vec![SmolStr::new_static("index")],
+            })),
+            visibility: PropertyVisibility::Public,
+            pure: Some(false),
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings
+        .insert(SmolStr::new_static("navigate-index"), RefCell::new(navigate_index_body.into()));
 }

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -140,7 +140,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
 
     let can_go_back = non_empty();
 
-    // Int-index adapter for chrome that speaks `current_index: int` /
+    // Int-index adapter that relies on `current_index: int` /
     // `index_changed(int)` rather than the route enum. Each route case's
     // resolved model is `route_ref == Route.X`, so its rhs is that route's enum
     // value; collected in declaration order these map ordinal <-> route.

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -444,3 +444,79 @@ export component TestCase inherits Window {
     assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "no-op at root");
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "still root");
 }
+
+// The int-index adapter: `current-route-index` reports the ordinal of the
+// current route in declaration order, and `navigate-index(i)` navigates to the
+// route at that ordinal. This is what int-index chrome (current_index /
+// index_changed) binds to, so it must agree with the route enum both ways.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_index_adapter() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let index = |instance: &crate::ComponentInstance| {
+        i_slint_backend_testing::mock_elapsed_time(100);
+        instance.get_property("current-route-index").unwrap()
+    };
+
+    // Setting the route enum drives current-route-index to the declared ordinal.
+    assert_eq!(index(&instance), Value::from(0.), "Home is ordinal 0");
+    instance.set_property("current-route", route("Details")).unwrap();
+    assert_eq!(index(&instance), Value::from(1.), "Details is ordinal 1");
+    instance.set_property("current-route", route("Settings")).unwrap();
+    assert_eq!(index(&instance), Value::from(2.), "Settings is ordinal 2");
+
+    // navigate-index(i) drives the route enum the other way (and the index with it).
+    instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "navigate-index(2) selects Settings"
+    );
+    assert_eq!(index(&instance), Value::from(2.));
+
+    instance.invoke("navigate-index", &[Value::from(0.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "navigate-index(0) selects Home"
+    );
+    assert_eq!(index(&instance), Value::from(0.));
+
+    // Out-of-range is a no-op: the route (and index) stay put.
+    instance.invoke("navigate-index", &[Value::from(9.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "out-of-range navigate-index is a no-op"
+    );
+    assert_eq!(index(&instance), Value::from(0.));
+}

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -4,7 +4,8 @@
 //! Data structures common between LSP and previewer
 
 use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile};
-use i_slint_compiler::object_tree::Document;
+use i_slint_compiler::langtype::ElementType;
+use i_slint_compiler::object_tree::{Document, ElementRc};
 use i_slint_compiler::parser::{TextSize, syntax_nodes};
 use i_slint_compiler::typeloader::TypeLoader;
 use i_slint_compiler::typeregister::TypeRegister;
@@ -79,6 +80,38 @@ impl CompilerConfiguration {
 
         (result, self.open_import_callback)
     }
+}
+
+/// One resolved entry of a `navigator` route table: which destination
+/// component a route enum value maps to, plus where that component is declared.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavigatorRouteEntry {
+    /// The route enum value name, e.g. `Home` for `Route.Home`.
+    pub route_name: String,
+    /// The destination component's name. Empty when the destination did not
+    /// resolve to a component (a diagnostic was already reported).
+    pub destination_component: String,
+    /// Where the destination component is declared. `None` when it did not
+    /// resolve or has no source node.
+    pub destination_uri: Option<Url>,
+    /// Byte offset of the destination component's declaration.
+    pub destination_offset: Option<TextSize>,
+}
+
+/// The authoritative route table for one `navigator`: the component that
+/// declares it (the entry/root) and its resolved routes, in declaration order.
+/// This is the compiler-resolved route -> destination mapping. It is not the
+/// screen-to-screen edge graph, which the flow-map derives separately.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavigatorTable {
+    /// The component that declares the `navigator`.
+    pub entry_component: String,
+    /// Where that component is declared.
+    pub entry_uri: Option<Url>,
+    /// Byte offset of the entry component's declaration.
+    pub entry_offset: Option<TextSize>,
+    /// The resolved routes, in declaration order.
+    pub routes: Vec<NavigatorRouteEntry>,
 }
 
 /// A cache of loaded documents
@@ -480,6 +513,96 @@ impl DocumentCache {
     pub fn all_paths_to_watch(&self) -> HashSet<PathBuf> {
         self.type_loader.all_files_to_watch()
     }
+
+    /// Return the navigator route tables declared in `text_document_uri`.
+    ///
+    /// For every component that contains a `navigator`, this yields its
+    /// entry/root and the compiler-resolved route table: each route enum value
+    /// mapped to its destination component and that component's location. This
+    /// is the authoritative route -> screen mapping only. It is not the
+    /// screen-to-screen edge graph, which the flow-map derives separately from
+    /// assignment detection.
+    ///
+    /// Reuses the `inner_components` walk that `element_at_document_and_offset`
+    /// relies on, so it sees the same un-inlined object tree.
+    pub fn navigator_tables(&self, text_document_uri: &Url) -> Vec<NavigatorTable> {
+        // Location of a component's declaration, from its source node.
+        fn component_location(
+            node: &Option<syntax_nodes::Component>,
+        ) -> (Option<Url>, Option<TextSize>) {
+            let Some(node) = node else { return (None, None) };
+            match file_to_uri(node.source_file.path()) {
+                Some(uri) => (Some(uri), Some(node.text_range().start())),
+                None => (None, None),
+            }
+        }
+
+        // Collect elements holding a navigator route table. A navigator is
+        // usually on the root element, but may be nested, so walk children too.
+        fn collect(element: &ElementRc, out: &mut Vec<ElementRc>) {
+            let elem = element.borrow();
+            if !elem.navigator_routes().is_empty() {
+                out.push(element.clone());
+            }
+            for child in &elem.children {
+                collect(child, out);
+            }
+        }
+
+        let Some(document) = self.get_document(text_document_uri) else {
+            return Vec::new();
+        };
+
+        let mut tables = Vec::new();
+        for component in &document.inner_components {
+            let mut navigator_elements = Vec::new();
+            collect(&component.root_element, &mut navigator_elements);
+            if navigator_elements.is_empty() {
+                continue;
+            }
+
+            let (entry_uri, entry_offset) = component_location(&component.node);
+            for element in &navigator_elements {
+                let element = element.borrow();
+                let routes = element
+                    .navigator_routes()
+                    .iter()
+                    .map(|route| {
+                        // The last segment of the qualified enum value, e.g.
+                        // `Home` from `Route.Home`.
+                        let route_name = route
+                            .route
+                            .text()
+                            .to_string()
+                            .rsplit('.')
+                            .next()
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string();
+                        let destination = route.component.borrow();
+                        let (destination_component, dest_node) = match &destination.base_type {
+                            ElementType::Component(c) => (c.id.to_string(), c.node.clone()),
+                            _ => (String::new(), None),
+                        };
+                        let (destination_uri, destination_offset) = component_location(&dest_node);
+                        NavigatorRouteEntry {
+                            route_name,
+                            destination_component,
+                            destination_uri,
+                            destination_offset,
+                        }
+                    })
+                    .collect();
+                tables.push(NavigatorTable {
+                    entry_component: component.id.to_string(),
+                    entry_uri: entry_uri.clone(),
+                    entry_offset,
+                    routes,
+                });
+            }
+        }
+        tables
+    }
 }
 
 #[cfg(test)]
@@ -558,5 +681,63 @@ mod tests {
         assert_eq!(base_type_at_position(&dc, &url, 27, 4), Some("VerticalBox".to_string()));
         assert_eq!(base_type_at_position(&dc, &url, 28, 8), Some("Text".to_string()));
         assert_eq!(base_type_at_position(&dc, &url, 51, 4), Some("VerticalBox".to_string()));
+    }
+
+    #[test]
+    fn test_navigator_tables() {
+        use i_slint_compiler::diagnostics::BuildDiagnostics;
+
+        // A component that declares a navigator over two routes, each resolving
+        // to a component in the same document.
+        let content = r#"
+enum Route { A, B }
+component A inherits Rectangle { }
+component B inherits Rectangle { }
+export component App inherits Window {
+    in-out property <Route> current-route: Route.A;
+    navigator (current-route) {
+        Route.A: A { }
+        Route.B: B { }
+    }
+}
+"#;
+
+        let mut dc = crate::language::test::empty_document_cache_experimental();
+        spin_on::spin_on(dc.preload_builtins());
+        let path =
+            if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
+        let url = Url::from_file_path(path).unwrap();
+
+        // The type-loader load path does not derive the experimental flag from
+        // the compiler config, so set it on the diagnostics to compile the
+        // experimental `navigator`.
+        let mut diag = BuildDiagnostics::default();
+        diag.enable_experimental = true;
+        let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
+        assert!(
+            !diag.has_errors(),
+            "unexpected errors: {:?}",
+            diag.iter().map(|d| d.message().to_string()).collect::<Vec<_>>()
+        );
+
+        let tables = dc.navigator_tables(&url);
+        assert_eq!(tables.len(), 1, "expected exactly one navigator table");
+        let table = &tables[0];
+        assert_eq!(table.entry_component, "App");
+        assert_eq!(table.entry_uri.as_ref(), Some(&url));
+
+        // The authoritative route table: Route.A -> A, Route.B -> B, in order.
+        let routes: Vec<(&str, &str)> = table
+            .routes
+            .iter()
+            .map(|r| (r.route_name.as_str(), r.destination_component.as_str()))
+            .collect();
+        assert_eq!(routes, vec![("A", "A"), ("B", "B")]);
+
+        // Destinations point at real declarations in this document.
+        for route in &table.routes {
+            assert_eq!(route.destination_uri.as_ref(), Some(&url));
+            assert!(route.destination_offset.is_some(), "missing offset for {}", route.route_name);
+        }
     }
 }

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -49,6 +49,17 @@ pub fn empty_document_cache() -> common::DocumentCache {
     common::DocumentCache::new(config)
 }
 
+/// Create an empty `DocumentCache` with experimental features enabled, so
+/// experimental constructs like `navigator` compile in tests.
+pub fn empty_document_cache_experimental() -> common::DocumentCache {
+    let config = crate::common::document_cache::CompilerConfiguration {
+        style: Some("fluent".to_string()),
+        enable_experimental: true,
+        ..Default::default()
+    };
+    common::DocumentCache::new(config)
+}
+
 /// Create a `DocumentCache` with one document loaded into it.
 pub fn loaded_document_cache(
     content: String,


### PR DESCRIPTION
_Part of stack #12561. Based on #12554._

### Summary
- Expose the compiler-resolved route table through the LSP document cache
- Add a route ↔ integer-index adapter (`current-route-index`, `navigate-index(i)`) so integer-indexed chrome (tab bars, segmented controls) can drive the same navigator.

### What's in it
`object_tree.rs`, `passes/lower_navigator.rs` (the index adapter), `tools/lsp/common/document_cache.rs`(the route-table query), `language/test.rs`.

### Tests
Interpreter tests for the index adapter.

---
_Experimental-gated; additive to `master`. See the stack for the full picture._