### PR TITLE
navigation: navigation contracts as interface members

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2407,8 +2407,10 @@ impl Element {
         // navigate(route) is enum-typed; recover the route enum from a route
         // case (`Route.X`), whose first path segment names the enum.
         let route_ty = routes.iter().find_map(|r| {
-            let name =
-                QualifiedTypeName::from_node(r.route.QualifiedName()?).members.into_iter().next()?;
+            let name = QualifiedTypeName::from_node(r.route.QualifiedName()?)
+                .members
+                .into_iter()
+                .next()?;
             let ty = tr.lookup(&name);
             matches!(ty, Type::Enumeration(_)).then_some(ty)
         });

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -451,6 +451,27 @@ impl InitCode {
     }
 }
 
+/// One `route` member of a navigation contract (an `interface`'s `route`
+/// declarations). Collected in declaration order by `Component::from_node`.
+#[derive(Debug, Clone)]
+pub struct ContractRoute {
+    /// The route name (the `DeclaredIdentifier`, e.g. `Home`).
+    pub name: SmolStr,
+    /// Typed parameters declared with the route (e.g. `id: int`). Parsed and
+    /// typed here; not yet consumed by this slice.
+    pub params: Vec<(SmolStr, Type)>,
+}
+
+/// A versionable navigation boundary declared as the `route` members of an
+/// `interface`. Reuses the existing `interface`/export machinery so the contract
+/// exports and imports across files like any other interface type. Later slices
+/// (mount / capability) consume this table.
+#[derive(Debug, Clone, Default)]
+pub struct NavigationContract {
+    /// The declared routes, in source order.
+    pub routes: Vec<ContractRoute>,
+}
+
 /// A component is a type in the language which can be instantiated,
 /// Or is materialized for repeated expression.
 #[derive(Default, Debug)]
@@ -495,6 +516,12 @@ pub struct Component {
 
     /// True if this component is imported from an external library.
     pub from_library: Cell<bool>,
+
+    /// The navigation contract declared by an `interface`'s `route` members, if
+    /// any. Kept apart from the interface's property/callback/function members so
+    /// `implements` iteration never sees routes (see object_tree/interfaces.rs).
+    /// Populated in `Component::from_node`; consumed by later navigation slices.
+    pub navigation_contract: RefCell<Option<NavigationContract>>,
 }
 
 impl Component {
@@ -546,7 +573,43 @@ impl Component {
             }
         });
         interfaces::apply_uses_statement(&c.root_element, node.UsesSpecifier(), tr, diag);
+        // An `interface`'s `route` members form a navigation contract. Collected
+        // here, on the Component, rather than into the interface's normal member
+        // lists so `implements` iteration is unaffected. Only reached under the
+        // experimental flag, since `is_interface()` requires the (experimental)
+        // `interface` keyword; misplaced/ungated `route` members are diagnosed in
+        // `Element::from_node`.
+        if c.is_interface() {
+            let routes = node
+                .Element()
+                .RouteDeclaration()
+                .filter_map(|route| {
+                    let name = parser::identifier_text(&route.DeclaredIdentifier())?;
+                    let params = route
+                        .ArgumentDeclaration()
+                        .filter_map(|a| {
+                            Some((
+                                parser::identifier_text(&a.DeclaredIdentifier())?,
+                                type_from_node(a.Type(), diag, tr),
+                            ))
+                        })
+                        .collect();
+                    Some(ContractRoute { name, params })
+                })
+                .collect::<Vec<_>>();
+            if !routes.is_empty() {
+                *c.navigation_contract.borrow_mut() = Some(NavigationContract { routes });
+            }
+        }
         c
+    }
+
+    /// Read-only view of the navigation contract declared by this component's
+    /// `route` members, if it is an `interface` declaring any. Mirrors
+    /// `Element::navigator_routes` as the authoritative accessor for tooling and
+    /// later navigation slices, kept separate from the interface's members.
+    pub fn navigation_contract(&self) -> Option<NavigationContract> {
+        self.navigation_contract.borrow().clone()
     }
 
     /// This component is a global component introduced with the "global" keyword
@@ -1259,6 +1322,22 @@ impl Element {
             tr.empty_type()
         };
         let is_interface = base_type == ElementType::Interface;
+        // `route` members declare a navigation contract; they are experimental
+        // and valid only in an `interface` body. Valid routes are collected onto
+        // the Component in `Component::from_node`; here we only reject misuse.
+        for route in node.RouteDeclaration() {
+            if !diag.enable_experimental && !tr.expose_internal_types {
+                diag.push_error(
+                    "navigation 'route' members are an experimental feature".into(),
+                    &route,
+                );
+            } else if !is_interface {
+                diag.push_error(
+                    "'route' members are only allowed inside an 'interface'".into(),
+                    &route,
+                );
+            }
+        }
         // This isn't truly qualified yet, the enclosing component is added at the end of Component::from_node
         let qualified_id = (!id.is_empty()).then(|| id.clone());
         if let ElementType::Component(c) = &base_type {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2308,8 +2308,63 @@ impl Element {
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
             cases.push(e);
         }
+        // Declare the navigator's public members now, before expression
+        // resolution, so widget chrome can bind to them from .slint (e.g.
+        // `current-index <- nav.current-route-index`). The lower_navigator pass
+        // fills in their bodies later, once the route table is resolved. Same
+        // shape as an interface function: the declaration is in scope now, the
+        // implementation comes later.
+        if !routes.is_empty() {
+            Self::declare_navigator_members(parent, &routes, tr);
+        }
         parent.borrow_mut().navigator_routes = routes;
         cases
+    }
+
+    /// Declare the navigator's public members (the surface widget chrome binds
+    /// to) up front. Only the signatures are known here; `lower_navigator`
+    /// supplies the bindings/bodies after the route table is resolved.
+    fn declare_navigator_members(elem: &ElementRc, routes: &[NavigatorRoute], tr: &TypeRegister) {
+        // navigate(route) is enum-typed; recover the route enum from a route
+        // case (`Route.X`), whose first path segment names the enum.
+        let route_ty = routes.iter().find_map(|r| {
+            let name =
+                QualifiedTypeName::from_node(r.route.QualifiedName()?).members.into_iter().next()?;
+            let ty = tr.lookup(&name);
+            matches!(ty, Type::Enumeration(_)).then_some(ty)
+        });
+        let func = |args: Vec<Type>, arg_names: Vec<SmolStr>| {
+            Type::Function(Rc::new(Function { return_type: Type::Void, args, arg_names }))
+        };
+
+        let mut e = elem.borrow_mut();
+        let mut declare = |name, property_type, visibility, pure| {
+            e.property_declarations.insert(
+                SmolStr::new_static(name),
+                PropertyDeclaration { property_type, visibility, pure, ..Default::default() },
+            );
+        };
+        // Read surface for chrome: ordinal of the current route and whether the
+        // back-stack has anything to pop.
+        declare("current-route-index", Type::Int32, PropertyVisibility::Output, None);
+        declare("can-go-back", Type::Bool, PropertyVisibility::Output, None);
+        // Navigation entry points. navigate-index(int) is the index-based surface
+        // chrome (Material's NavigationBar, a std nav bar) drives.
+        declare("back", func(vec![], vec![]), PropertyVisibility::Public, Some(false));
+        declare(
+            "navigate-index",
+            func(vec![Type::Int32], vec![SmolStr::new_static("index")]),
+            PropertyVisibility::Public,
+            Some(false),
+        );
+        if let Some(route_ty) = route_ty {
+            declare(
+                "navigate",
+                func(vec![route_ty], vec![SmolStr::new_static("route")]),
+                PropertyVisibility::Public,
+                Some(false),
+            );
+        }
     }
 
     /// Return the type of a property in this element or its base, along with the final name, in case

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2142,6 +2142,10 @@ impl Element {
 
         interfaces::apply_default_property_values(&r, &implemented_interface);
         interfaces::validate_function_implementations(&r.borrow(), &implemented_interface, diag);
+        // Checked here, not right after `implements` is resolved above: a
+        // navigator fills its route table while the host element's children are
+        // built (the loop above), so the table is only populated at this point.
+        interfaces::validate_navigation_contract_conformance(&r, &implemented_interface, diag);
 
         r
     }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -460,6 +460,9 @@ pub struct ContractRoute {
     /// Typed parameters declared with the route (e.g. `id: int`). Parsed and
     /// typed here; not yet consumed by this slice.
     pub params: Vec<(SmolStr, Type)>,
+    /// The deep-link URI declared with `@uri("...")`, if any. Metadata only; the
+    /// runtime navigate-payload plumbing is a later slice.
+    pub uri: Option<SmolStr>,
 }
 
 /// A versionable navigation boundary declared as the `route` members of an
@@ -470,6 +473,9 @@ pub struct ContractRoute {
 pub struct NavigationContract {
     /// The declared routes, in source order.
     pub routes: Vec<ContractRoute>,
+    /// The compile-time contract version from `@version(n)`. Absent means the
+    /// default version 1. Metadata only; no conformance checking in this slice.
+    pub version: Option<u32>,
 }
 
 /// A component is a type in the language which can be instantiated,
@@ -594,11 +600,40 @@ impl Component {
                             ))
                         })
                         .collect();
-                    Some(ContractRoute { name, params })
+                    // `@uri("...")`: unescape the string literal argument. Last
+                    // one wins if repeated. Metadata only in this slice.
+                    let uri = route.AtUri().last().and_then(|attr| {
+                        let raw = attr.text().to_string();
+                        match crate::literals::unescape_string(raw.trim()) {
+                            Some(s) => Some(s),
+                            None => {
+                                diag.push_error(
+                                    "@uri expects a string literal argument".into(),
+                                    &attr,
+                                );
+                                None
+                            }
+                        }
+                    });
+                    Some(ContractRoute { name, params, uri })
                 })
                 .collect::<Vec<_>>();
-            if !routes.is_empty() {
-                *c.navigation_contract.borrow_mut() = Some(NavigationContract { routes });
+            // `@version(n)`: an interface-level integer literal. Last one wins.
+            let version = node.Element().AtVersion().last().and_then(|attr| {
+                let raw = attr.text().to_string();
+                match raw.trim().parse::<u32>() {
+                    Ok(v) => Some(v),
+                    Err(_) => {
+                        diag.push_error(
+                            "@version expects an integer literal argument".into(),
+                            &attr,
+                        );
+                        None
+                    }
+                }
+            });
+            if !routes.is_empty() || version.is_some() {
+                *c.navigation_contract.borrow_mut() = Some(NavigationContract { routes, version });
             }
         }
         c

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -4,7 +4,7 @@
 //! Module containing interfaces related types and functions.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Display;
 use std::rc::Rc;
 
@@ -17,7 +17,7 @@ use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
     Component, Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
-    visit_named_references_in_expression,
+    recurse_elem, visit_named_references_in_expression,
 };
 use crate::parser;
 use crate::parser::{SyntaxKind, syntax_nodes};
@@ -488,6 +488,82 @@ pub(super) fn validate_function_implementations(
                     function_declaration.return_type,
                     function_impl.return_type,
                 ),
+            );
+        }
+    }
+}
+
+/// The route name is the last `.`-segment of the qualified enum value, e.g.
+/// `Home` from `Route.Home`. Mirrors the extraction in the LSP document cache.
+fn navigator_route_name(route: &syntax_nodes::Expression) -> SmolStr {
+    route.text().to_string().rsplit('.').next().unwrap_or_default().trim().into()
+}
+
+/// Verify that a component implementing a navigation-contract interface covers
+/// every contract route in its `navigator`. Contract routes live on the
+/// interface's `NavigationContract`, kept apart from its property/callback/
+/// function members, so this check is additive to the validation above.
+///
+/// Only route-name coverage is checked in this slice: the navigator's routes are
+/// bare enum values, so param-type conformance is deferred until the navigator
+/// carries typed params.
+pub(super) fn validate_navigation_contract_conformance(
+    root: &ElementRc,
+    implemented_interface: &Option<ImplementedInterface>,
+    diag: &mut BuildDiagnostics,
+) {
+    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
+        implemented_interface
+    else {
+        return;
+    };
+
+    // The contract lives on the interface's Component. No contract means the
+    // interface is a plain interface with nothing to conform to here.
+    let Some(contract) =
+        interface.borrow().enclosing_component.upgrade().and_then(|c| c.navigation_contract())
+    else {
+        return;
+    };
+    if contract.routes.is_empty() {
+        return;
+    }
+
+    // Find the implementing component's navigator: the first element in the tree
+    // with a non-empty route table (one navigator per component by convention).
+    let mut navigator_route_names: Option<HashSet<SmolStr>> = None;
+    recurse_elem(root, &(), &mut |elem, _| {
+        if navigator_route_names.is_none() {
+            let elem = elem.borrow();
+            let routes = elem.navigator_routes();
+            if !routes.is_empty() {
+                navigator_route_names =
+                    Some(routes.iter().map(|r| navigator_route_name(&r.route)).collect());
+            }
+        }
+    });
+
+    let Some(navigator_route_names) = navigator_route_names else {
+        // Implementing a nav contract without any navigator cannot satisfy it.
+        diag.push_error(
+            format!(
+                "component implements navigation contract '{interface_name}' but declares no navigator"
+            ),
+            &implements_specifier.QualifiedName(),
+        );
+        return;
+    };
+
+    // Every contract route must be covered by name. Extra navigator routes are
+    // allowed: a module may keep internal routes beyond its public contract.
+    for route in &contract.routes {
+        if !navigator_route_names.contains(&route.name) {
+            diag.push_error(
+                format!(
+                    "component implements '{interface_name}' but its navigator has no route for '{}'",
+                    route.name
+                ),
+                &implements_specifier.QualifiedName(),
             );
         }
     }

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -354,7 +354,7 @@ declare_syntax! {
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
                      *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *RouteDeclaration, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
-                     *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder ],
+                     *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder, *AtVersion ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],
         ConditionalElement -> [ Expression , SubElement],
@@ -370,7 +370,8 @@ declare_syntax! {
         /// Route.Home: HomeScreen { }
         Route -> [ Expression, ?SubElement ],
         /// `route Home;` or `route Details(id: int);`  a navigation contract member of an interface
-        RouteDeclaration -> [ DeclaredIdentifier, *ArgumentDeclaration ],
+        /// An optional `@uri("...")` prefix declares the route's deep-link URI.
+        RouteDeclaration -> [ DeclaredIdentifier, *ArgumentDeclaration, *AtUri ],
         CallbackDeclaration -> [ DeclaredIdentifier, *CallbackDeclarationParameter, ?ReturnType, ?TwoWayBinding ],
         // `foo: type` or just `type`
         CallbackDeclarationParameter -> [ ?DeclaredIdentifier, Type],
@@ -481,6 +482,10 @@ declare_syntax! {
         EnumValue -> [],
         /// `@rust-attr(...)`
         AtRustAttr -> [],
+        /// `@version(n)`: the navigation contract version, on an `interface`.
+        AtVersion -> [],
+        /// `@uri("...")`: a route's deep-link URI, on a `route` declaration.
+        AtUri -> [],
         /// `uses { Foo from Bar, Baz from Qux }`
         UsesSpecifier -> [ *UsesIdentifier ],
         /// `Interface.Foo from bar`

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -352,7 +352,7 @@ declare_syntax! {
         /// `id := Element { ... }`
         SubElement -> [ Element ],
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
-                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *SubElement,
+                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *RouteDeclaration, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
                      *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
@@ -369,6 +369,8 @@ declare_syntax! {
         Navigator -> [ Expression, *Route ],
         /// Route.Home: HomeScreen { }
         Route -> [ Expression, ?SubElement ],
+        /// `route Home;` or `route Details(id: int);`  a navigation contract member of an interface
+        RouteDeclaration -> [ DeclaredIdentifier, *ArgumentDeclaration ],
         CallbackDeclaration -> [ DeclaredIdentifier, *CallbackDeclarationParameter, ?ReturnType, ?TwoWayBinding ],
         // `foo: type` or just `type`
         CallbackDeclarationParameter -> [ ?DeclaredIdentifier, Type],

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -90,6 +90,13 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 {
                     parse_function(&mut *p);
                 }
+                // Experimental: `route` members declare a navigation contract.
+                // Parsed unconditionally; the experimental gate and the
+                // interface-only restriction are applied at object-tree lowering
+                // (see Element::from_node / Component::from_node).
+                SyntaxKind::Identifier if p.peek().as_str() == "route" => {
+                    parse_route_declaration(&mut *p);
+                }
                 SyntaxKind::Identifier | SyntaxKind::Star if p.peek().as_str() == "animate" => {
                     parse_property_animation(&mut *p);
                 }
@@ -896,5 +903,43 @@ fn parse_function(p: &mut impl Parser) {
         parse_code_block(&mut *p);
     } else if !p.test(SyntaxKind::Semicolon) {
         p.error("Expected function body or semicolon");
+    }
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,RouteDeclaration
+/// route Home;
+/// route Details(id: int);
+/// route Details(id: int, name: string);
+/// route Details(id: int,);
+/// ```
+fn parse_route_declaration(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "route");
+    let mut p = p.start_node(SyntaxKind::RouteDeclaration);
+    p.expect(SyntaxKind::Identifier); // "route"
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+    // Optional typed parameters, reusing the function argument grammar. The
+    // params are parsed and typed but not yet consumed by this slice.
+    if p.test(SyntaxKind::LParent) {
+        while p.peek().kind() != SyntaxKind::RParent {
+            let mut p_arg = p.start_node(SyntaxKind::ArgumentDeclaration);
+            {
+                let mut p = p_arg.start_node(SyntaxKind::DeclaredIdentifier);
+                p.expect(SyntaxKind::Identifier);
+            }
+            p_arg.expect(SyntaxKind::Colon);
+            parse_type(&mut *p_arg);
+            drop(p_arg);
+            if !p.test(SyntaxKind::Comma) {
+                break;
+            }
+        }
+        p.expect(SyntaxKind::RParent);
+    }
+    if !p.test(SyntaxKind::Semicolon) {
+        p.error("Expected ';' after route declaration");
     }
 }

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -95,7 +95,7 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 // interface-only restriction are applied at object-tree lowering
                 // (see Element::from_node / Component::from_node).
                 SyntaxKind::Identifier if p.peek().as_str() == "route" => {
-                    parse_route_declaration(&mut *p);
+                    parse_route_declaration(&mut *p, None);
                 }
                 SyntaxKind::Identifier | SyntaxKind::Star if p.peek().as_str() == "animate" => {
                     parse_property_animation(&mut *p);
@@ -187,18 +187,39 @@ pub fn parse_element_content(p: &mut impl Parser) {
                     }
                 }
             },
-            SyntaxKind::At => {
-                let checkpoint = p.checkpoint();
-                p.consume();
-                if p.peek().as_str() == "children" {
-                    let mut p =
-                        p.start_node_at(checkpoint.clone(), SyntaxKind::ChildrenPlaceholder);
-                    p.consume()
-                } else {
+            SyntaxKind::At => match p.nth(1).as_str() {
+                "children" => {
+                    let checkpoint = p.checkpoint();
+                    p.consume(); // "@"
+                    let mut p = p.start_node_at(checkpoint, SyntaxKind::ChildrenPlaceholder);
+                    p.consume() // "children"
+                }
+                // Experimental: `@version(n)` sets the navigation contract version.
+                // Collected in Component::from_node; misuse outside an interface is
+                // diagnosed there.
+                "version" => {
+                    parse_navigation_attribute(&mut *p, "version", SyntaxKind::AtVersion);
+                }
+                // Experimental: `@uri("...")` prefixes a `route` with its deep-link
+                // URI. Wrap the attribute and the route into one RouteDeclaration.
+                "uri" => {
+                    let checkpoint = p.checkpoint();
+                    parse_navigation_attribute(&mut *p, "uri", SyntaxKind::AtUri);
+                    while p.peek().as_str() == "@" && p.nth(1).as_str() == "uri" {
+                        parse_navigation_attribute(&mut *p, "uri", SyntaxKind::AtUri);
+                    }
+                    if p.peek().as_str() == "route" {
+                        parse_route_declaration(&mut *p, Some(checkpoint));
+                    } else {
+                        p.error("Parse error: Expected 'route' after @uri");
+                    }
+                }
+                _ => {
+                    p.consume(); // "@"
                     p.test(SyntaxKind::Identifier);
                     p.error("Parse error: Expected @children")
                 }
-            }
+            },
             _ => {
                 if !had_parse_error {
                     p.error("Parse error");
@@ -913,9 +934,11 @@ fn parse_function(p: &mut impl Parser) {
 /// route Details(id: int, name: string);
 /// route Details(id: int,);
 /// ```
-fn parse_route_declaration(p: &mut impl Parser) {
+/// The optional `checkpoint` lets a preceding `@uri(...)` attribute be wrapped
+/// into the RouteDeclaration node (mirrors struct/enum + `@rust-attr`).
+fn parse_route_declaration<P: Parser>(p: &mut P, checkpoint: Option<P::Checkpoint>) {
     debug_assert_eq!(p.peek().as_str(), "route");
-    let mut p = p.start_node(SyntaxKind::RouteDeclaration);
+    let mut p = p.start_node_at(checkpoint, SyntaxKind::RouteDeclaration);
     p.expect(SyntaxKind::Identifier); // "route"
     {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
@@ -942,4 +965,38 @@ fn parse_route_declaration(p: &mut impl Parser) {
     if !p.test(SyntaxKind::Semicolon) {
         p.error("Expected ';' after route declaration");
     }
+}
+
+/// Parse a navigation attribute `@name(<literal>)`, wrapping the argument tokens
+/// in `kind`. Mirrors `parse_rustattr` so the read-out reuses `attr.text()`. The
+/// caller has verified the attribute name at `nth(1)`.
+fn parse_navigation_attribute(p: &mut impl Parser, name: &str, kind: SyntaxKind) -> bool {
+    debug_assert_eq!(p.peek().as_str(), "@");
+    p.consume(); // "@"
+    p.consume(); // attribute name
+    if !p.expect(SyntaxKind::LParent) {
+        return false;
+    }
+    {
+        let mut p = p.start_node(kind);
+        let mut level = 1;
+        loop {
+            match p.peek().kind() {
+                SyntaxKind::LParent => level += 1,
+                SyntaxKind::RParent => {
+                    level -= 1;
+                    if level == 0 {
+                        break;
+                    }
+                }
+                SyntaxKind::Eof => {
+                    p.error(format!("unmatched parentheses in @{name}"));
+                    return false;
+                }
+                _ => {}
+            }
+            p.consume()
+        }
+    }
+    p.expect(SyntaxKind::RParent)
 }

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -488,6 +488,7 @@ fn duplicate_sub_component(
         private_properties: Default::default(),
         inherits_popup_window: core::cell::Cell::new(false),
         from_library: core::cell::Cell::new(false),
+        navigation_contract: component_to_duplicate.navigation_contract.clone(),
     };
 
     let new_component = Rc::new(new_component);

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,12 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Synthesize the navigator back-stack.
+//! Implement the navigator's public members (declared early by
+//! `from_navigator_node`) and add its private back-stack.
 //!
 //! `from_navigator_node` records the resolved route table on the enclosing
-//! element (`Element::navigator_routes`); navigation itself is just assigning
-//! the route property. This pass adds, on that same element, a back-stack plus
-//! the surface for going back:
+//! element (`Element::navigator_routes`) and declares the public members
+//! (`current-route-index`, `can-go-back`, `navigate`, `navigate-index`, `back`)
+//! up front, so .slint chrome can bind to them. Navigation itself is just
+//! assigning the route property. This pass fills in those members' bodies and
+//! adds, on the same element, the private back-stack that backs them:
 //!
 //!   navigate(route): push the current route, then switch to `route`
 //!   back():          restore and drop the top of the back-stack (no-op if empty)
@@ -22,7 +25,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};
-use crate::langtype::{Function, Type};
+use crate::langtype::Type;
 use crate::object_tree::*;
 use smol_str::SmolStr;
 use std::cell::RefCell;
@@ -194,79 +197,16 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
 
+    // The public members were declared early (before resolve) by
+    // `from_navigator_node` so .slint chrome can bind to them; here we only fill
+    // in their bodies/bindings, now that the route table is resolved.
     let mut e = elem.borrow_mut();
-    e.property_declarations.insert(
-        SmolStr::new_static("navigate"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![route_ty.clone()],
-                arg_names: vec![SmolStr::new_static("route")],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            // Synthesized after check_public_api; opt into the public surface so
-            // callers can invoke it and remove_unused_properties keeps it.
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("navigate"), RefCell::new(navigate_body.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("back"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![],
-                arg_names: vec![],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("back"), RefCell::new(back_body.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("can-go-back"),
-        PropertyDeclaration {
-            property_type: Type::Bool,
-            visibility: PropertyVisibility::Output,
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("current-route-index"),
-        PropertyDeclaration {
-            property_type: Type::Int32,
-            visibility: PropertyVisibility::Output,
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(
         SmolStr::new_static("current-route-index"),
         RefCell::new(current_route_index.into()),
-    );
-
-    e.property_declarations.insert(
-        SmolStr::new_static("navigate-index"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![Type::Int32],
-                arg_names: vec![SmolStr::new_static("index")],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            expose_in_public_api: true,
-            ..Default::default()
-        },
     );
     e.bindings
         .insert(SmolStr::new_static("navigate-index"), RefCell::new(navigate_index_body.into()));

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -84,9 +84,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
     // whose push/remove are silently no-ops.
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static(BACK_STACK),
-        RefCell::new(
-            Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into(),
-        ),
+        RefCell::new(Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into()),
     );
 
     let back_stack = || Expression::PropertyReference(NamedReference::new(elem, BACK_STACK.into()));
@@ -151,11 +149,9 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         .borrow()
         .navigator_routes
         .iter()
-        .filter_map(|r| {
-            match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
-                Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
-                _ => None,
-            }
+        .filter_map(|r| match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
+            Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
+            _ => None,
         })
         .collect();
 

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2096,6 +2096,70 @@ export interface AppNavV1 {
 }
 
 #[test]
+fn test_navigation_contract_attributes() {
+    // `@version(n)` on the interface and `@uri("...")` per route are parsed and
+    // stored as metadata on the contract (PR A9.2). `@version` attaches in the
+    // interface body (document-level attachment is awkward, see A9.2 report).
+    let source = r#"
+export interface AppNavV1 {
+    @version(2)
+    @uri("app://home") route Home;
+    @uri("app://details/{id}") route Details(id: int);
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "contract with attributes rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let interface = doc
+        .inner_components
+        .iter()
+        .find(|c| c.id == "AppNavV1")
+        .expect("interface component missing");
+    let contract = interface.navigation_contract().expect("navigation contract not populated");
+    assert_eq!(contract.version, Some(2));
+    assert_eq!(contract.routes.len(), 2);
+    assert_eq!(contract.routes[0].name, "Home");
+    assert_eq!(contract.routes[0].uri.as_deref(), Some("app://home"));
+    assert_eq!(contract.routes[1].name, "Details");
+    assert_eq!(contract.routes[1].uri.as_deref(), Some("app://details/{id}"));
+}
+
+#[test]
+fn test_navigation_contract_default_version() {
+    // Absent `@version` means no explicit version (the documented default is 1).
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "contract rejected: {:?}", diag.to_string_vec());
+    let doc = loader.get_document(&path).unwrap();
+    let interface =
+        doc.inner_components.iter().find(|c| c.id == "AppNavV1").expect("interface missing");
+    let contract = interface.navigation_contract().expect("contract not populated");
+    assert_eq!(contract.version, None);
+}
+
+#[test]
+fn test_navigation_contract_version_non_integer_rejected() {
+    // A non-integer `@version` argument is a clear diagnostic.
+    let source = r#"
+export interface AppNavV1 {
+    @version("x")
+    route Home;
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("@version expects an integer literal")),
+        "non-integer @version should be rejected: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
 fn test_route_outside_interface_rejected() {
     // `route` members are only meaningful in an interface body.
     let source = r#"

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1587,6 +1587,13 @@ impl TypeLoader {
         is_builtin: bool,
         import_stack: &HashSet<PathBuf>,
     ) -> (PathBuf, Document) {
+        // Mirror lib.rs `prepare_for_compile`: the main compile path sets this on the
+        // diagnostics up front, but LSP/live-editor loads reach the type loader with a
+        // fresh BuildDiagnostics that never got the flag. This is the single funnel every
+        // load entry point flows through, so propagate the config here.
+        let enable_experimental = state.borrow().tl.compiler_config.enable_experimental;
+        state.borrow_mut().diag.enable_experimental = enable_experimental;
+
         let dependency_registry =
             Rc::new(RefCell::new(TypeRegister::new(&state.borrow().tl.global_type_registry)));
         dependency_registry.borrow_mut().expose_internal_types =
@@ -1983,6 +1990,59 @@ fn test_dependency_loading() {
     for file in imported_files {
         assert!(loader.get_document(&file).is_none(), "{} is still loaded", file.display());
     }
+}
+
+// The experimental `navigator` compiles through the normal type-loader load
+// path only when the config enables experimental, and is rejected otherwise.
+// Guards the LSP/live-editor load path, which reaches the loader with a fresh
+// BuildDiagnostics that never got the flag from the config.
+#[test]
+fn test_load_navigator_experimental_from_config() {
+    let source = r#"
+enum Route { A, B }
+component A inherits Rectangle { }
+component B inherits Rectangle { }
+export component App inherits Window {
+    in-out property <Route> current-route: Route.A;
+    navigator (current-route) {
+        Route.A: A { }
+        Route.B: B { }
+    }
+}
+"#;
+
+    let load = |enable_experimental: bool| {
+        let mut compiler_config =
+            CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        compiler_config.style = Some("fluent".into());
+        compiler_config.enable_experimental = enable_experimental;
+
+        let mut build_diagnostics = BuildDiagnostics::default();
+        let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+        assert!(!build_diagnostics.has_errors());
+
+        // The caller-provided diagnostics start without the flag, exactly like
+        // the LSP load path; the loader must derive it from the config.
+        let mut diag = BuildDiagnostics::default();
+        assert!(!diag.enable_experimental);
+        let path = PathBuf::from("/foo/nav.slint");
+        spin_on::spin_on(loader.load_file(&path, &path, source.into(), false, &mut diag));
+        diag
+    };
+
+    let diag = load(true);
+    assert!(diag.enable_experimental, "the config flag must reach the diagnostics");
+    assert!(
+        !diag.iter().any(|d| d.message().contains("experimental")),
+        "navigator rejected with experimental enabled: {:?}",
+        diag.iter().map(|d| d.message().to_string()).collect::<Vec<_>>()
+    );
+
+    let diag = load(false);
+    assert!(
+        diag.iter().any(|d| d.message().contains("navigator is an experimental feature")),
+        "navigator should be rejected when experimental is disabled"
+    );
 }
 
 #[test]

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -391,6 +391,9 @@ impl Snapshotter {
                 root_constraints,
                 root_element,
                 from_library: core::cell::Cell::new(false),
+                navigation_contract: RefCell::new(
+                    component.navigation_contract.borrow().clone(),
+                ),
             }
         });
         self.keep_alive.push((component.clone(), result.clone()));
@@ -2043,6 +2046,155 @@ export component App inherits Window {
         diag.iter().any(|d| d.message().contains("navigator is an experimental feature")),
         "navigator should be rejected when experimental is disabled"
     );
+}
+
+/// Load `source` under the given experimental flag and return the loaded
+/// document alongside its diagnostics, mirroring the LSP load path.
+#[cfg(test)]
+fn load_source_for_contract_test(
+    source: &str,
+    enable_experimental: bool,
+) -> (TypeLoader, PathBuf, BuildDiagnostics) {
+    let mut compiler_config =
+        CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.enable_experimental = enable_experimental;
+    let mut build_diagnostics = BuildDiagnostics::default();
+    let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+    let mut diag = BuildDiagnostics::default();
+    let path = PathBuf::from("/foo/contract.slint");
+    spin_on::spin_on(loader.load_file(&path, &path, source.into(), false, &mut diag));
+    (loader, path, diag)
+}
+
+#[test]
+fn test_navigation_contract_populated() {
+    // An interface's `route` members are collected into a NavigationContract on
+    // the Component, with names and typed params, under the experimental flag.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "contract rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let interface = doc
+        .inner_components
+        .iter()
+        .find(|c| c.id == "AppNavV1")
+        .expect("interface component missing");
+    let contract = interface.navigation_contract().expect("navigation contract not populated");
+    assert_eq!(contract.routes.len(), 2);
+    assert_eq!(contract.routes[0].name, "Home");
+    assert!(contract.routes[0].params.is_empty());
+    assert_eq!(contract.routes[1].name, "Details");
+    assert_eq!(contract.routes[1].params.len(), 1);
+    assert_eq!(contract.routes[1].params[0].0, "id");
+    // The param type is parsed and typed even though this slice does not use it.
+    assert_eq!(contract.routes[1].params[0].1.to_string(), "int");
+}
+
+#[test]
+fn test_route_outside_interface_rejected() {
+    // `route` members are only meaningful in an interface body.
+    let source = r#"
+export component App inherits Rectangle {
+    route Home;
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("only allowed inside an 'interface'")),
+        "route outside an interface should be rejected: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_navigation_contract_requires_experimental() {
+    // A contract (an interface with routes) is rejected without experimental.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, false);
+    assert!(diag.has_errors(), "contract must be rejected without experimental");
+    assert!(
+        diag.iter().any(|d| d.message().contains("experimental")),
+        "expected an experimental-feature diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+    // No contract is collected when the interface itself is rejected.
+    if let Some(doc) = loader.get_document(&path) {
+        assert!(
+            doc.inner_components.iter().all(|c| c.navigation_contract().is_none()),
+            "no contract should be collected without experimental"
+        );
+    }
+}
+
+#[test]
+fn test_navigation_contract_cross_file_import() {
+    // The contract exports/imports across files via the existing interface
+    // machinery: declared in one file, imported and resolved in another. Real
+    // files on disk so the importer resolves the relative import.
+    let dir = std::env::temp_dir().join(format!("slint_nav_contract_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let nav_path = dir.join("nav.slint");
+    let main_path = dir.join("main.slint");
+    std::fs::write(
+        &nav_path,
+        r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+"#,
+    )
+    .unwrap();
+    let main_source = r#"
+import { AppNavV1 } from "nav.slint";
+export component App inherits Rectangle { }
+"#;
+    std::fs::write(&main_path, main_source).unwrap();
+
+    let mut compiler_config =
+        CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.enable_experimental = true;
+
+    let mut build_diagnostics = BuildDiagnostics::default();
+    let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+    assert!(!build_diagnostics.has_errors());
+
+    let mut diag = BuildDiagnostics::default();
+    spin_on::spin_on(loader.load_file(
+        &main_path,
+        &main_path,
+        main_source.into(),
+        false,
+        &mut diag,
+    ));
+
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(!diag.has_errors(), "cross-file interface import failed: {:?}", diag.to_string_vec());
+
+    // The imported interface resolved, carrying its contract across the file
+    // boundary.
+    let nav_doc = loader.get_document(&nav_path).expect("exporting document not loaded");
+    let interface = nav_doc
+        .inner_components
+        .iter()
+        .find(|c| c.id == "AppNavV1")
+        .expect("imported interface missing");
+    let contract = interface.navigation_contract().expect("contract missing after import");
+    assert_eq!(contract.routes.len(), 2);
+    assert_eq!(contract.routes[0].name, "Home");
+    assert_eq!(contract.routes[1].name, "Details");
 }
 
 #[test]

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -391,9 +391,7 @@ impl Snapshotter {
                 root_constraints,
                 root_element,
                 from_library: core::cell::Cell::new(false),
-                navigation_contract: RefCell::new(
-                    component.navigation_contract.borrow().clone(),
-                ),
+                navigation_contract: RefCell::new(component.navigation_contract.borrow().clone()),
             }
         });
         self.keep_alive.push((component.clone(), result.clone()));

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2260,6 +2260,96 @@ export component App inherits Rectangle { }
 }
 
 #[test]
+fn test_navigation_contract_conformance_ok() {
+    // A component whose navigator covers every contract route (by name) conforms.
+    // The contract route `Details(id: int)` has a param; the navigator route is a
+    // bare enum value: only route-name coverage is checked in this slice.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+enum Route { Home, Details }
+component HomeScreen inherits Rectangle { }
+component DetailsScreen inherits Rectangle { }
+export component App implements AppNavV1 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "conformant component rejected: {:?}", diag.to_string_vec());
+}
+
+#[test]
+fn test_navigation_contract_conformance_missing_route() {
+    // The navigator omits `Route.Details`, so it does not cover the contract.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+enum Route { Home, Details }
+component HomeScreen inherits Rectangle { }
+export component App implements AppNavV1 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("its navigator has no route for 'Details'")),
+        "missing route should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_navigation_contract_conformance_no_navigator() {
+    // A component implementing a nav contract but declaring no navigator at all.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+export component App implements AppNavV1 inherits Window { }
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("declares no navigator")),
+        "missing navigator should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_navigation_contract_conformance_extra_routes_allowed() {
+    // A navigator route not in the contract (`Route.Debug`) is allowed: a module
+    // may keep internal routes beyond its public contract.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+enum Route { Home, Debug }
+component HomeScreen inherits Rectangle { }
+component DebugScreen inherits Rectangle { }
+export component App implements AppNavV1 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Debug: DebugScreen { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "extra navigator route rejected: {:?}", diag.to_string_vec());
+}
+
+#[test]
 fn test_dependency_loading_from_rust() {
     let test_source_path: PathBuf =
         [env!("CARGO_MANIFEST_DIR"), "tests", "typeloader"].iter().collect();

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -767,3 +767,128 @@ export component TestCase inherits Window {
         "out-of-range tap is a no-op"
     );
 }
+
+// PR #13: the navigator's public members are declared before expression
+// resolution, so widget chrome binds to them INLINE in .slint (not from the
+// host language). This is the same IntChrome contract as
+// navigator_int_chrome_binding, but the two adapter members are wired in .slint:
+//   current-index: root.current-route-index       (the bar reflects the route)
+//   index-changed(i) => root.navigate-index(i)     (a tap navigates)
+// and can-go-back is read in a .slint binding too. Before #13 these members did
+// not exist at resolve time, so this binding failed with "does not have a
+// property 'current-route-index'" and had to be done from Rust.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_inline_chrome_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// Int-index chrome, same contract as Material's BaseNavigation: the host feeds
+// the highlighted index in, a tap fires index-changed out.
+component IntChrome {
+    in property <[string]> items;
+    in property <int> current-index;
+    callback index-changed(index: int);
+    public function select(index: int) {
+        if (index < 0 || index >= root.items.length) {
+            return;
+        }
+        root.index-changed(index);
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+
+    // The #13 proof: the chrome binds the navigator's synthesized members
+    // directly in .slint. These mirrors let the test observe the bound values.
+    out property <int> chrome-index: chrome.current-index;
+    out property <bool> chrome-can-back: root.can-go-back;
+
+    chrome := IntChrome {
+        items: ["Home", "Details", "Settings"];
+        current-index: root.current-route-index;            // display <- current-route-index
+        index-changed(i) => { root.navigate-index(i); }     // tap -> navigate-index
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+    // Simulate an item tap (Material fires select() from a NavigationItem click).
+    public function tap(index: int) { chrome.select(index); }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // Read side, all in .slint: the bar's current-index follows current-route-index.
+    settle();
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "Home -> 0");
+    assert_eq!(instance.get_property("chrome-can-back").unwrap(), Value::from(false), "root");
+
+    instance.set_property("current-route", route("Details")).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("chrome-index").unwrap(),
+        Value::from(1.),
+        "the bar's current-index reflects the route, bound in .slint"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("details"))
+    );
+
+    // Write side, all in .slint: tap -> select -> index-changed -> navigate-index.
+    instance.invoke("tap", &[Value::from(2.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "a .slint-wired tap navigates by ordinal"
+    );
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(2.), "bar shows 2");
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings"))
+    );
+    // navigate-index pushed the previous route, so can-go-back (bound in .slint) is true.
+    assert_eq!(
+        instance.get_property("chrome-can-back").unwrap(),
+        Value::from(true),
+        "can-go-back reflects the push, read in a .slint binding"
+    );
+
+    // Another tap moves it back to the first route.
+    instance.invoke("tap", &[Value::from(0.)]).unwrap();
+    settle();
+    assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "bar shows 0");
+
+    // Out-of-range tap is a no-op (the chrome's own guard).
+    instance.invoke("tap", &[Value::from(9.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "out-of-range tap is a no-op"
+    );
+}

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -708,12 +708,14 @@ export component App inherits Window {
             if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
         let url = Url::from_file_path(path).unwrap();
 
-        // The type-loader load path does not derive the experimental flag from
-        // the compiler config, so set it on the diagnostics to compile the
-        // experimental `navigator`.
+        // The normal load path derives the experimental flag from the compiler
+        // config (enabled by empty_document_cache_experimental), so a default
+        // BuildDiagnostics is enough to compile the experimental `navigator`.
         let mut diag = BuildDiagnostics::default();
-        diag.enable_experimental = true;
+        assert!(!diag.enable_experimental, "the diag must start without the flag");
         let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
+        // Proof the load path propagated the config flag onto the diagnostics.
+        assert!(diag.enable_experimental, "load path did not propagate enable_experimental");
         assert!(
             !diag.has_errors(),
             "unexpected errors: {:?}",


### PR DESCRIPTION
_Part of stack #12561. Based on #12556._

### Summary
Lets a module declare a **navigation contract** at its boundary so independently-authored parts can be composed without editing each other's internals.
- Let an `interface` carry a navigation contract (the routes at a boundary).
- Add route attributes `@version` / `@uri` for versioned and deep-linkable contracts.
- Add conformance checking via `implements`.
- Declare navigator public members early (for `.slint` binding), and propagate
  `enable_experimental` through the LSP document-load path.

### What's in it
`object_tree.rs`, `object_tree/interfaces.rs`, `parser/element.rs`, and the heaviest single file, `typeloader.rs` (contract loading + conformance), plus `passes/lower_navigator.rs`.

### Tests
Interpreter tests (+125).

---
_Experimental-gated; additive to `master`. See the stack for the full picture._