### PR TITLE
navigation: std-widgets presentation + Material binding

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -9283,6 +9283,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "navigation-std"
+version = "1.18.0"
+dependencies = [
+ "slint",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   'mcu-board-support',
   'memory',
   'navigation',
+  'navigation-std',
   'native-gestures',
   'opengl_texture',
   'opengl_underlay',

--- a/examples/navigation-std/Cargo.toml
+++ b/examples/navigation-std/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "navigation-std"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+publish = false
+license = "MIT"
+rust-version.workspace = true
+
+[[bin]]
+path = "main.rs"
+name = "navigation-std"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }

--- a/examples/navigation-std/README.md
+++ b/examples/navigation-std/README.md
@@ -1,0 +1,35 @@
+# Navigation (std-widgets)
+
+A multi-screen app whose navigation chrome is built from **std-widgets**, driving
+the experimental `navigator` construct. It pairs with the Material navigation
+example to show one route model behind different widget libraries.
+
+The chrome is a segmented tab bar assembled from a row of std `Button`s (std-widgets
+has no public tab-bar/segmented control). It binds to the navigator's int-index
+adapter:
+
+- the highlighted segment follows `current-route-index`,
+- clicking a segment navigates by ordinal via `navigate-index(index)`.
+
+## Why the wiring lives in `main.rs`
+
+The navigator's int-index adapter (`current-route-index` / `navigate-index`) is
+synthesized *after* expression resolution, so it cannot be referenced from
+`.slint`. The navigator therefore sits on the root `Window`, where its adapter
+members land on the component's public API, and `main.rs` bridges them to the tab
+bar's `current-index` / `selected(int)`.
+
+## Experimental features
+
+`navigator` is experimental. `build.rs` enables it for the `slint!` macro that
+compiles `navigation.slint`:
+
+```rust
+println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+```
+
+Run it with:
+
+```sh
+cargo run -p navigation-std
+```

--- a/examples/navigation-std/build.rs
+++ b/examples/navigation-std/build.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    // The navigator is experimental; enable it for the `slint!` macro that
+    // compiles navigation.slint at build time.
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+}

--- a/examples/navigation-std/main.rs
+++ b/examples/navigation-std/main.rs
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::slint!(export { App } from "navigation.slint";);
+
+pub fn main() {
+    let app = App::new().unwrap();
+
+    // Bridge the std-widgets tab bar to the navigator's int-index adapter. The
+    // adapter lives on the root's public API (current-route-index /
+    // navigate-index) but is synthesized too late to reference from .slint, so
+    // the wiring happens here instead.
+    let weak = app.as_weak();
+    app.on_nav_select(move |index| {
+        let app = weak.unwrap();
+        // A tab click navigates by ordinal ...
+        app.invoke_navigate_index(index);
+        // ... and the highlight follows the resulting current route.
+        app.set_nav_index(app.get_current_route_index());
+    });
+
+    // Seed the highlight from the initial route.
+    app.set_nav_index(app.get_current_route_index());
+
+    app.run().unwrap();
+}

--- a/examples/navigation-std/navigation.slint
+++ b/examples/navigation-std/navigation.slint
@@ -1,0 +1,101 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+// A segmented navigation bar built from std-widgets `Button`s. std-widgets has
+// no public tab-bar/segmented control, so this binds a plain Button row to the
+// navigator's int-index adapter: the highlighted segment follows `current-index`
+// and clicking one asks to navigate by ordinal via `selected`.
+component NavBar inherits HorizontalBox {
+    in property <[string]> titles;
+    in property <int> current-index;
+    callback selected(index: int);
+
+    for title[index] in titles: Button {
+        text: title;
+        // Highlight the active segment; purely driven by current-index.
+        primary: index == root.current-index;
+        clicked => { root.selected(index); }
+    }
+}
+
+component HomeScreen inherits VerticalBox {
+    Text {
+        text: "Home";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+component DetailsScreen inherits VerticalBox {
+    Text {
+        text: "Details";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+component SettingsScreen inherits VerticalBox {
+    Text {
+        text: "Settings";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+export component App inherits Window {
+    preferred-width: 400px;
+    preferred-height: 300px;
+    title: "Slint Navigation (std-widgets)";
+
+    // The current screen. Assigning this property navigates.
+    in-out property <Route> current-route: Route.Home;
+
+    // The navigator's int-index adapter (current-route-index / navigate-index)
+    // is synthesized after expression resolution, so it cannot be referenced
+    // from .slint. main.rs bridges it to these two members instead: it writes
+    // the highlighted segment here and reacts to a selection by ordinal.
+    in property <int> nav-index;
+    callback nav-select(index: int);
+
+    NavBar {
+        x: 0;
+        y: 0;
+        width: root.width;
+        height: 48px;
+        titles: ["Home", "Details", "Settings"];
+        current-index: root.nav-index;
+        selected(index) => { root.nav-select(index); }
+    }
+
+    // The navigator is a direct child of the root Window, so its adapter
+    // members land on the root's public API where main.rs can reach them.
+    navigator (current-route) {
+        Route.Home: HomeScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+        Route.Details: DetailsScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+        Route.Settings: SettingsScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+    }
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -629,3 +629,141 @@ export component TestCase inherits Window {
         "the navigator renders the Settings screen"
     );
 }
+
+// The presentation-agnostic proof: an int-index chrome that mimics Material's
+// `BaseNavigation` (`items` / `current_index` / `index_changed` / `select`)
+// drives the enum-typed navigator through the int-index adapter, both ways.
+// `IntChrome` copies that contract verbatim (only `select` is public so the test
+// can trigger a "tap"; Material's is protected and fired by item clicks). The
+// two adapter members are consumed exactly as native Material wiring would:
+//   current_index  <- current-route-index   (the bar reflects the route)
+//   index_changed(i) => navigate-index(i)    (a tap navigates)
+// Nothing about the `navigator { Route... }` block is chrome-specific, so std
+// chrome (PR A8) binds the same two members with zero change to the routes.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_int_chrome_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// Mirrors Material's BaseNavigation int API (items/current_index/index_changed/select).
+component IntChrome {
+    in property <[string]> items;
+    in-out property <int> current_index;
+    callback index_changed(index: int);
+    public function select(index: int) {
+        if (index < 0 || index >= root.items.length) {
+            return;
+        }
+        root.current_index = index;
+        root.index_changed(index);
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+
+    // Adapter members are synthesized after expression resolution, so they are a
+    // native/runtime surface, not source-referenceable. The test copies
+    // current-route-index into `chrome-index` and forwards index_changed out, then
+    // binds both to the adapter through the runtime API, as native code does.
+    in property <int> chrome-index;
+    out property <int> chrome-index-out: chrome.current_index;
+    callback chrome-index-changed(index: int);
+
+    chrome := IntChrome {
+        items: ["Home", "Details", "Settings"];
+        current_index: root.chrome-index;              // display <- current-route-index
+        index_changed(i) => { root.chrome-index-changed(i); }  // tap forwarded out
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+    // Simulate an item tap (Material fires select() from a NavigationItem click).
+    public function tap(index: int) { chrome.select(index); }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // The tap binding: index_changed(i) => navigate-index(i). Wired once, exactly
+    // as native Material code binds NavigationBar.index_changed to the adapter.
+    let weak = instance.as_weak();
+    instance
+        .set_callback("chrome-index-changed", move |args| {
+            let i: i32 = args[0].clone().try_into().unwrap();
+            weak.unwrap().invoke("navigate-index", &[Value::from(i as f64)]).unwrap();
+            Value::Void
+        })
+        .unwrap();
+
+    // The display binding: current_index <- current-route-index. Pushed after each
+    // route change (native code does the same via set_bar_index).
+    let mirror = |instance: &crate::ComponentInstance| {
+        let idx = instance.get_property("current-route-index").unwrap();
+        instance.set_property("chrome-index", idx).unwrap();
+        settle();
+    };
+
+    // Display side: moving the route moves the chrome's current_index.
+    mirror(&instance);
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "Home -> 0");
+    instance.set_property("current-route", route("Details")).unwrap();
+    mirror(&instance);
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(1.), "Details -> 1");
+    instance.set_property("current-route", route("Settings")).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("chrome-index-out").unwrap(),
+        Value::from(2.),
+        "Settings -> 2"
+    );
+
+    // Tap side: chrome.select(i) fires index_changed -> navigate-index(i) -> route.
+    instance.invoke("tap", &[Value::from(0.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "bar shows 0");
+
+    instance.invoke("tap", &[Value::from(2.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "tap 2 -> Settings"
+    );
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(2.), "bar shows 2");
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings"))
+    );
+
+    // Out-of-range tap is a no-op in the mimic's guard (same as BaseNavigation.select).
+    instance.invoke("tap", &[Value::from(9.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "out-of-range tap is a no-op"
+    );
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -520,3 +520,112 @@ export component TestCase inherits Window {
     );
     assert_eq!(index(&instance), Value::from(0.));
 }
+
+// PR A8: a std-widgets navigation presentation (a Button-row tab bar) driving
+// the navigator through its int-index adapter. The tab bar is a plain std
+// `Button` row that exposes `current-index` / `selected(int)`; the host bridges
+// those to the navigator's `current-route-index` / `navigate-index` (the adapter
+// is synthesized after resolve, so it is reachable from the host rather than
+// from .slint). This guards that the std presentation compiles with the
+// navigator and that both directions of the binding hold: the highlight source
+// follows the current route, and activating a tab moves the current route.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_std_chrome_index_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// The std presentation: a Button row whose active segment follows current-index.
+component NavBar inherits HorizontalBox {
+    in property <[string]> titles;
+    in property <int> current-index;
+    callback selected(index: int);
+    for title[index] in titles: Button {
+        text: title;
+        primary: index == root.current-index;
+        clicked => { root.selected(index); }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    // The chrome inputs the host bridges to the navigator adapter.
+    in property <int> nav-index;
+    callback nav-select(index: int);
+
+    NavBar {
+        titles: ["Home", "Details", "Settings"];
+        current-index: root.nav-index;
+        selected(index) => { root.nav-select(index); }
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // The host feeds the tab bar's highlight from the adapter. Setting the route
+    // (as an in-screen action would) moves current-route-index, which is what
+    // the chrome's current-index binds to.
+    settle();
+    instance.set_property("current-route", route("Details")).unwrap();
+    settle();
+    let highlight = instance.get_property("current-route-index").unwrap();
+    assert_eq!(highlight, Value::from(1.), "highlight source follows the current route");
+    instance.set_property("nav-index", highlight).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("nav-index").unwrap(),
+        Value::from(1.),
+        "the tab bar's current-index reflects the current route"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("details")),
+        "the navigator renders the Details screen"
+    );
+
+    // Activating a tab: the chrome's `selected(int)` is routed to navigate-index,
+    // which moves the current route (and its rendered screen).
+    instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "activating the Settings tab navigates by ordinal"
+    );
+    assert_eq!(
+        instance.get_property("current-route-index").unwrap(),
+        Value::from(2.),
+        "the highlight source moves with the activated tab"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings")),
+        "the navigator renders the Settings screen"
+    );
+}

--- a/ui-libraries/material/Cargo.toml
+++ b/ui-libraries/material/Cargo.toml
@@ -11,7 +11,7 @@
 # artifacts are reused. Developers working on the material library can load
 # both workspaces at once via `rust-analyzer.linkedProjects`.
 [workspace]
-members = ['examples/gallery']
+members = ['examples/gallery', 'examples/navigation']
 
 resolver = "3"
 

--- a/ui-libraries/material/examples/navigation/Cargo.toml
+++ b/ui-libraries/material/examples/navigation/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+# PR A8b: proves Material's navigation chrome binds to the experimental
+# `navigator` construct. `navigator` is experimental, so the compile is enabled
+# via build.rs (see there); no change to Material's int-based API is required.
+[package]
+name = "material-navigation"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+publish = false
+license.workspace = true
+
+[[bin]]
+path = "src/main.rs"
+name = "material-navigation"
+
+[dependencies]
+slint = { path = "../../../../api/rs/slint", features = ["renderer-skia"] }
+
+[build-dependencies]
+slint-build = { path = "../../../../api/rs/build" }

--- a/ui-libraries/material/examples/navigation/build.rs
+++ b/ui-libraries/material/examples/navigation/build.rs
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    // The `navigator` construct is experimental. slint-build has no typed setter
+    // for it, but `CompilerConfiguration::new()` reads this env var, and the
+    // compile runs in this same build-script process, so setting it here enables
+    // experimental for exactly this crate's `.slint` compile. Edition 2024 makes
+    // `set_var` unsafe; it is sound here because the build script is still
+    // single-threaded when this runs.
+    unsafe {
+        std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
+    }
+    slint_build::compile("ui/app.slint").expect("Slint build failed");
+}

--- a/ui-libraries/material/examples/navigation/src/main.rs
+++ b/ui-libraries/material/examples/navigation/src/main.rs
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// PR A8b acceptance: ONE route model (the `navigator { Route... }` block in
+// app.slint) drives Material's int-index chrome through the adapter. Material's
+// `BaseNavigation` int API is untouched; the binding lives here, in the two
+// lines that connect the bar to `navigate-index` / `current-route-index`.
+
+slint::include_modules!();
+
+fn main() -> Result<(), slint::PlatformError> {
+    let app = App::new()?;
+
+    // Bind Material's chrome to the navigator adapter:
+    //   index_changed(i) => navigate-index(i)   (the tap navigates)
+    //   current_index    <- current-route-index (the bar reflects the route)
+    // Both bar taps and in-screen buttons funnel through `request-index`, so
+    // every navigation goes through the adapter and the bar stays in sync.
+    let weak = app.as_weak();
+    app.on_request_index(move |index| {
+        let app = weak.unwrap();
+        app.invoke_navigate_index(index);
+        app.set_bar_index(app.get_current_route_index());
+    });
+
+    // Initial sync: the bar starts on whatever route the navigator starts on.
+    app.set_bar_index(app.get_current_route_index());
+
+    app.run()
+}

--- a/ui-libraries/material/examples/navigation/ui/app.slint
+++ b/ui-libraries/material/examples/navigation/ui/app.slint
@@ -1,0 +1,92 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// PR A8b: bind Material's int-index navigation chrome to the `navigator`
+// construct through its adapter. Material's `NavigationBar` (int `current_index`
+// / `index_changed`) is unchanged; only what feeds it changes. The SAME
+// `navigator { Route... }` block would drive std-widgets chrome (PR A8) with no
+// change to the route declarations, because both bind the same two adapter
+// members: `current-route-index` and `navigate-index`.
+
+import { MaterialWindow, NavigationBar, FilledButton, MaterialText } from "../../../src/material.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px; // leave room for the pinned NavigationBar
+        MaterialText { text: "Home"; horizontal-alignment: center; }
+        FilledButton { text: "Go to Details"; clicked => { root.go(1); } }
+        FilledButton { text: "Open Settings"; clicked => { root.go(2); } }
+    }
+}
+
+component DetailsScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px;
+        MaterialText { text: "Details"; horizontal-alignment: center; }
+        FilledButton { text: "Back to Home"; clicked => { root.go(0); } }
+    }
+}
+
+component SettingsScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px;
+        MaterialText { text: "Settings"; horizontal-alignment: center; }
+        FilledButton { text: "Back to Home"; clicked => { root.go(0); } }
+    }
+}
+
+export component App inherits MaterialWindow {
+    preferred-width: 400px;
+    preferred-height: 640px;
+    title: "Slint Navigation - Material";
+
+    // The navigator's route property (the adapter's enum target).
+    in-out property <Route> current-route: Route.Home;
+
+    // Mirror of the adapter's `current-route-index`. Rust keeps this in sync
+    // after every navigation; the bar's `current_index` binds to it below.
+    in-out property <int> bar-index;
+
+    // Every navigation request funnels here so Rust routes it through the
+    // adapter's `navigate-index`. Bar taps and in-screen buttons both call it.
+    callback request-index(index: int);
+
+    // The route model: one destination per route, in declaration order. This is
+    // the presentation-agnostic surface; swapping the chrome below never touches it.
+    navigator (current-route) {
+        Route.Home: HomeScreen { go(i) => { root.request-index(i); } }
+        Route.Details: DetailsScreen { go(i) => { root.request-index(i); } }
+        Route.Settings: SettingsScreen { go(i) => { root.request-index(i); } }
+    }
+
+    // Material's int-index chrome, one item per route in declaration order.
+    NavigationBar {
+        y: root.height - self.height;
+        width: 100%;
+        items: [
+            { text: "Home" },
+            { text: "Details" },
+            { text: "Settings" },
+        ];
+        // Display: the bar reflects the current route (via current-route-index).
+        current_index: root.bar-index;
+        // Tap: navigating the bar navigates the route (via navigate-index).
+        index_changed(i) => { root.request-index(i); }
+    }
+}


### PR DESCRIPTION
_Part of stack #12561. Based on #12555._

### Summary
Demonstrates that navigation logic and its visual presentation are decoupled:
- Binds the navigator to a std-widgets navigation presentation.
- Binds the navigator to Material components.

### What's in it
`examples/navigation-std`, `ui-libraries/material/examples/navigation`, and interpreter tests.

### Tests
Interpreter tests.

---
_Experimental-gated; additive to `master`. See the stack for the full picture._