### PR TITLE
navigation: capability contracts + external (cross-process) mount

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1276,19 +1276,34 @@ pub struct NavigatorRoute {
     pub mount: Option<FederatedMount>,
 }
 
-/// Records that a route destination is a build-time federated mount: an
-/// independently-built module's component (`impl_name`), verified at this
-/// integration site to satisfy a named navigation contract (`contract_name`).
-/// Metadata only; the destination is still a direct instantiation of the module.
+/// Records that a route destination is a federated mount against a named
+/// navigation contract (`contract_name`). Two kinds share this edge:
+///  - a build-time *local* mount: an independently-built module's component
+///    (`impl_name = Some`), verified here to satisfy the contract; the
+///    destination is a direct instantiation of that module.
+///  - an *external* cross-process mount (`impl_name = None`): the implementation
+///    is opaque at compile time and supplied by the host at runtime through a
+///    `ComponentFactory`. The destination is a `ComponentContainer`; the contract
+///    is the declared expectation the host's component must honor, not checked
+///    here. Metadata only.
 #[derive(Debug, Clone)]
 pub struct FederatedMount {
-    /// The mounted implementation component's name (e.g. `ModuleA`).
-    pub impl_name: SmolStr,
-    /// The navigation contract it was verified against (e.g. `AppNavV1`).
+    /// The mounted implementation component's name (e.g. `ModuleA`), or `None`
+    /// for an external mount whose implementation is not in this build.
+    pub impl_name: Option<SmolStr>,
+    /// The navigation contract it was declared/verified against (e.g. `AppNavV1`).
     pub contract_name: SmolStr,
     /// The contract's `@version`, if declared. The contract name encodes the
     /// version boundary; this is available metadata, not a compat check.
     pub contract_version: Option<u32>,
+}
+
+impl FederatedMount {
+    /// True for an external cross-process mount (host-supplied at runtime),
+    /// false for a build-time local mount. Lets tooling tell the two apart.
+    pub fn is_external(&self) -> bool {
+        self.impl_name.is_none()
+    }
 }
 
 impl Element {
@@ -2434,14 +2449,17 @@ impl Element {
         let mut cases: Vec<ElementRc> = Vec::new();
         let mut routes: Vec<NavigatorRoute> = Vec::new();
         for route in node.Route() {
-            // A destination is either a plain sub-element (`Route.X: Screen { }`)
-            // or a federated mount (`Route.X: mount Impl via Contract { }`). Both
-            // desugar to a conditional child that instantiates the destination
-            // component directly; a mount additionally verifies conformance and
-            // records the integration edge. The mounted implementation lives
-            // inside the MountDestination's SubElement, so both forms resolve
-            // their destination the same way.
+            // A destination is one of: a plain sub-element (`Route.X: Screen { }`),
+            // a build-time local mount (`Route.X: mount Impl via Contract { }`), or
+            // an external cross-process mount (`Route.X: mount extern via Contract
+            // { component-factory: ...; }`). Each desugars to a conditional child.
+            // Local and plain instantiate the destination component directly; a
+            // local mount also verifies conformance and records the edge. An
+            // external mount's destination is a `ComponentContainer` the host fills
+            // at runtime; only the contract edge is recorded (conformance at the
+            // seam is the host's responsibility).
             let mount_node = route.MountDestination();
+            let external = mount_node.as_ref().is_some_and(Self::mount_is_external);
             let (site, sub_element): (SyntaxNode, syntax_nodes::SubElement) =
                 if let Some(mount_node) = &mount_node {
                     (mount_node.clone().into(), mount_node.SubElement())
@@ -2463,19 +2481,29 @@ impl Element {
                 is_conditional_element: true,
                 is_listview: None,
             };
-            let e = Element::from_sub_element_node(
-                sub_element,
-                parent_type.clone(),
-                component_child_insertion_point,
-                is_in_legacy_component,
-                diag,
-                tr,
-            );
+            // An external mount carries no base name; its destination is the
+            // ComponentContainer, built directly (there is no compile-time impl to
+            // instantiate). All other destinations resolve their base name.
+            let e = if external {
+                Self::from_external_mount_node(&sub_element.Element(), tr, diag)
+            } else {
+                Element::from_sub_element_node(
+                    sub_element,
+                    parent_type.clone(),
+                    component_child_insertion_point,
+                    is_in_legacy_component,
+                    diag,
+                    tr,
+                )
+            };
             // Closed-set check: a destination must resolve to a component.
             // `ElementType::Error` means `from_sub_element_node` already
-            // reported an unknown name, so we don't double-report.
+            // reported an unknown name, so we don't double-report. An external
+            // mount is the one admitted exception: its destination is the
+            // `ComponentContainer` builtin, the runtime slot for the host module.
             match &e.borrow().base_type {
                 ElementType::Component(_) | ElementType::Error => {}
+                ElementType::Builtin(b) if external && b.name == "ComponentContainer" => {}
                 other => {
                     diag.push_error(
                         format!(
@@ -2485,11 +2513,17 @@ impl Element {
                     );
                 }
             }
-            // Integration-site verification: the mounted component must satisfy
-            // the named contract. Records the verified edge, or `None` if the
-            // route is a plain screen or conformance failed.
+            // Integration-site verification. A local mount verifies the mounted
+            // component against the contract and records the edge. An external
+            // mount only records the declared contract edge and checks that a
+            // `component-factory` is supplied; the absent impl is not conformance
+            // checked here. `None` for a plain screen or on failure.
             let mount = mount_node.and_then(|mount_node| {
-                Self::verify_federated_mount(&mount_node, &e, &parent_type, tr, diag)
+                if external {
+                    Self::verify_external_mount(&mount_node, &e, &parent_type, tr, diag)
+                } else {
+                    Self::verify_federated_mount(&mount_node, &e, &parent_type, tr, diag)
+                }
             });
             e.borrow_mut().repeated = Some(rei);
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone(), mount });
@@ -2532,11 +2566,50 @@ impl Element {
             ElementType::Component(c) => c.clone(),
             _ => return None,
         };
-        // Resolve the contract named after `via` to a navigation-contract
-        // interface. The `via <Contract>` clause is nested in the mounted
-        // instantiation's Element (A11), so the mount-block bindings stay
-        // contiguous with the base name. The contract name encodes the version
-        // boundary.
+        let (contract_name, contract) =
+            Self::resolve_mount_contract(mount_node, parent_type, tr, diag)?;
+        let impl_name = impl_comp.id.clone();
+        let conforms = interfaces::validate_mount_conformance(
+            &impl_name,
+            &impl_comp.root_element,
+            &contract_name,
+            &contract,
+            mount_node,
+            diag,
+        );
+        // A11: every capability the mounted module `needs` must be bound in the
+        // mount block. The block's callback handlers land as bindings on `dest`
+        // through the ordinary binding path, so an unbound need is simply a
+        // missing binding here.
+        let all_bound =
+            Self::verify_mount_capabilities(&impl_name, &impl_comp, dest, mount_node, diag);
+        (conforms && all_bound).then(|| FederatedMount {
+            impl_name: Some(impl_name),
+            contract_name,
+            contract_version: contract.version,
+        })
+    }
+
+    /// True when a mount is external (`mount extern via C { ... }`): the marker is
+    /// the `extern` soft keyword sitting as a direct token of the MountDestination
+    /// (a local mount has none). An external destination has no compile-time impl.
+    fn mount_is_external(mount_node: &syntax_nodes::MountDestination) -> bool {
+        mount_node.children_with_tokens().any(|n| {
+            n.as_token().is_some_and(|t| t.kind() == SyntaxKind::Identifier && t.text() == "extern")
+        })
+    }
+
+    /// Resolve the contract named after `via` to a navigation-contract interface.
+    /// The `via <Contract>` clause is nested in the mount's Element (A11) so the
+    /// mount-block bindings stay contiguous. Shared by local and external mounts;
+    /// the contract name encodes the version boundary. Cross-file resolution is
+    /// covered by the importer's `tr` already carrying imported types (A10.2).
+    fn resolve_mount_contract(
+        mount_node: &syntax_nodes::MountDestination,
+        parent_type: &ElementType,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> Option<(SmolStr, NavigationContract)> {
         let Some(contract_node) =
             mount_node.SubElement().Element().MountVia().map(|via| via.QualifiedName())
         else {
@@ -2567,26 +2640,79 @@ impl Element {
             );
             return None;
         };
-        let impl_name = impl_comp.id.clone();
-        let conforms = interfaces::validate_mount_conformance(
-            &impl_name,
-            &impl_comp.root_element,
-            &contract_name,
-            &contract,
-            mount_node,
+        Some((contract_name, contract))
+    }
+
+    /// Verify an external cross-process mount at its integration site. Unlike a
+    /// local mount there is no compile-time impl to conformance-check: the contract
+    /// is the declared expectation the host's runtime component must honor. We
+    /// verify only that (1) the boundary contract resolves and (2) a
+    /// `component-factory` is supplied (the runtime transport). Records an external
+    /// edge (`impl_name = None`) so tooling sees the declared boundary.
+    fn verify_external_mount(
+        mount_node: &syntax_nodes::MountDestination,
+        dest: &ElementRc,
+        parent_type: &ElementType,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> Option<FederatedMount> {
+        let (contract_name, contract) =
+            Self::resolve_mount_contract(mount_node, parent_type, tr, diag)?;
+        // The runtime transport: the host sets this ComponentFactory-typed property
+        // at runtime, and the container renders whatever component it produces.
+        // Without it the external seam has nothing to fill the route slot.
+        if !dest.borrow().bindings.contains_key("component-factory") {
+            diag.push_error(
+                format!("external mount via '{contract_name}' requires a 'component-factory'"),
+                mount_node,
+            );
+            return None;
+        }
+        Some(FederatedMount { impl_name: None, contract_name, contract_version: contract.version })
+    }
+
+    /// Build the destination of an external mount: a `ComponentContainer` the host
+    /// fills at runtime through a `ComponentFactory`. There is no compile-time impl
+    /// to instantiate and (by design) no base name on the Element, so the container
+    /// is looked up directly and the mount block's bindings (the `component-factory`
+    /// binding) are attached through the ordinary binding path.
+    fn from_external_mount_node(
+        element_node: &syntax_nodes::Element,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> ElementRc {
+        let base_type = tr.lookup_builtin_element("ComponentContainer").unwrap_or_else(|| {
+            // ComponentContainer is a core builtin; absence means a broken setup.
+            debug_assert!(false, "ComponentContainer builtin missing");
+            ElementType::Error
+        });
+        let r = Element {
+            id: SmolStr::default(),
+            base_type: base_type.clone(),
+            debug: vec![ElementDebugInfo {
+                qualified_id: None,
+                element_hash: 0,
+                type_name: base_type.type_name().unwrap_or_default().to_string(),
+                node: element_node.clone(),
+                layout: None,
+                element_boundary: false,
+            }],
+            ..Default::default()
+        }
+        .make_rc();
+        apply_default_type_properties(&mut r.borrow_mut());
+        // The block carries the `component-factory` binding (and nothing that needs
+        // an impl; capability binding across the seam is deferred). Attach it the
+        // same way a normal element body would, so unknown-property errors and the
+        // component-factory type check happen through the shared path.
+        r.borrow_mut().parse_bindings(
+            element_node.Binding().filter_map(|b| {
+                Some((b.child_token(SyntaxKind::Identifier)?, b.BindingExpression().into()))
+            }),
+            false,
             diag,
         );
-        // A11: every capability the mounted module `needs` must be bound in the
-        // mount block. The block's callback handlers land as bindings on `dest`
-        // through the ordinary binding path, so an unbound need is simply a
-        // missing binding here.
-        let all_bound =
-            Self::verify_mount_capabilities(&impl_name, &impl_comp, dest, mount_node, diag);
-        (conforms && all_bound).then(|| FederatedMount {
-            impl_name,
-            contract_name,
-            contract_version: contract.version,
-        })
+        r
     }
 
     /// Verify that the mount block binds every capability the mounted module

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -478,6 +478,19 @@ pub struct NavigationContract {
     pub version: Option<u32>,
 }
 
+/// A capability a component declares it requires from its host via `needs
+/// <Interface>` (A11): the interface named and the member names (callbacks/
+/// functions) pulled onto the component as unbound members. The federated-mount
+/// verifier requires each member be bound at the integration site.
+#[derive(Debug, Clone)]
+pub struct NeededCapability {
+    /// The capability interface named by the `needs` specifier.
+    pub interface_name: SmolStr,
+    /// The interface members declared unbound on the component, to be bound by
+    /// the host. In interface declaration order.
+    pub members: Vec<SmolStr>,
+}
+
 /// A component is a type in the language which can be instantiated,
 /// Or is materialized for repeated expression.
 #[derive(Default, Debug)]
@@ -645,6 +658,13 @@ impl Component {
     /// later navigation slices, kept separate from the interface's members.
     pub fn navigation_contract(&self) -> Option<NavigationContract> {
         self.navigation_contract.borrow().clone()
+    }
+
+    /// The capabilities this component declares via `needs` on its root, if any.
+    /// Read by the federated-mount verifier to require each be bound at the mount
+    /// site. Empty when the component needs nothing from its host.
+    pub fn needed_capabilities(&self) -> Vec<NeededCapability> {
+        self.root_element.borrow().needed_capabilities.clone()
     }
 
     /// This component is a global component introduced with the "global" keyword
@@ -981,6 +1001,10 @@ pub struct Element {
     /// LSP can recover the route -> component graph. Empty for elements without
     /// a `navigator`.
     pub navigator_routes: Vec<NavigatorRoute>,
+    /// Capabilities this element declares via `needs <Interface>` (A11). Populated
+    /// when the element is a component root; read by the federated-mount verifier
+    /// off the mounted component's root. Empty for elements with no `needs`.
+    pub needed_capabilities: Vec<NeededCapability>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
 
@@ -1690,6 +1714,13 @@ impl Element {
         }
 
         interfaces::apply_callbacks(&mut r, &implemented_interface, diag);
+
+        // A11: `needs <Interface>` declares the interface's callbacks/functions as
+        // unbound members on this element, to be bound by the host at the mount
+        // site. Same "declare on the component, bind at instantiation" mechanism
+        // as an interface callback, minus a local body.
+        let needed_interfaces = interfaces::get_needed_interfaces(&r, &node, tr, diag);
+        r.needed_capabilities = interfaces::apply_needs(&mut r, &needed_interfaces, diag);
 
         for func in node.Function() {
             #[cfg(feature = "slint-sc")]
@@ -2502,8 +2533,17 @@ impl Element {
             _ => return None,
         };
         // Resolve the contract named after `via` to a navigation-contract
-        // interface. The contract name encodes the version boundary.
-        let contract_node = mount_node.QualifiedName();
+        // interface. The `via <Contract>` clause is nested in the mounted
+        // instantiation's Element (A11), so the mount-block bindings stay
+        // contiguous with the base name. The contract name encodes the version
+        // boundary.
+        let Some(contract_node) =
+            mount_node.SubElement().Element().MountVia().map(|via| via.QualifiedName())
+        else {
+            // The parser always emits a MountVia for a mount; missing it means a
+            // malformed mount that was already diagnosed.
+            return None;
+        };
         let contract_name = QualifiedTypeName::from_node(contract_node.clone()).to_smolstr();
         let contract_comp = match parent_type.lookup_type_for_child_element(&contract_name, tr) {
             Ok(ElementType::Component(c)) if c.is_interface() => c,
@@ -2528,19 +2568,60 @@ impl Element {
             return None;
         };
         let impl_name = impl_comp.id.clone();
-        interfaces::validate_mount_conformance(
+        let conforms = interfaces::validate_mount_conformance(
             &impl_name,
             &impl_comp.root_element,
             &contract_name,
             &contract,
             mount_node,
             diag,
-        )
-        .then(|| FederatedMount {
+        );
+        // A11: every capability the mounted module `needs` must be bound in the
+        // mount block. The block's callback handlers land as bindings on `dest`
+        // through the ordinary binding path, so an unbound need is simply a
+        // missing binding here.
+        let all_bound =
+            Self::verify_mount_capabilities(&impl_name, &impl_comp, dest, mount_node, diag);
+        (conforms && all_bound).then(|| FederatedMount {
             impl_name,
             contract_name,
             contract_version: contract.version,
         })
+    }
+
+    /// Verify that the mount block binds every capability the mounted module
+    /// declares via `needs`. Each need is a callback/function declared unbound on
+    /// the module's root; the mount block binds it as a handler, which lands as a
+    /// binding on the instantiation `dest`. A need with no binding is a compile
+    /// error at the mount site. Returns true when all needs are bound.
+    fn verify_mount_capabilities(
+        impl_name: &SmolStr,
+        impl_comp: &Rc<Component>,
+        dest: &ElementRc,
+        mount_node: &syntax_nodes::MountDestination,
+        diag: &mut BuildDiagnostics,
+    ) -> bool {
+        let needs = impl_comp.needed_capabilities();
+        if needs.is_empty() {
+            return true;
+        }
+        let dest = dest.borrow();
+        let mut all_bound = true;
+        for cap in &needs {
+            for member in &cap.members {
+                if !dest.bindings.contains_key(member) {
+                    diag.push_error(
+                        format!(
+                            "mount of '{impl_name}' does not bind required capability '{member}' (from '{}')",
+                            cap.interface_name
+                        ),
+                        mount_node,
+                    );
+                    all_bound = false;
+                }
+            }
+        }
+        all_bound
     }
 
     /// Declare the navigator's public members (the surface widget chrome binds

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -16,8 +16,8 @@ use crate::expression_tree::{BindingExpression, Callable, Expression};
 use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
-    Component, Element, ElementRc, NavigationContract, PropertyDeclaration, QualifiedTypeName,
-    find_element_by_id, recurse_elem, visit_named_references_in_expression,
+    Component, Element, ElementRc, NavigationContract, NeededCapability, PropertyDeclaration,
+    QualifiedTypeName, find_element_by_id, recurse_elem, visit_named_references_in_expression,
 };
 use crate::parser;
 use crate::parser::{SyntaxKind, syntax_nodes};
@@ -323,6 +323,122 @@ fn apply_interface_property_declaration(
     }
 
     e.property_declarations.insert(unresolved_prop_name.clone(), prop_decl.clone());
+}
+
+/// A `needs <Interface>` specifier and the capability interface it resolves to.
+pub(super) struct NeededInterface {
+    needs_specifier: syntax_nodes::NeedsSpecifier,
+    interface: ElementRc,
+    interface_name: SmolStr,
+}
+
+/// Resolve the `needs` specifiers declared on `node` to capability interfaces,
+/// emitting diagnostics for anything that is not an interface. Experimental-gated
+/// exactly like `uses`. Mirrors `get_implemented_interface`'s lookup, but a
+/// component may need several capabilities, so this returns a list.
+pub(super) fn get_needed_interfaces(
+    e: &Element,
+    node: &syntax_nodes::Element,
+    tr: &TypeRegister,
+    diag: &mut BuildDiagnostics,
+) -> Vec<NeededInterface> {
+    let specifiers: Vec<syntax_nodes::NeedsSpecifier> = node.NeedsSpecifier().collect();
+    if specifiers.is_empty() {
+        return Vec::new();
+    }
+
+    #[cfg(feature = "slint-sc")]
+    for specifier in &specifiers {
+        diag.slint_sc_error("'needs' is", specifier);
+    }
+
+    if !diag.enable_experimental && !tr.expose_internal_types {
+        for specifier in &specifiers {
+            diag.push_error("'needs' is an experimental feature".into(), specifier);
+        }
+        return Vec::new();
+    }
+
+    let mut needed = Vec::new();
+    for needs_specifier in specifiers {
+        let interface_name =
+            QualifiedTypeName::from_node(needs_specifier.QualifiedName()).to_smolstr();
+        match e.base_type.lookup_type_for_child_element(&interface_name, tr) {
+            Ok(ElementType::Component(c)) if c.is_interface() => {
+                c.used.set(true);
+                needed.push(NeededInterface {
+                    needs_specifier,
+                    interface: c.root_element.clone(),
+                    interface_name,
+                });
+            }
+            Ok(_) => diag.push_error(
+                format!("Cannot use '{interface_name}' as a capability. It is not an interface"),
+                &needs_specifier.QualifiedName(),
+            ),
+            Err(err) => diag.push_error(err, &needs_specifier.QualifiedName()),
+        }
+    }
+    needed
+}
+
+/// Declare each capability member (callback/function) of the `needed` interfaces
+/// as an unbound member on `e`, and return the recorded needs for the mount
+/// verifier. "Unbound" means the declaration is added with no local binding, so
+/// the host binds it at the mount site. Reuses the same conflict-checked insert
+/// shape as `implements`, minus the requirement to provide a local body.
+pub(super) fn apply_needs(
+    e: &mut Element,
+    needed: &[NeededInterface],
+    diag: &mut BuildDiagnostics,
+) -> Vec<NeededCapability> {
+    let mut capabilities = Vec::new();
+    for NeededInterface { needs_specifier, interface, interface_name } in needed {
+        let mut members = Vec::new();
+        for (name, prop_decl) in interface.borrow().property_declarations.iter().filter(|(_, d)| {
+            matches!(d.property_type, Type::Callback { .. } | Type::Function { .. })
+        }) {
+            if apply_needed_member(e, name, prop_decl, needs_specifier, interface_name, diag) {
+                members.push(name.clone());
+            }
+        }
+        capabilities.push(NeededCapability { interface_name: interface_name.clone(), members });
+    }
+    capabilities
+}
+
+/// Declare a single capability member on `e` as an unbound declaration. Returns
+/// true when the member was declared, false on a conflict with an existing local
+/// member of the same name (a diagnostic is emitted in that case).
+fn apply_needed_member(
+    e: &mut Element,
+    name: &SmolStr,
+    prop_decl: &PropertyDeclaration,
+    needs_specifier: &syntax_nodes::NeedsSpecifier,
+    interface_name: &SmolStr,
+    diag: &mut BuildDiagnostics,
+) -> bool {
+    if matches!(prop_decl.property_type, Type::Invalid) {
+        return false;
+    }
+
+    let lookup_result = e.lookup_property(name);
+    if lookup_result.property_type != Type::Invalid && lookup_result.is_local_to_component {
+        diag.push_error(
+            format!(
+                "Conflict with '{interface_name}' which declares a capability member '{name}' with the same name"
+            ),
+            &needs_specifier.QualifiedName(),
+        );
+        return false;
+    }
+
+    // Point the declaration at the `needs` specifier for later diagnostics, since
+    // the member has no declaration of its own on this element.
+    let mut prop_decl = prop_decl.clone();
+    prop_decl.node = Some(needs_specifier.QualifiedName().into());
+    e.property_declarations.insert(name.clone(), prop_decl);
+    true
 }
 
 /// Apply default property values defined in the interface to the element.

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -354,7 +354,7 @@ declare_syntax! {
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
                      *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *RouteDeclaration, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
-                     *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder, *AtVersion ],
+                     *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder, *AtVersion, ?MountVia, *NeedsSpecifier ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],
         ConditionalElement -> [ Expression , SubElement],
@@ -369,10 +369,15 @@ declare_syntax! {
         Navigator -> [ Expression, *Route ],
         /// Route.Home: HomeScreen { }  or  Route.ModuleA: mount ModuleA via AppNavV1 { }
         Route -> [ Expression, ?SubElement, ?MountDestination ],
-        /// `mount ModuleA via AppNavV1 { }`  a build-time federated mount destination.
-        /// The SubElement is the mounted implementation (desugars to a direct
-        /// instantiation); the QualifiedName is the navigation contract it must satisfy.
-        MountDestination -> [ SubElement, QualifiedName ],
+        /// `mount ModuleA via AppNavV1 { open-settings => {} }`  a build-time federated mount.
+        /// The SubElement is the mounted implementation, a normal instantiation whose body
+        /// binds the module's capability needs. The `via <Contract>` clause is nested in the
+        /// Element as a MountVia so the mount-block bindings flow onto the instantiation
+        /// through the ordinary binding path (A11).
+        MountDestination -> [ SubElement ],
+        /// `via AppNavV1`  the navigation contract a mount must satisfy. Nested inside the
+        /// mounted instantiation's Element so its base name and bindings stay contiguous.
+        MountVia -> [ QualifiedName ],
         /// `route Home;` or `route Details(id: int);`  a navigation contract member of an interface
         /// An optional `@uri("...")` prefix declares the route's deep-link URI.
         RouteDeclaration -> [ DeclaredIdentifier, *ArgumentDeclaration, *AtUri ],
@@ -496,6 +501,8 @@ declare_syntax! {
         UsesIdentifier -> [QualifiedName, DeclaredIdentifier],
         /// `implements Interface.Foo`
         ImplementsSpecifier -> [ QualifiedName ],
+        /// `needs AppServices;`  a capability the component requires from its host (A11).
+        NeedsSpecifier -> [ QualifiedName ],
     }
 }
 

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -97,6 +97,12 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 SyntaxKind::Identifier if p.peek().as_str() == "route" => {
                     parse_route_declaration(&mut *p, None);
                 }
+                // Experimental: `needs <Capability>;` declares a capability the
+                // component requires from its host (A11). Parsed unconditionally;
+                // the experimental gate is applied at object-tree lowering.
+                SyntaxKind::Identifier if p.peek().as_str() == "needs" => {
+                    parse_needs_specifier(&mut *p);
+                }
                 SyntaxKind::Identifier | SyntaxKind::Star if p.peek().as_str() == "animate" => {
                     parse_property_animation(&mut *p);
                 }
@@ -449,28 +455,48 @@ fn parse_route(p: &mut impl Parser) {
 /// ```test,MountDestination
 /// mount ModuleA via AppNavV1 { }
 /// mount M via C {}
+/// mount ModuleA via AppNavV1 { open-settings => {} }
+/// mount ModuleA via AppNavV1 { play-media(url) => { root.x = url; } }
 /// ```
 fn parse_mount_destination(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "mount");
     let mut p = p.start_node(SyntaxKind::MountDestination);
     p.expect(SyntaxKind::Identifier); // "mount"
-    // The mounted implementation, wrapped as a SubElement so the desugar reuses
-    // the plain-route path and produces a direct instantiation of it.
+    // The mounted implementation is a normal instantiation `Impl { <bindings> }`,
+    // wrapped as a SubElement so the mount-block bindings flow onto it through the
+    // ordinary binding path (they satisfy the module's capability needs). The
+    // `via <Contract>` clause is nested in a MountVia node inside the Element so
+    // the base name and the trailing bindings stay contiguous.
+    let mut sub = p.start_node(SyntaxKind::SubElement);
+    let mut el = sub.start_node(SyntaxKind::Element);
+    parse_qualified_name(&mut *el); // the mounted implementation
     {
-        let mut sub = p.start_node(SyntaxKind::SubElement);
-        let mut el = sub.start_node(SyntaxKind::Element);
-        parse_qualified_name(&mut *el);
+        let mut via = el.start_node(SyntaxKind::MountVia);
+        if via.peek().as_str() != "via" {
+            via.error("Expected 'via <Contract>' after 'mount <Impl>'");
+        } else {
+            via.consume(); // "via"
+        }
+        parse_qualified_name(&mut *via); // the navigation contract to satisfy
     }
-    if p.peek().as_str() != "via" {
-        p.error("Expected 'via <Contract>' after 'mount <Impl>'");
-    } else {
-        p.consume(); // "via"
+    if !el.expect(SyntaxKind::LBrace) {
+        return;
     }
-    // The navigation contract the mounted implementation must satisfy.
+    parse_element_content(&mut *el);
+    el.expect(SyntaxKind::RBrace);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,NeedsSpecifier
+/// needs AppServices;
+/// needs Fully.Qualified.Services;
+/// ```
+fn parse_needs_specifier(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "needs");
+    let mut p = p.start_node(SyntaxKind::NeedsSpecifier);
+    p.expect(SyntaxKind::Identifier); // "needs"
     parse_qualified_name(&mut *p);
-    // Trailing braces are part of the mount site; empty in this slice.
-    p.expect(SyntaxKind::LBrace);
-    p.expect(SyntaxKind::RBrace);
+    p.expect(SyntaxKind::Semicolon);
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -457,19 +457,32 @@ fn parse_route(p: &mut impl Parser) {
 /// mount M via C {}
 /// mount ModuleA via AppNavV1 { open-settings => {} }
 /// mount ModuleA via AppNavV1 { play-media(url) => { root.x = url; } }
+/// mount extern via AppNavV1 { component-factory: root.f; }
+/// mount extern via C {}
 /// ```
 fn parse_mount_destination(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "mount");
     let mut p = p.start_node(SyntaxKind::MountDestination);
     p.expect(SyntaxKind::Identifier); // "mount"
+    // `extern` (soft keyword) marks an external cross-process destination: no
+    // statically-known impl. The destination resolves to a `ComponentContainer`
+    // the host fills at runtime; the Element carries no base name, which is how
+    // object_tree tells an external mount from a local one.
+    let external = p.peek().as_str() == "extern";
+    if external {
+        p.consume(); // "extern"
+    }
     // The mounted implementation is a normal instantiation `Impl { <bindings> }`,
     // wrapped as a SubElement so the mount-block bindings flow onto it through the
     // ordinary binding path (they satisfy the module's capability needs). The
     // `via <Contract>` clause is nested in a MountVia node inside the Element so
-    // the base name and the trailing bindings stay contiguous.
+    // the base name and the trailing bindings stay contiguous. An external mount
+    // omits the base name; its block binds `component-factory` on the container.
     let mut sub = p.start_node(SyntaxKind::SubElement);
     let mut el = sub.start_node(SyntaxKind::Element);
-    parse_qualified_name(&mut *el); // the mounted implementation
+    if !external {
+        parse_qualified_name(&mut *el); // the mounted implementation
+    }
     {
         let mut via = el.start_node(SyntaxKind::MountVia);
         if via.peek().as_str() != "via" {

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -400,6 +400,7 @@ fn duplicate_element_with_mapping(
             .collect(),
         repeated: elem.repeated.clone(),
         navigator_routes: elem.navigator_routes.clone(),
+        needed_capabilities: elem.needed_capabilities.clone(),
         is_component_placeholder: elem.is_component_placeholder,
         debug: elem.debug.clone(),
         enclosing_component: Rc::downgrade(root_component),

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -48,6 +48,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 named_references: Default::default(),
                 repeated: None,
                 navigator_routes: Default::default(),
+                needed_capabilities: Default::default(),
                 is_component_placeholder: false,
                 debug: original_elem.debug.clone(),
                 enclosing_component: Default::default(),

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -43,6 +43,7 @@ pub fn ensure_window(
         base_type: std::mem::replace(&mut win_elem_mut.base_type, window_type),
         bindings: Default::default(),
         change_callbacks: Default::default(),
+        needed_capabilities: Default::default(),
         is_component_placeholder: false,
         property_analysis: Default::default(),
         children: std::mem::take(&mut win_elem_mut.children),

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2399,7 +2399,8 @@ fn test_federated_mount_resolves_and_records_edge() {
     // instantiation (its destination base type is the ModuleA component).
     let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
     let edge = mounted.mount.as_ref().unwrap();
-    assert_eq!(edge.impl_name, "ModuleA");
+    assert!(!edge.is_external(), "a local mount is not external");
+    assert_eq!(edge.impl_name.as_deref(), Some("ModuleA"));
     assert_eq!(edge.contract_name, "AppNavV1");
     assert_eq!(
         mounted.component.borrow().base_type.to_string(),
@@ -2563,7 +2564,7 @@ export component ModuleA implements AppNavV1 inherits Rectangle {
 
     let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
     let edge = mounted.mount.as_ref().unwrap();
-    assert_eq!(edge.impl_name, "ModuleA");
+    assert_eq!(edge.impl_name.as_deref(), Some("ModuleA"));
     assert_eq!(edge.contract_name, "AppNavV1");
     // The mount desugars to a direct instantiation of the imported module.
     assert_eq!(
@@ -2707,7 +2708,7 @@ export component Shell inherits Window {
     let root = shell.root_element.borrow();
     let mounted =
         root.navigator_routes().iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
-    assert_eq!(mounted.mount.as_ref().unwrap().impl_name, "ModuleA");
+    assert_eq!(mounted.mount.as_ref().unwrap().impl_name.as_deref(), Some("ModuleA"));
     // The mount-block handlers land as bindings on the module instantiation.
     let dest = mounted.component.borrow();
     assert!(dest.bindings.contains_key("open-settings"));
@@ -2750,6 +2751,82 @@ export component Shell inherits Window {
             "mount of 'ModuleA' does not bind required capability 'open-settings' (from 'AppServices')"
         )),
         "unbound need should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+// A12: an external cross-process mount. `ModuleB` is not in this build; the shell
+// declares the boundary against `AppNavV1` statically and supplies a
+// ComponentFactory the host sets at runtime.
+#[cfg(test)]
+const EXTERNAL_MOUNT_TEST_SOURCE: &str = r#"
+interface AppNavV1 {
+    route Home;
+}
+enum ShellRoute { Home, ModuleB }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in property <component-factory> module-b-factory;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleB: mount extern via AppNavV1 {
+            component-factory: root.module-b-factory;
+        }
+    }
+}
+"#;
+
+#[test]
+fn test_external_mount_records_external_edge() {
+    // A conforming external mount compiles, desugars to a ComponentContainer route
+    // destination, and records an EXTERNAL federated-mount edge: no impl name, the
+    // declared contract, and the container as the runtime slot.
+    let (loader, path, diag) = load_source_for_contract_test(EXTERNAL_MOUNT_TEST_SOURCE, true);
+    assert!(!diag.has_errors(), "external mount rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let routes = root.navigator_routes();
+    assert_eq!(routes.len(), 2);
+
+    let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    let edge = mounted.mount.as_ref().unwrap();
+    assert!(edge.is_external(), "the edge must be external");
+    assert_eq!(edge.impl_name, None, "an external mount has no compile-time impl");
+    assert_eq!(edge.contract_name, "AppNavV1");
+    // The destination is the ComponentContainer the host fills at runtime, and it
+    // carries the component-factory transport binding.
+    let dest = mounted.component.borrow();
+    assert_eq!(dest.base_type.to_string(), "ComponentContainer");
+    assert!(dest.bindings.contains_key("component-factory"));
+}
+
+#[test]
+fn test_external_mount_missing_factory_rejected() {
+    // An external mount with no component-factory has no runtime transport for the
+    // host component, so the seam cannot be filled: a compile error.
+    let source = r#"
+interface AppNavV1 {
+    route Home;
+}
+enum ShellRoute { Home, ModuleB }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleB: mount extern via AppNavV1 { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d
+            .message()
+            .contains("external mount via 'AppNavV1' requires a 'component-factory'")),
+        "missing factory should be a diagnostic: {:?}",
         diag.to_string_vec()
     );
 }

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2602,6 +2602,159 @@ export component ModuleA inherits Rectangle {
 }
 
 #[test]
+fn test_needs_declares_capability_members() {
+    // A11: `needs <Interface>` pulls the interface's callbacks onto the component
+    // as unbound members. They are then declared (present in property_declarations)
+    // and callable from the component body, and recorded for the mount verifier.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+}
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+export component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    TouchArea { clicked => { root.open-settings(); } }
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "needs declaration rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let module = doc.inner_components.iter().find(|c| c.id == "ModuleA").expect("ModuleA missing");
+    let root = module.root_element.borrow();
+    // The capability callbacks are declared on the component.
+    assert!(root.property_declarations.contains_key("open-settings"));
+    assert!(root.property_declarations.contains_key("play-media"));
+
+    // The needs are recorded for the mount verifier.
+    let caps = module.needed_capabilities();
+    assert_eq!(caps.len(), 1);
+    assert_eq!(caps[0].interface_name, "AppServices");
+    assert!(caps[0].members.contains(&"open-settings".into()));
+    assert!(caps[0].members.contains(&"play-media".into()));
+}
+
+#[test]
+fn test_needs_requires_experimental() {
+    // `needs` is experimental-gated exactly like `uses`.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+}
+export component ModuleA inherits Rectangle {
+    needs AppServices;
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, false);
+    assert!(
+        diag.iter().any(|d| d.message().contains("'needs' is an experimental feature")),
+        "needs should be rejected without the experimental flag: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_mount_binds_needed_capabilities() {
+    // A11: a mount block that binds every capability the module needs compiles and
+    // still records the mount edge.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+    route Details;
+}
+enum ModuleRoute { Home, Details }
+component ModHome inherits Rectangle { }
+component ModDetails inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+        ModuleRoute.Details: ModDetails { }
+    }
+}
+enum ShellRoute { Home, ModuleA }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 {
+            open-settings => { }
+            play-media(url) => { }
+        }
+    }
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "mount binding all needs rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let mounted =
+        root.navigator_routes().iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    assert_eq!(mounted.mount.as_ref().unwrap().impl_name, "ModuleA");
+    // The mount-block handlers land as bindings on the module instantiation.
+    let dest = mounted.component.borrow();
+    assert!(dest.bindings.contains_key("open-settings"));
+    assert!(dest.bindings.contains_key("play-media"));
+}
+
+#[test]
+fn test_mount_unbound_need_rejected() {
+    // A11: the mount omits `open-settings`, so a required capability is unbound.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+}
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+enum ShellRoute { Home }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: mount ModuleA via AppNavV1 {
+            play-media(url) => { }
+        }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains(
+            "mount of 'ModuleA' does not bind required capability 'open-settings' (from 'AppServices')"
+        )),
+        "unbound need should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
 fn test_dependency_loading_from_rust() {
     let test_source_path: PathBuf =
         [env!("CARGO_MANIFEST_DIR"), "tests", "typeloader"].iter().collect();

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -573,6 +573,91 @@ export component TestCase inherits Window {
     );
 }
 
+// A12: an external cross-process mount. The shell declares the boundary statically
+// against `AppNavV1` and exposes a `component-factory` the host sets at runtime;
+// the destination is a ComponentContainer. `ModuleB` is a *separately compiled*
+// component (its own compilation, its own global namespace), delivered through the
+// factory the same way a host process would. Observing across the seam via a shared
+// global is impossible by design (separate compilations), so we observe the seam
+// directly: the runtime invokes the host factory to fill the route slot only once
+// the external route is active. That the factory returns a real embedded instance
+// is what renders the host component in the slot.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_external_mount_invokes_host_factory() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, Value};
+    use i_slint_core::component_factory::ComponentFactory;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    // The host module: opaque to the shell at build time, its own compilation.
+    let host_code = r#"
+export component ModuleB inherits Rectangle { background: red; }
+"#;
+    let mut host_compiler = Compiler::default();
+    host_compiler.set_style("fluent".into());
+    let host_result =
+        spin_on::spin_on(host_compiler.build_from_source(host_code.into(), Default::default()));
+    assert!(!host_result.has_errors(), "{:?}", host_result.diagnostics().collect::<Vec<_>>());
+    let host_def = host_result.component("ModuleB").unwrap();
+
+    // The shell: declares the external boundary and the runtime transport property.
+    let code = r#"
+interface AppNavV1 {
+    route Home;
+}
+component HomeScreen inherits Rectangle { }
+enum ShellRoute { Home, ModuleB }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in property <component-factory> module-b-factory;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleB: mount extern via AppNavV1 {
+            component-factory: root.module-b-factory;
+        }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    // The host factory records when the runtime asks it to build a component, and
+    // returns a real embedded instance to render in the route slot.
+    let invoked = Rc::new(Cell::new(false));
+    let invoked_in_factory = invoked.clone();
+    let factory = ComponentFactory::new(move |ctx| {
+        invoked_in_factory.set(true);
+        host_def.create_embedded(ctx).ok()
+    });
+    instance.set_property("module-b-factory", Value::ComponentFactory(factory)).unwrap();
+
+    // While the external route is inactive the container has nothing to build.
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert!(!invoked.get(), "the host factory is not invoked while the external route is inactive");
+
+    // Activating the external route drives the container to build the host
+    // component through the supplied factory: contract edge + container + factory
+    // transport are wired end-to-end.
+    instance
+        .set_property("current", Value::EnumerationValue("ShellRoute".into(), "ModuleB".into()))
+        .unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert!(
+        invoked.get(),
+        "activating the external route builds the host component via the factory"
+    );
+}
+
 // Without `enable_experimental`, `navigator` is rejected at object-tree
 // lowering with the experimental-feature diagnostic. `Compiler::default()`
 // does not enable experimental features.

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -409,6 +409,82 @@ export component TestCase inherits Window {
     );
 }
 
+// A11: a mounted module that `needs` a capability invokes it from inside itself,
+// and the integrator's binding at the mount site actually runs. ModuleA declares
+// `needs AppServices` and calls `play-media` from its own init; the shell binds
+// `play-media` to write a global. Observing that global proves the capability
+// wiring is end-to-end: the module's call reaches the integrator's expression.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_mount_binds_capability_end_to_end() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+}
+global CapProbe { in-out property <string> played; }
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    // The module invokes a capability it does not implement itself.
+    init => { root.play-media("song.mp3"); }
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+component HomeScreen inherits Rectangle { }
+enum ShellRoute { Home, ModuleA }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    out property <string> played: CapProbe.played;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 {
+            open-settings => { }
+            play-media(url) => { CapProbe.played = url; }
+        }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    // Before the module is mounted, nothing has invoked the capability.
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("played").unwrap(),
+        Value::from(SharedString::from("")),
+        "capability not invoked before the module is mounted"
+    );
+
+    // Mounting the module runs its init, which calls the bound capability; the
+    // integrator's handler writes the argument through to the global.
+    instance
+        .set_property("current", Value::EnumerationValue("ShellRoute".into(), "ModuleA".into()))
+        .unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("played").unwrap(),
+        Value::from(SharedString::from("song.mp3")),
+        "the module's capability call runs the integrator's bound expression"
+    );
+}
+
 // The cross-file counterpart of `navigator_mount_renders_module`: the contract
 // and the mounted module live in their own files, imported by the integrator.
 // Proves the mount desugars, verifies, and renders the imported module the same


### PR DESCRIPTION
_Part of stack #12561. Based on #12559._

### Summary
The capstone, for independently-deployed / cross-process parts:
- A module declares `needs Capability;` at its boundary, bound by the
  integrator at mount, so a federated part states what it needs from the host without hard-wiring.
- `mount extern via Contract` — a dynamic/external mount via `ComponentContainer` +  `ComponentFactory`, for closed-set check for the external seam (parts built and shipped on their own release cycle).

### What's in it
`object_tree.rs`, `object_tree/interfaces.rs`, `parser/element.rs`, `typeloader.rs`, and the `inlining` / `repeater_component` / `windows` passes.

### Tests
Interpreter tests.

---
_Experimental-gated; additive to `master`. See the stack for the full picture._