### PR TITLE
navigation: build-time federated mount

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1246,6 +1246,25 @@ pub struct NavigatorRoute {
     /// component (guaranteed to be an `ElementType::Component`, else a
     /// diagnostic was reported and this is `ElementType::Error`).
     pub component: ElementRc,
+    /// Set when this route is a build-time federated mount
+    /// (`mount Impl via Contract`); distinguishes a mounted sub-graph from a
+    /// plain screen for tooling. `None` for a plain route destination.
+    pub mount: Option<FederatedMount>,
+}
+
+/// Records that a route destination is a build-time federated mount: an
+/// independently-built module's component (`impl_name`), verified at this
+/// integration site to satisfy a named navigation contract (`contract_name`).
+/// Metadata only; the destination is still a direct instantiation of the module.
+#[derive(Debug, Clone)]
+pub struct FederatedMount {
+    /// The mounted implementation component's name (e.g. `ModuleA`).
+    pub impl_name: SmolStr,
+    /// The navigation contract it was verified against (e.g. `AppNavV1`).
+    pub contract_name: SmolStr,
+    /// The contract's `@version`, if declared. The contract name encodes the
+    /// version boundary; this is available metadata, not a compat check.
+    pub contract_version: Option<u32>,
 }
 
 impl Element {
@@ -2384,9 +2403,22 @@ impl Element {
         let mut cases: Vec<ElementRc> = Vec::new();
         let mut routes: Vec<NavigatorRoute> = Vec::new();
         for route in node.Route() {
-            let Some(sub_element) = route.SubElement() else {
-                continue;
-            };
+            // A destination is either a plain sub-element (`Route.X: Screen { }`)
+            // or a federated mount (`Route.X: mount Impl via Contract { }`). Both
+            // desugar to a conditional child that instantiates the destination
+            // component directly; a mount additionally verifies conformance and
+            // records the integration edge. The mounted implementation lives
+            // inside the MountDestination's SubElement, so both forms resolve
+            // their destination the same way.
+            let mount_node = route.MountDestination();
+            let (site, sub_element): (SyntaxNode, syntax_nodes::SubElement) =
+                if let Some(mount_node) = &mount_node {
+                    (mount_node.clone().into(), mount_node.SubElement())
+                } else if let Some(sub_element) = route.SubElement() {
+                    (sub_element.clone().into(), sub_element)
+                } else {
+                    continue;
+                };
             // Conditional child: shown only when the route matches, exactly as
             // `from_match_node` builds its cases.
             let rei = RepeatedElementInfo {
@@ -2401,7 +2433,7 @@ impl Element {
                 is_listview: None,
             };
             let e = Element::from_sub_element_node(
-                sub_element.clone(),
+                sub_element,
                 parent_type.clone(),
                 component_child_insertion_point,
                 is_in_legacy_component,
@@ -2418,12 +2450,18 @@ impl Element {
                         format!(
                             "navigator route destination must be a component, but '{other}' is not"
                         ),
-                        &sub_element,
+                        &site,
                     );
                 }
             }
+            // Integration-site verification: the mounted component must satisfy
+            // the named contract. Records the verified edge, or `None` if the
+            // route is a plain screen or conformance failed.
+            let mount = mount_node.and_then(|mount_node| {
+                Self::verify_federated_mount(&mount_node, &e, &parent_type, tr, diag)
+            });
             e.borrow_mut().repeated = Some(rei);
-            routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
+            routes.push(NavigatorRoute { route: route.Expression(), component: e.clone(), mount });
             cases.push(e);
         }
         // Declare the navigator's public members now, before expression
@@ -2437,6 +2475,66 @@ impl Element {
         }
         parent.borrow_mut().navigator_routes = routes;
         cases
+    }
+
+    /// Verify a federated mount destination at its integration site: the mounted
+    /// component (`dest`) must satisfy the navigation contract named after `via`.
+    /// Returns the recorded mount edge when it conforms, or `None` (after a
+    /// diagnostic) otherwise. Reuses the A9.3 route-coverage machinery so a mount
+    /// and an `implements` are judged the same way.
+    fn verify_federated_mount(
+        mount_node: &syntax_nodes::MountDestination,
+        dest: &ElementRc,
+        parent_type: &ElementType,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> Option<FederatedMount> {
+        // The mounted implementation. `Error` means its name failed to resolve
+        // and was already reported by `from_sub_element_node`.
+        let impl_comp = match &dest.borrow().base_type {
+            ElementType::Component(c) => c.clone(),
+            _ => return None,
+        };
+        // Resolve the contract named after `via` to a navigation-contract
+        // interface. The contract name encodes the version boundary.
+        let contract_node = mount_node.QualifiedName();
+        let contract_name = QualifiedTypeName::from_node(contract_node.clone()).to_smolstr();
+        let contract_comp = match parent_type.lookup_type_for_child_element(&contract_name, tr) {
+            Ok(ElementType::Component(c)) if c.is_interface() => c,
+            Ok(_) => {
+                diag.push_error(
+                    format!("mount contract '{contract_name}' is not an interface"),
+                    &contract_node,
+                );
+                return None;
+            }
+            Err(err) => {
+                diag.push_error(err, &contract_node);
+                return None;
+            }
+        };
+        let Some(contract) = contract_comp.navigation_contract().filter(|c| !c.routes.is_empty())
+        else {
+            diag.push_error(
+                format!("'{contract_name}' is not a navigation contract: it declares no routes"),
+                &contract_node,
+            );
+            return None;
+        };
+        let impl_name = impl_comp.id.clone();
+        interfaces::validate_mount_conformance(
+            &impl_name,
+            &impl_comp.root_element,
+            &contract_name,
+            &contract,
+            mount_node,
+            diag,
+        )
+        .then(|| FederatedMount {
+            impl_name,
+            contract_name,
+            contract_version: contract.version,
+        })
     }
 
     /// Declare the navigator's public members (the surface widget chrome binds

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2482,6 +2482,12 @@ impl Element {
     /// Returns the recorded mount edge when it conforms, or `None` (after a
     /// diagnostic) otherwise. Reuses the A9.3 route-coverage machinery so a mount
     /// and an `implements` are judged the same way.
+    ///
+    /// Cross-file is covered by resolution alone (A10.2): both `Impl` and
+    /// `Contract` may arrive via imports. The importer's `tr` already carries
+    /// imported types, so `lookup_type_for_child_element` resolves them; and an
+    /// import is a fully-loaded dependency, so the imported `Impl`'s
+    /// `navigator_routes` are already populated when this runs.
     fn verify_federated_mount(
         mount_node: &syntax_nodes::MountDestination,
         dest: &ElementRc,

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -501,8 +501,8 @@ fn navigator_route_name(route: &syntax_nodes::Expression) -> SmolStr {
 
 /// The set of route names covered by the first `navigator` found in `root`'s
 /// element tree (one navigator per component by convention), or `None` when the
-/// tree declares no navigator. Shared by interface conformance (A9.3) and
-/// federated mount (A10.1) so both judge contract coverage identically.
+/// tree declares no navigator. Shared by interface conformance and
+/// federated mount so both judge contract coverage identically.
 fn navigator_route_names(root: &ElementRc) -> Option<HashSet<SmolStr>> {
     let mut names: Option<HashSet<SmolStr>> = None;
     recurse_elem(root, &(), &mut |elem, _| {
@@ -519,7 +519,7 @@ fn navigator_route_names(root: &ElementRc) -> Option<HashSet<SmolStr>> {
 
 /// Verify a build-time federated mount: `impl_root` (the mounted component's
 /// root) must cover every route of `contract` by name. Reuses the same
-/// route-coverage rule as `implements` conformance (A9.3), but reports at the
+/// route-coverage rule as `implements` conformance, but reports at the
 /// mount site with mount-flavored errors. Returns true when the mount conforms.
 pub(super) fn validate_mount_conformance(
     impl_name: &str,

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -16,8 +16,8 @@ use crate::expression_tree::{BindingExpression, Callable, Expression};
 use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
-    Component, Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
-    recurse_elem, visit_named_references_in_expression,
+    Component, Element, ElementRc, NavigationContract, PropertyDeclaration, QualifiedTypeName,
+    find_element_by_id, recurse_elem, visit_named_references_in_expression,
 };
 use crate::parser;
 use crate::parser::{SyntaxKind, syntax_nodes};
@@ -499,6 +499,63 @@ fn navigator_route_name(route: &syntax_nodes::Expression) -> SmolStr {
     route.text().to_string().rsplit('.').next().unwrap_or_default().trim().into()
 }
 
+/// The set of route names covered by the first `navigator` found in `root`'s
+/// element tree (one navigator per component by convention), or `None` when the
+/// tree declares no navigator. Shared by interface conformance (A9.3) and
+/// federated mount (A10.1) so both judge contract coverage identically.
+fn navigator_route_names(root: &ElementRc) -> Option<HashSet<SmolStr>> {
+    let mut names: Option<HashSet<SmolStr>> = None;
+    recurse_elem(root, &(), &mut |elem, _| {
+        if names.is_none() {
+            let elem = elem.borrow();
+            let routes = elem.navigator_routes();
+            if !routes.is_empty() {
+                names = Some(routes.iter().map(|r| navigator_route_name(&r.route)).collect());
+            }
+        }
+    });
+    names
+}
+
+/// Verify a build-time federated mount: `impl_root` (the mounted component's
+/// root) must cover every route of `contract` by name. Reuses the same
+/// route-coverage rule as `implements` conformance (A9.3), but reports at the
+/// mount site with mount-flavored errors. Returns true when the mount conforms.
+pub(super) fn validate_mount_conformance(
+    impl_name: &str,
+    impl_root: &ElementRc,
+    contract_name: &str,
+    contract: &NavigationContract,
+    mount_site: &dyn crate::diagnostics::Spanned,
+    diag: &mut BuildDiagnostics,
+) -> bool {
+    let Some(names) = navigator_route_names(impl_root) else {
+        // A component with no navigator cannot satisfy a navigation contract.
+        diag.push_error(
+            format!(
+                "mount of '{impl_name}' does not satisfy contract '{contract_name}': it declares no navigator"
+            ),
+            mount_site,
+        );
+        return false;
+    };
+    // Every contract route must be covered by name. Extra routes are allowed:
+    // a module may keep internal routes beyond its public contract.
+    let missing: Vec<&str> =
+        contract.routes.iter().map(|r| r.name.as_str()).filter(|n| !names.contains(*n)).collect();
+    if !missing.is_empty() {
+        diag.push_error(
+            format!(
+                "mount of '{impl_name}' does not satisfy contract '{contract_name}': missing route(s) {}",
+                missing.join(", ")
+            ),
+            mount_site,
+        );
+        return false;
+    }
+    true
+}
+
 /// Verify that a component implementing a navigation-contract interface covers
 /// every contract route in its `navigator`. Contract routes live on the
 /// interface's `NavigationContract`, kept apart from its property/callback/
@@ -529,21 +586,9 @@ pub(super) fn validate_navigation_contract_conformance(
         return;
     }
 
-    // Find the implementing component's navigator: the first element in the tree
-    // with a non-empty route table (one navigator per component by convention).
-    let mut navigator_route_names: Option<HashSet<SmolStr>> = None;
-    recurse_elem(root, &(), &mut |elem, _| {
-        if navigator_route_names.is_none() {
-            let elem = elem.borrow();
-            let routes = elem.navigator_routes();
-            if !routes.is_empty() {
-                navigator_route_names =
-                    Some(routes.iter().map(|r| navigator_route_name(&r.route)).collect());
-            }
-        }
-    });
-
-    let Some(navigator_route_names) = navigator_route_names else {
+    // Find the implementing component's navigator route names (one navigator per
+    // component by convention).
+    let Some(navigator_route_names) = navigator_route_names(root) else {
         // Implementing a nav contract without any navigator cannot satisfy it.
         diag.push_error(
             format!(

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -367,8 +367,12 @@ declare_syntax! {
         /// navigator (current-route) { Route.Home: HomeScreen { } }
         /// The Expression is the current-route binding.
         Navigator -> [ Expression, *Route ],
-        /// Route.Home: HomeScreen { }
-        Route -> [ Expression, ?SubElement ],
+        /// Route.Home: HomeScreen { }  or  Route.ModuleA: mount ModuleA via AppNavV1 { }
+        Route -> [ Expression, ?SubElement, ?MountDestination ],
+        /// `mount ModuleA via AppNavV1 { }`  a build-time federated mount destination.
+        /// The SubElement is the mounted implementation (desugars to a direct
+        /// instantiation); the QualifiedName is the navigation contract it must satisfy.
+        MountDestination -> [ SubElement, QualifiedName ],
         /// `route Home;` or `route Details(id: int);`  a navigation contract member of an interface
         /// An optional `@uri("...")` prefix declares the route's deep-link URI.
         RouteDeclaration -> [ DeclaredIdentifier, *ArgumentDeclaration, *AtUri ],

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -427,6 +427,11 @@ fn parse_route(p: &mut impl Parser) {
             p.consume();
         }
     }
+    // A federated mount destination: `mount Impl via Contract { }`.
+    if p.peek().as_str() == "mount" {
+        parse_mount_destination(&mut *p);
+        return;
+    }
     if p.peek().kind() == SyntaxKind::LBrace {
         // empty route
         p.expect(SyntaxKind::LBrace);
@@ -438,6 +443,34 @@ fn parse_route(p: &mut impl Parser) {
         return;
     }
     parse_sub_element(&mut *p);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,MountDestination
+/// mount ModuleA via AppNavV1 { }
+/// mount M via C {}
+/// ```
+fn parse_mount_destination(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "mount");
+    let mut p = p.start_node(SyntaxKind::MountDestination);
+    p.expect(SyntaxKind::Identifier); // "mount"
+    // The mounted implementation, wrapped as a SubElement so the desugar reuses
+    // the plain-route path and produces a direct instantiation of it.
+    {
+        let mut sub = p.start_node(SyntaxKind::SubElement);
+        let mut el = sub.start_node(SyntaxKind::Element);
+        parse_qualified_name(&mut *el);
+    }
+    if p.peek().as_str() != "via" {
+        p.error("Expected 'via <Contract>' after 'mount <Impl>'");
+    } else {
+        p.consume(); // "via"
+    }
+    // The navigation contract the mounted implementation must satisfy.
+    parse_qualified_name(&mut *p);
+    // Trailing braces are part of the mount site; empty in this slice.
+    p.expect(SyntaxKind::LBrace);
+    p.expect(SyntaxKind::RBrace);
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2468,6 +2468,139 @@ export component Shell inherits Window {
     );
 }
 
+// The contract shared by the cross-file mount tests. Declared once, exported,
+// and imported by both the module and the integrator.
+#[cfg(test)]
+const XFILE_CONTRACT_SOURCE: &str = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details;
+}
+"#;
+
+// Lay out the real multi-team split on disk: contract, module, and integrator
+// each in their own file, wired by relative imports. Loads the integrator like
+// the LSP would (its imports pull in the module and the contract), reusing the
+// same on-disk approach as `test_navigation_contract_cross_file_import`.
+// Returns the loader, the integrator path, and its diagnostics. `tag` keeps
+// concurrent tests in distinct temp dirs.
+#[cfg(test)]
+fn load_cross_file_mount_test(
+    tag: &str,
+    module_a_source: &str,
+) -> (TypeLoader, PathBuf, BuildDiagnostics) {
+    let dir = std::env::temp_dir().join(format!("slint_nav_xmount_{}_{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("contract.slint"), XFILE_CONTRACT_SOURCE).unwrap();
+    std::fs::write(dir.join("module-a.slint"), module_a_source).unwrap();
+
+    let main_path = dir.join("main.slint");
+    let main_source = r#"
+import { ModuleA } from "module-a.slint";
+import { AppNavV1 } from "contract.slint";
+enum ShellRoute { Home, ModuleA }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+    std::fs::write(&main_path, main_source).unwrap();
+
+    let mut compiler_config =
+        CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.enable_experimental = true;
+
+    let mut build_diagnostics = BuildDiagnostics::default();
+    let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+    assert!(!build_diagnostics.has_errors());
+
+    let mut diag = BuildDiagnostics::default();
+    spin_on::spin_on(loader.load_file(
+        &main_path,
+        &main_path,
+        main_source.into(),
+        false,
+        &mut diag,
+    ));
+
+    let _ = std::fs::remove_dir_all(&dir);
+    (loader, main_path, diag)
+}
+
+#[test]
+fn test_federated_mount_cross_file_resolves_and_records_edge() {
+    // The real multi-team layout: contract, module (impl), and integrator each
+    // in a separate file. The imported `ModuleA` is built as part of its own
+    // document, so its `navigator_routes` are already populated when the
+    // integrator's mount verification runs. This proves the same edge is
+    // recorded cross-file as same-file, with zero production-code change.
+    let module_a_source = r#"
+import { AppNavV1 } from "contract.slint";
+enum ModuleRoute { Home, Details }
+component ModHome inherits Rectangle { }
+component ModDetails inherits Rectangle { }
+export component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+        ModuleRoute.Details: ModDetails { }
+    }
+}
+"#;
+    let (loader, path, diag) = load_cross_file_mount_test("ok", module_a_source);
+    assert!(!diag.has_errors(), "cross-file conforming mount rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let routes = root.navigator_routes();
+    assert_eq!(routes.len(), 2);
+
+    let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    let edge = mounted.mount.as_ref().unwrap();
+    assert_eq!(edge.impl_name, "ModuleA");
+    assert_eq!(edge.contract_name, "AppNavV1");
+    // The mount desugars to a direct instantiation of the imported module.
+    assert_eq!(
+        mounted.component.borrow().base_type.to_string(),
+        "ModuleA",
+        "cross-file mount must desugar to a direct instantiation of the imported module"
+    );
+}
+
+#[test]
+fn test_federated_mount_cross_file_non_conforming_rejected() {
+    // `ModuleA` (in its own file) omits `Details`, so it does not satisfy the
+    // imported `AppNavV1`. The A10.1 conformance error is raised at the
+    // integrator's mount site, across the file boundary.
+    // The module does not declare `implements`, so its only failure is at the
+    // integrator's mount site (mirroring the same-file negative test). This
+    // isolates the cross-file mount check: the error must originate there.
+    let module_a_source = r#"
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+export component ModuleA inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_cross_file_mount_test("bad", module_a_source);
+    assert!(
+        diag.iter().any(|d| d
+            .message()
+            .contains("mount of 'ModuleA' does not satisfy contract 'AppNavV1'")),
+        "cross-file non-conforming mount should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
 #[test]
 fn test_dependency_loading_from_rust() {
     let test_source_path: PathBuf =

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2349,6 +2349,125 @@ export component App implements AppNavV1 inherits Window {
     assert!(!diag.has_errors(), "extra navigator route rejected: {:?}", diag.to_string_vec());
 }
 
+// A shared same-file integrator: `Shell` mounts `ModuleA` (which covers
+// `AppNavV1`) as a route destination. Reused across the mount tests.
+#[cfg(test)]
+const MOUNT_TEST_SOURCE: &str = r#"
+interface AppNavV1 {
+    route Home;
+    route Details;
+}
+enum ModuleRoute { Home, Details }
+component ModHome inherits Rectangle { }
+component ModDetails inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+        ModuleRoute.Details: ModDetails { }
+    }
+}
+enum ShellRoute { Home, ModuleA }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+
+#[test]
+fn test_federated_mount_resolves_and_records_edge() {
+    // A conforming mount compiles, desugars to a direct instantiation of the
+    // module, and records a federated-mount edge distinct from a plain screen.
+    let (loader, path, diag) = load_source_for_contract_test(MOUNT_TEST_SOURCE, true);
+    assert!(!diag.has_errors(), "conforming mount rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let routes = root.navigator_routes();
+    assert_eq!(routes.len(), 2);
+
+    // The plain screen has no mount edge.
+    let home = routes.iter().find(|r| r.route.text().to_string().contains("Home")).unwrap();
+    assert!(home.mount.is_none());
+
+    // The mounted route records the edge and desugars to a direct ModuleA
+    // instantiation (its destination base type is the ModuleA component).
+    let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    let edge = mounted.mount.as_ref().unwrap();
+    assert_eq!(edge.impl_name, "ModuleA");
+    assert_eq!(edge.contract_name, "AppNavV1");
+    assert_eq!(
+        mounted.component.borrow().base_type.to_string(),
+        "ModuleA",
+        "mount must desugar to a direct instantiation of the module"
+    );
+}
+
+#[test]
+fn test_federated_mount_non_conforming_rejected() {
+    // ModuleA's navigator omits `Details`, so it does not satisfy `AppNavV1` at
+    // the mount site.
+    let source = r#"
+interface AppNavV1 {
+    route Home;
+    route Details;
+}
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+component ModuleA inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+enum ShellRoute { Home }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d
+            .message()
+            .contains("mount of 'ModuleA' does not satisfy contract 'AppNavV1'")),
+        "non-conforming mount should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_federated_mount_non_contract_rejected() {
+    // `Plain` is an interface with no routes, so it is not a navigation contract
+    // and cannot be a mount boundary.
+    let source = r#"
+interface Plain {
+    in property <int> value;
+}
+component ModuleA inherits Rectangle { }
+enum ShellRoute { Home }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: mount ModuleA via Plain { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("'Plain' is not a navigation contract")),
+        "non-contract mount should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
 #[test]
 fn test_dependency_loading_from_rust() {
     let test_source_path: PathBuf =

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -409,6 +409,94 @@ export component TestCase inherits Window {
     );
 }
 
+// The cross-file counterpart of `navigator_mount_renders_module`: the contract
+// and the mounted module live in their own files, imported by the integrator.
+// Proves the mount desugars, verifies, and renders the imported module the same
+// as the same-file case. Uses real files so relative imports resolve; skipped
+// on wasm, which has no filesystem.
+#[cfg(all(feature = "internal", not(target_arch = "wasm32")))]
+#[test]
+fn navigator_mount_cross_file_renders_module() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+
+    let dir = std::env::temp_dir().join(format!("slint_nav_xmount_interp_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("contract.slint"),
+        r#"
+export interface AppNavV1 {
+    route Home;
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("module-a.slint"),
+        r#"
+import { AppNavV1 } from "contract.slint";
+export global NavProbe { in-out property <string> active; }
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { init => { NavProbe.active = "module-home"; } }
+export component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+"#,
+    )
+    .unwrap();
+    let main_path = dir.join("main.slint");
+    let code = r#"
+import { ModuleA } from "module-a.slint";
+import { AppNavV1 } from "contract.slint";
+import { NavProbe } from "module-a.slint";
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "shell-home"; } }
+enum ShellRoute { Home, ModuleA }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), main_path));
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("ShellRoute".into(), v.into());
+
+    // The initial route renders the shell's own screen.
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("shell-home")),
+        "ShellRoute.Home renders HomeScreen"
+    );
+
+    // The mounted route renders the imported module's screen, proving the
+    // cross-file mount instantiated ModuleA directly as the route destination.
+    instance.set_property("current", route("ModuleA")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("module-home")),
+        "ShellRoute.ModuleA mounts and renders the imported ModuleA"
+    );
+}
+
 // Without `enable_experimental`, `navigator` is rejected at object-tree
 // lowering with the experimental-feature diagnostic. `Compiler::default()`
 // does not enable experimental features.

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -344,6 +344,71 @@ export component TestCase inherits Window {
     );
 }
 
+// A federated `mount Impl via Contract` route destination renders the mounted
+// module directly (no ComponentContainer indirection): switching the shell's
+// route to the mounted case instantiates `ModuleA`, whose screen records itself
+// in a global. Same observation approach as `navigator_shows_current_route`.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_mount_renders_module() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+interface AppNavV1 {
+    route Home;
+}
+global NavProbe { in-out property <string> active; }
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { init => { NavProbe.active = "module-home"; } }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "shell-home"; } }
+enum ShellRoute { Home, ModuleA }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("ShellRoute".into(), v.into());
+
+    // The initial route renders the shell's own screen.
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("shell-home")),
+        "ShellRoute.Home renders HomeScreen"
+    );
+
+    // Switching to the mounted route renders the module's own screen, proving the
+    // mount instantiated ModuleA directly as the route destination.
+    instance.set_property("current", route("ModuleA")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("module-home")),
+        "ShellRoute.ModuleA mounts and renders ModuleA"
+    );
+}
+
 // Without `enable_experimental`, `navigator` is rejected at object-tree
 // lowering with the experimental-feature diagnostic. `Compiler::default()`
 // does not enable experimental features.


### PR DESCRIPTION
_Part of stack #12561. Based on #12558._

### Summary
`mount Impl via Contract` — instantiates an independently-authored component at a route boundary against a navigation contract, resolved at **build time** (direct instantiation, closed-set check).

### What's in it
`object_tree.rs`, `object_tree/interfaces.rs`, `parser/element.rs`, `typeloader.rs` (mount resolution).

### Tests
Interpreter tests (+153), including cross-file mounting.

---
_Experimental-gated; additive to `master`. See the stack for the full picture._